### PR TITLE
Fix JAXBToolsTest on IBM i

### DIFF
--- a/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/JAXBToolsTest.java
+++ b/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/JAXBToolsTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -56,6 +56,8 @@ public class JAXBToolsTest extends FATServletClient {
      * True if running on Windows and the .bat file should be used.
      */
     private static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
+    private static final boolean isIBMi = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("os/400");
+
     /**
      * Environment variable that can be set to test the UNIX script on Windows.
      */
@@ -109,7 +111,11 @@ public class JAXBToolsTest extends FATServletClient {
             commandBuilder.append(xjcBat);
         } else {
             if (WLP_CYGWIN_HOME == null) {
-                commandBuilder.append("/bin/sh");
+                if (isIBMi) {
+                    commandBuilder.append("/QOpenSys/usr/bin/sh"); // IBM i
+                } else {
+                    commandBuilder.append("/bin/sh");
+                }
             } else {
                 commandBuilder.append(WLP_CYGWIN_HOME + "/bin/sh");
             }
@@ -163,7 +169,11 @@ public class JAXBToolsTest extends FATServletClient {
             commandBuilder.append(xjcBat);
         } else {
             if (WLP_CYGWIN_HOME == null) {
-                commandBuilder.append("/bin/sh");
+                if (isIBMi) {
+                    commandBuilder.append("/QOpenSys/usr/bin/sh"); // IBM i
+                } else {
+                    commandBuilder.append("/bin/sh");
+                }
             } else {
                 commandBuilder.append(WLP_CYGWIN_HOME + "/bin/sh");
             }
@@ -237,7 +247,11 @@ public class JAXBToolsTest extends FATServletClient {
             commandBuilder.append(schemagenBat);
         } else {
             if (WLP_CYGWIN_HOME == null) {
-                commandBuilder.append("/bin/sh");
+                if (isIBMi) {
+                    commandBuilder.append("/QOpenSys/usr/bin/sh"); // IBM i
+                } else {
+                    commandBuilder.append("/bin/sh");
+                }
             } else {
                 commandBuilder.append(WLP_CYGWIN_HOME + "/bin/sh");
             }


### PR DESCRIPTION
On IBM i, the com.ibm.ws.springboot.support_fat FAT fails with garbage characters in the results:

```
testXJCToolWithoutTarget:java.io.IOException: 2022-04-13-06:42:49:578 /bin/sh failed (1): N@@¤
...
¢aKK¦¢K§K£¢Kã
¢£â
¥
a£
a§â¤
Äa¤¢
Ö
K§¢%Exception in thread "main" java.io.FileNotFoundException: /bin/jaxb/tools/ws-xjc.jar (A file or directory in the path name does not exist.)
	at java.util.zip.ZipFile.open(Native Method)
	at java.util.zip.ZipFile.<init>(ZipFile.java:242)
	at java.util.zip.ZipFile.<init>(ZipFile.java:171)
	at java.util.jar.JarFile.<init>(JarFile.java:179)
	at java.util.jar.JarFile.<init>(JarFile.java:116)

	at com.ibm.ws.jaxb.fat.JAXBToolsTest.execute(JAXBToolsTest.java:308)
	at com.ibm.ws.jaxb.fat.JAXBToolsTest.testXJCToolWithoutTarget(JAXBToolsTest.java:119)
	at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:199)
	at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:320)
	at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:173)
	at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:143)
```