### PR TITLE
Jakarta Security 3.0: Add appropriate query parameters to end_session call

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OIDCConstants.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OIDCConstants.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.oauth20.util;
 
@@ -90,6 +87,7 @@ public interface OIDCConstants extends OAuth20Constants {
     public static final String OIDC_LOGOUT_AUTO_LOGOUT = "autoLogout";
     public static final String OIDC_LOGOUT_ID_TOKEN_HINT = OIDC_AUTHZ_PARAM_ID_TOKEN_HINT;
     public static final String OIDC_LOGOUT_REDIRECT_URI = "post_logout_redirect_uri";
+    public static final String OIDC_LOGOUT_CLIENT_ID = "client_id";
 
     /* parameters for oidc discovery response */
     public static final String OIDC_DISC_ISSUER = "issuer";

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServices.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServices.java
@@ -383,9 +383,10 @@ public class OidcEndpointServices extends OAuth20EndpointServices {
         Principal user = request.getUserPrincipal();
         String idTokenString = request.getParameter(OIDCConstants.OIDC_LOGOUT_ID_TOKEN_HINT);
         String redirectUri = request.getParameter(OIDCConstants.OIDC_LOGOUT_REDIRECT_URI);
+        String clientId = request.getParameter(OIDCConstants.OIDC_LOGOUT_CLIENT_ID);
         OAuth20Token cachedIdToken = null;
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "id_token_hint : " + idTokenString + " post_logout_redirect_uri : " + redirectUri);
+            Tr.debug(tc, "id_token_hint : " + idTokenString + " post_logout_redirect_uri : " + redirectUri + " client_id : " + clientId);
         }
         if (idTokenString != null && idTokenString.length() == 0) {
             idTokenString = null;
@@ -413,7 +414,7 @@ public class OidcEndpointServices extends OAuth20EndpointServices {
 
         String userName = ((user == null) ? null : user.getName());
         String tokenUsername = ((cachedIdToken == null) ? null : cachedIdToken.getUsername());
-        String clientId = ((cachedIdToken == null) ? null : cachedIdToken.getClientId());
+        clientId = ((cachedIdToken == null) ? clientId : cachedIdToken.getClientId());
 
         if (idTokenString != null && cachedIdToken == null && continueLogoff) {
             // if it's not there parse the idTokenString and validate signature.

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/logout/LogoutHandler.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/logout/LogoutHandler.java
@@ -68,7 +68,7 @@ public class LogoutHandler {
         String redirectUrl = logoutConfig.getRedirectURI();
 
         if (logoutConfig.isNotifyProvider() && endSessionEndPoint != null) {
-            RPInitiatedLogoutStrategy rpInitiatedLogoutStrategy = new RPInitiatedLogoutStrategy(req, oidcClientConfig, endSessionEndPoint, idTokenString);
+            RPInitiatedLogoutStrategy rpInitiatedLogoutStrategy = new RPInitiatedLogoutStrategy(oidcClientConfig, endSessionEndPoint, idTokenString);
             return rpInitiatedLogoutStrategy.logout();
         } else if (!logoutConfig.isNotifyProvider() && redirectUrl != null && !redirectUrl.isEmpty()) {
             CustomLogoutStrategy customLogoutStrategy = new CustomLogoutStrategy(redirectUrl);

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/logout/RPInitiatedLogoutStrategy.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/logout/RPInitiatedLogoutStrategy.java
@@ -1,20 +1,20 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.logout;
 
-import javax.servlet.http.HttpServletRequest;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
 import javax.servlet.http.HttpServletResponse;
 
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.webcontainer.security.AuthResult;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
@@ -25,7 +25,6 @@ import io.openliberty.security.oidcclientcore.http.OidcClientHttpUtil;
 
 public class RPInitiatedLogoutStrategy {
 
-    private final HttpServletRequest req;
     private final OidcClientConfig oidcClientConfig;
     private LogoutConfig logoutConfig;
     private final String endSessionEndPoint;
@@ -33,33 +32,56 @@ public class RPInitiatedLogoutStrategy {
 
     OidcClientHttpUtil oidcClientHttpUtil = OidcClientHttpUtil.getInstance();
 
-    public RPInitiatedLogoutStrategy(HttpServletRequest req, OidcClientConfig oidcClientConfig, String endSessionEndPoint, String idTokenString) {
-        this.req = req;
+    public RPInitiatedLogoutStrategy(OidcClientConfig oidcClientConfig, String endSessionEndPoint, String idTokenString) {
         this.oidcClientConfig = oidcClientConfig;
+        if (oidcClientConfig != null) {
+            logoutConfig = oidcClientConfig.getLogoutConfig();
+        }
         this.endSessionEndPoint = endSessionEndPoint;
         this.idTokenString = idTokenString;
     }
 
     public ProviderAuthenticationResult logout() {
-        String clientId = null;
-        String redirectURI = null;
+        String endSessionUrl = buildEndSessionUrl();
+        return new ProviderAuthenticationResult(AuthResult.REDIRECT_TO_PROVIDER, HttpServletResponse.SC_OK, null, null, null, endSessionUrl);
+
+    }
+
+    String buildEndSessionUrl() {
+        String queryString = "";
         if (oidcClientConfig != null) {
-            clientId = oidcClientConfig.getClientId();
+            queryString = appendParameter(queryString, "client_id", oidcClientConfig.getClientId());
         }
         if (logoutConfig != null) {
-            redirectURI = logoutConfig.getRedirectURI();
+            queryString = appendParameter(queryString, JakartaOIDCConstants.POST_LOGOUT_REDIRECT_URI, logoutConfig.getRedirectURI());
         }
-
-        if (idTokenString != null) {
-            req.setAttribute(JakartaOIDCConstants.ID_TOKEN_HINT, idTokenString);
+        queryString = appendParameter(queryString, JakartaOIDCConstants.ID_TOKEN_HINT, idTokenString);
+        String endSessionUrlWithQueryParams = endSessionEndPoint;
+        if (!endSessionEndPoint.contains("?")) {
+            endSessionUrlWithQueryParams += "?";
+        } else {
+            endSessionUrlWithQueryParams += "&";
         }
-        req.setAttribute(JakartaOIDCConstants.CLIENT_ID, clientId);
-        if (redirectURI != null && !redirectURI.isEmpty()) {
-            req.setAttribute(JakartaOIDCConstants.POST_LOGOUT_REDIRECT_URI, redirectURI);
+        endSessionUrlWithQueryParams += queryString;
+        return endSessionUrlWithQueryParams;
+    }
+
+    @FFDCIgnore(UnsupportedEncodingException.class)
+    String appendParameter(String queryString, String parameterName, String parameterValue) {
+        if (parameterValue != null && !parameterValue.isEmpty()) {
+            if (queryString == null) {
+                queryString = "";
+            }
+            if (!queryString.isEmpty()) {
+                queryString += "&";
+            }
+            try {
+                queryString += parameterName + "=" + URLEncoder.encode(parameterValue, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                // Do nothing - UTF-8 should be supported.
+            }
         }
-
-        return new ProviderAuthenticationResult(AuthResult.REDIRECT_TO_PROVIDER, HttpServletResponse.SC_OK, null, null, null, endSessionEndPoint);
-
+        return queryString;
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/logout/RPInitiatedLogoutStrategy.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/logout/RPInitiatedLogoutStrategy.java
@@ -55,12 +55,16 @@ public class RPInitiatedLogoutStrategy {
         if (logoutConfig != null) {
             queryString = appendParameter(queryString, JakartaOIDCConstants.POST_LOGOUT_REDIRECT_URI, logoutConfig.getRedirectURI());
         }
-        queryString = appendParameter(queryString, JakartaOIDCConstants.ID_TOKEN_HINT, idTokenString);
+        // Will look at including the ID token hint later
+//        queryString = appendParameter(queryString, JakartaOIDCConstants.ID_TOKEN_HINT, idTokenString);
+
         String endSessionUrlWithQueryParams = endSessionEndPoint;
-        if (!endSessionEndPoint.contains("?")) {
-            endSessionUrlWithQueryParams += "?";
-        } else {
-            endSessionUrlWithQueryParams += "&";
+        if (!queryString.isEmpty()) {
+            if (!endSessionEndPoint.contains("?")) {
+                endSessionUrlWithQueryParams += "?";
+            } else {
+                endSessionUrlWithQueryParams += "&";
+            }
         }
         endSessionUrlWithQueryParams += queryString;
         return endSessionUrlWithQueryParams;

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/logout/LogoutTests.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/logout/LogoutTests.java
@@ -1,22 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.logout;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import javax.servlet.http.HttpServletRequest;
-
-import org.jmock.Expectations;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -26,6 +21,7 @@ import com.ibm.ws.security.test.common.CommonTestClass;
 import com.ibm.ws.webcontainer.security.AuthResult;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
+import io.openliberty.security.oidcclientcore.JakartaOIDCConstants;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import test.common.SharedOutputManager;
 
@@ -37,8 +33,7 @@ public class LogoutTests extends CommonTestClass {
     private static final String redirectURI = "http://redirect-uri.com/some/path";
     private static final String idToken = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOi8vaGFybW9uaWM6ODAxMS9vYXV0aDIvZW5kcG9pbnQvT0F1dGhDb25maWdTYW1wbGUvdG9rZW4iLCJpYXQiOjEzODczODM5NTMsInN1YiI6InRlc3R1c2VyIiwiZXhwIjoxMzg3Mzg3NTUzLCJhdWQiOiJjbGllbnQwMSJ9.ottD3eYa6qrnItRpL_Q9UaKumAyo14LnlvwnyF3Kojk";
 
-    private final OidcClientConfig oidcClientConfigMock = null; // mockery.mock(OidcClientConfig.class);
-    private final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
+    private final OidcClientConfig oidcClientConfigMock = null;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
@@ -58,19 +53,15 @@ public class LogoutTests extends CommonTestClass {
 
     @Test
     public void test_RPInitiatedLogoutStrategy() throws Exception {
-        mockery.checking(new Expectations() {
-            {
-                allowing(request).setAttribute("id_token_hint", idToken);
-                allowing(request).setAttribute("post_logout_redirect_uri", null);
-                allowing(request).setAttribute("post_logout_redirect_uri", null);
-            }
-        });
-        RPInitiatedLogoutStrategy rpInitiatedLogoutStrategy = new RPInitiatedLogoutStrategy(request, oidcClientConfigMock, endSessionEndpoint, idToken);
+        RPInitiatedLogoutStrategy rpInitiatedLogoutStrategy = new RPInitiatedLogoutStrategy(oidcClientConfigMock, endSessionEndpoint, idToken);
         ProviderAuthenticationResult result = rpInitiatedLogoutStrategy.logout();
 
-        assertTrue(result.getStatus().equals(AuthResult.REDIRECT_TO_PROVIDER));
-        assertTrue(result.getHttpStatusCode() == 200);
-        assertTrue(result.getRedirectUrl().equals(endSessionEndpoint));
+        assertTrue("ProviderAuthenticationResult status [" + result.getStatus() + "] did not match expected value [" + AuthResult.REDIRECT_TO_PROVIDER + "].",
+                   result.getStatus().equals(AuthResult.REDIRECT_TO_PROVIDER));
+        assertEquals("HTTP status code did not match expected value.", 200, result.getHttpStatusCode());
+
+        String expectedRedirectUrl = endSessionEndpoint + "?" + JakartaOIDCConstants.ID_TOKEN_HINT + "=" + idToken;
+        assertEquals("Redirect URL did not match expected value.", expectedRedirectUrl, result.getRedirectUrl());
     }
 
     @Test
@@ -78,8 +69,10 @@ public class LogoutTests extends CommonTestClass {
         CustomLogoutStrategy customLogoutStrategy = new CustomLogoutStrategy(redirectURI);
         ProviderAuthenticationResult result = customLogoutStrategy.logout();
 
-        assertTrue(result.getStatus().equals(AuthResult.REDIRECT_TO_PROVIDER));
-        assertTrue(result.getHttpStatusCode() == 200);
-        assertTrue(result.getRedirectUrl().equals(redirectURI));
+        assertTrue("ProviderAuthenticationResult status [" + result.getStatus() + "] did not match expected value [" + AuthResult.REDIRECT_TO_PROVIDER + "].",
+                   result.getStatus().equals(AuthResult.REDIRECT_TO_PROVIDER));
+        assertEquals("HTTP status code did not match expected value.", 200, result.getHttpStatusCode());
+        assertEquals("Redirect URL did not match expected value.", redirectURI, result.getRedirectUrl());
     }
+
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/logout/LogoutTests.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/logout/LogoutTests.java
@@ -21,7 +21,6 @@ import com.ibm.ws.security.test.common.CommonTestClass;
 import com.ibm.ws.webcontainer.security.AuthResult;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 
-import io.openliberty.security.oidcclientcore.JakartaOIDCConstants;
 import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
 import test.common.SharedOutputManager;
 
@@ -60,7 +59,7 @@ public class LogoutTests extends CommonTestClass {
                    result.getStatus().equals(AuthResult.REDIRECT_TO_PROVIDER));
         assertEquals("HTTP status code did not match expected value.", 200, result.getHttpStatusCode());
 
-        String expectedRedirectUrl = endSessionEndpoint + "?" + JakartaOIDCConstants.ID_TOKEN_HINT + "=" + idToken;
+        String expectedRedirectUrl = endSessionEndpoint;
         assertEquals("Redirect URL did not match expected value.", expectedRedirectUrl, result.getRedirectUrl());
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/logout/RPInitiatedLogoutStrategyTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/logout/RPInitiatedLogoutStrategyTest.java
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.logout;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URLEncoder;
+
+import org.jmock.Expectations;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import io.openliberty.security.oidcclientcore.JakartaOIDCConstants;
+import io.openliberty.security.oidcclientcore.client.LogoutConfig;
+import io.openliberty.security.oidcclientcore.client.OidcClientConfig;
+import test.common.SharedOutputManager;
+
+public class RPInitiatedLogoutStrategyTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    private final OidcClientConfig oidcClientConfig = mockery.mock(OidcClientConfig.class);
+    private final LogoutConfig logoutConfig = mockery.mock(LogoutConfig.class);
+
+    private static final String CLIENT_ID = "myClientId";
+    private static final String END_SESSION_ENDPOINT = "https://localhost/oidc/op/end_session";
+    private static final String ID_TOKEN_STRING = "xxx.yyy.zzz";
+    private static final String POST_LOGOUT_REDIRECT_URI = "https://localhost/rp/post_logout";
+
+    RPInitiatedLogoutStrategy logoutStrategy;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() {
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientConfig).getLogoutConfig();
+                will(returnValue(logoutConfig));
+            }
+        });
+        logoutStrategy = new RPInitiatedLogoutStrategy(oidcClientConfig, END_SESSION_ENDPOINT, ID_TOKEN_STRING);
+    }
+
+    @After
+    public void tearDown() {
+        outputMgr.resetStreams();
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_buildEndSessionUrl_noLogoutConfig_noIdString() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientConfig).getLogoutConfig();
+                will(returnValue(null));
+                one(oidcClientConfig).getClientId();
+                will(returnValue(CLIENT_ID));
+            }
+        });
+        logoutStrategy = new RPInitiatedLogoutStrategy(oidcClientConfig, END_SESSION_ENDPOINT, null);
+
+        String expectedResult = END_SESSION_ENDPOINT + "?client_id=" + CLIENT_ID;
+
+        String result = logoutStrategy.buildEndSessionUrl();
+        assertEquals("End session URL did not match expected value.", expectedResult, result);
+    }
+
+    @Test
+    public void test_buildEndSessionUrl_noLogoutConfig_withIdString() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientConfig).getLogoutConfig();
+                will(returnValue(null));
+                one(oidcClientConfig).getClientId();
+                will(returnValue(CLIENT_ID));
+            }
+        });
+        logoutStrategy = new RPInitiatedLogoutStrategy(oidcClientConfig, END_SESSION_ENDPOINT, ID_TOKEN_STRING);
+
+        String expectedResult = END_SESSION_ENDPOINT + "?client_id=" + CLIENT_ID + "&" + JakartaOIDCConstants.ID_TOKEN_HINT + "=" + URLEncoder.encode(ID_TOKEN_STRING, "UTF-8");
+
+        String result = logoutStrategy.buildEndSessionUrl();
+        assertEquals("End session URL did not match expected value.", expectedResult, result);
+    }
+
+    @Test
+    public void test_buildEndSessionUrl_withLogoutConfig_noRedirectUri_withIdString() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientConfig).getClientId();
+                will(returnValue(CLIENT_ID));
+                one(logoutConfig).getRedirectURI();
+                will(returnValue(null));
+            }
+        });
+
+        String expectedResult = END_SESSION_ENDPOINT + "?client_id=" + CLIENT_ID + "&" + JakartaOIDCConstants.ID_TOKEN_HINT + "=" + URLEncoder.encode(ID_TOKEN_STRING, "UTF-8");
+
+        String result = logoutStrategy.buildEndSessionUrl();
+        assertEquals("End session URL did not match expected value.", expectedResult, result);
+    }
+
+    @Test
+    public void test_buildEndSessionUrl_withLogoutConfig_withRedirectUri_withIdString() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                one(oidcClientConfig).getClientId();
+                will(returnValue(CLIENT_ID));
+                one(logoutConfig).getRedirectURI();
+                will(returnValue(POST_LOGOUT_REDIRECT_URI));
+            }
+        });
+
+        String expectedResult = END_SESSION_ENDPOINT + "?client_id=" + CLIENT_ID + "&" + JakartaOIDCConstants.POST_LOGOUT_REDIRECT_URI + "="
+                                + URLEncoder.encode(POST_LOGOUT_REDIRECT_URI, "UTF-8") + "&" + JakartaOIDCConstants.ID_TOKEN_HINT + "="
+                                + URLEncoder.encode(ID_TOKEN_STRING, "UTF-8");
+
+        String result = logoutStrategy.buildEndSessionUrl();
+        assertEquals("End session URL did not match expected value.", expectedResult, result);
+    }
+
+    @Test
+    public void test_appendParameter_nullValue() throws Exception {
+        String queryString = "";
+        String parameterValue = null;
+        String result = logoutStrategy.appendParameter(queryString, "name", parameterValue);
+        assertEquals("Query string should not have changed.", queryString, result);
+    }
+
+    @Test
+    public void test_appendParameter_emptyValue() throws Exception {
+        String queryString = "";
+        String parameterValue = "";
+        String result = logoutStrategy.appendParameter(queryString, "name", parameterValue);
+        assertEquals("Query string should not have changed.", queryString, result);
+    }
+
+    @Test
+    public void test_appendParameter_simpleValue() throws Exception {
+        String queryString = "";
+        String parameterValue = "simple_string";
+        String result = logoutStrategy.appendParameter(queryString, "name", parameterValue);
+
+        String expectedResult = "name=" + parameterValue;
+        assertEquals("Query string did not match expected value.", expectedResult, result);
+    }
+
+    @Test
+    public void test_appendParameter_complexValue() throws Exception {
+        String queryString = "";
+        String parameterValue = "start !@#$%^&*()-= end";
+        String result = logoutStrategy.appendParameter(queryString, "name", parameterValue);
+
+        String expectedResult = "name=" + URLEncoder.encode(parameterValue, "UTF-8");
+        assertEquals("Query string did not match expected value.", expectedResult, result);
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/logout/RPInitiatedLogoutStrategyTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/logout/RPInitiatedLogoutStrategyTest.java
@@ -99,7 +99,7 @@ public class RPInitiatedLogoutStrategyTest extends CommonTestClass {
         });
         logoutStrategy = new RPInitiatedLogoutStrategy(oidcClientConfig, END_SESSION_ENDPOINT, ID_TOKEN_STRING);
 
