### PR TITLE
Removing NBSP from date/time

### DIFF
--- a/dev/com.ibm.ws.logging.hpel/src/com/ibm/ws/logging/hpel/FormatSet.java
+++ b/dev/com.ibm.ws.logging.hpel/src/com/ibm/ws/logging/hpel/FormatSet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corporation and others.
+ * Copyright (c) 2009, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -147,6 +147,7 @@ public class FormatSet {
                 newPattern = newPattern.replace('K', 'H');
                 newPattern = newPattern.replace('k', 'H');
                 newPattern = newPattern.replace('a', ' ');
+                newPattern = newPattern.replace('\u202F', ' ');
                 newPattern = newPattern.trim();
                 sdFormatter.applyPattern(newPattern);
                 formatter = sdFormatter;


### PR DESCRIPTION
JDK 20 introduced a NBSP in the date/time pattern which is breaking the date formats.

Fixes: #23978