### PR TITLE
Fix EE10 repeat rules for SAML

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,9 +19,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 import com.ibm.ws.security.saml.fat.IDPInitiated.EncryptionIDPInitiatedTests;
 import com.ibm.ws.security.saml.fat.IDPInitiated.IDPInitiatedDefaultConfigTests;
 import com.ibm.ws.security.saml.fat.IDPInitiated.MultipleSPIDPInitiatedTests;
@@ -35,7 +33,6 @@ import com.ibm.ws.security.saml.fat.SPInitiated.UserFeatureOnlySolicitedSPInitia
 import com.ibm.ws.security.saml.fat.SPInitiated.UserFeatureSolicitedSPInitiatedTests;
 import com.ibm.ws.security.saml.fat.common.DefaultConfigMissingMetaDataTests;
 
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -67,11 +64,17 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class FATSuite {
 
+    /*
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.3/fat/src/com/ibm/ws/security/saml/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.3/fat/src/com/ibm/ws/security/saml/fat/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,9 +19,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 import com.ibm.ws.security.saml.fat.IDPInitiated.PkixIDPInitiatedTests;
 import com.ibm.ws.security.saml.fat.IDPInitiated.TimeIDPInitiatedTests;
 import com.ibm.ws.security.saml.fat.IDPInitiated.TrustedIssuerIDPInitiatedTests;
@@ -32,7 +30,6 @@ import com.ibm.ws.security.saml.fat.SPInitiated.TimeUnsolicitedSPInitiatedTests;
 import com.ibm.ws.security.saml.fat.SPInitiated.TrustedIssuerSolicitedSPInitiatedTests;
 import com.ibm.ws.security.saml.fat.SPInitiated.TrustedIssuerUnsolicitedSPInitiatedTests;
 
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -54,11 +51,17 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class FATSuite {
 
+    /*
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/fat/src/com/ibm/ws/security/saml/sso/fat/config/mapToUserRegistry/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/fat/src/com/ibm/ws/security/saml/sso/fat/config/mapToUserRegistry/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,10 +17,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import componenttest.rules.repeater.EmptyAction;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.JakartaEE9Action;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
+
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -34,9 +32,16 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class FATSuite {
 
+    /*
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-            .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-            .andWith(new JakartaEE10Action());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
 }

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,11 +19,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -39,11 +36,17 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class FATSuite {
 
+    /*
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/fat/src/com/ibm/ws/security/saml/sso/fat/endpoint/samlmetadata/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/fat/src/com/ibm/ws/security/saml/sso/fat/endpoint/samlmetadata/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,10 +18,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import componenttest.rules.repeater.EmptyAction;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.JakartaEE9Action;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
+
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -35,9 +33,16 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class FATSuite {
 
+    /*
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-            .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-            .andWith(new JakartaEE10Action());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
 }

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,14 +18,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 import com.ibm.ws.security.saml.fat.jaxrs.config.IDPInitiated.RSSamlIDPInitiatedMapToUserRegistryConfigTests;
 import com.ibm.ws.security.saml.fat.jaxrs.config.IDPInitiated.RSSamlIDPInitiatedMiscConfigTests;
 import com.ibm.ws.security.saml.fat.jaxrs.config.IDPInitiated.RSSamlIDPInitiatedSSLConfigNoReconfigTests;
 import com.ibm.ws.security.saml.fat.jaxrs.config.IDPInitiated.RSSamlIDPInitiatedSSLConfigWithReconfigTests;
 
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -42,10 +40,17 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class FATSuite {
 
+    /*
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,9 +19,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 import com.ibm.ws.security.saml.fat.jaxrs.IDPInitiated.RSSamlIDPInitiatedAPITests;
 import com.ibm.ws.security.saml.fat.jaxrs.IDPInitiated.RSSamlIDPInitiatedBasic1ServerTests;
 import com.ibm.ws.security.saml.fat.jaxrs.IDPInitiated.RSSamlIDPInitiatedBasic2ServerTests;
@@ -31,7 +29,6 @@ import com.ibm.ws.security.saml.fat.jaxrs.IDPInitiated.RSSamlIDPInitiatedTrusted
 import com.ibm.ws.security.saml.fat.jaxrs.IDPInitiated.RSSamlIDPInitiatedTrustedIssuers2ServerTests;
 import com.ibm.ws.security.saml.fat.jaxrs.SPInitiated.RSSamlSolicitedSPInitiatedAPITests;
 
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -52,11 +49,17 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class FATSuite {
 
+    /*
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/fat/src/com/ibm/ws/security/saml/fat/logout/IDPInitiated/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/fat/src/com/ibm/ws/security/saml/fat/logout/IDPInitiated/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,9 +19,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.security.fat.common.AlwaysRunAndPassTest;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_IDPInitiated_LogoutUrl_LTPA_Tests;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_IDPInitiated_LogoutUrl_Tests;
 import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.SolicitedSPInitiatedLogin_IDPInitiated_LogoutUrl_LTPA_Tests;
@@ -29,7 +27,6 @@ import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.SolicitedSPInitiate
 import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.UnsolicitedSPInitiatedLogin_IDPInitiated_LogoutUrl_LTPA_Tests;
 import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.UnsolicitedSPInitiatedLogin_IDPInitiated_LogoutUrl_Tests;
 
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -52,11 +49,17 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
 
+    /*
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/fat/src/com/ibm/ws/security/saml/fat/logout/httpServletRequest/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/fat/src/com/ibm/ws/security/saml/fat/logout/httpServletRequest/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,8 +19,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.security.fat.common.AlwaysRunAndPassTest;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_servletRequestLogout_spLogoutFalse_LTPA_Tests;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_servletRequestLogout_spLogoutFalse_Tests;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_servletRequestLogout_spLogoutTrue_LTPA_Tests;
@@ -34,7 +33,6 @@ import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.UnsolicitedSPInitia
 import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.UnsolicitedSPInitiatedLogin_servletRequestLogout_spLogoutTrue_LTPA_Tests;
 import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.UnsolicitedSPInitiatedLogin_servletRequestLogout_spLogoutTrue_Tests;
 
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -70,10 +68,17 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
 
+    /*
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.ibm_security_logout/fat/src/com/ibm/ws/security/saml/fat/logout/ibmSecurityLogout/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.ibm_security_logout/fat/src/com/ibm/ws/security/saml/fat/logout/ibmSecurityLogout/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,8 +19,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.security.fat.common.AlwaysRunAndPassTest;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_ibmSecurityLogout_spLogoutFalse_LTPA_Tests;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_ibmSecurityLogout_spLogoutFalse_Tests;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_ibmSecurityLogout_spLogoutTrue_LTPA_Tests;
@@ -34,7 +33,6 @@ import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.UnsolicitedSPInitia
 import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.UnsolicitedSPInitiatedLogin_ibmSecurityLogout_spLogoutTrue_LTPA_Tests;
 import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.UnsolicitedSPInitiatedLogin_ibmSecurityLogout_spLogoutTrue_Tests;
 
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -70,10 +68,17 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
 
+    /*
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/FATSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,8 +20,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.security.fat.common.AlwaysRunAndPassTest;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_2ServerLogout_usingApps_Tests;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_2ServerLogout_usingServlets_Tests;
 import com.ibm.ws.security.saml.fat.logout.IDPInitiated_Login.IDPInitiatedLogin_Timeout_usingApps_Tests;
@@ -35,7 +34,6 @@ import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.UnsolicitedSPInitia
 import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.UnsolicitedSPInitiatedLogin_Timeout_usingApps_Tests;
 import com.ibm.ws.security.saml.fat.logout.SPInitiated_Login.UnsolicitedSPInitiatedLogin_Timeout_usingServlets_Tests;
 
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -73,10 +71,17 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
 
+    /*
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
+     *
+     */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
 
     @BeforeClass
     public static void setup() throws Exception {


### PR DESCRIPTION
No tests were being run on Java 8 for many of the SAML Fats - the EE10 (and EE9) runs were the only repeats being run and they were skipped because they should only run on Java 11 and above.