### PR TITLE
JAX-WS: Unmarshaller error when optional JAXB Elements when Unmarshaller obtained from pool

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/soapEnvelopePrefix/src/com/ibm/ws/jaxws/test/soapenv/prefix/SoapEnvelopePrefixTestServlet.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/soapEnvelopePrefix/src/com/ibm/ws/jaxws/test/soapenv/prefix/SoapEnvelopePrefixTestServlet.java
@@ -1,11 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
+ * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
+ * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -109,6 +107,47 @@ public class SoapEnvelopePrefixTestServlet extends FATServlet {
         String parsedResponse = parseSourceResponse(response);
         assertTrue("Expected parsed string to contain: " + EXPECTED_PASSING_RESPONSE + " but was actually: " + parsedResponse,
                    parsedResponse.contains(EXPECTED_PASSING_RESPONSE));
+        //assertNull(notFoundString + " is expected to be in generated schema: " + schemaString, notFoundString);
+    }
+
+    /*
+     * A positive test where an additional optional eleement is added to the request, to ensure that service will ignore it and process the request successfully.
+     * Additionally this test sends multiple requests that a unmarshaller obtained from the poll can also process the optional element in the second request.
+     *
+     * Default Envelope Namespace: SOAP 1.1 NS - http://schemas.xmlsoap.org/soap/envelope/
+     *
+     * Valid Element QNames:
+     *
+     * Envelope QName: {http://schemas.xmlsoap.org/soap/envelope/}Envelope
+     * Body QName: {http://schemas.xmlsoap.org/soap/envelope/}Body
+     * hello QName: {http://server.wsr.test.jaxws.ws.ibm.com}hello
+     * arg0 QName: {}arg0
+     */
+    @Test
+    public void testSoap11OptionalElementMashallerPool() throws Exception {
+
+        String msgString = "<Envelope xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                           + "  <Body>\n"
+                           + "    <ser:hello xmlns=\"\" xmlns:ser=\"http://server.wsr.test.jaxws.ws.ibm.com\">\n"
+                           + "       <arg0>from dispatch World</arg0>\n"
+                           + "       <arg1>from dispatch World</arg1>\n"
+                           + "    </ser:hello>\n"
+                           + "  </Body>\n"
+                           + "</Envelope>";
+
+        if (dispatch == null) {
+            throw new RuntimeException("dispatch  is null!");
+        }
+
+        StreamSource response = dispatch.invoke(new StreamSource(new StringReader(msgString)));
+        String parsedResponse = parseSourceResponse(response);
+        assertTrue("Expected parsed string to contain: " + EXPECTED_PASSING_RESPONSE + " but was actually: " + parsedResponse,
+                   parsedResponse.contains(EXPECTED_PASSING_RESPONSE));
+
+        StreamSource response1 = dispatch.invoke(new StreamSource(new StringReader(msgString)));
+        String parsedResponse1 = parseSourceResponse(response1);
+        assertTrue("Expected parsed string to contain: " + EXPECTED_PASSING_RESPONSE + " but was actually: " + parsedResponse1,
+                   parsedResponse1.contains(EXPECTED_PASSING_RESPONSE));
         //assertNull(notFoundString + " is expected to be in generated schema: " + schemaString, notFoundString);
     }
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/src/org/apache/cxf/jaxb/JAXBDataBinding.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/src/org/apache/cxf/jaxb/JAXBDataBinding.java
@@ -1028,7 +1028,9 @@ public class JAXBDataBinding extends AbstractInterceptorProvidingDataBinding
             Class<? extends ValidationEventHandler> handlerClass = oldEventHandler == null ? null : oldEventHandler.getClass();
             if (!setEventHandler) {
                 if (handlerClass != DefaultValidationEventHandler.class) {
-                    unm.setEventHandler(null);
+
+                    // Don't add an eventHandler if the unmarshaller doesn't already have one.
+                    // unm.setEventHandler(null);
                 }
             } else {
                 unm.setEventHandler(veventHandler);
@@ -1040,6 +1042,7 @@ public class JAXBDataBinding extends AbstractInterceptorProvidingDataBinding
             }
             if (setEventHandler) {
                 unm.setEventHandler(veventHandler);
+                
             }
             if (unmarshallerProperties != null) {
                 for (Map.Entry<String, Object> propEntry


### PR DESCRIPTION
This pull request address two issues: 

1. Unmarshallers obtained from the pool will no longer have a null event handler added to them that will prevent optional elements in the request from being parsed. 
2. Adds a test case for optional elements and the unmarshaller pool. 

Fixes #23583 