### PR TITLE
Basic scenarios with EmbeddedId and intermixed name patterns

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityDefiner.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityDefiner.java
@@ -257,15 +257,14 @@ class EntityDefiner implements Runnable {
                         embeddables.add(attr);
                         embeddablePrefixes.add(attributeName);
                         embeddableAccessors.add(Collections.singletonList(attr.getJavaMember()));
-                    } else {
-                        attributeNames.put(attributeName.toLowerCase(), attributeName);
-                        if (attr instanceof SingularAttribute && ((SingularAttribute<?, ?>) attr).isId())
-                            attributeNames.put("id", attributeName);
-                        attributeAccessors.put(attributeName, Collections.singletonList(attr.getJavaMember()));
-                        attributeTypes.put(attributeName, PersistentAttributeType.ELEMENT_COLLECTION.equals(attributeType) //
-                                        ? Collection.class //
-                                        : attr.getJavaType());
                     }
+                    attributeNames.put(attributeName.toLowerCase(), attributeName);
+                    if (attr instanceof SingularAttribute && ((SingularAttribute<?, ?>) attr).isId())
+                        attributeNames.put("id", attributeName);
+                    attributeAccessors.put(attributeName, Collections.singletonList(attr.getJavaMember()));
+                    attributeTypes.put(attributeName, PersistentAttributeType.ELEMENT_COLLECTION.equals(attributeType) //
+                                    ? Collection.class //
+                                    : attr.getJavaType());
                 }
 
                 for (Attribute<?, ?> attr; (attr = embeddables.poll()) != null;) {
@@ -283,31 +282,31 @@ class EntityDefiner implements Runnable {
                             embeddables.add(embAttr);
                             embeddablePrefixes.add(fullAttributeName);
                             embeddableAccessors.add(embAccessors);
-                        } else {
-                            // Allow the simple attribute name if it doesn't overlap
-                            embeddableAttributeName = embeddableAttributeName.toLowerCase();
-                            attributeNames.putIfAbsent(embeddableAttributeName, fullAttributeName);
-
-                            // Allow a qualified name such as @OrderBy("address.street.name")
-                            embeddableAttributeName = fullAttributeName.toLowerCase();
-                            attributeNames.put(embeddableAttributeName, fullAttributeName);
-
-                            // Allow a qualified name such as findByAddress_Street_Name if it doesn't overlap
-                            String embeddableAttributeName_ = embeddableAttributeName.replace('.', '_');
-                            attributeNames.putIfAbsent(embeddableAttributeName_, fullAttributeName);
-
-                            // Allow a qualified name such as findByAddressStreetName if it doesn't overlap
-                            String embeddableAttributeNameUndelimited = embeddableAttributeName.replace(".", "");
-                            attributeNames.putIfAbsent(embeddableAttributeNameUndelimited, fullAttributeName);
-
-                            if (embAttr instanceof SingularAttribute && ((SingularAttribute<?, ?>) embAttr).isId())
-                                attributeNames.put("id", fullAttributeName);
-
-                            attributeAccessors.put(fullAttributeName, embAccessors);
-                            attributeTypes.put(fullAttributeName, PersistentAttributeType.ELEMENT_COLLECTION.equals(attributeType) //
-                                            ? Collection.class //
-                                            : embAttr.getJavaType());
                         }
+
+                        // Allow the simple attribute name if it doesn't overlap
+                        embeddableAttributeName = embeddableAttributeName.toLowerCase();
+                        attributeNames.putIfAbsent(embeddableAttributeName, fullAttributeName);
+
+                        // Allow a qualified name such as @OrderBy("address.street.name")
+                        embeddableAttributeName = fullAttributeName.toLowerCase();
+                        attributeNames.put(embeddableAttributeName, fullAttributeName);
+
+                        // Allow a qualified name such as findByAddress_Street_Name if it doesn't overlap
+                        String embeddableAttributeName_ = embeddableAttributeName.replace('.', '_');
+                        attributeNames.putIfAbsent(embeddableAttributeName_, fullAttributeName);
+
+                        // Allow a qualified name such as findByAddressStreetName if it doesn't overlap
+                        String embeddableAttributeNameUndelimited = embeddableAttributeName.replace(".", "");
+                        attributeNames.putIfAbsent(embeddableAttributeNameUndelimited, fullAttributeName);
+
+                        if (embAttr instanceof SingularAttribute && ((SingularAttribute<?, ?>) embAttr).isId())
+                            attributeNames.put("id", fullAttributeName);
+
+                        attributeAccessors.put(fullAttributeName, embAccessors);
+                        attributeTypes.put(fullAttributeName, PersistentAttributeType.ELEMENT_COLLECTION.equals(attributeType) //
+                                        ? Collection.class //
+                                        : embAttr.getJavaType());
                     }
                 }
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityDefiner.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityDefiner.java
@@ -258,9 +258,9 @@ class EntityDefiner implements Runnable {
                         embeddablePrefixes.add(attributeName);
                         embeddableAccessors.add(Collections.singletonList(attr.getJavaMember()));
                     } else {
-                        attributeNames.put(attributeName.toUpperCase(), attributeName);
+                        attributeNames.put(attributeName.toLowerCase(), attributeName);
                         if (attr instanceof SingularAttribute && ((SingularAttribute<?, ?>) attr).isId())
-                            attributeNames.put("ID", attributeName);
+                            attributeNames.put("id", attributeName);
                         attributeAccessors.put(attributeName, Collections.singletonList(attr.getJavaMember()));
                         attributeTypes.put(attributeName, PersistentAttributeType.ELEMENT_COLLECTION.equals(attributeType) //
                                         ? Collection.class //
@@ -285,11 +285,11 @@ class EntityDefiner implements Runnable {
                             embeddableAccessors.add(embAccessors);
                         } else {
                             // Allow the simple attribute name if it doesn't overlap
-                            embeddableAttributeName = embeddableAttributeName.toUpperCase();
+                            embeddableAttributeName = embeddableAttributeName.toLowerCase();
                             attributeNames.putIfAbsent(embeddableAttributeName, fullAttributeName);
 
                             // Allow a qualified name such as @OrderBy("address.street.name")
-                            embeddableAttributeName = fullAttributeName.toUpperCase();
+                            embeddableAttributeName = fullAttributeName.toLowerCase();
                             attributeNames.put(embeddableAttributeName, fullAttributeName);
 
                             // Allow a qualified name such as findByAddress_Street_Name if it doesn't overlap
@@ -301,7 +301,7 @@ class EntityDefiner implements Runnable {
                             attributeNames.putIfAbsent(embeddableAttributeNameUndelimited, fullAttributeName);
 
                             if (embAttr instanceof SingularAttribute && ((SingularAttribute<?, ?>) embAttr).isId())
-                                attributeNames.put("ID", fullAttributeName);
+                                attributeNames.put("id", fullAttributeName);
 
                             attributeAccessors.put(fullAttributeName, embAccessors);
                             attributeTypes.put(fullAttributeName, PersistentAttributeType.ELEMENT_COLLECTION.equals(attributeType) //

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -56,18 +56,28 @@ class EntityInfo {
     }
 
     String getAttributeName(String name) {
-        // TODO update per outcome of #44
-        String attributeName = attributeNames.get(name.toUpperCase());
+        String lowerName = name.toLowerCase();
+        String attributeName = attributeNames.get(lowerName);
         if (attributeName == null)
             if ("All".equals(name))
                 attributeName = null; // Special case for CrudRepository.deleteAll and CrudRepository.findAll
-            else if ("ID".equals(name.toUpperCase()))
+            else if ("id".equals(lowerName))
                 throw new MappingException("Entity class " + type.getName() + " does not have a property named " + name +
                                            " or which is designated as the @Id."); // TODO NLS
             else if (name.length() == 0)
                 throw new MappingException("Error parsing method name or entity property name is missing."); // TODO NLS
-            else
-                throw new MappingException("Entity class " + type.getName() + " does not have a property named " + name + "."); // TODO NLS
+            else {
+                // tolerate possible mixture of . and _ separators:
+                lowerName = lowerName.replace('.', '_');
+                attributeName = attributeNames.get(lowerName);
+                if (attributeName == null) {
+                    // tolerate possible mixture of . and _ separators with lack of separators:
+                    lowerName = lowerName.replace("_", "");
+                    attributeName = attributeNames.get(lowerName);
+                    if (attributeName == null)
+                        throw new MappingException("Entity class " + type.getName() + " does not have a property named " + name + "."); // TODO NLS
+                }
+            }
 
         return attributeName;
     }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -270,7 +270,7 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                     q.append(whereClause);
             } else if (queryInfo.method.getAnnotation(Exists.class) != null) {
                 queryInfo.type = QueryInfo.Type.EXISTS;
-                String idAttrName = queryInfo.entityInfo.getAttributeName("ID");
+                String idAttrName = queryInfo.entityInfo.getAttributeName("id");
                 q = new StringBuilder(17 + idAttrName.length() + entityInfo.name.length() + (whereClause == null ? 0 : whereClause.length())) //
                                 .append("SELECT o.").append(idAttrName) //
                                 .append(" FROM ").append(queryInfo.entityInfo.name).append(" o");
@@ -817,7 +817,7 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
         } else if (methodName.startsWith("exists")) {
             int by = methodName.indexOf("By", 6);
             int c = by < 0 ? 6 : by + 2;
-            q = new StringBuilder(200).append("SELECT o.").append(queryInfo.entityInfo.getAttributeName("ID")) //
+            q = new StringBuilder(200).append("SELECT o.").append(queryInfo.entityInfo.getAttributeName("id")) //
                             .append(" FROM ").append(queryInfo.entityInfo.name).append(" o");
             if (methodName.length() > c)
                 generateWhereClause(queryInfo, methodName, c, methodName.length(), q);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Account.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Account.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+
+/**
+ *
+ */
+@Entity
+public class Account {
+
+    @EmbeddedId
+    public AccountId accountId;
+
+    public double balance;
+
+    public String bankName;
+
+    public boolean checking;
+
+    public String owner;
+
+    public Account() {
+    }
+
+    Account(long accountNum, long routingNum, String bankName, boolean checking, double balance, String owner) {
+        this.accountId = AccountId.of(accountNum, routingNum);
+        this.bankName = bankName;
+        this.checking = checking;
+        this.balance = balance;
+        this.owner = owner;
+    }
+
+    @Override
+    public String toString() {
+        return bankName + ' ' + accountId + " $" + balance + " owned by " + owner + (checking ? " with checking" : "");
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/AccountId.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/AccountId.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Embeddable;
+
+/**
+ * Id class for Account entity.
+ */
+@Embeddable
+public class AccountId {
+
+    public long accountNum;
+    public long routingNum;
+
+    public static AccountId of(long accountNum, long routingNum) {
+        AccountId a = new AccountId();
+        a.accountNum = accountNum;
+        a.routingNum = routingNum;
+        return a;
+    }
+
+    @Override
+    public String toString() {
+        return "AccountId:" + accountNum + ":" + routingNum;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Accounts.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Accounts.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Repository;
+
+/**
+ *
+ */
+@Repository
+public interface Accounts {
+
+    long deleteByOwnerEndsWith(String pattern);
+
+    Account findByAccountId(AccountId id);
+
+    @OrderBy("balance")
+    Stream<Account> findByAccountIdNotAndOwner(AccountId idToExclude, String owner);
+
+    @OrderBy("bankName")
+    Stream<Account> findByAccountIdAccountNum(long routingNum);
+
+    @OrderBy("owner")
+    Stream<Account> findByAccountIdRoutingNum(long routingNum);
+
+    Account findById(AccountId id);
+
+    @OrderBy(value = "owner", descending = true)
+    Stream<Account> findByIdInOrOwner(List<AccountId> id, String owner);
+
+    // TODO OrderBy on embeddable?
+
+    void save(Account a);
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,12 +13,16 @@
 package test.jakarta.data.jpa.web;
 
 import java.util.List;
+import java.util.stream.Stream;
 
+import jakarta.data.repository.Compare;
 import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Filter;
 import jakarta.data.repository.KeysetAwareSlice;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Pageable;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Select;
 
 /**
  *
@@ -38,4 +42,16 @@ public interface Businesses extends CrudRepository<Business, Integer> {
     @OrderBy("houseNum")
     @OrderBy("id")
     KeysetAwareSlice<Business> findByZipIn(Iterable<Integer> zipCodes, Pageable pagination);
+
+    @Filter(by = "location_address.city")
+    @Filter(by = "location.address_state")
+    @OrderBy(descending = true, ignoreCase = true, value = "name")
+    Stream<Business> in(String city, String state);
+
+    @Filter(by = "locationAddressCity", value = "Rochester")
+    @Filter(by = "locationAddressState", value = "MN")
+    @Filter(by = "locationAddress.street_direction", ignoreCase = true, op = Compare.StartsWith, value = "s")
+    @OrderBy("name") // Business.name, not Business.Location.Address.Street.name
+    @Select("name")
+    List<String> onSouthSide();
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -37,6 +37,9 @@ import componenttest.app.FATServlet;
 public class DataJPATestServlet extends FATServlet {
 
     @Inject
+    Accounts accounts;
+
+    @Inject
     Businesses businesses;
 
     @Inject
@@ -166,6 +169,54 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Repository methods for an entity where an embeddable is the id.
+     */
+    @Test
+    public void testEmbeddedId() {
+        // Clear out data before test
+        accounts.deleteByOwnerEndsWith("TestEmbeddedId");
+
+        accounts.save(new Account(1005380, 70081, "Think Bank", true, 552.18, "Ellen TestEmbeddedId"));
+        accounts.save(new Account(1004470, 70081, "Think Bank", true, 443.94, "Erin TestEmbeddedId"));
+        accounts.save(new Account(1006380, 70081, "Think Bank", true, 160.63, "Edward TestEmbeddedId"));
+        accounts.save(new Account(1007590, 70081, "Think Bank", true, 793.30, "Elizabeth TestEmbeddedId"));
+        accounts.save(new Account(1008410, 22158, "Home Federal Savings Bank", true, 829.91, "Elizabeth TestEmbeddedId"));
+        accounts.save(new Account(1006380, 22158, "Home Federal Savings Bank", true, 261.66, "Elliot TestEmbeddedId"));
+        accounts.save(new Account(1004470, 22158, "Home Federal Savings Bank", false, 416.14, "Emma TestEmbeddedId"));
+        accounts.save(new Account(1009130, 30372, "Mayo Credit Union", true, 945.20, "Elizabeth TestEmbeddedId"));
+        accounts.save(new Account(1004470, 30372, "Mayo Credit Union", true, 423.15, "Eric TestEmbeddedId"));
+        accounts.save(new Account(1008200, 30372, "Mayo Credit Union", true, 103.04, "Evan TestEmbeddedId"));
+
+        assertIterableEquals(List.of("Emma TestEmbeddedId", "Eric TestEmbeddedId", "Erin TestEmbeddedId"),
+                             accounts.findByAccountIdAccountNum(1004470)
+                                             .map(a -> a.owner)
+                                             .collect(Collectors.toList()));
+
+        assertIterableEquals(List.of("Edward TestEmbeddedId", "Elizabeth TestEmbeddedId", "Ellen TestEmbeddedId", "Erin TestEmbeddedId"),
+                             accounts.findByAccountIdRoutingNum(70081)
+                                             .map(a -> a.owner)
+                                             .collect(Collectors.toList()));
+
+        assertEquals("Emma TestEmbeddedId", accounts.findByAccountId(AccountId.of(1004470, 22158)).owner);
+
+        assertEquals("Erin TestEmbeddedId", accounts.findById(AccountId.of(1004470, 70081)).owner);
+
+        assertIterableEquals(List.of("Home Federal Savings Bank", "Mayo Credit Union"),
+                             accounts.findByAccountIdNotAndOwner(AccountId.of(1007590, 70081), "Elizabeth TestEmbeddedId")
+                                             .map(a -> a.bankName)
+                                             .collect(Collectors.toList()));
+
+        // TODO try other keywords with embeddables?
+        // "In" does not appear to work:
+        //assertIterableEquals(List.of("Evan TestEmbeddedId", "Emma TestEmbeddedId", "Edward TestEmbeddedId"),
+        //                     accounts.findByIdInOrOwner(List.of(AccountId.of(1006380, 70081), AccountId.of(1004470, 22158)), "Evan TestEmbeddedId")
+        //                                     .map(a -> a.owner)
+        //                                     .collect(Collectors.toList()));
+
+        accounts.deleteByOwnerEndsWith("TestEmbeddedId");
+    }
+
+    /**
      * Repository methods for an entity where the id is on the embeddable.
      */
     @Test
@@ -192,5 +243,7 @@ public class DataJPATestServlet extends FATServlet {
                                              .stream()
                                              .map(emp -> emp.badge.number)
                                              .collect(Collectors.toList()));
+
+        employees.deleteByLastName("TestIdOnEmbeddable");
     }
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -149,6 +149,20 @@ public class DataJPATestServlet extends FATServlet {
                              Stream.of(found)
                                              .map(b -> b.name)
                                              .collect(Collectors.toList()));
+    }
+
+    /**
+     * Intermix different name patterns for embeddable attributes.
+     */
+    @Test
+    public void testEmbeddableIntermixNamePatterns() {
+        assertIterableEquals(List.of("HALCON", "Geotek"),
+                             businesses.in("Stewartville", "MN")
+                                             .map(b -> b.name)
+                                             .collect(Collectors.toList()));
+
+        assertIterableEquals(List.of("Custom Alarm", "Mayo Clinic", "Olmsted Medical", "Reichel Foods"),
+                             businesses.onSouthSide());
     }
 
     /**


### PR DESCRIPTION
Allow embeddables as entity properties, including as the id (EmbeddedId). Test some basic scenarios. More scenarios will be needed to explore further.  Also, try out referring to embeddables with names that intermix the patterns.