### PR TITLE
Update javadoc options to use addBooleanOption

### DIFF
--- a/dev/wlp-gradle/java.gradle
+++ b/dev/wlp-gradle/java.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -113,7 +113,7 @@ subprojects {
       // Starting with JDK 9.0.4 the javadoc compiler started to striclty enforce proper HTML
       // syntax and other breaking changes.  Fixing all of these ocurrances would take far too
       // long and be a poor use of time, so we will disable these checks for JDK9 and up
-      options.addStringOption('Xdoclint:none', '-quiet')
+      options.addBooleanOption('Xdoclint:none', true)
     }
   }
   

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -266,9 +266,7 @@ if (bnd.get('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd.get('pub
     options.memberLevel = 'PUBLIC'
     options.noIndex true
     options.use true
-    if (JavaVersion.current().isJava8Compatible()) {
-      options.addStringOption('Xdoclint:none', '-quiet')
-    }
+    options.addBooleanOption('Xdoclint:none', true)
   }
 
   task zipJavadoc(type: Zip) {


### PR DESCRIPTION
- Previously addStringOption was used with an extra -quiet argument for a option that doesn't require a value.  Should use addBooleanOption instead.

#build