### PR TITLE
JAX-WS: Add logging BasicAuthWithoutSSL to help debug future failures

### DIFF
--- a/dev/io.openliberty.jaxws.security_fat/fat/src/com/ibm/ws/jaxws/security/fat/BasicAuthWithoutSSLTest.java
+++ b/dev/io.openliberty.jaxws.security_fat/fat/src/com/ibm/ws/jaxws/security/fat/BasicAuthWithoutSSLTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,6 +14,7 @@ package com.ibm.ws.jaxws.security.fat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -29,189 +30,182 @@ import componenttest.custom.junit.runner.Mode;
 @RunWith(FATRunner.class)
 public class BasicAuthWithoutSSLTest extends AbstractJaxWsTransportSecurityTest {
 
-	protected static final String SERVER_CONFIG_FILE_NAME = "basicAuthWithoutSSL.xml";
+    private static final Logger LOG = Logger.getLogger(BasicAuthWithoutSSLTest.class.getName());
 
-	@BeforeClass
-	public static void beforeAllTests() throws Exception {
-		buildDefaultApps();
+    protected static final String SERVER_CONFIG_FILE_NAME = "basicAuthWithoutSSL.xml";
 
-		updateSingleFileInServerRoot("server.xml", "serverConfigs/" + SERVER_CONFIG_FILE_NAME);
-		lastServerConfig = "serverConfigs/" + SERVER_CONFIG_FILE_NAME;
+    @BeforeClass
+    public static void beforeAllTests() throws Exception {
+        buildDefaultApps();
 
-		updateSingleFileInServerRoot(WEB_XML_IN_PROVIDER_WAR, "basicAuthWithoutSSL_provider_web.xml");
+        updateSingleFileInServerRoot("server.xml", "serverConfigs/" + SERVER_CONFIG_FILE_NAME);
+        lastServerConfig = "serverConfigs/" + SERVER_CONFIG_FILE_NAME;
 
-		server.startServer("JaxWsTransportSecurityServer.log");
-		server.setMarkToEndOfLog();
-	}
+        updateSingleFileInServerRoot(WEB_XML_IN_PROVIDER_WAR, "basicAuthWithoutSSL_provider_web.xml");
 
-	@AfterClass
-	public static void afterAllTests() throws Exception {
-		if (server != null && server.isStarted()) {
-			server.stopServer();
-		}
-	}
+        ArrayList<String> fileNames = server.listLibertyServerRoot("apps/TransportSecurityProvider.ear/TransportSecurityProvider.war/WEB-INF", null);
 
-	// Valid name and valid plain password
-	@Test
-	public void testValidNameAndValidPlainPasswordPOJO() throws Exception {
-		updateClientBndFile("bindings/validNameAndValidPlainPwd.xml");
+        for (String i : fileNames) {
+            LOG.info("List of files in app directory: " + i);
+        }
 
-		RequestParams params = new RequestParams("employee", "pojo", "http", server.getHttpDefaultPort(),
-				"/employee/employPojoService");
-		runTest(params, "Hello, employee from SayHelloPojoService", null);
-	}
+        server.startServer("JaxWsTransportSecurityServer.log");
+        server.setMarkToEndOfLog();
+    }
 
-	@Test
-	public void testValidNameAndValidPlainPasswordStateless() throws Exception {
-		updateClientBndFile("bindings/validNameAndValidPlainPwd.xml");
+    @AfterClass
+    public static void afterAllTests() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
 
-		RequestParams params = new RequestParams("employee", "stateless", "http", server.getHttpDefaultPort(),
-				"/employee/employStatelessService");
-		runTest(params, "From other bean: Hello, employee from SayHelloSingletonService", null);
-	}
+    // Valid name and valid plain password
+    @Test
+    public void testValidNameAndValidPlainPasswordPOJO() throws Exception {
+        updateClientBndFile("bindings/validNameAndValidPlainPwd.xml");
 
-	@Test
-	public void testValidNameAndValidPlainPasswordSingleton() throws Exception {
-		updateClientBndFile("bindings/validNameAndValidPlainPwd.xml");
+        RequestParams params = new RequestParams("employee", "pojo", "http", server.getHttpDefaultPort(), "/employee/employPojoService");
+        runTest(params, "Hello, employee from SayHelloPojoService", null);
+    }
 
-		RequestParams params = new RequestParams("employee", "singleton", "http", server.getHttpDefaultPort(),
-				"/employee/employSingletonService");
-		runTest(params, "From other bean: Hello, employee from SayHelloStatelessService", null);
-	}
+    @Test
+    public void testValidNameAndValidPlainPasswordStateless() throws Exception {
+        updateClientBndFile("bindings/validNameAndValidPlainPwd.xml");
 
-	// Valid name but invalid password
-	@Test
-	public void testValidNameButInvalidPasswordPOJO() throws Exception {
-		updateClientBndFile("bindings/validNameButInvalidPwd.xml");
+        RequestParams params = new RequestParams("employee", "stateless", "http", server.getHttpDefaultPort(), "/employee/employStatelessService");
+        runTest(params, "From other bean: Hello, employee from SayHelloSingletonService", null);
+    }
 
-		RequestParams params = new RequestParams("employee", "pojo", "http", server.getHttpDefaultPort(),
-				"/employee/employPojoService");
-		List<String> serverInfos = new ArrayList<String>(1);
-		serverInfos.add("CWWKS1100A.*employee");
-		runTest(params, "401", serverInfos);
-	}
+    @Test
+    public void testValidNameAndValidPlainPasswordSingleton() throws Exception {
+        updateClientBndFile("bindings/validNameAndValidPlainPwd.xml");
 
-	@Test
-	public void testValidNameButInvalidPasswordStateless() throws Exception {
-		updateClientBndFile("bindings/validNameButInvalidPwd.xml");
+        RequestParams params = new RequestParams("employee", "singleton", "http", server.getHttpDefaultPort(), "/employee/employSingletonService");
+        runTest(params, "From other bean: Hello, employee from SayHelloStatelessService", null);
+    }
 
-		RequestParams params = new RequestParams("employee", "stateless", "http", server.getHttpDefaultPort(),
-				"/employee/employStatelessService");
-		List<String> serverInfos = new ArrayList<String>(1);
-		serverInfos.add("CWWKS1100A.*employee");
-		runTest(params, "401", serverInfos);
-	}
+    // Valid name but invalid password
+    @Test
+    public void testValidNameButInvalidPasswordPOJO() throws Exception {
+        updateClientBndFile("bindings/validNameButInvalidPwd.xml");
 
-	@Test
-	public void testValidNameButInvalidPasswordSingleton() throws Exception {
-		updateClientBndFile("bindings/validNameButInvalidPwd.xml");
+        RequestParams params = new RequestParams("employee", "pojo", "http", server.getHttpDefaultPort(), "/employee/employPojoService");
+        List<String> serverInfos = new ArrayList<String>(1);
+        serverInfos.add("CWWKS1100A.*employee");
+        runTest(params, "401", serverInfos);
+    }
 
-		RequestParams params = new RequestParams("employee", "singleton", "http", server.getHttpDefaultPort(),
-				"/employee/employSingletonService");
-		List<String> serverInfos = new ArrayList<String>(1);
-		serverInfos.add("CWWKS1100A.*employee");
-		runTest(params, "401", serverInfos);
-	}
+    @Test
+    public void testValidNameButInvalidPasswordStateless() throws Exception {
+        updateClientBndFile("bindings/validNameButInvalidPwd.xml");
 
-	// Valid name and valid plain password but not authorized
-	@Test
-	public void testValidNameAndValidPlainPasswordButNOTAuthorizedPOJO() throws Exception {
-		updateClientBndFile("bindings/validNameAndValidPlainPwd.xml");
+        RequestParams params = new RequestParams("employee", "stateless", "http", server.getHttpDefaultPort(), "/employee/employStatelessService");
+        List<String> serverInfos = new ArrayList<String>(1);
+        serverInfos.add("CWWKS1100A.*employee");
+        runTest(params, "401", serverInfos);
+    }
 
-		RequestParams params = new RequestParams("employee", "pojo", "http", server.getHttpDefaultPort(),
-				"/manager/employPojoService");
-		List<String> serverInfos = new ArrayList<String>(1);
-		serverInfos.add("CWWKS9104A.*employee");
-		runTest(params, "403", serverInfos);
-	}
+    @Test
+    public void testValidNameButInvalidPasswordSingleton() throws Exception {
+        updateClientBndFile("bindings/validNameButInvalidPwd.xml");
 
-	@Test
-	public void testValidNameAndValidPlainPasswordButNOTAuthorizedStateless() throws Exception {
-		updateClientBndFile("bindings/validNameAndValidPlainPwd.xml");
+        RequestParams params = new RequestParams("employee", "singleton", "http", server.getHttpDefaultPort(), "/employee/employSingletonService");
+        List<String> serverInfos = new ArrayList<String>(1);
+        serverInfos.add("CWWKS1100A.*employee");
+        runTest(params, "401", serverInfos);
+    }
 
-		RequestParams params = new RequestParams("employee", "stateless", "http", server.getHttpDefaultPort(),
-				"/manager/employStatelessService");
-		List<String> serverInfos = new ArrayList<String>(1);
-		serverInfos.add("CWWKS9104A.*employee");
-		runTest(params, "403", serverInfos);
-	}
+    // Valid name and valid plain password but not authorized
+    @Test
+    public void testValidNameAndValidPlainPasswordButNOTAuthorizedPOJO() throws Exception {
+        updateClientBndFile("bindings/validNameAndValidPlainPwd.xml");
 
-	@Test
-	public void testValidNameAndValidPlainPasswordButNOTAuthorizedSingleton() throws Exception {
-		updateClientBndFile("bindings/validNameAndValidPlainPwd.xml");
+        RequestParams params = new RequestParams("employee", "pojo", "http", server.getHttpDefaultPort(), "/manager/employPojoService");
+        List<String> serverInfos = new ArrayList<String>(1);
+        serverInfos.add("CWWKS9104A.*employee");
+        runTest(params, "403", serverInfos);
+    }
 
-		RequestParams params = new RequestParams("employee", "singleton", "http", server.getHttpDefaultPort(),
-				"/manager/employSingletonService");
-		List<String> serverInfos = new ArrayList<String>(1);
-		serverInfos.add("CWWKS9104A.*employee");
-		runTest(params, "403", serverInfos);
-	}
+    @Test
+    public void testValidNameAndValidPlainPasswordButNOTAuthorizedStateless() throws Exception {
+        updateClientBndFile("bindings/validNameAndValidPlainPwd.xml");
 
-	// Valid name and valid encoded password
-	@Test
-	@Mode(Mode.TestMode.FULL)
-	public void testValidNameAndValidEncodedPasswordPOJO() throws Exception {
-		updateClientBndFile("bindings/validNameAndValidEncodedPwd.xml");
+        RequestParams params = new RequestParams("employee", "stateless", "http", server.getHttpDefaultPort(), "/manager/employStatelessService");
+        List<String> serverInfos = new ArrayList<String>(1);
+        serverInfos.add("CWWKS9104A.*employee");
+        runTest(params, "403", serverInfos);
+    }
 
-		RequestParams params = new RequestParams("employee", "pojo", "http", server.getHttpDefaultPort(),
-				"/employee/employPojoService");
-		runTest(params, "Hello, employee from SayHelloPojoService", null);
-	}
+    @Test
+    public void testValidNameAndValidPlainPasswordButNOTAuthorizedSingleton() throws Exception {
+        updateClientBndFile("bindings/validNameAndValidPlainPwd.xml");
 
-	@Test
-	@Mode(Mode.TestMode.FULL)
-	public void testValidNameAndValidEncodedPasswordStateless() throws Exception {
-		updateClientBndFile("bindings/validNameAndValidEncodedPwd.xml");
+        RequestParams params = new RequestParams("employee", "singleton", "http", server.getHttpDefaultPort(), "/manager/employSingletonService");
+        List<String> serverInfos = new ArrayList<String>(1);
+        serverInfos.add("CWWKS9104A.*employee");
+        runTest(params, "403", serverInfos);
+    }
 
-		RequestParams params = new RequestParams("employee", "stateless", "http", server.getHttpDefaultPort(),
-				"/employee/employStatelessService");
-		runTest(params, "From other bean: Hello, employee from SayHelloSingletonService", null);
-	}
+    // Valid name and valid encoded password
+    @Test
+    @Mode(Mode.TestMode.FULL)
+    public void testValidNameAndValidEncodedPasswordPOJO() throws Exception {
+        updateClientBndFile("bindings/validNameAndValidEncodedPwd.xml");
 
-	@Test
-	@Mode(Mode.TestMode.FULL)
-	public void testValidNameAndValidEncodedPasswordSingleton() throws Exception {
-		updateClientBndFile("bindings/validNameAndValidEncodedPwd.xml");
+        RequestParams params = new RequestParams("employee", "pojo", "http", server.getHttpDefaultPort(), "/employee/employPojoService");
+        runTest(params, "Hello, employee from SayHelloPojoService", null);
+    }
 
-		RequestParams params = new RequestParams("employee", "singleton", "http", server.getHttpDefaultPort(),
-				"/employee/employSingletonService");
-		runTest(params, "From other bean: Hello, employee from SayHelloStatelessService", null);
-	}
+    @Test
+    @Mode(Mode.TestMode.FULL)
+    public void testValidNameAndValidEncodedPasswordStateless() throws Exception {
+        updateClientBndFile("bindings/validNameAndValidEncodedPwd.xml");
 
-	// Invalid name
-	@Test
-	@Mode(Mode.TestMode.FULL)
-	public void testInvalidNamePOJO() throws Exception {
-		updateClientBndFile("bindings/invalidName.xml");
+        RequestParams params = new RequestParams("employee", "stateless", "http", server.getHttpDefaultPort(), "/employee/employStatelessService");
+        runTest(params, "From other bean: Hello, employee from SayHelloSingletonService", null);
+    }
 
-		RequestParams params = new RequestParams("employee", "pojo", "http", server.getHttpDefaultPort(),
-				"/employee/employPojoService");
-		List<String> serverInfos = new ArrayList<String>(1);
-		serverInfos.add("CWWKS1100A.*inexisteduser");
-		runTest(params, "401", serverInfos);
-	}
+    @Test
+    @Mode(Mode.TestMode.FULL)
+    public void testValidNameAndValidEncodedPasswordSingleton() throws Exception {
+        updateClientBndFile("bindings/validNameAndValidEncodedPwd.xml");
 
-	@Test
-	@Mode(Mode.TestMode.FULL)
-	public void testInvalidNameStateless() throws Exception {
-		updateClientBndFile("bindings/invalidName.xml");
+        RequestParams params = new RequestParams("employee", "singleton", "http", server.getHttpDefaultPort(), "/employee/employSingletonService");
+        runTest(params, "From other bean: Hello, employee from SayHelloStatelessService", null);
+    }
 
-		RequestParams params = new RequestParams("employee", "stateless", "http", server.getHttpDefaultPort(),
-				"/employee/employStatelessService");
-		List<String> serverInfos = new ArrayList<String>(1);
-		serverInfos.add("CWWKS1100A.*inexisteduser");
-		runTest(params, "401", serverInfos);
-	}
+    // Invalid name
+    @Test
+    @Mode(Mode.TestMode.FULL)
+    public void testInvalidNamePOJO() throws Exception {
+        updateClientBndFile("bindings/invalidName.xml");
 
-	@Test
-	@Mode(Mode.TestMode.FULL)
-	public void testInvalidNameSingleton() throws Exception {
-		updateClientBndFile("bindings/invalidName.xml");
+        RequestParams params = new RequestParams("employee", "pojo", "http", server.getHttpDefaultPort(), "/employee/employPojoService");
+        List<String> serverInfos = new ArrayList<String>(1);
+        serverInfos.add("CWWKS1100A.*inexisteduser");
+        runTest(params, "401", serverInfos);
+    }
 
-		RequestParams params = new RequestParams("employee", "singleton", "http", server.getHttpDefaultPort(),
-				"/employee/employSingletonService");
-		List<String> serverInfos = new ArrayList<String>(1);
-		serverInfos.add("CWWKS1100A.*inexisteduser");
-		runTest(params, "401", serverInfos);
-	}
+    @Test
+    @Mode(Mode.TestMode.FULL)
+    public void testInvalidNameStateless() throws Exception {
+        updateClientBndFile("bindings/invalidName.xml");
+
+        RequestParams params = new RequestParams("employee", "stateless", "http", server.getHttpDefaultPort(), "/employee/employStatelessService");
+        List<String> serverInfos = new ArrayList<String>(1);
+        serverInfos.add("CWWKS1100A.*inexisteduser");
+        runTest(params, "401", serverInfos);
+    }
+
+    @Test
+    @Mode(Mode.TestMode.FULL)
+    public void testInvalidNameSingleton() throws Exception {
+        updateClientBndFile("bindings/invalidName.xml");
+
+        RequestParams params = new RequestParams("employee", "singleton", "http", server.getHttpDefaultPort(), "/employee/employSingletonService");
+        List<String> serverInfos = new ArrayList<String>(1);
+        serverInfos.add("CWWKS1100A.*inexisteduser");
+        runTest(params, "401", serverInfos);
+    }
 }


