### PR TITLE
Updates to personalbuild.yml and rtcbuild.yml

### DIFF
--- a/.ci-orchestrator/personalbuild.yml
+++ b/.ci-orchestrator/personalbuild.yml
@@ -9,10 +9,37 @@ triggers:
   triggerMonitored: false
   keyword: "#pbbeta"
 - type: github
+  triggerName: "ol-exclamation-pbbeta"
+  triggerRank: 50
+  triggerMonitored: false
+  keyword: "!pbbeta"
+- type: github
   triggerName: "ol-fullpbbeta"
   triggerRank: 50
   triggerMonitored: false
   keyword: "#fullpbbeta"
+  propertyDefinitions:
+  - name: fat.test.mode
+    defaultValue: full
+    steps:
+    - stepName: fats
+  - name: create.im.repo
+    defaultValue: true
+    steps:
+    - stepName: compile
+  - name: spawn.zos
+    defaultValue: true
+    steps:
+    - stepName: compile
+  - name: spawn.fullfat.buckets
+    defaultValue: ""
+    steps:
+    - stepName: pr-changes
+- type: github
+  triggerName: "ol-exclamation-fullpbbeta"
+  triggerRank: 50
+  triggerMonitored: false
+  keyword: "!fullpbbeta"
   propertyDefinitions:
   - name: fat.test.mode
     defaultValue: full

--- a/.ci-orchestrator/personalbuild.yml
+++ b/.ci-orchestrator/personalbuild.yml
@@ -87,7 +87,7 @@ steps:
   dependsOn:
     - stepName: compile
       awaitOutputProperties: true
-  timeoutInMinutes: 30
+  timeoutInMinutes: 120
   properties:
     artifact_execution_id: ${compile:execution_id}
     aggregationId: ${compile:execution_id}

--- a/.ci-orchestrator/rtcbuild.yml
+++ b/.ci-orchestrator/rtcbuild.yml
@@ -18,11 +18,11 @@ triggers:
 #  triggerRank: 20
 #  triggerMonitored: false
 #  keyword: "#build"
-#- type: github
-#  triggerName: "ol-pb-exclamation-build"
-#  triggerRank: 20
-#  triggerMonitored: false
-#  keyword: "!build"
+- type: github
+  triggerName: "ol-pb-exclamation-build"
+  triggerRank: 20
+  triggerMonitored: false
+  keyword: "!build"
 - type: github
   triggerName: "ol-fullpb"
   triggerRank: 20

--- a/.ci-orchestrator/rtcbuild.yml
+++ b/.ci-orchestrator/rtcbuild.yml
@@ -8,16 +8,52 @@ triggers:
   triggerRank: 20
   triggerMonitored: false
   keyword: "#pb"
+- type: github
+  triggerName: "ol-exclamation-pb"
+  triggerRank: 20
+  triggerMonitored: false
+  keyword: "!pb"
 #- type: github
 #  triggerName: "ol-pb-build"
 #  triggerRank: 20
 #  triggerMonitored: false
 #  keyword: "#build"
+#- type: github
+#  triggerName: "ol-pb-exclamation-build"
+#  triggerRank: 20
+#  triggerMonitored: false
+#  keyword: "!build"
 - type: github
   triggerName: "ol-fullpb"
   triggerRank: 20
   triggerMonitored: false
   keyword: "#fullpb"
+  propertyDefinitions:
+  - name: fat.test.mode
+    defaultValue: full
+    steps:
+    - stepName: fats
+  - name: create.im.repo
+    defaultValue: true
+    steps:
+    - stepName: compile
+  - name: spawn.zos
+    defaultValue: true
+    steps:
+    - stepName: compile
+  - name: spawn.fullfat.buckets
+    defaultValue: ""
+    steps:
+    - stepName: pr-changes
+  - name: fat.buckets.to.run
+    defaultValue: all
+    steps:
+    - stepName: compile
+- type: github
+  triggerName: "ol-exclamation-fullpb"
+  triggerRank: 20
+  triggerMonitored: false
+  keyword: "!fullpb"
   propertyDefinitions:
   - name: fat.test.mode
     defaultValue: full


### PR DESCRIPTION
- Increase dependencyMapper's timeoutInMinutes from 30 to 120. The dependencyMapper step should take up to 30 minutes to execute and queue times may vary from 10 minutes to an hour. Since timeoutInMinutes includes queue time, setting it to 2 hours will allow for 1.5h queue times and 30 minutes executing the step.
- Add keywords that respond to ! instead of #.