### PR TITLE
Revert "Issue 21120: gate new function on beta edition"

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config.openapi/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.config.openapi/bnd.bnd
@@ -28,14 +28,13 @@ Private-Package:\
 -dsannotations:\
   com.ibm.ws.rest.handler.config.openapi.ConfigSchemaRESTHandler
 
--buildpath: \
-	com.ibm.websphere.appserver.spi.logging,\
-	com.ibm.websphere.org.osgi.core,\
-	com.ibm.websphere.rest.handler;version=latest,\
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-	com.ibm.ws.microprofile.openapi;version=latest,\
-	com.ibm.websphere.org.eclipse.microprofile.openapi.1.0;version=latest,\
-	io.openliberty.com.fasterxml.jackson;version=latest,\
-	com.ibm.ws.logging;version=latest,\
-	com.ibm.ws.kernel.boot
+-buildpath:\
+  com.ibm.websphere.appserver.spi.logging,\
+  com.ibm.websphere.org.osgi.core,\
+  com.ibm.websphere.rest.handler;version=latest,\
+  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+  com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+  com.ibm.ws.microprofile.openapi;version=latest,\
+  com.ibm.websphere.org.eclipse.microprofile.openapi.1.0;version=latest,\
+  io.openliberty.com.fasterxml.jackson;version=latest,\
+  com.ibm.ws.logging;version=latest

--- a/dev/com.ibm.ws.rest.handler.config.openapi/src/com/ibm/ws/rest/handler/config/openapi/ConfigSchemaRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config.openapi/src/com/ibm/ws/rest/handler/config/openapi/ConfigSchemaRESTHandler.java
@@ -22,7 +22,6 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.microprofile.openapi.Constants;
 import com.ibm.ws.microprofile.openapi.impl.core.util.Json;
 import com.ibm.ws.microprofile.openapi.impl.core.util.Yaml;
@@ -58,14 +57,6 @@ public class ConfigSchemaRESTHandler implements RESTHandler {
             }
             response.setResponseHeader("Accept", "GET");
             response.sendError(405); // Method Not Allowed
-            return;
-        }
-
-        // Delete once feature 18696 is GA.
-        // Remove com.ibm.ws.kernel.boot from bnd buildpath once the Beta check is no longer needed.
-        if (!ProductInfo.getBetaEdition() && request.getContextPath().contains("/ibm/api")) {
-            response.setResponseHeader("Accept", "GET");
-            response.sendError(404); // Not Found
             return;
         }
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigOpenApiSchemaTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigOpenApiSchemaTest.java
@@ -37,6 +37,7 @@ import componenttest.topology.utils.HttpsRequest;
 
 @RunWith(FATRunner.class)
 public class ConfigOpenApiSchemaTest extends FATServletClient {
+
     /**  */
     private static final String SERVER_NAME = "com.ibm.ws.rest.handler.config.openapi.fat";
 
@@ -46,9 +47,6 @@ public class ConfigOpenApiSchemaTest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         FATSuite.setupServerSideAnnotations(server);
-
-        // Delete once feature 18696 is GA.
-        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
 
         server.startServer();
 

--- a/dev/com.ibm.ws.rest.handler.validator.openapi/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator.openapi/bnd.bnd
@@ -41,5 +41,4 @@ Include-Resource: \
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.ws.microprofile.openapi,\
 	io.openliberty.com.fasterxml.jackson;version=latest,\
-	com.ibm.websphere.org.eclipse.microprofile.openapi.1.0,\
-	com.ibm.ws.kernel.boot
+	com.ibm.websphere.org.eclipse.microprofile.openapi.1.0

--- a/dev/com.ibm.ws.rest.handler.validator.openapi/src/com/ibm/ws/rest/handler/validator/openapi/ValidatorSchemaRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator.openapi/src/com/ibm/ws/rest/handler/validator/openapi/ValidatorSchemaRESTHandler.java
@@ -34,7 +34,6 @@ import org.osgi.service.component.annotations.Deactivate;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.microprofile.openapi.Constants;
 import com.ibm.ws.microprofile.openapi.impl.core.util.Json;
 import com.ibm.ws.microprofile.openapi.impl.core.util.Yaml;
@@ -73,14 +72,6 @@ public class ValidatorSchemaRESTHandler implements RESTHandler {
             }
             response.setResponseHeader("Accept", "GET");
             response.sendError(405); // Method Not Allowed
-            return;
-        }
-
-        // Delete once feature 18696 is GA.
-        // Remove com.ibm.ws.kernel.boot from bnd buildpath once the Beta check is no longer needed.
-        if (!ProductInfo.getBetaEdition() && request.getContextPath().contains("/ibm/api")) {
-            response.setResponseHeader("Accept", "GET");
-            response.sendError(404); // Not Found
             return;
         }
 
