### PR TITLE
SubjectDN change to remove the IBM from the name

### DIFF
--- a/dev/com.ibm.ws.crypto.certificateutil/src/com/ibm/ws/crypto/certificateutil/DefaultSubjectDN.java
+++ b/dev/com.ibm.ws.crypto.certificateutil/src/com/ibm/ws/crypto/certificateutil/DefaultSubjectDN.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -28,7 +28,7 @@ public class DefaultSubjectDN {
 
     /**
      * Create the default SubjectDN based on the host and server names.
-     * 
+     *
      * @param hostName May be {@code null}. If {@code null} an attempt is made to determine it.
      * @param serverName May be {@code null}.
      */
@@ -37,9 +37,9 @@ public class DefaultSubjectDN {
             hostName = getHostName();
         }
         if (serverName == null) {
-            subjectDN = "CN=" + hostName + ",O=ibm,C=us";
+            subjectDN = "CN=" + hostName;
         } else {
-            subjectDN = "CN=" + hostName + ",OU=" + serverName + ",O=ibm,C=us";
+            subjectDN = "CN=" + hostName + ",OU=" + serverName;
         }
     }
 
@@ -52,7 +52,7 @@ public class DefaultSubjectDN {
 
     /**
      * Get the host name.
-     * 
+     *
      * @return String value of the host name or "localhost" if not able to resolve
      */
     private String getHostName() {

--- a/dev/com.ibm.ws.crypto.certificateutil/test/com/ibm/ws/crypto/certificateutil/DefaultSubjectDNTest.java
+++ b/dev/com.ibm.ws.crypto.certificateutil/test/com/ibm/ws/crypto/certificateutil/DefaultSubjectDNTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -30,7 +30,7 @@ public class DefaultSubjectDNTest {
     public void DefaultSubjectDN() {
         DefaultSubjectDN dn = new DefaultSubjectDN();
         assertTrue("Default DN should not have expected pattern, was " + dn.getSubjectDN(),
-                   dn.getSubjectDN().matches("CN=.*,O=ibm,C=us"));
+                   dn.getSubjectDN().matches("CN=.*"));
         assertFalse("Default DN should not have the server name",
                     dn.getSubjectDN().contains("OU="));
     }
@@ -42,7 +42,7 @@ public class DefaultSubjectDNTest {
     public void DefaultSubjectDNStringString() {
         DefaultSubjectDN dn = new DefaultSubjectDN("myhost", "myserver");
         assertEquals("Subject DN should contain host and server",
-                     "CN=myhost,OU=myserver,O=ibm,C=us", dn.getSubjectDN());
+                     "CN=myhost,OU=myserver", dn.getSubjectDN());
     }
 
 }

--- a/dev/com.ibm.ws.security.utility/test/com/ibm/ws/security/utility/tasks/CreateSSLCertificateTaskTest.java
+++ b/dev/com.ibm.ws.security.utility/test/com/ibm/ws/security/utility/tasks/CreateSSLCertificateTaskTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -75,7 +75,7 @@ public class CreateSSLCertificateTaskTest {
     private static final String CIPHERTEXT = "{xor}OjE8MDs6Ejo=";
     private static final String VALIDITY = "365";
     private static final String SUBJECT_DN = "CN=localhost";
-    private static final String LONG_SUBJECT_DN = "CN=localhost,OU=myServer,O=IBM,C=US";
+    private static final String LONG_SUBJECT_DN = "CN=localhost,OU=myServer";
 
     private static final Mockery mock = new JUnit4Mockery() {
         {


### PR DESCRIPTION
Change to remove IBM from the default certificate SubjectDN.