### PR TITLE
Clear injection contexts for the error path in a catch block instead of finally

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/.classpath
@@ -14,6 +14,7 @@
 	<classpathentry kind="src" path="test-applications/lifecyclemismatch/src"/>
 	<classpathentry kind="src" path="test-applications/loadonstartup/src"/>
 	<classpathentry kind="src" path="test-applications/resourceInfoAtStartup/src"/>
+	<classpathentry kind="src" path="test-applications/ejbsubresource/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -23,6 +23,7 @@ src: \
     test-applications/contextandCDI/src,\
     test-applications/dependentIntoJax/src,\
     test-applications/disable/src,\
+    test-applications/ejbsubresource/src,\
     test-applications/interceptor/src,\
     test-applications/lifecyclemethod/src,\
     test-applications/lifecyclemismatch/src,\

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/FATSuite.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -25,6 +25,7 @@ import com.ibm.ws.jaxrs20.cdi12.fat.test.ContextAndClientTest;
 import com.ibm.ws.jaxrs20.cdi12.fat.test.ContextandCDI12Test;
 import com.ibm.ws.jaxrs20.cdi12.fat.test.DependentIntoJaxTest;
 import com.ibm.ws.jaxrs20.cdi12.fat.test.DisableTest;
+import com.ibm.ws.jaxrs20.cdi12.fat.test.EJBSubResourceTest;
 import com.ibm.ws.jaxrs20.cdi12.fat.test.InterceptorTest;
 import com.ibm.ws.jaxrs20.cdi12.fat.test.LifeCycle12Test;
 import com.ibm.ws.jaxrs20.cdi12.fat.test.LifeCycleMismatch12Test;
@@ -48,6 +49,7 @@ import componenttest.rules.repeater.RepeatTests;
                ContextandCDI12Test.class,     // Skip for JakartaEE9
                DependentIntoJaxTest.class,    // Skip for JakartaEE9
                DisableTest.class,             // Skip for JakartaEE9
