### PR TITLE
Telemetry - Enable strict context checking in tests

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
@@ -16,6 +16,8 @@ import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONL
 import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.JaxRsEndpoints.TEST_PASSED;
 import static org.junit.Assert.assertEquals;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -170,6 +172,7 @@ public class JaxRsIntegration extends FATServletClient {
         ShrinkHelper.exportAppToServer(server, jaegerApp, SERVER_ONLY);
         ShrinkHelper.exportAppToServer(server, asyncServerApp, SERVER_ONLY);
         ShrinkHelper.exportAppToServer(server, methodsApp, SERVER_ONLY);
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
 
         server.startServer();
     }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
@@ -16,8 +16,6 @@ import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONL
 import static io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.JaxRsEndpoints.TEST_PASSED;
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -172,8 +170,6 @@ public class JaxRsIntegration extends FATServletClient {
         ShrinkHelper.exportAppToServer(server, jaegerApp, SERVER_ONLY);
         ShrinkHelper.exportAppToServer(server, asyncServerApp, SERVER_ONLY);
         ShrinkHelper.exportAppToServer(server, methodsApp, SERVER_ONLY);
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
-
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/MultiThreadedContextTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/MultiThreadedContextTest.java
@@ -11,6 +11,9 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -53,7 +56,7 @@ public class MultiThreadedContextTest extends FATServletClient {
                         .addClass(MultiThreadedContextServlet.class);
 
         ShrinkHelper.exportAppToServer(server, apiTestWar, SERVER_ONLY);
-
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/MultiThreadedContextTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/MultiThreadedContextTest.java
@@ -11,8 +11,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -56,7 +54,6 @@ public class MultiThreadedContextTest extends FATServletClient {
                         .addClass(MultiThreadedContextServlet.class);
 
         ShrinkHelper.exportAppToServer(server, apiTestWar, SERVER_ONLY);
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
@@ -14,8 +14,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -70,7 +68,6 @@ public class Telemetry10 extends FATServletClient {
         //Set for testing purposes. The properties in the server.xml should override these variables.
         server.addEnvVar("OTEL_SERVICE_NAME", "overrideThisEnvVar");
         server.addEnvVar("OTEL_SDK_DISABLED", "true");
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,9 @@
 package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -67,6 +70,7 @@ public class Telemetry10 extends FATServletClient {
         //Set for testing purposes. The properties in the server.xml should override these variables.
         server.addEnvVar("OTEL_SERVICE_NAME", "overrideThisEnvVar");
         server.addEnvVar("OTEL_SDK_DISABLED", "true");
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryAPITest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryAPITest.java
@@ -11,8 +11,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -69,7 +67,6 @@ public class TelemetryAPITest extends FATServletClient {
                         .addClass(CommonSDKServlet.class);
 
         ShrinkHelper.exportAppToServer(server, apiTestWar, SERVER_ONLY);
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryAPITest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryAPITest.java
@@ -11,6 +11,9 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -66,7 +69,7 @@ public class TelemetryAPITest extends FATServletClient {
                         .addClass(CommonSDKServlet.class);
 
         ShrinkHelper.exportAppToServer(server, apiTestWar, SERVER_ONLY);
-
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryBeanTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryBeanTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,9 @@
 package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -50,6 +53,7 @@ public class TelemetryBeanTest extends FATServletClient {
                         .addAsResource(new StringAsset("otel.sdk.disabled=false"),
                                        "META-INF/microprofile-config.properties");
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryBeanTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryBeanTest.java
@@ -14,8 +14,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -53,7 +51,6 @@ public class TelemetryBeanTest extends FATServletClient {
                         .addAsResource(new StringAsset("otel.sdk.disabled=false"),
                                        "META-INF/microprofile-config.properties");
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvOnlyTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvOnlyTest.java
@@ -11,8 +11,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -55,7 +53,6 @@ public class TelemetryConfigEnvOnlyTest extends FATServletClient {
         // This tests that we do pick up config properties which are _only_ defined in the environment, using a format which MP Config only accepts for environment variables.
         server.addEnvVar("otel_service_name", "overrideDone");
         server.addEnvVar("otel_sdk_disabled", "false");
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvOnlyTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvOnlyTest.java
@@ -11,6 +11,9 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -52,6 +55,7 @@ public class TelemetryConfigEnvOnlyTest extends FATServletClient {
         // This tests that we do pick up config properties which are _only_ defined in the environment, using a format which MP Config only accepts for environment variables.
         server.addEnvVar("otel_service_name", "overrideDone");
         server.addEnvVar("otel_sdk_disabled", "false");
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvTest.java
@@ -11,8 +11,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -55,7 +53,6 @@ public class TelemetryConfigEnvTest extends FATServletClient {
         //These variables take priority
         server.addEnvVar("OTEL_SERVICE_NAME", "overrideDone");
         server.addEnvVar("OTEL_SDK_DISABLED", "false");
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvTest.java
@@ -11,6 +11,9 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -52,6 +55,7 @@ public class TelemetryConfigEnvTest extends FATServletClient {
         //These variables take priority
         server.addEnvVar("OTEL_SERVICE_NAME", "overrideDone");
         server.addEnvVar("OTEL_SDK_DISABLED", "false");
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigNullTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigNullTest.java
@@ -11,8 +11,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -57,7 +55,6 @@ public class TelemetryConfigNullTest extends FATServletClient {
         // This is not ideal and is a current limitation, but we still want to test the scenario to ensure we don't throw an exception when processing config
         server.addEnvVar("otel_service_name", "overrideDone");
         server.addEnvVar("otel_sdk_disabled", "false");
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigNullTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigNullTest.java
@@ -11,6 +11,9 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -54,6 +57,7 @@ public class TelemetryConfigNullTest extends FATServletClient {
         // This is not ideal and is a current limitation, but we still want to test the scenario to ensure we don't throw an exception when processing config
         server.addEnvVar("otel_service_name", "overrideDone");
         server.addEnvVar("otel_sdk_disabled", "false");
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigServerVarTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigServerVarTest.java
@@ -11,8 +11,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -55,7 +53,6 @@ public class TelemetryConfigServerVarTest extends FATServletClient {
         //Set for testing purposes. The variables in the server.xml should override these variables.
         server.addEnvVar("OTEL_SERVICE_NAME", "overrideThisEnvVar");
         server.addEnvVar("OTEL_SDK_DISABLED", "true");
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigServerVarTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigServerVarTest.java
@@ -11,6 +11,9 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -52,6 +55,7 @@ public class TelemetryConfigServerVarTest extends FATServletClient {
         //Set for testing purposes. The variables in the server.xml should override these variables.
         server.addEnvVar("OTEL_SERVICE_NAME", "overrideThisEnvVar");
         server.addEnvVar("OTEL_SDK_DISABLED", "true");
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigSystemPropTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigSystemPropTest.java
@@ -11,6 +11,9 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -52,6 +55,7 @@ public class TelemetryConfigSystemPropTest extends FATServletClient {
         // These should be overridden by the values in bootstrap.properties
         server.addEnvVar("OTEL_SERVICE_NAME", "overrideThisEnvVar");
         server.addEnvVar("OTEL_SDK_DISABLED", "true");
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigSystemPropTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigSystemPropTest.java
@@ -11,8 +11,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -55,7 +53,6 @@ public class TelemetryConfigSystemPropTest extends FATServletClient {
         // These should be overridden by the values in bootstrap.properties
         server.addEnvVar("OTEL_SERVICE_NAME", "overrideThisEnvVar");
         server.addEnvVar("OTEL_SDK_DISABLED", "true");
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLoggingExporterTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLoggingExporterTest.java
@@ -13,6 +13,9 @@ import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONL
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -48,6 +51,8 @@ public class TelemetryLoggingExporterTest extends FATServletClient {
 
         //Use logging exporter
         server.addEnvVar("otel_traces_exporter", "logging");
+
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLoggingExporterTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLoggingExporterTest.java
@@ -13,8 +13,6 @@ import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONL
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -52,7 +50,6 @@ public class TelemetryLoggingExporterTest extends FATServletClient {
         //Use logging exporter
         server.addEnvVar("otel_traces_exporter", "logging");
 
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLongRunningTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLongRunningTest.java
@@ -15,6 +15,8 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -58,6 +60,8 @@ public class TelemetryLongRunningTest extends FATServletClient {
                                        "META-INF/microprofile-config.properties");
 
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
+
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLongRunningTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLongRunningTest.java
@@ -15,8 +15,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -61,7 +59,6 @@ public class TelemetryLongRunningTest extends FATServletClient {
 
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
 
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMisconfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMisconfigTest.java
@@ -12,6 +12,9 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static org.junit.Assert.assertFalse;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -118,6 +121,7 @@ public class TelemetryMisconfigTest extends FATServletClient {
 
         ShrinkHelper.exportAppToServer(server, doesNotExistEndpointApp, SERVER_ONLY);
 
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMisconfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMisconfigTest.java
@@ -12,8 +12,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static org.junit.Assert.assertFalse;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -121,7 +119,6 @@ public class TelemetryMisconfigTest extends FATServletClient {
 
         ShrinkHelper.exportAppToServer(server, doesNotExistEndpointApp, SERVER_ONLY);
 
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMultiAppTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMultiAppTest.java
@@ -14,8 +14,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -91,7 +89,6 @@ public class TelemetryMultiAppTest extends FATServletClient {
 
         server.addEnvVar("OTEL_SDK_DISABLED", "false");
         server.addEnvVar("OTEL_BSP_SCHEDULE_DELAY", "100");
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMultiAppTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMultiAppTest.java
@@ -14,6 +14,9 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -88,6 +91,7 @@ public class TelemetryMultiAppTest extends FATServletClient {
 
         server.addEnvVar("OTEL_SDK_DISABLED", "false");
         server.addEnvVar("OTEL_BSP_SCHEDULE_DELAY", "100");
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
@@ -14,8 +14,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -61,7 +59,6 @@ public class TelemetryServiceNameTest extends FATServletClient {
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class);
 
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
@@ -14,6 +14,9 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -58,6 +61,7 @@ public class TelemetryServiceNameTest extends FATServletClient {
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class);
 
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
@@ -14,8 +14,6 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -148,7 +146,6 @@ public class TelemetrySpiTest extends FATServletClient {
 
         server.addEnvVar("OTEL_SDK_DISABLED", "false");
         server.addEnvVar("OTEL_BSP_SCHEDULE_DELAY", "100");
-        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
@@ -14,6 +14,9 @@ package io.openliberty.microprofile.telemetry.internal_fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -145,6 +148,7 @@ public class TelemetrySpiTest extends FATServletClient {
 
         server.addEnvVar("OTEL_SDK_DISABLED", "false");
         server.addEnvVar("OTEL_BSP_SCHEDULE_DELAY", "100");
+        server.setJvmOptions(new ArrayList<>(Arrays.asList("-Dio.opentelemetry.context.enableStrictContext=true")));
         server.startServer();
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/api/ContextAPIServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/api/ContextAPIServlet.java
@@ -90,12 +90,12 @@ public class ContextAPIServlet extends FATServlet {
     public void testContextStorage() {
         ContextStorage storage = ContextStorage.get();
         Context context = Context.current();
-        Scope scope = storage.attach(context);
-        assertNotNull(scope);
-        assertNotSame(Scope.noop(), scope);
-        Context stored = storage.current();
-        assertEquals(context, stored);
-        scope.close();
+        try(Scope scope = storage.attach(context)){
+            assertNotNull(scope);
+            assertNotSame(Scope.noop(), scope);
+            Context stored = storage.current();
+            assertEquals(context, stored);
+        }
     }
 
     /**
@@ -107,12 +107,12 @@ public class ContextAPIServlet extends FATServlet {
         ContextStorageProvider provider = new MyContextStorageProvider();
         ContextStorage storage = provider.get();
         Context context = Context.current();
-        Scope scope = storage.attach(context);
-        assertNotNull(scope);
-        assertEquals(Scope.noop(), scope);
-        Context stored = storage.current();
-        assertEquals(context, stored);
-        scope.close();
+        try(Scope scope = storage.attach(context)){
+            assertNotNull(scope);
+            assertEquals(Scope.noop(), scope);
+            Context stored = storage.current();
+            assertEquals(context, stored);
+        }
     }
 
     private static class MyContextStorageProvider implements ContextStorageProvider {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/api/ContextAPIServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/api/ContextAPIServlet.java
@@ -95,6 +95,7 @@ public class ContextAPIServlet extends FATServlet {
         assertNotSame(Scope.noop(), scope);
         Context stored = storage.current();
         assertEquals(context, stored);
+        scope.close();
     }
 
     /**
@@ -111,6 +112,7 @@ public class ContextAPIServlet extends FATServlet {
         assertEquals(Scope.noop(), scope);
         Context stored = storage.current();
         assertEquals(context, stored);
+        scope.close();
     }
 
     private static class MyContextStorageProvider implements ContextStorageProvider {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/bean/TelemetryBeanTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/bean/TelemetryBeanTestServlet.java
@@ -61,7 +61,6 @@ public class TelemetryBeanTestServlet extends FATServlet {
                         span.getSpanContext().equals(spanTwo.getSpanContext()));
             assertEquals("The current span was not the one we created and invoked makeCurrent() with", newSpan.getSpanContext(), spanTwo.getSpanContext());
             assertEquals("The injected span was not the same as the current span after calling makeCurrent()", spanTwo.getSpanContext(), injectedSpan.getSpanContext());
-            s.close();
         } finally {
             newSpan.end();
         }
@@ -84,7 +83,6 @@ public class TelemetryBeanTestServlet extends FATServlet {
             assertEquals("Didn't find expected value in injected baggage", "bar", injectedBaggage.getEntryValue("foo"));
             assertEquals("The current baggage was not the one we created and invoked makeCurrent() with", newBaggage.asMap(), baggageTwo.asMap());
             assertEquals("The injected baggage was not the same as the current baggage after calling makeCurrent()", baggageTwo.asMap(), injectedBaggage.asMap());
-            s.close();
         }
 
     }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/context/MultiThreadedContextServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/context/MultiThreadedContextServlet.java
@@ -59,7 +59,6 @@ public class MultiThreadedContextServlet extends FATServlet {
 
             //check that the baggage was not modified by the sub-task
             assertCurrentBaggage(MY_KEY_1, MY_VALUE_1);
-            s.close();
         }
     }
 
@@ -77,7 +76,6 @@ public class MultiThreadedContextServlet extends FATServlet {
 
             //check that the baggage was not modified by the sub-task
             assertCurrentBaggage(MY_KEY_1, MY_VALUE_1);
-            s.close();
         }
     }
 
@@ -99,7 +97,6 @@ public class MultiThreadedContextServlet extends FATServlet {
 
             //check that the baggage of the current context was not modified by the sub-task
             assertCurrentBaggage(MY_KEY_1, MY_VALUE_1);
-            s.close();
         }
     }
 
@@ -124,7 +121,6 @@ public class MultiThreadedContextServlet extends FATServlet {
 
             //check that the baggage of the current context was not modified by the sub-task
             assertCurrentBaggage(MY_KEY_1, MY_VALUE_1);
-            s.close();
         }
     }
 
@@ -180,10 +176,8 @@ public class MultiThreadedContextServlet extends FATServlet {
 
                     //check that the new baggage is in the current context
                     assertCurrentBaggage(key, MY_VALUE_3);
-                    s.close();
                 }
             }
-
             return results;
         }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/context/MultiThreadedContextServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/context/MultiThreadedContextServlet.java
@@ -26,6 +26,7 @@ import componenttest.app.FATServlet;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import jakarta.annotation.Resource;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -48,75 +49,83 @@ public class MultiThreadedContextServlet extends FATServlet {
     @Test
     public void testContextTaskWrapping() throws InterruptedException, ExecutionException, TimeoutException {
         //add some baggage to the current context
-        addBaggage(MY_KEY_1, MY_VALUE_1);
+        try (Scope s = addBaggage(MY_KEY_1, MY_VALUE_1)) {
 
-        // execute my async sub-task
-        ExecutorService executorService = Context.taskWrapping(managedExecutorService);
-        Future<Map<String, String>> future = executorService.submit(new GetBaggageValueCallable(MY_KEY_1));
-        Map<String, String> baggageValues = future.get(5, TimeUnit.SECONDS);
-        assertEquals(MY_VALUE_1, baggageValues.get(MY_KEY_1));
+            // execute my async sub-task
+            ExecutorService executorService = Context.taskWrapping(managedExecutorService);
+            Future<Map<String, String>> future = executorService.submit(new GetBaggageValueCallable(MY_KEY_1));
+            Map<String, String> baggageValues = future.get(5, TimeUnit.SECONDS);
+            assertEquals(MY_VALUE_1, baggageValues.get(MY_KEY_1));
 
-        //check that the baggage was not modified by the sub-task
-        assertCurrentBaggage(MY_KEY_1, MY_VALUE_1);
+            //check that the baggage was not modified by the sub-task
+            assertCurrentBaggage(MY_KEY_1, MY_VALUE_1);
+            s.close();
+        }
     }
 
     @Test
     public void testCurrentContextWrap() throws InterruptedException, ExecutionException, TimeoutException {
         //add some baggage to the current context
-        addBaggage(MY_KEY_1, MY_VALUE_1);
+        try (Scope s = addBaggage(MY_KEY_1, MY_VALUE_1)) {
 
-        // execute my async sub-task
-        Context context = Context.current();
-        ExecutorService executorService = context.wrap(managedExecutorService);
-        Future<Map<String, String>> future = executorService.submit(new GetBaggageValueCallable(MY_KEY_1));
-        Map<String, String> baggageValues = future.get(5, TimeUnit.SECONDS);
-        assertEquals(MY_VALUE_1, baggageValues.get(MY_KEY_1));
+            // execute my async sub-task
+            Context context = Context.current();
+            ExecutorService executorService = context.wrap(managedExecutorService);
+            Future<Map<String, String>> future = executorService.submit(new GetBaggageValueCallable(MY_KEY_1));
+            Map<String, String> baggageValues = future.get(5, TimeUnit.SECONDS);
+            assertEquals(MY_VALUE_1, baggageValues.get(MY_KEY_1));
 
-        //check that the baggage was not modified by the sub-task
-        assertCurrentBaggage(MY_KEY_1, MY_VALUE_1);
+            //check that the baggage was not modified by the sub-task
+            assertCurrentBaggage(MY_KEY_1, MY_VALUE_1);
+            s.close();
+        }
     }
 
     @Test
     public void testNewContextWrap() throws InterruptedException, ExecutionException, TimeoutException {
         //add some baggage to the current context
-        addBaggage(MY_KEY_1, MY_VALUE_1);
+        try(Scope s = addBaggage(MY_KEY_1, MY_VALUE_1)){
 
-        //create a new context with a different value in (should not contain MY_KEY_1)
-        Context context = newContextWithBaggage(MY_KEY_2, MY_VALUE_2);
-        // execute my async sub-task
-        ExecutorService executorService = context.wrap(managedExecutorService);
-        Future<Map<String, String>> future = executorService.submit(new GetBaggageValueCallable(MY_KEY_1, MY_KEY_2));
-        Map<String, String> baggageValues = future.get(5, TimeUnit.SECONDS);
-        //check that the value for MY_KEY_1 was null (from the new context)
-        assertEquals(null, baggageValues.get(MY_KEY_1));
-        //check that the value for MY_KEY_1 was MY_VALUE_2 (from the new context)
-        assertEquals(MY_VALUE_2, baggageValues.get(MY_KEY_2));
+            //create a new context with a different value in (should not contain MY_KEY_1)
+            Context context = newContextWithBaggage(MY_KEY_2, MY_VALUE_2);
+            // execute my async sub-task
+            ExecutorService executorService = context.wrap(managedExecutorService);
+            Future<Map<String, String>> future = executorService.submit(new GetBaggageValueCallable(MY_KEY_1, MY_KEY_2));
+            Map<String, String> baggageValues = future.get(5, TimeUnit.SECONDS);
+            //check that the value for MY_KEY_1 was null (from the new context)
+            assertEquals(null, baggageValues.get(MY_KEY_1));
+            //check that the value for MY_KEY_1 was MY_VALUE_2 (from the new context)
+            assertEquals(MY_VALUE_2, baggageValues.get(MY_KEY_2));
 
-        //check that the baggage of the current context was not modified by the sub-task
-        assertCurrentBaggage(MY_KEY_1, MY_VALUE_1);
+            //check that the baggage of the current context was not modified by the sub-task
+            assertCurrentBaggage(MY_KEY_1, MY_VALUE_1);
+            s.close();
+        }
     }
 
     @Test
     public void testNewContextWrapCallable() throws InterruptedException, ExecutionException, TimeoutException {
         //add some baggage to the current context
-        addBaggage(MY_KEY_1, MY_VALUE_1);
+        try(Scope s = addBaggage(MY_KEY_1, MY_VALUE_1)){
 
-        //create a new context with a different value in (should not contain MY_KEY_1)
-        Context context = newContextWithBaggage(MY_KEY_2, MY_VALUE_2);
+            //create a new context with a different value in (should not contain MY_KEY_1)
+            Context context = newContextWithBaggage(MY_KEY_2, MY_VALUE_2);
 
-        //only wrap this one callable
-        Callable<Map<String, String>> callable = new GetBaggageValueCallable(MY_KEY_1, MY_KEY_2);
-        callable = context.wrap(callable);
-        // execute my async sub-task
-        Future<Map<String, String>> future = managedExecutorService.submit(callable);
-        Map<String, String> baggageValues = future.get(5, TimeUnit.SECONDS);
-        //check that the value for MY_KEY_1 was null (from the new context)
-        assertEquals(null, baggageValues.get(MY_KEY_1));
-        //check that the value for MY_KEY_1 was MY_VALUE_2 (from the new context)
-        assertEquals(MY_VALUE_2, baggageValues.get(MY_KEY_2));
+            //only wrap this one callable
+            Callable<Map<String, String>> callable = new GetBaggageValueCallable(MY_KEY_1, MY_KEY_2);
+            callable = context.wrap(callable);
+            // execute my async sub-task
+            Future<Map<String, String>> future = managedExecutorService.submit(callable);
+            Map<String, String> baggageValues = future.get(5, TimeUnit.SECONDS);
+            //check that the value for MY_KEY_1 was null (from the new context)
+            assertEquals(null, baggageValues.get(MY_KEY_1));
+            //check that the value for MY_KEY_1 was MY_VALUE_2 (from the new context)
+            assertEquals(MY_VALUE_2, baggageValues.get(MY_KEY_2));
 
-        //check that the baggage of the current context was not modified by the sub-task
-        assertCurrentBaggage(MY_KEY_1, MY_VALUE_1);
+            //check that the baggage of the current context was not modified by the sub-task
+            assertCurrentBaggage(MY_KEY_1, MY_VALUE_1);
+            s.close();
+        }
     }
 
     //check that the current context contains baggage with a certain value
@@ -127,11 +136,11 @@ public class MultiThreadedContextServlet extends FATServlet {
     }
 
     //create a new current context by adding some baggage to the existing current context
-    private static void addBaggage(String key, String value) {
+    private static Scope addBaggage(String key, String value) {
         BaggageBuilder builder = Baggage.builder();
         builder.put(key, value);
         Baggage baggage = builder.build();
-        baggage.makeCurrent();
+        return baggage.makeCurrent();
     }
 
     //create a new context by adding some baggage to the root context
@@ -167,10 +176,12 @@ public class MultiThreadedContextServlet extends FATServlet {
 
                 //create a new baggage and make a new current context with it
                 //this new context should not affect the original one
-                addBaggage(key, MY_VALUE_3);
+                try (Scope s = addBaggage(key, MY_VALUE_3)) {
 
-                //check that the new baggage is in the current context
-                assertCurrentBaggage(key, MY_VALUE_3);
+                    //check that the new baggage is in the current context
+                    assertCurrentBaggage(key, MY_VALUE_3);
+                    s.close();
+                }
             }
 
             return results;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/JaxRsEndpoints.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/JaxRsEndpoints.java
@@ -190,11 +190,10 @@ public class JaxRsEndpoints extends Application {
                             .request(MediaType.TEXT_PLAIN)
                             .get(String.class);
             assertEquals(TEST_PASSED, result);
-            s.close();
         } finally {
             LOGGER.info("<<< getJax");
-            return Response.ok(Span.current().getSpanContext().getTraceId()).build();
         }
+        return Response.ok(Span.current().getSpanContext().getTraceId()).build();
     }
 
     //This URL is called by the test framework to trigger testing for calling JAX-RS client in Asnyc.
@@ -229,8 +228,8 @@ public class JaxRsEndpoints extends Application {
 
         } finally {
             LOGGER.info("<<< getJax");
-            return Response.ok(Span.current().getSpanContext().getTraceId()).build();
         }
+        return Response.ok(Span.current().getSpanContext().getTraceId()).build();
     }
 
     //A method to be called by JAX Clients
@@ -277,8 +276,9 @@ public class JaxRsEndpoints extends Application {
             assertEquals(TEST_PASSED, result);
         } finally {
             LOGGER.info("<<< getMP");
-            return Response.ok(Span.current().getSpanContext().getTraceId()).build();
         }
+        return Response.ok(Span.current().getSpanContext().getTraceId()).build();
+        
     }
 
     //This method is called via mpClient from the entry methods.
@@ -335,10 +335,8 @@ public class JaxRsEndpoints extends Application {
             assertEquals(TEST_PASSED, result);
 
             LOGGER.info("<<< getMPAsync");
-            s.close();
-        } finally {
-            return Response.ok(Span.current().getSpanContext().getTraceId()).build();
         }
+        return Response.ok(Span.current().getSpanContext().getTraceId()).build();
     }
 
     @RegisterRestClient

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/JaxRsEndpoints.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/JaxRsEndpoints.java
@@ -41,6 +41,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -178,20 +179,22 @@ public class JaxRsEndpoints extends Application {
         LOGGER.info(">>> getJax");
         assertNotNull(Span.current());
 
-        Baggage.builder().put("foo", "bar").build().makeCurrent();
-        Baggage baggage = Baggage.current();
-        assertEquals("bar", baggage.getEntryValue("foo"));
+        try (Scope s = Baggage.builder().put("foo", "bar").build().makeCurrent()) {
+            Baggage baggage = Baggage.current();
+            assertEquals("bar", baggage.getEntryValue("foo"));
 
-        String url = new String(uriInfo.getAbsolutePath().toString());
-        url = url.replace("jaxrsclient", "jaxrstwo"); //The jaxrsclient will use the URL as given so it needs the final part to be provided.
+            String url = new String(uriInfo.getAbsolutePath().toString());
+            url = url.replace("jaxrsclient", "jaxrstwo"); //The jaxrsclient will use the URL as given so it needs the final part to be provided.
 
-        String result = client.target(url)
-                        .request(MediaType.TEXT_PLAIN)
-                        .get(String.class);
-        assertEquals(TEST_PASSED, result);
-
-        LOGGER.info("<<< getJax");
-        return Response.ok(Span.current().getSpanContext().getTraceId()).build();
+            String result = client.target(url)
+                            .request(MediaType.TEXT_PLAIN)
+                            .get(String.class);
+            assertEquals(TEST_PASSED, result);
+            s.close();
+        } finally {
+            LOGGER.info("<<< getJax");
+            return Response.ok(Span.current().getSpanContext().getTraceId()).build();
+        }
     }
 
     //This URL is called by the test framework to trigger testing for calling JAX-RS client in Asnyc.
@@ -202,30 +205,32 @@ public class JaxRsEndpoints extends Application {
         LOGGER.info(">>> getJaxAsync");
         assertNotNull(Span.current());
 
-        Baggage.builder().put("foo", "bar").build().makeCurrent();
-        Baggage baggage = Baggage.current();
-        assertEquals("bar", baggage.getEntryValue("foo"));
+        try (Scope s = Baggage.builder().put("foo", "bar").build().makeCurrent()) {
+            Baggage baggage = Baggage.current();
+            assertEquals("bar", baggage.getEntryValue("foo"));
 
-        String url = new String(uriInfo.getAbsolutePath().toString());
-        url = url.replace("jaxrsclientasync", "jaxrstwo"); //The jaxrsclient will use the URL as given so it needs the final part to be provided.
+            String url = new String(uriInfo.getAbsolutePath().toString());
+            url = url.replace("jaxrsclientasync", "jaxrstwo"); //The jaxrsclient will use the URL as given so it needs the final part to be provided.
 
-        Client client = ClientBuilder.newClient();
-        Future<String> result = client.target(url)
-                        .request(MediaType.TEXT_PLAIN)
-                        .async()
-                        .get(String.class);
+            Client client = ClientBuilder.newClient();
+            Future<String> result = client.target(url)
+                            .request(MediaType.TEXT_PLAIN)
+                            .async()
+                            .get(String.class);
 
-        try {
-            String resultValue = result.get(10, SECONDS);
-            assertEquals(TEST_PASSED, resultValue);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+            try {
+                String resultValue = result.get(10, SECONDS);
+                assertEquals(TEST_PASSED, resultValue);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                client.close();
+            }
+
         } finally {
-            client.close();
+            LOGGER.info("<<< getJax");
+            return Response.ok(Span.current().getSpanContext().getTraceId()).build();
         }
-
-        LOGGER.info("<<< getJaxAsync");
-        return Response.ok(Span.current().getSpanContext().getTraceId()).build();
     }
 
     //A method to be called by JAX Clients
@@ -251,28 +256,29 @@ public class JaxRsEndpoints extends Application {
         LOGGER.info(">>> getMP");
         assertNotNull(Span.current());
 
-        Baggage.builder().put("foo", "bar").build().makeCurrent();
-        Baggage baggage = Baggage.current();
-        assertEquals("bar", baggage.getEntryValue("foo"));
+        try (Scope s = Baggage.builder().put("foo", "bar").build().makeCurrent()) {
+            Baggage baggage = Baggage.current();
+            assertEquals("bar", baggage.getEntryValue("foo"));
 
-        String baseUrl = uriInfo.getAbsolutePath().toString().replace("/mpclient", ""); //The mpclient will add the final part of the URL for you, so we remove the final part.
-        URI baseUri = null;
-        try {
-            baseUri = new URI(baseUrl);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+            String baseUrl = uriInfo.getAbsolutePath().toString().replace("/mpclient", ""); //The mpclient will add the final part of the URL for you, so we remove the final part.
+            URI baseUri = null;
+            try {
+                baseUri = new URI(baseUrl);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            assertNotNull(Span.current());
+            MPTwo two = RestClientBuilder.newBuilder()
+                            .baseUri(baseUri)
+                            .build(MPTwo.class);
+
+            String result = two.getMPTwo();
+            assertEquals(TEST_PASSED, result);
+        } finally {
+            LOGGER.info("<<< getMP");
+            return Response.ok(Span.current().getSpanContext().getTraceId()).build();
         }
-
-        assertNotNull(Span.current());
-        MPTwo two = RestClientBuilder.newBuilder()
-                        .baseUri(baseUri)
-                        .build(MPTwo.class);
-
-        String result = two.getMPTwo();
-        assertEquals(TEST_PASSED, result);
-
-        LOGGER.info("<<< getMP");
-        return Response.ok(Span.current().getSpanContext().getTraceId()).build();
     }
 
     //This method is called via mpClient from the entry methods.
@@ -307,28 +313,32 @@ public class JaxRsEndpoints extends Application {
         LOGGER.info(">>> getMPAsync");
         assertNotNull(Span.current());
 
-        Baggage.builder().put("foo", "bar").build().makeCurrent();
-        Baggage baggage = Baggage.current();
-        assertEquals("bar", baggage.getEntryValue("foo"));
+        try (Scope s = Baggage.builder().put("foo", "bar").build().makeCurrent()) {
 
-        String baseUrl = uriInfo.getAbsolutePath().toString().replace("/mpclientasync", ""); //The mpclient will add the final part of the URL for you, so we remove the final part.
-        URI baseUri = null;
-        try {
-            baseUri = new URI(baseUrl);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+            Baggage baggage = Baggage.current();
+            assertEquals("bar", baggage.getEntryValue("foo"));
+
+            String baseUrl = uriInfo.getAbsolutePath().toString().replace("/mpclientasync", ""); //The mpclient will add the final part of the URL for you, so we remove the final part.
+            URI baseUri = null;
+            try {
+                baseUri = new URI(baseUrl);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            assertNotNull(Span.current());
+            MPTwoAsync two = RestClientBuilder.newBuilder()
+                            .baseUri(baseUri)
+                            .build(MPTwoAsync.class);
+
+            String result = two.getMPTwo().toCompletableFuture().join();
+            assertEquals(TEST_PASSED, result);
+
+            LOGGER.info("<<< getMPAsync");
+            s.close();
+        } finally {
+            return Response.ok(Span.current().getSpanContext().getTraceId()).build();
         }
-
-        assertNotNull(Span.current());
-        MPTwoAsync two = RestClientBuilder.newBuilder()
-                        .baseUri(baseUri)
-                        .build(MPTwoAsync.class);
-
-        String result = two.getMPTwo().toCompletableFuture().join();
-        assertEquals(TEST_PASSED, result);
-
-        LOGGER.info("<<< getMPAsync");
-        return Response.ok(Span.current().getSpanContext().getTraceId()).build();
     }
 
     @RegisterRestClient

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3MultiPropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3MultiPropagationTestServlet.java
@@ -31,6 +31,7 @@ import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -59,9 +60,11 @@ public class B3MultiPropagationTestServlet extends FATServlet {
     public void testB3Propagation() throws URISyntaxException {
         Span span = testSpans.withTestSpan(() -> {
             Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
-            baggage.makeCurrent();
-            PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
-            client.get();
+            try (Scope s = baggage.makeCurrent()) {
+                PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+                client.get();
+                s.close();
+            }
         });
 
         List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3MultiPropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3MultiPropagationTestServlet.java
@@ -63,7 +63,6 @@ public class B3MultiPropagationTestServlet extends FATServlet {
             try (Scope s = baggage.makeCurrent()) {
                 PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
                 client.get();
-                s.close();
             }
         });
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3PropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3PropagationTestServlet.java
@@ -63,7 +63,6 @@ public class B3PropagationTestServlet extends FATServlet {
             try (Scope s = baggage.makeCurrent()) {
                 PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
                 client.get();
-                s.close();
             }
         });
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3PropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/B3PropagationTestServlet.java
@@ -31,6 +31,7 @@ import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -59,9 +60,11 @@ public class B3PropagationTestServlet extends FATServlet {
     public void testB3Propagation() throws URISyntaxException {
         Span span = testSpans.withTestSpan(() -> {
             Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
-            baggage.makeCurrent();
-            PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
-            client.get();
+            try (Scope s = baggage.makeCurrent()) {
+                PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+                client.get();
+                s.close();
+            }
         });
 
         List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/JaegerPropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/JaegerPropagationTestServlet.java
@@ -63,7 +63,6 @@ public class JaegerPropagationTestServlet extends FATServlet {
             try (Scope s = baggage.makeCurrent()) {
                 PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
                 client.get();
-                s.close();
             }
         });
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/JaegerPropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/JaegerPropagationTestServlet.java
@@ -31,6 +31,7 @@ import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -59,9 +60,11 @@ public class JaegerPropagationTestServlet extends FATServlet {
     public void testJaegerPropagation() throws URISyntaxException {
         Span span = testSpans.withTestSpan(() -> {
             Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
-            baggage.makeCurrent();
-            PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
-            client.get();
+            try (Scope s = baggage.makeCurrent()) {
+                PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+                client.get();
+                s.close();
+            }
         });
 
         List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTraceBaggagePropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTraceBaggagePropagationTestServlet.java
@@ -31,6 +31,7 @@ import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -59,9 +60,11 @@ public class W3CTraceBaggagePropagationTestServlet extends FATServlet {
     public void testW3cTraceBaggagePropagation() throws URISyntaxException {
         Span span = testSpans.withTestSpan(() -> {
             Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
-            baggage.makeCurrent();
-            PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
-            client.get();
+            try (Scope s = baggage.makeCurrent()) {
+                PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+                client.get();
+                s.close();
+            }
         });
 
         List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTraceBaggagePropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTraceBaggagePropagationTestServlet.java
@@ -63,7 +63,6 @@ public class W3CTraceBaggagePropagationTestServlet extends FATServlet {
             try (Scope s = baggage.makeCurrent()) {
                 PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
                 client.get();
-                s.close();
             }
         });
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTracePropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTracePropagationTestServlet.java
@@ -63,7 +63,6 @@ public class W3CTracePropagationTestServlet extends FATServlet {
             try (Scope s = baggage.makeCurrent()) {
                 PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
                 client.get();
-                s.close();
             }
         });
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTracePropagationTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/transports/W3CTracePropagationTestServlet.java
@@ -31,6 +31,7 @@ import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -59,9 +60,11 @@ public class W3CTracePropagationTestServlet extends FATServlet {
     public void testW3cTracePropagation() throws URISyntaxException {
         Span span = testSpans.withTestSpan(() -> {
             Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
-            baggage.makeCurrent();
-            PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
-            client.get();
+            try (Scope s = baggage.makeCurrent()) {
+                PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+                client.get();
+                s.close();
+            }
         });
 
         List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/propagator/PropagatorTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/propagator/PropagatorTestServlet.java
@@ -73,7 +73,6 @@ public class PropagatorTestServlet extends FATServlet {
                 // Call PropagatorTarget (below)
                 String result = ClientBuilder.newClient().target(getTargetURI()).request().get(String.class);
                 assertEquals("OK", result);
-                s.close();
             }
         });
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Api/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Api/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Bean/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Bean/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10ConfigEnv/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10ConfigEnv/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10ConfigNull/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10ConfigNull/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10ConfigServerVar/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10ConfigServerVar/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10ConfigSystemProp/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10ConfigSystemProp/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Context/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Context/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Jax/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Jax/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10LongRunning/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10LongRunning/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10MisConfig/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10MisConfig/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10MultiApp/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10MultiApp/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Spi/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Spi/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true


### PR DESCRIPTION
For #24176

- Enables strict context checking for the Telemetry FAT tests. 
- Closes the Scope when baggage.makeCurrent() or context.makeCurrent() are called.