### PR TITLE
include a javacore in the server dump for server or app startup

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -2159,7 +2159,7 @@ public class LibertyServer implements LogMonitorClient {
                 }
                 // Trigger a serverDump: this will contain the output of server introspectors, which can
                 // help pinpoint service resolution issues or missing dependencies.
-                serverDump();
+                serverDump("thread");
 
                 // If apps failed to start, try to make sure the port opened so we correctly
                 // flag a port issue as the culprit.
@@ -2588,7 +2588,7 @@ public class LibertyServer implements LogMonitorClient {
                 TopologyException serverStartException = new TopologyException(exMessage);
                 Log.error(c, method, serverStartException, errMessage);
                 // since a startup error was not expected, trigger a dump to help with debugging
-                serverDump();
+                serverDump("thread");
                 postStopServerArchive();
                 throw serverStartException;
             }


### PR DESCRIPTION
A little extra logging to failed fat tests that would have been useful in a recent build break I examined.