### PR TITLE
Update non-empty beans.xml test

### DIFF
--- a/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/config/beansxml/beans.xml
+++ b/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/config/beansxml/beans.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans>
+</beans>
+


### PR DESCRIPTION
This is a slight update to the existing non-empty beans.xml test to make it just a "non-empty" test rather than a CDI 1.0 beans.xml test.

#build