### PR TITLE
New FAT for jbatch 2.1 CDI

### DIFF
--- a/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/BatchInjectionTest.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/BatchInjectionTest.java
@@ -74,7 +74,15 @@ public class BatchInjectionTest extends FATServletClient {
                         .addPackages(true, "app.injection")
                         .addPackages(true, "fat.util");
 
+        if (!JakartaEE10Action.isActive()) {
+            implicit.deletePackages(true, "app.injection.ee10");
+        }
+
         addBatchJob(implicit, "Injection.xml");
+
+        if (JakartaEE10Action.isActive()) {
+            addBatchJob(implicit, "InjectionNonStringProps.xml");
+        }
 
         // Write the WebArchive to 'publish/servers/<server>/apps' and print the contents
         ShrinkHelper.exportAppToServer(server1, implicit);
@@ -95,7 +103,7 @@ public class BatchInjectionTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.stopServer();
+        server1.stopServer("CWWKY0011W");
     }
 
 }

--- a/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/resources/InjectionNonStringProps.xml
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/resources/InjectionNonStringProps.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<job id="InjectionNonStringProps" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" version="1.0">
+	<listeners> 
+		<listener ref="InjectionNonStringPropsJobListener">
+			<properties >
+				<property name="color" value="blue"/>
+				<property name="quantity" value="4"/>
+				<property name="shortProp" value="13"/>
+				<property name="longProp" value="2048000"/>
+				<property name="floatProp" value="60.305"/>
+				<property name="doubleProp" value="120.61"/>
+				<property name="boolProp" value="true"/>
+			</properties>
+		</listener>
+	</listeners> 
+	<step id="step1">
+		<batchlet ref="InjectionNonStringPropsBatchlet">
+			<properties >
+				<property name="color" value="#{jobParameters['color']}"/>
+				<property name="quantity" value="#{jobParameters['quantity']}"/>
+				<property name="shortProp" value="#{jobParameters['shortProp']}"/>
+				<property name="longProp" value="#{jobParameters['longProp']}"/>
+				<property name="floatProp" value="#{jobParameters['floatProp']}"/>
+				<property name="doubleProp" value="#{jobParameters['doubleProp']}"/>
+				<property name="boolProp" value="#{jobParameters['boolProp']}"/>
+			</properties>
+		</batchlet>
+	</step>
+</job>

--- a/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/src/app/injection/BatchInjectionServlet.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/src/app/injection/BatchInjectionServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package app.injection;
 
+import static org.junit.Assert.assertTrue;
+
+import java.util.Properties;
 import java.util.logging.Logger;
 
 import javax.inject.Inject;
@@ -20,9 +23,15 @@ import javax.servlet.annotation.WebServlet;
 import org.junit.Test;
 
 import app.injection.Injectables.NonBatchArtifact;
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import fat.util.JobWaiter;
 
 @SuppressWarnings("serial")
