### PR TITLE
fix and re-enable jakarta security 3.0 tokenMinValidity fat tests

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/configs/TestConfigMaps.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/configs/TestConfigMaps.java
@@ -531,18 +531,18 @@ public class TestConfigMaps {
 
     }
 
-    public static Map<String, Object> getTokenMinValidity30s() throws Exception {
-
-        Map<String, Object> updatedMap = new HashMap<String, Object>();
-        updatedMap.put(Constants.TOKEN_MIN_VALIDITY_EXPRESSION, 30 * 1000);
-        return updatedMap;
-
-    }
-
     public static Map<String, Object> getTokenMinValidity60s() throws Exception {
 
         Map<String, Object> updatedMap = new HashMap<String, Object>();
         updatedMap.put(Constants.TOKEN_MIN_VALIDITY_EXPRESSION, 60 * 1000);
+        return updatedMap;
+
+    }
+
+    public static Map<String, Object> getTokenMinValidity90s() throws Exception {
+
+        Map<String, Object> updatedMap = new HashMap<String, Object>();
+        updatedMap.put(Constants.TOKEN_MIN_VALIDITY_EXPRESSION, 90 * 1000);
         return updatedMap;
 
     }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/.classpath
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/.classpath
@@ -62,8 +62,8 @@
 	<classpathentry kind="src" path="test-applications/Endpoints.war/src"/>
 	<classpathentry kind="src" path="test-applications/TokenMinValidity5s.war/src"/>
 	<classpathentry kind="src" path="test-applications/TokenMinValidity20s.war/src"/>
-	<classpathentry kind="src" path="test-applications/TokenMinValidity30s.war/src"/>
 	<classpathentry kind="src" path="test-applications/TokenMinValidity60s.war/src"/>
+	<classpathentry kind="src" path="test-applications/TokenMinValidity90s.war/src"/>
 	<classpathentry kind="src" path="test-applications/TokenMinValidity0s.war/src"/>
 	<classpathentry kind="src" path="test-applications/TokenMinValidityNegative5s.war/src"/>
 	<classpathentry kind="src" path="test-applications/TokenMinValidity5sWithEL.war/src"/>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/bnd.bnd
@@ -76,8 +76,8 @@ src: \
     test-applications/ProviderMetadata.war/src,\
     test-applications/TokenMinValidity5s.war/src,\
     test-applications/TokenMinValidity20s.war/src,\
-    test-applications/TokenMinValidity30s.war/src,\
     test-applications/TokenMinValidity60s.war/src,\
+    test-applications/TokenMinValidity90s.war/src,\
     test-applications/TokenMinValidity0s.war/src,\
     test-applications/TokenMinValidityNegative5s.war/src,\
     test-applications/TokenMinValidity5sWithEL.war/src,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/FATSuite.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/FATSuite.java
@@ -28,6 +28,7 @@ import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationResponse
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationScopeTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationSigningTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationTests;
+import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationTokenMinValidityTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationUseNonceTests;
 import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationUserInfoTests;
 
@@ -42,7 +43,7 @@ import io.openliberty.security.jakartasec.fat.config.tests.ConfigurationUserInfo
                 ConfigurationExtraParametersTests.class,
                 ConfigurationPromptTests.class,
                 ConfigurationDisplayTests.class,
-//                ConfigurationTokenMinValidityTests.class,
+                ConfigurationTokenMinValidityTests.class,
                 // LogoutDefinition tests are handled in a separate FAT project as the test use sleeps to wait for tokens to expire and that causes the tests to take quite some time to run
                 ConfigurationELValuesOverrideTests.class,
                 ConfigurationELValuesOverrideWithoutHttpSessionTests.class,

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTokenMinValidityTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTokenMinValidityTests.java
@@ -52,7 +52,7 @@ import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdCo
  *
  * The test apps also set prompt=login, accessTokenExpiry=true, and identityTokenExpiry=true.
  * This is to make the RP redirect to the login page to make testing easier when the tokens are
