### PR TITLE
RTC294172 RTC293474 RTC294307 Build break fixes

### DIFF
--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/jsf/SimpleJSFWithSharedLibTest.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/jsf/SimpleJSFWithSharedLibTest.java
@@ -63,7 +63,7 @@ public class SimpleJSFWithSharedLibTest {
         CDIArchiveHelper.addBeansXML(simpleJSFWithSharedLib, DiscoveryMode.ALL);
 
         ShrinkHelper.exportToServer(server, "/InjectionSharedLibrary", sharedLibrary, DeployOptions.SERVER_ONLY);
-        ShrinkHelper.exportToServer(server, "/apps", simpleJSFWithSharedLib, DeployOptions.SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, simpleJSFWithSharedLib, DeployOptions.SERVER_ONLY);
         server.startServer();
         server.waitForStringInLogUsingMark("CWWKZ0001I.*Application " + APP_NAME + " started");
     }

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/VisTest.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/VisTest.java
@@ -731,10 +731,7 @@ public class VisTest extends FATServletClient {
         if (server != null) {
             server.stopServer();
         }
-    }
 
-    @AfterClass
-    public static void cleanupFeatures() throws Exception {
         server.uninstallSystemFeature("visTest-1.2");
         server.uninstallSystemFeature("visTest-3.0");
     }

--- a/dev/com.ibm.ws.org.jboss.weld/bnd.overrides
+++ b/dev/com.ibm.ws.org.jboss.weld/bnd.overrides
@@ -76,5 +76,6 @@ Service-Component: \
 Include-Resource: \
   @${repo;org.jboss.weld:weld-osgi-bundle;[2.4.8.Final,3)}!/!META-INF/maven/*, \
   org/jboss/weld/config=${bin}/org/jboss/weld/config, \
-  org/jboss/weld/context=${bin}/org/jboss/weld/context
+  org/jboss/weld/context=${bin}/org/jboss/weld/context, \
+  org/jboss/weld/bean/proxy=${bin}/org/jboss/weld/bean/proxy
 


### PR DESCRIPTION
This PR contains fixes for 

RTC293474 - This validates an app on startup. It is unlikely to fix the error, but tidies the test a little

RTC294307 - This fixes a test failure by merging two methods annotated AfterClass into one method. This fixes a bug that occurs if they run in the wrong order. 

RTC294172 a follow up to #23816 that ensures the updated file to weld is packaged in the jar we ship with liberty.