### PR TITLE
Revert "Add running condition to datasource"

### DIFF
--- a/dev/com.ibm.ws.jdbc/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc/bnd.bnd
@@ -66,7 +66,6 @@ Service-Component: \
     jaasLoginContextEntry=com.ibm.ws.security.jaas.common.JAASLoginContextEntry?; \
     jdbcRuntimeVersion=com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion; \
     recoveryAuthData=com.ibm.websphere.security.auth.data.AuthData?; \
-    runningCondition='org.osgi.service.condition.Condition';\
     greedy:='connectionManager,containerAuthData,driver,jaasLoginContextEntry,jdbcRuntimeVersion,recoveryAuthData';\
     properties:='\
       connectionManager.target=(id=unbound),\
@@ -74,8 +73,7 @@ Service-Component: \
       driver.target=(id=unbound),\
       jaasLoginContextEntry.target=(id=unbound),\
       recoveryAuthData.target=(id=unbound),\
-      creates.objectClass=|javax.sql.DataSource,\
-      runningCondition.target=(osgi.condition.id=io.openliberty.process.running)',\
+      creates.objectClass=|javax.sql.DataSource', \
   com.ibm.ws.jdbc.jdbcDriver; \
     implementation:=com.ibm.ws.jdbc.internal.JDBCDriverService; \
     provide:='com.ibm.ws.jdbc.internal.JDBCDriverService,com.ibm.wsspi.library.LibraryChangeListener'; \


### PR DESCRIPTION
This reverts commit 8ac10dc193b4944ad90ecec78f02060f53186112. 

Remove a workaround for checkpoint/restore which is not correct. This change only affects code paths using the checkpoint/restore option to the server command. 