### PR TITLE
Change broken admin center doc link to point to openliberty doc

### DIFF
--- a/dev/com.ibm.ws.transport.http/resources/wasdev_files/adminCenter-welcome.js
+++ b/dev/com.ibm.ws.transport.http/resources/wasdev_files/adminCenter-welcome.js
@@ -33,7 +33,7 @@ function buildAdminCenterDirectLink() {
 }
 function buildHowToSetupAdminCenterButton() {
 	var element = document.getElementById("welcome-section-content");
-	var url = "https://developer.ibm.com/wasdev/downloads/#asset/features-com.ibm.websphere.appserver.adminCenter-1.0";
+	var url = "https://openliberty.io/docs/latest/admin-center.html";
 	var button = buildButton(url, "How to Setup Admin Center");
 	element.appendChild(button);
 }


### PR DESCRIPTION
This changes code that is no longer used.  Making this change to keep the link consistent, but it's a bit misleading.  Here's where that link is really hosted: https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp_links.js