### PR TITLE
Clean up Telemetry bundles

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.telemetry-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.telemetry-1.0.feature
@@ -1,9 +1,0 @@
--include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.org.eclipse.microprofile.telemetry-1.0
-visibility=private
-singleton=true
--features=io.openliberty.mpCompatible-6.0
--jars=io.openliberty.mpTelemetry.1.0.thirdparty; location:="dev/api/third-party/,lib/"
-kind=beta
-edition=core
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-1.0/io.openliberty.mpTelemetry-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-1.0/io.openliberty.mpTelemetry-1.0.feature
@@ -32,8 +32,7 @@ IBM-API-Package: \
   io.openliberty.cdi-4.0, \
   io.openliberty.mpCompatible-6.0,\
   com.ibm.websphere.appserver.injection-2.0, \
-  io.openliberty.org.eclipse.microprofile.rest.client-3.0, \
-  io.openliberty.org.eclipse.microprofile.telemetry-1.0
+  io.openliberty.org.eclipse.microprofile.rest.client-3.0
 -bundles=\
   io.openliberty.com.squareup.okhttp,\
   io.openliberty.com.squareup.okio-jvm,\
@@ -43,6 +42,7 @@ IBM-API-Package: \
   com.ibm.ws.cdi.interfaces.jakarta, \
   io.openliberty.microprofile.telemetry.1.0.internal,\
   io.openliberty.io.opentelemetry.internal
+-jars=io.openliberty.mpTelemetry.1.0.thirdparty; location:="dev/api/third-party/,lib/"
 kind=beta
 edition=core
 WLP-Activation-Type: parallel 

--- a/dev/io.openliberty.io.opentelemetry.internal/bnd.bnd
+++ b/dev/io.openliberty.io.opentelemetry.internal/bnd.bnd
@@ -6,12 +6,9 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 
--include= ~../cnf/resources/bnd/bundle.props,~../cnf/resources/bnd/transform.props
+-include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 openTelemetryVersion=1.19.0
 
@@ -59,29 +56,29 @@ Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 	io.openliberty.com.squareup.okio-jvm;version=latest,\
 	io.openliberty.io.zipkin.zipkin2;version=latest,\
 	io.openliberty.jakarta.interceptor.2.1;version=latest,\
-	io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations-support;version='1.19.0.alpha',\
-	io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations;version='1.19.0.alpha',\
-	io.opentelemetry.instrumentation:opentelemetry-instrumentation-api;version='1.19.0',\
-	io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv;version='1.19.0.alpha',\
-	io.opentelemetry:opentelemetry-api;version='1.19.0',\
-	io.opentelemetry:opentelemetry-api-logs;version='1.19.0.alpha',\
-	io.opentelemetry:opentelemetry-context;version='1.19.0',\
-	io.opentelemetry:opentelemetry-exporter-jaeger;version='1.19.0',\
-	io.opentelemetry:opentelemetry-exporter-logging;version='1.19.0',\
-	io.opentelemetry:opentelemetry-exporter-otlp-common;version='1.19.0',\
-	io.opentelemetry:opentelemetry-exporter-otlp;version='1.19.0',\
-	io.opentelemetry:opentelemetry-exporter-common;version='1.19.0',\
-	io.opentelemetry:opentelemetry-exporter-zipkin;version='1.19.0',\
-	io.opentelemetry:opentelemetry-extension-trace-propagators;version='1.19.0',\
-	io.opentelemetry:opentelemetry-sdk;version='1.19.0',\
-	io.opentelemetry:opentelemetry-sdk-common;version='1.19.0',\
-	io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi;version='1.19.0',\
-	io.opentelemetry:opentelemetry-sdk-extension-autoconfigure;version='1.19.0.alpha',\
-	io.opentelemetry:opentelemetry-sdk-logs;version='1.19.0.alpha',\
-	io.opentelemetry:opentelemetry-sdk-metrics;version='1.19.0',\
-	io.opentelemetry:opentelemetry-sdk-trace;version='1.19.0',\
-	io.opentelemetry:opentelemetry-semconv;version='1.19.0.alpha',\
+	io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations-support;version='1.19.0.alpha';strategy=exact,\
+	io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations;version='1.19.0.alpha';strategy=exact,\
+	io.opentelemetry.instrumentation:opentelemetry-instrumentation-api;version='1.19.0';strategy=exact,\
+	io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv;version='1.19.0.alpha';strategy=exact,\
+	io.opentelemetry:opentelemetry-api;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-api-logs;version='1.19.0.alpha';strategy=exact,\
+	io.opentelemetry:opentelemetry-context;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-exporter-jaeger;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-exporter-logging;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-exporter-otlp-common;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-exporter-otlp;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-exporter-common;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-exporter-zipkin;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-extension-trace-propagators;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-sdk;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-sdk-common;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-sdk-extension-autoconfigure;version='1.19.0.alpha';strategy=exact,\
+	io.opentelemetry:opentelemetry-sdk-logs;version='1.19.0.alpha';strategy=exact,\
+	io.opentelemetry:opentelemetry-sdk-metrics;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-sdk-trace;version='1.19.0';strategy=exact,\
+	io.opentelemetry:opentelemetry-semconv;version='1.19.0.alpha';strategy=exact,\
 	com.ibm.ws.classloading;version=latest,\
 	org.eclipse.osgi;version=latest
 
