### PR TITLE
OpenTelemetry multi-app tests and client filter injection fix

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,6 +24,7 @@ import componenttest.annotation.MinimumJavaLevel;
                 Telemetry10.class,
                 JaxRsIntegration.class,
                 TelemetryBeanTest.class,
+                TelemetryMultiAppTest.class,
                 TelemetrySpiTest.class,
                 TelemetryConfigEnvTest.class,
                 TelemetryConfigServerVarTest.class,
@@ -31,6 +32,7 @@ import componenttest.annotation.MinimumJavaLevel;
                 TelemetryConfigEnvOnlyTest.class,
                 TelemetryConfigNullTest.class,
 })
+
 public class FATSuite {
 
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -30,8 +30,9 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpRequest;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporterProvider;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.JaxRsEndpoints;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 
 @RunWith(FATRunner.class)
@@ -47,6 +48,7 @@ public class JaxRsIntegration extends FATServletClient {
     public static void setUp() throws Exception {
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackage(JaxRsEndpoints.class.getPackage())
+                        .addPackage(InMemorySpanExporter.class.getPackage())
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                         .addAsResource(new StringAsset("otel.sdk.disabled=false\notel.traces.exporter=in-memory\notel.bsp.schedule.delay=100"),
                                        "META-INF/microprofile-config.properties");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMultiAppTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMultiAppTest.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporterProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp1.MultiApp1TestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp2.MultiApp2TargetResource;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp2.MultiApp2TestServlet;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+
+/**
+ * Test use of the multiple apps
+ */
+@RunWith(FATRunner.class)
+public class TelemetryMultiAppTest extends FATServletClient {
+
+    public static final String APP1_NAME = "multiapp1";
+    public static final String APP2_NAME = "multiapp2";
+
+    @TestServlets({
+                    @TestServlet(contextRoot = APP1_NAME, servlet = MultiApp1TestServlet.class),
+                    @TestServlet(contextRoot = APP2_NAME, servlet = MultiApp2TestServlet.class),
+    })
+    @Server("Telemetry10MultiApp")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // InMemorySpanExporter shared library
+        PropertiesAsset exporterConfig = new PropertiesAsset()
+                        .addProperty("otel.traces.exporter", "in-memory");
+        JavaArchive exporterJar = ShrinkWrap.create(JavaArchive.class, "exporter.jar")
+                        .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(exporterConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportToServer(server, "shared", exporterJar, SERVER_ONLY);
+
+        PropertiesAsset app1Config = new PropertiesAsset()
+                        .addProperty("otel.service.name", "multiapp1");
+        WebArchive multiapp1 = ShrinkWrap.create(WebArchive.class, APP1_NAME + ".war")
+                        .addClass(MultiApp1TestServlet.class)
+                        .addAsResource(app1Config, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportAppToServer(server, multiapp1, SERVER_ONLY);
+
+        PropertiesAsset app2Config = new PropertiesAsset()
+                        .addProperty("otel.service.name", "multiapp2");
+        WebArchive multiapp2 = ShrinkWrap.create(WebArchive.class, APP2_NAME + ".war")
+                        .addClass(MultiApp2TestServlet.class)
+                        .addClass(MultiApp2TargetResource.class)
+                        .addAsResource(app2Config, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportAppToServer(server, multiapp2, SERVER_ONLY);
+
+        server.addEnvVar("OTEL_SDK_DISABLED", "false");
+        server.addEnvVar("OTEL_BSP_SCHEDULE_DELAY", "100");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMultiAppTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMultiAppTest.java
@@ -30,11 +30,11 @@ import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporterProvider;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp1.MultiApp1TestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp2.MultiApp2TargetResource;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp2.MultiApp2TestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 
 /**

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
@@ -29,8 +29,6 @@ import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporterProvider;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.customizer.CustomizerTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.customizer.TestCustomizer;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.exporter.ExporterTestServlet;
@@ -42,6 +40,8 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.resource.Test
 import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler.SamplerTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler.TestSampler;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler.TestSamplerProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/InMemorySpanExporter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/InMemorySpanExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2023 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -22,16 +22,12 @@
 package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation;
 
 import static java.util.Comparator.comparingLong;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.LinkedList;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -47,7 +43,8 @@ public class InMemorySpanExporter implements SpanExporter {
     Logger logger = Logger.getLogger("io.openliberty.microprofile.telemetry.internal_fat.apps.jaxpropagation.InMemorySpanExporter");
 
     private boolean isStopped = false;
-    private final List<SpanData> finishedSpanItems = new CopyOnWriteArrayList<>();
+    // Static to allow multi-app testing
+    private static final List<SpanData> finishedSpanItems = new CopyOnWriteArrayList<>();
 
     /**
      * Careful when retrieving the list of finished spans. There is a chance when the response is already sent to the
@@ -58,14 +55,14 @@ public class InMemorySpanExporter implements SpanExporter {
     public List<SpanData> getFinishedSpanItems(int spanCount) {
         assertSpanCount(spanCount);
         return finishedSpanItems.stream().sorted(comparingLong(SpanData::getStartEpochNanos))
-                .collect(Collectors.toList());
+                        .collect(Collectors.toList());
     }
 
     public void assertSpanCount(int spanCount) {
         int retries = 120;
         while (retries > 0 && finishedSpanItems.size() != spanCount) {
             try {
-                retries --;
+                retries--;
                 Thread.sleep(100);
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -88,13 +85,13 @@ public class InMemorySpanExporter implements SpanExporter {
 
         List<SpanData> lSpans = new ArrayList<SpanData>(spans);
         Iterator<SpanData> iter = lSpans.listIterator();
-        while(iter.hasNext()){
-            if(iter.next().getName().contains("readspans")){
+        while (iter.hasNext()) {
+            if (iter.next().getName().contains("readspans")) {
                 iter.remove();
             }
         }
 
-        if (! lSpans.isEmpty()) { //this will be empty after a call to readSpans
+        if (!lSpans.isEmpty()) { //this will be empty after a call to readSpans
             StringBuilder sb = new StringBuilder();
             sb.append("----------------- list of spans (filtered but unordered, ordering will be based on the start time) ---------- ");
             for (SpanData spanData : lSpans) {
@@ -104,7 +101,7 @@ public class InMemorySpanExporter implements SpanExporter {
         }
 
         finishedSpanItems.addAll(lSpans);
-        
+
         return CompletableResultCode.ofSuccess();
     }
 
@@ -121,4 +118,3 @@ public class InMemorySpanExporter implements SpanExporter {
         return CompletableResultCode.ofSuccess();
     }
 }
-

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/JaxRsEndpoints.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/JaxRsEndpoints.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Future;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.sdk.trace.data.SpanData;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/multiapp1/MultiApp1TestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/multiapp1/MultiApp1TestServlet.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp1;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.client.ClientBuilder;
+
+@SuppressWarnings("serial")
+@WebServlet("/multiapp1")
+public class MultiApp1TestServlet extends FATServlet {
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Test
+    public void testResource() {
+        Span span = tracer.spanBuilder("test").startSpan();
+        span.end();
+
+        SpanData spanData = exporter.getFinishedSpanItems(1).get(0);
+        Resource resource = spanData.getResource();
+        assertThat(resource.getAttribute(ResourceAttributes.SERVICE_NAME), equalTo("multiapp1"));
+    }
+
+    @Test
+    public void callMultiApp() {
+        URI uri = getTargetUri();
+        String response = ClientBuilder.newClient().target(uri).request().get(String.class);
+        assertThat(response, equalTo("OK"));
+
+        // Note the exporter is static and in a shared library so it will contain traces from both apps
+        List<SpanData> spanData = exporter.getFinishedSpanItems(2);
+        SpanData app1client = spanData.get(0);
+        SpanData app2server = spanData.get(1);
+
+        assertThat(app1client.getKind(), equalTo(SpanKind.CLIENT));
+        assertThat(app1client.getResource().getAttribute(ResourceAttributes.SERVICE_NAME), equalTo("multiapp1"));
+
+        assertThat(app2server.getKind(), equalTo(SpanKind.SERVER));
+        assertThat(app2server.getResource().getAttribute(ResourceAttributes.SERVICE_NAME), equalTo("multiapp2"));
+    }
+
+    /**
+     * Get the URI for the "target" resource in multiapp2
+     *
+     * @return the URI for the "target" resource
+     */
+    private URI getTargetUri() {
+        try {
+            URI originalUri = URI.create(request.getRequestURL().toString());
+            URI targetUri = new URI(originalUri.getScheme(), originalUri.getAuthority(), "/multiapp2/target", null, null);
+            return targetUri;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void before() throws Exception {
+        exporter.reset();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/multiapp1/MultiApp1TestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/multiapp1/MultiApp1TestServlet.java
@@ -22,7 +22,7 @@ import java.util.List;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/multiapp2/MultiApp2TargetResource.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/multiapp2/MultiApp2TargetResource.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp2;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+@Path("/target")
+public class MultiApp2TargetResource extends Application {
+
+    @GET
+    public String get() {
+        return "OK";
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/multiapp2/MultiApp2TestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/multiapp2/MultiApp2TestServlet.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp2;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/multiapp2")
+public class MultiApp2TestServlet extends FATServlet {
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Test
+    public void testResource() {
+        Span span = tracer.spanBuilder("test").startSpan();
+        span.end();
+
+        SpanData spanData = exporter.getFinishedSpanItems(1).get(0);
+        Resource resource = spanData.getResource();
+        assertThat(resource.getAttribute(ResourceAttributes.SERVICE_NAME), equalTo("multiapp2"));
+    }
+
+    @Override
+    protected void before() throws Exception {
+        exporter.reset();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/multiapp2/MultiApp2TestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/multiapp2/MultiApp2TestServlet.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.resources.Resource;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/customizer/CustomizerTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/customizer/CustomizerTestServlet.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.resources.Resource;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/exporter/ExporterTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/exporter/ExporterTestServlet.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/propagator/PropagatorTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/propagator/PropagatorTestServlet.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/resource/ResourceTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/resource/ResourceTestServlet.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
-import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.InMemorySpanExporter;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.resources.Resource;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/spanexporter/InMemorySpanExporter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/spanexporter/InMemorySpanExporter.java
@@ -19,7 +19,7 @@
  */
 // Original file source: https://github.com/eclipse/microprofile-telemetry/blob/main/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/exporter/InMemorySpanExporter.java
 
-package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation;
+package io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter;
 
 import static java.util.Comparator.comparingLong;
 
@@ -40,7 +40,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class InMemorySpanExporter implements SpanExporter {
-    Logger logger = Logger.getLogger("io.openliberty.microprofile.telemetry.internal_fat.apps.jaxpropagation.InMemorySpanExporter");
+    private static final Logger LOGGER = Logger.getLogger(InMemorySpanExporter.class.getName());
 
     private boolean isStopped = false;
     // Static to allow multi-app testing
@@ -72,13 +72,13 @@ public class InMemorySpanExporter implements SpanExporter {
     }
 
     public void reset() {
-        logger.info("reset method called");
+        LOGGER.info("reset method called");
         finishedSpanItems.clear();
     }
 
     @Override
     public CompletableResultCode export(Collection<SpanData> spans) {
-        logger.info("export method called");
+        LOGGER.info("export method called");
         if (isStopped) {
             return CompletableResultCode.ofFailure();
         }
@@ -97,7 +97,7 @@ public class InMemorySpanExporter implements SpanExporter {
             for (SpanData spanData : lSpans) {
                 sb.append(System.lineSeparator() + spanData.toString() + System.lineSeparator());
             }
-            logger.info(sb.toString());
+            LOGGER.info(sb.toString());
         }
 
         finishedSpanItems.addAll(lSpans);
@@ -112,7 +112,7 @@ public class InMemorySpanExporter implements SpanExporter {
 
     @Override
     public CompletableResultCode shutdown() {
-        logger.info("shutdown method called");
+        LOGGER.info("shutdown method called");
         finishedSpanItems.clear();
         isStopped = true;
         return CompletableResultCode.ofSuccess();

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/spanexporter/InMemorySpanExporterProvider.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/spanexporter/InMemorySpanExporterProvider.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  *
  */
-package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation;
+package io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/spanexporter/package-info.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/spanexporter/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * Holds the test span exporter
+ * <p>
+ * We need this because the Span interface doesn't expose the attributes which are set on it, so we need to export any spans we want to test.
+ */
+package io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10MultiApp/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10MultiApp/bootstrap.properties
@@ -1,0 +1,1 @@
+bootstrap.include=../testports.properties

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10MultiApp/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10MultiApp/server.xml
@@ -1,0 +1,25 @@
+<server description="Server for testing Telemetry10">
+
+	<include location="../fatTestPorts.xml" />
+
+	<featureManager>
+		<feature>servlet-6.0</feature>
+		<feature>mpTelemetry-1.0</feature>
+		<feature>componentTest-2.0</feature>
+	</featureManager>
+	
+	<library id="exporter" apiTypeVisibility="+third-party">
+		<file name="${server.config.dir}/shared/exporter.jar" />
+	</library>
+
+	<application type="war" location="multiapp1.war">
+		<classloader apiTypeVisibility="+third-party" commonLibraryRef="exporter" />
+	</application>
+
+	<application type="war" location="multiapp2.war" >
+		<classloader apiTypeVisibility="+third-party" commonLibraryRef="exporter" />
+	</application>
+	
+	<logging traceSpecification="TELEMETRY=all:JCDI=all:org.jboss.weld=all"/>
+
+</server>


### PR DESCRIPTION
This threw up a new problem where JAX-RS can get the current application wrong when using JAX-RS client without the JAX-RS server component and passes this wrong information onto CDI. MP Config, on the other hand, has the right application. There's a bug open for this #23758

This resulted in the `OpenTelemetry` bean for app2 being created using the config for app1, because JAX-RS thought it was in app2 when it was actually in app1.

To avoid that, we need to work around the way we use CDI in the OpenTelemetry client filter, which also fixes #23736 

Fixes #23736 
Fixes #23461
