### PR TITLE
add fat tests for OpenIdAuthenticationMechanismDefinition display and displayExpression

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/OpenIdAuthenticationMechanismDefinitionWrapper.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/OpenIdAuthenticationMechanismDefinitionWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -563,7 +563,13 @@ public class OpenIdAuthenticationMechanismDefinitionWrapper implements OidcClien
              * Evaluate the EL expression to get the value.
              */
             Object obj = elHelper.evaluateElExpression(displayExpression);
-            if (obj instanceof String) {
+            if (obj instanceof DisplayType) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "processPrompt (promptType): " + obj);
+                }
+                result = (DisplayType) obj;
+                immediate = elHelper.isImmediateExpression(displayExpression);
+            } else if (obj instanceof String) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "processDisplay", "displayExpression evaluated to a String, compare to DisplayType enum options: " + obj);
                 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/commonTests/CommonAnnotatedSecurityTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/commonTests/CommonAnnotatedSecurityTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -52,6 +52,7 @@ import io.openliberty.security.jakartasec.fat.utils.ResponseValues;
 import io.openliberty.security.jakartasec.fat.utils.ServletMessageConstants;
 import io.openliberty.security.jakartasec.fat.utils.ServletRequestExpectationHelpers;
 import io.openliberty.security.jakartasec.fat.utils.WsSubjectExpectationHelpers;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.DisplayType;
 
 public class CommonAnnotatedSecurityTests extends CommonSecurityFat {
 
@@ -517,6 +518,9 @@ public class CommonAnnotatedSecurityTests extends CommonSecurityFat {
                                                                                                                                                                                                          Integer.toString(rpServer.getBvtSecurePort())).replace("rp_AppName_rp",
                                                                                                                                                                                                                                                                 appName);
 
+        }
+        if (value instanceof DisplayType) {
+            newValue = ((DisplayType) value).toString();
         }
         return newValue;
     }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/configs/TestConfigMaps.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/configs/TestConfigMaps.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import com.ibm.websphere.simplicity.log.Log;
 
 import io.openliberty.security.jakartasec.fat.utils.Constants;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.DisplayType;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.PromptType;
 
 public class TestConfigMaps {
@@ -413,6 +414,30 @@ public class TestConfigMaps {
     public static Map<String, Object> getExtraParametersContainsSpecialCharacterInValue() throws Exception {
         Map<String, Object> updatedMap = new HashMap<String, Object>();
         updatedMap.put(Constants.EXTRA_PARAMETERS_EXPRESSION, "key1=value&1");
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getDisplayPage() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.DISPLAY_EXPRESSION, DisplayType.PAGE);
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getDisplayPopup() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.DISPLAY_EXPRESSION, DisplayType.POPUP);
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getDisplayTouch() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.DISPLAY_EXPRESSION, DisplayType.TOUCH);
+        return updatedMap;
+    }
+
+    public static Map<String, Object> getDisplayWap() throws Exception {
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.DISPLAY_EXPRESSION, DisplayType.WAP);
         return updatedMap;
     }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
