### PR TITLE
WebContainer performance improvements

### DIFF
--- a/dev/com.ibm.ws.httpservice/test/com/ibm/ws/httpsvc/test/SessionTest.java
+++ b/dev/com.ibm.ws.httpservice/test/com/ibm/ws/httpsvc/test/SessionTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corporation and others.
+ * Copyright (c) 2009, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -166,6 +166,11 @@ public class SessionTest {
 
         @Override
         public List<String> getHeaderNames() {
+            return null;
+        }
+
+        @Override
+        public Set<String> getHeaderNamesSet() {
             return null;
         }
 

--- a/dev/com.ibm.ws.security.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -66,7 +66,8 @@ instrument.classesExcludes: com/ibm/ws/security/common/internal/resources/*.clas
     com.ibm.json4j;version=latest, \
     com.ibm.ws.webcontainer.security;version=latest, \
     com.ibm.ws.org.apache.httpcomponents;version=latest, \
-    com.ibm.ws.ssl;version=latest
+    com.ibm.ws.ssl;version=latest, \
+    com.ibm.ws.transport.http
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AuthUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AuthUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,8 @@ import javax.servlet.http.HttpServletRequest;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 
 public class AuthUtils {
 
@@ -24,24 +26,22 @@ public class AuthUtils {
 
     @Sensitive
     public String getBearerTokenFromHeader(HttpServletRequest req) {
-        return getBearerTokenFromHeader(req, "Authorization");
+        String hdrValue = ISRTServletRequest.getHeader(req, HttpHeaderKeys.HDR_AUTHORIZATION);
+        return getBearerTokenFromHeader(hdrValue, "Bearer ");
     }
 
     @Sensitive
-    public String getBearerTokenFromHeader(HttpServletRequest req, String... headersToCheck) {
-        if (headersToCheck == null) {
+    public String getBearerTokenFromHeader(HttpServletRequest req, String headerName) {
+        if (headerName == null) {
             return null;
         }
-        for (String headerName : headersToCheck) {
-            String hdrValue = req.getHeader(headerName);
-            //if we are looking at custom header, then just return the value
-            if (!isAuthorizationHeader(headerName)) {
-                return hdrValue;
-            } else {
-                return getBearerTokenFromHeader(hdrValue, "Bearer ");
-            }
+
+        //if we are looking at custom header, then just return the value
+        if (!isAuthorizationHeader(headerName)) {
+            return req.getHeader(headerName);
         }
-        return null;
+
+        return getBearerTokenFromHeader(req);
     }
 
     @Sensitive

--- a/dev/com.ibm.ws.security.oauth/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -165,5 +165,6 @@ Include-Resource: \
     com.ibm.ws.kernel.boot;version=latest, \
     com.ibm.ws.security.test.common;version=latest, \
     org.apache.derby:derby;version=10.11.1.1, \
+    com.ibm.ws.transport.http;version=latest, \
     com.ibm.ws.org.joda.time.1.6.2;version=latest
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
@@ -1254,7 +1254,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
      * @return boolean (false means the key is not allowed -- incorrect value for example)
      */
     @SuppressWarnings("unused")
-    protected boolean filterAdd(HeaderKeys key, byte[] value) {
+    protected boolean filterAdd(HeaderKeys key, byte[] value, boolean isWASPrivateHeader) {
         return true;
     }
 
@@ -1965,7 +1965,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             if (null != elem) {
                 filterRemove(key, null);
             }
-            if (!filterAdd(key, value)) {
+            if (!filterAdd(key, value, false)) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "New value disallowed: "
                                  + GenericUtils.getEnglishString(value));
@@ -2005,7 +2005,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             // extract the bits we need from the larger array
             byte[] temp = new byte[length];
             System.arraycopy(value, offset, temp, 0, length);
-            if (!filterAdd(key, temp)) {
+            if (!filterAdd(key, temp, false)) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "New value disallowed: "
                                  + GenericUtils.getEnglishString(temp));
@@ -2045,7 +2045,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             if (null != elem) {
                 filterRemove(key, null);
             }
-            if (!filterAdd(key, GenericUtils.getEnglishBytes(value))) {
+            if (!filterAdd(key, GenericUtils.getEnglishBytes(value), false)) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "New value disallowed: " + value);
                 }
@@ -2121,7 +2121,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             if (null != elem) {
                 filterRemove(key, null);
             }
-            if (!filterAdd(key, GenericUtils.getEnglishBytes(value))) {
+            if (!filterAdd(key, GenericUtils.getEnglishBytes(value), false)) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "New value disallowed: " + value);
                 }
@@ -2257,16 +2257,17 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
                          + "] with value [" + elem.getDebugValue() + "]");
         }
 
-        if (getRemoteIp() && name.toLowerCase().startsWith("x-forwarded") && !forwardHeaderErrorState) {
-            processForwardedHeader(elem, true);
-        }
-
-        else if (getRemoteIp() && name.toLowerCase().startsWith("forwarded") && !forwardHeaderErrorState) {
-            processForwardedHeader(elem, false);
+        if (getRemoteIp() && !forwardHeaderErrorState) {
+            String lowerCaseName = name.toLowerCase();
+            if (lowerCaseName.startsWith("x-forwarded")) {
+                processForwardedHeader(elem, true);
+            } else if (lowerCaseName.startsWith("forwarded")) {
+                processForwardedHeader(elem, false);
+            }
         }
 
         if (bFilter) {
-            if (key.useFilters() && !filterAdd(key, elem.asBytes())) {
+            if (key.useFilters() && !filterAdd(key, elem.asBytes(), false)) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "filter disallowed: " + elem.getDebugValue());
                 }
@@ -2277,7 +2278,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "checking to see if private header is allowed: " + name);
             }
-            if (!filterAdd(key, elem.asBytes())) {
+            if (!filterAdd(key, elem.asBytes(), true)) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, name + " is not trusted for this host; not adding header");
                 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
@@ -873,7 +873,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
     /**
      * This method is the same as getAllHeaderNames, but returns a Set instead.
      * This was done in order to avoid calling contains on every header name.
-     * 
+     *
      * @see com.ibm.wsspi.genericbnf.HeaderStorage#getAllHeaderNamesSet()
      */
     @Override
@@ -1016,13 +1016,24 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (null == header) {
             throw new IllegalArgumentException("Null input provided");
         }
-        List<HeaderField> list = new ArrayList<HeaderField>();
+        List<HeaderField> list;
         HeaderElement elem = findHeader(findKey(header));
