### PR TITLE
Added TCP portOpenRetries to MpHealth20 FAT to resolve port binding issues

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/DelayAppStartupHealthCheckTest.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/DelayAppStartupHealthCheckTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.microprofile.health20.fat;
 
@@ -31,6 +28,7 @@ import javax.json.JsonObject;
 
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -104,6 +102,13 @@ public class DelayAppStartupHealthCheckTest {
         if (server1.isStarted()) {
             server1.stopServer(EXPECTED_FAILURES);
         }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Once the tests and repeated tests are completed, ensure the server
+        // is fully stopped, in order to avoid conflicts with succeeding tests.
+        server1.stopServer(EXPECTED_FAILURES);
     }
 
     @Test

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/MultipleHealthCheckTest.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/MultipleHealthCheckTest.java
@@ -4,11 +4,8 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.microprofile.health20.fat;
 

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/ApplicationStateHealthCheck/server.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/ApplicationStateHealthCheck/server.xml
@@ -11,5 +11,10 @@
     </featureManager>
 
     <logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:com.ibm.websphere.org.eclipse.microprofile.health.2.0.*=all=enabled"/>
-    <webContainer deferServletLoad="false"/> 
+    <webContainer deferServletLoad="false"/>
+    
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+        <tcpOptions portOpenRetries="60" />                   
+    </httpEndpoint>
+    
 </server>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/DelayedHealthCheck/server.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/DelayedHealthCheck/server.xml
@@ -13,5 +13,10 @@
 	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:com.ibm.websphere.org.eclipse.microprofile.health.2.0.*=all=enabled"/>
 
 	<application location="DelayedHealthCheckApp.war"/>
-    <webContainer deferServletLoad="false"/> 
+    <webContainer deferServletLoad="false"/>
+    
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+        <tcpOptions portOpenRetries="60" />                   
+    </httpEndpoint>
+     
 </server>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/DifferentAppNameHealthCheck/server.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/DifferentAppNameHealthCheck/server.xml
@@ -13,4 +13,8 @@
 
 	<application name="DifferentAppNameHealthCheckApp-2.0" type="war" location="DifferentAppNameHealthCheckApp.war" autoStart="true"></application>
 	
+	<httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+		<tcpOptions portOpenRetries="60" />                   
+	</httpEndpoint>
+	
 </server>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/FailedApplicationStateHealthCheck/server.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/FailedApplicationStateHealthCheck/server.xml
@@ -43,4 +43,9 @@
     <javaPermission codebase="${kafkaCodebase}" className="java.net.SocketPermission" name="*" actions="connect"/>
     <javaPermission codebase="${kafkaCodebase}" className="java.lang.RuntimePermission" name="getClassLoader" actions="*"/>
     <javaPermission codebase="${kafkaCodebase}" className="java.io.FilePermission" name="*" actions="read"/>
+    
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+        <tcpOptions portOpenRetries="60" />                   
+    </httpEndpoint>
+	
 </server>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/MultipleHealthCheck/server.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/MultipleHealthCheck/server.xml
@@ -13,4 +13,8 @@
 
 	<application name="MultipleHealthCheckApp" type="war" location="MultipleHealthCheckApp.war" autoStart="true"></application>
 	
+	<httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+		<tcpOptions portOpenRetries="60" />                   
+	</httpEndpoint>
+	
 </server>


### PR DESCRIPTION
fixes #23872 
- The MpHealth20 FATs were failing, due to unable to bind to a port. Added "portOpenRetries=60" to all the server.xml in the FAT, so it tries to bind a port, at least 60 times before failing.
- The port conflicts maybe a result of infrastructure issues/slowness, where the previous tests may not have released the port in time, for the other tests to use. This method will allow some time for the ports to be released, before they can get used again.