### PR TITLE
sort criteria precedence and limit data type update

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -13,7 +13,6 @@
 package io.openliberty.data.internal.persistence;
 
 import java.lang.reflect.Member;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -24,9 +23,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.wsspi.persistence.PersistenceServiceUnit;
 
 import jakarta.data.Inheritance;
-import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.MappingException;
-import jakarta.data.repository.Pageable;
 import jakarta.data.repository.Sort;
 
 /**
@@ -111,53 +108,6 @@ class EntityInfo {
     }
 
     /**
-     * Adds dynamically specified Sort criteria to the end of an existing list, or
-     * if the list of dynamically specified Sort criteria doesn't already exist, this method creates it.
-     *
-     * @param current    existing list of sorts, or otherwise null.
-     * @param additional list to add from.
-     * @return the updated list that the sort criteria was added to.
-     */
-    @Trivial
-    List<Sort> getSorts(List<Sort> current, Sort... additional) {
-        boolean hasIdClass = idClass != null;
-        if (current == null)
-            current = new ArrayList<>();
-        for (Sort sort : additional) {
-            if (sort == null)
-                throw new DataException(new IllegalArgumentException("Sort: null"));
-            else if (hasIdClass && sort.property().equalsIgnoreCase("id"))
-                for (String name : idClassAttributeAccessors.keySet())
-                    current.add(getWithAttributeName(getAttributeName(name), sort));
-            else
-                current.add(getWithAttributeName(sort.property(), sort));
-        }
-        return current;
-    }
-
-    /**
-     * Obtains and processes sort criteria from pagination information.
-     *
-     * @param pagination pagination information.
-     * @return list of sort criteria.
-     */
-    @Trivial
-    List<Sort> getSorts(Pageable pagination) {
-        boolean hasIdClass = idClass != null;
-        List<Sort> sorts = new ArrayList<>();
-        for (Sort sort : pagination.sorts()) {
-            if (sort == null)
-                throw new DataException(new IllegalArgumentException("Sort: null"));
-            else if (hasIdClass && sort.property().equalsIgnoreCase("id"))
-                for (String name : idClassAttributeAccessors.keySet())
-                    sorts.add(getWithAttributeName(getAttributeName(name), sort));
-            else
-                sorts.add(getWithAttributeName(sort.property(), sort));
-        }
-        return sorts;
-    }
-
-    /**
      * Creates a Sort instance with the corresponding entity attribute name
      * or returns the existing instance if it already matches.
      *
@@ -166,7 +116,7 @@ class EntityInfo {
      * @return a Sort instance with the corresponding entity attribute name.
      */
     @Trivial
