### PR TITLE
Fix NPE in JakartaEE9Action#transformApp

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -360,18 +360,23 @@ public class JakartaEE9Action extends FeatureReplacementAction {
         final String m = "transformApp";
         Log.info(c, m, "Transforming app: " + appPath);
 
+        // Capture stdout/stderr streams
+        final PrintStream originalOut = System.out;
+        final PrintStream originalErr = System.err;
         // Setup file output stream and only keep if we fail
-        FileOutputStream fos = null;
+        PrintStream ps = null;
         File outputLog = new File("results/transformer_" + appPath.getFileName() + ".log");
         try {
-            fos = new FileOutputStream(outputLog);
+            FileOutputStream fos = new FileOutputStream(outputLog);
+            ps = new PrintStream(fos);
         } catch (FileNotFoundException e1) {
             e1.printStackTrace();
         }
 
-        PrintStream ps = new PrintStream(fos);
-        System.setOut(ps);
-        System.setErr(ps);
+        if (ps != null) {
+            System.setOut(ps);
+            System.setErr(ps);
+        }
 
         try {
             Class.forName("org.eclipse.transformer.cli.JakartaTransformerCLI");
@@ -425,30 +430,28 @@ public class JakartaEE9Action extends FeatureReplacementAction {
 
         try {
             // Invoke the jakarta transformer
-            String[] args = new String[(widen ? 16 : 15) + transformationRulesAppend.size() * 2];
+            String[] args = new String[(widen ? 15 : 14) + transformationRulesAppend.size() * 2];
 
             args[0] = appPath.toAbsolutePath().toString(); // input
             args[1] = outputPath.toAbsolutePath().toString(); // output
 
-            args[2] = "-q"; // quiet output
-
             // override jakarta default properties, which are
             // packaged in the transformer jar
-            args[3] = "-tr"; // package-renames
-            args[4] = defaultTransformationRules.get("-tr");
-            args[5] = "-ts"; // file selections and omissions
-            args[6] = defaultTransformationRules.get("-ts");
-            args[7] = "-tv"; // package version updates
-            args[8] = defaultTransformationRules.get("-tv");
-            args[9] = "-tb"; // bundle identity updates
-            args[10] = defaultTransformationRules.get("-tb");
-            args[11] = "-td"; // exact java string constant updates
-            args[12] = defaultTransformationRules.get("-td");
-            args[13] = "-tf"; // text updates
-            args[14] = defaultTransformationRules.get("-tf");
+            args[2] = "-tr"; // package-renames
+            args[3] = defaultTransformationRules.get("-tr");
+            args[4] = "-ts"; // file selections and omissions
+            args[5] = defaultTransformationRules.get("-ts");
+            args[6] = "-tv"; // package version updates
+            args[7] = defaultTransformationRules.get("-tv");
+            args[8] = "-tb"; // bundle identity updates
+            args[9] = defaultTransformationRules.get("-tb");
+            args[10] = "-td"; // exact java string constant updates
+            args[11] = defaultTransformationRules.get("-td");
+            args[12] = "-tf"; // text updates
+            args[13] = defaultTransformationRules.get("-tf");
             // The widen option handles jars inside of jars.
             if (widen) {
-                args[15] = "-w";
+                args[14] = "-w";
             }
 
             // Go through the additions
@@ -459,7 +462,7 @@ public class JakartaEE9Action extends FeatureReplacementAction {
                     additions[index++] = addition.getKey();
                     additions[index++] = addition.getValue();
                 }
-                System.arraycopy(additions, 0, args, widen ? 16 : 15, transformationRulesAppend.size() * 2);
+                System.arraycopy(additions, 0, args, widen ? 15 : 14, transformationRulesAppend.size() * 2);
             }
 
             Log.info(c, m, "Initializing transformer with args: " + Arrays.toString(args));
@@ -499,9 +502,10 @@ public class JakartaEE9Action extends FeatureReplacementAction {
             Log.error(c, m, e);
             throw new RuntimeException(e);
         } finally {
-            try {
-                fos.close();
-            } catch (IOException e) {
+            if (ps != null) {
+                System.setOut(originalOut);
+                System.setErr(originalErr);
+                ps.close();
             }
             Log.info(c, m, "Transforming complete app: " + outputPath);
         }


### PR DESCRIPTION
Defect 290531 (iSeries):

Should I catch the NPE or just log the information for now to debug it further? 

Should something also be ported over to JakartaEE10Action?

```
java.lang.NullPointerException: Null output stream
at java.io.PrintStream.requireNonNull(PrintStream.java:103)
at java.io.PrintStream.<init>(PrintStream.java:175)
at java.io.PrintStream.<init>(PrintStream.java:159)
at componenttest.rules.repeater.JakartaEE9Action.transformApp(JakartaEE9Action.java:375)
at componenttest.rules.repeater.JakartaEE9Action.transformApp(JakartaEE9Action.java:358)
at componenttest.rules.repeater.JakartaEE9LooseAppsRule.lambda$featureWabTransform$5(JakartaEE9LooseAppsRule.java:258)
at componenttest.rules.repeater.JakartaEE9LooseAppsRule$$Lambda$115/0x3383c128.accept(Unknown Source)
at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:195)
at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:186)
at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:204)
at java.util.Iterator.forEachRemaining(Iterator.java:127)
at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1812)
at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:524)
at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:514)
at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:162)
at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:185)
at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:245)
at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:429)
at componenttest.rules.repeater.JakartaEE9LooseAppsRule.featureWabTransform(JakartaEE9LooseAppsRule.java:251)
at componenttest.rules.repeater.JakartaEE9LooseAppsRule.before(JakartaEE9LooseAppsRule.java:66)
at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:115)
```