### PR TITLE
Disable IBM i tests that have never worked

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -40,6 +40,7 @@ import org.junit.Test;
 import com.ibm.db2.jcc.DB2JccDataSource;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
@@ -187,6 +188,7 @@ public class DB2TestServlet extends FATServlet {
     //Test that a datasource backed by Driver can be used with both the generic properties element and properties.db2.jcc
     //element when type="java.sql.Driver"
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testDSUsingDriver() throws Exception {
         Connection conn = db2_using_driver_type.getConnection();
         assertFalse("db2_using_driver_type should not wrap DB2JccDataSource", db2_using_driver_type.isWrapperFor(DB2JccDataSource.class));
@@ -217,6 +219,7 @@ public class DB2TestServlet extends FATServlet {
     //Test that the proper implementation classes are used for the various datasources configured in this test bucket
     //since the JDBC Driver used is named so as not to be recognized by the built-in logic
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testInferDB2DataSource() throws Exception {
         //The default datasource should continue to be inferred as an XADataSource, since it has properties.db2.jcc configured
         assertTrue("default datasource should wrap XADataSource", ds.isWrapperFor(XADataSource.class));

--- a/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -47,6 +47,7 @@ import javax.transaction.UserTransaction;
 import org.junit.Test;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 import jdbc.fat.driver.derby.FATJDBCSpecialOps;
 import jdbc.fat.driver.derby.FATVendorSpecificSomething;
@@ -145,6 +146,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
      * Test of basic database connectivity
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testBasicConnection() throws Exception {
         InitialContext context = new InitialContext();
         UserTransaction tran = (UserTransaction) context.lookup("java:comp/UserTransaction");
@@ -215,6 +217,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
      * Driver package and class name.
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testConnectionPoolDataSource() throws Exception {
         DataSource proxypoolds = InitialContext.doLookup("jdbc/proxypoolds");
 
@@ -240,6 +243,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
      * ConnectionPoolDataSource implementation is available from the driver.
      */
     @ExpectedFFDC("java.sql.SQLNonTransientException")
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     @Test
     public void testConnectionPoolDataSourceNotFound() throws Exception {
         try {
@@ -299,6 +303,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
                     "java.sql.SQLException", // intentional failure to enlist second resource that isn't two-phase capable
                     "javax.resource.ResourceException" // intentional failure to enlist second resource that isn't two-phase capable
     })
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     @Test
     public void testInterfaceAsClassNameInDataSourceDefinition() throws Exception {
         DataSource dsd_ds = InitialContext.doLookup("java:app/env/jdbc/dsd-with-datasource-interface");
@@ -380,6 +385,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
      * Test enlistment in transactions.
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testTransactionEnlistment() throws Exception {
         InitialContext context = new InitialContext();
         Connection con = ds.getConnection();
@@ -466,6 +472,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
      * giving highest precedence to XADataSource.
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testUnspecifiedClassNameInDataSourceDefinitionWithoutURL() throws Exception {
         DataSource dsd = InitialContext.doLookup("java:module/env/jdbc/dsd-infer-datasource-class");
 
@@ -536,6 +543,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
      * Unwrap and use vendor-specific API, including parameters and return types which are also vendor-specific.
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testUnwrapToVendorSpecificInterface() throws Exception {
         FATJDBCSpecialOps vendorApi = xads.unwrap(FATJDBCSpecialOps.class);
         assertNotNull(vendorApi);

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2019 IBM Corporation and others.
+ * Copyright (c) 2018,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/web/other/LoadFromAppServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/web/other/LoadFromAppServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/web/other/LoadFromAppServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/web/other/LoadFromAppServlet.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -40,6 +40,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATDatabaseServlet;
 
 @SuppressWarnings("serial")
@@ -116,6 +117,7 @@ public class LoadFromAppServlet extends FATDatabaseServlet {
     // where no information is provided about the vendor data source class name such that it must
     // be inferred from the detected java.sql.Driver impl class.
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testInferDataSourceFromDriverPackage() throws Exception {
         DataSource ds = InitialContext.doLookup("jdbc/miniDataSource");
         assertEquals(330, ds.getLoginTimeout());

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -37,6 +37,7 @@ import javax.transaction.UserTransaction;
 import org.junit.Test;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 import oracle.jdbc.OracleCallableStatement;
 import oracle.jdbc.OracleConnection;
@@ -75,6 +76,7 @@ public class OracleTestServlet extends FATServlet {
 
     // Verify that connections are/are not castable to OracleConnection based on whether enableConnectionCasting=true/false.
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testConnectionCasting() throws Exception {
         OracleConnection ocon = (OracleConnection) ds_casting.getConnection();
         try {
@@ -111,6 +113,7 @@ public class OracleTestServlet extends FATServlet {
     // Test for oracle.jdbc.OracleCallableStatement.getCursor.  Should be able to execute a procedure that returns a cursor
     // and use getCursor to obtain a result set.  The parent statement of the result set should be the WAS statement wrapper.
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testCursor() throws Exception {
         Connection con = ds.getConnection();
         try {
@@ -141,6 +144,7 @@ public class OracleTestServlet extends FATServlet {
     // In this test we cover specifying multiple onConnect SQL commands on a single data source,
     // the use of transactional onConnect commands, as well as the use of Liberty variables in the onConnect SQL.
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testOnConnectSQL() throws Exception {
         Connection con = ds_casting.getConnection();
         try {
@@ -166,6 +170,7 @@ public class OracleTestServlet extends FATServlet {
     // Ensure that readOnly true throws an exception
     @Test
     @ExpectedFFDC({ "java.sql.SQLException" })
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testReadOnlyException() throws Exception {
         try (Connection con = ds.getConnection(); PreparedStatement ps = con.prepareStatement("INSERT INTO MYTABLE VALUES(?,?)");) {
             con.setReadOnly(true);
@@ -183,6 +188,7 @@ public class OracleTestServlet extends FATServlet {
     // Test for JDBC 4.2 ref cursors.  Should be able to execute a procedure that returns a cursor
     // and use getObject to obtain a result set.  The parent statement of the result set should be the WAS statement wrapper.
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testRefCursor() throws Exception {
         Connection con = ds.getConnection();
         try {
@@ -216,6 +222,7 @@ public class OracleTestServlet extends FATServlet {
     // that returns values, obtain the return result set and use it.  The parent statement of the result set should
     // be the WAS statement wrapper.
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testReturnResultSet() throws Exception {
         Connection con = ds.getConnection();
         try {
@@ -244,6 +251,7 @@ public class OracleTestServlet extends FATServlet {
 
     // Test configured value of newly supported roleName data source property for Oracle.
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testRoleName() throws Exception {
         // First determine if we can run this test. Oracle driver for JDBC 4.2 is not compatible with Java 9+
         boolean atLeastJava9;
@@ -287,6 +295,7 @@ public class OracleTestServlet extends FATServlet {
     //Test that a datasource backed by Driver can be used with both the generic properties element and properties.oracle
     //element when type="java.sql.Driver"
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testDSUsingDriver() throws Exception {
         Connection conn = driver_ds.getConnection();
         assertFalse("driver_ds should not wrap OracleCommonDataSource", driver_ds.isWrapperFor(OracleCommonDataSource.class));
@@ -317,6 +326,7 @@ public class OracleTestServlet extends FATServlet {
     //Test that the proper implementation classes are used for the various datasources configured in this test bucket
     //since the JDBC Driver used is named so as not to be recognized by the built-in logic
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testInferOracleDataSource() throws Exception {
         //The default datasource should continue to be inferred as an XADataSource, since it has properties.oracle configured
         assertTrue("default datasource should wrap OracleXADataSource",
@@ -357,6 +367,7 @@ public class OracleTestServlet extends FATServlet {
      * Confirm that locks are not shared between transaction branches that are loosely coupled.
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testTransactionBranchesLooselyCoupled() throws Exception {
         tx.begin();
         try {
@@ -378,6 +389,7 @@ public class OracleTestServlet extends FATServlet {
      * Confirm that locks are shared between transaction branches that are tightly coupled.
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testTransactionBranchesTightlyCoupled() throws Exception {
         tx.begin();
         try {
@@ -397,6 +409,7 @@ public class OracleTestServlet extends FATServlet {
     }
 
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testBlobCreation() throws Exception {
         try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("/data/myDataFile.txt");) {
 

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_postgresql/test-applications/postgresqlApp/src/jdbc/fat/postgresql/web/PostgreSQLTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/test-applications/postgresqlApp/src/jdbc/fat/postgresql/web/PostgreSQLTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_postgresql/test-applications/postgresqlApp/src/jdbc/fat/postgresql/web/PostgreSQLTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/test-applications/postgresqlApp/src/jdbc/fat/postgresql/web/PostgreSQLTestServlet.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -46,6 +46,7 @@ import org.postgresql.jdbc.AutoSave;
 import org.postgresql.largeobject.LargeObjectManager;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
@@ -62,6 +63,7 @@ public class PostgreSQLTestServlet extends FATServlet {
 
     // Test that we can obtain a Connection from a datasource that uses the generic <properties> element with PostgreSQL
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testPostgresGenericProps() throws Exception {
         DataSource ds = InitialContext.doLookup("jdbc/postgres/genericprops");
         ds.getConnection().close();
@@ -71,6 +73,7 @@ public class PostgreSQLTestServlet extends FATServlet {
     // and a JDBC driver that does not match the jar name heuristic detection. This will confirm that our java.sql.Driver
     // detection mechanism works properly for PostgreSQL
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testAnonymousPostgresDriver() throws Exception {
         DataSource ds = InitialContext.doLookup("jdbc/anonymous/Driver");
         ds.getConnection().close();
@@ -78,6 +81,7 @@ public class PostgreSQLTestServlet extends FATServlet {
 
     // Verify we can auto-detect an XA DataSource implementation using a generically named PostgreSQL JDBC Driver
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testAnonymousPostgresDS() throws Exception {
         DataSource ds = InitialContext.doLookup("jdbc/anonymous/XADataSource");
         ds.getConnection().close();
@@ -92,6 +96,7 @@ public class PostgreSQLTestServlet extends FATServlet {
 
     // Verify that we can configure a <properties.postgresql> element by specifying only the 'URL' property
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testPostgresURLOnly() throws Exception {
         DataSource ds = InitialContext.doLookup("jdbc/postgres/urlOnly");
         ds.getConnection().close();
@@ -143,7 +148,8 @@ public class PostgreSQLTestServlet extends FATServlet {
 
     // Test that a basic PostgreSQL-only bean property (defaultFetchSize) gets set on a DataSource when configured in server.xml
     @Test
-    public void testBaiscPostgreSpecificProp() throws Exception {
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
+    public void testBasicPostgreSpecificProp() throws Exception {
         DataSource ds = InitialContext.doLookup("jdbc/anonymous/XADataSource");
 
         // Insert 6 rows into the DB. Uses ID's 0, 1, 2, 3, 4, and 5
@@ -169,6 +175,7 @@ public class PostgreSQLTestServlet extends FATServlet {
 
     // Verify behavior of the defaultReadOnly setting on <properties.postgresql>
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testReadOnly() throws Exception {
         // On a regular DS, should be able to write data
         DataSource regularDS = InitialContext.doLookup("jdbc/anonymous/XADataSource");
@@ -203,6 +210,7 @@ public class PostgreSQLTestServlet extends FATServlet {
     // Verify that the defaultAutoCommit setting defaults to true, and when it is set to false
     // connections obtained from these DataSources have autoCommit=false when initially obtained
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testDefaultAutoCommit() throws Exception {
         // On a regular DS, default AC should be true in an LTC, or false in a global tran
         DataSource writingDS = InitialContext.doLookup("jdbc/anonymous/XADataSource");

--- a/dev/com.ibm.ws.jdbc_fat_postgresql/test-applications/postgresqlApp/src/jdbc/fat/postgresql/web/PostgreSQLTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/test-applications/postgresqlApp/src/jdbc/fat/postgresql/web/PostgreSQLTestServlet.java
@@ -55,9 +55,6 @@ public class PostgreSQLTestServlet extends FATServlet {
 
     private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
 
-    @Resource(lookup = "jdbc/anonymous/XADataSource")
-    DataSource resRefDS;
-
     @Resource
     UserTransaction tx;
 

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerTest.java
@@ -27,6 +27,7 @@ import org.testcontainers.containers.MSSQLServerContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.annotation.TestServlet;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
@@ -93,6 +94,7 @@ public class SQLServerTest extends FATServletClient {
     }
 
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDKs
     public void testAuthenticationSchemeNTLM() throws Exception {
         server.setTraceMarkToEndOfDefaultTrace();
         runTest(server, APP_NAME + "/SQLServerTestServlet", testName);

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/test-applications/sqlserverfat/src/web/SQLServerTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/test-applications/sqlserverfat/src/web/SQLServerTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2021 IBM Corporation and others.
+ * Copyright (c) 2019,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/test-applications/sqlserverfat/src/web/SQLServerTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/test-applications/sqlserverfat/src/web/SQLServerTestServlet.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -47,6 +47,7 @@ import com.microsoft.sqlserver.jdbc.ISQLServerDataSource;
 import com.microsoft.sqlserver.jdbc.ISQLServerStatement;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -363,6 +364,7 @@ public class SQLServerTestServlet extends FATServlet {
     //Test that the proper implementation classes are used for the various datasources configured in this test bucket
     //since the JDBC Driver used is named so as not to be recognized by the built-in logic
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testInferSQLServerDataSource() throws Exception {
         //The default datasource should continue to be inferred as an XADataSource, since it has properties.microsoft.sqlserver configured
         assertTrue("default datasource should wrap XADataSource", ds.isWrapperFor(XADataSource.class));

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStartJavaEnvironmentVariablesTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStartJavaEnvironmentVariablesTest.java
@@ -1,11 +1,12 @@
 package com.ibm.ws.kernel.boot;
+
 /*******************************************************************************
  * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -37,6 +38,7 @@ import com.ibm.websphere.simplicity.OperatingSystem;
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -82,6 +84,7 @@ public class ServerStartJavaEnvironmentVariablesTest {
      * that IBM_JAVA_OPTIONS is set to the same value.
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to ENV vars being overwritten when running in test framework
     public void testServerStartOpenJ9JavaOptionsSet() throws Exception {
         Log.entering(c, testName.getMethodName());
 
@@ -117,6 +120,7 @@ public class ServerStartJavaEnvironmentVariablesTest {
      * @throws Exception
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to ENV vars being overwritten when running in test framework
     public void testServerStartIBMJavaOptionsSet() throws Exception {
         Log.entering(c, testName.getMethodName());
         try {

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStartJavaEnvironmentVariablesTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStartJavaEnvironmentVariablesTest.java
@@ -1,7 +1,7 @@
 package com.ibm.ws.kernel.boot;
 
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -43,6 +43,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
@@ -445,6 +446,7 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
      * output to test a connection.
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testAppDefinedDataSourceInJavaGlobalAndTestConnection() throws Exception {
         JsonObject ds = new HttpsRequest(server, "/ibm/api/config/dataSource/dataSource%5Bjava:global%2Fenv%2Fjdbc%2Fds4%5D")
                         .run(JsonObject.class);
@@ -1175,6 +1177,7 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
                    "jakarta.resource.ResourceException" // expected: Value 1:05:30 is not supported for agedTimeout
     })
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testValidateAppDefinedDataSources() throws Exception {
         JsonArray array = new HttpsRequest(server, "/ibm/api/validation/dataSource?auth=container&authAlias=derbyAuth3")
                         .run(JsonArray.class);

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DBRotationTest.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DBRotationTest.java
@@ -36,6 +36,7 @@ import com.ibm.ws.transaction.fat.util.TxTestContainerSuite;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.database.container.DatabaseContainerType;
@@ -46,6 +47,7 @@ import servlets.Simple2PCCloudServlet;
 
 @RunWith(FATRunner.class)
 @AllowedFFDC(value = { "javax.resource.spi.ResourceAllocationException" })
+@SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
 public class DBRotationTest extends FATServletClient {
     private static final Class<?> c = DBRotationTest.class;
 

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DualServerDynamicDBRotationTest1.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DualServerDynamicDBRotationTest1.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,6 +21,7 @@ import com.ibm.ws.transaction.fat.util.TxTestContainerSuite;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
@@ -30,6 +31,7 @@ import servlets.Simple2PCCloudServlet;
 @Mode
 @RunWith(FATRunner.class)
 @AllowedFFDC(value = { "javax.resource.spi.ResourceAllocationException" })
+@SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
 public class DualServerDynamicDBRotationTest1 extends DualServerDynamicCoreTest1 {
 
     @Server("com.ibm.ws.transaction_ANYDBCLOUD001")

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DualServerDynamicDBRotationTest2.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DualServerDynamicDBRotationTest2.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,6 +22,7 @@ import com.ibm.ws.transaction.fat.util.TxTestContainerSuite;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
@@ -31,6 +32,7 @@ import servlets.Simple2PCCloudServlet;
 @Mode
 @RunWith(FATRunner.class)
 @AllowedFFDC(value = { "javax.resource.spi.ResourceAllocationException" })
+@SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
 public class DualServerDynamicDBRotationTest2 extends DualServerDynamicCoreTest2 {
 
     @Server("com.ibm.ws.transaction_ANYDBCLOUD001")

--- a/dev/fattest.simplicity/src/componenttest/annotation/SkipIfSysProp.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/SkipIfSysProp.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -80,6 +80,7 @@ public @interface SkipIfSysProp {
 
     // OS system properties
     public static final String OS_ZOS = "os.name=z/OS";
+    public static final String OS_IBMI = "os.name=os/400";
 
     String[] value();
 

--- a/dev/fattest.simplicity/src/componenttest/annotation/SkipIfSysProp.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/SkipIfSysProp.java
@@ -80,7 +80,7 @@ public @interface SkipIfSysProp {
 
     // OS system properties
     public static final String OS_ZOS = "os.name=z/OS";
-    public static final String OS_IBMI = "os.name=os/400";
+    public static final String OS_IBMI = "os.name=OS/400";
 
     String[] value();
 

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
@@ -217,7 +217,7 @@ public class TCKRunner {
      * run the TCK and process the results
      */
     private void runTCK() throws Exception {
-        Assume.assumeThat(System.getProperty("os.name"), CoreMatchers.not("os/400")); // skip tests on IBM i due to mvn issue.
+        Assume.assumeThat(System.getProperty("os.name"), CoreMatchers.not("OS/400")); // skip tests on IBM i due to mvn issue.
         String[] testOutput = runCleanTestCmd();
         List<String> failingTestsList = postProcessTestResults(testOutput);
         assertTestsPassed(this.bucketName, this.testName, failingTestsList);

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -47,7 +47,9 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -215,6 +217,7 @@ public class TCKRunner {
      * run the TCK and process the results
      */
     private void runTCK() throws Exception {
+        Assume.assumeThat(System.getProperty("os.name"), CoreMatchers.not("os/400")); // skip tests on IBM i due to mvn issue.
         String[] testOutput = runCleanTestCmd();
         List<String> failingTestsList = postProcessTestResults(testOutput);
         assertTestsPassed(this.bucketName, this.testName, failingTestsList);
@@ -229,6 +232,7 @@ public class TCKRunner {
      * runs "mvn clean test" in the tck folder, passing through all the required properties
      */
     private String[] runCleanTestCmd() throws Exception {
+
         String[] testcmd = getMvnCommandArray(MVN_CLEAN, MVN_TEST);
         String[] mvnOutput = runCmd(testcmd, getTCKRunnerDir());
         TCKUtilities.writeStringsToFile(mvnOutput, getMvnTestOutputFile());


### PR DESCRIPTION
Disabling some tests on IBM i, which are currently failing. These have been identified as test bugs and were discovered when continuous testing on IBM i was enabled. To prevent cluttering builds with these failures the tests will be disabled on IBM i until they are addressed.
