### PR TITLE
Add internal servlet feature to features that depend on servlet feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.0.feature
@@ -10,6 +10,7 @@ Subsystem-Name: Internal Java RESTful Services 2.0
   com.ibm.websphere.appserver.containerServices-1.0, \
   com.ibm.websphere.appserver.injection-1.0, \
   com.ibm.websphere.appserver.servlet-3.1, \
+  io.openliberty.servlet.internal-3.1, \
   com.ibm.websphere.appserver.classloading-1.0, \
   com.ibm.websphere.appserver.eeCompatible-7.0, \
   com.ibm.websphere.appserver.javax.jaxrs-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.1.feature
@@ -11,6 +11,7 @@ Subsystem-Name: Internal Java RESTful Services 2.1
   com.ibm.websphere.appserver.httpcommons-1.0, \
   com.ibm.websphere.appserver.injection-1.0, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.classloading-1.0, \
   com.ibm.websphere.appserver.eeCompatible-8.0, \
   com.ibm.websphere.appserver.globalhandler-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
@@ -19,6 +19,7 @@ IBM-SPI-Package: com.ibm.wsspi.webservices.handler
   com.ibm.websphere.appserver.containerServices-1.0, \
   com.ibm.websphere.appserver.injection-1.0, \
   com.ibm.websphere.appserver.servlet-3.1, \
+  io.openliberty.servlet.internal-3.1, \
   com.ibm.websphere.appserver.classloading-1.0, \
   com.ibm.websphere.appserver.javax.jaxrs-2.0, \
   com.ibm.websphere.appserver.globalhandler-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
@@ -11,6 +11,7 @@ IBM-App-ForceRestart: uninstall, \
   com.ibm.websphere.appserver.jsonbInternal-1.0, \
   com.ibm.websphere.appserver.injection-1.0, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.classloading-1.0, \
   com.ibm.websphere.appserver.internal.slf4j-1.7, \
   com.ibm.websphere.appserver.jsonpInternal-1.1, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appAuthentication-2.0/io.openliberty.appAuthentication-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appAuthentication-2.0/io.openliberty.appAuthentication-2.0.feature
@@ -16,6 +16,7 @@ Subsystem-Name: Jakarta Authentication 2.0
   io.openliberty.appSecurity-4.0, \
   io.openliberty.jakarta.authentication-2.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=\
   io.openliberty.security.jaspic.2.0.internal

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-3.0/com.ibm.websphere.appserver.appSecurity-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-3.0/com.ibm.websphere.appserver.appSecurity-3.0.feature
@@ -14,6 +14,7 @@ IBM-API-Package: javax.security.enterprise; type="spec", \
 IBM-ShortName: appSecurity-3.0
 Subsystem-Name: Application Security 3.0
 -features=com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.eeCompatible-8.0, \
   com.ibm.websphere.appserver.el-3.0, \
   com.ibm.websphere.appserver.cdi-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-4.0/io.openliberty.appSecurity-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-4.0/io.openliberty.appSecurity-4.0.feature
@@ -16,6 +16,7 @@ Subsystem-Name: Application Security 4.0 (Jakarta Security 2.0)
 -features=io.openliberty.cdi-3.0, \
   io.openliberty.jakarta.authentication-2.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   com.ibm.websphere.appserver.security-1.0, \
   io.openliberty.securityAPI.jakarta-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/batch-1.0/com.ibm.websphere.appserver.batch-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/batch-1.0/com.ibm.websphere.appserver.batch-1.0.feature
@@ -21,6 +21,7 @@ Subsystem-Name: Batch API 1.0
   com.ibm.websphere.appserver.transaction-1.2, \
   com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:="1.3", \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.ws.persistence-1.0, \
   com.ibm.websphere.appserver.contextService-1.0, \
   com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.0,4.2,4.3", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/batch-2.0/io.openliberty.batch-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/batch-2.0/io.openliberty.batch-2.0.feature
