### PR TITLE
Call JaxRsFactoryImplicitBeanCDICustomizer.afterServiceInvoke() to release CreationContexts

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/BeanValidation12Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/BeanValidation12Test.java
@@ -1,16 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jaxrs20.cdi12.fat.test;
+
+import static org.junit.Assert.assertTrue;
 
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
@@ -65,7 +67,6 @@ public class BeanValidation12Test extends AbstractTest {
     @Test
     public void testIsViolatedInPerRequestWithCDI12_BeanValidation() throws Exception {
         runGetMethod("/rest/perrequest/book", 400, "I am a Student. null", true);
-        String uri = TestUtils.getBaseTestUri(appname, PARAM_URL_PATTERN, "/perrequest/book");
     }
 
     @Test
@@ -78,5 +79,19 @@ public class BeanValidation12Test extends AbstractTest {
     public void testIsViolatedInSingletonWithCDI12_BeanValidation() throws Exception {
         runGetMethod("/rest/singleton/book", 400, "Hello from SimpleBean null", true);
 //        String uri = TestUtils.getBaseTestUri(appname, PARAM_URL_PATTERN, "/singleton/book");
+    }
+
+    @Test
+    public void testIsViolatedInPerRequestWithCDI12Leak_BeanValidation() throws Exception {
+
+        for (int i = 0; i < 10000; i++) {
+            runGetMethod("/rest/perrequestleak/book", 400, "I am a Student. null", true);
+        }
+        Thread.sleep(10000);
+        System.gc();
+        StringBuilder lines = runGetMethod("/rest/perrequestleak/size", 200, "", false);
+        String result = lines.toString().trim();
+        System.out.println("Adam result=" + result);
+        assertTrue(Integer.valueOf(result) < 10000);
     }
 }

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/BeanValidation12Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/BeanValidation12Test.java
@@ -12,8 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.jaxrs20.cdi12.fat.test;
 
-import static org.junit.Assert.assertTrue;
-
+import static org.junit.Assert.assertEquals;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -23,16 +22,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
-import com.ibm.ws.jaxrs20.cdi12.fat.TestUtils;
-
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
 public class BeanValidation12Test extends AbstractTest {
-
-    private static final String PARAM_URL_PATTERN = "rest";
 
     @Server("com.ibm.ws.jaxrs20.cdi12.fat.beanvalidation")
     public static LibertyServer server;
@@ -84,12 +79,12 @@ public class BeanValidation12Test extends AbstractTest {
     @Test
     public void testIsViolatedInPerRequestWithCDI12Leak_BeanValidation() throws Exception {
 
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 10; i++) {
             runGetMethod("/rest/perrequestleak/book", 400, "I am a Student. null", true);
         }
         StringBuilder lines = runGetMethod("/rest/perrequestleak/size", 200, "", false);
         String result = lines.toString().trim();
-        System.out.println("Adam result=" + result);
-        assertTrue(Integer.valueOf(result) < 10000);
+
+        assertEquals(1, Integer.parseInt(result));
     }
 }

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/BeanValidation12Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/BeanValidation12Test.java
@@ -87,8 +87,6 @@ public class BeanValidation12Test extends AbstractTest {
         for (int i = 0; i < 10000; i++) {
             runGetMethod("/rest/perrequestleak/book", 400, "I am a Student. null", true);
         }
-        Thread.sleep(10000);
-        System.gc();
         StringBuilder lines = runGetMethod("/rest/perrequestleak/size", 200, "", false);
         String result = lines.toString().trim();
         System.out.println("Adam result=" + result);

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/beanvalidation/src/com/ibm/ws/jaxrs20/cdi12/fat/beanvalidation/BeanValidationApplication.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/beanvalidation/src/com/ibm/ws/jaxrs20/cdi12/fat/beanvalidation/BeanValidationApplication.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -29,6 +29,7 @@ public class BeanValidationApplication extends Application {
     public Set<Class<?>> getClasses() {
         Set<Class<?>> classes = new HashSet<Class<?>>();
         classes.add(BookStoreWithValidationPerRequest.class);
+        classes.add(BookStoreWithValidationPerRequestLeak.class);
         classes.add(BookStoreWithValidation.class);
         return classes;
     }

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/beanvalidation/src/com/ibm/ws/jaxrs20/cdi12/fat/beanvalidation/BookStoreWithValidationPerRequestLeak.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/beanvalidation/src/com/ibm/ws/jaxrs20/cdi12/fat/beanvalidation/BookStoreWithValidationPerRequestLeak.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.cdi12.fat.beanvalidation;
+
+import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Path("/perrequestleak/")
+public class BookStoreWithValidationPerRequestLeak {
+
+    static WeakHashMap<BookStoreWithValidationPerRequestLeak, String> map = new WeakHashMap<BookStoreWithValidationPerRequestLeak, String>();
+
+    Person person;
+
+    @Inject
+    public void setPerson(Person person) {
+        this.person = person;
+        System.out.println("PerRequest Person Injection successful...");
+
+        // Store references to 'this' in a weak hashmap to verify those references to person get cleaned up
+        map.put(this, null);
+    }
+
+    @GET
+    @Path("book")
+    @NotNull
+    @Produces(MediaType.TEXT_PLAIN)
+    public String book(@NotNull @QueryParam("id") String id) {
+        return person.talk() + " " + id;
+    }
+
+    @GET
+    @Path("size")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String book() {
+        int size = map.size();
+        System.out.println("hashmap size=" + size);
+        return Integer.toString(size);
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/beanvalidation/src/com/ibm/ws/jaxrs20/cdi12/fat/beanvalidation/BookStoreWithValidationPerRequestLeak.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/beanvalidation/src/com/ibm/ws/jaxrs20/cdi12/fat/beanvalidation/BookStoreWithValidationPerRequestLeak.java
@@ -6,15 +6,10 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jaxrs20.cdi12.fat.beanvalidation;
 
 import java.util.WeakHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.GET;
@@ -26,7 +21,7 @@ import javax.ws.rs.core.MediaType;
 @Path("/perrequestleak/")
 public class BookStoreWithValidationPerRequestLeak {
 
-    static WeakHashMap<BookStoreWithValidationPerRequestLeak, String> map = new WeakHashMap<BookStoreWithValidationPerRequestLeak, String>();
+    static WeakHashMap<BookStoreWithValidationPerRequestLeak, String> map = new WeakHashMap<>();
 
     Person person;
 
@@ -52,6 +47,23 @@ public class BookStoreWithValidationPerRequestLeak {
     @Produces(MediaType.TEXT_PLAIN)
     public String book() {
         int size = map.size();
+
+        // Explicitly call garbage collection to make sure references to person get cleaned up
+        for (int i = 0; i < 10; ++i) {
+            if (size == 1) {
+                break;
+            }
+
+            System.out.println("calling system gc");
+            System.gc();
+
+            try {
+                Thread.sleep(1000);
+            } catch (Exception e) {
+            }
+            size = map.size();
+        }
+
         System.out.println("hashmap size=" + size);
         return Integer.toString(size);
     }

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/injection/LibertyClearInjectRuntimeCtxOutInterceptor.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/injection/LibertyClearInjectRuntimeCtxOutInterceptor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -38,6 +38,14 @@ public class LibertyClearInjectRuntimeCtxOutInterceptor<T extends Message> exten
 
     @Override
     public void handleMessage(Message message) throws Fault {
+        //clear InjectionRuntimeContext on server-side only
+        if (!MessageUtils.isRequestor(message)) {
+            InjectionRuntimeContextHelper.removeRuntimeContext();
+        }
+    }
+
+    @Override
+    public void handleFault(Message message) {
         //clear InjectionRuntimeContext on server-side only
         if (!MessageUtils.isRequestor(message)) {
             InjectionRuntimeContextHelper.removeRuntimeContext();

--- a/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsInvoker.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsInvoker.java
@@ -198,7 +198,8 @@ public class LibertyJaxRsInvoker extends JAXRSInvoker {
     public Object invoke(Exchange exchange, final Object serviceObject, Method m, List<Object> params) {
 
         //bean customizer....
-        final Object realServiceObject;
+        Object realServiceObject = null;
+        JaxRsFactoryBeanCustomizer beanCustomizer = null;
 
         final OperationResourceInfo ori = exchange.get(OperationResourceInfo.class);
         final ClassResourceInfo cri = ori.getClassResourceInfo();
@@ -206,95 +207,100 @@ public class LibertyJaxRsInvoker extends JAXRSInvoker {
         // put related context object into ThreadLocal
         //SingleTon resources's replacement is put in InjectionUtil.injectContextProxiesAndApplication() method
 
-        if (!cri.isSingleton()) {
-            Class<?> clazz = serviceObject.getClass();
-            JaxRsFactoryBeanCustomizer beanCustomizer = libertyJaxRsServerFactoryBean.findBeanCustomizer(clazz);
-            if (beanCustomizer != null) {
+        try {
+            if (!cri.isSingleton()) {
+                Class<?> clazz = serviceObject.getClass();
+                beanCustomizer = libertyJaxRsServerFactoryBean.findBeanCustomizer(clazz);
+                if (beanCustomizer != null) {
 
-                realServiceObject = beanCustomizer.beforeServiceInvoke(serviceObject,
-                                                                       cri.isSingleton(),
-                                                                       libertyJaxRsServerFactoryBean.getBeanCustomizerContext(beanCustomizer));
-                if (realServiceObject == serviceObject && !beanCustomizer.getClass().getName().equalsIgnoreCase("com.ibm.ws.jaxrs20.ejb.JaxRsFactoryBeanEJBCustomizer")
-                    && !cri.contextsAvailable() && !cri.paramsAvailable()) {
-                    //call postConstruct method if it has not been repleaced with EJB/CDI for per-request resources
-                    Method postConstructMethod = ResourceUtils.findPostConstructMethod(realServiceObject.getClass());
-                    InjectionUtils.invokeLifeCycleMethod(realServiceObject, postConstructMethod);
+                    realServiceObject = beanCustomizer.beforeServiceInvoke(serviceObject,
+                                                                           cri.isSingleton(),
+                                                                           libertyJaxRsServerFactoryBean.getBeanCustomizerContext(beanCustomizer));
+                    if (realServiceObject == serviceObject && !beanCustomizer.getClass().getName().equalsIgnoreCase("com.ibm.ws.jaxrs20.ejb.JaxRsFactoryBeanEJBCustomizer")
+                        && !cri.contextsAvailable() && !cri.paramsAvailable()) {
+                        //call postConstruct method if it has not been repleaced with EJB/CDI for per-request resources
+                        Method postConstructMethod = ResourceUtils.findPostConstructMethod(realServiceObject.getClass());
+                        InjectionUtils.invokeLifeCycleMethod(realServiceObject, postConstructMethod);
+
+                    }
+
+                } else {
+                    realServiceObject = serviceObject;
+
+                    if (!cri.contextsAvailable() && !cri.paramsAvailable()) {
+
+                        //if bean customizer is null, means it is a pojo, we need to call postConstruct here
+                        Method postConstructMethod = ResourceUtils.findPostConstructMethod(serviceObject.getClass());
+                        InjectionUtils.invokeLifeCycleMethod(serviceObject, postConstructMethod);
+                    }
 
                 }
 
             } else {
                 realServiceObject = serviceObject;
-
-                if (!cri.contextsAvailable() && !cri.paramsAvailable()) {
-
-                    //if bean customizer is null, means it is a pojo, we need to call postConstruct here
-                    Method postConstructMethod = ResourceUtils.findPostConstructMethod(serviceObject.getClass());
-                    InjectionUtils.invokeLifeCycleMethod(serviceObject, postConstructMethod);
-                }
-
             }
 
-        } else {
-            realServiceObject = serviceObject;
-        }
+            //
+            Message message = JAXRSUtils.getCurrentMessage();
 
-        //
-        Message message = JAXRSUtils.getCurrentMessage();
+            Object theProvider = null;
+            if (isEnableBeanValidation && cxfBeanValidationProviderClass != null) {
 
-        Object theProvider = null;
-        if (isEnableBeanValidation && cxfBeanValidationProviderClass != null) {
+                theProvider = getProvider(message);
 
-            theProvider = getProvider(message);
+                try {
+                    if (isValidateServiceObject()) {
+                        //theProvider.validateBean(serviceObject);
+                        callValidationMethod("validateBean", new Object[] { realServiceObject }, theProvider);
 
-            try {
-                if (isValidateServiceObject()) {
-                    //theProvider.validateBean(serviceObject);
-                    callValidationMethod("validateBean", new Object[] { realServiceObject }, theProvider);
+                    }
+                    //theProvider.validateParameters(serviceObject, m, params.toArray());
+                    callValidationMethod("validateParameters", new Object[] { realServiceObject, m, params.toArray() }, theProvider);
+
+                } catch (RuntimeException e) {
+                    // Since BeanValidation is enabled, if this exception is a ConstraintViolationException
+                    // then we will want to put a FaultListener on the message so that
+                    // when this exception bubbles up to PhaseInterceptorChain that we do not
+                    // use default logging which will log this exception.  BeanValidation is
+                    // supposed to block logging these messages.
+                    if (beanValidationFaultListener != null && beanValidationFaultListener.cve.isInstance(e)) {
+                        Message m2 = exchange.getInMessage();
+                        m2.put(FaultListener.class.getName(), beanValidationFaultListener);
+                    }
+                    //re-throw exception.  If the FaultListener is set then a ConstraintViolation will not
+                    //be logged in the messages.log.
+                    throw e;
 
                 }
-                //theProvider.validateParameters(serviceObject, m, params.toArray());
-                callValidationMethod("validateParameters", new Object[] { realServiceObject, m, params.toArray() }, theProvider);
-
-            } catch (RuntimeException e) {
-                // Since BeanValidation is enabled, if this exception is a ConstraintViolationException
-                // then we will want to put a FaultListener on the message so that
-                // when this exception bubbles up to PhaseInterceptorChain that we do not
-                // use default logging which will log this exception.  BeanValidation is
-                // supposed to block logging these messages.
-                if (beanValidationFaultListener != null && beanValidationFaultListener.cve.isInstance(e)) {
-                    Message m2 = exchange.getInMessage();
-                    m2.put(FaultListener.class.getName(), beanValidationFaultListener);
-                }
-                //re-throw exception.  If the FaultListener is set then a ConstraintViolation will not
-                //be logged in the messages.log.
-                throw e;
-
             }
-        }
 
-        Object response = super.invoke(exchange, realServiceObject, m, params);
+            Object response = super.invoke(exchange, realServiceObject, m, params);
 
-        if (isEnableBeanValidation && cxfBeanValidationProviderClass != null && theProvider != null) {
+            if (isEnableBeanValidation && cxfBeanValidationProviderClass != null && theProvider != null) {
 
-            if (response instanceof MessageContentsList) {
-                MessageContentsList list = (MessageContentsList) response;
-                if (list.size() == 1) {
-                    Object entity = list.get(0);
+                if (response instanceof MessageContentsList) {
+                    MessageContentsList list = (MessageContentsList) response;
+                    if (list.size() == 1) {
+                        Object entity = list.get(0);
 
-                    if (entity instanceof Response) {
-                        //theProvider.validateReturnValue(serviceObject, m, ((Response) entity).getEntity());
-                        callValidationMethod("validateReturnValue", new Object[] { realServiceObject, m, ((Response) entity).getEntity() }, theProvider);
+                        if (entity instanceof Response) {
+                            //theProvider.validateReturnValue(serviceObject, m, ((Response) entity).getEntity());
+                            callValidationMethod("validateReturnValue", new Object[] { realServiceObject, m, ((Response) entity).getEntity() }, theProvider);
 
-                    } else {
-                        //theProvider.validateReturnValue(serviceObject, m, entity);
-                        callValidationMethod("validateReturnValue", new Object[] { realServiceObject, m, entity }, theProvider);
+                        } else {
+                            //theProvider.validateReturnValue(serviceObject, m, entity);
+                            callValidationMethod("validateReturnValue", new Object[] { realServiceObject, m, entity }, theProvider);
 
+                        }
                     }
                 }
             }
+            return response;
+        } finally {
+            if (beanCustomizer != null && realServiceObject != null) {
+                beanCustomizer.afterServiceInvoke(realServiceObject, cri.isSingleton(), libertyJaxRsServerFactoryBean.getBeanCustomizerContext(beanCustomizer));
+            }
         }
-
-        return response;
     }
 
     /**

--- a/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsInvoker.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsInvoker.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -31,7 +31,6 @@ import org.apache.cxf.logging.FaultListener;
 import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageContentsList;
-
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
@@ -300,6 +299,7 @@ public class LibertyJaxRsInvoker extends JAXRSInvoker {
             if (beanCustomizer != null && realServiceObject != null) {
                 beanCustomizer.afterServiceInvoke(realServiceObject, cri.isSingleton(), libertyJaxRsServerFactoryBean.getBeanCustomizerContext(beanCustomizer));
             }
+            InjectionRuntimeContextHelper.removeRuntimeContext();
         }
     }
 

--- a/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
@@ -639,21 +639,12 @@ public class LibertyJaxRsServerFactoryBean extends JAXRSServerFactoryBean {
             final OperationResourceInfo ori = exchange.get(OperationResourceInfo.class);
             final ClassResourceInfo cri = ori.getClassResourceInfo();
 
-            try {
-                Object rc = beanCustomizer.serviceInvoke(serviceObject,
-                                                         m,
-                                                         paramArray,
-                                                         cri.isSingleton(),
-                                                         getBeanCustomizerContext(beanCustomizer),
-                                                         exchange.getInMessage());
-
-                return rc;
-            } finally {
-                beanCustomizer.afterServiceInvoke(serviceObject,
-                                                  cri.isSingleton(),
-                                                  getBeanCustomizerContext(beanCustomizer));
-            }
-
+            return beanCustomizer.serviceInvoke(serviceObject,
+                                                     m,
+                                                     paramArray,
+                                                     cri.isSingleton(),
+                                                     getBeanCustomizerContext(beanCustomizer),
+                                                     exchange.getInMessage());
         } else
             return m.invoke(serviceObject, paramArray);
     }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/injection/LibertyClearInjectRuntimeCtxOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/injection/LibertyClearInjectRuntimeCtxOutInterceptor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,14 +20,14 @@ import org.apache.cxf.phase.AbstractPhaseInterceptor;
 
 /**
  * @param <T>
- * 
+ *
  */
 public class LibertyClearInjectRuntimeCtxOutInterceptor<T extends Message> extends AbstractPhaseInterceptor<T> {
 
     /**
      * we should clear InjectionRuntimeContext after JAXRSOutInterceptor
      * The last provider should be MessageBodyWriter
-     * 
+     *
      * @param phase
      */
     public LibertyClearInjectRuntimeCtxOutInterceptor(String phase) {
@@ -38,6 +38,14 @@ public class LibertyClearInjectRuntimeCtxOutInterceptor<T extends Message> exten
 
     @Override
     public void handleMessage(Message message) throws Fault {
+        //clear InjectionRuntimeContext on server-side only
+        if (!MessageUtils.isRequestor(message)) {
+            InjectionRuntimeContextHelper.removeRuntimeContext();
+        }
+    }
+
+    @Override
+    public void handleFault(Message message) {
         //clear InjectionRuntimeContext on server-side only
         if (!MessageUtils.isRequestor(message)) {
             InjectionRuntimeContextHelper.removeRuntimeContext();


### PR DESCRIPTION
This solves a memory leak in `JaxRsFactoryImplicitBeanCDICustomizer` where `CreationContext`s were not released

Fixes: #24155