### PR TITLE
Fix JPA test case for RTC 290560

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh19342/src/com/ibm/ws/jpa/olgh19342/testlogic/JPATestOLGH19342Logic.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh19342/src/com/ibm/ws/jpa/olgh19342/testlogic/JPATestOLGH19342Logic.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -98,8 +98,8 @@ public class JPATestOLGH19342Logic extends AbstractTestLogic {
                             }
                         } finally {
                             if (em != null) {
-                                if (jpaResource.getTj().isTransactionActive()) {
-                                    jpaResource.getTj().rollbackTransaction();
+                                if (em.getTransaction().isActive()) {
+                                    em.getTransaction().rollback();;
                                 }
                                 em.close();
                             }


### PR DESCRIPTION
Test creates its own EntityManager instances, instead of using the one wrapped by jpaResource, then tries to use EntityTransaction transaction wrapper from jpaResource (which is associated with the EntityManager wrapped by itself) instead of getting the EntityTransaction associated with the EntityManager instance created by the thread.  This results in the test calling EntityTransaction.isActive() and .rollback() on the wrong EntityManager instance.