### PR TITLE
Help Debug why servlet Mbean is not registered for TestEDF2 in com.ibm.ws.microprofile.metrics.2.x.monitor_fat

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF2/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF2/bootstrap.properties
@@ -1,2 +1,2 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.metrics.monitor.*=all:com.ibm.ws.webcontainer.monitor.WebContainerMonitor=all:com.ibm.websphere.monitor.meters=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.metrics.monitor.*=all:com.ibm.ws.webcontainer.monitor.WebContainerMonitor=all:com.ibm.websphere.monitor.meters=all:com.ibm.ws.webcontainer.servlet=all


### PR DESCRIPTION
Continued from https://github.com/OpenLiberty/open-liberty/pull/23714

From gathered traces and messages the servlet was initialized. However, it is when the servlet is first called is when the monitor-1.0 framework will register the servlet Mbean. It does this by _probing_ the servlet wrapper at the `service` call.

In TestEDF2, the `/metrics/vendor` endpoint is called and then we check the trace.
In normal conditions, this call to the endpoint will invoke the `service()` call to the `ServletWrapper`. the monitor-1.0 framework detects this and creates the servlet MBean and the result is a the servlet metrics. However, earlier traces did not cover the `ServletWrapper`, this new PR will add trace to provide coverage to that class to identify it a failure was encountered at some point or if the `ServletWrapper` did not run at all.

#build