### PR TITLE
XML-WS 4.0 + WS-AtomicTransaction 1.2: Add jaxws globalhandler bundle

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.ee-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.ee-10.0.feature
@@ -4,10 +4,12 @@ singleton=true
 visibility = private
 -features=\
   io.openliberty.xmlWS-4.0, \
-  com.ibm.websphere.appserver.servlet-6.0
+  com.ibm.websphere.appserver.servlet-6.0, \
+  io.openliberty.globalhandler1.0.internal.ee-10.0
 -bundles=\
   com.ibm.ws.wsat.common.jakarta; start-phase:=CONTAINER_LATE, \
   com.ibm.ws.wsat.webclient.jakarta, \
-  com.ibm.ws.wsat.webservice.jakarta
+  com.ibm.ws.wsat.webservice.jakarta, \
+  io.openliberty.jaxws.globalhandler.internal.jakarta
 kind=beta
 edition=base


### PR DESCRIPTION
This PR adds the `io.openliberty.jaxws.globalhandler.internal.jakarta` bundle to the `io.openliberty.wsAtomicTransaction1.2.internal.ee-10.0.feature` due to hard dependency on the globalhandler in EE10