### PR TITLE
Set GlobalOpenTelemetry to noop

### DIFF
--- a/dev/io.openliberty.io.opentelemetry.internal/bnd.bnd
+++ b/dev/io.openliberty.io.opentelemetry.internal/bnd.bnd
@@ -12,9 +12,11 @@
 bVersion=1.0
 openTelemetryVersion=1.19.0
 
-src: src
+src: src, resources
 
+Bundle-Name: io.openliberty.io.opentelemetry.internal
 Bundle-SymbolicName: io.openliberty.io.opentelemetry.internal; singleton:=true
+Bundle-Description: MicroProfile Telemetry Internal packages
 
 javac.source: 11
 javac.target: 11
@@ -31,11 +33,16 @@ Import-Package: \
   zipkin2.reporter.okhttp3,\
   jakarta.interceptor,\
   com.ibm.wsspi.classloading,\
-  org.osgi.framework
+  org.osgi.framework,\
+  com.ibm.websphere.ras,\
+  com.ibm.websphere.ras.annotation
 
 Export-Package: \
   io.opentelemetry.extension.trace.propagation;version=${openTelemetryVersion};thread-context=true,\
   io.opentelemetry.*;version=${openTelemetryVersion}
+  
+Private-Package: \
+  io.openliberty.io.opentelemetry.resources
 
 -includeresource: resources
 
@@ -79,6 +86,8 @@ Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 	io.opentelemetry:opentelemetry-sdk-trace;version='1.19.0';strategy=exact,\
 	io.opentelemetry:opentelemetry-semconv;version='1.19.0.alpha';strategy=exact,\
 	com.ibm.ws.classloading;version=latest,\
-	org.eclipse.osgi;version=latest
+	org.eclipse.osgi;version=latest,\
+	com.ibm.websphere.appserver.spi.logging;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest
 
 WS-TraceGroup: TELEMETRY

--- a/dev/io.openliberty.io.opentelemetry.internal/resources/io/openliberty/io/opentelemetry/resources/MPTelemetry.nlsprops
+++ b/dev/io.openliberty.io.opentelemetry.internal/resources/io/openliberty/io/opentelemetry/resources/MPTelemetry.nlsprops
@@ -25,9 +25,9 @@
 # Message prefix block: CWMOT5000 - CWMOT5999
 #-----------------------------------------------------------------------------------------------------------------------------
 
-CWMOT5000.cannot.get.globalopentelemetry=CWMOT5000W: Cannot get GlobalOpenTelemetry.
-CWMOT5000.cannot.get.globalopentelemetry.explanation=The GlobalOpenTelemetry instance should not be used as the entrypoint to telemetry functionality.
-CWMOT5000.cannot.get.globalopentelemetry.useraction=Use the OpenTelemetry instance instead.
+CWMOT5000.cannot.get.globalopentelemetry=CWMOT5000W: The GlobalOpenTelemetry.get method was called. This method returns a non-functional OpenTelemetry object. Use CDI to inject an OpenTelemetry object instead.
+CWMOT5000.cannot.get.globalopentelemetry.explanation=There is no global OpenTelemetry object and so using GlobalOpenTelemetry is not supported. Each application must instead use CDI to inject the OpenTelemetry object for that application.
+CWMOT5000.cannot.get.globalopentelemetry.useraction=Use CDI to inject the OpenTelemetry object.
 
 CWMOT5001.cannot.set.globalopentelemetry=CWMOT5001E: Setting GlobalOpenTelemetry is not supported
 CWMOT5001.cannot.set.globalopentelemetry.explanation=There is no global OpenTelemetry object and so calling the GlobalOpenTelemetry.set method is not supported. Each application must instead use CDI to inject the OpenTelemetry object for that application.

--- a/dev/io.openliberty.io.opentelemetry.internal/resources/io/openliberty/io/opentelemetry/resources/MPTelemetry.nlsprops
+++ b/dev/io.openliberty.io.opentelemetry.internal/resources/io/openliberty/io/opentelemetry/resources/MPTelemetry.nlsprops
@@ -26,9 +26,9 @@
 #-----------------------------------------------------------------------------------------------------------------------------
 
 CWMOT5000.cannot.get.globalopentelemetry=CWMOT5000W: The GlobalOpenTelemetry.get method was called. This method returns a non-functional OpenTelemetry object. Use CDI to inject an OpenTelemetry object instead.
