### PR TITLE
Telemetry propagation transport tests + client filter fixes

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -643,6 +643,11 @@
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-extension-trace-propagators</artifactId>
+      <version>1.19.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-common</artifactId>
       <version>1.19.0</version>
     </dependency>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -124,6 +124,7 @@ io.opentelemetry:opentelemetry-exporter-logging:1.19.0
 io.opentelemetry:opentelemetry-exporter-otlp-common:1.19.0
 io.opentelemetry:opentelemetry-exporter-otlp:1.19.0
 io.opentelemetry:opentelemetry-exporter-zipkin:1.19.0
+io.opentelemetry:opentelemetry-extension-trace-propagators:1.19.0
 io.opentelemetry:opentelemetry-sdk-common:1.19.0
 io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.19.0
 io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.19.0-alpha

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-1.0/io.openliberty.mpTelemetry-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-1.0/io.openliberty.mpTelemetry-1.0.feature
@@ -32,6 +32,7 @@ IBM-API-Package: \
   io.openliberty.cdi-4.0, \
   io.openliberty.mpCompatible-6.0,\
   com.ibm.websphere.appserver.injection-2.0, \
+  io.openliberty.org.eclipse.microprofile.rest.client-3.0, \
   io.openliberty.org.eclipse.microprofile.telemetry-1.0
 -bundles=\
   io.openliberty.com.squareup.okhttp,\

--- a/dev/io.openliberty.io.opentelemetry.internal/bnd.bnd
+++ b/dev/io.openliberty.io.opentelemetry.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -32,10 +32,25 @@ Import-Package: \
   zipkin2.internal,\
   zipkin2.reporter,\
   zipkin2.reporter.okhttp3,\
-  jakarta.interceptor
+  jakarta.interceptor,\
+  com.ibm.wsspi.classloading,\
+  org.osgi.framework
 
 Export-Package: \
+  io.opentelemetry.extension.trace.propagation;version=${openTelemetryVersion};thread-context=true,\
   io.opentelemetry.*;version=${openTelemetryVersion}
+
+-includeresource: resources
+
+app-resources= \
+  META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider
+
+Service-Component: \
+    io.openliberty.io.opentelemetry.internal.ResourceProvider; \
+        implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+        provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+        configuration-policy:=optional; \
+        properties:="resources=${app-resources}"
 
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 
@@ -57,6 +72,7 @@ Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 	io.opentelemetry:opentelemetry-exporter-otlp;version='1.19.0',\
 	io.opentelemetry:opentelemetry-exporter-common;version='1.19.0',\
 	io.opentelemetry:opentelemetry-exporter-zipkin;version='1.19.0',\
+	io.opentelemetry:opentelemetry-extension-trace-propagators;version='1.19.0',\
 	io.opentelemetry:opentelemetry-sdk;version='1.19.0',\
 	io.opentelemetry:opentelemetry-sdk-common;version='1.19.0',\
 	io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi;version='1.19.0',\
@@ -64,6 +80,8 @@ Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 	io.opentelemetry:opentelemetry-sdk-logs;version='1.19.0.alpha',\
 	io.opentelemetry:opentelemetry-sdk-metrics;version='1.19.0',\
 	io.opentelemetry:opentelemetry-sdk-trace;version='1.19.0',\
-	io.opentelemetry:opentelemetry-semconv;version='1.19.0.alpha'
+	io.opentelemetry:opentelemetry-semconv;version='1.19.0.alpha',\
+	com.ibm.ws.classloading;version=latest,\
+	org.eclipse.osgi;version=latest
 
 WS-TraceGroup: opentelemetry

--- a/dev/io.openliberty.io.opentelemetry.internal/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider
+++ b/dev/io.openliberty.io.opentelemetry.internal/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider
@@ -1,0 +1,3 @@
+io.opentelemetry.extension.trace.propagation.B3ConfigurablePropagator
+io.opentelemetry.extension.trace.propagation.B3MultiConfigurablePropagator
+io.opentelemetry.extension.trace.propagation.JaegerConfigurablePropagator

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -31,15 +31,14 @@ src: src, resources
 
 -dsannotations: \
   io.openliberty.microprofile.telemetry.internal.cdi.SPIMetaData,\