- * consider expired based on the tokenMinValidity and token lifetime (30s).
+ * consider expired based on the tokenMinValidity and token lifetime (60s).
  */
 /**
  * Tests appSecurity-5.0
@@ -112,8 +112,8 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
 
         swh.defaultDropinApp(rpServer, "TokenMinValidity5s.war", "oidc.client.tokenMinValidity5s.servlets", "oidc.client.base.*");
         swh.defaultDropinApp(rpServer, "TokenMinValidity20s.war", "oidc.client.tokenMinValidity20s.servlets", "oidc.client.base.*");
-        swh.defaultDropinApp(rpServer, "TokenMinValidity30s.war", "oidc.client.tokenMinValidity30s.servlets", "oidc.client.base.*");
         swh.defaultDropinApp(rpServer, "TokenMinValidity60s.war", "oidc.client.tokenMinValidity60s.servlets", "oidc.client.base.*");
+        swh.defaultDropinApp(rpServer, "TokenMinValidity90s.war", "oidc.client.tokenMinValidity90s.servlets", "oidc.client.base.*");
         swh.defaultDropinApp(rpServer, "TokenMinValidity0s.war", "oidc.client.tokenMinValidity0s.servlets", "oidc.client.base.*");
         swh.defaultDropinApp(rpServer, "TokenMinValidityNegative5s.war", "oidc.client.tokenMinValidityNegative5s.servlets", "oidc.client.base.*");
         swh.defaultDropinApp(rpServer, "TokenMinValidityDefault.war", "oidc.client.tokenMinValidityDefault.servlets", "oidc.client.base.*");
@@ -126,13 +126,13 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
                                        buildUpdatedConfigMap(opServer, rpServer, "TokenMinValidityEL20s", "allValues.openIdConfig.properties",
                                                              TestConfigMaps.getTokenMinValidity20s()),
                                        "oidc.client.tokenMinValidityEL.servlets", "oidc.client.base.*");
-        swh.deployConfigurableTestApps(rpServer, "TokenMinValidityEL30s.war", "TokenMinValidityEL.war",
-                                       buildUpdatedConfigMap(opServer, rpServer, "TokenMinValidityEL30s", "allValues.openIdConfig.properties",
-                                                             TestConfigMaps.getTokenMinValidity30s()),
-                                       "oidc.client.tokenMinValidityEL.servlets", "oidc.client.base.*");
         swh.deployConfigurableTestApps(rpServer, "TokenMinValidityEL60s.war", "TokenMinValidityEL.war",
                                        buildUpdatedConfigMap(opServer, rpServer, "TokenMinValidityEL60s", "allValues.openIdConfig.properties",
                                                              TestConfigMaps.getTokenMinValidity60s()),
+                                       "oidc.client.tokenMinValidityEL.servlets", "oidc.client.base.*");
+        swh.deployConfigurableTestApps(rpServer, "TokenMinValidityEL90s.war", "TokenMinValidityEL.war",
+                                       buildUpdatedConfigMap(opServer, rpServer, "TokenMinValidityEL90s", "allValues.openIdConfig.properties",
+                                                             TestConfigMaps.getTokenMinValidity90s()),
                                        "oidc.client.tokenMinValidityEL.servlets", "oidc.client.base.*");
         swh.deployConfigurableTestApps(rpServer, "TokenMinValidityEL0s.war", "TokenMinValidityEL.war",
                                        buildUpdatedConfigMap(opServer, rpServer, "TokenMinValidityEL0s", "allValues.openIdConfig.properties",
@@ -240,7 +240,7 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
 
     /**
      * Tests with tokenMinValidity = 5 * 1000.
-     * The token lifetime should effectively be 30s - 5s = 25s.
+     * The token lifetime should effectively be 60s - 5s = 55s.
      *
      * @throws Exception
      */
@@ -253,7 +253,7 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
 
     /**
      * Tests with tokenMinValidity = 20 * 1000.
-     * The token lifetime should effectively be 30s - 20s = 10s.
+     * The token lifetime should effectively be 60s - 20s = 40s.
      *
      * @throws Exception
      */
@@ -265,22 +265,8 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
     }
 
     /**
-     * Tests with tokenMinValidity = 30 * 1000.
-     * The token lifetime should effectively be 30s - 30s = 0s.
-     * The protected app should not be able to be reached, since the token is effectively never valid.
-     *
-     * @throws Exception
-     */
-    @Test
-    public void ConfigurationTokenMinValidityTests_tokenMinValidity_30s() throws Exception {
-
-        runBadEndToEndTokenMinValidityGreaterThanTokenLifetimeTest("TokenMinValidity30s", "TokenMinValidity30sServlet");
-
-    }
-
-    /**
      * Tests with tokenMinValidity = 60 * 1000.
-     * The token lifetime should effectively be 30s - 60s = -30s.
+     * The token lifetime should effectively be 60s - 60s = 0s.
      * The protected app should not be able to be reached, since the token is effectively never valid.
      *
      * @throws Exception
@@ -293,8 +279,22 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
     }
 
     /**
+     * Tests with tokenMinValidity = 90 * 1000.
+     * The token lifetime should effectively be 60s - 90s = -30s.
+     * The protected app should not be able to be reached, since the token is effectively never valid.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationTokenMinValidityTests_tokenMinValidity_90s() throws Exception {
+
+        runBadEndToEndTokenMinValidityGreaterThanTokenLifetimeTest("TokenMinValidity90s", "TokenMinValidity90sServlet");
+
+    }
+
+    /**
      * Tests with tokenMinValidity = 0.
-     * The token lifetime should effectively be 30s - 0s = 30s.
+     * The token lifetime should effectively be 60s - 0s = 60s.
      *
      * @throws Exception
      */
