### PR TITLE
Set Telemetry default service name

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
@@ -65,16 +65,17 @@ Private-Package: \
   io.openliberty.microprofile.telemetry.internal.helper
 
 -buildpath: \
-    io.openliberty.jakarta.restfulWS.3.1;version=latest,\
-    io.openliberty.jakarta.annotation.2.1;version=latest,\
-    io.openliberty.jakarta.interceptor.2.1;version=latest,\
-    io.openliberty.jakarta.cdi.4.0;version=latest,\
-    com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
-    com.ibm.ws.logging.core;version=latest,\
-    com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
-    com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-    io.openliberty.io.opentelemetry.internal;version=latest,\
-    io.openliberty.mpTelemetry.1.0.thirdparty;version=latest,\
-    io.openliberty.org.eclipse.microprofile.config.3.0,\
-    io.openliberty.org.jboss.resteasy.common;version=latest,\
-    com.ibm.websphere.org.osgi.core
+	io.openliberty.jakarta.restfulWS.3.1;version=latest,\
+	io.openliberty.jakarta.annotation.2.1;version=latest,\
+	io.openliberty.jakarta.interceptor.2.1;version=latest,\
+	io.openliberty.jakarta.cdi.4.0;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.ws.logging.core;version=latest,\
+	com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	io.openliberty.io.opentelemetry.internal;version=latest,\
+	io.openliberty.mpTelemetry.1.0.thirdparty;version=latest,\
+	io.openliberty.org.eclipse.microprofile.config.3.0,\
+	io.openliberty.org.jboss.resteasy.common;version=latest,\
+	com.ibm.websphere.org.osgi.core;version=latest,\
+	com.ibm.ws.container.service;version=latest,\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/cdi/OpenTelemetryProducer.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/cdi/OpenTelemetryProducer.java
@@ -100,8 +100,8 @@ public class OpenTelemetryProducer {
     }
 
     //Uses application name if the user has not given configured service.name resource attribute
