### PR TITLE
Upgrade to Jakarta Rest TCK version 3.1.3 resolving challenges

### DIFF
--- a/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -63,7 +63,7 @@
 
         <!-- Jakarta EE API -->
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
-        <jakarta.ws.rs-tck.version>3.1.2</jakarta.ws.rs-tck.version>
+        <jakarta.ws.rs-tck.version>3.1.3</jakarta.ws.rs-tck.version>
 
         <!-- TODO: update Arquillian BOM -->
         <arquillian-bom.version>1.7.0.Alpha13</arquillian-bom.version>


### PR DESCRIPTION
This PR upgrades the Liberty Jakarta Rest internal TCK to run with version 3.1.3, that resolves the challenged documented in [jakarta issue 1138](https://github.com/jakartaee/rest/issues/1138)