### PR TITLE
Update Faces 4.0 bnd, some packages removed/changed

### DIFF
--- a/dev/io.openliberty.org.apache.myfaces.4.0/bnd.bnd
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/bnd.bnd
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -80,21 +77,15 @@ Export-Package: \
   org.apache.myfaces.context;thread-context=true;version=${Implementation-Version}, \
   org.apache.myfaces.context.servlet;thread-context=true;version=${Implementation-Version}, \
   org.apache.myfaces.config.annotation;thread-context=true;version=${Implementation-Version}, \
-  org.apache.myfaces.config.impl.digester.elements;thread-context=true;version=${Implementation-Version}, \
-  org.apache.myfaces.el.convert;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.config.impl.element;thread-context=true;version=${Implementation-Version}, \
   org.apache.myfaces.flow;thread-context=true;version=${Implementation-Version}, \
   org.apache.myfaces.flow.cdi;thread-context=true;version=${Implementation-Version}, \
   org.apache.myfaces.lifecycle;thread-context=true;version=${Implementation-Version}, \
   org.apache.myfaces.lifecycle.clientwindow;thread-context=true;version=${Implementation-Version}, \
   org.apache.myfaces.push.cdi;thread-context=true;version=${Implementation-Version}, \
   org.apache.myfaces.renderkit;thread-context=true;version=${Implementation-Version}, \
-  org.apache.myfaces.shared.context.flash;thread-context=true;version=${Implementation-Version}, \
-  org.apache.myfaces.shared.taglib;thread-context=true;version=${Implementation-Version}, \
-  org.apache.myfaces.shared.taglib.core;thread-context=true;version=${Implementation-Version}, \
-  org.apache.myfaces.shared.util;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.context.flash;thread-context=true;version=${Implementation-Version}, \
   org.apache.myfaces.spi.impl;thread-context=true;version=${Implementation-Version}, \
-  org.apache.myfaces.taglib.core;thread-context=true;version=${Implementation-Version}, \
-  org.apache.myfaces.taglib.html;thread-context=true;version=${Implementation-Version}, \
   org.apache.myfaces.view;thread-context=true;version=${Implementation-Version}, \
   org.apache.myfaces.view.facelets;thread-context=true;version=${Implementation-Version}, \
   org.apache.myfaces.view.facelets.compiler;thread-context=true;version=${Implementation-Version}, \


### PR DESCRIPTION
fixes #24018

1. `org.apache.myfaces.config.impl.digester.elements` -> moved to `org.apache.myfaces.config.impl.element`.  FacesConfig/ManagedBeanImpl/ManagedPropertyImpl/MapEntriesImpl are missing in Faces 4.0 from this package.
2. `org.apache.myfaces.el.convert` ->removed , package does not exist in 4.0
3. `org.apache.myfaces.shared.context.flash` -> `org.apache.myfaces.context.flash`
4. `org.apache.myfaces.shared.taglib` -> removed
5. `org.apache.myfaces.shared.taglib.core` -> removed
6. `org.apache.myfaces.shared.util` -> These classes are spread across multiple packages now: `org.apache.myfaces.core.api.shared`, `org.apache.myfaces.core.api.shared.lang`, `org.apache.myfaces.util`, `org.apache.myfaces.util.lang`, `org.apache.myfaces.application.viewstate` ( this one is already on the TCCL). For now just going to remove this and see if we hit a scenario where it is necessary to add it.
7. `org.apache.myfaces.taglib.core` ->  removed
8. `org.apache.myfaces.taglib.html` -> removed