### PR TITLE
JAX-WS: Add ignore for `CWWKO0801E` in JAX-WS negative test case. 

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFNegativePropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFNegativePropertiesTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -75,7 +75,8 @@ public class LibertyCXFNegativePropertiesTest {
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null && server.isStarted()) {
-            server.stopServer("SRVE0777E", "SRVE0315E");
+            // Ignore different SSL connection errors for negative test cases
+            server.stopServer("SRVE0777E", "SRVE0315E", "CWWKO0801E");
         }
     }
 


### PR DESCRIPTION
This pull request ignores the following error in LibertyCXFNegativePropertiesTest's tear down method:

```CWWKO0801E: The SSL connection cannot be initialized from the 127.0.0.1 host and 61,320 port on the remote client to the 127.0.0.1 host and 8,020 port on the local server. Exception: javax.net.ssl.SSLHandshakeException: Received fatal alert: certificate_unknown```

This is caused by a change in messaging on certain JDKs and since the test case is a collection of negative tests, and all tests are passing, this error can be safely ignored. 

