### PR TITLE
Telemetry: test JAX-RS redirect and invalid

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
@@ -64,6 +64,7 @@ public class JaxRsIntegration extends FATServletClient {
     public static final String B3_MULTI_APP_NAME = "b3multi";
     public static final String JAEGER_APP_NAME = "jaeger";
     public static final String ASYNC_SERVER_APP_NAME = "jaxrsAsyncServer";
+    public static final String METHODS_APP_NAME = "jaxrsMethods";
 
     @TestServlets({
                     @TestServlet(contextRoot = W3C_TRACE_APP_NAME, servlet = W3CTracePropagationTestServlet.class),
@@ -72,8 +73,8 @@ public class JaxRsIntegration extends FATServletClient {
                     @TestServlet(contextRoot = B3_MULTI_APP_NAME, servlet = B3MultiPropagationTestServlet.class),
                     @TestServlet(contextRoot = JAEGER_APP_NAME, servlet = JaegerPropagationTestServlet.class),
                     @TestServlet(contextRoot = ASYNC_SERVER_APP_NAME, servlet = JaxRsServerAsyncTestServlet.class),
-                    @TestServlet(contextRoot = APP_NAME, servlet = JaxRsMethodTestServlet.class),
-                    @TestServlet(contextRoot = APP_NAME, servlet = JaxRsResponseCodeTestServlet.class),
+                    @TestServlet(contextRoot = METHODS_APP_NAME, servlet = JaxRsMethodTestServlet.class),
+                    @TestServlet(contextRoot = METHODS_APP_NAME, servlet = JaxRsResponseCodeTestServlet.class),
     })
     @Server(SERVER_NAME)
     public static LibertyServer server;
@@ -86,8 +87,6 @@ public class JaxRsIntegration extends FATServletClient {
                         .addProperty("otel.bsp.schedule.delay", "100");
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackage(JaxRsEndpoints.class.getPackage())
-                        .addPackage(JaxRsMethodTestEndpoints.class.getPackage())
-                        .addPackage(JaxRsResponseCodeTestEndpoints.class.getPackage())
                         .addPackage(InMemorySpanExporter.class.getPackage())
                         .addPackage(TestSpans.class.getPackage())
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
@@ -155,6 +154,14 @@ public class JaxRsIntegration extends FATServletClient {
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                         .addAsResource(appConfig, "META-INF/microprofile-config.properties");
 
+        WebArchive methodsApp = ShrinkWrap.create(WebArchive.class, METHODS_APP_NAME + ".war")
+                        .addPackage(JaxRsMethodTestEndpoints.class.getPackage())
+                        .addPackage(JaxRsResponseCodeTestEndpoints.class.getPackage())
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(TestSpans.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
         ShrinkHelper.exportAppToServer(server, w3cTraceApp, SERVER_ONLY);
         ShrinkHelper.exportAppToServer(server, w3cTraceBaggageApp, SERVER_ONLY);
@@ -162,6 +169,7 @@ public class JaxRsIntegration extends FATServletClient {
         ShrinkHelper.exportAppToServer(server, b3MultiApp, SERVER_ONLY);
         ShrinkHelper.exportAppToServer(server, jaegerApp, SERVER_ONLY);
         ShrinkHelper.exportAppToServer(server, asyncServerApp, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, methodsApp, SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/responses/JaxRsResponseCodeTestClient.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/responses/JaxRsResponseCodeTestClient.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.responses;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("responseCodeEndpoints")
+public interface JaxRsResponseCodeTestClient {
+
+    @Path("307")
+    @GET
+    public Response get307();
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/responses/JaxRsResponseCodeTestEndpoints.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/responses/JaxRsResponseCodeTestEndpoints.java
@@ -11,16 +11,23 @@ package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation
 
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
+import java.net.URI;
+
+import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.UriInfo;
 
 /**
  *
  */
+@ApplicationPath("/")
 @Path("responseCodeEndpoints")
-public class JaxRsResponseCodeTestEndpoints {
+public class JaxRsResponseCodeTestEndpoints extends Application {
 
     @Path("200")
     @GET
@@ -56,6 +63,22 @@ public class JaxRsResponseCodeTestEndpoints {
         return Response.status(Status.INTERNAL_SERVER_ERROR)
                         .entity("get500")
                         .build();
+    }
+
+    @Path("307")
+    @GET
+    public Response get307(@Context UriInfo uriInfo) {
+        URI targetUri = uriInfo.getBaseUriBuilder()
+                        .path(JaxRsResponseCodeTestEndpoints.class)
+                        .path(JaxRsResponseCodeTestEndpoints.class, "redirectTarget")
+                        .build();
+        return Response.temporaryRedirect(targetUri).entity("get307").build();
+    }
+
+    @Path("redirectTarget")
+    @GET
+    public Response redirectTarget() {
+        return Response.ok("redirectTarget").build();
     }
 
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/responses/JaxRsResponseCodeTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/responses/JaxRsResponseCodeTestServlet.java
@@ -10,6 +10,8 @@
 package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.responses;
 
 import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.isSpan;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -17,6 +19,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
@@ -31,6 +34,7 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
 
 /**
  *
@@ -73,6 +77,86 @@ public class JaxRsResponseCodeTestServlet extends FATServlet {
         doTestForStatusCode(500);
     }
 
+    @Test
+    public void testRedirect() {
+        doTestForStatusCode(307);
+    }
+
+    @Test
+    public void testRedirectWithRestClient() {
+        JaxRsResponseCodeTestClient client = RestClientBuilder.newBuilder()
+                        .baseUri(getBaseUri())
+                        .followRedirects(true)
+                        .build(JaxRsResponseCodeTestClient.class);
+
+        Span span = spans.withTestSpan(() -> {
+            Response response = client.get307();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("redirectTarget"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(4, span);
+
+        SpanData redirectClient = spans.get(1);
+        SpanData redirectServer;
+        SpanData targetServer;
+
+        if (spans.get(2).getAttributes().get(HTTP_STATUS_CODE) == 307L) {
+            redirectServer = spans.get(2);
+            targetServer = spans.get(3);
+        } else {
+            redirectServer = spans.get(3);
+            targetServer = spans.get(2);
+        }
+
+        assertThat(redirectClient, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withParentSpanId(span.getSpanContext().getSpanId())
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+
+        assertThat(redirectServer, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withParentSpanId(redirectClient.getSpanContext().getSpanId())
+                        .withAttribute(HTTP_METHOD, "GET")
+                        .withAttribute(HTTP_STATUS_CODE, 307L));
+
+        assertThat(targetServer, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withParentSpanId(redirectClient.getSpanContext().getSpanId())
+                        .withAttribute(HTTP_METHOD, "GET")
+                        .withAttribute(HTTP_STATUS_CODE, 200L));
+    }
+
+    @Test
+    public void testInvalidJaxRsPath() {
+        URI testUri = getBaseUri();
+        UriBuilder.fromUri(testUri)
+                        .path("responseCodeEndpoints")
+                        .path("invalid");
+        Span span = spans.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient()
+                            .target(testUri)
+                            .request()
+                            .build("GET")
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(404));
+        });
+
+        // Because the request is not handled by a JAX-RS resource method, we don't get a server span
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(2, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 404L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+    }
+
     private void doTestForStatusCode(int statusCode) {
         URI testUri = getTargetUri(statusCode);
         Span span = spans.withTestSpan(() -> {
@@ -104,6 +188,17 @@ public class JaxRsResponseCodeTestServlet extends FATServlet {
     private URI getTargetUri(int statusCode) {
         try {
             String path = request.getContextPath() + "/responseCodeEndpoints/" + statusCode;
+            URI originalUri = new URI(request.getRequestURL().toString());
+            URI result = new URI(originalUri.getScheme(), originalUri.getAuthority(), path, null, null);
+            return result;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private URI getBaseUri() {
+        try {
+            String path = request.getContextPath();
             URI originalUri = new URI(request.getRequestURL().toString());
             URI result = new URI(originalUri.getScheme(), originalUri.getAuthority(), path, null, null);
             return result;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Jax/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Jax/server.xml
@@ -41,6 +41,10 @@
         <classloader apiTypeVisibility="+third-party"/>
     </application>
 
+    <application type="war" location="jaxrsMethods.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
     <!--logging traceSpecification="TELEMETRY=all:RESTfulWS=all"/-->
 
 </server>


### PR DESCRIPTION
Test requesting a JAX-RS method which redirects to another JAX-RS method.

Test requesting a URL within a JAX-RS application but which does not map to a JAX-RS resource method.

For #23448