@@ -308,7 +308,7 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
     /**
      * Tests with tokenMinValidity = -5 * 1000.
      * Negative values must not be used and the default value of 10 * 1000 is used instead.
-     * The token lifetime should effectively be 30s - 10s = 20s.
+     * The token lifetime should effectively be 60s - 10s = 50s.
      *
      * @throws Exception
      */
@@ -320,7 +320,7 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
 
     /**
      * Tests with tokenMinValidityExpression = 5 * 1000.
-     * The token lifetime should effectively be 30s - 5s = 25s.
+     * The token lifetime should effectively be 60s - 5s = 55s.
      *
      * @throws Exception
      */
@@ -333,7 +333,7 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
 
     /**
      * Tests with tokenMinValidityExpression = 20 * 1000.
-     * The token lifetime should effectively be 30s - 20s = 10s.
+     * The token lifetime should effectively be 60s - 20s = 40s.
      *
      * @throws Exception
      */
@@ -345,22 +345,8 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
     }
 
     /**
-     * Tests with tokenMinValidityExpression = 30 * 1000.
-     * The token lifetime should effectively be 30s - 30s = 0s.
-     * The protected app should not be able to be reached, since the token is effectively never valid.
-     *
-     * @throws Exception
-     */
-    @Test
-    public void ConfigurationTokenMinValidityTests_tokenMinValidityExpression_30s() throws Exception {
-
-        runBadEndToEndTokenMinValidityGreaterThanTokenLifetimeTest("TokenMinValidityEL30s", "TokenMinValidityELServlet");
-
-    }
-
-    /**
      * Tests with tokenMinValidityExpression = 60 * 1000.
-     * The token lifetime should effectively be 30s - 60s = -30s.
+     * The token lifetime should effectively be 60s - 60s = 0s.
      * The protected app should not be able to be reached, since the token is effectively never valid.
      *
      * @throws Exception
@@ -373,8 +359,22 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
     }
 
     /**
+     * Tests with tokenMinValidityExpression = 90 * 1000.
+     * The token lifetime should effectively be 60s - 90s = -30s.
+     * The protected app should not be able to be reached, since the token is effectively never valid.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ConfigurationTokenMinValidityTests_tokenMinValidityExpression_90s() throws Exception {
+
+        runBadEndToEndTokenMinValidityGreaterThanTokenLifetimeTest("TokenMinValidityEL90s", "TokenMinValidityELServlet");
+
+    }
+
+    /**
      * Tests with tokenMinValidityExpression = 0 * 1000.
-     * The token lifetime should effectively be 30s - 0s = 30s.
+     * The token lifetime should effectively be 60s - 0s = 60s.
      *
      * @throws Exception
      */
@@ -388,7 +388,7 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
     /**
      * Tests with tokenMinValidityExpression = -5 * 1000.
      * Negative values must not be used and the default value of 10s is used instead.
-     * The token lifetime should effectively be 30s - 10s = 20s.
+     * The token lifetime should effectively be 60s - 10s = 50s.
      *
      * @throws Exception
      */
@@ -402,7 +402,7 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
     /**
      * Tests with tokenMinValidity = 5 * 1000 and tokenMinValidityExpression = 15 * 1000.
      * tokenMinValidityExpression should take precedence over tokenMinValidity.
-     * The token lifetime should effectively be 30s - 15s = 15s.
+     * The token lifetime should effectively be 60s - 15s = 45s.
      *
      * @throws Exception
      */
@@ -416,7 +416,7 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
     /**
      * Tests with no tokenMinValidity nor tokenMinValidityExpression.
      * tokenMinValidity should use the default value of 10 * 1000.
-     * The token lifetime should effectively be 30s - 10s = 20s.
+     * The token lifetime should effectively be 60s - 10s = 50s.
      *
      * @throws Exception
      */

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTokenMinValidityTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTokenMinValidityTests.java
@@ -73,7 +73,7 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
     @ClassRule
     public static RepeatTests repeat = createRandomTokenTypeRepeats();
 
-    private static int BUFFER_SECONDS = 1; // account for code execution delays
+    private static int BUFFER_SECONDS = 2; // account for code execution delays
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/shared/config/oidcTokenMinValidityProvider.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/publish/shared/config/oidcTokenMinValidityProvider.xml
@@ -17,14 +17,14 @@
 		signatureAlgorithm="RS256"
 		keyAliasName="rs256"
 		keystoreRef="key_allSigAlg"
