### PR TITLE
Issue 20813: Faces 4.0 FAT tests for outputScript and outputStylesheet.

### DIFF
--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/.classpath
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/.classpath
@@ -14,6 +14,7 @@
 	<classpathentry kind="src" path="test-applications/SubscribeToEventTest.war/src"/>
 	<classpathentry kind="src" path="test-applications/ProgrammaticFaceletTests.war/src"/>
 	<classpathentry kind="src" path="test-applications/Faces40URN.war/src"/>
+	<classpathentry kind="src" path="test-applications/WebSocket.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/bnd.bnd
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/bnd.bnd
@@ -25,6 +25,8 @@ src: \
     test-applications/MultipleInputFileTest.war/src,\
     test-applications/ProgrammaticFaceletTests.war/src,\
     test-applications/SubscribeToEventTest.war/src
+    test-applications/Faces40URN.war/src
+    test-applications/WebSocket.war/src
 
 fat.project: true
 

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/bnd.bnd
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/bnd.bnd
@@ -24,8 +24,8 @@ src: \
     test-applications/Faces40ThirdPartyApi.war/src,\
     test-applications/MultipleInputFileTest.war/src,\
     test-applications/ProgrammaticFaceletTests.war/src,\
-    test-applications/SubscribeToEventTest.war/src
-    test-applications/Faces40URN.war/src
+    test-applications/SubscribeToEventTest.war/src,\
+    test-applications/Faces40URN.war/src,\
     test-applications/WebSocket.war/src
 
 fat.project: true

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/FATSuite.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/FATSuite.java
@@ -29,6 +29,7 @@ import io.openliberty.org.apache.myfaces40.fat.tests.Faces40ThirdPartyApiTests;
 import io.openliberty.org.apache.myfaces40.fat.tests.Faces40URNTest;
 import io.openliberty.org.apache.myfaces40.fat.tests.FacesConfigTest;
 import io.openliberty.org.apache.myfaces40.fat.tests.FacesContextGetLifecycleTest;
+import io.openliberty.org.apache.myfaces40.fat.tests.Html5Tests;
 import io.openliberty.org.apache.myfaces40.fat.tests.InputTextTypeTest;
 import io.openliberty.org.apache.myfaces40.fat.tests.LayoutAttributeTests;
 import io.openliberty.org.apache.myfaces40.fat.tests.MultipleInputFileTest;
@@ -57,9 +58,10 @@ import io.openliberty.org.apache.myfaces40.fat.tests.WebSocketTests;
                 SelectItemTests.class,
                 SimpleTest.class,
                 SubscribeToEventTest.class,
-                UIViewRootGetDoctypeTest.class
-                Faces40URNTest.class
+                UIViewRootGetDoctypeTest.class,
+                Faces40URNTest.class,
                 WebSocketTests.class,
