### PR TITLE
Fix WL server dump on IBM i

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ServerDumpPackager.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ServerDumpPackager.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -46,9 +46,9 @@ import com.ibm.ws.kernel.boot.logging.TextFileOutputStreamFactory;
 /**
  * The ServerDumpPackager encapsulates the logic of creating an archive file containing
  * various server dump data.
- * 
+ *
  * The usage pattern of this helper class is as follows:
- * 
+ *
  * -- create an instance of the server dump packager using your chosen constructor
  * -- call initializeDumpDirectory() to create the temporary directory that will contain dump information
  * -- if additional information is to be included in the dump (such as a server introspection), the location
@@ -98,6 +98,11 @@ public class ServerDumpPackager {
             dumpDir = new File(serverOutputDir, BootstrapConstants.SERVER_DUMP_FOLDER_PREFIX + dumpTimestamp);
             if (!FileUtils.createDir(dumpDir))
                 throw new IllegalStateException("Dump directory could not be created.");
+
+            // Ensure the dump directory is accessible by the server
+            dumpDir.setReadable(true, false);
+            dumpDir.setWritable(true, false);
+            dumpDir.setExecutable(true, false);
         }
     }
 
@@ -122,7 +127,7 @@ public class ServerDumpPackager {
 
     /**
      * Package the server dump and optionally record error data.
-     * 
+     *
      * @return
      */
     public ReturnCode packageDump(boolean javaDumpsRequested) {
@@ -139,7 +144,7 @@ public class ServerDumpPackager {
 
         captureEnvData(dumpDir, bootProps.getInstallRoot());
 
-        // we also want the dump zip contains the lib inventory, so generate one. 
+        // we also want the dump zip contains the lib inventory, so generate one.
         File libInventory = new File(dumpDir, BootstrapConstants.SERVER_LIB_INVENTORY_FILE_NAME + ".txt");
         if (!new FolderStructureGenerator().generate(bootProps.getInstallRoot(), libInventory)) {
             System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("info.LibInventoryGenerationException"), serverName));
@@ -209,7 +214,7 @@ public class ServerDumpPackager {
 
     /**
      * Copy relevant data (like service data, shared config, etc) to the dump dir to be zipped up.
-     * 
+     *
      * @param dumpDir
      * @param installDir
      */
@@ -349,7 +354,7 @@ public class ServerDumpPackager {
 
     /**
      * Creates an archive containing the server dumps, server configurations.
-     * 
+     *
      * @param packageFile
      * @return
      */


### PR DESCRIPTION
Fixes: https://github.com/OpenLiberty/open-liberty/issues/24007

When the `server dump ...` command is run, it runs as the current user when it creates the `dump_<timestamp>` directory.  When the `introspections` directory is created (under `dump_<timestamp>`), it is done so by the server with the authority of the profile that the server runs under.  So if the authority of the profile that the Liberty server runs under (say fred) is insufficient compared the the profile running the `server dump ...` command (say root), then the server's profile will not have access to the `dump_<timestamp>` directory to be able to create the `introspections` directory underneath it.  This is likely an uncommon occurrence on non-IBM i platforms.

On the IBM i platform, however, the WebSphere Liberty server defaults to running under the QEJBSVR profile (Open Liberty does not).  If the person running the `server dump ...` command is not QEJBSVR, which would be almost never, then the `dump_<timestamp>` directory gets created by the one who runs the command (again, say fred) and fred has access to it, but everyone else (group/world) is excluded.  Then when the server tries to create the `introspections` directory, it is attempts to do so as QEJBSVR, but since only fred has access to it, the creation of the `introspections` directory fails and the dump is not performed.