@@ -21,6 +21,7 @@ Subsystem-Name: Jakarta Batch 2.0
   io.openliberty.jakarta.xmlBinding-3.0, \
   io.openliberty.jakarta.annotation-2.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   com.ibm.websphere.appserver.contextService-1.0, \
   io.openliberty.persistenceService-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/facesContainer-3.0/io.openliberty.facesContainer-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/facesContainer-3.0/io.openliberty.facesContainer-3.0.feature
@@ -15,6 +15,7 @@ IBM-API-Package: org.jboss.weld;type="internal",\
 -features=io.openliberty.facesProvider-3.0.0.Container, \
   io.openliberty.cdi-3.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   io.openliberty.jakarta.validation-3.0, \
   io.openliberty.pages-3.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-8.0/com.ibm.websphere.appserver.jakartaee-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-8.0/com.ibm.websphere.appserver.jakartaee-8.0.feature
@@ -23,6 +23,7 @@ Subsystem-Name: Jakarta EE Platform 8.0
   com.ibm.websphere.appserver.jacc-1.5, \
   com.ibm.websphere.appserver.javax.persistence.base-2.2, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.wasJmsClient-2.0, \
   com.ibm.websphere.appserver.javaMail-1.6, \
   com.ibm.websphere.appserver.j2eeManagement-1.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-9.1/io.openliberty.jakartaee-9.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-9.1/io.openliberty.jakartaee-9.1.feature
@@ -18,6 +18,7 @@ Subsystem-Name: Jakarta EE Platform 9.1
   io.openliberty.messagingSecurity-3.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   io.openliberty.concurrent-2.0, \
   io.openliberty.appAuthorization-2.0, \
   io.openliberty.xmlWS-3.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaspic-1.1/com.ibm.websphere.appserver.jaspic-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaspic-1.1/com.ibm.websphere.appserver.jaspic-1.1.feature
@@ -14,6 +14,7 @@ Subsystem-Name: Java Authentication SPI for Containers 1.1
 -features=com.ibm.websphere.appserver.internal.optional.jaxb-2.2, \
   com.ibm.websphere.appserver.appSecurity-2.0; ibm.tolerates:="3.0", \
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0", \
+  io.openliberty.servlet.internal-3.0; ibm.tolerates:="3.1,4.0", \
   com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0"
 -bundles=\
   com.ibm.websphere.javaee.jaspic.1.1; location:=dev/api/spec/; mavenCoordinates="javax.security.auth.message:javax.security.auth.message-api:1.1", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/javaee-7.0/com.ibm.websphere.appserver.javaee-7.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/javaee-7.0/com.ibm.websphere.appserver.javaee-7.0.feature
@@ -22,6 +22,7 @@ Subsystem-Name: Java EE Full Platform 7.0
   com.ibm.websphere.appserver.jaxws-2.2, \
   com.ibm.websphere.appserver.jacc-1.5, \
   com.ibm.websphere.appserver.servlet-3.1, \
+  io.openliberty.servlet.internal-3.1, \
   com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.2,4.3", \
   com.ibm.websphere.appserver.wasJmsClient-2.0, \
   com.ibm.websphere.appserver.javaMail-1.5, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/javaee-8.0/com.ibm.websphere.appserver.javaee-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/javaee-8.0/com.ibm.websphere.appserver.javaee-8.0.feature
@@ -23,6 +23,7 @@ Subsystem-Name: Java EE Full Platform 8.0
   com.ibm.websphere.appserver.jacc-1.5, \
   com.ibm.websphere.appserver.javax.persistence.base-2.2, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.wasJmsClient-2.0, \
   com.ibm.websphere.appserver.javaMail-1.6, \
   com.ibm.websphere.appserver.j2eeManagement-1.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsf-2.2/com.ibm.websphere.appserver.jsf-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsf-2.2/com.ibm.websphere.appserver.jsf-2.2.feature
@@ -34,6 +34,7 @@ IBM-ShortName: jsf-2.2
 Subsystem-Name: JavaServer Faces 2.2
 -features=com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces, \
   com.ibm.websphere.appserver.servlet-3.1, \
