### PR TITLE
uncomment test on CBH older version

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/FATSuite.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/FATSuite.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,8 +18,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-//comment out temporarily
-//import com.ibm.ws.wssecurity.fat.cxf.caller.CxfCallerUNTCBHPackageTests;
+import com.ibm.ws.wssecurity.fat.cxf.caller.CxfCallerUNTCBHPackageTests;
 import com.ibm.ws.wssecurity.fat.cxf.caller.CxfCallerUNTTests;
 import com.ibm.ws.wssecurity.fat.cxf.usernametoken.CxfSSLUNTBasicTests;
 import com.ibm.ws.wssecurity.fat.cxf.usernametoken.CxfSSLUNTNonceTests;
@@ -42,8 +41,7 @@ import componenttest.rules.repeater.RepeatTests;
 
                 //Full for EE7-wsseccbh-1.0 (also old ehcache) and EE7-wsseccbh-2.0 (also new ehcache)
                 //Full mode also runs Lite tests
-                //CxfCallerUNTCBHPackageTests.class,
-                //comment out temporarily until runtime update for bnd.overrides is ready; check back in Jan. 2023
+                CxfCallerUNTCBHPackageTests.class,
                 CxfSSLUNTNonceTimeOutTests.class,
                 CxfSSLUNTBasicTests.class,
                 CxfWssTemplatesTestsWithWSDL.class,

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTCBHPackageTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTCBHPackageTests.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -159,9 +159,11 @@ public class CxfCallerUNTCBHPackageTests {
                         "" // Password; original "test2"; null password as intended
             );
         } catch (Exception e) {
-            Log.info(thisClass, thisMethod, "In test method testCxfCallerHttpsPolicy, exception occurred as expected: " + e);
-            String result = server.waitForStringInLog("java.lang.IncompatibleClassChangeError: org/apache/ws/security/WSPasswordCallback");
-            Log.info(thisClass, thisMethod, "Searching for: " + result);
+            Log.info(thisClass, thisMethod, "In test method testCxfCallerHttpsPolicy, exception occurred: " + e);
+            //The exception results to HTTP request error 500 status code as expected.  Next do the search for error messagee in server log.
+            Log.info(thisClass, thisMethod, "Searching the input string 'java.lang.IncompatibleClassChangeError' in the log");
+            String result = server.waitForStringInLog("java.lang.IncompatibleClassChangeError");
+            Log.info(thisClass, thisMethod, "The search result is: " + result);
             if (result == null) {
                 Log.info(thisClass, thisMethod, "The message '...IncompatibleClassChangeError...' is not found ");
                 throw e;


### PR DESCRIPTION
Enable the new test case to cover customer usage scenario when older version of callbackhandler class is detected.
https://github.com/OpenLiberty/open-liberty/issues/23599