-WS-TraceGroup: opentelemetry
+WS-TraceGroup: TELEMETRY

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -75,9 +72,10 @@ Private-Package: \
     com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     io.openliberty.io.opentelemetry.internal;version=latest,\
-    io.openliberty.mpTelemetry.1.0.thirdparty;version=latest,\
     io.openliberty.org.eclipse.microprofile.config.3.0,\
     io.openliberty.org.eclipse.microprofile.rest.client.3.0,\
     io.openliberty.org.jboss.resteasy.common.ee10;version=latest,\
     com.ibm.websphere.org.osgi.core;version=latest,\
     com.ibm.ws.container.service;version=latest
+
+WS-TraceGroup: TELEMETRY

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
@@ -1,14 +1,11 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -30,11 +27,11 @@ tested.features:\
 
 -buildpath: \
 	io.openliberty.jakarta.servlet.6.0;version=latest,\
-	io.openliberty.mpTelemetry.1.0.thirdparty;version=latest,\
 	io.openliberty.jakarta.restfulWS.3.1;version=latest,\
 	io.openliberty.jakarta.cdi.4.0;version=latest,\
 	com.ibm.ws.componenttest.2.0;version=latest,\
 	io.openliberty.io.opentelemetry.internal;version=latest,\
 	io.openliberty.org.eclipse.microprofile.rest.client.3.0;version=latest,\
 	io.openliberty.jakarta.annotation.2.1;version=latest,\
-	io.openliberty.jakarta.concurrency.3.0;version=latest
+	io.openliberty.jakarta.concurrency.3.0;version=latest,\
+	io.openliberty.mpTelemetry.1.0.thirdparty;version=latest

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/longrunning/LongRunningTask.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/longrunning/LongRunningTask.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package io.openliberty.microprofile.telemetry.internal_fat.apps.longrunning;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -15,6 +24,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
 
+@SuppressWarnings("serial")
 @WebServlet("/longrunning")
 @ApplicationScoped
 public class LongRunningTask extends FATServlet {

--- a/dev/io.openliberty.mpTelemetry.1.0.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.mpTelemetry.1.0.thirdparty/bnd.bnd
@@ -1,16 +1,13 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= ~../cnf/resources/bnd/bundle.props,~../cnf/resources/bnd/transform.props
+-include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 publish.wlp.jar.suffix: dev/api/third-party
 
@@ -42,13 +39,14 @@ Private-Package: \
   io.opentelemetry.semconv.resource.attributes;version=${alphaOpenTelemetryVersion},\
   io.opentelemetry.instrumentation.annotations;version=${alphaOpenTelemetryVersion}
   
-Import-Package: \
-  *
-  
+Import-Package:
+
+Export-Package:
+
 -buildpath: \
   io.openliberty.jakarta.interceptor.2.1;version=latest,\
   io.openliberty.io.opentelemetry.internal;version=latest
   
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 
-WS-TraceGroup: opentelemetry
+WS-TraceGroup: TELEMETRY

--- a/dev/io.openliberty.org.eclipse.microprofile/bnd.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/bnd.bnd
@@ -1,14 +1,11 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion: 1.0
@@ -30,5 +27,4 @@ instrument.disabled: true
   com.ibm.websphere.javaee.cdi.2.0;version=latest,\
   com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
   com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
-  biz.aQute.bnd:biz.aQute.bnd;version=6.3.0,\
-  io.opentelemetry:opentelemetry-api
+  biz.aQute.bnd:biz.aQute.bnd;version=6.3.0


### PR DESCRIPTION
Clean up bnd files;
- set exact versions on buildpath
- set tracegroup correctly
- remove remnants of transformation
- remove private API feature
- Don't import or export from thirdparty jar

#build

