### PR TITLE
Remove two invalid JPA FAT tests, circa RTC 294860

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh19342/src/com/ibm/ws/jpa/olgh19342/ejb/TestOLGH19342_EJB_SF_Servlet.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/test-applications/olgh19342/src/com/ibm/ws/jpa/olgh19342/ejb/TestOLGH19342_EJB_SF_Servlet.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -42,7 +42,7 @@ public class TestOLGH19342_EJB_SF_Servlet extends EJBDBTestVehicleServlet {
     }
 
     // testCaseExpressionOperatorConcurrency
-    @Test
+    // @Test // Not a valid scenario, see RTC 294860
     public void jpa_spec10_query_olgh19342_testCaseExpressionOperatorConcurrency_EJB_SF_AMJTA_Web() throws Exception {
         final String testName = "jpa10_query_olgh19342_testCaseExpressionOperatorConcurrency_EJB_SF_AMJTA_Web";
         final String testMethod = "testCaseExpressionOperatorConcurrency";
@@ -58,7 +58,7 @@ public class TestOLGH19342_EJB_SF_Servlet extends EJBDBTestVehicleServlet {
         executeTest(testName, testMethod, testResource);
     }
 
-    @Test
+    // @Test // Not a valid scenario, see RTC 294860
     public void jpa_spec10_query_olgh19342_testCaseExpressionOperatorConcurrency_EJB_SF_CMTS_Web() throws Exception {
         final String testName = "jpa10_query_olgh19342_testCaseExpressionOperatorConcurrency_EJB_SF_CMTS_Web";
         final String testMethod = "testCaseExpressionOperatorConcurrency";


### PR DESCRIPTION
As stated in RTC:
```
I think I see the problem, the test is spawning 100 threads to run JPA workloads.  I had fixed this bucket last week because it was trying to use the EntityTransactionWrapper, which for resource local entitymanagers, is calling the wrong instance of EntityTransaction to manage the transaction.

I had removed it, and set it to use EntityTransaction from the em generated in the thread, but when I spotted the following:



[2/22/23 8:36:14:124 EST] 000000fe SystemErr                                                    R Exception in thread "pool-3-thread-92"
[2/22/23 8:36:14:124 EST] 000000fe SystemErr                                                    R java.lang.NullPointerException
[2/22/23 8:36:14:126 EST] 000000fe SystemErr                                                    R at com.ibm.ws.jpa.olgh19342.testlogic.JPATestOLGH19342Logic$1.run(JPATestOLGH19342Logic.java:83)
[2/22/23 8:36:14:126 EST] 000000fe SystemErr                                                    R at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1160)
[2/22/23 8:36:14:128 EST] 000000fe SystemErr                                                    R at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[2/22/23 8:36:14:128 EST] 000000fe SystemErr                                                    R at java.lang.Thread.run(Thread.java:822)
[2/22/23 8:36:14:129 EST] 0000021f SystemErr                                                    R Exception in thread "pool-4-thread-184"
[2/22/23 8:36:14:129 EST] 0000021f SystemErr                                                    R java.lang.IllegalStateException:
Exception Description: Cannot use an EntityTransaction while using JTA.
[2/22/23 8:36:14:148 EST] 0000002d SystemOut                                                    O JPATestOLGH19342Logic.testCaseExpressionOperatorConcurrency: End
[2/22/23 8:36:14:149 EST] 0000002d SystemOut                                                    O JEEExecutionContextHelper: Completed Execution of Test Logic: com.ibm.ws.jpa.olgh19342.testlogic.JPATestOLGH19342Logic.testCaseExpressionOperatorConcurrency().
[2/22/23 8:36:14:149 EST] 0000002d SystemOut                                                    O
** TEST END **********************************************************************

The above can only happen if using an AM-JTA EntityManager, which was unexpected since I figured this test bucket was only using AM-RL.  It looks like the test bucket actually uses AM-JTA, AM-RL, and CM-TS.  That was unexpected since UserTransaction is sensitive to the thread it runs on, and can only be used with threads that have a JEE context associated with them.

Unless ExecutorService somehow gives the threads it creates some sort of JEE context, then the only version of this test that makes sense to run is the AM-RL version, and the other two (AM-JTA, CM-TS) should be disabled because they are invalid.
```