-CWMOT5000.cannot.get.globalopentelemetry.explanation=There is no global OpenTelemetry object and so using GlobalOpenTelemetry is not supported. Each application must instead use CDI to inject the OpenTelemetry object for that application.
+CWMOT5000.cannot.get.globalopentelemetry.explanation=The GlobalOpenTelemetry class is not supported because no global OpenTelemetry object exists. Instead, each application must use CDI to inject the OpenTelemetry object for that application.
 CWMOT5000.cannot.get.globalopentelemetry.useraction=Use CDI to inject the OpenTelemetry object.
 
-CWMOT5001.cannot.set.globalopentelemetry=CWMOT5001E: Setting GlobalOpenTelemetry is not supported
-CWMOT5001.cannot.set.globalopentelemetry.explanation=There is no global OpenTelemetry object and so calling the GlobalOpenTelemetry.set method is not supported. Each application must instead use CDI to inject the OpenTelemetry object for that application.
+CWMOT5001.cannot.set.globalopentelemetry=CWMOT5001E: Setting the GlobalOpenTelemetry class is not supported.
+CWMOT5001.cannot.set.globalopentelemetry.explanation=The GlobalOpenTelemetry class is not supported because no global OpenTelemetry object exists. Instead, each application must use CDI to inject the OpenTelemetry object for that application.
 CWMOT5001.cannot.set.globalopentelemetry.useraction=Do not call the GlobalOpenTelemetry.get method. Where the application code needs to obtain an OpenTelemetry object, use CDI to inject it.

--- a/dev/io.openliberty.io.opentelemetry.internal/resources/io/openliberty/io/opentelemetry/resources/MPTelemetry.nlsprops
+++ b/dev/io.openliberty.io.opentelemetry.internal/resources/io/openliberty/io/opentelemetry/resources/MPTelemetry.nlsprops
@@ -29,6 +29,6 @@ CWMOT5000.cannot.get.globalopentelemetry=CWMOT5000W: Cannot get GlobalOpenTeleme
 CWMOT5000.cannot.get.globalopentelemetry.explanation=The GlobalOpenTelemetry instance should not be used as the entrypoint to telemetry functionality.
 CWMOT5000.cannot.get.globalopentelemetry.useraction=Use the OpenTelemetry instance instead.
 
-CWMOT5001.cannot.set.globalopentelemetry=CWMOT5001E: Cannot set GlobalOpenTelemetry.
-CWMOT5001.cannot.set.globalopentelemetry.explanation=The GlobalOpenTelemetry instance should not be used as the entrypoint to telemetry functionality.
-CWMOT5001.cannot.set.globalopentelemetry.useraction=Use the OpenTelemetry instance instead.
+CWMOT5001.cannot.set.globalopentelemetry=CWMOT5001E: Setting GlobalOpenTelemetry is not supported
+CWMOT5001.cannot.set.globalopentelemetry.explanation=There is no global OpenTelemetry object and so calling the GlobalOpenTelemetry.set method is not supported. Each application must instead use CDI to inject the OpenTelemetry object for that application.
+CWMOT5001.cannot.set.globalopentelemetry.useraction=Do not call the GlobalOpenTelemetry.get method. Where the application code needs to obtain an OpenTelemetry object, use CDI to inject it.

