### PR TITLE
allow more output to response following exception in forward based on wc parm

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/FATSuite.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.jsp23.fat;
 
@@ -21,6 +18,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import com.ibm.ws.fat.util.FatLogHandler;
 import com.ibm.ws.jsp23.fat.tests.JSP23JSP22ServerTest;
 import com.ibm.ws.jsp23.fat.tests.JSPCdiTest;
+import com.ibm.ws.jsp23.fat.tests.JSPExceptionTests;
 import com.ibm.ws.jsp23.fat.tests.JSPJava8Test;
 import com.ibm.ws.jsp23.fat.tests.JSPPrepareJSPThreadCountDefaultValueTests;
 import com.ibm.ws.jsp23.fat.tests.JSPPrepareJSPThreadCountNonDefaultValueTests;
@@ -28,11 +26,10 @@ import com.ibm.ws.jsp23.fat.tests.JSPSkipMetaInfTests;
 import com.ibm.ws.jsp23.fat.tests.JSPTests;
 import com.ibm.ws.jsp23.fat.tests.JSTLTests;
 
-import componenttest.topology.impl.JavaInfo;
-
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.JavaInfo;
 
 /**
  * JSP 2.3 Tests
@@ -42,6 +39,7 @@ import componenttest.rules.repeater.RepeatTests;
 @RunWith(Suite.class)
 @SuiteClasses({
                 JSPTests.class,
+                JSPExceptionTests.class,
                 JSPSkipMetaInfTests.class,
                 JSPJava8Test.class,
                 JSPCdiTest.class,
@@ -68,24 +66,23 @@ public class FATSuite {
     public static RepeatTests repeat;
 
     static {
-        if(JavaInfo.JAVA_VERSION>=11)
-        {
+        if (JavaInfo.JAVA_VERSION >= 11) {
             repeat = RepeatTests
-                    .with(new EmptyAction().fullFATOnly())
-                    .andWith(new FeatureReplacementAction("cdi-1.2", "cdi-2.0")
-                            .withID("CDI-2.0")
-                            .forceAddFeatures(false)
-                            .fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE10_FEATURES());
+                            .with(new EmptyAction().fullFATOnly())
+                            .andWith(new FeatureReplacementAction("cdi-1.2", "cdi-2.0")
+                                            .withID("CDI-2.0")
+                                            .forceAddFeatures(false)
+                                            .fullFATOnly())
+                            .andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly())
+                            .andWith(FeatureReplacementAction.EE10_FEATURES());
         } else {
             repeat = RepeatTests
-                        .with(new EmptyAction().fullFATOnly())
-                        .andWith(new FeatureReplacementAction("cdi-1.2", "cdi-2.0")
-                                        .withID("CDI-2.0")
-                                        .forceAddFeatures(false)
-                                        .fullFATOnly())
-                        .andWith(FeatureReplacementAction.EE9_FEATURES());
+                            .with(new EmptyAction().fullFATOnly())
+                            .andWith(new FeatureReplacementAction("cdi-1.2", "cdi-2.0")
+                                            .withID("CDI-2.0")
+                                            .forceAddFeatures(false)
+                                            .fullFATOnly())
+                            .andWith(FeatureReplacementAction.EE9_FEATURES());
         }
     }
 }

--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPExceptionTests.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPExceptionTests.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jsp23.fat.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.logging.Logger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jsp23.fat.JSPUtils;
+import com.meterware.httpunit.GetMethodWebRequest;
+import com.meterware.httpunit.WebConversation;
+import com.meterware.httpunit.WebRequest;
+import com.meterware.httpunit.WebResponse;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Test exception behavior from JSP
+ */
+
+@SkipForRepeat("CDI-2.0")
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class JSPExceptionTests {
+    private static final Logger LOG = Logger.getLogger(JSPExceptionTests.class.getName());
+    private static final String APP_NAME = "TestServlet";
+
+    @Server("jspServletExceptionWrapServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, APP_NAME + ".war"); 
+        server.startServer(JSPExceptionTests.class.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Stop the server, with expected exception
+        if (server != null && server.isStarted()) {
+            server.stopServer("SRVE0777E");
+        }
+    }
+
+    /**
+     * Test Exception in log following exception in dispatch forward
+     * call with donotcloseoutputonforwardforservleterror=true
+     *
+     * @throws Exception
+     *                       if something goes wrong
+     */
+    @Test
+    public void testServletException() throws Exception {
+        String verifyText1 = "java.lang.Exception: Exception from JSP";
+        String verifyText2 = "com.ibm.websphere.servlet.error.ServletErrorReport: java.lang.Exception: Exception from JSP";
+        server.setMarkToEndOfLog();
+
+        WebConversation wc = new WebConversation();
+        wc.setExceptionsThrownOnErrorStatus(false);
+
+        String url = JSPUtils.createHttpUrlString(server, APP_NAME, "exception.jsp");
+        LOG.info("url: " + url);
+
+        WebRequest request = new GetMethodWebRequest(url);
+        WebResponse response = wc.getResponse(request);
+        LOG.info("Response: " + response.getText());
+        //exception.jsp throws 'Exception',
+        //   response code is 500
+        //   both response and messages.log have the verify messages
+        assertEquals("Expected " + 500 + " status code was not returned!",
+                     500, response.getResponseCode());
+        assertTrue("Response should contain " + verifyText1 + ".",
+                   response.getText().contains(verifyText1));
+        assertTrue("Log should contain " + verifyText2 + ".",
+                   null != server.waitForStringInLogUsingMark(verifyText2));
+    }
+
+    /**
+     * Test that previously truncated text appears in response from
+     * forwarded exception with donotcloseoutputonforwardforservleterror=true
+     *
+     * @throws Exception
+     *                       if something goes wrong
+     */
+    @Test
+    public void testFwdException() throws Exception {
+        String verifyText1 = "more text following flush";
+
+        WebConversation wc = new WebConversation();
+        wc.setExceptionsThrownOnErrorStatus(false);
+
+        String url = JSPUtils.createHttpUrlString(server, APP_NAME, "testfwdexc.jsp");
+        LOG.info("url: " + url);
+
+        WebRequest request = new GetMethodWebRequest(url);
+        WebResponse response = wc.getResponse(request);
+        LOG.info("Response: " + response.getText());
+        //after forward, exception.jsp throws 'Exception', testfwdexc catches and creates more output
+        //   response code is 200
+        //   response contains text that previously would have been truncated
+        assertEquals("Expected " + 200 + " status code was not returned!",
+                     200, response.getResponseCode());
+        assertTrue("Response should contain " + verifyText1 + ".",
+                   response.getText().contains(verifyText1));
+    }
+}

--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspServletExceptionWrapServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspServletExceptionWrapServer/bootstrap.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7777
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HTTPChannel=all:TCPChannel=all:GenericBNF=all:com.ibm.ws.jsp*=all
+

--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspServletExceptionWrapServer/server.xml
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspServletExceptionWrapServer/server.xml
@@ -1,0 +1,19 @@
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server description="Server for testing JavaServer Pages 2.3">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+
+    <webContainer donotcloseoutputonforwardforservleterror="true"/>
+</server>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestServlet.war/resources/exception.jsp
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestServlet.war/resources/exception.jsp
@@ -1,0 +1,9 @@
+<%--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+--%><% throw new Exception("Exception from JSP"); %>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestServlet.war/resources/include.jsp
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestServlet.war/resources/include.jsp
@@ -1,0 +1,11 @@
+<%--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+--%>
+<p>Some text before flush.
+

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestServlet.war/resources/moreoutput.jsp
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestServlet.war/resources/moreoutput.jsp
@@ -1,0 +1,17 @@
+<%--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+--%>
+<html>
+<body>
+<jsp:include page="include.jsp" flush="true"/>
+<br>
+<p>more text following flush
+
+</body>
+</html>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestServlet.war/resources/testfwdexc.jsp
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestServlet.war/resources/testfwdexc.jsp
@@ -1,0 +1,16 @@
+<%--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+--%><% 
+try {
+    request.getRequestDispatcher("exception.jsp").forward(request, response);                        
+}
+catch (Throwable t) {
+    request.getRequestDispatcher("moreoutput.jsp").forward(request, response);
+} %>
+

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
@@ -191,3 +191,7 @@ skipEncodedCharVerification.desc=A request is rejected if the request URI contai
 
 maxFileCount.name=The maximum uploaded files in a single request
 maxFileCount.desc=The maximum number of files that can be uploaded by a multipart/form-data request. The default value is 5000. For unlimited file upload, set the value to -1.
+
+donotCloseOutputOnForwardForServletError.name=Do not close output on forwarded servlet error 
+donotCloseOutputOnForwardForServletError.desc=When this property is set to true, if a servlet called from dispatch forward throws an exception other than IOException and ServletException, the output is not automatically closed.
+

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype.xml
@@ -349,6 +349,12 @@
             description="%skipEncodedCharVerification.desc"
             required="false" type="Boolean" default="false" />
 
+        <!--com.ibm.ws.webcontainer.-->
+        <AD id="donotCloseOutputOnForwardForServletError"
+            name="%donotCloseOutputOnForwardForServletError.name"
+            description="%donotCloseOutputOnForwardForServletError.desc"
+            required="false" type="Boolean" />
+
         <AD name="internal" description="internal use only"
             id="extensionFactory" required="true" type="String" cardinality="100"
             ibm:type="pid" ibm:reference="com.ibm.wsspi.webcontainer.extension.ExtensionFactory" default="*" ibm:final="true"/> 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppRequestDispatcher.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppRequestDispatcher.java
@@ -1414,8 +1414,11 @@ public class WebAppRequestDispatcher implements RequestDispatcher, WebContainerC
                                                     CollaboratorHelper.allCollabEnum);
         } catch (ServletErrorReport ser) {
             // PK79464
-            if (dispatcherRethrowSER&&httpServletReq.getAttribute(WebContainerConstants.IGNORE_DISPATCH_STATE) == null)
+            if (dispatcherRethrowSER&&httpServletReq.getAttribute(WebContainerConstants.IGNORE_DISPATCH_STATE) == null) {
+                if (WCCustomProperties.DO_NOT_CLOSE_OUTPUT_ON_FORWARD_EXCEPTION) 
+                   exception = true;
                 throw ser;
+	    }
             webapp.sendError(httpServletReq, httpServletRes, ser);
         } catch (ServletException se) {
             exception = true;

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WCCustomProperties.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WCCustomProperties.java
@@ -329,6 +329,9 @@ public class WCCustomProperties {
     //23.0.0.1
     public static boolean SKIP_ENCODED_CHAR_VERIFICATION;
 
+    //23.0.0.3
+    public static boolean DO_NOT_CLOSE_OUTPUT_ON_FORWARD_EXCEPTION;
+    
     static {
         setCustomPropertyVariables(); //initializes all the variables
     }
@@ -423,7 +426,8 @@ public class WCCustomProperties {
         WCCustomProperties.FullyQualifiedPropertiesMap.put("redirecttorelativeurl", "com.ibm.ws.webcontainer.redirecttorelativeurl");
         WCCustomProperties.FullyQualifiedPropertiesMap.put("sethtmlcontenttypeonerror", "com.ibm.ws.webcontainer.sethtmlcontenttypeonerror"); //PH34054
         WCCustomProperties.FullyQualifiedPropertiesMap.put("excludeallhandledtypesclasses", "com.ibm.ws.webcontainer.excludeallhandledtypesclasses");
-        WCCustomProperties.FullyQualifiedPropertiesMap.put("skipencodedcharverification", "com.ibm.ws.webcontainer.skipencodedcharverification");
+	WCCustomProperties.FullyQualifiedPropertiesMap.put("skipencodedcharverification", "com.ibm.ws.webcontainer.skipencodedcharverification");
+        WCCustomProperties.FullyQualifiedPropertiesMap.put("donotcloseoutputonforwardforservleterror", "com.ibm.ws.webcontainer.donotcloseoutputonforwardforservleterror");
     }
 
     //some properties require "com.ibm.ws.webcontainer." on the front
@@ -812,7 +816,10 @@ public class WCCustomProperties {
 
         //23.0.0.1 - Servlet 6.0
         SKIP_ENCODED_CHAR_VERIFICATION = (Boolean.valueOf(customProps.getProperty("com.ibm.ws.webcontainer.skipencodedcharverification"))).booleanValue();
-        
+
+        //23.0.0.3
+        DO_NOT_CLOSE_OUTPUT_ON_FORWARD_EXCEPTION = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.donotcloseoutputonforwardforservleterror", "false")).booleanValue();
+
         //Default for Servlet 5.0 +
         if(com.ibm.ws.webcontainer.osgi.WebContainer.getServletContainerSpecLevel() >= com.ibm.ws.webcontainer.osgi.WebContainer.SPEC_LEVEL_50) {
             if(com.ibm.ws.webcontainer.osgi.WebContainer.getServletContainerSpecLevel() >= com.ibm.ws.webcontainer.osgi.WebContainer.SPEC_LEVEL_60) {


### PR DESCRIPTION
fixes #23827 

This change adds Web Container custom property donotCloseOutputOnForwardForServletError, a boolean value, default false.  When true, this will allow exceptions in JSP after a dispatch forward, other than IOException and ServletException (which already allow more output), to create more response output in their error handler.