### PR TITLE
JAX-WS and JAX-RS: Add timeouts to Rest Clients in interop Test

### DIFF
--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/.classpath
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/jaxrs-prototype/src"/>
+	<classpathentry kind="src" path="test-applications/jaxws-peopleservice/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-prototype/src/com/ibm/ws/jaxrs/fat/prototype/PrototypeClientTestServlet.java
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-prototype/src/com/ibm/ws/jaxrs/fat/prototype/PrototypeClientTestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -35,7 +35,11 @@ public class PrototypeClientTestServlet extends FATServlet {
 
     @Override
     public void before() throws ServletException {
-        client = ClientBuilder.newClient();
+        // Increasing the timeouts for the rest client to prevent failures in slow builds
+        ClientBuilder cb = ClientBuilder.newBuilder();
+        cb.property("com.ibm.ws.jaxrs.client.connection.timeout", "50000");
+        cb.property("com.ibm.ws.jaxrs.client.receive.timeout", "50000");
+        client = cb.build();
     }
 
     @Override
@@ -49,6 +53,7 @@ public class PrototypeClientTestServlet extends FATServlet {
                         .path("echo")
                         .request(MediaType.TEXT_PLAIN_TYPE)
                         .get();
+
         assertEquals(200, response.getStatus());
         assertEquals("Echo from JAXRS Endpoint 2", response.readEntity(String.class));
     }

--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxws-peopleservice/src/com/ibm/ws/jaxws/test/wsr/server/impl/Bill.java
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxws-peopleservice/src/com/ibm/ws/jaxws/test/wsr/server/impl/Bill.java
@@ -1,18 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jaxws.test.wsr.server.impl;
-
-import static org.junit.Assert.assertEquals;
 
 import javax.jws.WebService;
 import javax.ws.rs.client.Client;
@@ -30,7 +28,12 @@ public class Bill implements People {
     @Override
     public String hello() {
         // Implement JAX-RS call here
-        Client client = ClientBuilder.newClient();
+        // Increasing the timeouts for the rest client to prevent failures in slow builds
+        ClientBuilder cb = ClientBuilder.newBuilder();
+        cb.property("com.ibm.ws.jaxrs.client.connection.timeout", "50000");
+        cb.property("com.ibm.ws.jaxrs.client.receive.timeout", "50000");
+
+        Client client = cb.build();
         Response response = client.target(URI_CONTEXT_ROOT)
                         .path("jaxwsEP2")
                         .request(MediaType.TEXT_PLAIN_TYPE)


### PR DESCRIPTION
This pull request increase the timeouts for the rest clients tests to allow for slower JAX-WS client-service response. 