--- a/dev/io.openliberty.io.opentelemetry.internal/resources/io/openliberty/io/opentelemetry/resources/MPTelemetry.nlsprops
+++ b/dev/io.openliberty.io.opentelemetry.internal/resources/io/openliberty/io/opentelemetry/resources/MPTelemetry.nlsprops
@@ -1,0 +1,34 @@
+#CMVCPATHNAME N/A
+#COMPONENTPREFIX CWMOT
+#COMPONENTNAMEFOR CWMOT MicroProfile Telemetry Tracing
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#ISMESSAGEFILE true
+# -------------------------------------------------------------------------------------------------
+#*******************************************************************************
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+# This file follows the WebSphere Message Guidelines.
+# For more information, visit:
+# http://washome.austin.ibm.com/xwiki/bin/view/MessagesTeam/
+
+#-----------------------------------------------------------------------------------------------------------------------------
+# Message prefix block: CWMOT5000 - CWMOT5999
+#-----------------------------------------------------------------------------------------------------------------------------
+
+CWMOT5000.cannot.get.globalopentelemetry=CWMOT5000W: Cannot get GlobalOpenTelemetry.
+CWMOT5000.cannot.get.globalopentelemetry.explanation=The GlobalOpenTelemetry instance should not be used as the entrypoint to telemetry functionality.
+CWMOT5000.cannot.get.globalopentelemetry.useraction=Use the OpenTelemetry instance instead.
+
+CWMOT5001.cannot.set.globalopentelemetry=CWMOT5001E: Cannot set GlobalOpenTelemetry.
+CWMOT5001.cannot.set.globalopentelemetry.explanation=The GlobalOpenTelemetry instance should not be used as the entrypoint to telemetry functionality.
+CWMOT5001.cannot.set.globalopentelemetry.useraction=Use the OpenTelemetry instance instead.

--- a/dev/io.openliberty.io.opentelemetry.internal/resources/io/openliberty/io/opentelemetry/resources/MPTelemetry.nlsprops
+++ b/dev/io.openliberty.io.opentelemetry.internal/resources/io/openliberty/io/opentelemetry/resources/MPTelemetry.nlsprops
@@ -29,6 +29,6 @@ CWMOT5000.cannot.get.globalopentelemetry=CWMOT5000W: The GlobalOpenTelemetry.get
 CWMOT5000.cannot.get.globalopentelemetry.explanation=The GlobalOpenTelemetry class is not supported because no global OpenTelemetry object exists. Instead, each application must use CDI to inject the OpenTelemetry object for that application.
 CWMOT5000.cannot.get.globalopentelemetry.useraction=Use CDI to inject the OpenTelemetry object.
 
-CWMOT5001.cannot.set.globalopentelemetry=CWMOT5001E: Setting the GlobalOpenTelemetry class is not supported.
+CWMOT5001.cannot.set.globalopentelemetry=CWMOT5001E: Setting the GlobalOpenTelemetry object is not supported.
 CWMOT5001.cannot.set.globalopentelemetry.explanation=The GlobalOpenTelemetry class is not supported because no global OpenTelemetry object exists. Instead, each application must use CDI to inject the OpenTelemetry object for that application.
 CWMOT5001.cannot.set.globalopentelemetry.useraction=Do not call the GlobalOpenTelemetry.get method. Where the application code needs to obtain an OpenTelemetry object, use CDI to inject it.

--- a/dev/io.openliberty.io.opentelemetry.internal/src/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/dev/io.openliberty.io.opentelemetry.internal/src/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Originally, if a global OpenTelemetry instance is not set then GlobalOpenTelemetry.get()
+ * attempts to create and configure one automatically.
+ *
+ * To support per-application configuration, the global instance is set to a no-op
+ * implementation in this class
+ */
+package io.opentelemetry.api;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerBuilder;
+import io.opentelemetry.api.trace.TracerProvider;
+
+public final class GlobalOpenTelemetry {
+
+    private static final TraceComponent tc = Tr.register(GlobalOpenTelemetry.class);
+    private static boolean warned = false;
+
+    public static OpenTelemetry get() {
+        //Warns the user the first time they try to get the GlobalOpenTelemetry instance
+        //The GlobalOpenTelemetry instance should not be used as the entrypoint to telemetry functionality.
+        //OpenTCWMOT5000W: Cannot get GlobalOpenTelemetry.get
+        if (!warned) {
+            String msg = Tr.formatMessage(tc, "CWMOT5000.cannot.get.globalopentelemetry");
+            Tr.warning(tc, msg);
+            warned = true;
+        }
+        return OpenTelemetry.noop();
+    }
+
+    //GlobalOpenTelemetry cannot be set twice
+    public static void set(OpenTelemetry openTelemetry) {
+        throw new IllegalStateException(Tr.formatMessage(tc, "CWMOT5001.cannot.set.globalopentelemetry"));
+    }
+
+    public static TracerProvider getTracerProvider() {
+        return get().getTracerProvider();
+    }
+
+    public static Tracer getTracer(String instrumentationScopeName) {
+        return get().getTracer(instrumentationScopeName);
+    }
+
+    public static TracerBuilder tracerBuilder(String instrumentationScopeName) {
+        return get().tracerBuilder(instrumentationScopeName);
+    }
+}

