### PR TITLE
Synchronously touch all JSPs during checkpoint

### DIFF
--- a/dev/com.ibm.ws.jsp/bnd.bnd
+++ b/dev/com.ibm.ws.jsp/bnd.bnd
@@ -168,4 +168,5 @@ instrument.classesExcludes: com/ibm/ws/jsp/resources/*.class
 	com.ibm.ws.javaee.version;version=latest, \
 	io.openliberty.jakarta.servlet.jsp.jstl.2.0.internal;version=latest, \
 	io.openliberty.jakarta.servlet.jsp.tags.3.0.internal;version=latest, \
+	com.ibm.ws.kernel.boot.common;version=latest,\
 	io.openliberty.el.internal.cdi;version=latest

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webcontainerext/AbstractJSPExtensionProcessor.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webcontainerext/AbstractJSPExtensionProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2022 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -107,6 +107,8 @@ import com.ibm.wsspi.webcontainer.servlet.IServletConfig;
 import com.ibm.wsspi.webcontainer.servlet.IServletContext;
 import com.ibm.wsspi.webcontainer.servlet.IServletWrapper;
 import com.ibm.wsspi.webcontainer.webapp.WebAppConfig;
+
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 
 public abstract class AbstractJSPExtensionProcessor extends com.ibm.ws.webcontainer.extension.WebExtensionProcessor {
     static protected Logger logger;
@@ -952,6 +954,23 @@ public abstract class AbstractJSPExtensionProcessor extends com.ibm.ws.webcontai
                     logger.logp(Level.FINE, CLASS_NAME, "JSPExtensionProcessor", "Pretouch threw an unexpected exception: ", ex);
                 }
             }
+        } else if (CheckpointPhase.getPhase() != CheckpointPhase.INACTIVE) {
+            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINE)) {
+                logger.logp(Level.FINE, CLASS_NAME, "JSPExtensionProcessor", "PrepareJSPs for checkpoint mode");
+            }
+
+            try {
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINE)) {
+                    logger.logp(Level.FINE, CLASS_NAME, "JSPExtensionProcessor", "Starting the synchronous Pretouch logic ");
+                }
+                PrepareJspHelper pretouchHelper = prepareJspHelperFactory.createPrepareJspHelper(this, webapp, jspOptions);
+                pretouchHelper.run();
+            } catch (Exception ex) {
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable(Level.FINE)) {
+                    logger.logp(Level.FINE, CLASS_NAME, "JSPExtensionProcessor", "Checkpoint Pretouch threw an unexpected exception: ", ex);
+                }
+            }
+            
         }
         // @BLB End Pretouch
     }


### PR DESCRIPTION
JSPs by default are compiled at first request. In a checkpoint/restore scenario, let's precompile all of the JSPs at checkpoint time to reduce first response times.