### PR TITLE
Change org.gradle.jvmargs to -Xmx6400m

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -35,7 +35,7 @@ bnd_preCompileRefresh=false
 # By default Gradle will reserve 1GB of heap space.
 # Very large builds might need more memory to hold Gradle's model and caches.
 # Set file encoding to override the system encoding.
-org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6400m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # Fix for the TLS protocol version used to communicate with Maven Central when using the IBM JVM.
 systemProp.com.ibm.jsse2.overrideDefaultTLS=true


### PR DESCRIPTION
- Indexing the release repository failed due to OOM. Increasing the heap from 4096m to 6400m.

```
> Task :cnf:index

Problem in daemon expiration check
java.lang.OutOfMemoryError: Java heap space
	at java.base/java.lang.J9VMInternals.primitiveClone(Native Method)
	at java.base/java.lang.Object.clone(Object.java:56)
	at org.gradle.launcher.daemon.server.api.DaemonStateControl$State.values(DaemonStateControl.java:78)
	at org.gradle.launcher.daemon.registry.DaemonInfo$Serializer.read(DaemonInfo.java:133)
	at org.gradle.launcher.daemon.registry.DaemonRegistryContent$Serializer.readInfosMap(DaemonRegistryContent.java:139)
	at org.gradle.launcher.daemon.registry.DaemonRegistryContent$Serializer.read(DaemonRegistryContent.java:119)
	at org.gradle.launcher.daemon.registry.DaemonRegistryContent$Serializer.read(DaemonRegistryContent.java:113)
	at org.gradle.cache.internal.SimpleStateCache.deserialize(SimpleStateCache.java:144)
	at org.gradle.cache.internal.SimpleStateCache.access$000(SimpleStateCache.java:34)
	at org.gradle.cache.internal.SimpleStateCache$1.create(SimpleStateCache.java:52)
	at org.gradle.cache.internal.DefaultFileLockManager$DefaultFileLock.readFile(DefaultFileLockManager.java:193)
###############################################################################
	at org.gradle.cache.internal.OnDemandFileAccess.readFile(OnDemandFileAccess.java:43)
	at org.gradle.cache.internal.SimpleStateCache.get(SimpleStateCache.java:49)
	at org.gradle.cache.internal.FileIntegrityViolationSuppressingPersistentStateCacheDecorator.get(FileIntegrityViolationSuppressingPersistentStateCacheDecorator.java:34)
	at org.gradle.launcher.daemon.registry.PersistentDaemonRegistry.getAll(PersistentDaemonRegistry.java:71)
	at org.gradle.launcher.daemon.registry.PersistentDaemonRegistry.getDaemonsMatching(PersistentDaemonRegistry.java:116)
	at org.gradle.launcher.daemon.registry.PersistentDaemonRegistry.getIdle(PersistentDaemonRegistry.java:84)
	at org.gradle.launcher.daemon.server.CompatibleDaemonExpirationStrategy.checkExpiration(CompatibleDaemonExpirationStrategy.java:54)
	at org.gradle.launcher.daemon.server.expiry.AllDaemonExpirationStrategy.checkExpiration(AllDaemonExpirationStrategy.java:46)
	at org.gradle.launcher.daemon.server.expiry.AnyDaemonExpirationStrategy.checkExpiration(AnyDaemonExpirationStrategy.java:43)
	at org.gradle.launcher.daemon.server.MasterExpirationStrategy.checkExpiration(MasterExpirationStrategy.java:73)
	at org.gradle.launcher.daemon.server.Daemon$DaemonExpirationPeriodicCheck.run(Daemon.java:268)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
	at java.base/java.lang.Thread.run(Thread.java:840)

> Task :cnf:index FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':cnf:index'.
> Java heap space
```