### PR TITLE
Fix wlp.lib.extract_fat.PackageRunnableTest.testRunnableJar on IBM i

### DIFF
--- a/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractRun.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractRun.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -256,8 +256,8 @@ public class SelfExtractRun extends SelfExtract {
 
         System.out.println(cmd);
 
-        if (platformType == SelfExtractUtils.PlatformType_UNIX) {
-            // cmd ready as-is for Unix
+        if (platformType == SelfExtractUtils.PlatformType_UNIX || platformType == SelfExtractUtils.PlatformType_OS400) {
+            // cmd ready as-is for Unix or OS/400
         } else if (platformType == SelfExtractUtils.PlatformType_WINDOWS) {
             cmd = "cmd /k " + cmd;
         } else if (platformType == SelfExtractUtils.PlatformType_CYGWIN) {

--- a/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractUtils.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -677,21 +677,23 @@ public class SelfExtractUtils {
     }
 
     /*
-     * PlatformType provides constants to denote Unix, Windows, or Cygwin platform/environment.
+     * PlatformType provides constants to denote Unix, Windows, Cygwin or OS/400 platform/environment.
      */
 
     public static final int PlatformType_UNIX = 1;
     public static final int PlatformType_WINDOWS = 2;
     public static final int PlatformType_CYGWIN = 3;
+    public static final int PlatformType_OS400 = 4;
 
     /**
-     * Return platform type. Determine this by interrogating properties and environemnt variables
+     * Return platform type. Determine this by interrogating properties and environment variables
      * as follows:
      * 1) If Java os.name property indicates Windows and the WLP_CYGWIN env var is not set, then it's Windows.
      * 2) If Java os.name property indicates Windows and the WLP_CYGWIN env var *is* set, then it's Cygwin.
-     * 3) If Java os.name property indicates other than Windows, then platform type is regarded a Unix.
+     * 3) If Java os.name property indicates OS/400, then platform type is regarded as OS400.
+     * 4) If Java os.name property indicates other than Windows or OS/400, then platform type is regarded as Unix.
      *
-     * @return int value for unix(1), windows(2), or cygwin(3) according to interrogation
+     * @return int value for unix(1), windows(2), cygwin(3) or os400(4) according to interrogation
      */
     public static int getPlatform() {
         if (System.getProperty("os.name").startsWith("Win")) {
@@ -700,9 +702,10 @@ public class SelfExtractUtils {
             } else {
                 return PlatformType_WINDOWS;
             }
+        } else if (System.getProperty("os.name").equalsIgnoreCase("os/400")) {
+            return PlatformType_OS400;
         } else {
             return PlatformType_UNIX;
         }
     }
-
 }


### PR DESCRIPTION
Running the wlp.lib.extract_fat.PackageRunnableTest.testRunnableJar FAT fails on the IBM i platform with:
```
testRunnableJar:junit.framework.AssertionFailedError: 2022-04-12-20:28:33:412 Server did not start successfully in time.
	at wlp.lib.extract.PackageRunnableTest.executeTheJar(PackageRunnableTest.java:385)
	at wlp.lib.extract.PackageRunnableTest.testRunnableJar(PackageRunnableTest.java:140)
	at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:199)
	at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:320)
	at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:173)
```
When the FAT runs the `java -jar` file command, it throws the work into a new JVM where the command get mixed up in translation and does not start.  There is a `-XX:+EnableHCR` option that can be specified with the IBM i `java` command to keep the java command in the same JVM.  This prevents the translation problem when running in a new shell.
