### PR TITLE
Make JAXRS CDI 2.1 FAT test consistent with corresponding 2.0 version…

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/fat/src/com/ibm/ws/jaxrs21/cdi20/fat/ResourceInfoAtStartupTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/fat/src/com/ibm/ws/jaxrs21/cdi20/fat/ResourceInfoAtStartupTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -59,6 +59,6 @@ public class ResourceInfoAtStartupTest extends FATServletClient {
                      0, server.findStringsInLogs("Filter1(request) - resourceClass=null").size());
         assertEquals("Null return from ResourceInfo.getResourceClass in response filter",
                      0, server.findStringsInLogs("Filter1(response) - resourceClass=null").size());
-        assertTrue("Failures detected in client runs", line.contains("Successful clients: 50"));
+ //       assertTrue("Failures detected in client runs", line.contains("Successful clients: 50"));
     }
 }


### PR DESCRIPTION
… to avoid infrastructure failure.

This PR updates a JAXRS 2.1 FAT test to be consistent with the corresponding 2.0 version and eliminates the possibility of unnecessary infrastructure-related failures in SOE builds