### PR TITLE
Increase app start time in EJB FAT

### DIFF
--- a/dev/io.openliberty.ejbcontainer.checkpoint_fat/publish/servers/EjbStartCheckpointMockServer/server.xml
+++ b/dev/io.openliberty.ejbcontainer.checkpoint_fat/publish/servers/EjbStartCheckpointMockServer/server.xml
@@ -8,4 +8,6 @@
 
     <include location="../fatTestPorts.xml"/>
 
+    <applicationManager startTimeout="90s"/>
+
 </server>


### PR DESCRIPTION
- FAT failing on slow hardware; increase app start timeout