+  io.openliberty.servlet.internal-3.1, \
   com.ibm.websphere.appserver.jsp-2.3, \
   com.ibm.websphere.appserver.javax.cdi-1.2, \
   com.ibm.websphere.appserver.eeCompatible-7.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsf-2.3/com.ibm.websphere.appserver.jsf-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsf-2.3/com.ibm.websphere.appserver.jsf-2.3.feature
@@ -38,6 +38,7 @@ Subsystem-Name: JavaServer Faces 2.3
 -features=com.ibm.websphere.appserver.internal.optional.jaxb-2.2, \
   com.ibm.websphere.appserver.jsfProvider-2.3.0.MyFaces, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.jsp-2.3, \
   com.ibm.websphere.appserver.eeCompatible-8.0, \
   com.ibm.websphere.appserver.javax.cdi-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsfContainer-2.2/com.ibm.websphere.appserver.jsfContainer-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsfContainer-2.2/com.ibm.websphere.appserver.jsfContainer-2.2.feature
@@ -9,6 +9,7 @@ IBM-App-ForceRestart: install, uninstall
 -bundles=\
   com.ibm.ws.jsfContainer.classloading.2.2
 -features=com.ibm.websphere.appserver.servlet-3.1, \
+  io.openliberty.servlet.internal-3.1, \
   com.ibm.websphere.appserver.jsp-2.3, \
   com.ibm.websphere.appserver.eeCompatible-7.0, \
   com.ibm.websphere.appserver.jsfProvider-2.2.0.Container, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsfContainer-2.3/com.ibm.websphere.appserver.jsfContainer-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsfContainer-2.3/com.ibm.websphere.appserver.jsfContainer-2.3.feature
@@ -15,6 +15,7 @@ IBM-API-Package: org.jboss.weld;type="internal",\
 -features=com.ibm.websphere.appserver.websocket-1.1, \
   com.ibm.websphere.appserver.jsfProvider-2.3.0.Container, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.jsp-2.3, \
   com.ibm.websphere.appserver.eeCompatible-8.0, \
   com.ibm.websphere.appserver.cdi-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
@@ -36,6 +36,7 @@ IBM-SPI-Package: com.ibm.wsspi.jsp.taglib.config
 Subsystem-Name: JavaServer Pages 2.2
 -features=com.ibm.websphere.appserver.javax.jsp-2.2, \
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1", \
+  io.openliberty.servlet.internal-3.0; ibm.tolerates:="3.1", \
   com.ibm.websphere.appserver.eeCompatible-6.0, \
   com.ibm.websphere.appserver.javax.el-2.2
 -bundles=com.ibm.ws.org.eclipse.jdt.core, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.3/com.ibm.websphere.appserver.jsp-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.3/com.ibm.websphere.appserver.jsp-2.3.feature
@@ -35,6 +35,7 @@ IBM-SPI-Package: com.ibm.wsspi.jsp.taglib.config
 Subsystem-Name: JavaServer Pages 2.3
 -features=com.ibm.websphere.appserver.javax.jsp-2.3, \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="6.0,8.0", \
   com.ibm.websphere.appserver.el-3.0, \
   com.ibm.websphere.appserver.javax.el-3.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-1.2/com.ibm.websphere.appserver.microProfile-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-1.2/com.ibm.websphere.appserver.microProfile-1.2.feature
@@ -13,6 +13,7 @@ Subsystem-Name: MicroProfile 1.2
   com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:="1.3", \
   com.ibm.websphere.appserver.mpConfig-1.1, \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.mpFaultTolerance-1.0, \
   com.ibm.websphere.appserver.mpJwt-1.0, \
   com.ibm.websphere.appserver.mpMetrics-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-1.3/com.ibm.websphere.appserver.microProfile-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-1.3/com.ibm.websphere.appserver.microProfile-1.3.feature
@@ -20,6 +20,7 @@ Subsystem-Name: MicroProfile 1.3
   com.ibm.websphere.appserver.mpOpenAPI-1.0, \
   com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:="1.3", \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.mpFaultTolerance-1.0, \
   com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1", \
   com.ibm.websphere.appserver.mpHealth-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-1.4/com.ibm.websphere.appserver.microProfile-1.4.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-1.4/com.ibm.websphere.appserver.microProfile-1.4.feature