-    private Sort getWithAttributeName(String name, Sort sort) {
+    Sort getWithAttributeName(String name, Sort sort) {
         name = getAttributeName(name);
         if (name == sort.property())
             return sort;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/KeysetAwarePageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/KeysetAwarePageImpl.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -129,9 +129,9 @@ public class KeysetAwarePageImpl<T> implements KeysetAwarePage<T> {
 
         T entity = results.get(index);
 
-        final Object[] keyValues = new Object[queryInfo.keyset.size()];
+        final Object[] keyValues = new Object[queryInfo.sorts.size()];
         int k = 0;
-        for (Sort keyInfo : queryInfo.keyset)
+        for (Sort keyInfo : queryInfo.sorts)
             try {
                 List<Member> accessors = queryInfo.entityInfo.attributeAccessors.get(keyInfo.property());
                 Object value = entity;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -30,6 +30,7 @@ import jakarta.data.repository.Sort;
 import jakarta.persistence.Query;
 
 /**
+ * Query information.
  */
 class QueryInfo {
     private final TraceComponent tc = Tr.register(QueryInfo.class);
@@ -42,6 +43,12 @@ class QueryInfo {
      * Information about the type of entity to which the query pertains.
      */
     EntityInfo entityInfo;
+
+    /**
+     * Indicates if the query has an ORDER BY clause.
+     * This is accurate only for generated or partially provided queries.
+     */
+    boolean hasOrder;
 
     /**
      * Indicates if the query has a WHERE clause.
@@ -371,6 +378,7 @@ class QueryInfo {
     QueryInfo withJPQL(String jpql) {
         QueryInfo q = new QueryInfo(method, returnArrayType, returnTypeParam);
         q.entityInfo = entityInfo;
+        q.hasOrder = hasOrder;
         q.hasWhere = hasWhere;
         q.jpql = jpql;
         q.jpqlAfterKeyset = jpqlAfterKeyset;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1580,7 +1580,7 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                             TypedQuery<?> query = em.createQuery(queryInfo.jpql, queryInfo.entityInfo.type);
                             queryInfo.setParameters(query, args);
 
-                            int maxResults = limit != null ? (int) limit.maxResults() // TODO fix data type in spec
+                            int maxResults = limit != null ? limit.maxResults() //
                                             : pagination != null ? pagination.size() //
                                                             : queryInfo.maxResults;
 
@@ -1944,7 +1944,7 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
         if (limit.startAt() != 1L)
             throw new DataException(new IllegalArgumentException("Limit with starting point " + limit.startAt() +
                                                                  ", which is greater than 1, cannot be used to request pages or slices."));
-        return Pageable.ofSize((int) limit.maxResults()); // TODO remove cast once spec is updated
+        return Pageable.ofSize(limit.maxResults());
     }
 
     private static final Object toReturnValue(int i, Class<?> returnType, QueryInfo queryInfo) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -219,49 +219,26 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
     /**
      * Appends JQPL to sort based on the specified entity attribute.
      * For most properties will be of a form such as o.Name or LOWER(o.Name) DESC or ...
-     * For IdClass, will include all Id properties, such as: o.IdAttr1 DESC, o.idAttr2 DESC, o.idAttr3 DESC
      *
-     * @param q          builder for the JPQL query.
-     * @param entityInfo entity information.
-     * @param ignoreCase if ordering is to be independent of case.
-     * @param attribute  name of attribute (@OrderBy value or Sort property or parsed from OrderBy query-by-method).
-     * @param descending if ordering is to be in descending order
-     * @param keyset     keyset to populate with sort criteria. Null if not generating a query for keyset pagination.
+     * @param q             builder for the JPQL query.
+     * @param Sort          sort criteria for a single attribute (name must already be converted to a valid entity attribute name).
+     * @param sameDirection indicate to append the Sort in the normal direction. Otherwise reverses it (for keyset pagination in previous page direction).
      * @return the same builder for the JPQL query.
      */
     @Trivial
-    private void appendSort(StringBuilder q, EntityInfo entityInfo, boolean ignoreCase, String attribute, boolean descending, List<Sort> keyset) {
-        Set<String> names = entityInfo.idClass != null && "id".equalsIgnoreCase(attribute) //
-                        ? entityInfo.idClassAttributeAccessors.keySet() //
-                        : Set.of(attribute);
+    private void appendSort(StringBuilder q, Sort sort, boolean sameDirection) {
 
-        boolean first = true;
-        for (String name : names) {
-            if (first)
-                first = false;
-            else
-                q.append(", ");
+        q.append(sort.ignoreCase() ? "LOWER(o." : "o.").append(sort.property());
 
-            q.append(ignoreCase ? "LOWER(o." : "o.").append(name = entityInfo.getAttributeName(name));
+        if (sort.ignoreCase())
+            q.append(")");
 
-            if (ignoreCase)
-                q.append(")");
-
-            if (keyset == null) {
-                if (descending)
-                    q.append(" DESC");
-            } else {
-                if (!descending)
-                    q.append(" DESC");
-
-                keyset.add(ignoreCase ? //
-                                descending ? //
-                                                Sort.descIgnoreCase(name) : //
-                                                Sort.ascIgnoreCase(name) : //
-                                descending ? //
-                                                Sort.desc(name) : //
-                                                Sort.asc(name));
-            }
+        if (sameDirection) {
+            if (sort.isDescending())
+                q.append(" DESC");
+        } else {
+            if (sort.isAscending())
+                q.append(" DESC");
         }
     }
 
@@ -273,25 +250,19 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
      * @return information about the query.
      */
     private QueryInfo completeQueryInfo(EntityInfo entityInfo, QueryInfo queryInfo) {
-
         queryInfo.entityInfo = entityInfo;
-        boolean isKeysetAwarePage = KeysetAwarePage.class.equals(queryInfo.method.getReturnType())
-                                    || KeysetAwarePage.class.equals(queryInfo.returnTypeParam);
-        boolean needsKeysetQueries = isKeysetAwarePage
-                                     || KeysetAwareSlice.class.equals(queryInfo.method.getReturnType())
-                                     || KeysetAwareSlice.class.equals(queryInfo.returnTypeParam)
-                                     || Iterator.class.equals(queryInfo.method.getReturnType())
-                                     || Iterator.class.equals(queryInfo.returnTypeParam);
-        boolean countPages = isKeysetAwarePage
-                             || Page.class.equals(queryInfo.method.getReturnType())
-                             || Page.class.equals(queryInfo.returnTypeParam);
+
+        boolean countPages = Page.class.equals(queryInfo.method.getReturnType())
+                             || KeysetAwarePage.class.equals(queryInfo.method.getReturnType())
+                             || Page.class.equals(queryInfo.returnTypeParam)
+                             || KeysetAwarePage.class.equals(queryInfo.returnTypeParam);
         StringBuilder q = null;
 
         // TODO would it be more efficient to invoke method.getAnnotations() once?
 
-        // @Query annotation
         Query query = queryInfo.method.getAnnotation(Query.class);
         if (query == null) {
+            // Query by annotations
             Filter[] filters = queryInfo.method.getAnnotationsByType(Filter.class);
             StringBuilder whereClause = filters.length > 0 ? generateWhereClause(queryInfo, filters) : null;
 
@@ -333,7 +304,7 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                     throw new UnsupportedOperationException(queryInfo.method.getName() + " without any parameters");
                 queryInfo.saveParamType = paramTypes[0];
             } else {
-                // Repository method name pattern queries
+                // Query by method name
                 q = generateMethodNameQuery(queryInfo, countPages);//keyset queries before orderby
 
                 // @Select annotation only
@@ -355,7 +326,7 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
             if (upperTrimmed.startsWith("SELECT")) {
                 int orderBy = upper.lastIndexOf("ORDER BY");
                 queryInfo.type = QueryInfo.Type.SELECT;
-                queryInfo.hasOrder = orderBy > 0;
+                queryInfo.sorts = queryInfo.sorts == null ? new ArrayList<>() : queryInfo.sorts;
                 queryInfo.jpqlCount = query.count().length() > 0 ? query.count() : null;
 
                 if (countPages && queryInfo.jpqlCount == null) {
@@ -416,8 +387,8 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
         // The @OrderBy annotation from Jakarta Data provides sort criteria statically
         OrderBy[] orderBy = queryInfo.method.getAnnotationsByType(OrderBy.class);
         if (orderBy.length > 0) {
-            queryInfo.hasOrder = true;
             queryInfo.type = queryInfo.type == null ? QueryInfo.Type.SELECT : queryInfo.type;
+            queryInfo.sorts = queryInfo.sorts == null ? new ArrayList<>(orderBy.length + 2) : queryInfo.sorts;
             if (q == null)
                 if (queryInfo.jpql == null) {
                     q = generateSelectClause(queryInfo);
@@ -427,24 +398,11 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                     q = new StringBuilder(queryInfo.jpql);
                 }
 
-            StringBuilder o = needsKeysetQueries ? new StringBuilder(100) : q;
-            StringBuilder r = needsKeysetQueries ? new StringBuilder(100) : null; // reverse order
-            List<Sort> keyset = needsKeysetQueries ? new ArrayList<>(orderBy.length) : null;
+            for (int i = 0; i < orderBy.length; i++)
+                queryInfo.addSort(orderBy[i].ignoreCase(), orderBy[i].value(), orderBy[i].descending());
 
-            for (int i = 0; i < orderBy.length; i++) {
-                o.append(i == 0 ? " ORDER BY " : ", ");
-                appendSort(o, entityInfo, orderBy[i].ignoreCase(), orderBy[i].value(), orderBy[i].descending(), null);
-
-                if (needsKeysetQueries) {
-                    r.append(i == 0 ? " ORDER BY " : ", ");
-                    appendSort(r, entityInfo, orderBy[i].ignoreCase(), orderBy[i].value(), orderBy[i].descending(), keyset);
-                }
-            }
-
-            if (needsKeysetQueries) {
-                generateKeysetQueries(queryInfo, keyset, q, o, r);
-                q.append(o);
-            }
+            if (!queryInfo.hasDynamicSortCriteria())
+                generateOrderBy(queryInfo, q);
         }
 
         queryInfo.jpql = q == null ? queryInfo.jpql : q.toString();
@@ -812,13 +770,12 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
      * _ OR (o.lastName = ?5 AND o.firstName = ?6 AND o.ssn > ?7) )
      *
      * @param queryInfo query information
-     * @param keyset    key names and direction
      * @param q         query up to the WHERE clause, if present
      * @param o         ORDER BY clause in forward direction. Null if forward direction is not needed.
      * @param r         ORDER BY clause in reverse direction. Null if reverse direction is not needed.
      */
-    private void generateKeysetQueries(QueryInfo queryInfo, List<Sort> keyset, StringBuilder q, StringBuilder o, StringBuilder r) {
-        int numKeys = keyset.size();
+    private void generateKeysetQueries(QueryInfo queryInfo, StringBuilder q, StringBuilder o, StringBuilder r) {
+        int numKeys = queryInfo.sorts.size();
         String paramPrefix = queryInfo.paramNames == null ? "?" : ":keyset";
         StringBuilder a = o == null ? null : new StringBuilder(200).append(queryInfo.hasWhere ? " AND (" : " WHERE (");
         StringBuilder b = r == null ? null : new StringBuilder(200).append(queryInfo.hasWhere ? " AND (" : " WHERE (");
@@ -828,7 +785,7 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
             if (b != null)
                 b.append(i == 0 ? "(" : " OR (");
             for (int k = 0; k <= i; k++) {
-                Sort keyInfo = keyset.get(k);
+                Sort keyInfo = queryInfo.sorts.get(k);
                 String name = keyInfo.property();
                 boolean asc = keyInfo.isAscending();
                 boolean lower = keyInfo.ignoreCase();
@@ -862,7 +819,6 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
             queryInfo.jpqlAfterKeyset = new StringBuilder(q).append(a).append(')').append(o).toString();
         if (b != null)
             queryInfo.jpqlBeforeKeyset = new StringBuilder(q).append(b).append(')').append(r).toString();
-        queryInfo.keyset = keyset;
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "forward & reverse keyset queries", queryInfo.jpqlAfterKeyset, queryInfo.jpqlBeforeKeyset);
@@ -890,7 +846,7 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                     generateCount(queryInfo, q.substring(where));
             }
             if (orderBy >= c)
-                generateOrderBy(queryInfo, orderBy, q);
+                parseOrderBy(queryInfo, orderBy, q);
             queryInfo.type = QueryInfo.Type.SELECT;
         } else if (methodName.startsWith("delete")) {
             int by = methodName.indexOf("By", 6);
@@ -950,56 +906,33 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
     }
 
     /**
-     * Generates the JPQL ORDER BY clause for a repository findBy method such as findByLastNameLikeOrderByLastNameAscFirstNameDesc
+     * Generates the JPQL ORDER BY clause. This method is common between the OrderBy annotation and keyword.
      */
-    private void generateOrderBy(QueryInfo queryInfo, int orderBy, StringBuilder q) {
-        String methodName = queryInfo.method.getName();
+    private void generateOrderBy(QueryInfo queryInfo, StringBuilder q) {
         boolean needsKeysetQueries = KeysetAwarePage.class.equals(queryInfo.method.getReturnType())
                                      || KeysetAwareSlice.class.equals(queryInfo.method.getReturnType())
                                      || Iterator.class.equals(queryInfo.method.getReturnType())
                                      || KeysetAwarePage.class.equals(queryInfo.returnTypeParam)
                                      || KeysetAwareSlice.class.equals(queryInfo.returnTypeParam)
                                      || Iterator.class.equals(queryInfo.returnTypeParam);
+
         StringBuilder o = needsKeysetQueries ? new StringBuilder(100) : q; // forward order
-        StringBuilder r = needsKeysetQueries ? new StringBuilder(100).append(" ORDER BY ") : null; // reverse order
-        List<Sort> keyset = needsKeysetQueries ? new ArrayList<>() : null;
+        StringBuilder r = needsKeysetQueries ? new StringBuilder(100) : null; // previous page order
 
-        queryInfo.hasOrder = true;
+        boolean first = true;
+        for (Sort sort : queryInfo.sorts) {
+            o.append(first ? " ORDER BY " : ", ");
+            appendSort(o, sort, true);
 
-        o.append(" ORDER BY ");
-
-        for (int length = methodName.length(), asc = 0, desc = 0, iNext, i = orderBy + 7; i >= 0 && i < length; i = iNext) {
-            asc = asc == -1 || asc > i ? asc : methodName.indexOf("Asc", i);
-            desc = desc == -1 || desc > i ? desc : methodName.indexOf("Desc", i);
-            iNext = Math.min(asc, desc);
-            if (iNext < 0)
-                iNext = Math.max(asc, desc);
-
-            boolean ignoreCase;
-            boolean descending = iNext > 0 && iNext == desc;
-            int endBefore = iNext < 0 ? methodName.length() : iNext;
-            if (ignoreCase = endsWith("IgnoreCase", methodName, i, endBefore))
-                endBefore -= 10;
-
-            String attribute = methodName.substring(i, endBefore);
-
-            appendSort(o, queryInfo.entityInfo, ignoreCase, attribute, descending, null);
-
-            if (needsKeysetQueries)
-                appendSort(r, queryInfo.entityInfo, ignoreCase, attribute, descending, keyset);
-
-            if (iNext > 0) {
-                iNext += (iNext == desc ? 4 : 3);
-                if (iNext < length) {
-                    o.append(", ");
-                    if (needsKeysetQueries)
-                        r.append(", ");
-                }
+            if (needsKeysetQueries) {
+                r.append(first ? " ORDER BY " : ", ");
+                appendSort(r, sort, false);
             }
+            first = false;
         }
 
         if (needsKeysetQueries) {
-            generateKeysetQueries(queryInfo, keyset, q, o, r);
+            generateKeysetQueries(queryInfo, q, o, r);
             q.append(o);
         }
     }
@@ -1531,39 +1464,36 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
                                 else
                                     throw new DataException("Repository method " + method + " cannot have multiple Pageable parameters."); // TODO NLS
                             else if (param instanceof Sort)
-                                sortList = queryInfo.entityInfo.getSorts(sortList, (Sort) param);
+                                sortList = queryInfo.combineSorts(sortList, (Sort) param);
                             else if (param instanceof Sort[])
-                                sortList = queryInfo.entityInfo.getSorts(sortList, (Sort[]) param);
+                                sortList = queryInfo.combineSorts(sortList, (Sort[]) param);
                         }
 
                         if (pagination != null) {
                             if (limit != null)
                                 throw new DataException("Repository method " + method + " cannot have both Limit and Pageable as parameters."); // TODO NLS
-                            if (sortList == null || sortList.isEmpty())
-                                sortList = queryInfo.entityInfo.getSorts(pagination);
+                            if (sortList == null)
+                                sortList = queryInfo.combineSorts(sortList, pagination.sorts());
                             else if (sortList != null && !pagination.sorts().isEmpty())
                                 throw new DataException("Repository method " + method + " cannot specify Sort parameters if Pageable also has Sort parameters."); // TODO NLS
                         }
+
+                        if (sortList == null && queryInfo.hasDynamicSortCriteria())
+                            sortList = queryInfo.sorts;
 
                         if (sortList != null && !sortList.isEmpty()) {
                             boolean forward = pagination == null || pagination.mode() != Pageable.Mode.CURSOR_PREVIOUS;
                             StringBuilder q = new StringBuilder(queryInfo.jpql);
                             StringBuilder o = null; // ORDER BY clause based on Sorts
                             for (Sort sort : sortList) {
-                                o = o == null ? new StringBuilder(100).append(queryInfo.hasOrder ? ", " : " ORDER BY ") : o.append(", ");
-                                o.append(sort.ignoreCase() ? "LOWER(o." : "o.").append(sort.property());
-                                if (sort.ignoreCase())
-                                    o.append(')');
-                                if (forward ? sort.isDescending() : sort.isAscending())
-                                    o.append(" DESC");
+                                o = o == null ? new StringBuilder(100).append(" ORDER BY ") : o.append(", ");
+                                appendSort(o, sort, forward);
                             }
 
                             if (pagination == null || pagination.mode() == Pageable.Mode.OFFSET)
-                                (queryInfo = queryInfo.withJPQL(q.append(o).toString())).keyset = sortList; // offset pagination can be a starting point for keyset pagination
+                                queryInfo = queryInfo.withJPQL(q.append(o).toString(), sortList); // offset pagination can be a starting point for keyset pagination
                             else // CURSOR_NEXT or CURSOR_PREVIOUS
-                                generateKeysetQueries(queryInfo = queryInfo.withJPQL(null), sortList, q, forward ? o : null, forward ? null : o); // TODO merging of sort criteria
-
-                            queryInfo.hasOrder = true;
+                                generateKeysetQueries(queryInfo = queryInfo.withJPQL(null, sortList), q, forward ? o : null, forward ? null : o);
                         }
 
                         boolean asyncCompatibleResultForPagination = pagination != null &&
@@ -1858,6 +1788,40 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
             else
                 queryInfo.maxResults = num;
         }
+    }
+
+    /**
+     * Identifies the statically specified sort criteria for a repository findBy method such as
+     * findByLastNameLikeOrderByLastNameAscFirstNameDesc
+     */
+    private void parseOrderBy(QueryInfo queryInfo, int orderBy, StringBuilder q) {
+        String methodName = queryInfo.method.getName();
+
+        queryInfo.sorts = queryInfo.sorts == null ? new ArrayList<>() : queryInfo.sorts;
+
+        for (int length = methodName.length(), asc = 0, desc = 0, iNext, i = orderBy + 7; i >= 0 && i < length; i = iNext) {
+            asc = asc == -1 || asc > i ? asc : methodName.indexOf("Asc", i);
+            desc = desc == -1 || desc > i ? desc : methodName.indexOf("Desc", i);
+            iNext = Math.min(asc, desc);
+            if (iNext < 0)
+                iNext = Math.max(asc, desc);
+
+            boolean ignoreCase;
+            boolean descending = iNext > 0 && iNext == desc;
+            int endBefore = iNext < 0 ? methodName.length() : iNext;
+            if (ignoreCase = endsWith("IgnoreCase", methodName, i, endBefore))
+                endBefore -= 10;
+
+            String attribute = methodName.substring(i, endBefore);
+
+            queryInfo.addSort(ignoreCase, attribute, descending);
+
+            if (iNext > 0)
+                iNext += (iNext == desc ? 4 : 3);
+        }
+
+        if (!queryInfo.hasDynamicSortCriteria())
+            generateOrderBy(queryInfo, q);
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1935,7 +1935,7 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testKeysetWithLimit() {
         // This is not a recommended pattern. Testing to see how it is handled.
-        KeysetAwarePage<Prime> page = primes.findByNumberBetween(15L, 45L, Limit.of(5L));
+        KeysetAwarePage<Prime> page = primes.findByNumberBetween(15L, 45L, Limit.of(5));
 
         assertEquals(1L, page.number());
         assertEquals(5L, page.numberOfElements());
@@ -3280,7 +3280,7 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testSliceWithLimit() {
         // This is not a recommended pattern. Testing to see how it is handled.
-        Slice<Prime> slice = primes.findByRomanNumeralEndsWithAndNumberLessThan("II", 50L, Limit.of(4L), Sort.desc("number"));
+        Slice<Prime> slice = primes.findByRomanNumeralEndsWithAndNumberLessThan("II", 50L, Limit.of(4), Sort.desc("number"));
 
         assertEquals(1L, slice.number());
         assertEquals(4L, slice.numberOfElements());

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -143,6 +143,8 @@ public interface Primes {
 
     Stream<Prime> findByNumberLessThanOrderByEven(long max, Sort... sorts);
 
+    KeysetAwareSlice<Prime> findByNumberLessThanOrderByEvenAscSumOfBitsAsc(long max, Pageable pagination);
+
     @Asynchronous
     CompletionStage<KeysetAwarePage<Prime>> findByNumberLessThanOrderByNumberDesc(long max, Pageable pagination);
 
@@ -238,8 +240,10 @@ public interface Primes {
     @Query("SELECT DISTINCT LENGTH(p.romanNumeral) FROM Prime p WHERE p.number <= ?1 ORDER BY LENGTH(p.romanNumeral) DESC")
     Page<Integer> romanNumeralLengths(long maxNumber, Pageable pagination);
 
-    @Query("SELECT o.romanNumeral FROM Prime o WHERE o.number <= ?1 ORDER BY LENGTH(o.romanNumeral) DESC")
-    Page<String> romanNumerals(long maxNumber, Pageable pagination);
-
     void save(Prime... primes);
+
+    @Query("SELECT o FROM Prime o WHERE (o.number <= ?1)")
+    @OrderBy(value = "even", descending = true)
+    @OrderBy(value = "sumOfBits", descending = true)
+    KeysetAwarePage<Prime> upTo(long maxNumber, Pageable pagination);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -131,11 +131,17 @@ public interface Primes {
 
     Stream<Prime> findByNumberLessThan(long max);
 
+    @OrderBy("even")
+    @OrderBy("sumOfBits")
+    Page<Prime> findByNumberLessThan(long max, Pageable pagination);
+
     Streamable<Prime> findByNumberLessThanEqualOrderByNumberAsc(long max, Pageable pagination);
 
     Streamable<Prime> findByNumberLessThanEqualOrderByNumberDesc(long max, Limit limit);
 
     Page<Prime> findByNumberLessThanEqualOrderByNumberDesc(long max, Pageable pagination);
+
+    Stream<Prime> findByNumberLessThanOrderByEven(long max, Sort... sorts);
 
     @Asynchronous
     CompletionStage<KeysetAwarePage<Prime>> findByNumberLessThanOrderByNumberDesc(long max, Pageable pagination);
@@ -231,6 +237,9 @@ public interface Primes {
 
     @Query("SELECT DISTINCT LENGTH(p.romanNumeral) FROM Prime p WHERE p.number <= ?1 ORDER BY LENGTH(p.romanNumeral) DESC")
     Page<Integer> romanNumeralLengths(long maxNumber, Pageable pagination);
+
+    @Query("SELECT o.romanNumeral FROM Prime o WHERE o.number <= ?1 ORDER BY LENGTH(o.romanNumeral) DESC")
+    Page<String> romanNumerals(long maxNumber, Pageable pagination);
 
     void save(Prime... primes);
 }

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/Limit.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/Limit.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,9 +16,10 @@ package jakarta.data.repository;
  * Method signatures are copied from the jakarta.data.repository.Limit from the Jakarta Data repo.
  */
 public class Limit {
-    private final long max, start;
+    private final int max;
+    private final long start;
 
-    private Limit(long startAt, long maxResults) {
+    private Limit(long startAt, int maxResults) {
         start = startAt;
         max = maxResults;
         if (start < 1)
@@ -27,11 +28,11 @@ public class Limit {
             throw new IllegalArgumentException("maxResults: " + max);
     }
 
-    public long maxResults() {
+    public int maxResults() {
         return max;
     }
 
-    public static Limit of(long maxResults) {
+    public static Limit of(int maxResults) {
         return new Limit(1L, maxResults);
     }
 
@@ -39,7 +40,10 @@ public class Limit {
         if (startAt >= endAt)
             throw new IllegalArgumentException("startAt: " + startAt + ", endAt: " + endAt);
 
-        return new Limit(startAt, 1 + (endAt - startAt));
+        if (Integer.MAX_VALUE <= endAt - startAt)
+            throw new IllegalArgumentException("startAt: " + startAt + ", endAt: " + endAt + ", maxResults > " + Integer.MAX_VALUE);
+
+        return new Limit(startAt, 1 + (int) (endAt - startAt));
     }
 
     public long startAt() {


### PR DESCRIPTION
Align with updates that were recently made to Jakarta Data.
A data type is corrected on the Limit interface.
Sort criteria precedence is established between sort criteria that is specified statically vs dynamically.  This pull covers scenarios with OrderBy annotation and keyword, Sort parameters, Sort parameters to Pageable, and both types of pagination.
