### PR TITLE
fix npe when request.getCookies returns null

### DIFF
--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieBasedStorage.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieBasedStorage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -63,6 +63,12 @@ public class CookieBasedStorage implements Storage {
     @Sensitive
     public String get(String name) {
         Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "No cookies were sent by the client.");
+            }
+            return null;
+        }
         for (Cookie c : cookies) {
             if (c.getName().equals(name)) {
                 return c.getValue();

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/storage/CookieBasedStorageTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/storage/CookieBasedStorageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -161,6 +161,20 @@ public class CookieBasedStorageTest extends CommonTestClass {
         String value = storage.get(doesNotExistCookieName);
 
         assertNull("Expected the value to be null if the cookie name does not exist in the cookies.", value);
+    }
+
+    @Test
+    public void test_get_nullCookies() {
+        mockery.checking(new Expectations() {
+            {
+                one(request).getCookies();
+                will(returnValue(null));
+            }
+        });
+
+        String value = storage.get(testCookieName);
+
+        assertNull("Expected the value to be null if no cookies were sent.", value);
     }
 
     @Test


### PR DESCRIPTION
handle the case if no cookies are sent by the client causing HttpServletRequest#getCookies to return null.