@@ -21,6 +21,7 @@ Subsystem-Name: MicroProfile 1.4
   com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:="1.3", \
   com.ibm.websphere.appserver.mpFaultTolerance-1.1, \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1", \
   com.ibm.websphere.appserver.mpHealth-1.0
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-2.0/com.ibm.websphere.appserver.microProfile-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-2.0/com.ibm.websphere.appserver.microProfile-2.0.feature
@@ -22,6 +22,7 @@ Subsystem-Name: MicroProfile 2.0
   com.ibm.websphere.appserver.javax.annotation-1.3, \
   com.ibm.websphere.appserver.mpFaultTolerance-1.1, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.jaxrs-2.1, \
   com.ibm.websphere.appserver.mpHealth-1.0
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-2.1/com.ibm.websphere.appserver.microProfile-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-2.1/com.ibm.websphere.appserver.microProfile-2.1.feature
@@ -22,6 +22,7 @@ Subsystem-Name: MicroProfile 2.1
   com.ibm.websphere.appserver.javax.annotation-1.3, \
   com.ibm.websphere.appserver.mpFaultTolerance-1.1, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.jaxrs-2.1, \
   com.ibm.websphere.appserver.mpHealth-1.0
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-2.2/com.ibm.websphere.appserver.microProfile-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-2.2/com.ibm.websphere.appserver.microProfile-2.2.feature
@@ -21,6 +21,7 @@ Subsystem-Name: MicroProfile 2.2
   com.ibm.websphere.appserver.javax.annotation-1.3, \
   com.ibm.websphere.appserver.mpFaultTolerance-2.0, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.jaxrs-2.1, \
   com.ibm.websphere.appserver.mpHealth-1.0, \
   com.ibm.websphere.appserver.mpOpenTracing-1.3

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-3.0/com.ibm.websphere.appserver.microProfile-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-3.0/com.ibm.websphere.appserver.microProfile-3.0.feature
@@ -21,6 +21,7 @@ Subsystem-Name: MicroProfile 3.0
   com.ibm.websphere.appserver.javax.annotation-1.3, \
   com.ibm.websphere.appserver.mpFaultTolerance-2.0, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.jaxrs-2.1, \
   com.ibm.websphere.appserver.mpHealth-2.0, \
   com.ibm.websphere.appserver.mpOpenTracing-1.3

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-3.2/com.ibm.websphere.appserver.microProfile-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-3.2/com.ibm.websphere.appserver.microProfile-3.2.feature
@@ -21,6 +21,7 @@ Subsystem-Name: MicroProfile 3.2
   com.ibm.websphere.appserver.javax.annotation-1.3, \
   com.ibm.websphere.appserver.mpFaultTolerance-2.0, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.jaxrs-2.1, \
   com.ibm.websphere.appserver.mpHealth-2.1, \
   com.ibm.websphere.appserver.mpOpenTracing-1.3

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-3.3/com.ibm.websphere.appserver.microProfile-3.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-3.3/com.ibm.websphere.appserver.microProfile-3.3.feature
@@ -21,6 +21,7 @@ Subsystem-Name: MicroProfile 3.3
   com.ibm.websphere.appserver.mpFaultTolerance-2.1, \
   com.ibm.websphere.appserver.javax.annotation-1.3, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.jaxrs-2.1, \
   com.ibm.websphere.appserver.mpHealth-2.2, \
   com.ibm.websphere.appserver.mpOpenTracing-1.3

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.0/com.ibm.websphere.appserver.microProfile-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.0/com.ibm.websphere.appserver.microProfile-4.0.feature
@@ -9,6 +9,7 @@ Subsystem-Version: 7.0.0
 Subsystem-Name: MicroProfile 4.0
 -features=\
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   io.openliberty.mpCompatible-4.0, \
   com.ibm.websphere.appserver.mpOpenTracing-2.0, \
   com.ibm.websphere.appserver.jsonp-1.1, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.1/com.ibm.websphere.appserver.microProfile-4.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.1/com.ibm.websphere.appserver.microProfile-4.1.feature
