### PR TITLE
Update scheduledPersonalBuilds.yml

### DIFF
--- a/.ci-orchestrator/personalbuild.yml
+++ b/.ci-orchestrator/personalbuild.yml
@@ -1,7 +1,7 @@
 type: pipeline_definition
 product: Liberty
-name: OpenLiberty Personal Build
-description: A build run against OpenLiberty Pull Requests
+name: Open Liberty Personal Build
+description: A build run against Open Liberty Pull Requests
 triggers:
 - type: github
   triggerName: "ol-pbbeta"

--- a/.ci-orchestrator/rtcbuild.yml
+++ b/.ci-orchestrator/rtcbuild.yml
@@ -1,7 +1,7 @@
 type: pipeline_definition
 product: Liberty
-name: OpenLiberty Personal Build RTC
-description: A build run against OpenLiberty Pull Requests
+name: Open Liberty Personal Build RTC
+description: A build run against Open Liberty Pull Requests
 triggers:
 - type: github
   triggerName: "ol-pb"

--- a/.ci-orchestrator/scheduledPersonalBuilds.yml
+++ b/.ci-orchestrator/scheduledPersonalBuilds.yml
@@ -1,10 +1,10 @@
 type: pipeline_definition
 product: Liberty
-name: OpenLiberty Personal Build
-description: A build run against OpenLiberty Pull Requests
+name: Open Liberty Personal Build
+description: A build run against Open Liberty Pull Requests
 triggers:
 - type: schedule
-  triggerName: "OpenLiberty Personal product only change"
+  triggerName: "Open Liberty Personal product only change"
   triggerRank: 50
   triggerMonitored: false
   triggerThreshold: 100
@@ -32,7 +32,7 @@ triggers:
     - stepName: pr-changes
     
 - type: schedule
-  triggerName: "OpenLiberty Personal unittest only change"
+  triggerName: "Open Liberty Personal unittest only change"
   triggerRank: 50
   triggerMonitored: false
   triggerThreshold: 100
@@ -60,7 +60,7 @@ triggers:
     - stepName: pr-changes
     
 - type: schedule
-  triggerName: "OpenLiberty Personal FAT only change"
+  triggerName: "Open Liberty Personal FAT only change"
   triggerRank: 50
   triggerMonitored: false
   triggerThreshold: 100
@@ -88,7 +88,7 @@ triggers:
     - stepName: pr-changes
     
 - type: schedule
-  triggerName: "OpenLiberty Personal BVT only change"
+  triggerName: "Open Liberty Personal BVT only change"
   triggerRank: 50
   triggerMonitored: false
   triggerThreshold: 100
@@ -116,7 +116,7 @@ triggers:
     - stepName: pr-changes
     
 - type: schedule
-  triggerName: "OpenLiberty Personal infrastructure only change"
+  triggerName: "Open Liberty Personal infrastructure only change"
   triggerRank: 50
   triggerMonitored: false
   triggerThreshold: 100

--- a/.ci-orchestrator/scheduledPersonalBuilds.yml
+++ b/.ci-orchestrator/scheduledPersonalBuilds.yml
@@ -1,10 +1,10 @@
 type: pipeline_definition
-product: OpenLiberty
+product: Liberty
 name: OpenLiberty Personal Build
 description: A build run against OpenLiberty Pull Requests
 triggers:
 - type: schedule
-  triggerName: "Personal product only change"
+  triggerName: "OpenLiberty Personal product only change"
   triggerRank: 50
   triggerMonitored: false
   triggerThreshold: 100
@@ -32,7 +32,7 @@ triggers:
     - stepName: pr-changes
     
 - type: schedule
-  triggerName: "Personal unittest only change"
+  triggerName: "OpenLiberty Personal unittest only change"
   triggerRank: 50
   triggerMonitored: false
   triggerThreshold: 100
@@ -60,7 +60,7 @@ triggers:
     - stepName: pr-changes
     
 - type: schedule
-  triggerName: "Personal FAT only change"
+  triggerName: "OpenLiberty Personal FAT only change"
   triggerRank: 50
   triggerMonitored: false
   triggerThreshold: 100
@@ -88,7 +88,7 @@ triggers:
     - stepName: pr-changes
     
 - type: schedule
-  triggerName: "Personal BVT only change"
+  triggerName: "OpenLiberty Personal BVT only change"
   triggerRank: 50
   triggerMonitored: false
   triggerThreshold: 100
@@ -116,7 +116,7 @@ triggers:
     - stepName: pr-changes
     
 - type: schedule
-  triggerName: "Personal infrastructure only change"
+  triggerName: "OpenLiberty Personal infrastructure only change"
   triggerRank: 50
   triggerMonitored: false
   triggerThreshold: 100
@@ -172,6 +172,7 @@ steps:
     disable.run.createDoc: ${pr-changes:disable.run.createDoc}
     skip.open.liberty.build.if.possible: ${pr-changes:skip.open.liberty.build.if.possible}
     skip.open.liberty.fats.if.possible: ${pr-changes:skip.open.liberty.fats.if.possible}
+    spawn.fullfat.buckets: ${pr-changes:spawn.fullfat.buckets}
   includeProperties:
   - file: compilePersonal.properties
   - file: compile.properties
@@ -227,7 +228,8 @@ steps:
     fat.test.mode: lite
     fats_to_omit: "com.ibm.ws.collective.controller.deploy_fat, com.ibm.ws.health.manager.odrlib_fat, com.ibm.ws.dynamic.routing_ihs_fat, com.ibm.ws.node.scaling_fat, com.ibm.ws.scaling.member_fat_multinode, com.ibm.ws.node.health_fat"
     fat_uploads_to_expect: ${compile:fat_uploads_to_expect}
-    outputServer: libertyfs.hursley.ibm.com
+    fileserver: libfsfe04.hursley.ibm.com
+    outputServer: libfsfe04.hursley.ibm.com
     outputPath: /liberty/personal/2/ciorchestrator
     command: ant -f build-test.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
     aggregationId: ${compile:execution_id}


### PR DESCRIPTION
- Update scheduledPersonalBuilds.yml to match personalbuild.yml.
- Change product from OpenLiberty to Liberty.
- Change name from "OpenLiberty Personal Build" to "Open Liberty Personal Build".
- Prefix "Open Liberty " in triggerName.
- Add spawn.fullfat.buckets to compile step properties.
- Set FAT step to use the libfsfe04.hursley.ibm.com fileserver. This change isn't necessary anymore, but I think it is better to be consistent with what's in the personalbuild.yml.