### PR TITLE
Remove commented out staging repo

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,24 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2021 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2021, 2023 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
         http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0 
-    Contributors: 
-        IBM Corporation - initial API and implementation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <!--<repositories>
-        <repository>
-            <id>eclipse-staging</id>
-            <url>https://oss.sonatype.org/content/repositories/orgeclipsemicroprofile-1632/</url>
-        </repository>
-    </repositories>-->
     
     <properties>
         <arquillian.version>1.7.0.Alpha13</arquillian.version>


### PR DESCRIPTION
Staging repo was only used during initial development.

fixes https://github.com/OpenLiberty/open-liberty/issues/24211