### PR TITLE
check to prevent npe in case access token is missing in the token response

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -72,7 +72,7 @@ public class OidcIdentityStore implements IdentityStore {
             OidcTokensCredential castCredential = (OidcTokensCredential) credential;
             TokenResponse tokenResponse = castCredential.getTokenResponse();
             Client client = castCredential.getClient();
-            if (tokenResponse != null && client != null) {
+            if (tokenResponse != null && client != null && tokenResponse.getAccessTokenString() != null) {
                 try {
                     HttpServletRequest request = castCredential.getRequest();
                     JwtClaims idTokenClaims = client.validate(tokenResponse, request, castCredential.getResponse());
@@ -160,7 +160,7 @@ public class OidcIdentityStore implements IdentityStore {
         }
 
         String accessTokenString = tokenResponse.getAccessTokenString();
-
+        
         boolean isJWT = false;
         Map<String, Object> jwtClaims = null;
 


### PR DESCRIPTION
address #24338

we may not run into this once the token response validation is done to make sure that the required parameters exist in the response ( #24376 )