### PR TITLE
Transactional annotation for Jakarta Data

### DIFF
--- a/dev/com.ibm.ws.transaction.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cdi/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -50,6 +50,7 @@ Export-Package: \
 	com.ibm.tx.jta;version=latest,\
 	com.ibm.tx.util;version=latest,\
 	com.ibm.ws.cdi.interfaces;version=latest, \
+	com.ibm.ws.kernel.service;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest
 	
 -testpath: \

--- a/dev/com.ibm.ws.transaction/bnd.bnd
+++ b/dev/com.ibm.ws.transaction/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -137,6 +137,7 @@ instrument.classesExcludes: com/ibm/ws/transaction/services/TransactionMessages*
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
 	com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
+	com.ibm.ws.cdi.interfaces;version=latest,\
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.recoverylog;version=latest,\
 	com.ibm.ws.classloading;version=latest

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3884,8 +3884,9 @@ public class DataTestServlet extends FATServlet {
      * Use a repository interface that uses the Transactional annotation to manage transactions.
      */
     @Test
-    public void testTransactional() throws IllegalStateException, NotSupportedException, SecurityException, SystemException {
-        personnel.removeAll();
+    public void testTransactional() throws ExecutionException, IllegalStateException, InterruptedException, //
+                    NotSupportedException, SecurityException, SystemException, TimeoutException {
+        personnel.removeAll().get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
 
         Person p1 = new Person();
         p1.firstName = "Thomas";
@@ -4020,7 +4021,7 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals("Tyler", people.getFirstNameInCurrentOrNoTransaction(p3.ssn));
 
-        personnel.removeAll();
+        personnel.removeAll().get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -67,9 +67,12 @@ import jakarta.inject.Inject;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
+import jakarta.transaction.InvalidTransactionException;
 import jakarta.transaction.NotSupportedException;
 import jakarta.transaction.Status;
 import jakarta.transaction.SystemException;
+import jakarta.transaction.TransactionRequiredException;
+import jakarta.transaction.TransactionalException;
 import jakarta.transaction.UserTransaction;
 
 import org.junit.Test;
@@ -3875,6 +3878,149 @@ public class DataTestServlet extends FATServlet {
                              page4.stream().map(p -> p.number).collect(Collectors.toList()));
 
         assertEquals(null, page4.nextPageable());
+    }
+
+    /**
+     * Use a repository interface that uses the Transactional annotation to manage transactions.
+     */
+    @Test
+    public void testTransactional() throws IllegalStateException, NotSupportedException, SecurityException, SystemException {
+        personnel.removeAll();
+
+        Person p1 = new Person();
+        p1.firstName = "Thomas";
+        p1.lastName = "TestTransactional";
+        p1.ssn = 300201001;
+
+        Person p2 = new Person();
+        p2.firstName = "Timothy";
+        p2.lastName = "TestTransactional";
+        p2.ssn = 300201002;
+
+        Person p3 = new Person();
+        p3.firstName = "Tyler";
+        p3.lastName = "TestTransactional";
+        p3.ssn = 300201003;
+
+        people.save(List.of(p1, p2, p3));
+
+        System.out.println("TxType.SUPPORTS in transaction");
+
+        tran.begin();
+        try {
+            assertEquals(true, people.setFirstNameInCurrentTransaction(p3.ssn, "Ty")); // update with MANDATORY
+            assertEquals("Ty", people.getFirstNameInCurrentOrNoTransaction(p3.ssn)); // read value with SUPPORTS
+        } finally {
+            tran.rollback();
+        }
+
+        assertIterableEquals(List.of("Thomas", "Timothy", "Tyler"),
+                             people.findFirstNames("TestTransactional"));
+
+        System.out.println("TxType.SUPPORTS from no transaction");
+
+        assertEquals("Tyler", people.getFirstNameInCurrentOrNoTransaction(p3.ssn));
+
+        System.out.println("TxType.REQUIRED in transaction");
+
+        tran.begin();
+        try {
+            assertEquals(true, people.setFirstNameInCurrentOrNewTransaction(p1.ssn, "Tommy"));
+        } finally {
+            tran.rollback();
+        }
+
+        assertIterableEquals(List.of("Thomas", "Timothy", "Tyler"),
+                             people.findFirstNames("TestTransactional"));
+
+        System.out.println("TxType.REQUIRED from no transaction");
+
+        assertEquals(true, people.setFirstNameInCurrentOrNewTransaction(p1.ssn, "Tom"));
+
+        assertIterableEquals(List.of("Timothy", "Tom", "Tyler"),
+                             people.findFirstNames("TestTransactional"));
+
+        System.out.println("TxType.MANDATORY in transaction");
+
+        tran.begin();
+        try {
+            assertEquals(true, people.setFirstNameInCurrentTransaction(p3.ssn, "Ty"));
+        } finally {
+            tran.rollback();
+        }
+
+        assertIterableEquals(List.of("Timothy", "Tom", "Tyler"),
+                             people.findFirstNames("TestTransactional"));
+
+        System.out.println("TxType.MANDATORY from no transaction is an error");
+
+        try {
+            boolean result = people.setFirstNameInCurrentTransaction(p3.ssn, "Ty");
+            fail("Invoked TxType.MANDATORY operation with no transaction on thread. Result: " + result);
+        } catch (TransactionalException x) {
+            if (!(x.getCause() instanceof TransactionRequiredException))
+                throw x;
+        }
+
+        System.out.println("TxType.REQUIRES_NEW in transaction");
+
+        tran.begin();
+        try {
+            assertEquals(true, people.setFirstNameInNewTransaction(p2.ssn, "Timmy"));
+        } finally {
+            tran.rollback();
+        }
+
+        assertIterableEquals(List.of("Timmy", "Tom", "Tyler"),
+                             people.findFirstNames("TestTransactional"));
+
+        System.out.println("TxType.REQUIRES_NEW from no transaction");
+
+        assertEquals(true, people.setFirstNameInCurrentOrNewTransaction(p2.ssn, "Tim"));
+
+        assertIterableEquals(List.of("Tim", "Tom", "Tyler"),
+                             people.findFirstNames("TestTransactional"));
+
+        System.out.println("TxType.NEVER in transaction");
+
+        tran.begin();
+        try {
+            boolean result = people.setFirstNameWhenNoTransactionIsPresent(p3.ssn, "Ty");
+            fail("Invoked TxType.NEVER operation with transaction on thread. Result: " + result);
+        } catch (TransactionalException x) {
+            if (!(x.getCause() instanceof InvalidTransactionException))
+                throw x;
+        } finally {
+            tran.rollback();
+        }
+
+        assertIterableEquals(List.of("Tim", "Tom", "Tyler"),
+                             people.findFirstNames("TestTransactional"));
+
+        System.out.println("TxType.NEVER from no transaction");
+
+        assertEquals(true, people.setFirstNameWhenNoTransactionIsPresent(p3.ssn, "Ty"));
+
+        assertIterableEquals(List.of("Tim", "Tom", "Ty"),
+                             people.findFirstNames("TestTransactional"));
+
+        System.out.println("TxType.NOT_SUPPORTED in transaction");
+
+        tran.begin();
+        try {
+            assertEquals(true, people.setFirstNameWithCurrentTransactionSuspended(p3.ssn, "Tyler"));
+        } finally {
+            tran.rollback();
+        }
+
+        assertIterableEquals(List.of("Tim", "Tom", "Tyler"),
+                             people.findFirstNames("TestTransactional"));
+
+        System.out.println("TxType.NOT_SUPPORTED from no transaction");
+
+        assertEquals("Tyler", people.getFirstNameInCurrentOrNoTransaction(p3.ssn));
+
+        personnel.removeAll();
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,8 +14,14 @@ package test.jakarta.data.web;
 
 import java.util.List;
 
+import jakarta.data.repository.Filter;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Select;
+import jakarta.data.repository.Update;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
 
 /**
  * This example only references the entity class as a parameterized type.
@@ -23,9 +29,45 @@ import jakarta.data.repository.Repository;
  * to be discovered another way.
  */
 @Repository
+@Transactional(TxType.SUPPORTS)
 public interface PersonRepo {
     @Query("SELECT o FROM Person o WHERE o.lastName=?1")
     List<Person> find(String lastName);
 
+    @Filter(by = "lastName")
+    @OrderBy("firstName")
+    @Select("firstName")
+    List<String> findFirstNames(String surname);
+
     void save(List<Person> people);
+
+    @Filter(by = "ssn")
+    @Select("firstName")
+    @Transactional(TxType.SUPPORTS)
+    String getFirstNameInCurrentOrNoTransaction(Long ssn);
+
+    @Filter(by = "ssn")
+    @Update(attr = "firstName")
+    @Transactional(TxType.REQUIRED)
+    boolean setFirstNameInCurrentOrNewTransaction(Long ssn, String newFirstName);
+
+    @Filter(by = "ssn")
+    @Update(attr = "firstName")
+    @Transactional(TxType.MANDATORY)
+    boolean setFirstNameInCurrentTransaction(Long ssn, String newFirstName);
+
+    @Filter(by = "ssn")
+    @Update(attr = "firstName")
+    @Transactional(TxType.REQUIRES_NEW)
+    boolean setFirstNameInNewTransaction(Long ssn, String newFirstName);
+
+    @Filter(by = "ssn")
+    @Update(attr = "firstName")
+    @Transactional(TxType.NEVER)
+    boolean setFirstNameWhenNoTransactionIsPresent(Long ssn, String newFirstName);
+
+    @Filter(by = "ssn")
+    @Update(attr = "firstName")
+    @Transactional(TxType.NOT_SUPPORTED)
+    boolean setFirstNameWithCurrentTransactionSuspended(Long ssn, String newFirstName);
 }


### PR DESCRIPTION
Experiment with the Transactional annotation on a repository interface and its methods.
If Jakarta Data includes these on the bean, then repository methods will be intercepted and exhibit the specified transactional behavior.