-        while (null != elem) {
-            if (!elem.wasRemoved()) {
-                list.add(elem);
+        if (null == elem) {
+            list = Collections.emptyList();
+        } else if (elem.nextInstance == null) {
+            if (elem.wasRemoved()) {
+                list = Collections.emptyList();
+            } else {
+                list = Collections.singletonList(elem);
             }
-            elem = elem.nextInstance;
+        } else {
+            list = new ArrayList<HeaderField>();
+            do {
+                if (!elem.wasRemoved()) {
+                    list.add(elem);
+                }
+                elem = elem.nextInstance;
+            } while (null != elem);
         }
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "getHeaders(s): " + header + " " + list.size());

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
@@ -19,9 +19,12 @@ import java.io.ObjectOutput;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -848,8 +851,11 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.entry(tc, "getAllHeaderNames");
         }
-        List<String> vals = new ArrayList<String>();
-        if (0 != this.numberOfHeaders) {
+        List<String> vals;
+        if (0 == this.numberOfHeaders) {
+            vals = Collections.emptyList();
+        } else {
+            vals = new ArrayList<>(numberOfHeaders);
             HeaderElement elem = this.hdrSequence;
             while (null != elem) {
                 if (!elem.wasRemoved() && !vals.contains(elem.getName())) {
@@ -860,6 +866,36 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         }
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.exit(tc, "getAllHeaderNames: size=" + vals.size());
+        }
+        return vals;
+    }
+
+    /**
+     * This method is the same as getAllHeaderNames, but returns a Set instead.
+     * This was done in order to avoid calling contains on every header name.
+     * 
+     * @see com.ibm.wsspi.genericbnf.HeaderStorage#getAllHeaderNamesSet()
+     */
+    @Override
+    public Set<String> getAllHeaderNamesSet() {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
+            Tr.entry(tc, "getAllHeaderNamesSet");
+        }
+        Set<String> vals;
+        if (0 == this.numberOfHeaders) {
+            vals = Collections.emptySet();
+        } else {
+            vals = new LinkedHashSet<>(numberOfHeaders);
+            HeaderElement elem = this.hdrSequence;
+            while (null != elem) {
+                if (!elem.wasRemoved()) {
+                    vals.add(elem.getName());
+                }
+                elem = elem.nextSequence;
+            }
+        }
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
+            Tr.exit(tc, "getAllHeaderNamesSet: size=" + vals.size());
         }
         return vals;
     }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpBaseMessageImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpBaseMessageImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2020 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -261,21 +261,23 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
      * genericbnf.HeaderKeys, byte[])
      */
     @Override
-    protected boolean filterAdd(HeaderKeys key, byte[] value) {
+    protected boolean filterAdd(HeaderKeys key, byte[] value, boolean isWASPrivateHeader) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(tc, "Adding: " + key.getName() + ":" + GenericUtils.getEnglishString(value));
         }
         boolean rc = true;
-        if (HttpHeaderKeys.HDR_CONTENT_LENGTH.equals(key)) {
-            rc = setContentLength(value);
-        } else if (HttpHeaderKeys.HDR_CONNECTION.equals(key)) {
-            matchAndParseConnection(value);
-        } else if (HttpHeaderKeys.HDR_TRANSFER_ENCODING.equals(key)) {
-            matchAndParseTransfer(value);
-        } else if (HttpHeaderKeys.HDR_CONTENT_ENCODING.equals(key)) {
-            matchAndParseContent(value);
-        } else if (HttpHeaderKeys.HDR_EXPECT.equals(key)) {
-            matchAndParseExpect(value);
+        if (!isWASPrivateHeader) {
+            if (HttpHeaderKeys.HDR_CONTENT_LENGTH.equals(key)) {
+                rc = setContentLength(value);
+            } else if (HttpHeaderKeys.HDR_CONNECTION.equals(key)) {
+                matchAndParseConnection(value);
+            } else if (HttpHeaderKeys.HDR_TRANSFER_ENCODING.equals(key)) {
+                matchAndParseTransfer(value);
+            } else if (HttpHeaderKeys.HDR_CONTENT_ENCODING.equals(key)) {
+                matchAndParseContent(value);
+            } else if (HttpHeaderKeys.HDR_EXPECT.equals(key)) {
+                matchAndParseExpect(value);
+            }
         }
         return rc;
     }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpRequestMessageImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpRequestMessageImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2021 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -2166,10 +2166,11 @@ public class HttpRequestMessageImpl extends HttpBaseMessageImpl implements HttpR
      * genericbnf.HeaderKeys, byte[])
      */
     @Override
