### PR TITLE
Telemetry: More JAX-RS tests and bug fixes

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
@@ -32,7 +32,8 @@ src: src, resources
 -dsannotations: \
   io.openliberty.microprofile.telemetry.internal.cdi.SPIMetaData,\
   io.openliberty.microprofile.telemetry.internal.rest.TelemetryClientAsyncTaskWrapper,\
-  io.openliberty.microprofile.telemetry.internal.rest.TelemetryClientBuilderListener
+  io.openliberty.microprofile.telemetry.internal.rest.TelemetryClientBuilderListener,\
+  io.openliberty.microprofile.telemetry.internal.rest.TelemetryServletContainerInitializer
 
 -dsannotations-inherit: true
 
@@ -68,6 +69,7 @@ Private-Package: \
     io.openliberty.jakarta.annotation.2.1;version=latest,\
     io.openliberty.jakarta.interceptor.2.1;version=latest,\
     io.openliberty.jakarta.cdi.4.0;version=latest,\
+    io.openliberty.jakarta.servlet.6.0;version=latest,\
     com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
     com.ibm.ws.logging.core;version=latest,\
     com.ibm.ws.cdi.interfaces.jakarta;version=latest,\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryClientAsyncTaskWrapper.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryClientAsyncTaskWrapper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,7 @@
 package io.openliberty.microprofile.telemetry.internal.rest;
 
 import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -36,6 +37,11 @@ public class TelemetryClientAsyncTaskWrapper implements ClientAsyncTaskWrapper {
     @Override
     public <T> Callable<T> wrap(Callable<T> c) {
         return Context.current().wrap(c);
+    }
+
+    @Override
+    public <T> Supplier<T> wrap(Supplier<T> s) {
+        return Context.current().wrapSupplier(s);
     }
 
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryServletContainerInitializer.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryServletContainerInitializer.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal.rest;
+
+import static org.osgi.service.component.annotations.ConfigurationPolicy.IGNORE;
+
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+
+import jakarta.servlet.ServletContainerInitializer;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+
+/**
+ * Registers our ServletRequestListener
+ */
+@Component(configurationPolicy = IGNORE)
+public class TelemetryServletContainerInitializer implements ServletContainerInitializer {
+
+    /** {@inheritDoc} */
+    @Override
+    public void onStartup(Set<Class<?>> c, ServletContext sc) throws ServletException {
+        sc.addListener(TelemetryServletRequestListener.class);
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryServletRequestListener.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryServletRequestListener.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal.rest;
+
+import io.opentelemetry.context.Scope;
+import jakarta.servlet.ServletRequestEvent;
+import jakarta.servlet.ServletRequestListener;
+
+/**
+ * Closes the Scope at the end of the request.
+ * <p>
+ * Context is set for a thread, so it's important that you start and end a Scope on the same thread.
+ * <p>
+ * When using async resource methods, the two filter methods of TelemetryContainerFilter may be called on different threads.
+ * Using a ServletRequestListener ensures that we close the scope on the original request thread.
+ */
+public class TelemetryServletRequestListener implements ServletRequestListener {
+
+    /** {@inheritDoc} */
+    @Override
+    public void requestDestroyed(ServletRequestEvent sre) {
+        // End the span scope (if present)
+        Scope scope = (Scope) sre.getServletRequest().getAttribute(TelemetryContainerFilter.SPAN_SCOPE);
+        if (scope != null) {
+            scope.close();
+            sre.getServletRequest().removeAttribute(TelemetryContainerFilter.SPAN_SCOPE);
+        }
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
@@ -35,6 +35,10 @@ import componenttest.topology.utils.HttpRequest;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.JaxRsEndpoints;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.async.JaxRsServerAsyncTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.methods.JaxRsMethodTestEndpoints;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.methods.JaxRsMethodTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.responses.JaxRsResponseCodeTestEndpoints;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.responses.JaxRsResponseCodeTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.B3MultiPropagationTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.B3PropagationTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.JaegerPropagationTestServlet;
@@ -63,6 +67,8 @@ public class JaxRsIntegration extends FATServletClient {
                     @TestServlet(contextRoot = B3_MULTI_APP_NAME, servlet = B3MultiPropagationTestServlet.class),
                     @TestServlet(contextRoot = JAEGER_APP_NAME, servlet = JaegerPropagationTestServlet.class),
                     @TestServlet(contextRoot = ASYNC_SERVER_APP_NAME, servlet = JaxRsServerAsyncTestServlet.class),
+                    @TestServlet(contextRoot = APP_NAME, servlet = JaxRsMethodTestServlet.class),
+                    @TestServlet(contextRoot = APP_NAME, servlet = JaxRsResponseCodeTestServlet.class),
     })
     @Server(SERVER_NAME)
     public static LibertyServer server;
@@ -75,6 +81,8 @@ public class JaxRsIntegration extends FATServletClient {
                         .addProperty("otel.bsp.schedule.delay", "100");
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackage(JaxRsEndpoints.class.getPackage())
+                        .addPackage(JaxRsMethodTestEndpoints.class.getPackage())
+                        .addPackage(JaxRsResponseCodeTestEndpoints.class.getPackage())
                         .addPackage(InMemorySpanExporter.class.getPackage())
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                         .addAsResource(appConfig, "META-INF/microprofile-config.properties");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLongRunningTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLongRunningTest.java
@@ -54,7 +54,7 @@ public class TelemetryLongRunningTest extends FATServletClient {
                         .addPackage(LongRunningTask.class.getPackage())
                         .addPackage(InMemorySpanExporter.class.getPackage())
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
-                        .addAsResource(new StringAsset("otel.sdk.disabled=false\notel.traces.exporter=in-memory"),
+                        .addAsResource(new StringAsset("otel.sdk.disabled=false\notel.traces.exporter=none"),
                                        "META-INF/microprofile-config.properties");
 
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMultiAppTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMultiAppTest.java
@@ -33,6 +33,7 @@ import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp1.MultiApp1TestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp2.MultiApp2TargetResource;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp2.MultiApp2TestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
@@ -60,6 +61,7 @@ public class TelemetryMultiAppTest extends FATServletClient {
                         .addProperty("otel.traces.exporter", "in-memory");
         JavaArchive exporterJar = ShrinkWrap.create(JavaArchive.class, "exporter.jar")
                         .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                        .addPackage(TestSpans.class.getPackage())
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                         .addAsResource(exporterConfig, "META-INF/microprofile-config.properties");
 
@@ -69,6 +71,7 @@ public class TelemetryMultiAppTest extends FATServletClient {
                         .addProperty("otel.service.name", "multiapp1");
         WebArchive multiapp1 = ShrinkWrap.create(WebArchive.class, APP1_NAME + ".war")
                         .addClass(MultiApp1TestServlet.class)
+                        .addPackage(TestSpans.class.getPackage())
                         .addAsResource(app1Config, "META-INF/microprofile-config.properties");
 
         ShrinkHelper.exportAppToServer(server, multiapp1, SERVER_ONLY);
@@ -78,6 +81,7 @@ public class TelemetryMultiAppTest extends FATServletClient {
         WebArchive multiapp2 = ShrinkWrap.create(WebArchive.class, APP2_NAME + ".war")
                         .addClass(MultiApp2TestServlet.class)
                         .addClass(MultiApp2TargetResource.class)
+                        .addPackage(TestSpans.class.getPackage())
                         .addAsResource(app2Config, "META-INF/microprofile-config.properties");
 
         ShrinkHelper.exportAppToServer(server, multiapp2, SERVER_ONLY);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
@@ -30,6 +30,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.ServiceNameServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
@@ -53,6 +54,7 @@ public class TelemetryServiceNameTest extends FATServletClient {
                         .addAsResource(new StringAsset("otel.sdk.disabled=false\notel.traces.exporter=in-memory\notel.bsp.schedule.delay=100"),
                                        "META-INF/microprofile-config.properties")
                         .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class, ServiceNameServlet.class)
+                        .addPackage(TestSpans.class.getPackage())
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class);
 
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -40,6 +40,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.resource.Test
 import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler.SamplerTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler.TestSampler;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler.TestSamplerProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
@@ -78,6 +79,7 @@ public class TelemetrySpiTest extends FATServletClient {
         WebArchive exporterTestWar = ShrinkWrap.create(WebArchive.class, EXPORTER_APP_NAME + ".war")
                         .addClass(ExporterTestServlet.class)
                         .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                        .addPackage(TestSpans.class.getPackage())
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                         .addAsResource(exporterConfig, "META-INF/microprofile-config.properties");
 
@@ -105,6 +107,7 @@ public class TelemetrySpiTest extends FATServletClient {
                         .addClass(ResourceTestServlet.class)
                         .addClass(TestResourceProvider.class)
                         .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                        .addPackage(TestSpans.class.getPackage())
                         .addAsServiceProvider(ResourceProvider.class, TestResourceProvider.class)
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                         .addAsResource(resourceConfig, "META-INF/microprofile-config.properties");
@@ -120,6 +123,7 @@ public class TelemetrySpiTest extends FATServletClient {
                         .addClass(PropagatorTestServlet.class)
                         .addClasses(TestPropagator.class, TestPropagatorProvider.class)
                         .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                        .addPackage(TestSpans.class.getPackage())
                         .addAsServiceProvider(ConfigurablePropagatorProvider.class, TestPropagatorProvider.class)
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                         .addAsResource(propagatorConfig, "META-INF/microprofile-config.properties");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/TestExceptionMapper.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/TestExceptionMapper.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * Maps an exception to an error response in a similar manner to FATServlet
+ */
+@Provider
+public class TestExceptionMapper implements ExceptionMapper<Throwable> {
+
+    @Context
+    private UriInfo uriInfo;
+
+    /** {@inheritDoc} */
+    @Override
+    public Response toResponse(Throwable t) {
+        StringWriter sw = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            System.out.println("ERROR: " + t);
+            pw.println("ERROR: Caught exception attempting to call " + uriInfo.getRequestUri().toString());
+            t.printStackTrace(pw);
+        }
+        return Response.ok(sw.toString()).build();
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/async/JaxRsServerAsyncTestEndpoint.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/async/JaxRsServerAsyncTestEndpoint.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.async;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import jakarta.annotation.Resource;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+
+/**
+ * This endpoint is used to test MP Telemetry integration with async JAX-RS resource methods.
+ * <p>
+ * It does the following:
+ * <ul>
+ * <li>Creates a span
+ * <li>Reads the baggage entry with key {@link #BAGGAGE_KEY} and if present sets span attribute {@link #BAGGAGE_VALUE_ATTR} to the entry value
+ * <li>Submits a subtask to a managed executor with the context propagated and returns a CompletableFuture representing the result of the subtask
+ * <li>In the subtask it:
+ * <ul><li>Creates a span
+ * <li>Sleeps three seconds (to ensure that there is no chance of the subtask completing before the resource method returns)
+ * <li>Reads the baggage entry with key {@link #BAGGAGE_KEY} and if present sets span attribute {@link #BAGGAGE_VALUE_ATTR} to the entry value
+ * <li>Returns "OK"
+ * </ul></ul>
+ *
+ */
+@ApplicationPath("/")
+@Path("JaxRsServerAsyncTestEndpoint")
+public class JaxRsServerAsyncTestEndpoint extends Application {
+
+    public static final String BAGGAGE_KEY = "test.baggage.key";
+    public static final AttributeKey<String> BAGGAGE_VALUE_ATTR = AttributeKey.stringKey("test.baggage");
+
+    @Resource
+    private ManagedExecutorService managedExecutor;
+
+    @Inject
+    private Tracer tracer;
+
+    @GET
+    public CompletionStage<String> get() {
+        Span span = Span.current();
+
+        // Retrieve the test baggage value (if present) and store in the span
+        String baggageValue = Baggage.current().getEntryValue(BAGGAGE_KEY);
+        if (baggageValue != null) {
+            span.setAttribute(BAGGAGE_VALUE_ATTR, baggageValue);
+        }
+
+        // Call a subtask, propagating the context
+        ExecutorService contextExecutor = Context.taskWrapping(managedExecutor);
+        CompletableFuture<String> result = CompletableFuture.supplyAsync(this::subtask, contextExecutor);
+
+        // Return the async result
+        return result;
+    }
+
+    private String subtask() {
+        Span span = tracer.spanBuilder("subtask").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+            // Sleep a while to ensure that this is running after get() has returned
+            Thread.sleep(3000);
+
+            // Retrieve the test baggage value (if present) and store in the span
+            String baggageValue = Baggage.current().getEntryValue(BAGGAGE_KEY);
+            if (baggageValue != null) {
+                span.setAttribute(BAGGAGE_VALUE_ATTR, baggageValue);
+            }
+
+            return "OK";
+
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } finally {
+            span.end();
+        }
+    }
+
+    public static URI getBaseUri(HttpServletRequest request) {
+        try {
+            URI originalUri = URI.create(request.getRequestURL().toString());
+            URI targetUri = new URI(originalUri.getScheme(), originalUri.getAuthority(), request.getContextPath(), null, null);
+            System.out.println("Using URI: " + targetUri);
+            return targetUri;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/async/JaxRsServerAsyncTestEndpointClient.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/async/JaxRsServerAsyncTestEndpointClient.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.async;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+/**
+ * Client interface for {@link JaxRsServerAsyncTestEndpoint}
+ */
+@Path("JaxRsServerAsyncTestEndpoint")
+public interface JaxRsServerAsyncTestEndpointClient {
+
+    @GET
+    public String get();
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/async/JaxRsServerAsyncTestEndpointClient.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/async/JaxRsServerAsyncTestEndpointClient.java
@@ -19,6 +19,11 @@ import jakarta.ws.rs.Path;
 public interface JaxRsServerAsyncTestEndpointClient {
 
     @GET
-    public String get();
+    @Path("completionstage")
+    public String getCompletionStage();
+
+    @GET
+    @Path("suspend")
+    public String getSuspend();
 
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/async/JaxRsServerAsyncTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/async/JaxRsServerAsyncTestServlet.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.async;
+
+import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.async.JaxRsServerAsyncTestEndpoint.BAGGAGE_VALUE_ATTR;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+
+@SuppressWarnings("serial")
+@WebServlet("/jaxrsServerAsync")
+public class JaxRsServerAsyncTestServlet extends FATServlet {
+
+    private static final String TEST_VALUE = "test.value";
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter spanExporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Test
+    public void testJaxRsServerAsync() {
+        Span span = tracer.spanBuilder("test").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+            // Add the test value to baggage
+            Baggage baggage = Baggage.builder()
+                            .put(JaxRsServerAsyncTestEndpoint.BAGGAGE_KEY, TEST_VALUE)
+                            .build();
+            baggage.makeCurrent();
+
+            // Make the request to the test endpoint
+            JaxRsServerAsyncTestEndpointClient client = RestClientBuilder.newBuilder()
+                            .baseUri(JaxRsServerAsyncTestEndpoint.getBaseUri(request))
+                            .build(JaxRsServerAsyncTestEndpointClient.class);
+            String response = client.get();
+            assertEquals("OK", response);
+        } finally {
+            span.end();
+        }
+
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(4);
+
+        SpanData testSpan = spanData.get(0);
+        SpanData clientSpan = spanData.get(1);
+        SpanData serverSpan = spanData.get(2);
+        SpanData subtaskSpan = spanData.get(3);
+
+        // Assert correct parent-child links
+        // Shows that propagation occurred
+        assertEquals("client parent span id", testSpan.getSpanId(), clientSpan.getParentSpanId());
+        assertEquals("server parent span id", clientSpan.getSpanId(), serverSpan.getParentSpanId());
+        assertEquals("subtask parent span id", serverSpan.getSpanId(), subtaskSpan.getParentSpanId());
+
+        // Assert baggage propagated on server span
+        assertEquals(TEST_VALUE, serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        // Assert baggage propagated on subtask span
+        assertEquals(TEST_VALUE, subtaskSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));
+
+        // Assert that the server span finished after the subtask span
+        // Even though the resource method returned quickly, the span should not end until the response is actually returned
+        assertThat(serverSpan.getEndEpochNanos(), greaterThan(subtaskSpan.getEndEpochNanos()));
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/methods/JaxRsMethodTestEndpoints.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/methods/JaxRsMethodTestEndpoints.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.methods;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
+import jakarta.ws.rs.OPTIONS;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+
+@Path("methodTestEndpoints")
+public class JaxRsMethodTestEndpoints {
+
+    @GET
+    public String get() {
+        new Exception("Test stack").printStackTrace();
+        return "get";
+    }
+
+    @HEAD
+    public void head() {
+    }
+
+    @POST
+    public String post(String string) {
+        return "post";
+    }
+
+    @PUT
+    public String put(String string) {
+        return "put";
+    }
+
+    @DELETE
+    public String delete() {
+        return "delete";
+    }
+
+    @PATCH
+    public String patch(String string) {
+        return "patch";
+    }
+
+    @OPTIONS
+    public Response options() {
+        return Response.ok("options")
+                        .header(HttpHeaders.ALLOW, "GET")
+                        .header(HttpHeaders.ALLOW, "HEAD")
+                        .header(HttpHeaders.ALLOW, "POST")
+                        .header(HttpHeaders.ALLOW, "PUT")
+                        .header(HttpHeaders.ALLOW, "DELETE")
+                        .header(HttpHeaders.ALLOW, "PATCH")
+                        .header(HttpHeaders.ALLOW, "OPTIONS")
+                        .build();
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/methods/JaxRsMethodTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/methods/JaxRsMethodTestServlet.java
@@ -1,0 +1,270 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.methods;
+
+import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.isSpan;
+import static jakarta.ws.rs.client.Entity.text;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Test tracing requests of each JAX-RS method type
+ */
+@SuppressWarnings("serial")
+@WebServlet("/JaxRsMethodTest")
+public class JaxRsMethodTestServlet extends FATServlet {
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private TestSpans utils;
+
+    @Test
+    public void testGet() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .build("GET").invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("get"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+    }
+
+    @Test
+    public void testPost() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .buildPost(text("test"))
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("post"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "POST")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "POST")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+    }
+
+    @Test
+    public void testPut() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .buildPut(text("test"))
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("put"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "PUT")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "PUT")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+    }
+
+    @Test
+    public void testHead() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .build("HEAD")
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(204));
+            assertThat(response.hasEntity(), is(false));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "HEAD")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 204L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "HEAD")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 204L));
+
+    }
+
+    @Test
+    public void testDelete() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .build("DELETE")
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("delete"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "DELETE")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "DELETE")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+    }
+
+    @Test
+    public void testPatch() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .build("PATCH", text("test"))
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("patch"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "PATCH")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "PATCH")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+    }
+
+    @Test
+    public void testOptions() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .build("OPTIONS")
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("options"));
+            assertThat(response.getStringHeaders().get(HttpHeaders.ALLOW), containsInAnyOrder("GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "OPTIONS")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "OPTIONS")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+    }
+
+    private URI getUri() {
+        try {
+            String path = request.getContextPath() + "/methodTestEndpoints";
+            URI originalUri = new URI(request.getRequestURL().toString());
+            URI result = new URI(originalUri.getScheme(), originalUri.getAuthority(), path, null, null);
+            return result;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/responses/JaxRsResponseCodeTestEndpoints.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/responses/JaxRsResponseCodeTestEndpoints.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.responses;
+
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+/**
+ *
+ */
+@Path("responseCodeEndpoints")
+public class JaxRsResponseCodeTestEndpoints {
+
+    @Path("200")
+    @GET
+    public Response get200() {
+        return Response.ok("get200").build();
+    }
+
+    @Path("202")
+    @GET
+    public Response get202() {
+        return Response.accepted("get202").build();
+    }
+
+    @Path("400")
+    @GET
+    public Response get400() {
+        return Response.status(BAD_REQUEST)
+                        .entity("get400")
+                        .build();
+    }
+
+    @Path("404")
+    @GET
+    public Response get404() {
+        return Response.status(Status.NOT_FOUND)
+                        .entity("get404")
+                        .build();
+    }
+
+    @Path("500")
+    @GET
+    public Response get500() {
+        return Response.status(Status.INTERNAL_SERVER_ERROR)
+                        .entity("get500")
+                        .build();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/responses/JaxRsResponseCodeTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/responses/JaxRsResponseCodeTestServlet.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.responses;
+
+import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.isSpan;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+
+/**
+ *
+ */
+@SuppressWarnings("serial")
+@WebServlet("/JaxRsResponseCodeTestServlet")
+public class JaxRsResponseCodeTestServlet extends FATServlet {
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private TestSpans spans;
+
+    @Test
+    public void test200() {
+        doTestForStatusCode(200);
+    }
+
+    @Test
+    public void test202() {
+        doTestForStatusCode(202);
+    }
+
+    @Test
+    public void test400() {
+        doTestForStatusCode(400);
+    }
+
+    @Test
+    public void test404() {
+        doTestForStatusCode(404);
+    }
+
+    @Test
+    public void test500() {
+        doTestForStatusCode(500);
+    }
+
+    private void doTestForStatusCode(int statusCode) {
+        URI testUri = getTargetUri(statusCode);
+        Span span = spans.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .build("GET").invoke();
+            assertThat(response.getStatus(), equalTo(statusCode));
+            assertThat(response.readEntity(String.class), equalTo("get" + statusCode));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, (long) statusCode)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, (long) statusCode));
+
+    }
+
+    private URI getTargetUri(int statusCode) {
+        try {
+            String path = request.getContextPath() + "/responseCodeEndpoints/" + statusCode;
+            URI originalUri = new URI(request.getRequestURL().toString());
+            URI result = new URI(originalUri.getScheme(), originalUri.getAuthority(), path, null, null);
+            return result;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3MultiPropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3MultiPropagationTestServlet.java
@@ -13,7 +13,6 @@ import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropa
 import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_METADATA_ATTR;
 import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_VALUE_ATTR;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
@@ -26,12 +25,12 @@ import org.junit.Test;
 import componenttest.app.FATServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint;
+import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -53,28 +52,25 @@ public class B3MultiPropagationTestServlet extends FATServlet {
     @Inject
     private HttpServletRequest request;
 
+    @Inject
+    private TestSpans testSpans;
+
     @Test
     public void testB3Propagation() throws URISyntaxException {
-        Span span = tracer.spanBuilder("test").startSpan();
-        try (Scope scope = span.makeCurrent()) {
+        Span span = testSpans.withTestSpan(() -> {
             Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
             baggage.makeCurrent();
             PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
             client.get();
-        } finally {
-            span.end();
-        }
+        });
 
-        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3);
-
-        SpanData testSpan = spanData.get(0);
-        SpanData clientSpan = spanData.get(1);
-        SpanData serverSpan = spanData.get(2);
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);
 
         // Assert correct parent-child links
         // Shows that propagation occurred
-        assertEquals("client parent span id", testSpan.getSpanId(), clientSpan.getParentSpanId());
-        assertEquals("server parent span id", clientSpan.getSpanId(), serverSpan.getParentSpanId());
+        TestSpans.assertLinearParentage(spanData);
+
+        SpanData serverSpan = spanData.get(2);
 
         // B3 does not support baggage, so baggage should not be propagated
         assertNull("baggage value propagated", serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3PropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3PropagationTestServlet.java
@@ -13,7 +13,6 @@ import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropa
 import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_METADATA_ATTR;
 import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_VALUE_ATTR;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
@@ -26,12 +25,12 @@ import org.junit.Test;
 import componenttest.app.FATServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint;
+import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -53,28 +52,25 @@ public class B3PropagationTestServlet extends FATServlet {
     @Inject
     private HttpServletRequest request;
 
+    @Inject
+    private TestSpans testSpans;
+
     @Test
     public void testB3Propagation() throws URISyntaxException {
-        Span span = tracer.spanBuilder("test").startSpan();
-        try (Scope scope = span.makeCurrent()) {
+        Span span = testSpans.withTestSpan(() -> {
             Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
             baggage.makeCurrent();
             PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
             client.get();
-        } finally {
-            span.end();
-        }
+        });
 
-        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3);
-
-        SpanData testSpan = spanData.get(0);
-        SpanData clientSpan = spanData.get(1);
-        SpanData serverSpan = spanData.get(2);
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);
 
         // Assert correct parent-child links
         // Shows that propagation occurred
-        assertEquals("client parent span id", testSpan.getSpanId(), clientSpan.getParentSpanId());
-        assertEquals("server parent span id", clientSpan.getSpanId(), serverSpan.getParentSpanId());
+        TestSpans.assertLinearParentage(spanData);
+
+        SpanData serverSpan = spanData.get(2);
 
         // B3 does not support baggage, so baggage should not be propagated
         assertNull("baggage value propagated", serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/JaegerPropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/JaegerPropagationTestServlet.java
@@ -25,12 +25,12 @@ import org.junit.Test;
 import componenttest.app.FATServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint;
+import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -52,28 +52,25 @@ public class JaegerPropagationTestServlet extends FATServlet {
     @Inject
     private HttpServletRequest request;
 
+    @Inject
+    private TestSpans testSpans;
+
     @Test
     public void testJaegerPropagation() throws URISyntaxException {
-        Span span = tracer.spanBuilder("test").startSpan();
-        try (Scope scope = span.makeCurrent()) {
+        Span span = testSpans.withTestSpan(() -> {
             Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
             baggage.makeCurrent();
             PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
             client.get();
-        } finally {
-            span.end();
-        }
+        });
 
-        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3);
-
-        SpanData testSpan = spanData.get(0);
-        SpanData clientSpan = spanData.get(1);
-        SpanData serverSpan = spanData.get(2);
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);
 
         // Assert correct parent-child links
         // Shows that propagation occurred
-        assertEquals("client parent span id", testSpan.getSpanId(), clientSpan.getParentSpanId());
-        assertEquals("server parent span id", clientSpan.getSpanId(), serverSpan.getParentSpanId());
+        TestSpans.assertLinearParentage(spanData);
+
+        SpanData serverSpan = spanData.get(2);
 
         // Assert baggage is propagated
         assertEquals("baggage value propagated", BAGGAGE_VALUE, serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTraceBaggagePropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTraceBaggagePropagationTestServlet.java
@@ -25,12 +25,12 @@ import org.junit.Test;
 import componenttest.app.FATServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.common.PropagationHeaderEndpoint;
+import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -52,28 +52,25 @@ public class W3CTraceBaggagePropagationTestServlet extends FATServlet {
     @Inject
     private HttpServletRequest request;
 
+    @Inject
+    private TestSpans testSpans;
+
     @Test
     public void testW3cTraceBaggagePropagation() throws URISyntaxException {
-        Span span = tracer.spanBuilder("test").startSpan();
-        try (Scope scope = span.makeCurrent()) {
+        Span span = testSpans.withTestSpan(() -> {
             Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
             baggage.makeCurrent();
             PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
             client.get();
-        } finally {
-            span.end();
-        }
+        });
 
-        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3);
-
-        SpanData testSpan = spanData.get(0);
-        SpanData clientSpan = spanData.get(1);
-        SpanData serverSpan = spanData.get(2);
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);
 
         // Assert correct parent-child links
         // Shows that propagation occurred
-        assertEquals("client parent span id", testSpan.getSpanId(), clientSpan.getParentSpanId());
-        assertEquals("server parent span id", clientSpan.getSpanId(), serverSpan.getParentSpanId());
+        TestSpans.assertLinearParentage(spanData);
+
+        SpanData serverSpan = spanData.get(2);
 
         // Assert baggage is propagated
         assertEquals("baggage value propagated", BAGGAGE_VALUE, serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/multiapp2/MultiApp2TestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/multiapp2/MultiApp2TestServlet.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp2;
 
-import static org.hamcrest.Matchers.equalTo;
+import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.hasResourceAttribute;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
@@ -21,7 +21,6 @@ import componenttest.app.FATServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import jakarta.inject.Inject;
@@ -42,14 +41,8 @@ public class MultiApp2TestServlet extends FATServlet {
         Span span = tracer.spanBuilder("test").startSpan();
         span.end();
 
-        SpanData spanData = exporter.getFinishedSpanItems(1).get(0);
-        Resource resource = spanData.getResource();
-        assertThat(resource.getAttribute(ResourceAttributes.SERVICE_NAME), equalTo("multiapp2"));
-    }
-
-    @Override
-    protected void before() throws Exception {
-        exporter.reset();
+        SpanData spanData = exporter.getFinishedSpanItems(1, span).get(0);
+        assertThat(spanData, hasResourceAttribute(ResourceAttributes.SERVICE_NAME, "multiapp2"));
     }
 
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/customizer/CustomizerTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/customizer/CustomizerTestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -46,7 +46,7 @@ public class CustomizerTestServlet extends FATServlet {
         Span span = tracer.spanBuilder("span").startSpan();
         span.end();
 
-        SpanData spanData = exporter.getFinishedSpanItems(1).get(0);
+        SpanData spanData = exporter.getFinishedSpanItems(1, span).get(0);
 
         // Attributes added by TestCustomizer should have been merged into the default resource
         Resource resource = spanData.getResource();

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/exporter/ExporterTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/exporter/ExporterTestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.exporter;
 
+import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.hasAttribute;
+import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.hasName;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
 
 import org.junit.Test;
 
@@ -46,9 +46,9 @@ public class ExporterTestServlet extends FATServlet {
         Span span = tracer.spanBuilder("test span").setAttribute(FOO_KEY, "bar").startSpan();
         span.end();
 
-        SpanData spanData = exporter.getFinishedSpanItems(1).get(0);
-        assertThat(spanData.getName(), equalTo("test span"));
-        assertThat(spanData.getAttributes().asMap(), hasEntry(FOO_KEY, "bar"));
+        SpanData spanData = exporter.getFinishedSpanItems(1, span).get(0);
+        assertThat(spanData, hasName("test span"));
+        assertThat(spanData, hasAttribute(FOO_KEY, "bar"));
     }
 
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/resource/ResourceTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/resource/ResourceTestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package io.openliberty.microprofile.telemetry.internal_fat.apps.spi.resource;
 
-import static org.hamcrest.Matchers.equalTo;
+import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.hasResourceAttribute;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
@@ -21,7 +21,6 @@ import componenttest.app.FATServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -47,11 +46,10 @@ public class ResourceTestServlet extends FATServlet {
         Span span = tracer.spanBuilder("span").startSpan();
         span.end();
 
-        SpanData spanData = exporter.getFinishedSpanItems(1).get(0);
+        SpanData spanData = exporter.getFinishedSpanItems(1, span).get(0);
 
         // Attributes added by TestResourceProvider should have been merged into the default resource
-        Resource resource = spanData.getResource();
-        assertThat(resource.getAttribute(TestResourceProvider.TEST_KEY1), equalTo(TEST_VALUE1));
-        assertThat(resource.getAttribute(TestResourceProvider.TEST_KEY2), equalTo(TEST_VALUE2));
+        assertThat(spanData, hasResourceAttribute(TestResourceProvider.TEST_KEY1, TEST_VALUE1));
+        assertThat(spanData, hasResourceAttribute(TestResourceProvider.TEST_KEY2, TEST_VALUE2));
     }
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/ServiceNameServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/ServiceNameServlet.java
@@ -10,7 +10,7 @@
 
 package io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry;
 
-import static org.hamcrest.Matchers.equalTo;
+import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.hasResourceAttribute;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
@@ -21,7 +21,6 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -53,11 +52,10 @@ public class ServiceNameServlet extends FATServlet {
         Span span = tracer.spanBuilder("span").startSpan();
         span.end();
 
-        SpanData spanData = exporter.getFinishedSpanItems(1).get(0);
+        SpanData spanData = exporter.getFinishedSpanItems(1, span).get(0);
         System.out.println(spanData.toString());
         // Attributes added by TestResourceProvider should have been merged into the default resource
-        Resource resource = spanData.getResource();
-        assertThat(resource.getAttribute(SERVICE_NAME_KEY), equalTo(APP_NAME));
+        assertThat(spanData, hasResourceAttribute(SERVICE_NAME_KEY, APP_NAME));
     }
 
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/AbstractSpanMatcher.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/AbstractSpanMatcher.java
@@ -1,0 +1,384 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+
+/**
+ * Matcher for some object which represents span data
+ * <p>
+ * This holds the common code for matching a span returned from Jaeger, Zipkin or the InMemorySpanExporter
+ *
+ * @param <SPAN> the span datatype
+ * @param <SELF> the matcher type
+ */
+public abstract class AbstractSpanMatcher<SPAN, SELF extends AbstractSpanMatcher<SPAN, SELF>> extends TypeSafeDiagnosingMatcher<SPAN> {
+
+    private final List<AttributeData<?>> expectedAttributes = new ArrayList<>();
+    private final List<String> expectedEvents = new ArrayList<>();
+    private final List<Class<?>> expectedExceptions = new ArrayList<>();
+    private SpanKind expectedKind = null;
+    private StatusCode expectedStatusCode = null;
+    private String expectedTraceId = null;
+    private String expectedParentSpanId = null;
+    private Boolean expectHasParent = null;
+    private String expectedName = null;
+    private String expectedServiceName = null;
+    private final List<AttributeData<?>> expectedResourceAttributes = new ArrayList<>();
+
+    /**
+     * Explicit constructor.
+     * <p>
+     * It's necessary to manually pass in the span class to avoid hamcrest doing reflection and triggering an AccessControlException
+     *
+     * @param spanClass the span class
+     */
+    protected AbstractSpanMatcher(Class<SPAN> spanClass) {
+        super(spanClass);
+    }
+
+    protected static class AttributeData<T> {
+        public final AttributeKey<T> key;
+        public final T value;
+
+        /**
+         * @param key
+         * @param value
+         */
+        public AttributeData(AttributeKey<T> key, T value) {
+            super();
+            this.key = key;
+            this.value = value;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String toString() {
+            return key + " = " + value;
+        }
+    }
+
+    /*
+     * Describes what we're looking for
+     */
+    @Override
+    public void describeTo(Description desc) {
+        desc.appendText("Span");
+
+        if (expectedName != null) {
+            desc.appendText("\n  with name: ");
+            desc.appendText(expectedName);
+        }
+
+        if (expectedTraceId != null) {
+            desc.appendText("\n  with traceId: ");
+            desc.appendText(expectedTraceId.toString());
+        }
+
+        if (expectedParentSpanId != null) {
+            desc.appendText("\n  with parent: ");
+            desc.appendText(expectedParentSpanId.toString());
+        }
+
+        if (expectHasParent != null) {
+            if (expectHasParent) {
+                desc.appendText("\n with a parent");
+            } else {
+                desc.appendText("\n with no parent");
+            }
+        }
+
+        if (expectedKind != null) {
+            desc.appendText("\n  with kind: ");
+            desc.appendValue(expectedKind);
+        }
+
+        if (expectedStatusCode != null) {
+            desc.appendText("\n  with status code: ");
+            desc.appendValue(expectedStatusCode);
+        }
+
+        if (!expectedAttributes.isEmpty()) {
+            desc.appendText("\n  with attributes: ");
+            desc.appendValue(expectedAttributes);
+        }
+
+        if (!expectedEvents.isEmpty()) {
+            desc.appendText("\n  with event logs: ");
+            desc.appendValue(expectedEvents);
+        }
+
+        if (!expectedExceptions.isEmpty()) {
+            desc.appendText("\n  with exception logs: ");
+            desc.appendValue(expectedExceptions);
+        }
+
+        if (expectedServiceName != null) {
+            desc.appendText("\n  with service name: ");
+            desc.appendText(expectedServiceName);
+        }
+
+        if (!expectedResourceAttributes.isEmpty()) {
+            desc.appendText("\n  with resource attributes: ");
+            desc.appendValue(expectedResourceAttributes);
+        }
+    }
+
+    /*
+     * Returns whether the span matches and adds a description of why it didn't match
+     */
+    @Override
+    protected boolean matchesSafely(SPAN span, Description desc) {
+        // For now, we just use the toString of the span as the description of why it didn't match
+        // We could list out or highlight the elements that didn't match, but usually it's obvious
+        // enough from the toString().
+        desc.appendValue(span);
+
+        if (expectedTraceId != null && !expectedTraceId.equals(getTraceId(span))) {
+            return false;
+        }
+
+        if (expectedName != null && !expectedName.equals(getName(span))) {
+            return false;
+        }
+
+        String parentSpanId = getParentSpanId(span);
+
+        if (expectedParentSpanId != null) {
+            if (!expectedParentSpanId.equals(parentSpanId)) {
+                return false;
+            }
+        }
+
+        if (expectHasParent != null) {
+            boolean hasParent = parentSpanId != null;
+            if (hasParent != expectHasParent) {
+                return false;
+            }
+        }
+
+        if (expectedKind != null) {
+            if (expectedKind != getKind(span)) {
+                return false;
+            }
+        }
+
+        if (expectedStatusCode != null) {
+            if (expectedStatusCode != getStatusCode(span)) {
+                return false;
+            }
+        }
+
+        for (AttributeData<?> attribute : expectedAttributes) {
+            if (!hasAttribute(span, attribute)) {
+                return false;
+            }
+        }
+
+        for (String eventName : expectedEvents) {
+            if (!hasEvent(span, eventName)) {
+                return false;
+            }
+        }
+
+        for (Class<?> exceptionClass : expectedExceptions) {
+            if (!hasException(span, exceptionClass)) {
+                return false;
+            }
+        }
+
+        if (expectedServiceName != null) {
+            if (!expectedServiceName.equals(getServiceName(span))) {
+                return false;
+            }
+        }
+
+        if (!expectedResourceAttributes.isEmpty()) {
+            for (AttributeData<?> attribute : expectedResourceAttributes) {
+                if (!hasResourceAttribute(span, attribute)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    // Abstract methods, to be implemented for each specific span data structure
+    // -------------------------------------------------------------------------
+
+    /**
+     * Gets the traceId of the span
+     *
+     * @param span the span
+     * @return the traceId
+     */
+    abstract protected String getTraceId(SPAN span);
+
+    /**
+     * Gets the name of the span
+     *
+     * @param span the span
+     * @return the span name
+     */
+    abstract protected String getName(SPAN span);
+
+    /**
+     * Gets the span ID of the parent span
+     *
+     * @param span the span
+     * @return the ID of the span's parent, or {@code null} if it has no parent
+     */
+    abstract protected String getParentSpanId(SPAN span);
+
+    /**
+     * Gets the span kind (CLIENT/SERVER/INTERNAL etc.)
+     *
+     * @param span the span
+     * @return the span kind
+     */
+    abstract protected SpanKind getKind(SPAN span);
+
+    /**
+     * Gets the status code (OK, ERROR, UNSET)
+     *
+     * @param span the span
+     * @return the status code
+     */
+    abstract protected StatusCode getStatusCode(SPAN span);
+
+    /**
+     * Returns whether the span has the given attribute with the expected value
+     *
+     * @param <T>   the attribute type
+     * @param span  the span
+     * @param key   the attribute key
+     * @param value the expected value
+     * @return {@code} true if {@code span} has the given attribute and it has the expected value, otherwise {@code false}
+     */
+    abstract protected <T> boolean hasAttribute(SPAN span, AttributeData<T> attributeData);
+
+    /**
+     * Returns whether the span has an event with the given name
+     *
+     * @param span  the span
+     * @param event the event name
+     * @return {@code true} if {@code span} has an event named {@code event}, otherwise {@code false}
+     */
+    abstract protected boolean hasEvent(SPAN span, String event);
+
+    /**
+     * Returns whehter the span has an exception event with the given name
+     *
+     * @param span           the span
+     * @param exceptionClass the expected exception class
+     * @return {@code true} if {@code span} has an event for an exception thrown of type {@code exceptionClass}, otherwise {@code false}
+     */
+    abstract protected boolean hasException(SPAN span, Class<?> exceptionClass);
+
+    /**
+     * Gets the {@link ResourceAttributes#SERVICE_NAME} from the span
+     *
+     * @param span the span
+     * @return the service name
+     */
+    abstract protected String getServiceName(SPAN span);
+
+    /**
+     * Returns whether the span has the given resource attribute with the expected value
+     *
+     * @param <T>   the resource attribute type
+     * @param span  the span
+     * @param key   the resource attribute key
+     * @param value the expected value
+     * @return {@code} true if {@code span} has the given resource attribute and it has the expected value, otherwise {@code false}
+     */
+    abstract protected <T> boolean hasResourceAttribute(SPAN span, AttributeData<T> attributeData);
+
+    /**
+     * Returns {@code this}. Needed for generics.
+     *
+     * @return {@code this}
+     */
+    abstract protected SELF self();
+
+    // Common configuration methods
+    // ----------------------------
+
+    public SELF withEventLog(String name) {
+        expectedEvents.add(name);
+        return self();
+    }
+
+    public SELF withExceptionLog(Class<?> exceptionClass) {
+        expectedExceptions.add(exceptionClass);
+        return self();
+    }
+
+    public SELF withTraceId(String traceId) {
+        expectedTraceId = traceId;
+        return self();
+    }
+
+    public SELF withName(String name) {
+        expectedName = name;
+        return self();
+    }
+
+    public SELF withNoParent() {
+        expectHasParent = false;
+        return self();
+    }
+
+    public SELF withParent() {
+        expectHasParent = true;
+        return self();
+    }
+
+    public SELF withParentSpanId(String spanId) {
+        expectedParentSpanId = spanId;
+        return self();
+    }
+
+    public SELF withKind(SpanKind kind) {
+        expectedKind = kind;
+        return self();
+    }
+
+    public <T> SELF withAttribute(AttributeKey<T> key, T value) {
+        expectedAttributes.add(new AttributeData<T>(key, value));
+        return self();
+    }
+
+    public SELF withStatus(StatusCode status) {
+        expectedStatusCode = status;
+        return self();
+    }
+
+    public SELF withServiceName(String serviceName) {
+        expectedServiceName = serviceName;
+        return self();
+    }
+
+    public <T> SELF withResourceAttribute(AttributeKey<T> key, T value) {
+        expectedResourceAttributes.add(new AttributeData<T>(key, value));
+        return self();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/SpanDataMatcher.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/SpanDataMatcher.java
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.common;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
+/**
+ * A hamcrest matcher for matching {@link SpanData} instances
+ * <p>
+ * Example usage:
+ *
+ * <pre>
+ * assertThat(span, isSpan().withName("foo").withKind(SERVER));
+ *
+ * assertThat(span, hasName("foo"));
+ * </pre>
+ */
+public class SpanDataMatcher extends AbstractSpanMatcher<SpanData, SpanDataMatcher> {
+
+    protected SpanDataMatcher() {
+        super(SpanData.class);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected String getTraceId(SpanData span) {
+        return span.getTraceId();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected String getName(SpanData span) {
+        return span.getName();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected String getParentSpanId(SpanData span) {
+        String spanId = span.getParentSpanId();
+        if (SpanId.isValid(spanId)) {
+            return spanId;
+        } else {
+            return null;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected SpanKind getKind(SpanData span) {
+        return span.getKind();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected StatusCode getStatusCode(SpanData span) {
+        return span.getStatus().getStatusCode();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected <T> boolean hasAttribute(SpanData span, AttributeData<T> attributeData) {
+        return attributeData.value.equals(span.getAttributes().get(attributeData.key));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected boolean hasEvent(SpanData span, String event) {
+        for (EventData eventData : span.getEvents()) {
+            if (event.equals(eventData.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected boolean hasException(SpanData span, Class<?> exceptionClass) {
+        String expectedClassName = exceptionClass.getCanonicalName();
+
+        for (EventData eventData : span.getEvents()) {
+            if (SemanticAttributes.EXCEPTION_EVENT_NAME.equals(eventData.getName())) {
+                String exceptionClassName = eventData.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE);
+                if (expectedClassName.equals(exceptionClassName)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected String getServiceName(SpanData span) {
+        return span.getResource().getAttribute(ResourceAttributes.SERVICE_NAME);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected <T> boolean hasResourceAttribute(SpanData span, AttributeData<T> attributeData) {
+        return attributeData.value.equals(span.getResource().getAttribute(attributeData.key));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected SpanDataMatcher self() {
+        return this;
+    }
+
+    // Static construction methods
+    // ---------------------------
+
+    public static SpanDataMatcher isSpan() {
+        return new SpanDataMatcher();
+    }
+
+    public static SpanDataMatcher hasEventLog(String name) {
+        return isSpan().withEventLog(name);
+    }
+
+    public static SpanDataMatcher hasExceptionLog(Class<?> exceptionClass) {
+        return isSpan().withExceptionLog(exceptionClass);
+    }
+
+    public static SpanDataMatcher hasTraceId(String traceId) {
+        return isSpan().withTraceId(traceId);
+    }
+
+    public static SpanDataMatcher hasName(String name) {
+        return isSpan().withName(name);
+    }
+
+    public static SpanDataMatcher hasNoParent() {
+        return isSpan().withNoParent();
+    }
+
+    public static SpanDataMatcher hasParent() {
+        return isSpan().withParent();
+    }
+
+    public static SpanDataMatcher hasParentSpanId(String spanId) {
+        return isSpan().withParentSpanId(spanId);
+    }
+
+    public static SpanDataMatcher hasKind(SpanKind kind) {
+        return isSpan().withKind(kind);
+    }
+
+    public static <T> SpanDataMatcher hasAttribute(AttributeKey<T> key, T value) {
+        return isSpan().withAttribute(key, value);
+    }
+
+    public static SpanDataMatcher hasStatus(StatusCode status) {
+        return isSpan().withStatus(status);
+    }
+
+    public static SpanDataMatcher hasServiceName(String serviceName) {
+        return isSpan().withServiceName(serviceName);
+    }
+
+    public static <T> SpanDataMatcher hasResourceAttribute(AttributeKey<T> key, T value) {
+        return isSpan().withResourceAttribute(key, value);
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/TestSpans.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/TestSpans.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.common;
+
+import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.hasNoParent;
+import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.hasParentSpanId;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Utility methods for working with spans in tests
+ */
+@ApplicationScoped
+public class TestSpans {
+
+    private static final Logger LOGGER = Logger.getLogger(TestSpans.class.getName());
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private Tracer tracer;
+
+    /**
+     * Asserts that the first span in the list has no parent and that every other span is a child of the span preceding it in the list.
+     *
+     * @param spans the list of spans
+     */
+    public static void assertLinearParentage(List<SpanData> spans) {
+        if (spans.isEmpty()) {
+            return;
+        }
+
+        SpanData first = spans.get(0);
+        assertThat("Span 1", first, hasNoParent());
+
+        SpanData prev = first;
+        for (int i = 1; i < spans.size(); i++) {
+            SpanData current = spans.get(i);
+            assertThat("Span " + i, current, hasParentSpanId(prev.getSpanId()));
+            prev = current;
+        }
+    }
+
+    /**
+     * Creates a test span, makes it current, runs an action and ends the span
+     * <p>
+     * If {@code runnable} throws an exception or error, we assume that a test failure has occurred and instruct {@link InMemorySpanExporter} to ignore stray spans with the same
+     * traceId as the test span.
+     * <p>
+     * This method is intended to remove common boilerplate code in tests which use FATServlet
+     *
+     * @param runnable the action to run
+     * @return the test span
+     * @throws Exception if {@code runnable} throws an exception
+     */
+    public Span withTestSpan(ThrowingRunnable runnable) {
+        String spanName = "testSpan-" + request.getRequestURI();
+        Span span = tracer.spanBuilder(spanName).startSpan();
+
+        LOGGER.info("Created test span. SpanId: " + span.getSpanContext().getSpanId() + " TraceId: " + span.getSpanContext().getTraceId() + " Name: " + spanName);
+
+        try {
+            Context contextBefore = Context.current();
+            try (Scope scope = span.makeCurrent()) {
+                runnable.run();
+            } finally {
+                span.end();
+            }
+            assertEquals("Context Leak: initial context was not restored after test span", contextBefore, Context.current());
+        } catch (RuntimeException e) {
+            exporter.addFailedTestTraceId(span.getSpanContext().getTraceId());
+            throw e;
+        } catch (Exception e) {
+            // Wrap non-runtime exceptions
+            exporter.addFailedTestTraceId(span.getSpanContext().getTraceId());
+            throw new RuntimeException(e);
+        } catch (Throwable e) {
+            exporter.addFailedTestTraceId(span.getSpanContext().getTraceId());
+            throw e;
+        }
+
+        return span;
+    }
+
+    @FunctionalInterface
+    public static interface ThrowingRunnable {
+        public void run() throws Exception;
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/spanexporter/InMemorySpanExporter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/spanexporter/InMemorySpanExporter.java
@@ -22,17 +22,26 @@
 package io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter;
 
 import static java.util.Comparator.comparingLong;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.fail;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BooleanSupplier;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
 
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -45,19 +54,146 @@ public class InMemorySpanExporter implements SpanExporter {
     private boolean isStopped = false;
     // Static to allow multi-app testing
     private static final List<SpanData> finishedSpanItems = new CopyOnWriteArrayList<>();
+    private static final Set<String> failedTestTraceIds = Collections.synchronizedSet(new HashSet<>());
+
+    /**
+     * Retrieve a list of finished span items with the same traceId as {@code span}
+     * <p>
+     * Asserts that the expected number of spans are received within the timeout
+     *
+     * @param spanCount the number of traces to wait for before returning
+     * @param span      the span with the traceId to look for
+     * @return the list of spans
+     */
+    public List<SpanData> getFinishedSpanItems(int spanCount, Span span) {
+        return getFinishedSpanItems(spanCount, span.getSpanContext().getTraceId());
+    }
+
+    /**
+     * Retrieve a list of finished span items for a given traceId
+     * <p>
+     * Asserts that the expected number of spans are received within the timeout
+     *
+     * @param spanCount the number of traces to wait for before returning
+     * @param traceId   the traceId to look for
+     * @return the list of spans
+     */
+    public List<SpanData> getFinishedSpanItems(int spanCount, String traceId) {
+        // Wait for the right number of spans to arrive
+        waitFor(Duration.ofSeconds(12), () -> getSpansForTraceId(traceId).size() >= spanCount);
+
+        // Actually get the spans and check there are the right number
+        List<SpanData> spans = getSpansForTraceId(traceId);
+        LOGGER.info("Retrieved traces for " + traceId + ", expected: " + spanCount + " found: " + spans.size());
+
+        // If we do not have the right number, report the traceId as belonging to a failed test and
+        // create a good failure message
+        if (spans.size() != spanCount) {
+            addFailedTestTraceId(traceId);
+            String foundSpans = spans.stream().map(Object::toString).collect(Collectors.joining("\n"));
+            fail("Expected " + spanCount + " traces but found " + spans.size() + "\n" + foundSpans);
+        }
+
+        // Remove the found spans from the list of finished spans so that we can log any unclaimed spans at shutdown
+        finishedSpanItems.removeAll(spans);
+
+        // Sort and return the spans
+        return sortByParentage(spans);
+    }
+
+    private List<SpanData> getSpansForTraceId(String traceId) {
+        return finishedSpanItems.stream()
+                        .filter(s -> s.getTraceId().equals(traceId))
+                        .collect(toList());
+    }
+
+    /**
+     * Wait up to {@code timeout} for {@code condition} to return {@code true}
+     * <p>
+     * This method will not throw an exception if {@code condition} never returns {@code true}. Callers should assert the condition after this method returns and create an
+     * appropriate error message.
+     *
+     * @param timeout   the timeout to wait
+     * @param condition the condition to check
+     */
+    private static void waitFor(Duration timeout, BooleanSupplier condition) {
+        long timeoutNanos = timeout.toNanos();
+        long startNanos = System.nanoTime();
+        while ((System.nanoTime() - startNanos) < timeoutNanos) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * Create a new list which contains the contents of {@code spans} sorted so that all spans appear before their children in the list
+     *
+     * @param spans a list of spans
+     * @return a new list of spans sorted by parentage
+     */
+    private List<SpanData> sortByParentage(List<SpanData> spans) {
+        Set<String> allSpanIds = spans.stream().map(SpanData::getSpanId).collect(toSet());
+
+        ArrayList<SpanData> result = new ArrayList<>();
+
+        // Start with all root spans and spans whose parents are not present in the list
+        // For each, add it to the list then recursively add its children
+        spans.stream().filter(s -> !s.getParentSpanContext().isValid() || !allSpanIds.contains(s.getParentSpanId()))
+                        .sorted((a, b) -> Long.compare(a.getStartEpochNanos(), b.getStartEpochNanos()))
+                        .forEach(s -> {
+                            result.add(s);
+                            addChildren(s, spans, result);
+                        });
+
+        return result;
+    }
+
+    private void addChildren(SpanData parent, List<SpanData> source, List<SpanData> destination) {
+        source.stream().filter(s -> parent.getSpanId().equals(s.getParentSpanId()))
+                        .sorted((a, b) -> Long.compare(a.getStartEpochNanos(), b.getStartEpochNanos()))
+                        .forEach(s -> {
+                            destination.add(s);
+                            addChildren(s, source, destination);
+                        });
+    }
+
+    /**
+     * Register that a traceId belongs to a test which has failed
+     * <p>
+     * If a test fails, we can expect that it may not claim all of its spans. When we check for remaining spans at shutdown, we will ignore any with this traceId since there's no
+     * point logging a failure twice.
+     *
+     * @param traceId the traceId associated with a failed test
+     */
+    public void addFailedTestTraceId(String traceId) {
+        failedTestTraceIds.add(traceId);
+    }
 
     /**
      * Careful when retrieving the list of finished spans. There is a chance when the response is already sent to the
      * client and the server still writing the end of the spans. This means that a response is available to assert from
      * the test side but not all spans may be available yet. For this reason, this method requires the number of
      * expected spans.
+     *
+     * @deprecated Use {@link #getFinishedSpanItems(int, Span)} or {@link #getFinishedSpanItems(int, String)} instead.
+     *             They allow us to avoid mixing up spans from different tests without having to sleep between tests.
      */
+    @Deprecated
     public List<SpanData> getFinishedSpanItems(int spanCount) {
         assertSpanCount(spanCount);
-        return finishedSpanItems.stream().sorted(comparingLong(SpanData::getStartEpochNanos))
+        List<SpanData> results = finishedSpanItems.stream().sorted(comparingLong(SpanData::getStartEpochNanos))
                         .collect(Collectors.toList());
+        finishedSpanItems.removeAll(results);
+        return results;
     }
 
+    @Deprecated
     public void assertSpanCount(int spanCount) {
         int retries = 120;
         while (retries > 0 && finishedSpanItems.size() != spanCount) {
@@ -71,6 +207,10 @@ public class InMemorySpanExporter implements SpanExporter {
         Assert.assertEquals(spanCount, finishedSpanItems.size());
     }
 
+    /**
+     * @deprecated No longer any need to reset. Any left over spans will now be ignored by {@code getFinishedSpanItems} and reported at app shutdown.
+     */
+    @Deprecated
     public void reset() {
         LOGGER.info("reset method called");
         finishedSpanItems.clear();
@@ -93,7 +233,7 @@ public class InMemorySpanExporter implements SpanExporter {
 
         if (!lSpans.isEmpty()) { //this will be empty after a call to readSpans
             StringBuilder sb = new StringBuilder();
-            sb.append("----------------- list of spans (filtered but unordered, ordering will be based on the start time) ---------- ");
+            sb.append("----------------- list of spans (filtered but unordered, ordering will be based on parentage) ---------- ");
             for (SpanData spanData : lSpans) {
                 sb.append(System.lineSeparator() + spanData.toString() + System.lineSeparator());
             }
@@ -114,7 +254,31 @@ public class InMemorySpanExporter implements SpanExporter {
     @Override
     public CompletableResultCode shutdown() {
         LOGGER.info("shutdown method called");
-        finishedSpanItems.clear();
+
+        // Sleep a while to allow any async work which may still be going on to export spans
+        try {
+            Thread.sleep(Duration.ofSeconds(3).toMillis());
+        } catch (InterruptedException e) {
+            // Ignore here, still want to do the check
+            LOGGER.severe("TEST9999E: Shutdown check for unclaimed spans interrupted");
+            e.printStackTrace();
+        }
+
+        // Search for and report any exported spans which were not retrieved by a test
+        List<SpanData> unclaimedSpans = finishedSpanItems.stream()
+                        .filter(s -> !failedTestTraceIds.contains(s.getTraceId()))
+                        .collect(Collectors.toList());
+
+        if (!unclaimedSpans.isEmpty()) {
+            String unclaimedNames = unclaimedSpans.stream()
+                            .map(SpanData::getName)
+                            .collect(Collectors.joining(", "));
+            LOGGER.severe("TEST9999E: Found unexpected spans at shutdown, full data in log: " + unclaimedNames);
+            for (SpanData span : unclaimedSpans) {
+                LOGGER.severe(span.toString());
+            }
+        }
+
         isStopped = true;
         return CompletableResultCode.ofSuccess();
     }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Jax/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Jax/server.xml
@@ -8,6 +8,7 @@
         <feature>componentTest-2.0</feature>
         <feature>restfulWS-3.1</feature>
         <feature>mpRestClient-3.0</feature>
+        <feature>concurrent-3.0</feature>
     </featureManager>
 
     <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
@@ -35,7 +36,11 @@
     <application type="war" location="jaeger.war">
         <classloader apiTypeVisibility="+third-party"/>
     </application>
-    
+
+    <application type="war" location="jaxrsAsyncServer.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
     <!--logging traceSpecification="TELEMETRY=all:RESTfulWS=all"/-->
 
 </server>

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/io/openliberty/restfulWS/client/AsyncClientExecutorService.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/io/openliberty/restfulWS/client/AsyncClientExecutorService.java
@@ -195,8 +195,10 @@ public class AsyncClientExecutorService implements ExecutorService {
     
     public <T> CompletableFuture<T> supplyAsync(Supplier<T> supplier) {
         ExecutorService executor = getDelegate();
-        if (executor instanceof CompletionStageExecutor)
-            return ((CompletionStageExecutor) executor).supplyAsync(supplier);
+        if (executor instanceof CompletionStageExecutor) {
+            return ((CompletionStageExecutor) executor).supplyAsync(wrap(supplier));
+        }
+        // No need to wrap here as tasks will be wrapped when CompletableFuture submits them to this executor
         return CompletableFuture.supplyAsync(supplier, this);
     }
 

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/io/openliberty/restfulWS/client/ClientAsyncTaskWrapper.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/io/openliberty/restfulWS/client/ClientAsyncTaskWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,9 @@
 package io.openliberty.restfulWS.client;
 
 import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 /**
  * Other components can implement this interface to wrap the task used for async client requests.
@@ -22,5 +25,24 @@ public interface ClientAsyncTaskWrapper {
     Runnable wrap(Runnable r);
 
     <T> Callable<T> wrap(Callable<T> c);
+
+    @FFDCIgnore(RuntimeException.class)
+    default <T> Supplier<T> wrap(Supplier<T> s) {
+        // Turn the supplier into a callable to wrap it and then back again
+        // Implementors should override this with a more efficient implementation that wraps the supplier directly
+        Callable<T> c = wrap((Callable<T>) s::get);
+        return () -> {
+            try {
+                return c.call();
+            } catch (RuntimeException e) {
+                // Pass through any runtime exceptions
+                throw e;
+            } catch (Exception e) {
+                // Won't have any non-runtime exception thrown from the supplier, but may have from the wrapper
+                // Rethrowing it as a runtime exception is the best we can do here
+                throw new RuntimeException(e);
+            }
+        };
+    }
 
 }

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/io/openliberty/restfulWS/client/internal/AsyncClientExecutorHelper.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/io/openliberty/restfulWS/client/internal/AsyncClientExecutorHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import io.openliberty.restfulWS.client.ClientAsyncTaskWrapper;
 
@@ -61,6 +62,26 @@ public abstract class AsyncClientExecutorHelper {
             c = instance.getThreadContextWrapper().wrap(c);
         }
         return c;
+    }
+    
+    public static <T> Supplier<T> wrap(Supplier<T> s) {
+        AsyncClientExecutorHelper instance = AsyncClientExecutorHelper.instance.get();
+        if (instance != null) {
+            for (ClientAsyncTaskWrapper wrapper : instance.getTaskWrappers()) {
+                try {
+                    Supplier<T> wrapped = wrapper.wrap(s);
+                    if (wrapped == null) {
+                        throw new NullPointerException("ClientAsyncTaskWrapper " + wrapper + " returned null");
+                    }
+                    s = wrapped;
+                } catch (Exception e) {
+                    // FFDC
+                }
+            }
+            // The ThreadContext wrapper needs to be last so that it is run first before any other wrappers.
+            s = instance.getThreadContextWrapper().wrap(s);
+        }
+        return s;
     }
 
     abstract public ExecutorService getExecutorService();


### PR DESCRIPTION
New Telemetry JAX-RS tests: (all for #23448)
- Test telemetry with JAX-RS server-side async (`CompletionStage` and `@Suspended AsyncResponse`)
- Test telemetry with all HTTP methods
- Test telemetry with a selection of different HTTP response codes

Bug fixes:
- Close the scope correctly for `SERVER` spans when JAX-RS server-side async is used (product bug) (fixes #24174)
- Wrap rest async client tasks correctly when `concurrent-3.0` is enabled (product bug in restfulWS) (fixes #24235)
- Don't rely on timestamps to order spans in `InMemorySpanExporter` (test bug) (fixes #24194)

Other improvements:
- Add `SpanDataMatcher` (based on existing `SpanMatcher` for Jaeger spans) to create better error messages when spans are not as expected
- Add `TestSpans` utility to create and close test spans to reduce test boilerplate.