### PR TITLE
add fat tests for OpenIdAuthenticationMechanismDefinition extraParameters

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/configs/TestConfigMaps.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/configs/TestConfigMaps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -310,6 +310,102 @@ public class TestConfigMaps {
     public static Map<String, Object> getUseNonceExpressionFalse() throws Exception {
         Map<String, Object> updatedMap = new HashMap<String, Object>();
         updatedMap.put(Constants.USE_NONCE_EXPRESSION, String.valueOf(false));
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersTwoParams() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key1=value1,key2=value2");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersDuplicateKeys() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key1=value1,key1=value2");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersContainsSpaceInKey() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key 1=value1");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersContainsTrailingSpaceInKey() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key1 =value1");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersContainsSpaceInValue() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key1=value 1");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersContainsLeadingSpaceInValue() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key1= value1");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersContainsTrailingSpaceInValue() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key1=value1 ");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersContainsEmptyKey() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "=value1");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersContainsEmptyValue() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key1=");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersContainsSpaceAsValue() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key1= ");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersContainsTwoEqualsSigns() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key1=value1=value2");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersMissingEqualsSign() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key1value1");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersIsEmpty() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersIsAnEqualsSign() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "=");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersContainsSpecialCharacterInKey() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key&1=value1");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getExtraParametersContainsSpecialCharacterInValue() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key1=value&1");
         return updatedMap;
     }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,8 @@ public class Constants extends com.ibm.ws.security.fat.common.Constants {
     public static final String USE_NONCE_EXPRESSION = "useNonceExpression";
     public static final String USE_SESSION = "useSession";
     public static final String USE_SESSION_EXPRESSION = "useSessionExpression";
+    public static final String EXTRA_PARAMETERS = "extraParameters";
+    public static final String EXTRA_PARAMETERS_EXPRESSION = "extraParametersExpression";
     public static final String RESPONSE_TYPE = "responseType";
     public static final String PROVIDER = "provider";
     public static final String LOGOUT = "logout";

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -125,6 +125,15 @@ public class BaseOpenIdConfig extends MinimumBaseOpenIdConfig {
         boolean value = true;
         if (config.containsKey(Constants.USE_NONCE_EXPRESSION)) {
             value = getBooleanValue(Constants.USE_NONCE_EXPRESSION);
+        }
+        return value;
+    }
+
+    public String[] getExtraParametersExpression() {
+
+        String[] value = {};
+        if (config.containsKey(Constants.EXTRA_PARAMETERS_EXPRESSION)) {
+            value = getStringArrayValue(Constants.EXTRA_PARAMETERS_EXPRESSION, ",");
         }
         return value;
     }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/.classpath
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/.classpath
@@ -23,6 +23,12 @@
 	<classpathentry kind="src" path="test-applications/UseNonceFalse.war/src"/>
 	<classpathentry kind="src" path="test-applications/UseNonceTrueWithEL.war/src"/>
 	<classpathentry kind="src" path="test-applications/UseNonceFalseWithEL.war/src"/>
+	<classpathentry kind="src" path="test-applications/ExtraParametersUsingEL.war/src"/>
+	<classpathentry kind="src" path="test-applications/ExtraParametersOneParam.war/src"/>
+	<classpathentry kind="src" path="test-applications/ExtraParametersTwoParams.war/src"/>
+	<classpathentry kind="src" path="test-applications/ExtraParametersOneParamWithEL.war/src"/>
+	<classpathentry kind="src" path="test-applications/ExtraParametersSpaceAsKey.war/src"/>
+	<classpathentry kind="src" path="test-applications/ExtraParametersLeadingSpaceInKey.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -36,7 +36,13 @@ src: \
     test-applications/UseNonceTrue.war/src,\
     test-applications/UseNonceFalse.war/src,\
     test-applications/UseNonceTrueWithEL.war/src,\
-    test-applications/UseNonceFalseWithEL.war/src
+    test-applications/UseNonceFalseWithEL.war/src,\
+    test-applications/ExtraParametersOneParam.war/src,\
+    test-applications/ExtraParametersTwoParams.war/src,\
+    test-applications/ExtraParametersOneParamWithEL.war/src,\
+    test-applications/ExtraParametersUsingEL.war/src,\
+    test-applications/ExtraParametersSpaceAsKey.war/src,\
+    test-applications/ExtraParametersLeadingSpaceInKey.war/src
     
 -dependson: \
     build.changeDetector,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -92,6 +92,7 @@ autoFVT.doLast {
 	'jakartasec-3.0_fat.config.rp.scope',
 	'jakartasec-3.0_fat.config.rp.responseMode',
 	'jakartasec-3.0_fat.config.rp.useNonce',
+	'jakartasec-3.0_fat.config.rp.extraParameters',
 	'jakartasec-3.0_fat.config.rp.userinfo.jwt.jwt',
 	'jakartasec-3.0_fat.config.rp.userinfo.jwt.opaque',
 	'jakartasec-3.0_fat.config.rp.userinfo.json.jwt',

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/FATSuite.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationClaimsDefinitionTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationELValuesOverrideTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationELValuesOverrideWithoutHttpSessionTests;
+import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationExtraParametersTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationResponseModeTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationScopeTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationTests;
@@ -34,6 +35,7 @@ import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationUserInfo
                 ConfigurationScopeTests.class,
                 ConfigurationResponseModeTests.class,
                 ConfigurationUseNonceTests.class,
+                ConfigurationExtraParametersTests.class,
                 // LogoutDefinition tests are handled in a separate FAT project as the test use sleeps to wait for tokens to expire and that causes the tests to take quite some time to run
                 ConfigurationELValuesOverrideTests.class,
                 ConfigurationELValuesOverrideWithoutHttpSessionTests.class,

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationExtraParametersTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationExtraParametersTests.java
@@ -1,0 +1,506 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.fat.config.tests;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.ibm.ws.security.fat.common.expectations.Expectations;
+import com.ibm.ws.security.fat.common.expectations.ResponseMessageExpectation;
+import com.ibm.ws.security.fat.common.expectations.ResponseStatusExpectation;
+import com.ibm.ws.security.fat.common.expectations.ResponseUrlExpectation;
+import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
+import com.ibm.ws.security.fat.common.web.WebResponseUtils;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.security.jakartasec.fat.commonTests.CommonAnnotatedSecurityTests;
+import io.openliberty.security.jakartasec.fat.configs.TestConfigMaps;
+import io.openliberty.security.jakartasec.fat.utils.Constants;
+import io.openliberty.security.jakartasec.fat.utils.ShrinkWrapHelpers;
+
+/**
+ * Tests @OpenIdAuthenticationMechanismDefinition extraParameters and extraParametersExpression.
+ *
+ * This class contains tests to ensure that extra parameters specified in extraParameters
+ * or resolved from extraParametersExpression are added to the authentication endpoint request correctly.
+ * This includes making making sure that multiple parameters are added correctly,
+ * special characters are encoded in the keys/values,
+ * extraParametersExpression takes precedence over extraParameters,
+ * and that the parameters are in the format of key=value.
+ */
+/**
+ * Tests appSecurity-5.0
+ */
+@SuppressWarnings("restriction")
+@RunWith(FATRunner.class)
+public class ConfigurationExtraParametersTests extends CommonAnnotatedSecurityTests {
+
+    protected static Class<?> thisClass = ConfigurationExtraParametersTests.class;
+
+    @Server("jakartasec-3.0_fat.config.op")
+    public static LibertyServer opServer;
+    @Server("jakartasec-3.0_fat.config.rp.extraParameters")
+    public static LibertyServer rpServer;
+
+    protected static ShrinkWrapHelpers swh = null;
+
+    @ClassRule
+    public static RepeatTests repeat = createRandomTokenTypeRepeats();
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        // write property that is used to configure the OP to generate JWT or Opaque tokens
+        setTokenTypeInBootstrap(opServer);
+
+        // Add servers to server trackers that will be used to clean servers up and prevent servers
+        // from being restored at the end of each test (so far, the tests are not reconfiguring the servers)
+        updateTrackers(opServer, rpServer, false);
+
+        List<String> waitForMsgs = null;
+        opServer.startServerUsingExpandedConfiguration("server_extraParameters.xml", waitForMsgs);
+        SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
+        opHttpBase = "http://localhost:" + opServer.getBvtPort();
+        opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
+
+        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
+
+        rpHttpBase = "http://localhost:" + rpServer.getBvtPort();
+        rpHttpsBase = "https://localhost:" + rpServer.getBvtSecurePort();
+
+        deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
+
+    }
+
+    /**
+     * Deploy the apps that this test class uses
+     *
+     * @throws Exception
+     */
+    public static void deployMyApps() throws Exception {
+
+        swh = new ShrinkWrapHelpers(opHttpBase, opHttpsBase, rpHttpBase, rpHttpsBase);
+
+        swh.defaultDropinApp(rpServer, "ExtraParametersOneParam.war", "oidc.client.extraParametersOneParam.servlets", "oidc.client.base.*");
+        swh.defaultDropinApp(rpServer, "ExtraParametersTwoParams.war", "oidc.client.extraParametersTwoParams.servlets", "oidc.client.base.*");
+
+        // these two need their own apps, since the leading spaces in the keys were being stripped
+        // when reading the key/value pairs from a file using java.util.Properties
+        swh.defaultDropinApp(rpServer, "ExtraParametersLeadingSpaceInKey.war", "oidc.client.extraParametersLeadingSpaceInKey.servlets", "oidc.client.base.*");
+        swh.defaultDropinApp(rpServer, "ExtraParametersSpaceAsKey.war", "oidc.client.extraParametersSpaceAsKey.servlets", "oidc.client.base.*");
+
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersOneParamELTwoDifferentParams.war", "ExtraParametersOneParamWithEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersOneParamELTwoDifferentParams", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersTwoParams()),
+                                       "oidc.client.extraParametersOneParamWithEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELDuplicateKeys.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELDuplicateKeys", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersDuplicateKeys()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELSpaceInKey.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELSpaceInKey", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersContainsSpaceInKey()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELTrailingSpaceInKey.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELTrailingSpaceInKey", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersContainsTrailingSpaceInKey()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELSpaceInValue.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELSpaceInValue", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersContainsSpaceInValue()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELLeadingSpaceInValue.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELLeadingSpaceInValue", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersContainsLeadingSpaceInValue()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELTrailingSpaceInValue.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELTrailingSpaceInValue", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersContainsTrailingSpaceInValue()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELEmptyKey.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELEmptyKey", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersContainsEmptyKey()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELEmptyValue.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELEmptyValue", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersContainsEmptyValue()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELSpaceAsValue.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELSpaceAsValue", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersContainsSpaceAsValue()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELTwoEqualsSigns.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELTwoEqualsSigns", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersContainsTwoEqualsSigns()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELMissingEqualsSign.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersMissingEqualsSign", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersMissingEqualsSign()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELEmpty.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELEmpty", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersIsEmpty()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELEqualsSign.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELEqualsSign", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersIsAnEqualsSign()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELSpecialCharacterInKey.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELSpecialCharacterInKey", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersContainsSpecialCharacterInKey()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "ExtraParametersELSpecialCharacterInValue.war", "ExtraParametersUsingEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "ExtraParametersELSpecialCharacterInValue", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getExtraParametersContainsSpecialCharacterInValue()),
+                                       "oidc.client.extraParametersUsingEL.servlets", "oidc.client.base.*");
+
+    }
+
+    private void runGoodEndToEndWithExtraParametersCheck(String appRoot, String app, String expectedExtraParameters) throws Exception {
+
+        WebClient webClient = getAndSaveWebClient();
+
+        String url = rpHttpsBase + "/" + appRoot + "/" + app;
+
+        Page response = invokeAppReturnLoginPage(webClient, url);
+
+        // disable redirect, so we are able to see the 302 responses
+        // (otherwise, can't see redirect response from auth endpoint)
+        webClient.getOptions().setRedirectEnabled(false);
+
+        response = actions.doFormLogin(response, Constants.TESTUSER, Constants.TESTUSERPWD);
+
+        // follow redirect from login form to auth endpoint
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        String authEndpointRegex = "https:\\/\\/localhost:" + opServer.getBvtSecurePort() + "\\/oidc\\/endpoint\\/OP1\\/authorize";
+        String defaultParametersRegex = "\\?scope=[^&]*&response_type=[^&]*&client_id=[^&]*&redirect_uri=[^&]*&state=[^&]*&nonce=[^&]*&prompt=[^&]*&response_mode=[^&]*&display=[^&]*";
+        String authEndpointWithParametersRegex = authEndpointRegex + defaultParametersRegex;
+        if (expectedExtraParameters != null && !expectedExtraParameters.isEmpty()) {
+            authEndpointWithParametersRegex += "&" + Pattern.quote(expectedExtraParameters) + "$";
+        }
+
+        // validate 302 response and that the auth endpoint is correct with expected query params
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(Constants.REDIRECT_STATUS));
+        expectations.addExpectation(new ResponseMessageExpectation(Constants.STRING_CONTAINS, Constants.FOUND_MSG, "Did not receive the Found message."));
+        expectations.addExpectation(new ResponseUrlExpectation(Constants.STRING_MATCHES, authEndpointWithParametersRegex, "The auth endpoint and its query params were not as expected."));
+        validationUtils.validateResult(response, expectations);
+
+        // follow redirect from auth endpoint to redirect uri
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        // follow redirect from callback servlet to original request
+        response = actions.invokeUrl(_testName, webClient, WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION));
+
+        // validate that we were able to get to the original request and that we have an openid context
+        validationUtils.validateResult(response, getGeneralAppExpecations(app));
+
+    }
+
+    /****************************************************************************************************************/
+    /* Tests */
+    /****************************************************************************************************************/
+
+    /**
+     *
+     * Test with extraParameters={"key1=value1"}
+     * It should append key1=value1 as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParameters_oneParam() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersOneParam", "ExtraParametersOneParamServlet", "key1=value1");
+
+    }
+
+    /**
+     *
+     * Test with extraParameters={"key1=value1", "key2=value2"}
+     * It should append key1=value1 and key2=value2 as a query params to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParameters_twoParams() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersTwoParams", "ExtraParametersTwoParamsServlet", "key1=value1&key2=value2");
+
+    }
+
+    /**
+     *
+     * Test with extraParameters={"key3=value3"} and extraParametersExpression which resolves to {"key1=value1", "key2=value2"}
+     * The value resolved by extraParametersExpression should take precedence
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParameters_oneParam_extraParametersExpression_twoDifferentParams() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersOneParamELTwoDifferentParams", "ExtraParametersOneParamWithELServlet", "key1=value1&key2=value2");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"key1=value1", "key1=value2"}
+     * It should append key1=value1 and key1=value2 as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_duplicateKeys() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELDuplicateKeys", "ExtraParametersUsingELServlet", "key1=value1&key1=value2");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"key 1=value1"}
+     * It should URL encode the space and append key+1=value1 as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_spaceInKey() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELSpaceInKey", "ExtraParametersUsingELServlet", "key+1=value1");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {" key1=value1"}
+     * It should URL encode the space and append +key1=value1 as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_leadingSpaceInKey() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersLeadingSpaceInKey", "ExtraParametersLeadingSpaceInKeyServlet", "+key1=value1");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"key1 =value1"}
+     * It should URL encode the space and append key1+=value1 as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_trailingSpaceInKey() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELTrailingSpaceInKey", "ExtraParametersUsingELServlet", "key1+=value1");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"key1=value 1"}
+     * It should URL encode the space and append key1=value+1 as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_spaceInValue() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELSpaceInValue", "ExtraParametersUsingELServlet", "key1=value+1");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"key1= value1"}
+     * It should URL encode the space and append key1=+value1 as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_leadingSpaceInValue() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELLeadingSpaceInValue", "ExtraParametersUsingELServlet", "key1=+value1");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"key1=value1 "}
+     * It should URL encode the space and append key1=value1+ as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_trailingSpaceInValue() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELTrailingSpaceInValue", "ExtraParametersUsingELServlet", "key1=value1+");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"=value1"}
+     * It should append =value1 as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_emptyKey() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELEmptyKey", "ExtraParametersUsingELServlet", "=value1");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {" =value1"}
+     * It should URL encode the space and append +=value1 as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_spaceAsKey() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersSpaceAsKey", "ExtraParametersSpaceAsKeyServlet", "+=value1");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"key1="}
+     * It should append key1= as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_emptyValue() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELEmptyValue", "ExtraParametersUsingELServlet", "key1=");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"key1= "}
+     * It should URL encode the space and append key1=+ as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_spaceAsValue() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELSpaceAsValue", "ExtraParametersUsingELServlet", "key1=+");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"key1=value1=value2"}
+     * It should URL encode the second equals sign and append key1=value1%3Dvalue2 as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_twoEqualsSigns() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELTwoEqualsSigns", "ExtraParametersUsingELServlet", "key1=value1%3Dvalue2");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"key1value1"}
+     * It should not append key1value1 as a query param to the authentication endpoint request, since it is malformed
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_missingEqualsSign() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELMissingEqualsSign", "ExtraParametersUsingELServlet", "");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {""}
+     * It should not append anything to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_empty() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELEmpty", "ExtraParametersUsingELServlet", "");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"="}
+     * It should append "=" as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_equalsSign() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELEqualsSign", "ExtraParametersUsingELServlet", "=");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"key&1=value1"}
+     * It should URL encode the & in the key and append key%261=value1 as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_specialCharacterInKey() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELSpecialCharacterInKey", "ExtraParametersUsingELServlet", "key%261=value1");
+
+    }
+
+    /**
+     *
+     * Test with extraParametersExpression which resolves to {"key1=value&1"}
+     * It should URL encode the & in the value and append key1=value%261 as a query param to the authentication endpoint request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationExtraParametersTests_extraParametersExpression_specialCharacterInValue() throws Exception {
+
+        runGoodEndToEndWithExtraParametersCheck("ExtraParametersELSpecialCharacterInValue", "ExtraParametersUsingELServlet", "key1=value%261");
+
+    }
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/servers/jakartasec-3.0_fat.config.op/configs/server_extraParameters.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/servers/jakartasec-3.0_fat.config.op/configs/server_extraParameters.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 3.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcProvider_extraParameters.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/shared/config/oidcProvider_extraParameters.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/shared/config/oidcProvider_extraParameters.xml
@@ -1,0 +1,59 @@
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+		 		 
+	<openidConnectProvider
+		id="OP1"
+		signatureAlgorithm="RS256"
+		keyAliasName="rs256"
+		keystoreRef="key_allSigAlg"
+		oauthProviderRef="OAuth1" />
+
+	<oauthProvider
+		id="OAuth1"
+		autoAuthorize="true"
+		tokenFormat="${opTokenFormat}"
+	>
+		<autoAuthorizeClient>client_1</autoAuthorizeClient>
+		
+		<localStore>
+			<client
+				name="client_1"
+				secret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersOneParam/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersTwoParams/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersOneParamELTwoDifferentParams/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELDuplicateKeys/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELSpaceInKey/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersLeadingSpaceInKey/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELTrailingSpaceInKey/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELSpaceInValue/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELLeadingSpaceInValue/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELTrailingSpaceInValue/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELEmptyKey/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersSpaceAsKey/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELEmptyValue/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELSpaceAsValue/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELMissingEqualsSign/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELTwoEqualsSigns/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELEmpty/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELEqualsSign/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELSpecialCharacterInKey/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/ExtraParametersELSpecialCharacterInValue/Callback"
+				scope="ALL_SCOPES"
+				enabled="true"
+			></client>
+		</localStore>
+	</oauthProvider>		
+			
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersLeadingSpaceInKey.war/src/oidc/client/extraParametersLeadingSpaceInKey/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersLeadingSpaceInKey.war/src/oidc/client/extraParametersLeadingSpaceInKey/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersLeadingSpaceInKey.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersLeadingSpaceInKey.war/src/oidc/client/extraParametersLeadingSpaceInKey/servlets/ExtraParametersLeadingSpaceInKeyServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersLeadingSpaceInKey.war/src/oidc/client/extraParametersLeadingSpaceInKey/servlets/ExtraParametersLeadingSpaceInKeyServlet.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersLeadingSpaceInKey.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/ExtraParametersLeadingSpaceInKeyServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         extraParameters = { " key1=value1" },
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class ExtraParametersLeadingSpaceInKeyServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersLeadingSpaceInKey.war/src/oidc/client/extraParametersLeadingSpaceInKey/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersLeadingSpaceInKey.war/src/oidc/client/extraParametersLeadingSpaceInKey/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersLeadingSpaceInKey.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersOneParam.war/src/oidc/client/extraParametersOneParam/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersOneParam.war/src/oidc/client/extraParametersOneParam/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersOneParam.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersOneParam.war/src/oidc/client/extraParametersOneParam/servlets/ExtraParametersOneParamServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersOneParam.war/src/oidc/client/extraParametersOneParam/servlets/ExtraParametersOneParamServlet.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersOneParam.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/ExtraParametersOneParamServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         extraParameters = { "key1=value1" },
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class ExtraParametersOneParamServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersOneParam.war/src/oidc/client/extraParametersOneParam/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersOneParam.war/src/oidc/client/extraParametersOneParam/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersOneParam.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersOneParamWithEL.war/src/oidc/client/extraParametersOneParamWithEL/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersOneParamWithEL.war/src/oidc/client/extraParametersOneParamWithEL/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersOneParamWithEL.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersOneParamWithEL.war/src/oidc/client/extraParametersOneParamWithEL/servlets/ExtraParametersOneParamWithELServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersOneParamWithEL.war/src/oidc/client/extraParametersOneParamWithEL/servlets/ExtraParametersOneParamWithELServlet.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersOneParamWithEL.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/ExtraParametersOneParamWithELServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         extraParameters = { "key3=value3" },
+                                         extraParametersExpression = "${openIdConfig.extraParametersExpression}",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class ExtraParametersOneParamWithELServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersOneParamWithEL.war/src/oidc/client/extraParametersOneParamWithEL/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersOneParamWithEL.war/src/oidc/client/extraParametersOneParamWithEL/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersOneParamWithEL.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersSpaceAsKey.war/src/oidc/client/extraParametersSpaceAsKey/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersSpaceAsKey.war/src/oidc/client/extraParametersSpaceAsKey/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersSpaceAsKey.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersSpaceAsKey.war/src/oidc/client/extraParametersSpaceAsKey/servlets/ExtraParametersSpaceAsKeyServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersSpaceAsKey.war/src/oidc/client/extraParametersSpaceAsKey/servlets/ExtraParametersSpaceAsKeyServlet.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersSpaceAsKey.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/ExtraParametersSpaceAsKeyServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         extraParameters = { " =value1" },
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class ExtraParametersSpaceAsKeyServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersSpaceAsKey.war/src/oidc/client/extraParametersSpaceAsKey/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersSpaceAsKey.war/src/oidc/client/extraParametersSpaceAsKey/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersSpaceAsKey.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersTwoParams.war/src/oidc/client/extraParametersTwoParams/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersTwoParams.war/src/oidc/client/extraParametersTwoParams/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersTwoParams.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersTwoParams.war/src/oidc/client/extraParametersTwoParams/servlets/ExtraParametersTwoParamsServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersTwoParams.war/src/oidc/client/extraParametersTwoParams/servlets/ExtraParametersTwoParamsServlet.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersTwoParams.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/ExtraParametersTwoParamsServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         extraParameters = { "key1=value1", "key2=value2" },
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class ExtraParametersTwoParamsServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersTwoParams.war/src/oidc/client/extraParametersTwoParams/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersTwoParams.war/src/oidc/client/extraParametersTwoParams/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersTwoParams.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersUsingEL.war/src/oidc/client/extraParametersUsingEL/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersUsingEL.war/src/oidc/client/extraParametersUsingEL/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersUsingEL.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersUsingEL.war/src/oidc/client/extraParametersUsingEL/servlets/ExtraParametersUsingELServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersUsingEL.war/src/oidc/client/extraParametersUsingEL/servlets/ExtraParametersUsingELServlet.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersUsingEL.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/ExtraParametersUsingELServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         extraParametersExpression = "${openIdConfig.extraParametersExpression}",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class ExtraParametersUsingELServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersUsingEL.war/src/oidc/client/extraParametersUsingEL/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/ExtraParametersUsingEL.war/src/oidc/client/extraParametersUsingEL/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.extraParametersUsingEL.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -218,7 +218,7 @@ public class JakartaOidcAuthorizationRequest extends AuthorizationRequest {
             return;
         }
         for (String extraParamAndValue : extraParametersArray) {
-            String[] keyAndValue = extraParamAndValue.split("=");
+            String[] keyAndValue = extraParamAndValue.split("=", 2);
             String key = keyAndValue[0];
             String value = "";
             if (keyAndValue.length > 1) {

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequest.java
@@ -219,11 +219,14 @@ public class JakartaOidcAuthorizationRequest extends AuthorizationRequest {
         }
         for (String extraParamAndValue : extraParametersArray) {
             String[] keyAndValue = extraParamAndValue.split("=", 2);
-            String key = keyAndValue[0];
-            String value = "";
-            if (keyAndValue.length > 1) {
-                value = keyAndValue[1];
+            if (keyAndValue.length < 2) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "addExtraParameters", "skipping extra param '" + extraParamAndValue + "' because it is not in the format key=value");
+                }
+                continue;
             }
+            String key = keyAndValue[0];
+            String value = keyAndValue[1];
             authzParameters.addParameter(key, value);
         }
     }

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequestTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequestTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -261,6 +261,21 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
                 one(authzParameters).addParameter(key1, value1);
                 one(authzParameters).addParameter(key2, value2);
                 one(authzParameters).addParameter(key3, value3);
+            }
+        });
+        authzRequest.addExtraParameters(authzParameters);
+    }
+
+    @Test
+    public void test_addConditionalParameters_twoEqualsSigns() throws OidcDiscoveryException {
+        String key = "some_parameter";
+        String value = "value=1";
+        final String[] extraParams = new String[] { key + "=" + value };
+        mockery.checking(new Expectations() {
+            {
+                one(config).getExtraParameters();
+                will(returnValue(extraParams));
+                one(authzParameters).addParameter(key, value);
             }
         });
         authzRequest.addExtraParameters(authzParameters);

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequestTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/authentication/JakartaOidcAuthorizationRequestTest.java
@@ -209,7 +209,6 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
             {
                 one(config).getExtraParameters();
                 will(returnValue(extraParams));
-                one(authzParameters).addParameter(key, "");
             }
         });
         authzRequest.addExtraParameters(authzParameters);
@@ -276,6 +275,20 @@ public class JakartaOidcAuthorizationRequestTest extends CommonTestClass {
                 one(config).getExtraParameters();
                 will(returnValue(extraParams));
                 one(authzParameters).addParameter(key, value);
+            }
+        });
+        authzRequest.addExtraParameters(authzParameters);
+    }
+
+    @Test
+    public void test_addConditionalParameters_noEqualsSign() throws OidcDiscoveryException {
+        String key = "some_parameter";
+        String value = "value";
+        final String[] extraParams = new String[] { key + value };
+        mockery.checking(new Expectations() {
+            {
+                one(config).getExtraParameters();
+                will(returnValue(extraParams));
             }
         });
         authzRequest.addExtraParameters(authzParameters);


### PR DESCRIPTION
add fat tests for OpenIdAuthenticationMechanismDefinition extraParameters and extraParametersExpression

add tests to ensure that extra parameters specified in `extraParameters` or resolved from `extraParametersExpression` are added to the authentication endpoint request correctly. this includes making making sure that multiple parameters are added correctly, special characters are encoded in the keys/values, `extraParametersExpression` takes precedence over `extraParameters`, and that the parameters are in the format of `key=value`.