@@ -13,6 +13,7 @@ Subsystem-Name: MicroProfile 4.1
   com.ibm.websphere.appserver.jaxrs-2.1, \
   com.ibm.websphere.appserver.jaxrsClient-2.1, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   io.openliberty.mpCompatible-4.0, \
   com.ibm.websphere.appserver.mpConfig-2.0, \
   com.ibm.websphere.appserver.mpFaultTolerance-3.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-5.0/io.openliberty.microProfile-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-5.0/io.openliberty.microProfile-5.0.feature
@@ -12,6 +12,7 @@ Subsystem-Name: MicroProfile 5.0
   io.openliberty.jsonp-2.0, \
   io.openliberty.restfulWS-3.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   io.openliberty.mpCompatible-5.0, \
   io.openliberty.mpConfig-3.0, \
   io.openliberty.mpFaultTolerance-4.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-1.0/com.ibm.websphere.appserver.mpGraphQL-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-1.0/com.ibm.websphere.appserver.mpGraphQL-1.0.feature
@@ -12,6 +12,7 @@ Subsystem-Name: MicroProfile GraphQL 1.0
   io.openliberty.mpCompatible-0.0; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.javax.annotation-1.3, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.internal.slf4j-1.7, \
   com.ibm.websphere.appserver.org.eclipse.microprofile.graphql-1.0, \
   com.ibm.websphere.appserver.org.reactivestreams.reactive-streams-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-1.0/com.ibm.websphere.appserver.mpHealth-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-1.0/com.ibm.websphere.appserver.mpHealth-1.0.feature
@@ -15,6 +15,7 @@ Subsystem-Name: MicroProfile Health 1.0
   com.ibm.wsspi.appserver.webBundle-1.0, \
   com.ibm.websphere.appserver.contextService-1.0, \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.org.eclipse.microprofile.health-1.0, \
   com.ibm.websphere.appserver.jndi-1.0, \
   com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-2.0/com.ibm.websphere.appserver.mpHealth-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-2.0/com.ibm.websphere.appserver.mpHealth-2.0.feature
@@ -15,6 +15,7 @@ Subsystem-Name: MicroProfile Health 2.0
   com.ibm.wsspi.appserver.webBundle-1.0, \
   com.ibm.websphere.appserver.contextService-1.0, \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.org.eclipse.microprofile.health-2.0, \
   com.ibm.websphere.appserver.jndi-1.0, \
   com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-2.1/com.ibm.websphere.appserver.mpHealth-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-2.1/com.ibm.websphere.appserver.mpHealth-2.1.feature
@@ -15,6 +15,7 @@ Subsystem-Name: MicroProfile Health 2.1
   com.ibm.wsspi.appserver.webBundle-1.0, \
   com.ibm.websphere.appserver.contextService-1.0, \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.org.eclipse.microprofile.health-2.1, \
   com.ibm.websphere.appserver.jndi-1.0, \
   com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-2.2/com.ibm.websphere.appserver.mpHealth-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-2.2/com.ibm.websphere.appserver.mpHealth-2.2.feature
@@ -15,6 +15,7 @@ Subsystem-Name: MicroProfile Health 2.2
   com.ibm.wsspi.appserver.webBundle-1.0, \
   com.ibm.websphere.appserver.contextService-1.0, \
   com.ibm.websphere.appserver.servlet-4.0; ibm.tolerates:="3.1", \
+  io.openliberty.servlet.internal-4.0; ibm.tolerates:="3.1", \
   com.ibm.websphere.appserver.org.eclipse.microprofile.health-2.2, \
   com.ibm.websphere.appserver.cdi-2.0; ibm.tolerates:="1.2", \
   com.ibm.websphere.appserver.jndi-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-3.0/com.ibm.websphere.appserver.mpHealth-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-3.0/com.ibm.websphere.appserver.mpHealth-3.0.feature