+                Html5Tests.class
 })
 
 public class FATSuite {

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/FATSuite.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/FATSuite.java
@@ -37,6 +37,7 @@ import io.openliberty.org.apache.myfaces40.fat.tests.SelectItemTests;
 import io.openliberty.org.apache.myfaces40.fat.tests.SimpleTest;
 import io.openliberty.org.apache.myfaces40.fat.tests.SubscribeToEventTest;
 import io.openliberty.org.apache.myfaces40.fat.tests.UIViewRootGetDoctypeTest;
+import io.openliberty.org.apache.myfaces40.fat.tests.WebSocketTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -57,6 +58,8 @@ import io.openliberty.org.apache.myfaces40.fat.tests.UIViewRootGetDoctypeTest;
                 SimpleTest.class,
                 SubscribeToEventTest.class,
                 UIViewRootGetDoctypeTest.class
+                Faces40URNTest.class
+                WebSocketTests.class,
 })
 
 public class FATSuite {

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/JSFUtils.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/JSFUtils.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.org.apache.myfaces40.fat;
+
+import java.net.URL;
+
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * A utility class for JSF tests.
+ */
+public class JSFUtils {
+
+    protected static final Class<?> c = JSFUtils.class;
+
+    /**
+     * Construct a URL for a test case so a request can be made.
+     *
+     * @param server - The server that is under test, this is used to get the port and host name.
+     * @param contextRoot - The context root of the application
+     * @param path - Additional path information for the request.
+     * @return - A fully formed URL.
+     * @throws Exception
+     */
+    public static URL createHttpUrl(LibertyServer server, String contextRoot, String path) throws Exception {
+        return new URL(createHttpUrlString(server, contextRoot, path));
+    }
+
+    /**
+     * Construct a URL for a test case so a request can be made.
+     *
+     * @param server - The server that is under test, this is used to get the port and host name.
+     * @param contextRoot - The context root of the application
+     * @param path - Additional path information for the request.
+     * @return - A fully formed URL string.
+     * @throws Exception
+     */
+    public static String createHttpUrlString(LibertyServer server, String contextRoot, String path) {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("http://")
+          .append(server.getHostname())
+          .append(":")
+          .append(server.getHttpDefaultPort())
+          .append("/")
+          .append(contextRoot)
+          .append("/")
+          .append(path);
+
+        return sb.toString();
+    }
+
+    /**
+     * Create a custom wait mechanism that waits for any background JavaScript to finish
+     * and verifies a message in the page response.
+     *
+     * @param page The current HtmlPage
+     * @return A boolean value indicating if the response message was found
+     * @throws InterruptedException
+     */
+    public static boolean waitForPageResponse(HtmlPage page, String responseMessage) throws InterruptedException {
+        int i = 0;
+        boolean isTextFound = false;
+        while (!isTextFound && i < 10) {
+            isTextFound = page.asText().contains(responseMessage);
+            i++;
+
+            Log.info(c, "waitForPageResponse", "Waiting for: " + responseMessage + " isTextFound: " + isTextFound + " i: " + i);
+            Log.info(c, "waitForPageResponse", page.asText());
+            Log.info(c, "waitForPageResponse", page.asXml());
+            Thread.sleep(1000);
+        }
+        return isTextFound;
+    }
+}

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/tests/Html5Tests.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/tests/Html5Tests.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+package io.openliberty.org.apache.myfaces40.fat.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.org.apache.myfaces40.fat.JSFUtils;
+
+/**
+ * Tests for verifying HTML 5 behavior of Faces 4.0.
+ */
+@RunWith(FATRunner.class)
+public class Html5Tests {
+    @Rule
+    public TestName name = new TestName();
+
+    String contextRoot = "HTML5Tests";
+
+    protected static final Class<?> c = Html5Tests.class;
+
+    @Server("faces40_html5Server")
+    public static LibertyServer faces40_html5Server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+
+        ShrinkHelper.defaultDropinApp(faces40_html5Server, "HTML5Tests.war",
+                                      "io.openliberty.org.apache.faces40.fat.html5");
+
+        faces40_html5Server.startServer(Html5Tests.class.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Stop the server
+        if (faces40_html5Server != null && faces40_html5Server.isStarted()) {
+            faces40_html5Server.stopServer();
+        }
+    }
+
+    /**
+     * Test the 'type' attribute for &lt;link&gt; is not rendered when using outputStylesheet in HTML 5.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testOutputStylesheet_Html5() throws Exception {
+        try (WebClient webClient = new WebClient()) {
+            URL url = JSFUtils.createHttpUrl(faces40_html5Server, contextRoot, "outputStylesheetHtml5.jsf");
+            HtmlPage page = (HtmlPage) webClient.getPage(url);
+
+            // Log the page for debugging if necessary in the future.
+            Log.info(c, name.getMethodName(), page.asText());
+            Log.info(c, name.getMethodName(), page.asXml());
+
+            DomElement linkElement = page.getElementsByTagName("link").get(0);
+            assertEquals(DomElement.ATTRIBUTE_NOT_DEFINED, linkElement.getAttribute("type"));
+        }
+    }
+
+    /**
+     * Test the 'type' attribute for &lt;link&gt; is rendered when using outputStylesheet prior to HTML 5.
+     * This test is intended to prevent HTML 5 behavior from being accidently back-ported.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testOutputStylesheet_PreHtml5() throws Exception {
+        try (WebClient webClient = new WebClient()) {
+            URL url = JSFUtils.createHttpUrl(faces40_html5Server, contextRoot, "outputStylesheet.jsf");
+            HtmlPage page = (HtmlPage) webClient.getPage(url);
+
+            // Log the page for debugging if necessary in the future.
+            Log.info(c, name.getMethodName(), page.asText());
+            Log.info(c, name.getMethodName(), page.asXml());
+
+            DomElement linkElement = page.getElementsByTagName("link").get(0);
+            assertEquals("text/css", linkElement.getAttribute("type"));
+        }
+    }
+
+    /**
+     * Test the 'type' attribute for &lt;script&gt; is not rendered when using outputScript in HTML 5.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testOutputScript_Html5() throws Exception {
+        try (WebClient webClient = new WebClient()) {
+            URL url = JSFUtils.createHttpUrl(faces40_html5Server, contextRoot, "outputScriptHtml5.jsf");
+            HtmlPage page = (HtmlPage) webClient.getPage(url);
+
+            // Log the page for debugging if necessary in the future.
+            Log.info(c, name.getMethodName(), page.asText());
+            Log.info(c, name.getMethodName(), page.asXml());
+
+            DomElement linkElement = page.getElementsByTagName("script").get(0);
+            assertEquals(DomElement.ATTRIBUTE_NOT_DEFINED, linkElement.getAttribute("type"));
+        }
+    }
+
+    /**
+     * Test the 'type' attribute for &lt;script&gt; is rendered when using outputScript prior to HTML 5.
+     * This test is intended to prevent HTML 5 behavior from being accidently back-ported.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testOutputScript_PreHtml5() throws Exception {
+        try (WebClient webClient = new WebClient()) {
+            URL url = JSFUtils.createHttpUrl(faces40_html5Server, contextRoot, "outputScript.jsf");
+            HtmlPage page = (HtmlPage) webClient.getPage(url);
+
+            // Log the page for debugging if necessary in the future.
+            Log.info(c, name.getMethodName(), page.asText());
+            Log.info(c, name.getMethodName(), page.asXml());
+
+            DomElement linkElement = page.getElementsByTagName("script").get(0);
+            assertEquals("text/javascript", linkElement.getAttribute("type"));
+        }
+    }
+}

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/tests/WebSocketTests.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/tests/WebSocketTests.java
@@ -110,12 +110,6 @@ public class WebSocketTests {
 
             assertTrue(JSFUtils.waitForPageResponse(openPage, "Called onerror listener"));
             assertTrue(JSFUtils.waitForPageResponse(openPage, "Called onclose listener"));
-
-            //TODO: Should the onClose(@Observes @Closed WebsocketEvent event) method in WebsocketPushBean get invoked for onclose?
-//            String result = server.waitForStringInLogUsingMark("Channel myChannel was closed successfully!");
-//
-//            // Verify that the correct message is found in the logs
-//            assertNotNull("Message not found: 'Channel myChannel was closed successfully!'", result);
         }
     }
 

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/tests/WebSocketTests.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/tests/WebSocketTests.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.org.apache.myfaces40.fat.tests;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URL;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.org.apache.myfaces40.fat.JSFUtils;
+
+/**
+ * This test class is to be used for the tests that test feature specified
+ * in JSF 4.0 specification for <f:websocket> onerror="...”.
+ */
+@RunWith(FATRunner.class)
+public class WebSocketTests {
+
+    private static final String WEB_SOCKET_TEST_APP_NAME = "WebSocket";
+    protected static final Class<?> c = WebSocketTests.class;
+
+    @Rule
+    public TestName name = new TestName();
+
+    @Server("faces40_WebSocketServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, WEB_SOCKET_TEST_APP_NAME + ".war",
+                                      "io.openliberty.org.apache.faces40.fat.websocket");
+
+        // Start the server and use the class name so we can find logs easily.
+        server.startServer(WebSocketTests.class.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Stop the server
+        if (server != null && server.isStarted()) {
+            server.stopServer("SRVE0190E"); // SRVE0190E is due to ENABLE_WEBSOCKET_ENDPOINT being false for triggering onerror on a websocket.
+        }
+    }
+
+    @Before
+    public void setupPerTest() throws Exception {
+        server.setMarkToEndOfLog();
+    }
+
+    /**
+     * Test to ensure that the <f:websocket> onerror listener works properly.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testOnErrorWebsocket() throws Exception {
+        try (WebClient webClient = new WebClient()) {
+            webClient.getOptions().setThrowExceptionOnScriptError(false);
+
+            // Construct the URL for the test
+            String contextRoot = "WebSocket";
+            URL url = JSFUtils.createHttpUrl(server, contextRoot, "OnErrorWebSocketTest.jsf");
+
+            HtmlPage testOnErrorWebSocketPage = (HtmlPage) webClient.getPage(url);
+
+            // Log the page for debugging if necessary in the future.
+            Log.info(c, name.getMethodName(), testOnErrorWebSocketPage.asText());
+            Log.info(c, name.getMethodName(), testOnErrorWebSocketPage.asXml());
+
+            // Verify that the page contains the expected messages.
+            assertContains(testOnErrorWebSocketPage.asText(),
+                           "JSF 4.0 WebSocket - Test that onerror is invoked correctly.");
+
+            // Get the form that we are dealing with
+            HtmlForm form = testOnErrorWebSocketPage.getFormByName("form1");
+
+            // Get the button that opens the push connection
+            HtmlSubmitInput openButton = form.getInputByName("form1:openButton");
+
+            // Now click the open button. This should result in an error since 'jakarta.faces.ENABLE_WEBSOCKET_ENDPOINT' is set to 'false'
+            HtmlPage openPage = openButton.click();
+
+            assertTrue(JSFUtils.waitForPageResponse(openPage, "Called onerror listener"));
+            assertTrue(JSFUtils.waitForPageResponse(openPage, "Called onclose listener"));
+
+            //TODO: Should the onClose(@Observes @Closed WebsocketEvent event) method in WebsocketPushBean get invoked for onclose?
+//            String result = server.waitForStringInLogUsingMark("Channel myChannel was closed successfully!");
+//
+//            // Verify that the correct message is found in the logs
+//            assertNotNull("Message not found: 'Channel myChannel was closed successfully!'", result);
+        }
+    }
+
+    private void assertContains(String str, String lookFor) {
+        Log.info(c, name.getMethodName(), "Looking for '" + lookFor + "' in string: " + str);
+        if (str == null || !str.contains(lookFor))
+            fail("Expected to find '" + lookFor + "' in response, but response was: " + str);
+    }
+}

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/publish/servers/faces40_WebSocketServer/bootstrap.properties
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/publish/servers/faces40_WebSocketServer/bootstrap.properties
@@ -1,0 +1,18 @@
+###############################################################################
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7777
+com.ibm.ws.logging.trace.specification=*=info=enabled:com.ibm.ws.app.manager.*=all:org.apache.myfaces.*=all:com.ibm.ws.jsf*=all:com.ibm.ws.runtime.update.*=all:logservice=detail
+com.ibm.ws.logging.max.file.size=20
+com.ibm.ws.logging.max.files=10
+com.ibm.ws.logging.trace.format=BASIC

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/publish/servers/faces40_WebSocketServer/server.xml
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/publish/servers/faces40_WebSocketServer/server.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing JavaServer Faces 4.0, CDI, and WebSockets">
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>faces-4.0</feature>
+        <feature>websocket-2.1</feature>
+    </featureManager>
+</server>

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/publish/servers/faces40_html5Server/bootstrap.properties
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/publish/servers/faces40_html5Server/bootstrap.properties
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7777
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf*=all
+com.ibm.ws.logging.max.file.size=20
+com.ibm.ws.logging.max.files=10
+com.ibm.ws.logging.trace.format=BASIC
+#osgi.debug=osgi.debug.options

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/publish/servers/faces40_html5Server/osgi.debug.options
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/publish/servers/faces40_html5Server/osgi.debug.options
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+org.eclipse.osgi/debug=true
+org.eclipse.osgi/debug/loader=true

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/publish/servers/faces40_html5Server/server.xml
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/publish/servers/faces40_html5Server/server.xml
@@ -1,0 +1,21 @@
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing Faces 4.0">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>faces-4.0</feature>
+    </featureManager>
+
+</server>

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/WEB-INF/resources/css/styles.css
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/WEB-INF/resources/css/styles.css
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c)  2023  IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+@CHARSET "UTF-8";
+
+p {
+    font-size: x-large; font-weight: bold;
+}

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/WEB-INF/resources/scripts/helloMessage.js
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/WEB-INF/resources/scripts/helloMessage.js
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c)  2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+document.getElementById("helloMessage").innerHTML = "Hello from script";

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/WEB-INF/web.xml
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/WEB-INF/web.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0">
+     
+    <display-name>JSF40Html5Test</display-name>
+
+    <context-param>
+        <param-name>jakarta.faces.WEBAPP_RESOURCES_DIRECTORY</param-name>
+        <param-value>WEB-INF/resources</param-value>
+    </context-param>
+    
+    <servlet>
+        <servlet-name>Faces Servlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>Faces Servlet</servlet-name>
+        <url-pattern>*.jsf</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/outputScript.xhtml
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/outputScript.xhtml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ -->
+ <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:head>
+        <title>Pre HTML 5 outputScript test.</title>
+    </h:head>
+
+    <h:body>
+        <p>Verify the 'type' attribute for &lt;script&gt; is rendered when using outputScript prior to HTML 5.</p>
+        
+        <div>
+            <p id="helloMessage"></p>
+        </div>
+        
+        <h:outputScript library="scripts" name="helloMessage.js"/>
+    </h:body>
+
+</html>
+

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/outputScriptHtml5.xhtml
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/outputScriptHtml5.xhtml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ -->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:head>
+        <title>HTML 5 outputScript test.</title>
+    </h:head>
+
+    <h:body>
+        <p>Verify the 'type' attribute for &lt;script&gt; is not rendered when using outputScript in HTML 5.</p>
+        
+        <div>
+            <p id="helloMessage"></p>
+        </div>
+        
+        <h:outputScript library="scripts" name="helloMessage.js"/>
+    </h:body>
+
+</html>
+

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/outputStylesheet.xhtml
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/outputStylesheet.xhtml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ -->
+ <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:head>
+        <title>Pre HTML 5 outputStylesheet test.</title>
+        <h:outputStylesheet library="css" name="styles.css"/>
+    </h:head>
+
+    <h:body>
+        <p>Verify the 'type' attribute for &lt;link&gt; is rendered when using outputStylesheet prior to HTML 5.</p>
+    </h:body>
+
+</html>
+

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/outputStylesheetHtml5.xhtml
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/HTML5Tests.war/resources/outputStylesheetHtml5.xhtml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ -->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:head>
+        <title>HTML 5 outputStylesheet test.</title>
+        <h:outputStylesheet library="css" name="styles.css"/>
+    </h:head>
+
+    <h:body>
+        <p>Verify the 'type' attribute for &lt;link&gt; is not rendered when using outputStylesheet in HTML 5.</p>
+    </h:body>
+
+</html>
+

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/WebSocket.war/resources/OnErrorWebSocketTest.xhtml
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/WebSocket.war/resources/OnErrorWebSocketTest.xhtml
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
+    
+
+<h:head>
+    <title>JSF 4.0 WebSocket test</title>
+    
+    <script type="text/javascript" src="websocketListeners.js"></script>     
+</h:head>
+<h:body>
+    JSF 4.0 WebSocket - Test that onerror is invoked correctly.
+    <br/>
+    <h:form id="form1">
+        <h:commandButton id="openButton" value="Click here to open channel" onclick="faces.push.open('websocketId')">
+            <f:ajax/>
+        </h:commandButton>
+    </h:form>
+    
+    <f:websocket id="websocketId" channel="myChannel" onerror="websocketErrorListener" onmessage="websocketMessageListener" onopen="websocketOpenListener" onclose="websocketCloseListener" connected="false"/>
+    
+    <div id="messageId"></div>
+</h:body>
+</html>

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/WebSocket.war/resources/WEB-INF/beans.xml
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/WebSocket.war/resources/WEB-INF/beans.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+ <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+    version="4.0" bean-discovery-mode="all">
+</beans>

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/WebSocket.war/resources/WEB-INF/web.xml
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/WebSocket.war/resources/WEB-INF/web.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0">
+     
+    <display-name>JSF40WebSocketTest</display-name>
+
+    <servlet>
+        <servlet-name>Faces Servlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>Faces Servlet</servlet-name>
+        <url-pattern>*.jsf</url-pattern>
+    </servlet-mapping>
+
+    <context-param>
+        <param-name>jakarta.faces.ENABLE_WEBSOCKET_ENDPOINT</param-name>
+        <param-value>false</param-value>
+</context-param>
+
+</web-app>

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/WebSocket.war/resources/websocketListeners.js
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/WebSocket.war/resources/websocketListeners.js
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+function websocketMessageListener(message, channel, event) {
+   	document.getElementById("messageId").innerHTML += "Called onmessage listener with message: " + message + "<br/>";
+}
+
+function websocketOpenListener(channel) {
+	document.getElementById("messageId").innerHTML += "Called onopen listener" + "<br/>";
+}
+
+function websocketCloseListener(channel) {
+	document.getElementById("messageId").innerHTML += "Called onclose listener" + "<br/>";
+}
+
+function websocketErrorListener(code, channel, event) {
+	document.getElementById("messageId").innerHTML += "Called onerror listener" + "<br/>";
+}

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/WebSocket.war/src/io/openliberty/org/apache/faces40/fat/websocket/WebsocketPushBean.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/WebSocket.war/src/io/openliberty/org/apache/faces40/fat/websocket/WebsocketPushBean.java
@@ -39,16 +39,8 @@ public class WebsocketPushBean implements Serializable {
     private PushContext myChannel;
 
     public void send() {
-        LOGGER.log(Level.INFO, "Method send was invoked successfully!");
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            // TODO Auto-generated catch block
-            // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
-            e.printStackTrace();
-        }
-//        throw new RuntimeException("Test onerror exception.");
         myChannel.send("Message from the server via push!");
+        LOGGER.log(Level.INFO, "Method send was invoked successfully!");
     }
 
     public void onOpen(@Observes @Opened WebsocketEvent event) {

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/WebSocket.war/src/io/openliberty/org/apache/faces40/fat/websocket/WebsocketPushBean.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/WebSocket.war/src/io/openliberty/org/apache/faces40/fat/websocket/WebsocketPushBean.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.org.apache.faces40.fat.websocket;
+
+import java.io.Serializable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.faces.event.WebsocketEvent;
+import jakarta.faces.event.WebsocketEvent.Closed;
+import jakarta.faces.event.WebsocketEvent.Opened;
+import jakarta.faces.push.Push;
+import jakarta.faces.push.PushContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@Named
+@ApplicationScoped
+public class WebsocketPushBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static Logger LOGGER = Logger.getLogger(WebsocketPushBean.class.getName());
+
+    @Inject
+    @Push
+    private PushContext myChannel;
+
+    public void send() {
+        LOGGER.log(Level.INFO, "Method send was invoked successfully!");
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            // TODO Auto-generated catch block
+            // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
+            e.printStackTrace();
+        }
+//        throw new RuntimeException("Test onerror exception.");
+        myChannel.send("Message from the server via push!");
+    }
+
+    public void onOpen(@Observes @Opened WebsocketEvent event) {
+        String channel = event.getChannel();
+        LOGGER.log(Level.INFO, "Channel {0} was opened successfully!", channel);
+    }
+
+    public void onClose(@Observes @Closed WebsocketEvent event) {
+        String channel = event.getChannel();
+        LOGGER.log(Level.INFO, "Channel {0} was closed successfully!", channel);
+    }
+
+}


### PR DESCRIPTION
for #20813

Also contains the test for #20836

Verify that the 'type' attribute is not rendered when outputScript and outputStylesheet are rendered into <script> and <link> respectively. This only applies to rendering to HTML 5.