-  io.openliberty.microprofile.telemetry.internal.cdi.OpenTelemetryProducer,\
-  io.openliberty.microprofile.telemetry.internal.rest.TelemetryClientFilter,\
-  io.openliberty.microprofile.telemetry.internal.rest.TelemetryContainerFilter,\
-  io.openliberty.microprofile.telemetry.internal.rest.TelemetryClientAsyncTaskWrapper
+  io.openliberty.microprofile.telemetry.internal.rest.TelemetryClientAsyncTaskWrapper,\
+  io.openliberty.microprofile.telemetry.internal.rest.TelemetryClientBuilderListener
 
 -dsannotations-inherit: true
 
 app-resources= \
-  META-INF/services/jakarta.ws.rs.ext.Providers
+  META-INF/services/jakarta.ws.rs.ext.Providers | \
+  META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener
 
 Include-Resource: \
   META-INF=resources/META-INF
@@ -65,17 +64,18 @@ Private-Package: \
   io.openliberty.microprofile.telemetry.internal.helper
 
 -buildpath: \
-	io.openliberty.jakarta.restfulWS.3.1;version=latest,\
-	io.openliberty.jakarta.annotation.2.1;version=latest,\
-	io.openliberty.jakarta.interceptor.2.1;version=latest,\
-	io.openliberty.jakarta.cdi.4.0;version=latest,\
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.ws.logging.core;version=latest,\
-	com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
-	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-	io.openliberty.io.opentelemetry.internal;version=latest,\
-	io.openliberty.mpTelemetry.1.0.thirdparty;version=latest,\
-	io.openliberty.org.eclipse.microprofile.config.3.0,\
-	io.openliberty.org.jboss.resteasy.common;version=latest,\
-	com.ibm.websphere.org.osgi.core;version=latest,\
-	com.ibm.ws.container.service;version=latest,\
+    io.openliberty.jakarta.restfulWS.3.1;version=latest,\
+    io.openliberty.jakarta.annotation.2.1;version=latest,\
+    io.openliberty.jakarta.interceptor.2.1;version=latest,\
+    io.openliberty.jakarta.cdi.4.0;version=latest,\
+    com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+    com.ibm.ws.logging.core;version=latest,\
+    com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
+    com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+    io.openliberty.io.opentelemetry.internal;version=latest,\
+    io.openliberty.mpTelemetry.1.0.thirdparty;version=latest,\
+    io.openliberty.org.eclipse.microprofile.config.3.0,\
+    io.openliberty.org.eclipse.microprofile.rest.client.3.0,\
+    io.openliberty.org.jboss.resteasy.common.ee10;version=latest,\
+    com.ibm.websphere.org.osgi.core;version=latest,\
+    com.ibm.ws.container.service;version=latest

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/resources/META-INF/services/jakarta.ws.rs.ext.Providers
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/resources/META-INF/services/jakarta.ws.rs.ext.Providers
@@ -1,2 +1,1 @@
 io.openliberty.microprofile.telemetry.internal.rest.TelemetryContainerFilter
