### PR TITLE
Only validate header name once

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
@@ -499,7 +499,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "appendHeader(s,s): " + header);
         }
-        validateHeaderName(header);
         if (this.bHeaderValidation) {
             if (getCharacterValidation()) //PI45266
                 value = getValidatedCharacters(value); //PI57228
@@ -522,7 +521,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "appendHeader(b,s): " + GenericUtils.getEnglishString(header));
         }
-        validateHeaderName(header.toString());
         if (this.bHeaderValidation) {
             if (getCharacterValidation()) //PI45266
                 value = getValidatedCharacters(value); //PI57228
@@ -545,7 +543,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "appendHeader(h,s): " + key.getName());
         }
-        validateHeaderName(key.getName());
         if (this.bHeaderValidation) {
             if (getCharacterValidation()) //PI45266
                 value = getValidatedCharacters(value); //PI57228
@@ -1957,7 +1954,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setHeader(h,b): " + key.getName());
         }
-        validateHeaderName(key.getName());
         if (this.bHeaderValidation) {
             checkHeaderValue(value, 0, value.length);
         }
@@ -1995,7 +1991,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setHeader(h,b,i,i): " + key.getName());
         }
-        validateHeaderName(key.getName());
         if (this.bHeaderValidation) {
             checkHeaderValue(value, offset, length);
         }
@@ -2036,7 +2031,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setHeader(h,s): " + key.getName());
         }
-        validateHeaderName(key.getName());
         if (this.bHeaderValidation) {
             if (getCharacterValidation()) //PI45266
                 value = getValidatedCharacters(value); //PI57228
@@ -2113,7 +2107,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (elem != null && elem.asString() != null) {
             return elem;
         }
-        validateHeaderName(key.getName());
         if (this.bHeaderValidation) {
             if (getCharacterValidation()) //PI45266
                 value = getValidatedCharacters(value); //PI57228
@@ -3892,7 +3885,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
                 }
 
                 // PH52074 Check for other invalid chars
-                if (!isValidTchar((char) (b & 0xFF))) {
+                if (!HttpHeaderKeys.isValidTchar((char) (b & 0xFF))) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
                         final int maskedCodePoint = b & 0xFF;
                         Tr.debug(tc, "Invalid character found in http header name.  The Unicode is: " + String.format("%04x", maskedCodePoint));
@@ -4772,66 +4765,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             }
         }
         return nodename;