@@ -42,6 +42,8 @@ public class Constants extends com.ibm.ws.security.fat.common.Constants {
     public static final String LOGOUT_REDIRECT_URI = "logoutRedirectURI";
     public static final String PROMPT = "prompt";
     public static final String PROMPT_EXPRESSION = "promptExpression";
+    public static final String DISPLAY = "display";
+    public static final String DISPLAY_EXPRESSION = "displayExpression";
 
     public static final String CALLER_NAME_CLAIM = "callerNameClaim";
     public static final String CALLER_GROUPS_CLAIM = "callerGroupsClaim";

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
@@ -15,6 +15,7 @@ package oidc.client.base.servlets;
 import io.openliberty.security.jakartasec.fat.utils.Constants;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.DisplayType;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.PromptType;
 
 /**
@@ -162,6 +163,17 @@ public class BaseOpenIdConfig extends MinimumBaseOpenIdConfig {
         }
 
         return value;
+    }
+
+    public DisplayType getDisplayExpression() {
+
+        DisplayType value = DisplayType.PAGE;
+        if (config.containsKey(Constants.DISPLAY_EXPRESSION)) {
+            value = getDisplayTypeValue(Constants.DISPLAY_EXPRESSION);
+        }
+
+        return value;
+
     }
 
     public String getCallerNameClaim() {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/MinimumBaseOpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/MinimumBaseOpenIdConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import io.openliberty.security.jakartasec.fat.utils.Constants;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.DisplayType;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.PromptType;
 
 /**
@@ -127,6 +128,20 @@ public class MinimumBaseOpenIdConfig {
             return returnValue;
         }
 
+    }
+
+    public DisplayType getDisplayTypeValue(String key) {
+        String value = config.getProperty(key);
+        try {
+            if (value == null || value.isEmpty()) {
+                throw new Exception("Don't know what to do with a null or empty DisplayType value");
+            }
+            return DisplayType.valueOf(value);
+        } catch (Exception e) {
+            System.out.println("getDisplayTypeValue couldn't handle the value specified in the config properties - setting a default to page.");
+            System.out.println(e.getMessage());
+            return DisplayType.PAGE;
+        }
     }
 
     public int getIntValue(String key, int defaultValue) {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/.classpath
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/.classpath
@@ -42,6 +42,13 @@
 	<classpathentry kind="src" path="test-applications/ExtraParametersOneParamWithEL.war/src"/>
 	<classpathentry kind="src" path="test-applications/ExtraParametersSpaceAsKey.war/src"/>
 	<classpathentry kind="src" path="test-applications/ExtraParametersLeadingSpaceInKey.war/src"/>
+	<classpathentry kind="src" path="test-applications/DisplayPage.war/src"/>
+	<classpathentry kind="src" path="test-applications/DisplayPopup.war/src"/>
+	<classpathentry kind="src" path="test-applications/DisplayTouch.war/src"/>
+	<classpathentry kind="src" path="test-applications/DisplayWap.war/src"/>
+	<classpathentry kind="src" path="test-applications/DisplayEL.war/src"/>
+	<classpathentry kind="src" path="test-applications/DisplayEmpty.war/src"/>
+	<classpathentry kind="src" path="test-applications/DisplayPopupWithEL.war/src"/>
 	<classpathentry kind="src" path="test-applications/JwksEndpoint.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/bnd.bnd
@@ -56,8 +56,14 @@ src: \
     test-applications/ExtraParametersUsingEL.war/src,\
     test-applications/ExtraParametersSpaceAsKey.war/src,\
     test-applications/ExtraParametersLeadingSpaceInKey.war/src,\
+    test-applications/DisplayPage.war/src,\
+    test-applications/DisplayPopup.war/src,\
+    test-applications/DisplayTouch.war/src,\
+    test-applications/DisplayWap.war/src,\
+    test-applications/DisplayEL.war/src,\
+    test-applications/DisplayEmpty.war/src,\
+    test-applications/DisplayPopupWithEL.war/src,\
     test-applications/JwksEndpoint.war/src
-
     
 -dependson: \
     build.changeDetector,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/build.gradle
@@ -106,6 +106,7 @@ autoFVT.doLast {
 	'jakartasec-3.0_fat.config.rp.responseMode',
 	'jakartasec-3.0_fat.config.rp.useNonce',
 	'jakartasec-3.0_fat.config.rp.extraParameters',
+	'jakartasec-3.0_fat.config.rp.display',
 	'jakartasec-3.0_fat.config.rp.userinfo.jwt.jwt',
 	'jakartasec-3.0_fat.config.rp.userinfo.jwt.opaque',
 	'jakartasec-3.0_fat.config.rp.userinfo.json.jwt',

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/FATSuite.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/FATSuite.java
@@ -18,6 +18,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationClaimsDefinitionTests;
+import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationDisplayTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationELValuesOverrideTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationELValuesOverrideWithoutHttpSessionTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationExtraParametersTests;
@@ -37,6 +38,7 @@ import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationUserInfo
                 ConfigurationResponseModeTests.class,
                 ConfigurationUseNonceTests.class,
                 ConfigurationExtraParametersTests.class,
+                ConfigurationDisplayTests.class,
                 // LogoutDefinition tests are handled in a separate FAT project as the test use sleeps to wait for tokens to expire and that causes the tests to take quite some time to run
                 ConfigurationELValuesOverrideTests.class,
                 ConfigurationELValuesOverrideWithoutHttpSessionTests.class,

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationDisplayTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationDisplayTests.java
@@ -1,0 +1,303 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.fat.config.tests;
+
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.ibm.ws.security.fat.common.expectations.Expectations;
+import com.ibm.ws.security.fat.common.expectations.ResponseUrlExpectation;
+import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
+import com.ibm.ws.security.fat.common.web.WebResponseUtils;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.security.jakartasec.fat.commonTests.CommonAnnotatedSecurityTests;
+import io.openliberty.security.jakartasec.fat.configs.TestConfigMaps;
+import io.openliberty.security.jakartasec.fat.utils.Constants;
+import io.openliberty.security.jakartasec.fat.utils.ShrinkWrapHelpers;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.DisplayType;
+
+/**
+ * Tests @OpenIdAuthenticationMechanismDefinition display and displayExpression
+ *
+ * This class contains tests to validate that the display/displayExpression value is
+ * correctly added to the authentication endpoint request as a query param.
+ * Additionally, it validates that not specifying any display/displayExpression value
+ * uses the default of page and that the displayExpression value takes precedence over
+ * the display value.
+ */
+/**
+ * Tests appSecurity-5.0
+ */
+@SuppressWarnings("restriction")
+@RunWith(FATRunner.class)
+public class ConfigurationDisplayTests extends CommonAnnotatedSecurityTests {
+
+    protected static Class<?> thisClass = ConfigurationDisplayTests.class;
+
+    @Server("jakartasec-3.0_fat.config.op")
+    public static LibertyServer opServer;
+    @Server("jakartasec-3.0_fat.config.rp.display")
+    public static LibertyServer rpServer;
+
+    protected static ShrinkWrapHelpers swh = null;
+
+    @ClassRule
+    public static RepeatTests repeat = createRandomTokenTypeRepeats();
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        // write property that is used to configure the OP to generate JWT or Opaque tokens
+        setTokenTypeInBootstrap(opServer);
+
+        // Add servers to server trackers that will be used to clean servers up and prevent servers
+        // from being restored at the end of each test (so far, the tests are not reconfiguring the servers)
+        updateTrackers(opServer, rpServer, false);
+
+        List<String> waitForMsgs = null;
+        opServer.startServerUsingExpandedConfiguration("server_display.xml", waitForMsgs);
+        SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
+        opHttpBase = "http://localhost:" + opServer.getBvtPort();
+        opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
+
+        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
+
+        rpHttpBase = "http://localhost:" + rpServer.getBvtPort();
+        rpHttpsBase = "https://localhost:" + rpServer.getBvtSecurePort();
+
+        deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
+
+    }
+
+    /**
+     * Deploy the apps that this test class uses
+     *
+     * @throws Exception
+     */
+    public static void deployMyApps() throws Exception {
+
+        swh = new ShrinkWrapHelpers(opHttpBase, opHttpsBase, rpHttpBase, rpHttpsBase);
+
+        swh.defaultDropinApp(rpServer, "DisplayPage.war", "oidc.client.displayPage.servlets", "oidc.client.base.*");
+        swh.defaultDropinApp(rpServer, "DisplayPopup.war", "oidc.client.displayPopup.servlets", "oidc.client.base.*");
+        swh.defaultDropinApp(rpServer, "DisplayTouch.war", "oidc.client.displayTouch.servlets", "oidc.client.base.*");
+        swh.defaultDropinApp(rpServer, "DisplayWap.war", "oidc.client.displayWap.servlets", "oidc.client.base.*");
+        swh.defaultDropinApp(rpServer, "DisplayEmpty.war", "oidc.client.displayEmpty.servlets", "oidc.client.base.*");
+
+        swh.deployConfigurableTestApps(rpServer, "DisplayELPage.war", "DisplayEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "DisplayELPage", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getDisplayPage()),
+                                       "oidc.client.displayEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "DisplayELPopup.war", "DisplayEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "DisplayELPopup", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getDisplayPopup()),
+                                       "oidc.client.displayEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "DisplayELTouch.war", "DisplayEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "DisplayELTouch", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getDisplayTouch()),
+                                       "oidc.client.displayEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "DisplayELWap.war", "DisplayEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "DisplayELWap", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getDisplayWap()),
+                                       "oidc.client.displayEL.servlets", "oidc.client.base.*");
+
+        swh.deployConfigurableTestApps(rpServer, "DisplayPopupELTouch.war", "DisplayPopupWithEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "DisplayPopupELTouch", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getDisplayTouch()),
+                                       "oidc.client.displayPopupWithEL.servlets", "oidc.client.base.*");
+    }
+
+    private void runGoodEndToEndTestWithDisplayCheck(String appRoot, String app, DisplayType displayType) throws Exception {
+
+        WebClient webClient = getAndSaveWebClient();
+        webClient.getOptions().setRedirectEnabled(false);
+
+        String url = rpHttpsBase + "/" + appRoot + "/" + app;
+        Page response = invokeApp(webClient, url);
+
+        String authEndpoint = WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION);
+        response = actions.invokeUrl(_testName, webClient, authEndpoint);
+
+        String displayString = displayType.toString().toLowerCase();
+        String authEndpointDisplayRegex = "https:\\/\\/localhost:" + opServer.getBvtSecurePort() + "\\/oidc\\/endpoint\\/OP[0-9]*\\/authorize\\?.*display=" + displayString + "(&|$)";
+
+        Expectations authExpectations = new Expectations();
+        authExpectations.addFoundStatusCodeAndMessageForCurrentAction();
+        authExpectations.addExpectation(new ResponseUrlExpectation(Constants.STRING_MATCHES, authEndpointDisplayRegex, "Did not find the correct d in authorization endpoint request."));
+        validationUtils.validateResult(response, authExpectations);
+
+        webClient.getOptions().setRedirectEnabled(true);
+
+        String loginPageUrl = WebResponseUtils.getResponseHeaderField(response, Constants.RESPONSE_HEADER_LOCATION);
+        response = actions.invokeUrl(_testName, webClient, loginPageUrl);
+        response = actions.doFormLogin(response, Constants.TESTUSER, Constants.TESTUSERPWD);
+
+        validationUtils.validateResult(response, getGeneralAppExpecations(app));
+
+    }
+
+    /****************************************************************************************************************/
+    /* Tests */
+    /****************************************************************************************************************/
+
+    /**
+     *
+     * Tests with display=page
+     * The authentication endpoint request should append 'display=page' as a query parameter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationDisplayTests_display_page() throws Exception {
+
+        runGoodEndToEndTestWithDisplayCheck("DisplayPage", "DisplayPageServlet", DisplayType.PAGE);
+
+    }
+
+    /**
+     *
+     * Tests with display=popup
+     * The authentication endpoint request should append 'display=popup' as a query parameter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationDisplayTests_display_popup() throws Exception {
+
+        runGoodEndToEndTestWithDisplayCheck("DisplayPopup", "DisplayPopupServlet", DisplayType.POPUP);
+
+    }
+
+    /**
+     *
+     * Tests with display=touch
+     * The authentication endpoint request should append 'display=touch' as a query parameter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationDisplayTests_display_touch() throws Exception {
+
+        runGoodEndToEndTestWithDisplayCheck("DisplayTouch", "DisplayTouchServlet", DisplayType.TOUCH);
+
+    }
+
+    /**
+     *
+     * Tests with display=wap
+     * The authentication endpoint request should append 'display=wap' as a query parameter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationDisplayTests_display_wap() throws Exception {
+
+        runGoodEndToEndTestWithDisplayCheck("DisplayWap", "DisplayWapServlet", DisplayType.WAP);
+
+    }
+
+    /**
+     *
+     * Tests with displayExpression=page
+     * The authentication endpoint request should append 'display=page' as a query parameter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationDisplayTests_displayEL_page() throws Exception {
+
+        runGoodEndToEndTestWithDisplayCheck("DisplayELPage", "DisplayELServlet", DisplayType.PAGE);
+
+    }
+
+    /**
+     *
+     * Tests with displayExpression=popup
+     * The authentication endpoint request should append 'display=popup' as a query parameter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationDisplayTests_displayEL_popup() throws Exception {
+
+        runGoodEndToEndTestWithDisplayCheck("DisplayELPopup", "DisplayELServlet", DisplayType.POPUP);
+
+    }
+
+    /**
+     *
+     * Tests with displayExpression=touch
+     * The authentication endpoint request should append 'display=touch' as a query parameter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationDisplayTests_displayEL_touch() throws Exception {
+
+        runGoodEndToEndTestWithDisplayCheck("DisplayELTouch", "DisplayELServlet", DisplayType.TOUCH);
+
+    }
+
+    /**
+     *
+     * Tests with displayExpression=wap
+     * The authentication endpoint request should append 'display=wap' as a query parameter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationDisplayTests_displayEL_wap() throws Exception {
+
+        runGoodEndToEndTestWithDisplayCheck("DisplayELWap", "DisplayELServlet", DisplayType.WAP);
+
+    }
+
+    /**
+     *
+     * Tests without display nor displayExpression
+     * The default value of page should be used.
+     * The authentication endpoint request should append 'display=page' as a query parameter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationDisplayTests_display_empty() throws Exception {
+
+        runGoodEndToEndTestWithDisplayCheck("DisplayEmpty", "DisplayEmptyServlet", DisplayType.PAGE);
+
+    }
+
+    /**
+     *
+     * Tests with display=popup and displayExpression=touch
+     * The displayExpression should take precedence over display.
+     * The authentication endpoint request should append 'display=touch' as a query parameter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationDisplayTests_display_popup_EL_touch() throws Exception {
+
+        runGoodEndToEndTestWithDisplayCheck("DisplayPopupELTouch", "DisplayPopupWithELServlet", DisplayType.TOUCH);
+
+    }
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/servers/jakartasec-3.0_fat.config.op/configs/server_display.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/servers/jakartasec-3.0_fat.config.op/configs/server_display.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 3.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcDisplayProvider.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/shared/config/oidcDisplayProvider.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/shared/config/oidcDisplayProvider.xml
@@ -1,0 +1,50 @@
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+		 		 
+	<openidConnectProvider
+		id="OP1"
+		signatureAlgorithm="RS256"
+		keyAliasName="rs256"
+		keystoreRef="key_allSigAlg"
+		oauthProviderRef="OAuth1" />
+
+	<oauthProvider
+		id="OAuth1"
+		autoAuthorize="true"
+		tokenFormat="${opTokenFormat}"
+	>
+		<autoAuthorizeClient>client_1</autoAuthorizeClient>
+		
+		<localStore>
+			<client
+				name="client_1"
+				secret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/DisplayPage/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/DisplayPopup/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/DisplayTouch/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/DisplayWap/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/DisplayELPage/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/DisplayELPopup/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/DisplayELTouch/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/DisplayELWap/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/DisplayEmpty/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/DisplayPopupELTouch/Callback"
+				scope="ALL_SCOPES"
+				enabled="true"
+			>
+			</client>
+		</localStore>
+	</oauthProvider>		
+			
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayEL.war/src/oidc/client/displayEL/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayEL.war/src/oidc/client/displayEL/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayEL.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayEL.war/src/oidc/client/displayEL/servlets/DisplayELServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayEL.war/src/oidc/client/displayEL/servlets/DisplayELServlet.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayEL.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/DisplayELServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         displayExpression = "${openIdConfig.displayExpression}",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class DisplayELServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayEL.war/src/oidc/client/displayEL/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayEL.war/src/oidc/client/displayEL/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayEL.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayEmpty.war/src/oidc/client/displayEmpty/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayEmpty.war/src/oidc/client/displayEmpty/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayEmpty.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayEmpty.war/src/oidc/client/displayEmpty/servlets/DisplayEmptyServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayEmpty.war/src/oidc/client/displayEmpty/servlets/DisplayEmptyServlet.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayEmpty.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/DisplayEmptyServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class DisplayEmptyServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayEmpty.war/src/oidc/client/displayEmpty/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayEmpty.war/src/oidc/client/displayEmpty/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayEmpty.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPage.war/src/oidc/client/displayPage/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPage.war/src/oidc/client/displayPage/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayPage.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPage.war/src/oidc/client/displayPage/servlets/DisplayPageServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPage.war/src/oidc/client/displayPage/servlets/DisplayPageServlet.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayPage.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.DisplayType;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/DisplayPageServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         display = DisplayType.PAGE,
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class DisplayPageServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPage.war/src/oidc/client/displayPage/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPage.war/src/oidc/client/displayPage/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayPage.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPopup.war/src/oidc/client/displayPopup/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPopup.war/src/oidc/client/displayPopup/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayPopup.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPopup.war/src/oidc/client/displayPopup/servlets/DisplayPopupServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPopup.war/src/oidc/client/displayPopup/servlets/DisplayPopupServlet.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayPopup.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.DisplayType;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/DisplayPopupServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         display = DisplayType.POPUP,
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class DisplayPopupServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPopup.war/src/oidc/client/displayPopup/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPopup.war/src/oidc/client/displayPopup/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayPopup.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPopupWithEL.war/src/oidc/client/displayPopupWithEL/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPopupWithEL.war/src/oidc/client/displayPopupWithEL/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayPopupWithEL.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPopupWithEL.war/src/oidc/client/displayPopupWithEL/servlets/DisplayPopupWithELServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPopupWithEL.war/src/oidc/client/displayPopupWithEL/servlets/DisplayPopupWithELServlet.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayPopupWithEL.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.DisplayType;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/DisplayPopupWithELServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         display = DisplayType.POPUP,
+                                         displayExpression = "${openIdConfig.displayExpression}",
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class DisplayPopupWithELServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPopupWithEL.war/src/oidc/client/displayPopupWithEL/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayPopupWithEL.war/src/oidc/client/displayPopupWithEL/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayPopupWithEL.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayTouch.war/src/oidc/client/displayTouch/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayTouch.war/src/oidc/client/displayTouch/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayTouch.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayTouch.war/src/oidc/client/displayTouch/servlets/DisplayTouchServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayTouch.war/src/oidc/client/displayTouch/servlets/DisplayTouchServlet.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayTouch.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.DisplayType;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/DisplayTouchServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         display = DisplayType.TOUCH,
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class DisplayTouchServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayTouch.war/src/oidc/client/displayTouch/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayTouch.war/src/oidc/client/displayTouch/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayTouch.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayWap.war/src/oidc/client/displayWap/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayWap.war/src/oidc/client/displayWap/servlets/CallbackServlet.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayWap.servlets;
+
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
+
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
+
+    private static final long serialVersionUID = -417476984908088827L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayWap.war/src/oidc/client/displayWap/servlets/DisplayWapServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayWap.war/src/oidc/client/displayWap/servlets/DisplayWapServlet.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayWap.servlets;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.DisplayType;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseServlet;
+
+@WebServlet("/DisplayWapServlet")
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
+                                         clientId = "client_1",
+                                         clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
+                                         claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
+                                         redirectURI = "${baseURL}/Callback",
+                                         display = DisplayType.WAP,
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}")
+@DeclareRoles("all")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
+public class DisplayWapServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayWap.war/src/oidc/client/displayWap/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/DisplayWap.war/src/oidc/client/displayWap/servlets/OpenIdConfig.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.displayWap.servlets;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
+
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
+
+    // override and/or create new get methods
+
+}


### PR DESCRIPTION
add fat tests for OpenIdAuthenticationMechanismDefinition `display` and `displayExpression`

created tests to validate that the display/displayExpression value is correctly added to the authentication endpoint request as a query param. additionally, it validates that not specifying any display/displayExpression value uses the default of page and that the displayExpression value takes precedence over the display value.