### PR TITLE
Issue 24092: Prevent aborted connections from invoking endRequest and end during cleanup/destroy.

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2021 IBM Corporation and others.
+ * Copyright (c) 2001, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -2466,13 +2466,19 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         if (isTraceOn && tc.isEntryEnabled()) 
             Tr.entry(this, tc, "destroy");
 
+        if(isAborted()){
+            if(isTraceOn && tc.isEntryEnabled())
+                Tr.exit(this, tc, "destroy", "ManagedConnection is aborted -- skipping destroy");
+            return;
+        }
+        
         // Save the first exception to occur and raise it after all other destroy processing is complete.
         // Don't map exceptions and fire ConnectionError event from destroy because the
         // ManagedConnection is already being destroyed and there is no further action to take.
 
         ResourceException dsae = null;
 
-        if (inRequest || isAborted())
+        if (inRequest)
             try {
                 inRequest = false;
                 mcf.jdbcRuntime.endRequest(sqlConn);
@@ -2483,12 +2489,6 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 }
                 Tr.debug(tc, "Error during end request in destroy.", x);
             }
-
-        if(isAborted()){
-            if(isTraceOn && tc.isEntryEnabled())
-                Tr.exit(this, tc, "destroy", "ManagedConnection is aborted -- skipping destroy");
-            return;
-        }
 
         try {
             //  - We can't use the normal cleanup here because it dissociates
@@ -2723,7 +2723,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 }
                 Tr.debug(tc, "Error during end request in cleanup.", x);
             }
-
+        
         // According to the JCA 1.5 spec, all remaining handles must be invalidated on
         // cleanup.  This is achieved by closing the handles.  Dissociating the handles would
         // not be adequate because dissociated handles may be used again.  
@@ -3126,15 +3126,16 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         switch (stateMgr.transtate) {
 
             case WSStateManager.GLOBAL_TRANSACTION_ACTIVE: {
+                
+                if (aborted.get()) {
+                    break;
+                }
+                
                 try {
                     ((WSRdbXaResourceImpl) xares).end();
                 } catch (javax.transaction.xa.XAException xae) {
                     // No FFDC code needed; this is a normal case.
                     // Continue with the rollback if an exception is thrown on end. 
-                }
-                
-                if (aborted.get()) {
-                    break;
                 }
 
                 try {

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/src/jdbc/fat/v43/web/JDBC43TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/src/jdbc/fat/v43/web/JDBC43TestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1106,7 +1106,7 @@ public class JDBC43TestServlet extends FATServlet {
             }).get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
         }
 
-        assertEquals(ends + 1, requests[END].get());
+        assertEquals(ends, requests[END].get());
         tx.begin();
         try {
 
@@ -1139,7 +1139,7 @@ public class JDBC43TestServlet extends FATServlet {
             tx.rollback();
         }
 
-        assertEquals(ends + 1, requests[END].get());
+        assertEquals(ends, requests[END].get());
     }
 
     /**
@@ -1175,7 +1175,7 @@ public class JDBC43TestServlet extends FATServlet {
             }).get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
         }
 
-        assertEquals(ends + 1, requests[END].get());
+        assertEquals(ends, requests[END].get());
         tx.begin();
         try {
 
@@ -1203,7 +1203,7 @@ public class JDBC43TestServlet extends FATServlet {
             tx.rollback();
         }
 
-        assertEquals(ends + 1, requests[END].get());
+        assertEquals(ends, requests[END].get());
     }
 
     /**
@@ -1448,7 +1448,7 @@ public class JDBC43TestServlet extends FATServlet {
 
         tx.begin();
         try {
-            assertEquals(ends + 1, requests[END].get());
+            assertEquals(ends, requests[END].get());
 
             Connection con3 = defaultDataSource.getConnection();
             requests = (AtomicInteger[]) con3.unwrap(Supplier.class).get();
@@ -1473,7 +1473,7 @@ public class JDBC43TestServlet extends FATServlet {
             tx.rollback();
         }
 
-        assertEquals(ends + 1, requests[END].get());
+        assertEquals(ends, requests[END].get());
     }
 
     /**
@@ -1503,7 +1503,7 @@ public class JDBC43TestServlet extends FATServlet {
             con1.abort(singleThreadExecutor);
         }
 
-        assertEquals(ends + 1, requests[END].get());
+        assertEquals(ends, requests[END].get());
         tx.begin();
         try {
             Connection con2 = unsharablePool1DataSource.getConnection();
@@ -1524,7 +1524,7 @@ public class JDBC43TestServlet extends FATServlet {
             tx.rollback();
         }
 
-        assertEquals(ends + 1, requests[END].get());
+        assertEquals(ends, requests[END].get());
     }
 
     /**


### PR DESCRIPTION
fixes #24092

Issues have been identified (hangs) when an aborted connection invokes end() on transactions with SQL server's JDBC driver. The liberty connection management code is being updated to prevent aborted connections from invoking end() and endRequest.