-    private String getServiceName() {
-        String appName = config.getOptionalValue(SERVICE_NAME_PROPERTY, String.class).orElse(null);
+    private String getServiceName(ConfigProperties c) {
+        String appName = c.getString(SERVICE_NAME_PROPERTY);
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
         if (appName == null) {
             if (cmd != null) {
@@ -114,7 +114,7 @@ public class OpenTelemetryProducer {
     //Adds the service name to the resource attributes
     private Resource customizeResource(Resource resource, ConfigProperties c) {
         ResourceBuilder builder = resource.toBuilder();
-        builder.put(ResourceAttributes.SERVICE_NAME, getServiceName());
+        builder.put(ResourceAttributes.SERVICE_NAME, getServiceName(c));
         return builder.build();
     }
 
@@ -161,9 +161,9 @@ public class OpenTelemetryProducer {
         HashMap<String, String> telemetryProperties = new HashMap<>();
         for (String propertyName : config.getPropertyNames()) {
             if (propertyName.startsWith("otel.")) {
-               config.getOptionalValue(propertyName, String.class).ifPresent(
-                                                                            value -> telemetryProperties.put(propertyName, value));
-            }    
+                config.getOptionalValue(propertyName, String.class).ifPresent(
+                                                                              value -> telemetryProperties.put(propertyName, value));
+            }
         }
         //Metrics and logs are disabled by default
         telemetryProperties.put(CONFIG_METRICS_EXPORTER_PROPERTY, "none");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/cdi/OpenTelemetryProducer.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/cdi/OpenTelemetryProducer.java
@@ -3,19 +3,9 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
-<<<<<<< HEAD
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
-=======
-<<<<<<< HEAD
- * http://www.eclipse.org/legal/epl-v10.html
-=======
- * http://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
->>>>>>> ff7918f97a (Set Telemetry default service name)
->>>>>>> f8ad6cfe65 (Set Telemetry default service name)
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -173,6 +163,7 @@ public class OpenTelemetryProducer {
             if (propertyName.startsWith("otel.")) {
                config.getOptionalValue(propertyName, String.class).ifPresent(
                                                                             value -> telemetryProperties.put(propertyName, value));
+            }    
         }
         //Metrics and logs are disabled by default
         telemetryProperties.put(CONFIG_METRICS_EXPORTER_PROPERTY, "none");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/cdi/OpenTelemetryProducer.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/cdi/OpenTelemetryProducer.java
@@ -3,9 +3,19 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
+<<<<<<< HEAD
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
+=======
+<<<<<<< HEAD
+ * http://www.eclipse.org/legal/epl-v10.html
+=======
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+>>>>>>> ff7918f97a (Set Telemetry default service name)
+>>>>>>> f8ad6cfe65 (Set Telemetry default service name)
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -22,6 +32,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.microprofile.config.Config;
 
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
+
 import io.openliberty.microprofile.telemetry.internal.helper.AgentDetection;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -30,10 +43,14 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.resources.ResourceBuilder;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
@@ -48,6 +65,7 @@ public class OpenTelemetryProducer {
     private static final String CONFIG_METRICS_EXPORTER_PROPERTY = "otel.metrics.exporter";
     private static final String ENV_LOGS_EXPORTER_PROPERTY = "OTEL_LOGS_EXPORTER";
     private static final String CONFIG_LOGS_EXPORTER_PROPERTY = "otel.logs.exporter";
+    private static final String SERVICE_NAME_PROPERTY = "otel.service.name";
 
     @Inject
     Config config;
@@ -64,11 +82,13 @@ public class OpenTelemetryProducer {
         }
 
         HashMap<String, String> telemetryProperties = getTelemetryProperties();
+
         //Builds tracer provider if user has enabled tracing aspects with config properties
         if (!checkDisabled(telemetryProperties)) {
             OpenTelemetry openTelemetry = AccessController.doPrivileged((PrivilegedAction<OpenTelemetry>) () -> {
                 return AutoConfiguredOpenTelemetrySdk.builder()
                                 .addPropertiesCustomizer(x -> telemetryProperties) //Overrides OpenTelemetry's property order
+                                .addResourceCustomizer(this::customizeResource)//Defaults service name to application name
                                 .setServiceClassLoader(Thread.currentThread().getContextClassLoader())
                                 .setResultAsGlobal(false)
                                 .registerShutdownHook(false)
@@ -87,6 +107,25 @@ public class OpenTelemetryProducer {
         //Operations on a Tracer, or on Spans have no side effects and do nothing
         return OpenTelemetry.noop();
 
+    }
+
+    //Uses application name if the user has not given configured service.name resource attribute
+    private String getServiceName() {
+        String appName = config.getOptionalValue(SERVICE_NAME_PROPERTY, String.class).orElse(null);
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (appName == null) {
+            if (cmd != null) {
+                appName = cmd.getModuleMetaData().getApplicationMetaData().getName();
+            }
+        }
+        return appName;
+    }
+
+    //Adds the service name to the resource attributes
+    private Resource customizeResource(Resource resource, ConfigProperties c) {
+        ResourceBuilder builder = resource.toBuilder();
+        builder.put(ResourceAttributes.SERVICE_NAME, getServiceName());
+        return builder.build();
     }
 
     public void disposeOpenTelemetry(@Disposes OpenTelemetry openTelemetry) {
@@ -134,7 +173,6 @@ public class OpenTelemetryProducer {
             if (propertyName.startsWith("otel.")) {
                config.getOptionalValue(propertyName, String.class).ifPresent(
                                                                             value -> telemetryProperties.put(propertyName, value));
-            }
         }
         //Metrics and logs are disabled by default
         telemetryProperties.put(CONFIG_METRICS_EXPORTER_PROPERTY, "none");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
@@ -31,8 +31,8 @@ import componenttest.annotation.MinimumJavaLevel;
                 TelemetryConfigSystemPropTest.class,
                 TelemetryConfigEnvOnlyTest.class,
                 TelemetryConfigNullTest.class,
+                TelemetryServiceNameTest.class,
 })
 
 public class FATSuite {
-
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.ServiceNameServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporterProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+
+@RunWith(FATRunner.class)
+public class TelemetryServiceNameTest extends FATServletClient {
+
+    public static final String SERVER_NAME = "Telemetry10ConfigEnv";
+    //The APP_NAME is expected to be the value used for otel.service.name
+    public static final String APP_NAME = "TelemetryApp";
+
+    @Server(SERVER_NAME)
+    @TestServlets({
+                    @TestServlet(servlet = ServiceNameServlet.class, contextRoot = APP_NAME),
+    })
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addAsResource(new StringAsset("otel.sdk.disabled=false\notel.traces.exporter=in-memory\notel.bsp.schedule.delay=100"),
+                                       "META-INF/microprofile-config.properties")
+                        .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class, ServiceNameServlet.class)
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class);
+
+        ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
@@ -32,8 +32,6 @@ import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.ServiceNameServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 
 @RunWith(FATRunner.class)

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/ServiceNameServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/ServiceNameServlet.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 import componenttest.app.FATServlet;
 
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/ServiceNameServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/ServiceNameServlet.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+
+@WebServlet("/ServiceNameServlet")
+@ApplicationScoped
+public class ServiceNameServlet extends FATServlet {
+
+    @Inject
+    Tracer tracer;
+
+    @Inject
+    Span span;
+
+    @Inject
+    OpenTelemetry openTelemetry;
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    public static final AttributeKey<String> SERVICE_NAME_KEY = AttributeKey.stringKey("service.name");
+    public static final String APP_NAME = "TelemetryApp";
+
+    //Tests if otel.service.name is set to the application name by default
+    @Test
+    public void testServiceNameConfig() {
+        Span span = tracer.spanBuilder("span").startSpan();
+        span.end();
+
+        SpanData spanData = exporter.getFinishedSpanItems(1).get(0);
+        System.out.println(spanData.toString());
+        // Attributes added by TestResourceProvider should have been merged into the default resource
+        Resource resource = spanData.getResource();
+        assertThat(resource.getAttribute(SERVICE_NAME_KEY), equalTo(APP_NAME));
+    }
+
+}


### PR DESCRIPTION
For issue #23867

Provides the app name as the default for the tracing service name and tests this is done when no configuration is given. 