### PR TITLE
Qualify qsh command references on IBM i

### DIFF
--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/Machine.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/Machine.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -439,11 +439,11 @@ public class Machine {
      * @throws Exception
      */
     public ProgramOutput execute(String cmd, String[] parameters, String workDir, Properties envVars, int timeout) throws Exception {
-        // On iSeries, we should be adding the qsh -c flag to the start of any command.
+        // On iSeries, we should be adding the /QOpenSys/usr/bin/qsh -c flag to the start of any command.
         // This means commands are executed in a native-like shell, rather than a
-        // PASE environment.
+        // PASE environment.  Need to fully qualify the /QOpenSys/usr/bin/qsh command to avoid translation issues.
         if (OperatingSystem.ISERIES.compareTo(getOperatingSystem()) == 0) {
-            cmd = "qsh -c " + cmd;
+            cmd = "/QOpenSys/usr/bin/qsh -c " + cmd;
         }
         return LocalProvider.executeCommand(this, cmd, parameters, workDir, envVars);
     }


### PR DESCRIPTION
We are seeing an assortment of strange character translation issues (CCSID) on the IBM i platform in some of our testing.  In talking with one of my IBM i OSS co-workers, a likely cause of this is using an unqualified reference to the `qsh` shell.  In Machine.java we take IBM i commands that come through the execute() method and prefix them with `qsh -c`.  When that happens, the `qsh` that is used can either point to `/usr/bin/qsh` or `/QOpenSys/usr/bin/qsh`, depending on how the system PATH is specified.  The `/QOpenSys/usr/bin/qsh` version of qsh tends to do some extra character translations that could result in the unintelligible characters we are seeing.  By switching to `/usr/bin/qsh` we will use a consistent version that is less likely to perform extra character translations.  This may not fix any current issues, but provides for a more consistent test environment.