### PR TITLE
Fix IBMi username issue

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleCustomTrace.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleCustomTrace.java
@@ -94,9 +94,9 @@ public class OracleCustomTrace extends FATServletClient {
             server.stopServer("DSRA7043W");
         }
 
-        server.addEnvVar("URL", oracle.getJdbcUrl());
-        server.addEnvVar("USER", oracle.getUsername());
-        server.addEnvVar("PASSWORD", oracle.getPassword());
+        server.addEnvVar("ORACLE_URL", oracle.getJdbcUrl());
+        server.addEnvVar("ORACLE_USER", oracle.getUsername());
+        server.addEnvVar("ORACLE_PASSWORD", oracle.getPassword());
         server.addEnvVar("SSL_PASSWORD", SSL_PASSWORD);
 
         server.setJvmOptions(Stream.of(serverJvmOptClone, jvmOpts, TIME_ZONE_OPTION, TRACE_OPTION)

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleSSLTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleSSLTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -55,8 +55,8 @@ public class OracleSSLTest extends FATServletClient {
         // Set server environment variables
         server.addEnvVar("BASIC_URL", oracle.getJdbcUrl());
         server.addEnvVar("SSL_URL", oracle.getJdbcSSLUrl());
-        server.addEnvVar("USER", oracle.getUsername());
-        server.addEnvVar("PASS", oracle.getPassword());
+        server.addEnvVar("ORACLE_USER", oracle.getUsername());
+        server.addEnvVar("ORACLE_PASS", oracle.getPassword());
         server.addEnvVar("WALLET_PASS", oracle.getWalletPassword());
 
         // Create a normal Java EE application and export to server

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -42,12 +42,12 @@ public class OracleTest extends FATServletClient {
     public static void setUp() throws Exception {
 
         // Set server environment variables
-        server.addEnvVar("URL", oracle.getJdbcUrl());
-        server.addEnvVar("USER", oracle.getUsername());
-        server.addEnvVar("PASSWORD", oracle.getPassword());
-        server.addEnvVar("DBNAME", oracle.getSid());
-        server.addEnvVar("PORT", Integer.toString(oracle.getFirstMappedPort()));
-        server.addEnvVar("HOST", oracle.getHost());
+        server.addEnvVar("ORACLE_URL", oracle.getJdbcUrl());
+        server.addEnvVar("ORACLE_USER", oracle.getUsername());
+        server.addEnvVar("ORACLE_PASSWORD", oracle.getPassword());
+        server.addEnvVar("ORACLE_DBNAME", oracle.getSid());
+        server.addEnvVar("ORACLE_PORT", Integer.toString(oracle.getFirstMappedPort()));
+        server.addEnvVar("ORACLE_HOST", oracle.getHost());
 
         // Create a normal Java EE application and export to server
         ShrinkHelper.defaultApp(server, JEE_APP, "web");

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleTraceTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleTraceTest.java
@@ -51,9 +51,10 @@ public class OracleTraceTest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
 
-        server.addEnvVar("URL", oracle.getJdbcUrl());
-        server.addEnvVar("USER", oracle.getUsername());
-        server.addEnvVar("PASSWORD", oracle.getPassword());
+        // Set server environment variables
+        server.addEnvVar("ORACLE_URL", oracle.getJdbcUrl());
+        server.addEnvVar("ORACLE_USER", oracle.getUsername());
+        server.addEnvVar("ORACLE_PASSWORD", oracle.getPassword());
         server.addEnvVar("SSL_PASSWORD", SSL_PASSWORD);
 
         Map<String, String> jvmOps = server.getJvmOptionsAsMap();

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleUCPTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleUCPTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -52,9 +52,9 @@ public class OracleUCPTest extends FATServletClient {
     public static void setUp() throws Exception {
 
         // Set server environment variables
-        server.addEnvVar("URL", oracle.getJdbcUrl());
-        server.addEnvVar("USER", oracle.getUsername());
-        server.addEnvVar("PASSWORD", oracle.getPassword());
+        server.addEnvVar("ORACLE_URL", oracle.getJdbcUrl());
+        server.addEnvVar("ORACLE_USER", oracle.getUsername());
+        server.addEnvVar("ORACLE_PASSWORD", oracle.getPassword());
 
         // Create a normal Java EE application and export to server
         ShrinkHelper.defaultApp(server, JEE_APP, "ucp.web");
@@ -90,9 +90,9 @@ public class OracleUCPTest extends FATServletClient {
         try {
             //update to UCP
             props.setMaxPoolSize("2");
-            props.setUser("${env.USER}");
-            props.setPassword("${env.PASSWORD}");
-            props.setURL("${env.URL}");
+            props.setUser("${env.ORACLE_USER}");
+            props.setPassword("${env.ORACLE_PASSWORD}");
+            props.setURL("${env.ORACLE_URL}");
             props.setConnectionWaitTimeout("30");
 
             //Update config

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ssl/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ssl/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021, 2022 IBM Corporation and others.
+    Copyright (c) 2021, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@
     <!-- Default datasource to test user/password auth still works -->
     <dataSource id="DefaultDataSource">
     	<jdbcDriver libraryRef="DBLib"/>
-    	<properties.oracle URL="${env.BASIC_URL}" user="${env.USER}" password="${env.PASS}"/>
+    	<properties.oracle URL="${env.BASIC_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASS}"/>
     </dataSource>
     
     <!-- Shared oracle connection properties -->

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.trace/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.trace/server.xml
@@ -30,12 +30,12 @@
     
     <dataSource id="DefaultDataSource">
     	<jdbcDriver libraryRef="DBLib"/>
-    	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
+    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
     </dataSource>
     
     <dataSource id="default-dup" jndiName="jdbc/default-dup">
     	<jdbcDriver libraryRef="DBLib"/>
-    	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
+    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
     </dataSource>
     
 	<!--
@@ -44,7 +44,7 @@
     -->
     <dataSource id="conn-prop-ds" jndiName="jdbc/conn-prop-ds">
     	<jdbcDriver libraryRef="DBLib"/>
-    	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" 
+    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" 
     	connectionProperties="
 	    	oracle.net.ssl_version=1.2;
 	    	oracle.net.authentication_services=(TCPS);
@@ -59,7 +59,7 @@
     
     <dataSource id="conn-prop-ds-generic" jndiName="jdbc/conn-prop-ds-generic">
     	<jdbcDriver libraryRef="DBLib"/>
-    	<properties URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"
+    	<properties URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"
     	connectionProperties="
 	    	oracle.net.ssl_version=1.2;
 	    	oracle.net.authentication_services=(TCPS);

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2016, 2021 IBM Corporation and others.
+    Copyright (c) 2016, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -37,37 +37,37 @@
     <!-- This DataSource intentionally uses a connectionManagerRef -->
     <dataSource id="ucpDS" jndiName="jdbc/ucpDS" connectionManagerRef="conMgr" validationTimeout="20" >
     	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp maxStatements="5"  maxPoolSize="3" user="${env.USER}" password="${env.PASSWORD}" connectionWaitTimeout="30" URL="${env.URL}" />
+    	<properties.oracle.ucp maxStatements="5"  maxPoolSize="3" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" connectionWaitTimeout="30" URL="${env.ORACLE_URL}" />
     </dataSource>
     
     <dataSource id="ucpDSSameConMgr" jndiName="jdbc/ucpDSSameConMgr" connectionManagerRef="sharedConMgr" validationTimeout="20" >
     	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" />
+    	<properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
     </dataSource>
     
     <dataSource id="ucpXADS" jndiName="jdbc/ucpXADS" type="javax.sql.XADataSource">
     	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" />
+    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
     </dataSource>
     
     <dataSource id="ucpXADS2" jndiName="jdbc/ucpXADS2" type="javax.sql.XADataSource">
     	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" />
+    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
     </dataSource>
     
     <dataSource id="ucpConnectionPoolDS" jndiName="jdbc/ucpConnectionPoolDS" type="javax.sql.ConnectionPoolDataSource" >
     	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" />
+    	<properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
     </dataSource>
     
     <dataSource id="ucpDriverDS" jndiName="jdbc/ucpDriverDS" type="java.sql.Driver" >
     	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
+    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
     </dataSource>
     
     <dataSource id="ucpDSAuthData" jndiName="jdbc/ucpDSAuthData">
    	    <jdbcDriver libraryRef="UCPDBLib" />
-   		<properties.oracle.ucp URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
+   		<properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
    		<containerAuthData user="wrong" password="wrong" />
     </dataSource>
     
@@ -76,13 +76,13 @@
     	<connectionManager maxPoolSize="2" minPoolSize="1"/> 
     	<jdbcDriver libraryRef="UCPDBLib" javax.sql.DataSource="oracle.ucp.jdbc.PoolDataSourceImpl"/>
     	<!-- TODO remove noship guard -->
-    	<properties maxPoolSize="3" connectionWaitTimeout="30" URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" connectionFactoryClassName="oracle.jdbc.pool.OracleDataSource"/>
+    	<properties maxPoolSize="3" connectionWaitTimeout="30" URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" connectionFactoryClassName="oracle.jdbc.pool.OracleDataSource"/>
     </dataSource>
     
     <!-- This Oracle DataSource uses Liberty connection pooling rather than UCP -->
     <dataSource id="oracleDS" jndiName="jdbc/oracleDS" connectionManagerRef="sharedConMgr" type="javax.sql.DataSource">
     	<jdbcDriver libraryRef="UCPDBLib"/>
-    	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
+    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
     </dataSource>
     
     <javaPermission codebase="${shared.resource.dir}/ucp/ojdbc8_g.jar" className="java.security.AllPermission"/>

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2016, 2021 IBM Corporation and others.
+    Copyright (c) 2016, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -34,29 +34,29 @@
     
     <dataSource id="DefaultDataSource">
     	<jdbcDriver libraryRef="DBLib"/>
-    	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
+    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
     </dataSource>
 
     <dataSource id="casting-ds" jndiName="jdbc/casting-ds" enableConnectionCasting="true">
     	<jdbcDriver libraryRef="DBLib"/>
-    	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" roleName="TestRole"/>
+    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" roleName="TestRole"/>
     	<onConnect>UPDATE CONCOUNT SET NUMCONNECTIONS = NUMCONNECTIONS + 1</onConnect>
     	<onConnect>CREATE GLOBAL TEMPORARY TABLE ${TEMP_TABLE_NAME}(CURTIME NVARCHAR2(100)) ON COMMIT PRESERVE ROWS</onConnect>
     	<onConnect>INSERT INTO ${TEMP_TABLE_NAME} VALUES (CURRENT_TIMESTAMP)</onConnect>
     </dataSource>
     
     <dataSource id="driver-ds" jndiName="jdbc/driver-ds" type="java.sql.Driver">
-    	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
+    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
     	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
     <dataSource id="generic-driver-ds" jndiName="jdbc/generic-driver-ds">
-    	<properties URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
+    	<properties URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
     	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
     <dataSource id="inferred-ds" jndiName="jdbc/inferred-ds">
-    	<properties databaseName="${env.DBNAME}" portNumber="${env.PORT}" serverName="${env.HOST}" user="${env.USER}" password="${env.PASSWORD}" driverType="thin"/>
+    	<properties databaseName="${env.ORACLE_DBNAME}" portNumber="${env.ORACLE_PORT}" serverName="${env.ORACLE_HOST}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" driverType="thin"/>
     	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracletracefat/src/trace/web/OracleTraceTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracletracefat/src/trace/web/OracleTraceTestServlet.java
@@ -30,9 +30,9 @@ import componenttest.app.FATServlet;
 @DataSourceDefinition(
                       name = "java:comp/env/jdbc/conn_prop_dsd",
                       className = "oracle.jdbc.pool.OracleDataSource",
-                      url = "${env.URL}",
-                      user = "${env.USER}",
-                      password = "${env.PASSWORD}",
+                      url = "${env.ORACLE_URL}",
+                      user = "${env.ORACLE_USER}",
+                      password = "${env.ORACLE_PASSWORD}",
                       properties = {
                                      "connectionProperties=" +
                                      "oracle.net.ssl_version=1.2;" +

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -51,13 +51,13 @@ import oracle.ucp.jdbc.PoolXADataSource;
                                  @DataSourceDefinition(
                                                        name = "java:comp/env/jdbc/dsdUCPDS",
                                                        className = "oracle.ucp.jdbc.PoolDataSourceImpl",
-                                                       url = "${env.URL}",
+                                                       url = "${env.ORACLE_URL}",
                                                        isolationLevel = Connection.TRANSACTION_SERIALIZABLE,
                                                        maxIdleTime = 30,
                                                        minPoolSize = 1,
                                                        initialPoolSize = 1, //This property should be allowed when using UCP
-                                                       user = "${env.USER}",
-                                                       password = "${env.PASSWORD}",
+                                                       user = "${env.ORACLE_USER}",
+                                                       password = "${env.ORACLE_PASSWORD}",
                                                        maxPoolSize = 3,
                                                        maxStatements = 9,
                                                        properties = {
@@ -69,10 +69,10 @@ import oracle.ucp.jdbc.PoolXADataSource;
                                  @DataSourceDefinition(
                                                        name = "java:comp/env/jdbc/dsdXAUCPDS",
                                                        className = "oracle.ucp.jdbc.PoolXADataSourceImpl",
-                                                       url = "${env.URL}",
+                                                       url = "${env.ORACLE_URL}",
                                                        initialPoolSize = 1,
-                                                       user = "${env.USER}",
-                                                       password = "${env.PASSWORD}",
+                                                       user = "${env.ORACLE_USER}",
+                                                       password = "${env.ORACLE_PASSWORD}",
                                                        maxStatements = 10,
                                                        properties = {
                                                                       "validationTimeout=30"
@@ -80,10 +80,10 @@ import oracle.ucp.jdbc.PoolXADataSource;
                                  @DataSourceDefinition(
                                                        name = "java:comp/env/jdbc/dsdXAUCPDS2",
                                                        className = "oracle.ucp.jdbc.PoolXADataSourceImpl",
-                                                       url = "${env.URL}",
+                                                       url = "${env.ORACLE_URL}",
                                                        initialPoolSize = 1,
-                                                       user = "${env.USER}",
-                                                       password = "${env.PASSWORD}",
+                                                       user = "${env.ORACLE_USER}",
+                                                       password = "${env.ORACLE_PASSWORD}",
                                                        maxStatements = 10,
                                                        properties = {
                                                                       "validationTimeout=30"

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerSSLTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerSSLTest.java
@@ -58,11 +58,11 @@ public class SQLServerSSLTest extends FATServletClient {
     public static void setUp() throws Exception {
         FATSuite.setupDatabase(sqlserver, true);
 
-        server.addEnvVar("DBNAME", FATSuite.DB_NAME);
-        server.addEnvVar("HOST", sqlserver.getHost());
-        server.addEnvVar("PORT", Integer.toString(sqlserver.getFirstMappedPort()));
-        server.addEnvVar("USER", sqlserver.getUsername());
-        server.addEnvVar("PASSWORD", sqlserver.getPassword());
+        server.addEnvVar("SQL_DBNAME", FATSuite.DB_NAME);
+        server.addEnvVar("SQL_HOST", sqlserver.getHost());
+        server.addEnvVar("SQL_PORT", Integer.toString(sqlserver.getFirstMappedPort()));
+        server.addEnvVar("SQL_USER", sqlserver.getUsername());
+        server.addEnvVar("SQL_PASSWORD", sqlserver.getPassword());
         server.addEnvVar("TRUSTSTORE_PASS", "WalletPasswd123");
 
         // Create a normal Java EE application and export to server

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerTest.java
@@ -54,11 +54,11 @@ public class SQLServerTest extends FATServletClient {
     public static void setUp() throws Exception {
         FATSuite.setupDatabase(sqlserver, false);
 
-        server.addEnvVar("DBNAME", FATSuite.DB_NAME);
-        server.addEnvVar("HOST", sqlserver.getHost());
-        server.addEnvVar("PORT", Integer.toString(sqlserver.getFirstMappedPort()));
-        server.addEnvVar("USER", sqlserver.getUsername());
-        server.addEnvVar("PASSWORD", sqlserver.getPassword());
+        server.addEnvVar("SQL_DBNAME", FATSuite.DB_NAME);
+        server.addEnvVar("SQL_HOST", sqlserver.getHost());
+        server.addEnvVar("SQL_PORT", Integer.toString(sqlserver.getFirstMappedPort()));
+        server.addEnvVar("SQL_USER", sqlserver.getUsername());
+        server.addEnvVar("SQL_PASSWORD", sqlserver.getPassword());
 
         // Create a normal Java EE application and export to server
         ShrinkHelper.defaultApp(server, APP_NAME, "web");

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/publish/servers/com.ibm.ws.jdbc.fat.sqlserver.ssl/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/publish/servers/com.ibm.ws.jdbc.fat.sqlserver.ssl/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
   
   <application location="sqlserversslfat.war" />
   
-  <authData id="dbAuth" user="${env.USER}" password="${env.PASSWORD}"/>
+  <authData id="dbAuth" user="${env.SQL_USER}" password="${env.SQL_PASSWORD}"/>
   <jdbcDriver id="sqlServerDriver">
     <library>
     	<fileset dir="${shared.resource.dir}/sqlserver" includes="mssql-jdbc.jar"/>
@@ -29,12 +29,12 @@
   </jdbcDriver>
   
   <dataSource jndiName="jdbc/sqlserver-ssl-unsecure" jdbcDriverRef="sqlServerDriver" containerAuthDataRef="dbAuth">
-    <properties.microsoft.sqlserver databaseName="${env.DBNAME}" serverName="${env.HOST}" portNumber="${env.PORT}"
+    <properties.microsoft.sqlserver databaseName="${env.SQL_DBNAME}" serverName="${env.SQL_HOST}" portNumber="${env.SQL_PORT}"
                 SSLProtocol="TLSv1.2" encrypt="true" trustServerCertificate="true"/>
   </dataSource>
   
     <dataSource jndiName="jdbc/sqlserver-ssl-secure" jdbcDriverRef="sqlServerDriver" containerAuthDataRef="dbAuth">
-    <properties.microsoft.sqlserver databaseName="${env.DBNAME}" serverName="${env.HOST}" portNumber="${env.PORT}"
+    <properties.microsoft.sqlserver databaseName="${env.SQL_DBNAME}" serverName="${env.SQL_HOST}" portNumber="${env.SQL_PORT}"
                 SSLProtocol="TLSv1.2" encrypt="true" hostNameInCertificate="localhost"
                 trustStore="security/truststore.p12" trustStorePassword="${TRUSTSTORE_PASS}"/>
   </dataSource>

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/publish/servers/com.ibm.ws.jdbc.fat.sqlserver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/publish/servers/com.ibm.ws.jdbc.fat.sqlserver/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019,2021 IBM Corporation and others.
+    Copyright (c) 2019, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -36,41 +36,41 @@
   <dataSource id="DefaultDataSource">
     <jdbcDriver libraryRef="SQLServerLibAnon"/>
     <properties.microsoft.sqlserver
-      databaseName="${env.DBNAME}" serverName="${env.HOST}" portNumber="${env.PORT}"/>
-    <containerAuthData user="${env.USER}" password="${env.PASSWORD}"/>
-    <recoveryAuthData user="${env.USER}" password="${env.PASSWORD}"/>
+      databaseName="${env.SQL_DBNAME}" serverName="${env.SQL_HOST}" portNumber="${env.SQL_PORT}"/>
+    <containerAuthData user="${env.SQL_USER}" password="${env.SQL_PASSWORD}"/>
+    <recoveryAuthData user="${env.SQL_USER}" password="${env.SQL_PASSWORD}"/>
   </dataSource>
 
   <dataSource jndiName="jdbc/ss" isolationLevel="TRANSACTION_SNAPSHOT">
     <jdbcDriver libraryRef="SQLServerLibAnon"/>
     <properties.microsoft.sqlserver
-      databaseName="${env.DBNAME}" serverName="${env.HOST}" portNumber="${env.PORT}"
-      user="${env.USER}" password="${env.PASSWORD}" trustServerCertificate="true"
+      databaseName="${env.SQL_DBNAME}" serverName="${env.SQL_HOST}" portNumber="${env.SQL_PORT}"
+      user="${env.SQL_USER}" password="${env.SQL_PASSWORD}" trustServerCertificate="true"
       packetSize="-1" serverNameAsACE="true" transparentNetworkIPResolution="false"/>
   </dataSource>
   
   <dataSource jndiName="jdbc/ss-using-driver">
   	<jdbcDriver libraryRef="SQLServerLibAnon"/>
-  	<properties user="${env.USER}" password="${env.PASSWORD}"
-      url="jdbc:sqlserver://${env.HOST}:${env.PORT};databaseName=${env.DBNAME};"/>
+  	<properties user="${env.SQL_USER}" password="${env.SQL_PASSWORD}"
+      url="jdbc:sqlserver://${env.SQL_HOST}:${env.SQL_PORT};databaseName=${env.SQL_DBNAME};"/>
   </dataSource>
   
   <dataSource jndiName="jdbc/ss-using-driver-type" type="java.sql.Driver">
   	<jdbcDriver libraryRef="SQLServerLibAnon"/>
-  	<properties.microsoft.sqlserver user="${env.USER}" password="${env.PASSWORD}" serverName="${env.HOST}"
-  	  url="jdbc:sqlserver://${env.HOST}:${env.PORT};databaseName=${env.DBNAME};" />
+  	<properties.microsoft.sqlserver user="${env.SQL_USER}" password="${env.SQL_PASSWORD}" serverName="${env.SQL_HOST}"
+  	  url="jdbc:sqlserver://${env.SQL_HOST}:${env.SQL_PORT};databaseName=${env.SQL_DBNAME};" />
   </dataSource>
   
   <dataSource jndiName="jdbc/ss-inferred">
     <jdbcDriver libraryRef="SQLServerLibAnon"/>
-    <properties user="${env.USER}" password="${env.PASSWORD}"
-      databaseName="${env.DBNAME}" serverName="${env.HOST}" portNumber="${env.PORT}"/>
+    <properties user="${env.SQL_USER}" password="${env.SQL_PASSWORD}"
+      databaseName="${env.SQL_DBNAME}" serverName="${env.SQL_HOST}" portNumber="${env.SQL_PORT}"/>
   </dataSource>
   
   <dataSource jndiName="jdbc/ntlm">
     <jdbcDriver libraryRef="SQLServerLibAnon"/>
-    <properties user="${env.USER}" password="${env.PASSWORD}"
-      databaseName="${env.DBNAME}" serverName="${env.HOST}" portNumber="${env.PORT}" authenticationScheme="NTLM" />
+    <properties user="${env.SQL_USER}" password="${env.SQL_PASSWORD}"
+      databaseName="${env.SQL_DBNAME}" serverName="${env.SQL_HOST}" portNumber="${env.SQL_PORT}" authenticationScheme="NTLM" />
   </dataSource>
 
   <javaPermission codebase="${server.config.dir}/apps/sqlserverfat.war" className="java.security.AllPermission"/>


### PR DESCRIPTION
When running our Database Container test suites we often set environment variables on the server to pass the programmatically constructed container variables to the server.

The problem is that in some instances we are clashing with environment variables set on the OS and picked up by the Liberty server at runtime. Namely: `USER` and `PASSWORD`

Avoid this by using the more specific `ORACLE_USER` and `SQL_USER` variable names. 
Note that OS environment variables are non-mutable at runtime.