### PR TITLE
Update MP Metrics 5.0 tests for SmallRye RC3 updates

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/monitoring/GrpcMetricsTestUtils.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/monitoring/GrpcMetricsTestUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -116,7 +116,6 @@ public class GrpcMetricsTestUtils {
             con.setDoOutput(true);
             con.setUseCaches(false);
             con.setRequestMethod("GET");
-            con.setRequestProperty("Accept", "text/plain");
 
             retcode = con.getResponseCode();
             if (retcode != 200) {

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -442,7 +442,6 @@ public class TestEnableDisableFeaturesTest {
             con.setDoOutput(true);
             con.setUseCaches(false);
             con.setRequestMethod("GET");
-            con.setRequestProperty("Accept", "text/plain");
             String sep = System.getProperty("line.separator");
             String line = null;
             StringBuilder lines = new StringBuilder();
@@ -476,7 +475,6 @@ public class TestEnableDisableFeaturesTest {
             });
             String authorization = "Basic "
                     + Base64.getEncoder().encodeToString(("theUser:thePassword").getBytes(StandardCharsets.UTF_8)); // Java
-            con.setRequestProperty("Accept", "text/plain");                                                        // 8
             con.setRequestProperty("Authorization", authorization);
             con.setRequestMethod("GET");
 


### PR DESCRIPTION
- After RC3 was put in, tests no longer need to explicitly set the Accept header.
- Update REST 3.1 test to handle MP 5.0
