### PR TITLE
Fix transaction testcontainer timeouts

### DIFF
--- a/dev/com.ibm.ws.transaction.fat.util/src/com/ibm/ws/transaction/fat/util/TxTestContainerSuite.java
+++ b/dev/com.ibm.ws.transaction.fat.util/src/com/ibm/ws/transaction/fat/util/TxTestContainerSuite.java
@@ -13,7 +13,6 @@
 package com.ibm.ws.transaction.fat.util;
 
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 
 import com.ibm.websphere.simplicity.log.Log;
 
@@ -33,22 +32,8 @@ public class TxTestContainerSuite extends TestContainerSuite {
         if (testContainer == null) {
           testContainer = DatabaseContainerFactory.createType(databaseContainerType);
         }
-
-        switch (databaseContainerType) {
-          case Derby:
-          case SQLServer:
-            testContainer.waitingFor(Wait.forHealthcheck()).start();
-            break;
-          case Oracle:
-            testContainer.waitingFor(Wait.forLogMessage(".*DATABASE IS READY TO USE!.*", 1)).start();
-            break;
-          case Postgres:
-            testContainer.waitingFor(Wait.forLogMessage(".*database system is ready.*", 2)).start();
-            break;
-          default:
-            testContainer.start();
-            break;
-        }
+        testContainer.setStartupAttempts(2);
+        testContainer.start();
         Log.info(TxTestContainerSuite.class, "beforeSuite", "started test container of type: " + databaseContainerType);
     }
 


### PR DESCRIPTION
By calling `testContainer.waitingFor` the specific waitTimeout for the container is overwritting the configured values, and defaulting to 60 seconds. 
For larger containers such as DB2, Oracle, and SQLServer 60 seconds isn't enough time on our test infrastructure. 

All of this has already been configured within the DatabaseContainerFactory.
If you want better reliability then we can introduce a retry with startup attempts. 