+               EJBSubResourceTest.class,
                InterceptorTest.class,
                LifeCycle12Test.class,         // Skip for JakartaEE9
                LifeCycleMismatch12Test.class, // Skip for JakartaEE9

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/EJBSubResourceTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/EJBSubResourceTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.cdi12.fat.test;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.jaxrs.ejbsubresource.EJBSubResourceClientTestServlet;
+
+@RunWith(FATRunner.class)
+public class EJBSubResourceTest extends FATServletClient {
+
+    private static final String appName = "ejbsubresource";
+
+    @Server("io.openliberty.jaxrs.fat.ejbsubresource")
+    @TestServlet(servlet = EJBSubResourceClientTestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Build an application and export it to the dropins directory
+        ShrinkHelper.defaultDropinApp(server, appName, "io.openliberty.jaxrs.ejbsubresource");
+
+        // Make sure we don't fail because we try to start an
+        // already started server
+        try {
+            server.startServer("ejbsubresource.log", true);
+        } catch (Exception e) {
+            System.out.println(e.toString());
+        }
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        if (server != null) {
+            server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
+        }
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/publish/servers/io.openliberty.jaxrs.fat.ejbsubresource/.gitignore
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/publish/servers/io.openliberty.jaxrs.fat.ejbsubresource/.gitignore
@@ -1,0 +1,2 @@
+/apps
+/dropins

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/publish/servers/io.openliberty.jaxrs.fat.ejbsubresource/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/publish/servers/io.openliberty.jaxrs.fat.ejbsubresource/bootstrap.properties
@@ -1,0 +1,4 @@
+#com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all:org.jboss.resteasy*=all
+#com.ibm.ws.logging.max.file.size=0
+
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/publish/servers/io.openliberty.jaxrs.fat.ejbsubresource/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/publish/servers/io.openliberty.jaxrs.fat.ejbsubresource/server.xml
@@ -1,0 +1,11 @@
+<server>
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>jaxrs-2.0</feature>
+        <feature>servlet-3.1</feature>
+        <feature>ejb-3.2</feature>
+    </featureManager>
+
+  	<include location="../fatTestPorts.xml"/>
+  	<javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
+</server>

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/ejbsubresource/src/io/openliberty/jaxrs/ejbsubresource/EJBSubResourceApplication.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/ejbsubresource/src/io/openliberty/jaxrs/ejbsubresource/EJBSubResourceApplication.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jaxrs.ejbsubresource;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class EJBSubResourceApplication extends Application {
+
+    @Override
+    public java.util.Set<java.lang.Class<?>> getClasses() {
+        Set<Class<?>> resources = new HashSet<Class<?>>();
+        resources.add(SingletonRootResource.class);
+        return resources;
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/ejbsubresource/src/io/openliberty/jaxrs/ejbsubresource/EJBSubResourceClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/ejbsubresource/src/io/openliberty/jaxrs/ejbsubresource/EJBSubResourceClientTestServlet.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jaxrs.ejbsubresource;
+
+
+import static org.junit.Assert.assertEquals;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/EJBSubResourceClientTestServlet")
+public class EJBSubResourceClientTestServlet extends FATServlet {
+
+    private static final String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/ejbsubresource/";
+
+    private Client client;
+
+    @Override
+    public void before() throws ServletException {
+        client = ClientBuilder.newClient();
+    }
+
+    @Override
+    public void after() {
+        client.close();
+    }
+
+    @Test
+    public void testIsub() {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("root/sub")
+                        .request(MediaType.TEXT_PLAIN_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+        assertEquals(URI_CONTEXT_ROOT + "root/sub", response.readEntity(String.class));
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/ejbsubresource/src/io/openliberty/jaxrs/ejbsubresource/ILocalSingletonBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/ejbsubresource/src/io/openliberty/jaxrs/ejbsubresource/ILocalSingletonBean.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jaxrs.ejbsubresource;
+
+import javax.ws.rs.GET;
+
+public interface ILocalSingletonBean {
+
+   public void remove();
+
+   @GET
+   public String get();
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/ejbsubresource/src/io/openliberty/jaxrs/ejbsubresource/LocalSingletonBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/ejbsubresource/src/io/openliberty/jaxrs/ejbsubresource/LocalSingletonBean.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jaxrs.ejbsubresource;
+
+import javax.ejb.Local;
+import javax.ejb.Stateless;
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+@Stateless(name = "LocalSingletonBean")
+@Local({ ILocalSingletonBean.class })
+public class LocalSingletonBean implements ILocalSingletonBean {
+
+    public LocalSingletonBean() {}
+
+    @Override
+    public void remove() {}
+
+    @Context
+    private UriInfo ui;
+
+    @Override
+    @GET
+    public String get() {
+        return ui.getRequestUri().toASCIIString();
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/ejbsubresource/src/io/openliberty/jaxrs/ejbsubresource/SingletonRootResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/ejbsubresource/src/io/openliberty/jaxrs/ejbsubresource/SingletonRootResource.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jaxrs.ejbsubresource;
+
+import javax.ejb.EJB;
+import javax.ejb.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+@Singleton
+@Path("/root")
+public class SingletonRootResource {
+
+    // For some reason this line is needed for @Context injection to work in LocalSingletonBean
+    @Context private UriInfo uri;
+
+    @EJB
+    ILocalSingletonBean bean;
+
+    @Path("/sub")
+    public ILocalSingletonBean getSubResource() {
+        return bean;
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsInvoker.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsInvoker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -295,11 +295,19 @@ public class LibertyJaxRsInvoker extends JAXRSInvoker {
                 }
             }
             return response;
+        } catch (RuntimeException e) {
+            InjectionRuntimeContextHelper.removeRuntimeContext();
+            throw e;
+        } catch (Error e) {
+            InjectionRuntimeContextHelper.removeRuntimeContext();
+            throw e;
+        } catch (Throwable t) {
+            InjectionRuntimeContextHelper.removeRuntimeContext();
+            throw new RuntimeException(t);
         } finally {
             if (beanCustomizer != null && realServiceObject != null) {
                 beanCustomizer.afterServiceInvoke(realServiceObject, cri.isSingleton(), libertyJaxRsServerFactoryBean.getBeanCustomizerContext(beanCustomizer));
             }
-            InjectionRuntimeContextHelper.removeRuntimeContext();
         }
     }
 

--- a/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:


### PR DESCRIPTION
We should only be clearing the context in the case of an error, allowing the context to persist though the `AbstractPhaseInterceptorChain` to be cleared at the end of the request processing in `LibertyClearInjectRuntimeCtxOutInterceptor`

Fixes #24444 