### PR TITLE
enable logout test after 24062 was resolved

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/fat/src/io/openliberty/security/jakartasec/fat/logout/tests/BasicLogoutTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/fat/src/io/openliberty/security/jakartasec/fat/logout/tests/BasicLogoutTests.java
@@ -39,6 +39,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import io.openliberty.security.jakartasec.fat.commonTests.CommonLogoutAndRefreshTests;
 import io.openliberty.security.jakartasec.fat.configs.TestConfigMaps;
+import io.openliberty.security.jakartasec.fat.utils.CommonExpectations;
 import io.openliberty.security.jakartasec.fat.utils.Constants;
 import io.openliberty.security.jakartasec.fat.utils.MessageConstants;
 import io.openliberty.security.jakartasec.fat.utils.ShrinkWrapHelpers;
@@ -1171,14 +1172,12 @@ public class BasicLogoutTests extends CommonLogoutAndRefreshTests {
 
     // Do not need tests with NotifyProvider = false since end_session won't be invoked - other tests that use the logout redirect uri already check for parms being passed
 
-    // TODO - not working yet - issue https://github.com/OpenLiberty/open-liberty/issues/24062
     /**
-     * Invoke an app protected by the @OpenIdAuthenticationMechanismDefinition annotation and are granted access - invoke the post method of the app to perform a request.logout() -
-     * expect TODO
+     * Invoke an app protected by the @OpenIdAuthenticationMechanismDefinition annotation and are granted access - invoke the post method of the app to perform a request.logout()
      *
      * @throws Exception
      */
-    //@Test
+    @Test
     public void BasicLogoutTests_invoke_reqLogout() throws Exception {
 
         String appName = "GoodRedirectNotifyProviderTrueTestEndSessionLogoutServlet";
@@ -1187,7 +1186,8 @@ public class BasicLogoutTests extends CommonLogoutAndRefreshTests {
         runGoodEndToEndTest(webClient, appName, baseAppName);
 
         String url = rpHttpsBase + "/GoodRedirectNotifyProviderTrueTestEndSessionLogoutServlet/" + baseAppName;
-        actions.invokeUrlWithParametersUsingPost(_testName, webClient, url, null);
+        Page response = actions.invokeUrlWithParametersUsingPost(_testName, webClient, url, null);
+        validationUtils.validateResult(response, CommonExpectations.successfullyReachedTestEndSessiontPage(rpHttpsBase, true));
 
     }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/test-applications/BasicLogout.war/src/oidc/client/basicLogout/servlets/BasicLogoutServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/test-applications/BasicLogout.war/src/oidc/client/basicLogout/servlets/BasicLogoutServlet.java
@@ -63,7 +63,12 @@ public class BasicLogoutServlet extends BaseServlet {
         }
 
         request.logout();
-        ServletLogger.printLine(outputStream, "BasicLogoutServlet: End");
+        // In some cases the response is already committed before we return to the app, so, catch that specific exception on the print that follows
+        try {
+            ServletLogger.printLine(outputStream, "BasicLogoutServlet: End");
+        } catch (IOException io) {
+            System.out.println("Ignoring an IO exception due to the already closed stream when we try to log that the logout app has completed.");
+        }
 
     }
 }


### PR DESCRIPTION
Enable BasicLogoutTests_invoke_reqLogout after issue 24062 (java.lang.IllegalStateException: cannot remove cookie if the response is committed) was resolved.