### PR TITLE
For RTC294574, make sure min java limits are in place for com.ibm.ws.…

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.javasupport_fat/fat/src/io/openliberty/jpa/test/javasupport/TestJPA20_JavaSourceLevel.java
+++ b/dev/com.ibm.ws.jpa.tests.javasupport_fat/fat/src/io/openliberty/jpa/test/javasupport/TestJPA20_JavaSourceLevel.java
@@ -30,6 +30,7 @@ import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
+@MinimumJavaLevel(javaLevel = 7)
 public class TestJPA20_JavaSourceLevel extends AbstractTestJavaSourceLevel {
     @Server("javaSupportServer_JPA20")
     public static LibertyServer server_jss_jpa20;

--- a/dev/com.ibm.ws.jpa.tests.javasupport_fat/fat/src/io/openliberty/jpa/test/javasupport/TestJPA21_JavaSourceLevel.java
+++ b/dev/com.ibm.ws.jpa.tests.javasupport_fat/fat/src/io/openliberty/jpa/test/javasupport/TestJPA21_JavaSourceLevel.java
@@ -27,6 +27,7 @@ import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
+@MinimumJavaLevel(javaLevel = 8)
 public class TestJPA21_JavaSourceLevel extends AbstractTestJavaSourceLevel {
     @Server("javaSupportServer_JPA21")
     public static LibertyServer server_jss_jpa21;

--- a/dev/com.ibm.ws.jpa.tests.javasupport_fat/fat/src/io/openliberty/jpa/test/javasupport/TestJPA22_JavaSourceLevel.java
+++ b/dev/com.ibm.ws.jpa.tests.javasupport_fat/fat/src/io/openliberty/jpa/test/javasupport/TestJPA22_JavaSourceLevel.java
@@ -27,6 +27,7 @@ import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
+@MinimumJavaLevel(javaLevel = 8)
 public class TestJPA22_JavaSourceLevel extends AbstractTestJavaSourceLevel {
     @Server("javaSupportServer_JPA22")
     public static LibertyServer server_jss_jpa22;

--- a/dev/com.ibm.ws.jpa.tests.javasupport_fat/fat/src/io/openliberty/jpa/test/javasupport/TestJPA30_JavaSourceLevel.java
+++ b/dev/com.ibm.ws.jpa.tests.javasupport_fat/fat/src/io/openliberty/jpa/test/javasupport/TestJPA30_JavaSourceLevel.java
@@ -27,6 +27,7 @@ import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
+@MinimumJavaLevel(javaLevel = 8)
 public class TestJPA30_JavaSourceLevel extends AbstractTestJavaSourceLevel {
     @Server("javaSupportServer_JPA30")
     public static LibertyServer server_jss_jpa30;

--- a/dev/com.ibm.ws.jpa.tests.javasupport_fat/fat/src/io/openliberty/jpa/test/javasupport/TestJPA31_JavaSourceLevel.java
+++ b/dev/com.ibm.ws.jpa.tests.javasupport_fat/fat/src/io/openliberty/jpa/test/javasupport/TestJPA31_JavaSourceLevel.java
@@ -27,6 +27,7 @@ import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
+@MinimumJavaLevel(javaLevel = 11)
 public class TestJPA31_JavaSourceLevel extends AbstractTestJavaSourceLevel {
     @Server("javaSupportServer_JPA31")
     public static LibertyServer server_jss_jpa31;


### PR DESCRIPTION
Make sure that there are min java versions set for each subbucket in com.ibm.ws.jpa.tests.javasupport_fat