-        String expectedResult = END_SESSION_ENDPOINT + "?client_id=" + CLIENT_ID + "&" + JakartaOIDCConstants.ID_TOKEN_HINT + "=" + URLEncoder.encode(ID_TOKEN_STRING, "UTF-8");
+        String expectedResult = END_SESSION_ENDPOINT + "?client_id=" + CLIENT_ID;
 
         String result = logoutStrategy.buildEndSessionUrl();
         assertEquals("End session URL did not match expected value.", expectedResult, result);
@@ -116,7 +116,7 @@ public class RPInitiatedLogoutStrategyTest extends CommonTestClass {
             }
         });
 
-        String expectedResult = END_SESSION_ENDPOINT + "?client_id=" + CLIENT_ID + "&" + JakartaOIDCConstants.ID_TOKEN_HINT + "=" + URLEncoder.encode(ID_TOKEN_STRING, "UTF-8");
+        String expectedResult = END_SESSION_ENDPOINT + "?client_id=" + CLIENT_ID;
 
         String result = logoutStrategy.buildEndSessionUrl();
         assertEquals("End session URL did not match expected value.", expectedResult, result);
@@ -134,8 +134,7 @@ public class RPInitiatedLogoutStrategyTest extends CommonTestClass {
         });
 
         String expectedResult = END_SESSION_ENDPOINT + "?client_id=" + CLIENT_ID + "&" + JakartaOIDCConstants.POST_LOGOUT_REDIRECT_URI + "="
-                                + URLEncoder.encode(POST_LOGOUT_REDIRECT_URI, "UTF-8") + "&" + JakartaOIDCConstants.ID_TOKEN_HINT + "="
-                                + URLEncoder.encode(ID_TOKEN_STRING, "UTF-8");
+                                + URLEncoder.encode(POST_LOGOUT_REDIRECT_URI, "UTF-8");
 
         String result = logoutStrategy.buildEndSessionUrl();
         assertEquals("End session URL did not match expected value.", expectedResult, result);


### PR DESCRIPTION
The `RPInitiatedLogoutStrategy` code sets the query parameters needed for the end_session call in the wrong place. Before, they were being set as attributes in an unrelated `HttpServletRequest` object. Now they'll be added as query parameters in the end_session URL.