### PR TITLE
PR for Issue 24037: Update SAML metatype descriptions

### DIFF
--- a/dev/com.ibm.ws.security.saml.websso.2.0/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/resources/OSGI-INF/l10n/metatype.properties
@@ -186,10 +186,10 @@ spHostAndPort=SAML host name and port number
 spHostAndPort.desc=Specifies the hostname and port number by which the IdP addresses this SAML service provider. Use this attribute if the browser needs to be redirected to a router or proxy server instead of directly connecting to the service provider. The format for the value for this attribute is (scheme)://(proxyOrRouterHost):(proxyOrRouterPort). For example, https://myRouter.com:443.
 
 reAuthnOnAssertionExpire=Authenticate again when assertion expires
-reAuthnOnAssertionExpire.desc=Authenticate the incoming HTTP request again when the NotOnOrAfter in the Conditions element of the SAML Assertion is expired.
+reAuthnOnAssertionExpire.desc=Authenticate the incoming HTTP request again when the NotOnOrAfter value in the Conditions element of the SAML Assertion is expired.
 
 reAuthnCushion=Cushion time to authenticate again
-reAuthnCushion.desc=The time period to authenticate the user again when the Subject associated with a SAML Assertion is about to expire. This cushion is applied to both the NotOnOrAfter in the Conditions element and the SessionNotOnOrAfter attribute of the SAML Assertion.
+reAuthnCushion.desc=The time period to authenticate the user again when the Subject associated with a SAML Assertion is about to expire. This cushion is applied to both the NotOnOrAfter value in the Conditions element and the SessionNotOnOrAfter attribute of the SAML Assertion.
 
 targetPageUrl=Target page URL
 targetPageUrl.desc=The default landing page for the IdP-initiated SSO if the relayState is missing.  This property must be set to a valid URL if useRelayStateForTarget is set to false.

--- a/dev/com.ibm.ws.security.saml.websso.2.0/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/resources/OSGI-INF/l10n/metatype.properties
@@ -186,10 +186,10 @@ spHostAndPort=SAML host name and port number
 spHostAndPort.desc=Specifies the hostname and port number by which the IdP addresses this SAML service provider. Use this attribute if the browser needs to be redirected to a router or proxy server instead of directly connecting to the service provider. The format for the value for this attribute is (scheme)://(proxyOrRouterHost):(proxyOrRouterPort). For example, https://myRouter.com:443.
 
 reAuthnOnAssertionExpire=Authenticate again when assertion expires
-reAuthnOnAssertionExpire.desc=Authenticate the incoming HTTP request again when a SAML Assertion is about to expire.  
+reAuthnOnAssertionExpire.desc=Authenticate the incoming HTTP request again when the NotOnOrAfter in the Conditions element of the SAML Assertion is expired.
 
 reAuthnCushion=Cushion time to authenticate again
-reAuthnCushion.desc=The time period to authenticate again when a SAML Assertion is about to expire, which is indicated by either the statement NotOnOrAfter or the attribute SessionNotOnOrAfter of the SAML Assertion.
+reAuthnCushion.desc=The time period to authenticate the user again when the Subject associated with a SAML Assertion is about to expire. This cushion is applied to both the NotOnOrAfter in the Conditions element and the SessionNotOnOrAfter attribute of the SAML Assertion.
 
 targetPageUrl=Target page URL
 targetPageUrl.desc=The default landing page for the IdP-initiated SSO if the relayState is missing.  This property must be set to a valid URL if useRelayStateForTarget is set to false.


### PR DESCRIPTION
Updates the descriptions for `reAuthnCushion` and `reAuthnOnAssertionExpire` in the SAML metatype.

Resolves #24037