-    protected boolean filterAdd(HeaderKeys key, byte[] value) {
-        boolean rc = super.filterAdd(key, value);
-
-        if (HttpHeaderKeys.isWasPrivateHeader(key.getName()) && !this.deserialized) {
+    protected boolean filterAdd(HeaderKeys key, byte[] value, boolean isWASPrivateHeader) {
+        boolean rc = true;
+        if (!isWASPrivateHeader) {
+            rc = super.filterAdd(key, value, isWASPrivateHeader);
+        } else if (!this.deserialized) {
             rc = isPrivateHeaderTrusted(key);
         }
         return rc;

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpRequestImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpRequestImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corporation and others.
+ * Copyright (c) 2009, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,6 +14,7 @@ package com.ibm.ws.http.dispatcher.internal.channel;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.http.channel.internal.HttpBaseMessageImpl;
@@ -144,6 +145,14 @@ public class HttpRequestImpl implements Http2Request, HttpRequestExt {
     @Override
     public List<String> getHeaderNames() {
         return this.message.getAllHeaderNames();
+    }
+
+    /*
+     * @see com.ibm.websphere.http.HttpRequestExt#getHeaderNamesSet()
+     */
+    @Override
+    public Set<String> getHeaderNamesSet() {
+        return this.message.getAllHeaderNamesSet();
     }
 
     /*

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpRequestImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpRequestImpl.java
@@ -13,6 +13,7 @@
 package com.ibm.ws.http.dispatcher.internal.channel;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -132,9 +133,17 @@ public class HttpRequestImpl implements Http2Request, HttpRequestExt {
     @Override
     public List<String> getHeaders(String name) {
         List<HeaderField> hdrs = this.message.getHeaders(name);
-        List<String> values = new ArrayList<String>(hdrs.size());
-        for (HeaderField header : hdrs) {
-            values.add(header.asString());
+        int size = hdrs.size();
+        List<String> values;
+        if (size == 0) {
+            values = Collections.emptyList();
+        } else if (size == 1) {
+            values = Collections.singletonList(hdrs.get(0).asString());
+        } else {
+            values = new ArrayList<String>(hdrs.size());
+            for (HeaderField header : hdrs) {
+                values.add(header.asString());
+            }
         }
         return values;
     }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpResponseImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpResponseImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009 IBM Corporation and others.
+ * Copyright (c) 2009, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -154,6 +154,15 @@ public class HttpResponseImpl implements HttpResponse, HttpResponseExt {
     @Override
     public void setHeader(HttpHeaderKeys key, String value) {
         this.message.setHeader(key, value);
+    }
+
+    /*
+     * @see com.ibm.websphere.http.HttpResponseExt#setHeaderIfAbsent(com.ibm.wsspi.http.channel.values.HttpHeaderKeys, java.lang.String)
+     */
+    @Override
+    public String setHeaderIfAbsent(HttpHeaderKeys key, String value) {
+        HeaderField oldValue = this.message.setHeaderIfAbsent(key, value);
+        return oldValue == null ? null : oldValue.asString();
     }
 
     /*

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/genericbnf/HeaderStorage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/genericbnf/HeaderStorage.java
@@ -15,6 +15,7 @@ package com.ibm.wsspi.genericbnf;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This interface is for the storage of headers that are in the Augmented BNF
@@ -112,6 +113,15 @@ public interface HeaderStorage {
      * @return List<String>
      */
     List<String> getAllHeaderNames();
+
+    /**
+     * Query a set of all the unique header names found in this particular
+     * message.
+     * This set is never null but may be empty.
+     *
+     * @return Set<String>
+     */
+    Set<String> getAllHeaderNamesSet();
 
     /**
      * Create a new instance of this header with the given byte[] value.

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/genericbnf/HeaderStorage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/genericbnf/HeaderStorage.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2009 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -449,6 +449,20 @@ public interface HeaderStorage {
      *             if input is invalid
      */
     void setHeader(HeaderKeys header, String value);
+
+    /**
+     * Set the header to the given string value if the header is not alredy set.
+     * <p>
+     * Any String encoding or decoding on the value will be performed with the
+     * ISO-8859-1 charset.
+     *
+     * @param header
+     * @param value
+     * @return HeaderField
+     * @throws IllegalArgumentException
+     *             if input is invalid
+     */
+    HeaderField setHeaderIfAbsent(HeaderKeys header, String value);
 
     /**
      * Set the header to the given byte[] value, erasing any existing values.

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/genericbnf/KeyMatcher.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/genericbnf/KeyMatcher.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2009 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -233,6 +233,11 @@ public class KeyMatcher {
             for (int i = 0; i < stop; i++) {
                 temp = vlist[i];
                 if (temp.length == length) {
+                    // Short circuit if the String literal was used and matches the one that is in
+                    // the GenericKey
+                    if (start == 0 && data == this.list[i].getName()) {
+                        return this.list[i];
+                    }
                     // potential match, scan backwards because most things vary
                     // later on... Content-Length vs Content-Language for example
                     for (x = end, y = temp.length - 1; x >= start; x--, y--) {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2021 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -226,6 +226,11 @@ public class HttpHeaderKeys extends HeaderKeys {
     public static final HttpHeaderKeys HDR_$WSFO = new HttpHeaderKeys("$WSFO");
 
     public static final HttpHeaderKeys HDR_HSTS = new HttpHeaderKeys("Strict-Transport-Security");
+
+    public static final HttpHeaderKeys HDR_AUTHORIZATION_ENCODING = new HttpHeaderKeys("Authorization-Encoding");
+
+    public static final HttpHeaderKeys HDR_ORIGIN = new HttpHeaderKeys("Origin");
+
     /** Max value of header keys that will be kept in key storage */
     public static final int ORD_MAX = 1024;
 
@@ -296,9 +301,9 @@ public class HttpHeaderKeys extends HeaderKeys {
      *
      * @param name
      * @param offset
-     *            - starting point in that name
+     *                   - starting point in that name
      * @param length
-     *            - length to use from that starting point
+     *                   - length to use from that starting point
      * @return HttpHeaderKeys
      */
     public static HttpHeaderKeys match(String name, int offset, int length) {
@@ -314,9 +319,9 @@ public class HttpHeaderKeys extends HeaderKeys {
      *
      * @param name
      * @param offset
-     *            - starting point in that name
+     *                   - starting point in that name
      * @param length
-     *            - length to use from that offset
+     *                   - length to use from that offset
      * @return HttpHeaderKeys
      */
     public static HttpHeaderKeys match(byte[] name, int offset, int length) {
@@ -331,14 +336,14 @@ public class HttpHeaderKeys extends HeaderKeys {
      *
      * @param name
      * @param offset
-     *            - starting point in that input name
+     *                   - starting point in that input name
      * @param length
-     *            - length to use from that offset
+     *                   - length to use from that offset
      * @return HttpHeaderKeys
      * @throws NullPointerException
-     *             if input name is null
+     *                                      if input name is null
      * @throws IllegalArgumentException
-     *             if the input name contains CR or LF chars
+     *                                      if the input name contains CR or LF chars
      */
     public static HttpHeaderKeys find(byte[] name, int offset, int length) {
         HttpHeaderKeys key = (HttpHeaderKeys) myMatcher.match(name, offset, length);
@@ -369,9 +374,9 @@ public class HttpHeaderKeys extends HeaderKeys {
      * @param name
      * @return HttpHeaderKeys
      * @throws NullPointerException
-     *             if input name is null
+     *                                      if input name is null
      * @throws IllegalArgumentException
-     *             if the input name contains CR or LF chars
+     *                                      if the input name contains CR or LF chars
      */
     public static HttpHeaderKeys find(String name) {
         HttpHeaderKeys key = (HttpHeaderKeys) myMatcher.match(name, 0, name.length());
@@ -402,9 +407,9 @@ public class HttpHeaderKeys extends HeaderKeys {
      * @param name
      * @return HttpHeaderKeys
      * @throws NullPointerException
-     *             if input name is null
+     *                                      if input name is null
      * @throws IllegalArgumentException
-     *             if the input name contains CR or LF chars
+     *                                      if the input name contains CR or LF chars
      */
     public static HttpHeaderKeys find(byte[] name) {
         return find(name, 0, name.length);

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
@@ -427,7 +427,7 @@ public class HttpHeaderKeys extends HeaderKeys {
         if (headerName == null) {
             return false;
         }
-        return sensitiveHeaderList.contains(headerName);
+        return headerName.length() > 0 && headerName.charAt(0) == '$' && sensitiveHeaderList.contains(headerName);
     }
 
     /** private headers defined as sensitive */
@@ -447,7 +447,7 @@ public class HttpHeaderKeys extends HeaderKeys {
         if (headerName == null) {
             return false;
         }
-        return privateHeaderList.contains(headerName);
+        return headerName.length() > 0 && headerName.charAt(0) == '$' && privateHeaderList.contains(headerName);
     }
 
     private static int generateNextOrdinal() {

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/ext/HttpRequestExt.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/ext/HttpRequestExt.java
@@ -1,16 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.http.ext;
+
+import java.util.Set;
 
 import com.ibm.wsspi.http.HttpRequest;
 import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
@@ -30,5 +32,13 @@ public interface HttpRequestExt extends HttpRequest {
     default String getHeader(HttpHeaderKeys key) {
         return getHeader(key.getName());
     }
+
+    /**
+     * Access a set of all header names found in this message. This set is never
+     * null, but might be empty.
+     *
+     * @return Set<String>
+     */
+    Set<String> getHeaderNamesSet();
 
 }

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/ext/HttpResponseExt.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/ext/HttpResponseExt.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -40,6 +40,22 @@ public interface HttpResponseExt extends HttpResponse {
      */
     default void setHeader(HttpHeaderKeys key, String value) {
         setHeader(key.getName(), value);
+    }
+
+    /**
+     * Set a header on the message using the provided name and value pair if
+     * there isn't a value already set for this header.
+     *
+     * @param key
+     * @param value
+     * @return old value or null
+     */
+    default String setHeaderIfAbsent(HttpHeaderKeys key, String value) {
+        String oldValue = getHeader(key);
+        if (oldValue == null) {
+            setHeader(key, value);
+        }
+        return oldValue;
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.cors/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.cors/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -49,8 +49,9 @@ instrument.classesExcludes: com/ibm/ws/webcontainer/cors/internal/resources/*.cl
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.wsspi.org.osgi.service.component.annotations,\
 	com.ibm.ws.kernel.service,\
-	com.ibm.ws.webcontainer;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+	com.ibm.ws.webcontainer;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.ws.transport.http
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.webcontainer.cors/src/com/ibm/ws/webcontainer/cors/CorsHelper.java
+++ b/dev/com.ibm.ws.webcontainer.cors/src/com/ibm/ws/webcontainer/cors/CorsHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -38,6 +38,8 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.webcontainer.cors.config.CorsConfig;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 
 @Component(service = { CorsHelper.class }, configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true, property = { "service.vendor=IBM" })
 public class CorsHelper {
@@ -122,14 +124,15 @@ public class CorsHelper {
         boolean continueHandlingRequest = false;
 
         // 6.1.1 and 6.2.1: If the Origin header is not present terminate this set of steps. The request is outside the scope of the CORS specification.
-        if (request.getHeader(REQUEST_HEADER_ORIGIN) != null) {
+        String originHeader = ISRTServletRequest.getHeader(request, HttpHeaderKeys.HDR_ORIGIN);
+        if (originHeader != null) {
             logCorsRequestInfo(request);
 
-            CorsRequestType type = getRequestType(request);
+            CorsRequestType type = getRequestType(originHeader, request);
             if (type == CorsRequestType.PRE_FLIGHT) {
-                continueHandlingRequest = handlePreflightRequest(request, response);
+                continueHandlingRequest = handlePreflightRequest(originHeader, request, response);
             } else if (type == CorsRequestType.SIMPLE || type == CorsRequestType.ACTUAL) {
-                continueHandlingRequest = handleSimpleCrossOriginRequest(request, response);
+                continueHandlingRequest = handleSimpleCrossOriginRequest(originHeader, request, response);
             }
 
             logCorsResponseInfo(response);
@@ -142,8 +145,7 @@ public class CorsHelper {
         return continueHandlingRequest;
     }
 
-    private boolean handleSimpleCrossOriginRequest(HttpServletRequest request, HttpServletResponse response) {
-        String requestOrigin = request.getHeader(REQUEST_HEADER_ORIGIN);
+    private boolean handleSimpleCrossOriginRequest(String requestOrigin, HttpServletRequest request, HttpServletResponse response) {
 
         // 6.1.1: If the Origin header is not present terminate this set of steps. The request is outside the scope of the CORS specification.
         if (requestOrigin == null) {
@@ -187,8 +189,7 @@ public class CorsHelper {
         return false;
     }
 
-    private boolean handlePreflightRequest(HttpServletRequest request, HttpServletResponse response) {
-        String requestOrigin = request.getHeader(REQUEST_HEADER_ORIGIN);
+    private boolean handlePreflightRequest(String requestOrigin, HttpServletRequest request, HttpServletResponse response) {
 
         // 6.2.1: If the Origin header is not present terminate this set of steps. The request is outside the scope of the CORS specification.
         if (requestOrigin == null) {
@@ -302,10 +303,9 @@ public class CorsHelper {
         return true;
     }
 
-    private CorsRequestType getRequestType(HttpServletRequest request) {
+    private CorsRequestType getRequestType(String origin, HttpServletRequest request) {
         CorsRequestType type = CorsRequestType.OTHER;
 
-        String origin = request.getHeader(REQUEST_HEADER_ORIGIN);
         if (origin != null && !origin.isEmpty()) {
             String requestMethod = request.getMethod();
             if ("OPTIONS".equals(requestMethod)) {

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebProviderAuthenticatorProxy.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebProviderAuthenticatorProxy.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -47,6 +47,8 @@ import com.ibm.ws.webcontainer.security.openid20.OpenidClientService;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcClient;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServer;
 import com.ibm.ws.webcontainer.security.util.SSOAuthFilter;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceMap;
 import com.ibm.wsspi.security.tai.TrustAssociationInterceptor;
@@ -185,7 +187,7 @@ public class WebProviderAuthenticatorProxy implements WebAuthenticator {
             if (!isNewAuth) {
                 if ("BASIC".equals(authResult.getAuditAuthConfigProviderAuthType())) {
                     // check BA header, and if it exists, use denied and set username, otherwise, challenge
-                    String authHeader = webRequest.getHttpServletRequest().getHeader("Authorization");
+                    String authHeader = ISRTServletRequest.getHeader(webRequest.getHttpServletRequest(), HttpHeaderKeys.HDR_AUTHORIZATION);
                     if (authHeader != null && authHeader.startsWith("Basic ")) {
                         String basicAuthHeader = decodeCookieString(authHeader.substring(6));
                         int index = basicAuthHeader.indexOf(':');
@@ -215,7 +217,7 @@ public class WebProviderAuthenticatorProxy implements WebAuthenticator {
                                                    webRequest.getHttpServletResponse(),
                                                    props);
             if (authResult.getStatus() != AuthResult.CONTINUE) {
-                String authHeader = webRequest.getHttpServletRequest().getHeader("Authorization");
+                String authHeader = ISRTServletRequest.getHeader(webRequest.getHttpServletRequest(), HttpHeaderKeys.HDR_AUTHORIZATION);
                 if (authHeader != null && authHeader.startsWith("Basic ")) {
                     String basicAuthHeader = decodeCookieString(authHeader.substring(6));
                     int index = basicAuthHeader.indexOf(':');

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebRequestImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebRequestImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,13 +22,14 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.ws.security.jwtsso.token.proxy.JwtSSOTokenHelper;
 import com.ibm.ws.security.krb5.SpnegoUtil;
-import com.ibm.ws.webcontainer.security.internal.BasicAuthAuthenticator;
 import com.ibm.ws.webcontainer.security.internal.CertificateLoginAuthenticator;
 import com.ibm.ws.webcontainer.security.internal.SSOAuthenticator;
 import com.ibm.ws.webcontainer.security.metadata.FormLoginConfiguration;
 import com.ibm.ws.webcontainer.security.metadata.LoginConfiguration;
 import com.ibm.ws.webcontainer.security.metadata.MatchResponse;
 import com.ibm.ws.webcontainer.security.metadata.SecurityMetadata;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 
 /**
  *
@@ -153,7 +154,7 @@ public class WebRequestImpl implements WebRequest {
      * @return {@code true} if some authentication data is available, {@code false} otherwise.
      */
     private boolean determineIfRequestHasAuthenticationData() {
-        String hdrValue = request.getHeader(BasicAuthAuthenticator.BASIC_AUTH_HEADER_NAME);
+        String hdrValue = ISRTServletRequest.getHeader(request, HttpHeaderKeys.HDR_AUTHORIZATION);
         return isBasicOrBearerAuthHeaderInRequest(hdrValue) || isClientCertHeaderInRequest(request) || isSSOCookieInRequest(request)
                || spnegoUtil.isSpnegoOrKrb5Token(hdrValue);
     }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/BasicAuthAuthenticator.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/BasicAuthAuthenticator.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -39,6 +39,8 @@ import com.ibm.ws.webcontainer.security.WebAuthenticator;
 import com.ibm.ws.webcontainer.security.WebRequest;
 import com.ibm.ws.webcontainer.security.metadata.LoginConfiguration;
 import com.ibm.ws.webcontainer.security.metadata.SecurityMetadata;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 
 /**
  *
@@ -97,13 +99,13 @@ public class BasicAuthAuthenticator implements WebAuthenticator {
     private AuthenticationResult handleBasicAuth(String inRealm, HttpServletRequest req, HttpServletResponse res) {
 
         AuthenticationResult result = null;
-        String hdrValue = req.getHeader(BASIC_AUTH_HEADER_NAME);
+        String hdrValue = ISRTServletRequest.getHeader(req, HttpHeaderKeys.HDR_AUTHORIZATION);
         if (hdrValue == null || !hdrValue.startsWith("Basic ")) {
             result = new AuthenticationResult(AuthResult.SEND_401, inRealm, AuditEvent.CRED_TYPE_BASIC, null, AuditEvent.OUTCOME_CHALLENGE);
             return result;
         }
         // Parse the username & password from the header.
-        String encoding = req.getHeader("Authorization-Encoding");
+        String encoding = ISRTServletRequest.getHeader(req, HttpHeaderKeys.HDR_AUTHORIZATION_ENCODING);
 
         hdrValue = decodeBasicAuth(hdrValue.substring(6), encoding);
 
@@ -128,10 +130,10 @@ public class BasicAuthAuthenticator implements WebAuthenticator {
             Subject authenticatedSubject = authenticationService.authenticate(thisAuthMech, authenticationData, null);
             authResult = new AuthenticationResult(AuthResult.SUCCESS, authenticatedSubject, AuditEvent.CRED_TYPE_BASIC, username, AuditEvent.OUTCOME_SUCCESS);
         } catch (AuthenticationException e) {
-            
+
             authResult = new AuthenticationResult(AuthResult.SEND_401, e.getMessage(), AuditEvent.CRED_TYPE_BASIC, username, AuditEvent.OUTCOME_DENIED);
 
-            if (e instanceof com.ibm.ws.security.authentication.PasswordExpiredException) {  
+            if (e instanceof com.ibm.ws.security.authentication.PasswordExpiredException) {
                 authResult.passwordExpired = true;
             } else if (e instanceof com.ibm.ws.security.authentication.UserRevokedException) {
                 authResult.userRevoked = true;

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -41,6 +41,8 @@ import com.ibm.ws.webcontainer.security.WebRequest;
 import com.ibm.ws.webcontainer.security.metadata.LoginConfiguration;
 import com.ibm.ws.webcontainer.security.metadata.SecurityMetadata;
 import com.ibm.ws.webcontainer.security.util.SSOAuthFilter;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 
 /**
@@ -48,7 +50,6 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
  */
 public class SSOAuthenticator implements WebAuthenticator {
     public static final String DEFAULT_SSO_COOKIE_NAME = "LtpaToken2";
-    private static final String Authorization_Header = "Authorization";
     public final static String REQ_METHOD_POST = "POST";
     public final static String REQ_CONTENT_TYPE_NAME = "Content-Type";
     public final static String REQ_CONTENT_TYPE_APP_FORM_URLENCODED = "application/x-www-form-urlencoded";
@@ -310,7 +311,7 @@ public class SSOAuthenticator implements WebAuthenticator {
         String param = null;
         String reqMethod = req.getMethod();
         if (REQ_METHOD_POST.equalsIgnoreCase(reqMethod)) {
-            String contentType = req.getHeader(REQ_CONTENT_TYPE_NAME);
+            String contentType = ISRTServletRequest.getHeader(req, HttpHeaderKeys.HDR_CONTENT_TYPE);
 
             if (REQ_CONTENT_TYPE_APP_FORM_URLENCODED.equals(contentType)) {
                 param = req.getParameter(ACCESS_TOKEN);
@@ -325,7 +326,7 @@ public class SSOAuthenticator implements WebAuthenticator {
      */
     private String getBearerTokenFromHeader(HttpServletRequest req) {
 
-        String hdrValue = req.getHeader(Authorization_Header);
+        String hdrValue = ISRTServletRequest.getHeader(req, HttpHeaderKeys.HDR_AUTHORIZATION);
         String bearerAuthzMethod = "Bearer ";
         if (hdrValue != null && hdrValue.startsWith(bearerAuthzMethod)) {
             return hdrValue.substring(bearerAuthzMethod.length());

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/upgrade/H2HandlerImpl.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/upgrade/H2HandlerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2020 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,9 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.http2.upgrade.H2UpgradeHandler;
 import com.ibm.ws.webcontainer.servlet.H2Handler;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
 import com.ibm.wsspi.http.HttpInboundConnection;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.http.ee8.Http2InboundConnection;
 
 /**
@@ -54,9 +56,9 @@ public class H2HandlerImpl implements H2Handler {
         Map<String, String> h2Headers = null;
         HttpServletRequest hsrt = (HttpServletRequest) request;
 
-        String upgradeHeaders = hsrt.getHeader(CONSTANT_upgrade);
+        String upgradeHeaders = ISRTServletRequest.getHeader(hsrt, HttpHeaderKeys.HDR_UPGRADE);
         if(upgradeHeaders != null) {
-            String connectionHeaders = hsrt.getHeader(CONSTANT_connection);
+            String connectionHeaders = ISRTServletRequest.getHeader(hsrt, HttpHeaderKeys.HDR_CONNECTION);
             if(connectionHeaders != null) {
                 h2Headers = new HashMap<String, String>();
                 h2Headers.put(CONSTANT_connection,connectionHeaders);
@@ -94,7 +96,7 @@ public class H2HandlerImpl implements H2Handler {
             h2uh.init(new H2UpgradeHandler());
         }
         
-        String http2Settings = request.getHeader(HTTP2_SETTINGS);
+        String http2Settings = ISRTServletRequest.getHeader(request, HttpHeaderKeys.HDR_HTTP2_SETTINGS);
         
         Map<String, String> http2Headers = (http2Settings == null ? Collections.emptyMap() : Collections.singletonMap(HTTP2_SETTINGS, http2Settings));
         boolean upgraded = h2ic.handleHTTP2UpgradeRequest(http2Headers);

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/filter/WebAppFilterChain.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/filter/WebAppFilterChain.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2021 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -174,7 +174,9 @@ protected static final Logger logger = LoggerFactory.getInstance().getLogger("co
                             IRequestExtended iReq = (IRequestExtended)srtReq.getIRequest();
                             if (iReq != null) {
                                 httpInboundConnection = iReq.getHttpInboundConnection();
-                                logger.logp(Level.FINE, CLASS_NAME, "invokeTarget", "HttpInboundConnection: " + httpInboundConnection);
+                                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+                                    logger.logp(Level.FINE, CLASS_NAME, "invokeTarget", "HttpInboundConnection: " + httpInboundConnection);
+                                }
                             }
                         }
 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/request/IRequestImpl.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/request/IRequestImpl.java
@@ -36,6 +36,7 @@ import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.util.ThreadPool;
 import com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants;
+import com.ibm.ws.webcontainer.util.ListEnumeration;
 import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.wsspi.http.HttpCookie;
 import com.ibm.wsspi.http.HttpInboundConnection;
@@ -302,7 +303,7 @@ public class IRequestImpl implements IRequestExtended
   public Enumeration<String> getHeaders(String headerName)
   {
     List<String> values = this.request.getHeaders(headerName);
-    return Collections.enumeration(values);
+    return values.size() == 0 ? Collections.emptyEnumeration() : new ListEnumeration<String>(values);
   }
 
   public InputStream getInputStream() throws IOException

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/request/IRequestImpl.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/request/IRequestImpl.java
@@ -19,9 +19,11 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 
 import javax.servlet.http.Cookie;
@@ -34,7 +36,6 @@ import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.util.ThreadPool;
 import com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants;
-import com.ibm.ws.webcontainer.util.IteratorEnumerator;
 import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.wsspi.http.HttpCookie;
 import com.ibm.wsspi.http.HttpInboundConnection;
@@ -292,18 +293,16 @@ public class IRequestImpl implements IRequestExtended
       return null;
   }
 
-  @SuppressWarnings("unchecked")
-  public Enumeration getHeaderNames()
+  public Enumeration<String> getHeaderNames()
   {
-    List<String> names = this.request.getHeaderNames();
-    return new IteratorEnumerator(names.iterator());
+    Set<String> names = ((HttpRequestExt)this.request).getHeaderNamesSet();
+    return Collections.enumeration(names);
   }
 
-  @SuppressWarnings("unchecked")
-  public Enumeration getHeaders(String headerName)
+  public Enumeration<String> getHeaders(String headerName)
   {
     List<String> values = this.request.getHeaders(headerName);
-    return new IteratorEnumerator(values.iterator());
+    return Collections.enumeration(values);
   }
 
   public InputStream getInputStream() throws IOException

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/request/IRequestImpl.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/request/IRequestImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2022 IBM Corporation and others.
+ * Copyright (c) 2010, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,6 @@ import com.ibm.websphere.servlet.request.extended.IRequestExtended;
 import com.ibm.websphere.servlet.response.IResponse;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.util.ThreadPool;
 import com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants;
 import com.ibm.ws.webcontainer.util.IteratorEnumerator;
@@ -45,7 +44,6 @@ import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.http.channel.values.VersionValues;
 import com.ibm.wsspi.http.ee7.HttpInboundConnectionExtended;
 import com.ibm.wsspi.webcontainer.WCCustomProperties;
-import com.ibm.wsspi.http.HttpInboundConnection; 
 
 import io.openliberty.http.ext.HttpRequestExt;
 
@@ -281,7 +279,7 @@ public class IRequestImpl implements IRequestExtended
     return this.request.getHeader(headerName);
   }
 
-  private String getHeader(HttpHeaderKeys key)
+  public String getHeader(HttpHeaderKeys key)
   {
     return ((HttpRequestExt)this.request).getHeader(key);
   }
@@ -885,10 +883,10 @@ public class IRequestImpl implements IRequestExtended
                       Tr.debug(tc, " isTrusted --> true ssl --> " + isSSL);
                   return isSSL;
               }
-              String FORWARDED_PROTO_header =  getHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
-              if (FORWARDED_PROTO_header != null && !useForwarded) {
+              if (!useForwarded) {
+                  String FORWARDED_PROTO_header = getHeader(HttpHeaderKeys.HDR_X_FORWARDED_PROTO);
                   // router may set this header for all protocols so check specifically for regular ssl (https) and websocket ssl (wss)
-                  if ((FORWARDED_PROTO_header.equalsIgnoreCase("https"))||(FORWARDED_PROTO_header.equalsIgnoreCase("wss"))) {
+                  if (FORWARDED_PROTO_header != null && (FORWARDED_PROTO_header.equalsIgnoreCase("https") || FORWARDED_PROTO_header.equalsIgnoreCase("wss"))) {
                       isSSL = true;
                       if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                           Tr.debug(tc, " isTrusted --> true --> containsHeader --> X-Forwarded-Proto  --> "+FORWARDED_PROTO_header+" ssl --> " + isSSL);

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/response/IResponseImpl.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/response/IResponseImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2022 IBM Corporation and others.
+ * Copyright (c) 2010, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -231,14 +231,11 @@ public class IResponseImpl implements IResponse
   public void setContentLanguage(String value)
   {
       //PM25421
-      if (((HttpResponseExt)response).getHeader(HttpHeaderKeys.HDR_CONTENT_LANGUAGE) != null){
+      if (((HttpResponseExt)response).setHeaderIfAbsent(HttpHeaderKeys.HDR_CONTENT_LANGUAGE, value) != null){
           if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())  {
               Tr.debug(tc, "setContentLanguage(String)", "Ignored as the Content-Language already set");
           }
-          return;
       }
-
-      ((HttpResponseExt)this.response).setHeader(HttpHeaderKeys.HDR_CONTENT_LANGUAGE, value);
   }
   
   public void setContentLength(int length) {

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/FileServletWrapper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/FileServletWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2008 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -46,7 +46,6 @@ import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.ws.webcontainer.extension.DefaultExtensionProcessor;
 import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTOutputStream;
-import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTServletResponse;
 import com.ibm.ws.webcontainer.srt.WriteBeyondContentLengthException;
 import com.ibm.ws.webcontainer.webapp.WebApp;
@@ -56,6 +55,7 @@ import com.ibm.ws.webcontainer.webapp.WebAppEventSource;
 import com.ibm.ws.webcontainer.webapp.WebAppRequestDispatcher;
 import com.ibm.ws.webcontainer.webapp.WebAppServletInvocationEvent;
 import com.ibm.ws.webcontainer.webapp.WebGroup; //PM79476
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.webcontainer.IPlatformHelper;
 import com.ibm.wsspi.webcontainer.WCCustomProperties;
 import com.ibm.wsspi.webcontainer.WebContainer;
@@ -786,7 +786,7 @@ public abstract class FileServletWrapper implements IServletWrapper, IServletWra
     // (3) this is not a forward &
     // (4) control header wasn't already added (by dynacache)
     // (5) request is not authenticated
-        if ((esiControl != null) && (req.getHeader("Surrogate-Capability") != null)
+        if ((esiControl != null) && (ISRTServletRequest.getHeader(req, HttpHeaderKeys.HDR_SURROGATE_CAPABILITY) != null)
                 && (req.getAttribute(WebAppRequestDispatcher.DISPATCH_NESTED_ATTR) == null) && (!resp.containsHeader("Surrogate-Control"))
                 && (req.getAuthType() == null)) {
       resp.addHeader("Surrogate-Control", esiControl);

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/RequestUtils.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/RequestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2006 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,9 +25,11 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.webcontainer.WCCustomProperties;
 import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
 import com.ibm.ejs.ras.TraceNLS;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
 import com.ibm.wsspi.webcontainer.util.EncodingUtils;
 
 public class RequestUtils extends com.ibm.wsspi.webcontainer.util.RequestUtils
@@ -95,7 +97,7 @@ public class RequestUtils extends com.ibm.wsspi.webcontainer.util.RequestUtils
             encoding = SYSTEM_CLIENT_ENCODING;
             return encoding;
         }
-        String header = req.getHeader(ACCEPT_CHARSET_HEADER);
+        String header = ISRTServletRequest.getHeader(req, HttpHeaderKeys.HDR_ACCEPT_CHARSET);
         if (header != null)
         {
         	if (header.indexOf(SHORT_ASCII)!=-1)
@@ -168,9 +170,8 @@ public class RequestUtils extends com.ibm.wsspi.webcontainer.util.RequestUtils
     }
     public static String getLanguage(HttpServletRequest req)
     {
-        String header;
         String encoding = null;
-        header = req.getHeader(ACCEPT_LANGUAGE_HEADER);
+        String header = ISRTServletRequest.getHeader(req, HttpHeaderKeys.HDR_ACCEPT_LANGUAGE);
         if (header != null)
         {
             StringTokenizer st = new StringTokenizer(header, HEADER_SEPARATOR);

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/session/impl/HttpSessionContextImpl.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/session/impl/HttpSessionContextImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -43,6 +43,8 @@ import com.ibm.ws.session.store.memory.MemoryStore;
 import com.ibm.ws.session.utils.LoggingUtil;
 import com.ibm.ws.webcontainer.osgi.collaborator.CollaboratorHelperImpl;
 import com.ibm.ws.webcontainer.session.IHttpSessionContext;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.session.IGenericSessionManager;
 import com.ibm.wsspi.session.ISession;
 import com.ibm.wsspi.session.ISessionAffinityManager;
@@ -483,7 +485,7 @@ public class HttpSessionContextImpl extends SessionContext implements IHttpSessi
      * retrieves the latest session copy from the backend if the incoming
      * request is the failover one.
      */
-    if ( (id != null) && (Boolean.valueOf(_request.getHeader("$WSFO")).booleanValue()) ) {
+    if ( (id != null) && (Boolean.valueOf(ISRTServletRequest.getHeader(_request, HttpHeaderKeys.HDR_$WSFO)).booleanValue()) ) {
         IStore iStore = _coreHttpSessionManager.getIStore();
         iStore.removeFromMemory( id );
     }
@@ -824,7 +826,7 @@ private String getUser() {
     {
       if (_smc.getEnableUrlRewriting())
       {
-        boolean useCookies = _smc.getEnableCookies() && _request.getHeader("Cookie") != null;
+        boolean useCookies = _smc.getEnableCookies() && ISRTServletRequest.getHeader(_request, HttpHeaderKeys.HDR_COOKIE) != null;
         if (!useCookies)
         { // Either the server doesn't support cookies, or we didn't get
           // any cookies from the client, so we have to assume url-rewriting.

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/ISRTServletRequest.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/ISRTServletRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ package com.ibm.ws.webcontainer.srt;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
+
 public interface ISRTServletRequest {
 
     SRTRequestContext getRequestContext();
@@ -23,4 +25,13 @@ public interface ISRTServletRequest {
     void setSSLAttributesInRequest(HttpServletRequest httpServletReq, String cs);
     
     String getCipherSuite();
+
+    String getHeader(HttpHeaderKeys headerKey);
+
+    static String getHeader(HttpServletRequest request, HttpHeaderKeys headerKey) {
+        if (request instanceof ISRTServletRequest) {
+            return ((ISRTServletRequest) request).getHeader(headerKey);
+        }
+        return request.getHeader(headerKey.getName());
+    }
 }

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2022 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -78,6 +78,7 @@ import com.ibm.ws.webcontainer.async.AsyncIllegalStateException;
 import com.ibm.ws.webcontainer.async.AsyncListenerEntry;
 import com.ibm.ws.webcontainer.internalRuntimeExport.srt.IPrivateRequestAttributes;
 import com.ibm.ws.webcontainer.osgi.collaborator.CollaboratorHelperImpl;
+import com.ibm.ws.webcontainer.osgi.request.IRequestImpl;
 import com.ibm.ws.webcontainer.servlet.RequestUtils;
 import com.ibm.ws.webcontainer.session.SessionManagerConfigBase;
 import com.ibm.ws.webcontainer.util.EmptyEnumeration;
@@ -86,6 +87,7 @@ import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.ws.webcontainer.webapp.WebAppConfiguration;
 import com.ibm.ws.webcontainer.webapp.WebAppDispatcherContext;
 import com.ibm.ws.webcontainer.webapp.WebGroup;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.webcontainer.IPoolable;
 import com.ibm.wsspi.webcontainer.WCCustomProperties;
 import com.ibm.wsspi.webcontainer.WebContainer;
@@ -573,6 +575,29 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
         }// PK80362 End
         if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  //306998.15
             logger.logp(Level.FINE, CLASS_NAME,"getHeader", "this->"+this+": "+" name --> " + name + " header --> " + PasswordNullifier.nullifyParams(header));
+        }
+        return header;
+    }
+
+    /**
+     * Returns the value of a header field, or null if not known.
+     * @param headerKey the HttpHeaderKeys for the header name
+     */
+    @Override
+    public String getHeader(HttpHeaderKeys headerKey) {
+
+        if (WCCustomProperties.CHECK_REQUEST_OBJECT_IN_USE){
+            checkRequestObjectInUse();
+        }
+       
+        String header = null;
+        String name = headerKey.getName();
+        if ( (suppressHeadersInRequest == null) ||  !(isHeaderinSuppressedHeadersList(name))){  
+            if (_request != null)
+                header = _request instanceof IRequestImpl ? ((IRequestImpl)_request).getHeader(headerKey) : _request.getHeader(name);
+        }// PK80362 End
+        if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  //306998.15
+            logger.logp(Level.FINE, CLASS_NAME,"getHeader", "this->"+this+": "+" headerKey --> " + name + " header --> " + PasswordNullifier.nullifyParams(header));
         }
         return header;
     }
@@ -1653,7 +1678,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
         // from the accepted languages
         if (encoding == null && webAppCfg.isAutoRequestEncoding())
         {
-            String acceptLanguage = getHeader("Accept-Language");
+            String acceptLanguage = getHeader(HttpHeaderKeys.HDR_ACCEPT_LANGUAGE);
             if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))  //306998.15
                 logger.logp(Level.FINE, CLASS_NAME,"getReaderEncoding", "accept-language --> " + acceptLanguage);
 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletResponse.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletResponse.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2022 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -46,6 +46,7 @@ import com.ibm.ws.webcontainer.core.Response;
 import com.ibm.ws.webcontainer.servlet.IServletWrapperInternal;
 import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.ws.webcontainer.webapp.WebAppDispatcherContext;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.webcontainer.WCCustomProperties;
 import com.ibm.wsspi.webcontainer.WebContainerConstants;
 import com.ibm.wsspi.webcontainer.WebContainerRequestState;
@@ -60,6 +61,7 @@ import com.ibm.wsspi.webcontainer.util.EncodingUtils;
 import com.ibm.wsspi.webcontainer.util.IOutputStreamObserver;
 import com.ibm.wsspi.webcontainer.util.IResponseOutput;
 import com.ibm.wsspi.webcontainer.util.WrappingEnumeration;
+import com.ibm.ws.webcontainer.osgi.response.IResponseImpl;
 import com.ibm.ws.webcontainer.osgi.response.WCOutputStream;
 /**
  * The Servlet Runtime Response object
@@ -387,6 +389,14 @@ public class SRTServletResponse implements HttpServletResponse, IResponseOutput,
             logger.logp(Level.FINE, CLASS_NAME,"containsHeader", " name --> " + name + " response --> " + String.valueOf(_response.containsHeader(name)));
         }
         return _response.containsHeader(name);
+    }
+
+    private boolean containsHeader(HttpHeaderKeys headerKey) {
+        // 311717
+        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  //306998.15
+            logger.logp(Level.FINE, CLASS_NAME,"containsHeader", " headerKey --> " + headerKey.getName() + " response --> " + String.valueOf(_response.containsHeader(headerKey.getName())));
+        }
+        return _response instanceof IResponseImpl ? ((IResponseImpl)_response).containsHeader(headerKey) : _response.containsHeader(headerKey.getName());
     }
 
     public boolean containsHeader(byte[] name) {
@@ -962,7 +972,7 @@ public class SRTServletResponse implements HttpServletResponse, IResponseOutput,
 
             // PQ59244 - disallow content length header if content is encoded
             // LIBERTY
-            if (containsHeader(HEADER_CONTENT_ENCODING) && containsHeader(HEADER_CONTENT_LENGTH)) {
+            if (containsHeader(HttpHeaderKeys.HDR_CONTENT_ENCODING) && containsHeader(HttpHeaderKeys.HDR_CONTENT_LENGTH)) {
 
                 if (keepContentLength){
                     if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/util/ListEnumeration.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/util/ListEnumeration.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.webcontainer.util;
+
+import java.util.Enumeration;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public class ListEnumeration<T> implements Enumeration<T> {
+    private final List<T> list;
+    private final int size;
+    private int index = 0;
+
+    /**
+     * Constructor for ListEnumeration.
+     * 
+     * @param list
+     */
+    public ListEnumeration(List<T> list) {
+        this.list = list;
+        this.size = list.size();
+    }
+
+    /**
+     * @return boolean
+     * @see java.util.Enumeration#hasMoreElements()
+     */
+    public boolean hasMoreElements() {
+        return index < size;
+    }
+
+    /**
+     * @return Object
+     * @see java.util.Enumeration#nextElement()
+     */
+    public T nextElement() {
+        if (index >= size) {
+            throw new NoSuchElementException();
+        }
+        return list.get(index++);
+    }
+}

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/EncodingUtils.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/EncodingUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2006 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.webcontainer.WCCustomProperties; 
 import com.ibm.wsspi.webcontainer.WebContainer;
 import com.ibm.wsspi.webcontainer.WebContainerConstants;
@@ -219,7 +221,7 @@ public class EncodingUtils {
      */
     public static Vector getLocales(HttpServletRequest req) {
     	init();
-        String acceptLanguage = req.getHeader("Accept-Language");
+        String acceptLanguage = ISRTServletRequest.getHeader(req, HttpHeaderKeys.HDR_ACCEPT_LANGUAGE);
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {
             logger.logp(Level.FINE, CLASS_NAME,"getLocales", "Accept-Language --> " + acceptLanguage);
         }


### PR DESCRIPTION
- Update to use HttpHeaderKeys in other places to avoid parsing the header name
- Add is logging enabled to avoid calling a log method
- Add a new addHeaderIfAbsent and use it instead of doing get and a null check followed by a set.  This avoids looking up the value a second time.
