### PR TITLE
Fix executor issue in JAXRS EE8

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs21/sse/LibertySseEventSinkImpl.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs21/sse/LibertySseEventSinkImpl.java
@@ -189,7 +189,7 @@ public class LibertySseEventSinkImpl implements SseEventSink {
                 return new CompletableFuture<>();
             } 
             // Use Liberty thread pool
-            return completionStageFactory.newIncompleteFuture();
+            return completionStageFactory.newIncompleteFuture(JAXRSClientCompletionStageFactoryConfig.getExecutorService());
         }
         return AccessController.doPrivileged((PrivilegedAction<CompletableFuture<?>>)() -> {
             if (JAVA8 || COMPLETION_STAGE_FACTORY_IS_NULL) {
@@ -199,7 +199,7 @@ public class LibertySseEventSinkImpl implements SseEventSink {
                 return new CompletableFuture<>();
             }
             // Use Liberty thread pool
-            return completionStageFactory.newIncompleteFuture();
+            return completionStageFactory.newIncompleteFuture(JAXRSClientCompletionStageFactoryConfig.getExecutorService());
         });
     }
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/bnd.bnd
@@ -34,14 +34,8 @@ Export-Package: \
   org.apache.cxf.jaxrs.client.blueprint;version=${cxfVersion}, \
   org.apache.cxf.jaxrs.client.spec;version=${cxfVersion}
 
-Service-Component: \
-  com.ibm.ws.jaxrs21.clientconfig.JAXRSClientCompletionStageFactoryConfig; \
-    implementation:=com.ibm.ws.jaxrs21.clientconfig.JAXRSClientCompletionStageFactoryConfig; \
-    provide:=com.ibm.ws.jaxrs21.clientconfig.JAXRSClientCompletionStageFactoryConfig; \
-    completionStageFactory=com.ibm.ws.threading.CompletionStageFactory; \
-    configuration-policy:=ignore; \
-    immediate:=true;\
-    properties:="service.vendor=IBM"
+-dsannotations: \
+  com.ibm.ws.jaxrs21.clientconfig.JAXRSClientCompletionStageFactoryConfig
 
 -includeresource: \
   @${repo;org.apache.cxf:cxf-rt-rs-client;${cxfVersion};EXACT}!/!META-INF/*, \
@@ -53,8 +47,14 @@ Service-Component: \
   org.apache.cxf:cxf-rt-rs-client;strategy=exact;version=${cxfVersion}, \
   com.ibm.websphere.javaee.jaxrs.2.1;version=latest, \
   com.ibm.ws.logging.core, \
+  com.ibm.websphere.org.osgi.service.component;version=latest,\
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest, \
   com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2;version=latest, \
   com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2;version=latest, \
   com.ibm.ws.threading;version=latest, \
-  com.ibm.ws.org.osgi.annotation.versioning;version=latest
+  com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+  com.ibm.websphere.org.osgi.core;version=latest,\
+  com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+  com.ibm.ws.kernel.service;version=latest, \
+  com.ibm.ws.kernel.boot;version=latest
+  

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/src/com/ibm/ws/jaxrs21/clientconfig/JAXRSClientCompletionStageFactoryConfig.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/src/com/ibm/ws/jaxrs21/clientconfig/JAXRSClientCompletionStageFactoryConfig.java
@@ -12,12 +12,43 @@
  *******************************************************************************/
 package com.ibm.ws.jaxrs21.clientconfig;
 
-import com.ibm.ws.threading.CompletionStageFactory;
+import java.util.concurrent.ExecutorService;
 
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import com.ibm.ws.threading.CompletionStageFactory;
+import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
+
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE, service = { JAXRSClientCompletionStageFactoryConfig.class }, immediate = true, property = { "service.vendor=IBM" })
 public class JAXRSClientCompletionStageFactoryConfig {
+    
+    private static final AtomicServiceReference<ExecutorService> executorServiceRef = new AtomicServiceReference<ExecutorService>("executorService");
+    private static final AtomicServiceReference<ExecutorService> managedExecutorServiceRef = new AtomicServiceReference<ExecutorService>("managedExecutorService");
 
     private static volatile CompletionStageFactory completionStageFactory = null;
 
+    @Activate
+    protected void activate(ComponentContext cc) {
+        executorServiceRef.activate(cc);
+        managedExecutorServiceRef.activate(cc);
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext cc) {
+        executorServiceRef.deactivate(cc);
+        managedExecutorServiceRef.deactivate(cc);
+    }
+
+    
+    @Reference(name = "completionStageFactory", service = CompletionStageFactory.class)
     protected void setCompletionStageFactory(CompletionStageFactory completionStageFactory) {        
         JAXRSClientCompletionStageFactoryConfig.completionStageFactory = completionStageFactory;
     }
@@ -29,4 +60,42 @@ public class JAXRSClientCompletionStageFactoryConfig {
     public static CompletionStageFactory getCompletionStageFactory() {
         return completionStageFactory;
     }
+    
+    //Jim start
+    @Reference(name = "executorService", service = ExecutorService.class, target = "(component.name=com.ibm.ws.threading)")
+    protected void setExecutorService(ServiceReference<ExecutorService> ref) {
+        System.out.println("Jim... CompletionStageFactory.setExecutorService:  ref = " + ref);
+        executorServiceRef.setReference(ref);
+
+    }
+
+    protected void unsetExecutorService(ServiceReference<ExecutorService> ref) {
+        System.out.println("Jim... CompletionStageFactory.unsetExecutorService");
+        executorServiceRef.unsetReference(ref);
+    }
+
+    @Reference(name = "managedExecutorService", service = ExecutorService.class, target = "(id=DefaultManagedExecutorService)", policyOption = ReferencePolicyOption.GREEDY,
+               cardinality = ReferenceCardinality.OPTIONAL)
+    protected void setManagedExecutorService(ServiceReference<ExecutorService> ref) {
+        System.out.println("Jim... CompletionStageFactory.setManagedExecutorService: ref = " + ref);
+        managedExecutorServiceRef.setReference(ref);
+    }
+
+    protected void unsetManagedExecutorService(ServiceReference<ExecutorService> ref) {
+        System.out.println("Jim... CompletionStageFactory.unsetManagedExecutorService");
+        managedExecutorServiceRef.unsetReference(ref);
+    }
+
+    public static ExecutorService getExecutorService() {
+        ExecutorService managedExecutorService = managedExecutorServiceRef.getService();
+        if (managedExecutorService != null) {
+            System.out.println("Jim... CompletionStageFactory.getExecutorService returning managedExectorService: " + managedExecutorService.getClass().getName());
+            return managedExecutorService;
+        } 
+        System.out.println("Jim... CompletionStageFactory.getExecutorService returning exectorServiceRef: " + executorServiceRef.getServiceWithException().getClass().getName());
+        return executorServiceRef.getService();
+    }
+
+    //Jim end
+
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/src/org/apache/cxf/jaxrs/client/CompletionStageRxInvokerImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/src/org/apache/cxf/jaxrs/client/CompletionStageRxInvokerImpl.java
@@ -197,7 +197,7 @@ public class CompletionStageRxInvokerImpl implements CompletionStageRxInvoker {
         }
 
         if (ex == null) {
-            return completionStageFactory.supplyAsync(supplier);
+            return completionStageFactory.supplyAsync(supplier,JAXRSClientCompletionStageFactoryConfig.getExecutorService()); //Liberty change
         }
 
         return completionStageFactory.supplyAsync(supplier, ex); 


### PR DESCRIPTION
Fixes #23914 
Ensure CompletionStage function (running synchronously or asynchronously) after completion can access the java:comp namespace.