-
-    }
-
-    /*
-     * A valid header name is "!" / "#" / "$" / "%" / "&" / "'" /
-     * "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
-     *
-     * The information about valid chars in a header name comes from
-     * RCF 9110 section 5.6.2 tchars
-     * https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2
-     *
-     * PH52074
-     */
-
-    private void validateHeaderName(String name) {
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-            Tr.entry(tc, "validateHeaderName, name is " + name);
-        }
-        char[] a = name.toCharArray();
-        char c;
-        boolean valid = true;
-
-        for (int i = 0; i < a.length; i++) {
-            c = a[i];
-            valid = isValidTchar(c);
-            if (!valid) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-                    Tr.debug(tc, "validateHeaderName invalid char " + String.format("%04x", (int) c));
-                }
-                break;
-            }
-        }
-
-        // if we found an error, throw the exception now
-        if (!valid) {
-            IllegalArgumentException iae = new IllegalArgumentException("Header name contained an invalid character");
-            FFDCFilter.processException(iae, getClass().getName() + ".validateHeaderName(String)", "1", this);
-            throw iae;
-        }
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-            Tr.exit(tc, "validateHeaderName");
-        }
-
-    }
-
-    private boolean isValidTchar(char c) {
-        boolean valid = ((c >= 'a') && (c <= 'z')) ||
-                        ((c >= 'A') && (c <= 'Z')) ||
-                        ((c >= '0') && (c <= '9')) ||
-                        (c == '!') || (c == '#') ||
-                        (c == '$') || (c == '%') ||
-                        (c == '&') || (c == '\'') ||
-                        (c == '*') || (c == '+') ||
-                        (c == '-') || (c == '.') ||
-                        (c == '^') || (c == '_') ||
-                        (c == '`') || (c == '|') ||
-                        (c == '~');
-
-        return valid;
-
     }
 
     private void processForwardedErrorState() {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.wsspi.genericbnf.BNFHeaders;
 import com.ibm.wsspi.genericbnf.HeaderKeys;
 import com.ibm.wsspi.genericbnf.KeyMatcher;
@@ -240,7 +241,7 @@ public class HttpHeaderKeys extends HeaderKeys {
      *
      * @param name
      */
-    public HttpHeaderKeys(String name) {
+    private HttpHeaderKeys(String name) {
         super(name, generateNextOrdinal());
         if (NEXT_ORDINAL.get() <= ORD_MAX) {
 
@@ -275,7 +276,7 @@ public class HttpHeaderKeys extends HeaderKeys {
      * @param shouldLog
      * @param shouldFilter
      */
-    public HttpHeaderKeys(String name, boolean shouldLog, boolean shouldFilter) {
+    private HttpHeaderKeys(String name, boolean shouldLog, boolean shouldFilter) {
         super(name, generateNextOrdinal());
         super.setShouldLogValue(shouldLog);
         super.setUseFilters(shouldFilter);
@@ -353,13 +354,10 @@ public class HttpHeaderKeys extends HeaderKeys {
                 // testing again inside a sync block
                 key = (HttpHeaderKeys) myMatcher.match(name, offset, length);
                 if (null == key) {
+                    String headerName = new String(name, offset, length);
                     // make sure the name is valid
-                    for (int i = offset; i < length; i++) {
-                        if (BNFHeaders.CR == name[i] || BNFHeaders.LF == name[i]) {
-                            throw new IllegalArgumentException("Invalid CRLF in name: " + i);
-                        }
-                    }
-                    key = new HttpHeaderKeys(new String(name, offset, length), true);
+                    validateHeaderName(headerName);
+                    key = new HttpHeaderKeys(headerName, true);
                 }
             } // end-sync
 
@@ -387,17 +385,53 @@ public class HttpHeaderKeys extends HeaderKeys {
                 key = (HttpHeaderKeys) myMatcher.match(name, 0, name.length());
                 if (null == key) {
                     // make sure the name is valid
-                    for (int i = 0, size = name.length(); i < size; i++) {
-                        char c = name.charAt(i);
-                        if (BNFHeaders.CR == c || BNFHeaders.LF == c) {
-                            throw new IllegalArgumentException("Invalid CRLF in name: " + i);
-                        }
-                    }
+                    validateHeaderName(name);
                     key = new HttpHeaderKeys(name, true);
                 }
             } // end-sync
         }
         return key;
+    }
+
+    /*
+     * A valid header name is "!" / "#" / "$" / "%" / "&" / "'" /
+     * "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+     *
+     * The information about valid chars in a header name comes from
+     * RCF 9110 section 5.6.2 tchars
+     * https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2
+     *
+     * PH52074
+     */
+    private static void validateHeaderName(String name) {
+        for (int i = 0, size = name.length(); i < size; i++) {
+            char c = name.charAt(i);
+            if (BNFHeaders.CR == c || BNFHeaders.LF == c) {
+                throw new IllegalArgumentException("Invalid CRLF in name: " + i);
+            }
+            // if we found an error, throw the exception now
+            if (!isValidTchar(c)) {
+                IllegalArgumentException iae = new IllegalArgumentException("Header name contained an invalid character " + i);
+                FFDCFilter.processException(iae, HttpHeaderKeys.class.getName() + ".validateHeaderName(String)", "1", name);
+                throw iae;
+            }
+        }
+    }
+
+    public static boolean isValidTchar(char c) {
+        boolean valid = ((c >= 'a') && (c <= 'z')) ||
+                        ((c >= 'A') && (c <= 'Z')) ||
+                        ((c >= '0') && (c <= '9')) ||
+                        (c == '!') || (c == '#') ||
+                        (c == '$') || (c == '%') ||
+                        (c == '&') || (c == '\'') ||
+                        (c == '*') || (c == '+') ||
+                        (c == '-') || (c == '.') ||
+                        (c == '^') || (c == '_') ||
+                        (c == '`') || (c == '|') ||
+                        (c == '~');
+
+        return valid;
     }
 
     /**


### PR DESCRIPTION
- Only validate header name when creating HttpHeaderKeys the first time.
- Correctly validate byte[] header names.  byte[].toString doesn't give you a String of the byte[] contents.
- Make all HttpHeaderKeys constructors private to prevent anyone creating one without validation.

This pull request is a performance improvement for the changes done in #24157.  Also going to tag #24187 since that is the PR associated with #24157.