@@ -136,16 +127,16 @@ public class ValidatorSchemaRESTHandler implements RESTHandler {
         try {
             cloudantEnabled = getServiceReferences(context.getBundleContext(), Validator.class,
                                                    "(component.name=com.ibm.ws.rest.handler.validator.cloudant.CloudantDatabaseValidator)")
-                            .iterator()
-                            .hasNext();
+                                                                   .iterator()
+                                                                   .hasNext();
             jcaEnabled = getServiceReferences(context.getBundleContext(), Validator.class,
                                               "(component.name=com.ibm.ws.rest.handler.validator.jca.ConnectionFactoryValidator)")
-                            .iterator()
-                            .hasNext();
+                                                              .iterator()
+                                                              .hasNext();
             jdbcEnabled = getServiceReferences(context.getBundleContext(), Validator.class,
                                                "(component.name=com.ibm.ws.rest.handler.validator.jdbc.DataSourceValidator)")
-                            .iterator()
-                            .hasNext();
+                                                               .iterator()
+                                                               .hasNext();
         } catch (InvalidSyntaxException e) {
             //Should never happen.
             e.printStackTrace();

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
@@ -73,9 +73,6 @@ public class ValidateOpenApiSchemaTest extends FATServletClient {
         jar.addPackage("com.ibm.ws.rest.handler.validator.loginmodule");
         ShrinkHelper.exportToServer(server, "/", jar, SERVER_ONLY);
 
-        // Delete once feature 18696 is GA.
-        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
-
         server.startServer();
 
         // Wait for the API to become available

--- a/dev/io.openliberty.rest.handler.config.openapi.2.0/bnd.bnd
+++ b/dev/io.openliberty.rest.handler.config.openapi.2.0/bnd.bnd
@@ -33,13 +33,12 @@ Private-Package:\
   io.openliberty.rest.handler.config.openapi20.ConfigSchemaRESTHandler
 
 -buildpath: \
-	com.ibm.websphere.appserver.spi.logging,\
-	com.ibm.websphere.rest.handler;version=latest,\
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.wsspi.org.osgi.service.component.annotations,\
-	com.ibm.ws.rest.handler.validator,\
-	com.ibm.websphere.org.osgi.service.component,\
-	com.ibm.websphere.org.osgi.core,\
-	io.openliberty.io.smallrye.openapi.core,\
-	io.openliberty.org.eclipse.microprofile.openapi.2.0,\
-	com.ibm.ws.kernel.boot
+    com.ibm.websphere.appserver.spi.logging,\
+    com.ibm.websphere.rest.handler;version=latest,\
+    com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+    com.ibm.wsspi.org.osgi.service.component.annotations,\
+    com.ibm.ws.rest.handler.validator,\
+    com.ibm.websphere.org.osgi.service.component,\
+    com.ibm.websphere.org.osgi.core,\
+    io.openliberty.io.smallrye.openapi.core,\
+    io.openliberty.org.eclipse.microprofile.openapi.2.0

--- a/dev/io.openliberty.rest.handler.config.openapi.2.0/src/io/openliberty/rest/handler/config/openapi20/ConfigSchemaRESTHandler.java
+++ b/dev/io.openliberty.rest.handler.config.openapi.2.0/src/io/openliberty/rest/handler/config/openapi20/ConfigSchemaRESTHandler.java
@@ -19,7 +19,6 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.wsspi.rest.handler.RESTHandler;
 import com.ibm.wsspi.rest.handler.RESTRequest;
 import com.ibm.wsspi.rest.handler.RESTResponse;
@@ -54,14 +53,6 @@ public class ConfigSchemaRESTHandler implements RESTHandler {
             }
             response.setResponseHeader("Accept", "GET");
             response.sendError(405); // Method Not Allowed
-            return;
-        }
-
-        // Delete once feature 18696 is GA.
-        // Remove com.ibm.ws.kernel.boot from bnd buildpath once the Beta check is no longer needed.
-        if (!ProductInfo.getBetaEdition() && request.getContextPath().contains("/ibm/api")) {
-            response.setResponseHeader("Accept", "GET");
-            response.sendError(404); // Not Found
             return;
         }
 

--- a/dev/io.openliberty.rest.handler.validator.openapi.2.0/bnd.bnd
+++ b/dev/io.openliberty.rest.handler.validator.openapi.2.0/bnd.bnd
@@ -38,13 +38,12 @@ Include-Resource: \
   io.openliberty.rest.handler.validator.openapi20.ValidatorSchemaRESTHandler
 
 -buildpath: \
-	com.ibm.websphere.appserver.spi.logging,\
-	com.ibm.websphere.rest.handler;version=latest,\
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.wsspi.org.osgi.service.component.annotations,\
-	com.ibm.ws.rest.handler.validator,\
-	com.ibm.websphere.org.osgi.service.component,\
-	com.ibm.websphere.org.osgi.core,\
-	io.openliberty.io.smallrye.openapi.core,\
-	io.openliberty.org.eclipse.microprofile.openapi.2.0,\
-	com.ibm.ws.kernel.boot
+    com.ibm.websphere.appserver.spi.logging,\
+    com.ibm.websphere.rest.handler;version=latest,\
+    com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+    com.ibm.wsspi.org.osgi.service.component.annotations,\
+    com.ibm.ws.rest.handler.validator,\
+    com.ibm.websphere.org.osgi.service.component,\
+    com.ibm.websphere.org.osgi.core,\
+    io.openliberty.io.smallrye.openapi.core,\
+    io.openliberty.org.eclipse.microprofile.openapi.2.0

--- a/dev/io.openliberty.rest.handler.validator.openapi.2.0/src/io/openliberty/rest/handler/validator/openapi20/ValidatorSchemaRESTHandler.java
+++ b/dev/io.openliberty.rest.handler.validator.openapi.2.0/src/io/openliberty/rest/handler/validator/openapi20/ValidatorSchemaRESTHandler.java
@@ -31,7 +31,6 @@ import org.osgi.service.component.annotations.Deactivate;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.wsspi.rest.handler.RESTHandler;
 import com.ibm.wsspi.rest.handler.RESTRequest;
 import com.ibm.wsspi.rest.handler.RESTResponse;
@@ -45,9 +44,11 @@ import io.smallrye.openapi.runtime.io.OpenApiSerializer;
 /**
  * Displays validation schema
  */
-@Component(configurationPolicy = ConfigurationPolicy.IGNORE, service = { RESTHandler.class }, property = { RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/openapi/platform",
-                                                                                                           RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/ibm/api/platform",
-                                                                                                           RESTHandler.PROPERTY_REST_HANDLER_ROOT + "=/validation" })
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE, 
+           service = { RESTHandler.class }, 
+           property = { RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/openapi/platform",
+                        RESTHandler.PROPERTY_REST_HANDLER_CONTEXT_ROOT + "=/ibm/api/platform",
+                        RESTHandler.PROPERTY_REST_HANDLER_ROOT + "=/validation" })
 public class ValidatorSchemaRESTHandler implements RESTHandler {
     private static final TraceComponent tc = Tr.register(ValidatorSchemaRESTHandler.class);
 
@@ -67,14 +68,6 @@ public class ValidatorSchemaRESTHandler implements RESTHandler {
             }
             response.setResponseHeader("Accept", "GET");
             response.sendError(405); // Method Not Allowed
-            return;
-        }
-
-        // Delete once feature 18696 is GA.
-        // Remove com.ibm.ws.kernel.boot from bnd buildpath once the Beta check is no longer needed.
-        if (!ProductInfo.getBetaEdition() && request.getContextPath().contains("/ibm/api")) {
-            response.setResponseHeader("Accept", "GET");
-            response.sendError(404); // Not Found
             return;
         }
 


### PR DESCRIPTION
Reverting to prepare Admin Center test connection function fo GA. This revert removes the beta gates in place for the new rest handler validor/config endpoints.

This reverts commit 6f94b84f08f0dc5762a9d0cb17ab7709e186da4a.