@@ -13,6 +13,7 @@ Subsystem-Name: MicroProfile Health 3.0
   com.ibm.websphere.appserver.mpConfig-2.0, \
   com.ibm.wsspi.appserver.webBundle-1.0, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   io.openliberty.mpCompatible-4.0, \
   com.ibm.websphere.appserver.org.eclipse.microprofile.health-3.0, \
   com.ibm.websphere.appserver.cdi-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-3.1/com.ibm.websphere.appserver.mpHealth-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-3.1/com.ibm.websphere.appserver.mpHealth-3.1.feature
@@ -14,6 +14,7 @@ Subsystem-Name: MicroProfile Health 3.1
  com.ibm.websphere.appserver.jndi-1.0, \
  com.ibm.websphere.appserver.json-1.0, \
  com.ibm.websphere.appserver.servlet-4.0,\
+ io.openliberty.servlet.internal-4.0, \
  com.ibm.websphere.appserver.mpConfig-2.0,\
  com.ibm.wsspi.appserver.webBundle-1.0, \
  io.openliberty.mpCompatible-4.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpLRACoordinator-1.0/io.openliberty.mpLRACoordinator-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpLRACoordinator-1.0/io.openliberty.mpLRACoordinator-1.0.feature
@@ -7,6 +7,7 @@ IBM-App-ForceRestart: install, \
 IBM-ShortName: mpLRACoordinator-1.0
 Subsystem-Name: MicroProfile Long Running Actions Coordinator 1.0
 -features=com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.jaxrs-2.1, \
   io.openliberty.mpCompatible-4.0; ibm.tolerates:="0.0", \
   io.openliberty.org.eclipse.microprofile.lra-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-1.0/com.ibm.websphere.appserver.mpMetrics-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-1.0/com.ibm.websphere.appserver.mpMetrics-1.0.feature
@@ -12,6 +12,7 @@ Subsystem-Name: MicroProfile Metrics 1.0
   io.openliberty.mpCompatible-0.0, \
   com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:="1.3", \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"
 -bundles=com.ibm.ws.microprofile.metrics, \
  com.ibm.ws.microprofile.metrics.common, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-1.1/com.ibm.websphere.appserver.mpMetrics-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-1.1/com.ibm.websphere.appserver.mpMetrics-1.1.feature
@@ -12,6 +12,7 @@ Subsystem-Name: MicroProfile Metrics 1.1
   io.openliberty.mpCompatible-0.0, \
   com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:="1.3", \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.org.eclipse.microprofile.metrics-1.1, \
   com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"
 -bundles=com.ibm.ws.microprofile.metrics, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-2.0/com.ibm.websphere.appserver.mpMetrics-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-2.0/com.ibm.websphere.appserver.mpMetrics-2.0.feature
@@ -12,6 +12,7 @@ Subsystem-Name: MicroProfile Metrics 2.0
   io.openliberty.mpCompatible-0.0, \
   com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:="1.3", \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.org.eclipse.microprofile.metrics-2.0, \
   com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"
 -bundles=com.ibm.ws.microprofile.metrics.common, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-2.2/com.ibm.websphere.appserver.mpMetrics-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-2.2/com.ibm.websphere.appserver.mpMetrics-2.2.feature
@@ -12,6 +12,7 @@ Subsystem-Name: MicroProfile Metrics 2.2
   io.openliberty.mpCompatible-0.0, \
   com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:="1.3", \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.org.eclipse.microprofile.metrics-2.2, \
   com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"
 -bundles=com.ibm.ws.microprofile.metrics.common, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-2.3/com.ibm.websphere.appserver.mpMetrics-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-2.3/com.ibm.websphere.appserver.mpMetrics-2.3.feature
@@ -12,6 +12,7 @@ Subsystem-Name: MicroProfile Metrics 2.3
   io.openliberty.mpCompatible-0.0, \
   com.ibm.websphere.appserver.javax.annotation-1.3; ibm.tolerates:="1.2", \
   com.ibm.websphere.appserver.servlet-4.0; ibm.tolerates:="3.1", \