--- a/dev/io.openliberty.io.opentelemetry.internal/src/io/opentelemetry/api/package-info.java
+++ b/dev/io.openliberty.io.opentelemetry.internal/src/io/opentelemetry/api/package-info.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+/**
+ * @version 3.0
+ */
+@org.osgi.annotation.versioning.Version("3.0")
+@TraceOptions(traceGroup = "TELEMETRY", messageBundle = "io.openliberty.io.opentelemetry.resources.MPTelemetry")
+package io.opentelemetry.api;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
@@ -33,7 +33,9 @@ import componenttest.annotation.MinimumJavaLevel;
                 MultiThreadedContextTest.class,
                 TelemetryMisconfigTest.class,
                 TelemetryLongRunningTest.class,
+                TelemetryGlobalOpenTelemetryTest.class,
                 TelemetryDisabledTest.class,
 })
 
-public class FATSuite {}
+public class FATSuite {
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryGlobalOpenTelemetryTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryGlobalOpenTelemetryTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.globalopentelemetry.TelemetryGlobalOpenTelemetryServlet;
+
+@RunWith(FATRunner.class)
+public class TelemetryGlobalOpenTelemetryTest extends FATServletClient {
+
+    public static final String SERVER_NAME = "Telemetry10";
+    public static final String APP_NAME = "TelemetryApp";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addClasses(TelemetryGlobalOpenTelemetryServlet.class)
+                        .addAsResource(new StringAsset("otel.sdk.disabled=false"),
+                                       "META-INF/microprofile-config.properties");
+        ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
+        server.startServer();
+    }
+
+    @Test
+    public void testSetGlobalOpenTelemetry() throws Exception {
+        runTest(server, APP_NAME + "/GlobalOpenTelemetryServlet", "testSetGlobalOpenTelemetry");
+    }
+
+    //A warning should only be shown the first time the user attempts to get the GlobalOpenTelemetry instance
+    @Test
+    public void testGetGlobalOpenTelemetry() throws Exception {
+        server.setMarkToEndOfLog();
+        runTest(server, APP_NAME + "/GlobalOpenTelemetryServlet", "testGetGlobalOpenTelemetry");
+        assertFalse(server.waitForStringInLogUsingMark("CWMOT5000W: Cannot get GlobalOpenTelemetry.").isEmpty());
+
+        server.setMarkToEndOfLog();
+        runTest(server, APP_NAME + "/GlobalOpenTelemetryServlet", "testGetGlobalOpenTelemetry");
+        assertNull(server.verifyStringNotInLogUsingMark("CWMOT5000W: Cannot get GlobalOpenTelemetry.", 1000));
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer("CWMOT5000W", //Cannot get GlobalOpenTelemetry
+                          "CWMOT5001E" //Cannot set GlobalOpenTelemetry
+        );
+
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryGlobalOpenTelemetryTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryGlobalOpenTelemetryTest.java
@@ -61,11 +61,11 @@ public class TelemetryGlobalOpenTelemetryTest extends FATServletClient {
     public void testGetGlobalOpenTelemetry() throws Exception {
         server.setMarkToEndOfLog();
         runTest(server, APP_NAME + "/GlobalOpenTelemetryServlet", "testGetGlobalOpenTelemetry");
-        assertFalse(server.waitForStringInLogUsingMark("CWMOT5000W: Cannot get GlobalOpenTelemetry.").isEmpty());
+        assertFalse(server.waitForStringInLogUsingMark("CWMOT5000W: The GlobalOpenTelemetry.get method was called. This method returns a non-functional OpenTelemetry object. Use CDI to inject an OpenTelemetry object instead.").isEmpty());
 
         server.setMarkToEndOfLog();
         runTest(server, APP_NAME + "/GlobalOpenTelemetryServlet", "testGetGlobalOpenTelemetry");
-        assertNull(server.verifyStringNotInLogUsingMark("CWMOT5000W: Cannot get GlobalOpenTelemetry.", 1000));
+        assertNull(server.verifyStringNotInLogUsingMark("CWMOT5000W: The GlobalOpenTelemetry.get method was called. This method returns a non-functional OpenTelemetry object. Use CDI to inject an OpenTelemetry object instead.", 1000));
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/globalopentelemetry/TelemetryGlobalOpenTelemetryServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/globalopentelemetry/TelemetryGlobalOpenTelemetryServlet.java
@@ -41,7 +41,7 @@ public class TelemetryGlobalOpenTelemetryServlet extends FATServlet {
             fail("Able to set GlobalOpenTelemetry");
         } catch (IllegalStateException e) {
             assertThat(e.getMessage(),
-                       containsString("CWMOT5001E: Cannot set GlobalOpenTelemetry."));
+                       containsString("CWMOT5001E: Setting GlobalOpenTelemetry is not supported"));
         }
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/globalopentelemetry/TelemetryGlobalOpenTelemetryServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/globalopentelemetry/TelemetryGlobalOpenTelemetryServlet.java
@@ -41,7 +41,7 @@ public class TelemetryGlobalOpenTelemetryServlet extends FATServlet {
             fail("Able to set GlobalOpenTelemetry");
         } catch (IllegalStateException e) {
             assertThat(e.getMessage(),
-                       containsString("CWMOT5001E: Setting GlobalOpenTelemetry is not supported"));
+                       containsString("CWMOT5001E: Setting the GlobalOpenTelemetry class is not supported."));
         }
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/globalopentelemetry/TelemetryGlobalOpenTelemetryServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/globalopentelemetry/TelemetryGlobalOpenTelemetryServlet.java
@@ -41,7 +41,7 @@ public class TelemetryGlobalOpenTelemetryServlet extends FATServlet {
             fail("Able to set GlobalOpenTelemetry");
         } catch (IllegalStateException e) {
             assertThat(e.getMessage(),
-                       containsString("CWMOT5001E: Setting the GlobalOpenTelemetry class is not supported."));
+                       containsString("CWMOT5001E: Setting the GlobalOpenTelemetry object is not supported."));
         }
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/globalopentelemetry/TelemetryGlobalOpenTelemetryServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/globalopentelemetry/TelemetryGlobalOpenTelemetryServlet.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.microprofile.telemetry.internal_fat.apps.globalopentelemetry;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+
+@WebServlet("/GlobalOpenTelemetryServlet")
+@ApplicationScoped
+public class TelemetryGlobalOpenTelemetryServlet extends FATServlet {
+
+    @Inject
+    OpenTelemetry openTelemetry;
+
+    //The GlobalOpenTelemetry object can only be set once
+    @Test
+    public void testSetGlobalOpenTelemetry() {
+        try {
+            GlobalOpenTelemetry.set(openTelemetry);
+            fail("Able to set GlobalOpenTelemetry");
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage(),
+                       containsString("CWMOT5001E: Cannot set GlobalOpenTelemetry."));
+        }
+    }
+
+    @Test
+    public void testGetGlobalOpenTelemetry() {
+        OpenTelemetry global = GlobalOpenTelemetry.get();
+    }
+}


### PR DESCRIPTION
For issue #23923 

- GlobalOpenTelmetry is always returned as OpenTelemetry.noop()
- Users are warned when getting the GlobalOpenTelemetry object
- Users are unable to set the GlobalOpenTelemetry object themselves