-		idTokenLifetime="30s"
+		idTokenLifetime="60s"
 		oauthProviderRef="OAuth1" />
 
 	<oauthProvider
 		id="OAuth1"
 		autoAuthorize="true"
 		tokenFormat="${opTokenFormat}"
-		accessTokenLifetime="30s"
+		accessTokenLifetime="60s"
 	>
 		<autoAuthorizeClient>client_1</autoAuthorizeClient>
 		
@@ -34,14 +34,14 @@
 				secret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
 				redirect="https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidity5s/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidity20s/Callback,
-							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidity30s/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidity60s/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidity90s/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidity0s/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidityNegative5s/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidityEL5s/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidityEL20s/Callback,
-							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidityEL30s/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidityEL60s/Callback,
+							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidityEL90s/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidityEL0s/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidityELNegative5s/Callback,
 							https://localhost:${bvt.prop.security_2_HTTP_default.secure}/TokenMinValidity5sEL15s/Callback,

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/TokenMinValidity90s.war/src/oidc/client/tokenMinValidity90s/servlets/CallbackServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/TokenMinValidity90s.war/src/oidc/client/tokenMinValidity90s/servlets/CallbackServlet.java
@@ -10,16 +10,14 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package oidc.client.tokenMinValidity30s.servlets;
+package oidc.client.tokenMinValidity90s.servlets;
 
-import jakarta.enterprise.context.Dependent;
-import jakarta.inject.Named;
-import oidc.client.base.servlets.BaseOpenIdConfig;
+import jakarta.servlet.annotation.WebServlet;
+import oidc.client.base.servlets.BaseCallbackServlet;
 
-@Named
-@Dependent
-public class OpenIdConfig extends BaseOpenIdConfig {
+@WebServlet("/Callback")
+public class CallbackServlet extends BaseCallbackServlet {
 
-    // override and/or create new get methods
+    private static final long serialVersionUID = -417476984908088827L;
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/TokenMinValidity90s.war/src/oidc/client/tokenMinValidity90s/servlets/OpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/TokenMinValidity90s.war/src/oidc/client/tokenMinValidity90s/servlets/OpenIdConfig.java
@@ -10,14 +10,16 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package oidc.client.tokenMinValidity30s.servlets;
+package oidc.client.tokenMinValidity90s.servlets;
 
-import jakarta.servlet.annotation.WebServlet;
-import oidc.client.base.servlets.BaseCallbackServlet;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import oidc.client.base.servlets.BaseOpenIdConfig;
 
-@WebServlet("/Callback")
-public class CallbackServlet extends BaseCallbackServlet {
+@Named
+@Dependent
+public class OpenIdConfig extends BaseOpenIdConfig {
 
-    private static final long serialVersionUID = -417476984908088827L;
+    // override and/or create new get methods
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/TokenMinValidity90s.war/src/oidc/client/tokenMinValidity90s/servlets/TokenMinValidity90sServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config/test-applications/TokenMinValidity90s.war/src/oidc/client/tokenMinValidity90s/servlets/TokenMinValidity90sServlet.java
@@ -10,7 +10,7 @@
  * Contributors:
  * IBM Corporation - initial API and implementation
  *******************************************************************************/
-package oidc.client.tokenMinValidity30s.servlets;
+package oidc.client.tokenMinValidity90s.servlets;
 
 import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
@@ -22,19 +22,19 @@ import jakarta.servlet.annotation.ServletSecurity;
 import jakarta.servlet.annotation.WebServlet;
 import oidc.client.base.servlets.BaseServlet;
 
-@WebServlet("/TokenMinValidity30sServlet")
+@WebServlet("/TokenMinValidity90sServlet")
 @OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
                                          clientId = "client_1",
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),
                                          redirectURI = "${baseURL}/Callback",
                                          jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
-                                         tokenMinValidity = 30 * 1000,
+                                         tokenMinValidity = 90 * 1000,
                                          prompt = PromptType.LOGIN,
                                          logout = @LogoutDefinition(accessTokenExpiry = true, identityTokenExpiry = true))
 @DeclareRoles("all")
 @ServletSecurity(@HttpConstraint(rolesAllowed = "all"))
-public class TokenMinValidity30sServlet extends BaseServlet {
+public class TokenMinValidity90sServlet extends BaseServlet {
 
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
- increased the token lifetime to 60s to ensure tokens are valid for long enough when running on slower machines
- made the `tokenMinValidity` tests less flaky by using the `exp` claim to determine the remaining lifetime rather than trying to figure it out using by subtracting the code execution times from the total lifetime