+  io.openliberty.servlet.internal-4.0; ibm.tolerates:="3.1", \
   com.ibm.websphere.appserver.cdi-2.0; ibm.tolerates:="1.2", \
   com.ibm.websphere.appserver.monitor-1.0, \
   com.ibm.websphere.appserver.org.eclipse.microprofile.metrics-2.3

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-3.0/com.ibm.websphere.appserver.mpMetrics-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-3.0/com.ibm.websphere.appserver.mpMetrics-3.0.feature
@@ -10,6 +10,7 @@ Subsystem-Name: MicroProfile Metrics 3.0
   com.ibm.websphere.appserver.mpConfig-2.0, \
   com.ibm.websphere.appserver.javax.annotation-1.3, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   io.openliberty.mpCompatible-4.0, \
   com.ibm.websphere.appserver.cdi-2.0, \
   com.ibm.websphere.appserver.org.eclipse.microprofile.metrics-3.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-4.0/io.openliberty.mpMetrics-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-4.0/io.openliberty.mpMetrics-4.0.feature
@@ -10,6 +10,7 @@ Subsystem-Name: MicroProfile Metrics 4.0
   io.openliberty.mpConfig-3.0, \
   io.openliberty.jakarta.annotation-2.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   io.openliberty.mpCompatible-5.0, \
   io.openliberty.cdi-3.0, \
   io.openliberty.org.eclipse.microprofile.metrics-4.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-1.0/com.ibm.websphere.appserver.mpOpenAPI-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-1.0/com.ibm.websphere.appserver.mpOpenAPI-1.0.feature
@@ -38,6 +38,7 @@ IBM-API-Package: \
   io.openliberty.mpCompatible-0.0, \
   com.ibm.wsspi.appserver.webBundle-1.0, \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-1.0, \
   com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1"
 -bundles=\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-1.1/com.ibm.websphere.appserver.mpOpenAPI-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-1.1/com.ibm.websphere.appserver.mpOpenAPI-1.1.feature
@@ -38,6 +38,7 @@ IBM-API-Package: \
   io.openliberty.mpCompatible-0.0, \
   com.ibm.wsspi.appserver.webBundle-1.0, \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-1.1, \
   com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1"
 -bundles=\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-2.0/com.ibm.websphere.appserver.mpOpenAPI-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-2.0/com.ibm.websphere.appserver.mpOpenAPI-2.0.feature
@@ -37,6 +37,7 @@ IBM-API-Package: \
 -features=com.ibm.websphere.appserver.mpConfig-2.0, \
   com.ibm.wsspi.appserver.webBundle-1.0, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.jaxrs-2.1, \
   io.openliberty.mpCompatible-4.0, \
   com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-2.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-3.0/io.openliberty.mpOpenAPI-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-3.0/io.openliberty.mpOpenAPI-3.0.feature
@@ -37,6 +37,7 @@ IBM-API-Package: \
 -features=io.openliberty.mpConfig-3.0, \
   com.ibm.wsspi.appserver.webBundle-1.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   io.openliberty.restfulWS-3.0, \
   io.openliberty.mpCompatible-5.0, \
   io.openliberty.org.eclipse.microprofile.openapi-3.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/openapi-3.1/com.ibm.websphere.appserver.openapi-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/openapi-3.1/com.ibm.websphere.appserver.openapi-3.1.feature
@@ -11,6 +11,7 @@ Subsystem-Name: OpenAPI 3.1
 
 -features=com.ibm.wsspi.appserver.webBundle-1.0, \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+  io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.adminSecurity-1.0, \
   io.openliberty.securityAPI.javaee-1.0, \
   com.ibm.websphere.appserver.mpOpenAPI-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.0/io.openliberty.pages-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.0/io.openliberty.pages-3.0.feature
@@ -34,6 +34,7 @@ WLP-AlsoKnownAs: jsp-3.0
 IBM-SPI-Package: com.ibm.wsspi.jsp.taglib.config
 Subsystem-Name: Jakarta Server Pages 3.0
 -features=com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   io.openliberty.jakarta.pages-3.0, \
   io.openliberty.expressionLanguage-4.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWSClient-3.0/io.openliberty.restfulWSClient-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWSClient-3.0/io.openliberty.restfulWSClient-3.0.feature