### PR DESCRIPTION
This pull request adds logging to the BasicAuthWithoutSSL setup method to help debug failures resulting from test dependent files missing from application. 
```
Expected response 200 within 10 seconds, last received 404 (Not Found) while connecting to http://localhost:8010/TransportSecurityClient/TestTransportSecurityServlet?user=employee&serviceType=pojo&schema=http&port=8010&path=/employee/employPojoService&testMethod=testValidNameAndValidPlainPasswordPOJO_EE10_FEATURES
    at componenttest.topology.utils.HttpUtils.getHttpConnection(HttpUtils.java:300)
    at componenttest.topology.utils.HttpUtils.getHttpConnection(HttpUtils.java:217)
    at componenttest.topology.utils.HttpUtils.getHttpConnection(HttpUtils.java:200)
    at componenttest.topology.utils.HttpUtils.getHttpConnection(HttpUtils.java:186)
    at com.ibm.ws.jaxws.security.fat.AbstractJaxWsTransportSecurityTest.checkExpectedResponses(AbstractJaxWsTransportSecurityTest.java:457)
    at com.ibm.ws.jaxws.security.fat.AbstractJaxWsTransportSecurityTest.runTest(AbstractJaxWsTransportSecurityTest.java:443)
    at com.ibm.ws.jaxws.security.fat.AbstractJaxWsTransportSecurityTest.runTest(AbstractJaxWsTransportSecurityTest.java:414)
    at com.ibm.ws.jaxws.security.fat.BasicAuthWithoutSSLTest.testValidNameAndValidPlainPasswordPOJO(BasicAuthWithoutSSLTest.java:61)

```