### PR TITLE
Update feature add/remove for LargeProjectRepeatAction

### DIFF
--- a/dev/com.ibm.ws.security.oidc.server_fat.oidc/fat/src/com/ibm/ws/security/openidconnect/server/fat/oidc/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.server_fat.oidc/fat/src/com/ibm/ws/security/openidconnect/server/fat/oidc/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,9 +21,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE10RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 import com.ibm.ws.security.fat.common.utils.ldaputils.CommonRemoteLDAPServerSuite;
 import com.ibm.ws.security.openidconnect.server.fat.BasicTests.OIDC.OIDCInvokeNonexistentPathTest;
 import com.ibm.ws.security.openidconnect.server.fat.BasicTests.OIDC.OIDCPublicClientAuthCodeTest;
@@ -52,7 +50,6 @@ import com.ibm.ws.security.openidconnect.server.fat.OIDC.OIDCScopesPasswordTest;
 import com.ibm.ws.security.openidconnect.server.fat.OIDC.OIDCScopesTest;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -106,16 +103,15 @@ public class FATSuite extends CommonRemoteLDAPServerSuite {
     }
 
     /*
-     * Run EE9 and EE10 tests in only LITE mode on all but Windows - the transforms just run too slowly on the Windows OS.
-     * So, we'll run without EE9 and EE10 in LIte mode on Windows.
-     * We'll run EE7/EE8 tests everywhere in FULL mode.
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
      *
-     * This was done to increase coverage of EE9 and EE10 while not adding a large amount of of test runtime.
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                    .andWith(new SecurityTestRepeatAction().onlyOnWindows().liteFATOnly())
-                    .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().removeFeatures(REMOVE).addFeatures(INSERT).liteFATOnly())
-                    .andWith(new SecurityTestFeatureEE10RepeatAction().notOnWindows().removeFeatures(REMOVE).addFeatures(INSERT).liteFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats(null, null, REMOVE, INSERT);
 
 }


### PR DESCRIPTION
For RTC 294487

Merge the add/remove features from the `com.ibm.ws.security.oidc.server_fat.oidc` FatSuite in the `LargeProjectRepeatActions` to help with coverage without exceeding the time for automated tests.