### PR TITLE
Correct Scope error message and add missing unit tests to OpenIdAuthMech test

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/OpenIdAuthenticationMechanismDefinitionWrapper.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/OpenIdAuthenticationMechanismDefinitionWrapper.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,6 +14,7 @@ package io.openliberty.security.jakartasec;
 
 import static io.openliberty.security.jakartasec.JakartaSec30Constants.EMPTY_DEFAULT;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -216,9 +217,11 @@ public class OpenIdAuthenticationMechanismDefinitionWrapper implements OidcClien
                 return null;
             }
 
-            issueWarningMessage("scopeExpression", scopeExpression, EMPTY_DEFAULT);
+            String[] defaultScope = new String[] { OpenIdConstant.OPENID_SCOPE, OpenIdConstant.EMAIL_SCOPE, OpenIdConstant.PROFILE_SCOPE }; /* Default value from spec. */
 
-            return new String[] { OpenIdConstant.OPENID_SCOPE, OpenIdConstant.EMAIL_SCOPE, OpenIdConstant.PROFILE_SCOPE }; /* Default value from spec. */
+            issueWarningMessage("scopeExpression", scopeExpression, Arrays.toString(defaultScope));
+
+            return defaultScope;
         }
     }
 


### PR DESCRIPTION
Added tests based on the ToDo comments in `OpenIdAuthenticationMechanismDefinitionWrapperTest`
- getProviderMetadata
- scope
- extraParameters

During test creation, I noted that the error message for evaluateScope was using the wrong default (empty vs default list of scopes) so I fixed that.