### PR TITLE
JAX-WS: Add ignore for CWWKO0801E in JAX-WS positive test case.

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFPositivePropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFPositivePropertiesTest.java
@@ -73,7 +73,7 @@ public class LibertyCXFPositivePropertiesTest {
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null && server.isStarted()) {
-            server.stopServer();
+            server.stopServer("CWWKO0801E");
         }
     }
 


### PR DESCRIPTION
This pull request ignores the following error in LibertyCXFPositivePropertiesTest's tear down method:

```CWWKO0801E: The SSL connection cannot be initialized from the 127.0.0.1 host and 61,320 port on the remote client to the 127.0.0.1 host and 8,020 port on the local server. Exception: javax.net.ssl.SSLHandshakeException: Received fatal alert: certificate_unknown```

This is caused by a change in messaging on certain JDKs and since the test case is a collection of negative tests, and all tests are passing, this error can be safely ignored.