@@ -50,6 +59,57 @@ public class BatchInjectionServlet extends FATServlet {
     public void testInjectionWithinBatchJob() throws Exception {
         logger.fine("Running test = testInjectionWithinBatchJob");
         new JobWaiter().completeNewJob("Injection", null);
+    }
+
+    /**
+     * Test that non-String BatchProperty values can be injected via CDI. Only applicable to EE 10 features (batch-2.1).
+     *
+     * @throws Exception
+     */
+    @Test
+    @Mode(TestMode.LITE)
+    @SkipForRepeat({ EmptyAction.ID, EE7FeatureReplacementAction.ID, EE8FeatureReplacementAction.ID, JakartaEE9Action.ID })
+    public void testInjectionNonStringProperties() throws Exception {
+        logger.fine("Running test = testInjectionNonStringProperties");
+        Properties jobProps = new Properties();
+        jobProps.put("color", "blue");
+        jobProps.put("quantity", "4");
+        jobProps.put("shortProp", "13");
+        jobProps.put("longProp", "2048000");
+        jobProps.put("floatProp", "60.305");
+        jobProps.put("doubleProp", "120.61");
+        jobProps.put("boolProp", "true");
+
+        new JobWaiter().completeNewJob("InjectionNonStringProps", jobProps);
+    }
+
+    /**
+     * Test the failure condition when a BatchProperty cannot be converted to its declared type.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Mode(TestMode.LITE)
+    @SkipForRepeat({ EmptyAction.ID, EE7FeatureReplacementAction.ID, EE8FeatureReplacementAction.ID, JakartaEE9Action.ID })
+    @ExpectedFFDC({ "java.lang.NumberFormatException", "java.lang.RuntimeException" })
+    public void testInjectionNonStringPropertiesBadType() throws Exception {
+        logger.fine("Running test = testInjectionNonStringProperties");
+        Properties jobProps = new Properties();
+        jobProps.put("color", "blue");
+        jobProps.put("quantity", "circle"); // Not an int
+        jobProps.put("shortProp", "13");
+        jobProps.put("longProp", "2048000");
+        jobProps.put("floatProp", "60.305");
+        jobProps.put("doubleProp", "120.61");
+        jobProps.put("boolProp", "true");
+
+        boolean jobFailed = false;
+        try {
+            new JobWaiter().completeNewJob("InjectionNonStringProps", jobProps);
+        } catch (IllegalStateException e) {
+            jobFailed = true;
+        }
+        assertTrue("Injection job did not fail when using an incorrect property type", jobFailed);
     }
 
     @Inject

--- a/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/src/app/injection/ee10/InjectablesNonStringProps.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/src/app/injection/ee10/InjectablesNonStringProps.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package app.injection.ee10;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.logging.Logger;
+
+import javax.batch.api.AbstractBatchlet;
+import javax.batch.api.BatchProperty;
+import javax.batch.api.listener.AbstractJobListener;
+import javax.batch.operations.JobOperator;
+import javax.batch.runtime.context.JobContext;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import app.injection.NoActiveBatchJobException;
+import app.injection.beans.AbstractScopedBean;
+
+/**
+ * Groups inner classes consisting of batch artifacts all sharing common injections.
+ */
+public class InjectablesNonStringProps {
+
+    private static final String expectedColor = "blue";
+    private static final Integer expectedQuantity = 4;
+    private static final Short expectedShort = 13;
+    private static final Long expectedLong = 2048000L;
+    private static final Float expectedFloat = 60.305F;
+    private static final Double expectedDouble = 120.61D;
+    private static final Boolean expectedBool = true;
+
+    public static Logger logger = Logger.getLogger("test");
+
+    @Dependent
+    @Named("InjectionNonStringPropsJobListener")
+    public static class JobListener extends AbstractJobListener {
+
+        @Inject
+        NonStringPropsBean bean;
+
+        @Inject
+        JobContext jobCtx;
+
+        @Inject
+        @BatchProperty
+        protected String color;
+
+        @Inject
+        @BatchProperty
+        protected Integer quantity;
+
+        @Inject
+        @BatchProperty
+        Short shortProp;
+
+        @Inject
+        @BatchProperty
+        Long longProp;
+
+        @Inject
+        @BatchProperty
+        Float floatProp;
+
+        @Inject
+        @BatchProperty
+        Double doubleProp;
+
+        @Inject
+        @BatchProperty
+        Boolean boolProp;
+
+        @Override
+        public void beforeJob() throws Exception {
+            super.beforeJob();
+            logger.fine("In JobListener beforeJob(), color = " + color + ", quantity = " + quantity);
+            validateJobName(bean, jobCtx.getJobName());
+            validatePropertyValues(bean);
+        }
+    }
+
+    @Dependent
+    @Named("InjectionNonStringPropsBatchlet")
+    public static class Batchlet extends AbstractBatchlet {
+
+        @Inject
+        NonStringPropsBean bean;
+
+        @Inject
+        JobContext jobCtx;
+
+        @Inject
+        JobOperator jobOp;
+
+        @Inject
+        @BatchProperty
+        String color;
+        @Inject
+        @BatchProperty
+        Integer quantity;
+        @Inject
+        @BatchProperty
+        Short shortProp;
+        @Inject
+        @BatchProperty
+        Long longProp;
+        @Inject
+        @BatchProperty
+        Float floatProp;
+        @Inject
+        @BatchProperty
+        Double doubleProp;
+        @Inject
+        @BatchProperty
+        Boolean boolProp;
+
+        @Override
+        public String process() throws Exception {
+            logger.fine("In Batchlet process(), color = " + color + ", quantity = " + quantity);
+            validateJobName(bean, jobCtx.getJobName());
+            validatePropertyValues(bean);
+            assertNotNull("Failed to inject default JobOperator", jobOp);
+            return null;
+        }
+
+    }
+
+    /**
+     * For each bean passed in, validate that {@link AbstractScopedBean#getJobName()} returns the expected job name
+     * from the {@link JobContext}.
+     *
+     * This proves that the batch runtime, via CDI, was able to inject the active JobContext into each of these beans.
+     *
+     * @param beans           list of beans to validate
+     * @param expectedJobName expected job name from JSL
+     * @throws NoActiveBatchJobException if there is no active job (JobContext)
+     */
+    private static void validateJobName(NonStringPropsBean bean, String expectedJobName) throws NoActiveBatchJobException {
+        logger.fine("Validating bean = " + bean);
+        assertEquals("Incorrect job name value for bean: " + bean, expectedJobName, bean.getJobName());
+    }
+
+    /**
+     * Validate that each property has been injected with the expected value, coming from either the JSL or runtime parameters.
+     *
+     * @param bean
+     */
+    private static void validatePropertyValues(NonStringPropsBean bean) {
+        logger.fine("Validating properties of bean = " + bean);
+        assertEquals("Incorrect color value for bean: " + bean, expectedColor, bean.getColor());
+        assertEquals("Incorrect quantity value for bean: " + bean, expectedQuantity, bean.getQuantity());
+        assertEquals("Incorrect short value for bean: " + bean, expectedShort, bean.getShortProp());
+        assertEquals("Incorrect long value for bean: " + bean, expectedLong, bean.getLongProp());
+        assertEquals("Incorrect float value for bean: " + bean, expectedFloat, bean.getFloatProp());
+        assertEquals("Incorrect double value for bean: " + bean, expectedDouble, bean.getDoubleProp());
+        assertEquals("Incorrect boolean value for bean: " + bean, expectedBool, bean.getBoolProp());
+    }
+
+}

--- a/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/src/app/injection/ee10/NonStringPropsBean.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/src/app/injection/ee10/NonStringPropsBean.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package app.injection.ee10;
+
+import javax.batch.api.BatchProperty;
+import javax.batch.runtime.context.JobContext;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import app.injection.NoActiveBatchJobException;
+
+@Dependent
+@Named("NonStringPropsBean")
+public class NonStringPropsBean {
+
+    @Inject
+    private JobContext jobContext;
+
+    @Inject
+    @BatchProperty(name = "color")
+    protected String color;
+
+    @Inject
+    @BatchProperty(name = "quantity")
+    protected Integer quantity;
+
+    @Inject
+    @BatchProperty(name = "shortProp")
+    protected Short shortProp;
+
+    @Inject
+    @BatchProperty(name = "longProp")
+    protected Long longProp;
+
+    @Inject
+    @BatchProperty(name = "floatProp")
+    protected Float floatProp;
+
+    @Inject
+    @BatchProperty(name = "doubleProp")
+    protected Double doubleProp;
+
+    @Inject
+    @BatchProperty(name = "boolProp")
+    protected Boolean boolProp;
+
+    /**
+     *
+     * @return The value returned by calling getJobName() on the injected JobContext.
+     * @throws NoActiveBatchJobException If and only if the JobContext is null.
+     */
+    public String getJobName() throws NoActiveBatchJobException {
+        if (jobContext != null) {
+            return jobContext.getJobName();
+        } else {
+            throw new NoActiveBatchJobException("From getJobName()");
+        }
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public Short getShortProp() {
+        return shortProp;
+    }
+
+    public Long getLongProp() {
+        return longProp;
+    }
+
+    public Float getFloatProp() {
+        return floatProp;
+    }
+
+    public Double getDoubleProp() {
+        return doubleProp;
+    }
+
+    public Boolean getBoolProp() {
+        return boolProp;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + ",  jobCtx= " + jobContext + ", color =" + color + ", quantity = " + quantity + ", shortProp = " + shortProp
+               + ", longProp = " + longProp + ", floatProp = " + floatProp + ", doubleProp = " + doubleProp + ", boolProp = " + boolProp;
+    }
+
+}


### PR DESCRIPTION
Add a new FAT to jbatch CDI bucket which tests the added functionality with batch-2.1: injection of default JobOperator and non-String values for BatchProperty injection