@@ -29,6 +29,7 @@ Subsystem-Name: Jakarta RESTful Web Services 3.0 Client
   com.ibm.websphere.appserver.globalhandler-1.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   io.openliberty.jakarta.restfulWS-3.0, \
   com.ibm.websphere.appserver.org.reactivestreams.reactive-streams-1.0, \
   com.ibm.websphere.appserver.jndi-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-7.0/com.ibm.websphere.appserver.webProfile-7.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-7.0/com.ibm.websphere.appserver.webProfile-7.0.feature
@@ -16,6 +16,7 @@ Subsystem-Name: Java EE Web Profile 7.0
   com.ibm.websphere.appserver.transaction-1.2, \
   com.ibm.websphere.appserver.websocket-1.1, \
   com.ibm.websphere.appserver.servlet-3.1, \
+  io.openliberty.servlet.internal-3.1, \
   com.ibm.websphere.appserver.jpa-2.1, \
   com.ibm.websphere.appserver.jsp-2.3, \
   com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.2,4.3", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-8.0/com.ibm.websphere.appserver.webProfile-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-8.0/com.ibm.websphere.appserver.webProfile-8.0.feature
@@ -20,6 +20,7 @@ Subsystem-Name: Java EE Web Profile 8.0
   com.ibm.websphere.appserver.websocket-1.1, \
   com.ibm.websphere.appserver.jsp-2.3, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.ejbLite-3.2, \
   com.ibm.websphere.appserver.jaxrs-2.1, \
   com.ibm.websphere.appserver.managedBeans-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-9.1/io.openliberty.webProfile-9.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-9.1/io.openliberty.webProfile-9.1.feature
@@ -21,6 +21,7 @@ Subsystem-Name: Jakarta EE Web Profile 9.1
   io.openliberty.restfulWS-3.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   io.openliberty.pages-3.0, \
   com.ibm.websphere.appserver.jndi-1.0, \
   com.ibm.websphere.appserver.transaction-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/websocket-1.0/com.ibm.websphere.appserver.websocket-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/websocket-1.0/com.ibm.websphere.appserver.websocket-1.0.feature
@@ -11,6 +11,7 @@ IBM-API-Package: javax.websocket; type="spec", \
 IBM-ShortName: websocket-1.0
 Subsystem-Name: Java WebSocket 1.0
 -features= com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+ io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
  io.openliberty.javaee.websocket-1.0, \
  com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="6.0,8.0"
 -bundles=com.ibm.ws.wsoc, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/websocket-1.1/com.ibm.websphere.appserver.websocket-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/websocket-1.1/com.ibm.websphere.appserver.websocket-1.1.feature
@@ -11,6 +11,7 @@ IBM-API-Package: javax.websocket; version="1.1"; type="spec", \
 IBM-ShortName: websocket-1.1
 Subsystem-Name: Java WebSocket 1.1
 -features= com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
+ io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
  io.openliberty.javaee.websocket-1.1, \
  com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="6.0,8.0"
 -bundles=com.ibm.ws.wsoc, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/websocket-2.0/io.openliberty.websocket-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/websocket-2.0/io.openliberty.websocket-2.0.feature
@@ -11,6 +11,7 @@ IBM-ShortName: websocket-2.0
 Subsystem-Name: Jakarta WebSocket 2.0
 -features=io.openliberty.jakarta.websocket-2.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=com.ibm.ws.wsoc.jakarta, \
  com.ibm.ws.wsoc.2.0.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWS-3.0/io.openliberty.xmlWS-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWS-3.0/io.openliberty.xmlWS-3.0.feature
@@ -11,6 +11,7 @@ IBM-API-Package: \
  org.apache.cxf.databinding;type="internal"
 -features=com.ibm.websphere.appserver.eeCompatible-9.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.servlet.internal-5.0, \
   com.ibm.websphere.appserver.globalhandler-1.0, \
   io.openliberty.xmlws.common-3.0
 -bundles=\


### PR DESCRIPTION
- When doing install if public features don't have dependency on the internal servlet feature, other features will not be able to find it after product and feature install because of how install works.

fixes #24371