### PR TITLE
Mail 2.0: Add missing mapping files to bnd.bnd.

### DIFF
--- a/dev/io.openliberty.mail.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.mail.2.0.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.mail.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.mail.2.0.internal/bnd.bnd
@@ -45,13 +45,10 @@ Service-Component: \
 -dsannotations=io.openliberty.mail.internal.MailSessionService, \
   io.openliberty.mail.internal.injection.MailSessionDefinitionInjectionProcessorProvider, \
   io.openliberty.mail.internal.injection.MailSessionResourceFactoryBuilder
-
-## The only file that is used by the app-resources is the
-## mailcap file, this is because it is used by JAF to assess
-## what type of content the Message classes uses with its DataHandler
-## I originally included the other files, but commented them out for now
-## as I'm not entirely sure they are needed for the feature to work properly
 app-resources= \
+  META-INF/javamail.default.address.map | \
+  META-INF/javamail.default.providers | \
+  META-INF/javamail.charset.map | \
   META-INF/mailcap 
 
 Private-Package: \


### PR DESCRIPTION
This pull request adds the following mapping files to the app-resources header: 

```
  META-INF/javamail.default.address.map | \
  META-INF/javamail.default.providers | \
  META-INF/javamail.charset.map | \
```