-io.openliberty.microprofile.telemetry.internal.rest.TelemetryClientFilter

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/resources/META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/resources/META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener
@@ -1,0 +1,1 @@
+io.openliberty.microprofile.telemetry.internal.rest.TelemetryRestClientBuilderListener

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryClientBuilderListener.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryClientBuilderListener.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal.rest;
+
+import static org.osgi.service.component.annotations.ConfigurationPolicy.IGNORE;
+
+import org.osgi.service.component.annotations.Component;
+
+import io.openliberty.restfulWS.client.ClientBuilderListener;
+import jakarta.ws.rs.client.ClientBuilder;
+
+/**
+ * Adds the Telemetry client filter when a rest client is built.
+ * <p>
+ * This gets called for both JAX-RS Client and MP Rest Client.
+ */
+@Component(configurationPolicy = IGNORE)
+public class TelemetryClientBuilderListener implements ClientBuilderListener {
+
+    public void building(ClientBuilder clientBuilder) {
+        TelemetryClientFilter currentFilter = TelemetryClientFilter.getCurrent();
+        clientBuilder.register(currentFilter);
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryClientFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryClientFilter.java
@@ -51,6 +51,20 @@ public class TelemetryClientFilter implements ClientRequestFilter, ClientRespons
     private static final NetClientAttributesGetterImpl NET_CLIENT_ATTRIBUTES_GETTER = new NetClientAttributesGetterImpl();
     private static final HttpClientAttributesGetterImpl HTTP_CLIENT_ATTRIBUTES_GETTER = new HttpClientAttributesGetterImpl();
 
+    /**
+     * Retrieve the TelemetryClientFilter for the current application using CDI
+     * <p>
+     * Implementation note: It's important that there's a class which is registered as a CDI bean on the stack from this bundle when {@code CDI.current()} is called so that CDI
+     * finds the correct BDA and bean manager.
+     * <p>
+     * Calling it from this static method ensures that {@code TelemetryClientFilter} is the first thing on the stack and CDI will find the right BDA.
+     *
+     * @return the TelemetryClientFilter for the current application
+     */
+    public static TelemetryClientFilter getCurrent() {
+        return CDI.current().select(TelemetryClientFilter.class).get();
+    }
+
     // RestEasy sometimes creates and injects client filters using CDI and sometimes doesn't so we need to work around that
     // See: https://github.com/OpenLiberty/open-liberty/issues/23758
     public void init() {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryRestClientBuilderListener.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryRestClientBuilderListener.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal.rest;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener;
+
+/**
+ * Add our client filter when a new Rest Client is created.
+ */
+public class TelemetryRestClientBuilderListener implements RestClientBuilderListener {
+
+    /** {@inheritDoc} */
+    @Override
+    public void onNewBuilder(RestClientBuilder builder) {
+        TelemetryClientFilter currentFilter = TelemetryClientFilter.getCurrent();
+        builder.register(currentFilter);
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,21 +16,29 @@ import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONL
 import static org.junit.Assert.assertEquals;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.PropertiesAsset;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpRequest;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.JaxRsEndpoints;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.B3MultiPropagationTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.B3PropagationTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.JaegerPropagationTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.W3CTraceBaggagePropagationTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.W3CTracePropagationTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
@@ -40,20 +48,91 @@ public class JaxRsIntegration extends FATServletClient {
 
     public static final String SERVER_NAME = "Telemetry10Jax";
     public static final String APP_NAME = "JaxPropagation";
+    public static final String W3C_TRACE_APP_NAME = "w3cTrace";
+    public static final String W3C_TRACE_BAGGAGE_APP_NAME = "w3cTraceBaggage";
+    public static final String B3_APP_NAME = "b3";
+    public static final String B3_MULTI_APP_NAME = "b3multi";
+    public static final String JAEGER_APP_NAME = "jaeger";
 
+    @TestServlets({
+                    @TestServlet(contextRoot = W3C_TRACE_APP_NAME, servlet = W3CTracePropagationTestServlet.class),
+                    @TestServlet(contextRoot = W3C_TRACE_BAGGAGE_APP_NAME, servlet = W3CTraceBaggagePropagationTestServlet.class),
+                    @TestServlet(contextRoot = B3_APP_NAME, servlet = B3PropagationTestServlet.class),
+                    @TestServlet(contextRoot = B3_MULTI_APP_NAME, servlet = B3MultiPropagationTestServlet.class),
+                    @TestServlet(contextRoot = JAEGER_APP_NAME, servlet = JaegerPropagationTestServlet.class),
+    })
     @Server(SERVER_NAME)
     public static LibertyServer server;
 
     @BeforeClass
     public static void setUp() throws Exception {
+        PropertiesAsset appConfig = new PropertiesAsset()
+                        .addProperty("otel.sdk.disabled", "false")
+                        .addProperty("otel.traces.exporter", "in-memory")
+                        .addProperty("otel.bsp.schedule.delay", "100");
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackage(JaxRsEndpoints.class.getPackage())
                         .addPackage(InMemorySpanExporter.class.getPackage())
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
-                        .addAsResource(new StringAsset("otel.sdk.disabled=false\notel.traces.exporter=in-memory\notel.bsp.schedule.delay=100"),
-                                       "META-INF/microprofile-config.properties");
+                        .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        PropertiesAsset w3cTraceAppConfig = new PropertiesAsset()
+                        .include(appConfig)
+                        .addProperty("otel.propagators", "tracecontext");
+        WebArchive w3cTraceApp = ShrinkWrap.create(WebArchive.class, W3C_TRACE_APP_NAME + ".war")
+                        .addClass(W3CTracePropagationTestServlet.class)
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(PropagationHeaderEndpoint.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(w3cTraceAppConfig, "META-INF/microprofile-config.properties");
+
+        PropertiesAsset w3cTraceBaggageAppConfig = new PropertiesAsset()
+                        .include(appConfig)
+                        .addProperty("otel.propagators", "tracecontext, baggage");
+        WebArchive w3cTraceBaggageApp = ShrinkWrap.create(WebArchive.class, W3C_TRACE_BAGGAGE_APP_NAME + ".war")
+                        .addClass(W3CTraceBaggagePropagationTestServlet.class)
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(PropagationHeaderEndpoint.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(w3cTraceBaggageAppConfig, "META-INF/microprofile-config.properties");
+
+        PropertiesAsset b3AppConfig = new PropertiesAsset()
+                        .include(appConfig)
+                        .addProperty("otel.propagators", "b3");
+        WebArchive b3App = ShrinkWrap.create(WebArchive.class, B3_APP_NAME + ".war")
+                        .addClass(B3PropagationTestServlet.class)
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(PropagationHeaderEndpoint.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(b3AppConfig, "META-INF/microprofile-config.properties");
+
+        PropertiesAsset b3MultiAppConfig = new PropertiesAsset()
+                        .include(appConfig)
+                        .addProperty("otel.propagators", "b3multi");
+        WebArchive b3MultiApp = ShrinkWrap.create(WebArchive.class, B3_MULTI_APP_NAME + ".war")
+                        .addClass(B3MultiPropagationTestServlet.class)
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(PropagationHeaderEndpoint.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(b3MultiAppConfig, "META-INF/microprofile-config.properties");
+
+        PropertiesAsset jaegerAppConfig = new PropertiesAsset()
+                        .include(appConfig)
+                        .addProperty("otel.propagators", "jaeger");
+        WebArchive jaegerApp = ShrinkWrap.create(WebArchive.class, JAEGER_APP_NAME + ".war")
+                        .addClass(JaegerPropagationTestServlet.class)
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(PropagationHeaderEndpoint.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(jaegerAppConfig, "META-INF/microprofile-config.properties");
 
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, w3cTraceApp, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, w3cTraceBaggageApp, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, b3App, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, b3MultiApp, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, jaegerApp, SERVER_ONLY);
+
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/common/PropagationHeaderClient.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/common/PropagationHeaderClient.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/propagationHeaderEndpoint")
+public interface PropagationHeaderClient {
+
+    @GET
+    public String get();
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/common/PropagationHeaderEndpoint.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/common/PropagationHeaderEndpoint.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+
+/**
+ * This endpoint is used to test propagation.
+ *
+ * It does the following:
+ * <ul>
+ * <li>Creates a span
+ * <li>Collects the names of all known propagation headers which are present in the HTTP request and sets that as a span attribute with key {@link #PROPAGATION_HEADERS_ATTR}
+ * <li>Reads the baggage entry with key {@link #BAGGAGE_KEY} and if present sets
+ * <ul><li>span attribute {@link #BAGGAGE_VALUE_ATTR} to the entry value
+ * <li>span attribute {@link #BAGGAGE_METADATA_ATTR} to the entry metadata value
+ * </ul></ul>
+ *
+ * Tests using this endpoint should generally do the following:
+ * <ul>
+ * <li>Start a span
+ * <li>Set the baggage entry {@link #BAGGAGE_KEY} to a known test value
+ * <li>Request this endpoint
+ * <li>End their span
+ * <li>Retrieve the created spans (e.g. via {@link InMemorySpanExporter})
+ * <li>Verify that their span has a child CLIENT span which has a child SERVER span (which will be the span created by this endpoint) (if traceIds should be propagated)
+ * <li>Verify the value of the {@link #BAGGAGE_VALUE_ATTR} attribute in the SERVER span is value of the test baggage entry (if baggage should be propagated)
+ * <li>Verify the value of the {@link #BAGGAGE_METADATA_ATTR} attribute in the SERVER span (if baggage metadata should be propagated)
+ * <li>Verify the value of the {@link #PROPAGATION_HEADERS_ATTR} attribute in the SERVER span is the list of headers expected to be used for propagation
+ * </ul>
+ */
+@ApplicationPath("/")
+@Path("/propagationHeaderEndpoint")
+public class PropagationHeaderEndpoint extends Application {
+
+    public static final String BAGGAGE_KEY = "test.baggage.key";
+    public static final AttributeKey<String> BAGGAGE_METADATA_ATTR = AttributeKey.stringKey("test.baggage.metadata");
+    public static final AttributeKey<String> BAGGAGE_VALUE_ATTR = AttributeKey.stringKey("test.baggage");
+    public static final AttributeKey<List<String>> PROPAGATION_HEADERS_ATTR = AttributeKey.stringArrayKey("test.propagation.headers");
+
+    private static final List<String> PROPAGATION_HEADER_NAMES = Arrays.asList("baggage", "traceparent",
+                                                                               "b3",
+                                                                               "X-B3-TraceId", "X-B3-SpanId", "X-B3-ParentSpanId", "X-B3-Sampled",
+                                                                               "uber-trace-id");
+
+    @GET
+    public String get(@Context HttpHeaders headers) {
+        Span span = Span.current();
+
+        // Extract the propagation headers and store in the span
+        List<String> propagationHeaders = headers.getRequestHeaders().keySet().stream()
+                        .filter(PropagationHeaderEndpoint::isPropagationHeader)
+                        .collect(Collectors.toList());
+        span.setAttribute(PropagationHeaderEndpoint.PROPAGATION_HEADERS_ATTR, propagationHeaders);
+
+        // Extract the test baggage value (if present) and store in the span
+        BaggageEntry baggageEntry = Baggage.current().asMap().get(BAGGAGE_KEY);
+        if (baggageEntry != null) {
+            span.setAttribute(BAGGAGE_VALUE_ATTR, baggageEntry.getValue());
+            span.setAttribute(BAGGAGE_METADATA_ATTR, baggageEntry.getMetadata().getValue());
+        }
+
+        return "OK";
+    }
+
+    public static boolean isPropagationHeader(String header) {
+        return PROPAGATION_HEADER_NAMES.contains(header)
+               || header.startsWith("uberctx-"); // Jaeger baggage headers use keys as part of the header but have a common prefix
+    }
+
+    public static URI getBaseUri(HttpServletRequest request) {
+        try {
+            URI originalUri = URI.create(request.getRequestURL().toString());
+            URI targetUri = new URI(originalUri.getScheme(), originalUri.getAuthority(), request.getContextPath(), null, null);
+            System.out.println("Using URI: " + targetUri);
+            return targetUri;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3MultiPropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3MultiPropagationTestServlet.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports;
+
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_KEY;
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_METADATA_ATTR;
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_VALUE_ATTR;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderClient;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+
+@SuppressWarnings("serial")
+@WebServlet("/b3MultiPropagation")
+public class B3MultiPropagationTestServlet extends FATServlet {
+
+    private static final String BAGGAGE_VALUE = "test.baggage.value";
+    private static final String BAGGAGE_METADATA = "test.baggage.metadata";
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter spanExporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Test
+    public void testB3Propagation() throws URISyntaxException {
+        Span span = tracer.spanBuilder("test").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+            Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+            baggage.makeCurrent();
+            PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+            client.get();
+        } finally {
+            span.end();
+        }
+
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3);
+
+        SpanData testSpan = spanData.get(0);
+        SpanData clientSpan = spanData.get(1);
+        SpanData serverSpan = spanData.get(2);
+
+        // Assert correct parent-child links
+        // Shows that propagation occurred
+        assertEquals("client parent span id", testSpan.getSpanId(), clientSpan.getParentSpanId());
+        assertEquals("server parent span id", clientSpan.getSpanId(), serverSpan.getParentSpanId());
+
+        // B3 does not support baggage, so baggage should not be propagated
+        assertNull("baggage value propagated", serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        assertNull("baggage metadata propagated", serverSpan.getAttributes().get(BAGGAGE_METADATA_ATTR));
+
+        // Assert that the expected headers were used
+        assertThat(serverSpan.getAttributes().get(PropagationHeaderEndpoint.PROPAGATION_HEADERS_ATTR),
+                   containsInAnyOrder("X-B3-TraceId", "X-B3-SpanId", "X-B3-Sampled"));
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3PropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3PropagationTestServlet.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports;
+
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_KEY;
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_METADATA_ATTR;
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_VALUE_ATTR;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderClient;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+
+@SuppressWarnings("serial")
+@WebServlet("/b3Propagation")
+public class B3PropagationTestServlet extends FATServlet {
+
+    private static final String BAGGAGE_VALUE = "test.baggage.value";
+    private static final String BAGGAGE_METADATA = "test.baggage.metadata";
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter spanExporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Test
+    public void testB3Propagation() throws URISyntaxException {
+        Span span = tracer.spanBuilder("test").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+            Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+            baggage.makeCurrent();
+            PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+            client.get();
+        } finally {
+            span.end();
+        }
+
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3);
+
+        SpanData testSpan = spanData.get(0);
+        SpanData clientSpan = spanData.get(1);
+        SpanData serverSpan = spanData.get(2);
+
+        // Assert correct parent-child links
+        // Shows that propagation occurred
+        assertEquals("client parent span id", testSpan.getSpanId(), clientSpan.getParentSpanId());
+        assertEquals("server parent span id", clientSpan.getSpanId(), serverSpan.getParentSpanId());
+
+        // B3 does not support baggage, so baggage should not be propagated
+        assertNull("baggage value propagated", serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        assertNull("baggage metadata propagated", serverSpan.getAttributes().get(BAGGAGE_METADATA_ATTR));
+
+        // Assert that the expected headers were used
+        assertThat(serverSpan.getAttributes().get(PropagationHeaderEndpoint.PROPAGATION_HEADERS_ATTR), containsInAnyOrder("b3"));
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/JaegerPropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/JaegerPropagationTestServlet.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports;
+
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_KEY;
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_METADATA_ATTR;
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_VALUE_ATTR;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderClient;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+
+@SuppressWarnings("serial")
+@WebServlet("/jaegerPropagation")
+public class JaegerPropagationTestServlet extends FATServlet {
+
+    private static final String BAGGAGE_VALUE = "test.baggage.value";
+    private static final String BAGGAGE_METADATA = "test.baggage.metadata";
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter spanExporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Test
+    public void testJaegerPropagation() throws URISyntaxException {
+        Span span = tracer.spanBuilder("test").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+            Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+            baggage.makeCurrent();
+            PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+            client.get();
+        } finally {
+            span.end();
+        }
+
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3);
+
+        SpanData testSpan = spanData.get(0);
+        SpanData clientSpan = spanData.get(1);
+        SpanData serverSpan = spanData.get(2);
+
+        // Assert correct parent-child links
+        // Shows that propagation occurred
+        assertEquals("client parent span id", testSpan.getSpanId(), clientSpan.getParentSpanId());
+        assertEquals("server parent span id", clientSpan.getSpanId(), serverSpan.getParentSpanId());
+
+        // Assert baggage is propagated
+        assertEquals("baggage value propagated", BAGGAGE_VALUE, serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        // Jaeger does not propagate baggage metadata, so we get back the result of BaggageEntryMetadata.empty().getValue() which is an empty string.
+        assertEquals("baggage metadata propagated", "", serverSpan.getAttributes().get(BAGGAGE_METADATA_ATTR));
+
+        // Assert that the expected headers were used
+        assertThat(serverSpan.getAttributes().get(PropagationHeaderEndpoint.PROPAGATION_HEADERS_ATTR), containsInAnyOrder("uber-trace-id", "uberctx-" + BAGGAGE_KEY));
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTraceBaggagePropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTraceBaggagePropagationTestServlet.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports;
+
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_KEY;
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_METADATA_ATTR;
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_VALUE_ATTR;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderClient;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+
+@SuppressWarnings("serial")
+@WebServlet("/w3cTraceBaggagePropagation")
+public class W3CTraceBaggagePropagationTestServlet extends FATServlet {
+
+    private static final String BAGGAGE_VALUE = "test.baggage.value";
+    private static final String BAGGAGE_METADATA = "test.baggage.metadata";
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter spanExporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Test
+    public void testW3cTraceBaggagePropagation() throws URISyntaxException {
+        Span span = tracer.spanBuilder("test").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+            Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+            baggage.makeCurrent();
+            PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+            client.get();
+        } finally {
+            span.end();
+        }
+
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3);
+
+        SpanData testSpan = spanData.get(0);
+        SpanData clientSpan = spanData.get(1);
+        SpanData serverSpan = spanData.get(2);
+
+        // Assert correct parent-child links
+        // Shows that propagation occurred
+        assertEquals("client parent span id", testSpan.getSpanId(), clientSpan.getParentSpanId());
+        assertEquals("server parent span id", clientSpan.getSpanId(), serverSpan.getParentSpanId());
+
+        // Assert baggage is propagated
+        assertEquals("baggage value propagated", BAGGAGE_VALUE, serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        assertEquals("baggage metadata propagated", BAGGAGE_METADATA, serverSpan.getAttributes().get(BAGGAGE_METADATA_ATTR));
+
+        // Assert that the expected headers were used
+        assertThat(serverSpan.getAttributes().get(PropagationHeaderEndpoint.PROPAGATION_HEADERS_ATTR), containsInAnyOrder("traceparent", "baggage"));
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTracePropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTracePropagationTestServlet.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports;
+
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_KEY;
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_METADATA_ATTR;
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_VALUE_ATTR;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderClient;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+
+@SuppressWarnings("serial")
+@WebServlet("/w3cTracePropagation")
+public class W3CTracePropagationTestServlet extends FATServlet {
+
+    private static final String BAGGAGE_VALUE = "test.baggage.value";
+    private static final String BAGGAGE_METADATA = "test.baggage.metadata";
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter spanExporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Test
+    public void testW3cTracePropagation() throws URISyntaxException {
+        Span span = tracer.spanBuilder("test").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+            Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+            baggage.makeCurrent();
+            PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+            client.get();
+        } finally {
+            span.end();
+        }
+
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3);
+
+        SpanData testSpan = spanData.get(0);
+        SpanData clientSpan = spanData.get(1);
+        SpanData serverSpan = spanData.get(2);
+
+        // Assert correct parent-child links
+        // Shows that propagation occurred
+        assertEquals("client parent span id", testSpan.getSpanId(), clientSpan.getParentSpanId());
+        assertEquals("server parent span id", clientSpan.getSpanId(), serverSpan.getParentSpanId());
+
+        // Baggage is not propagated if only tracecontext is enabled
+        assertNull("baggage value propagated", serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        assertNull("baggage metadata propagated", serverSpan.getAttributes().get(BAGGAGE_METADATA_ATTR));
+
+        // Assert that the expected headers were used
+        assertThat(serverSpan.getAttributes().get(PropagationHeaderEndpoint.PROPAGATION_HEADERS_ATTR), containsInAnyOrder("traceparent"));
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/spanexporter/InMemorySpanExporter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/spanexporter/InMemorySpanExporter.java
@@ -78,7 +78,7 @@ public class InMemorySpanExporter implements SpanExporter {
 
     @Override
     public CompletableResultCode export(Collection<SpanData> spans) {
-        LOGGER.info("export method called");
+        LOGGER.info("export method called, exporter = " + System.identityHashCode(this) + ", collection: " + System.identityHashCode(finishedSpanItems));
         if (isStopped) {
             return CompletableResultCode.ofFailure();
         }
@@ -101,6 +101,7 @@ public class InMemorySpanExporter implements SpanExporter {
         }
 
         finishedSpanItems.addAll(lSpans);
+        LOGGER.info("There are now " + finishedSpanItems.size() + " items");
 
         return CompletableResultCode.ofSuccess();
     }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Jax/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Jax/server.xml
@@ -1,19 +1,41 @@
 <server description="Server for testing Telemetry10">
 
-	<include location="../fatTestPorts.xml" />
+    <include location="../fatTestPorts.xml" />
 
-	<featureManager>
-		<feature>servlet-6.0</feature>
-                <feature>mpTelemetry-1.0</feature>
-		<feature>componentTest-2.0</feature>
-		<feature>restfulWS-3.1</feature>
-		<feature>mpRestClient-3.0</feature>
-	</featureManager>
+    <featureManager>
+        <feature>servlet-6.0</feature>
+        <feature>mpTelemetry-1.0</feature>
+        <feature>componentTest-2.0</feature>
+        <feature>restfulWS-3.1</feature>
+        <feature>mpRestClient-3.0</feature>
+    </featureManager>
 
     <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
 
     <application id="JaxPropagation" name="JaxPropagation" type="war" location="JaxPropagation.war">
         <classloader apiTypeVisibility="+third-party"/>
     </application>
+
+    <application type="war" location="w3cTrace.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
+    <application type="war" location="w3cTraceBaggage.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
+    <application type="war" location="b3.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
+    <application type="war" location="b3multi.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
+    <application type="war" location="jaeger.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+    
+    <!--logging traceSpecification="TELEMETRY=all:RESTfulWS=all"/-->
 
 </server>


### PR DESCRIPTION
- Add tests for propagating baggage and context using w3c, b3 and jaeger formats.
- Control client filter creation in Telemetry

Previously, we provided the client filter class to JAX-RS and relied on it to create instances as required.

However, JAX-RS was sometimes not using the right application context - see https://github.com/OpenLiberty/open-liberty/issues/23985 - so I'm moving the creation of the filter instances into Telemetry where we can delegate the creation to CDI which does get the application context correct.

For #23448