### PR TITLE
Address Jakarta Rest build defects

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/bookstore/src/com/ibm/ws/jaxrs20/fat/bookstore/AsyncInvokerTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/bookstore/src/com/ibm/ws/jaxrs20/fat/bookstore/AsyncInvokerTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -43,6 +45,9 @@ public class AsyncInvokerTestServlet extends HttpServlet {
 
     private static final long serialVersionUID = 2880606295862546001L;
     private static final long TIMEOUT = 5000;
+    // The FUTURE_TIMEOUT was added so that Future.get() operations will not sit until the hard
+    // FAT timeout of 3 hours. 
+    private static final long FUTURE_TIMEOUT = 10000;
     private static final long SLEEP = 20000;
 
     private static final boolean isZOS() {
@@ -287,9 +292,12 @@ public class AsyncInvokerTestServlet extends HttpServlet {
         long startTime = System.currentTimeMillis();
 
         try {
-            Response response = future.get();
+            Response response = future.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("InterruptedException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -333,10 +341,13 @@ public class AsyncInvokerTestServlet extends HttpServlet {
 
         try {
             System.out.println("testAsyncInvoker_getConnectionTimeout before future.get()");
-            Response response = future.get();
+            Response response = future.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             System.out.println("testAsyncInvoker_getConnectionTimeout Did not time out as expected");
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("InterruptedException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             System.out.println("testAsyncInvoker_getConnectionTimeout Failed InterruptedException " + e);
             ret.append("InterruptedException");
@@ -372,9 +383,12 @@ public class AsyncInvokerTestServlet extends HttpServlet {
         long startTime = System.currentTimeMillis();
 
         try {
-            Response response = future.get();
+            Response response = future.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("InterruptedException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -417,9 +431,12 @@ public class AsyncInvokerTestServlet extends HttpServlet {
         long startTime2 = System.currentTimeMillis();
 
         try {
-            Response response = future.get();
+            Response response = future.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("InterruptedException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -453,10 +470,13 @@ public class AsyncInvokerTestServlet extends HttpServlet {
         long startTime = System.currentTimeMillis();
 
         try {
-            Book response = future.get();
+            Book response = future.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.getName());
-        } catch (InterruptedException e) {
+        } catch (TimeoutException e) {
+            ret.append("InterruptedException");
+            e.printStackTrace();
+       } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
         } catch (ExecutionException e) {
@@ -500,9 +520,12 @@ public class AsyncInvokerTestServlet extends HttpServlet {
         System.out.println("testAsyncInvoker_getConnectionTimeoutwithInvocationCallback with TIMEOUT " + TIMEOUT + " asyncInvoker.get elapsed time " + elapsed);
         long startTime2 = System.currentTimeMillis();
         try {
-            Book response = future.get();
+            Book response = future.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.getName());
+        } catch (TimeoutException e) {
+            ret.append("InterruptedException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -536,9 +559,12 @@ public class AsyncInvokerTestServlet extends HttpServlet {
         long startTime = System.currentTimeMillis();
 
         try {
-            Book response = future.get();
+            Book response = future.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.getName());
+        } catch (TimeoutException e) {
+            ret.append("InterruptedException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -584,9 +610,12 @@ public class AsyncInvokerTestServlet extends HttpServlet {
         System.out.println("testAsyncInvoker_postConnectionTimeoutwithInvocationCallback with TIMEOUT " + TIMEOUT + " asyncInvoker.post elapsed time " + elapsed);
         long startTime2 = System.currentTimeMillis();
         try {
-            Book response = future.get();
+            Book response = future.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.getName());
+        } catch (TimeoutException e) {
+            ret.append("InterruptedException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/test-applications/jaxrs21bookstore/src/com/ibm/ws/jaxrs21/fat/JAXRS21bookstore/CompletionStageRxInvokerTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/test-applications/jaxrs21bookstore/src/com/ibm/ws/jaxrs21/fat/JAXRS21bookstore/CompletionStageRxInvokerTestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -49,6 +50,9 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
 
     private static final long serialVersionUID = 2880606295862546001L;
     private static final long TIMEOUT = 5000;
+    // The FUTURE_TIMEOUT was added so that CompletableFuture.get() operations will not sit until the hard
+    // FAT timeout of 3 hours.
+    private static final long FUTURE_TIMEOUT = 10000;
     private static final long SLEEP = 20000;
     private static final long clientBuilderTimeout = 15000;
 
@@ -595,9 +599,12 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
         long startTime = System.currentTimeMillis();
 
         try {
-            Response response = completableFuture.get();
+            Response response = completableFuture.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("TimeoutException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -630,9 +637,12 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
         long startTime = System.currentTimeMillis();
 
         try {
-            Response response = completableFuture.get();
+            Response response = completableFuture.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("TimeoutException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -666,9 +676,12 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
         long startTime = System.currentTimeMillis();
 
         try {
-            Response response = completableFuture.get();
+            Response response = completableFuture.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("TimeoutException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -717,9 +730,12 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
         long startTime2 = System.currentTimeMillis();
 
         try {
-            Response response = completableFuture.get();
+            Response response = completableFuture.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("TimeoutException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -763,9 +779,12 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
         long startTime2 = System.currentTimeMillis();
 
         try {
-            Response response = completableFuture.get();
+            Response response = completableFuture.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("TimeoutException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -810,9 +829,12 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
         long startTime2 = System.currentTimeMillis();
 
         try {
-            Response response = completableFuture.get();
+            Response response = completableFuture.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("TimeoutException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -852,9 +874,12 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
         long startTime = System.currentTimeMillis();
 
         try {
-            Response response = completableFuture.get();
+            Response response = completableFuture.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("TimeoutException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -887,9 +912,12 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
         long startTime = System.currentTimeMillis();
 
         try {
-            Response response = completableFuture.get();
+            Response response = completableFuture.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("TimeoutException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -923,9 +951,12 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
         long startTime = System.currentTimeMillis();
 
         try {
-            Response response = completableFuture.get();
+            Response response = completableFuture.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("TimeoutException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -975,9 +1006,12 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
         long startTime2 = System.currentTimeMillis();
 
         try {
-            Response response = completableFuture.get();
+            Response response = completableFuture.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("TimeoutException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -1021,9 +1055,12 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
         long startTime2 = System.currentTimeMillis();
 
         try {
-            Response response = completableFuture.get();
+            Response response = completableFuture.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("TimeoutException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();
@@ -1067,9 +1104,12 @@ public class CompletionStageRxInvokerTestServlet extends HttpServlet {
         long startTime2 = System.currentTimeMillis();
 
         try {
-            Response response = completableFuture.get();
+            Response response = completableFuture.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
             // Did not time out as expected
             ret.append(response.readEntity(String.class));
+        } catch (TimeoutException e) {
+            ret.append("TimeoutException");
+            e.printStackTrace();
         } catch (InterruptedException e) {
             ret.append("InterruptedException");
             e.printStackTrace();

--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 import javax.servlet.annotation.WebServlet;
@@ -43,12 +44,13 @@ import componenttest.app.FATServlet;
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/CxfClientPropsTestServlet")
 public class CxfClientPropsTestServlet extends FATServlet {
+   
     private final static Logger _log = Logger.getLogger(CxfClientPropsTestServlet.class.getName());
     private static final long defaultMargin = 14000;
     private final static String proxyPort = "8888";
     private final static String proxyHost = "127.0.0.1";
     private final static String myHost = "1.1.1.1";
-    private static final long aixMargin = 61000;    
+    private static final long slowHardwareMargin = 61000;    
     
     private static final boolean isZOS() {
         String osName = System.getProperty("os.name");
@@ -57,14 +59,10 @@ public class CxfClientPropsTestServlet extends FATServlet {
         }
         return false;
     }
-    
-    private static final boolean isAIX() {
-        String osName = System.getProperty("os.name");
-        if (osName.toLowerCase().contains("AIX".toLowerCase())) {
-            return true;
-        }
-        return false;
-    }
+ 
+    private static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
+    private static final boolean isAIX = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("aix");
+
 
     /**
      * Not actually testing CXF client properties, but rather testing socket timeouts,
@@ -101,8 +99,8 @@ public class CxfClientPropsTestServlet extends FATServlet {
         String target = null;
         long CXF_TIMEOUT = 5000;
         long MARGIN = defaultMargin;
-        if (isAIX()) {
-            MARGIN = aixMargin;
+        if (isAIX || isWindows) {
+            MARGIN = slowHardwareMargin;
         }        
         
         Client client = ClientBuilder.newBuilder()
@@ -137,8 +135,8 @@ public class CxfClientPropsTestServlet extends FATServlet {
         final String m = "testCXFReadTimeout";
         long CXF_TIMEOUT = 5000;
         long MARGIN = defaultMargin;
-        if (isAIX()) {
-            MARGIN = aixMargin;
+        if (isAIX || isWindows) {
+            MARGIN = slowHardwareMargin;
         }    
         
         Client client = ClientBuilder.newBuilder()
@@ -169,8 +167,8 @@ public class CxfClientPropsTestServlet extends FATServlet {
         long IBM_TIMEOUT = 5000;
         long MARGIN = defaultMargin;
         long CXF_TIMEOUT = 20000;
-        if (isAIX()) {
-            MARGIN = aixMargin;
+        if (isAIX || isWindows) {
+            MARGIN = slowHardwareMargin;
         }    
         
         Client client = ClientBuilder.newBuilder()
@@ -207,8 +205,8 @@ public class CxfClientPropsTestServlet extends FATServlet {
         long IBM_TIMEOUT = 5000;
         long MARGIN = defaultMargin;
         long CXF_TIMEOUT = 20000;
-        if (isAIX()) {
-            MARGIN = aixMargin;
+        if (isAIX || isWindows) {
+            MARGIN = slowHardwareMargin;
         }    
         
         Client client = ClientBuilder.newBuilder()

--- a/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/fat/src/io/openliberty/jakarta/rest31/tck/JakartaRest31TckPackageTest.java
+++ b/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/fat/src/io/openliberty/jakarta/rest31/tck/JakartaRest31TckPackageTest.java
@@ -15,6 +15,7 @@ package io.openliberty.jakarta.rest31.tck;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import org.junit.AfterClass;
@@ -32,8 +33,8 @@ import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.tck.TCKRunner;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
+import componenttest.topology.utils.tck.TCKRunner;
 
 /**
  * This is a test class that runs a whole Maven TCK as one test FAT test.
@@ -42,6 +43,8 @@ import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 @RunWith(FATRunner.class)
 public class JakartaRest31TckPackageTest {
 
+    private static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
+    
     private static final Set<String> featuresToRemove = new HashSet<>();
     static {
         featuresToRemove.add("appSecurity-5.0");
@@ -77,21 +80,24 @@ public class JakartaRest31TckPackageTest {
     @Test
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void testJakarta31RestTck() throws Exception {
-        HashMap<String, String> props = new HashMap<String, String>(); 
-        // The Java Se Bootstrap API added in EE10 is optional and not supported by Open Liberty.   So the 
-        // following property is being added to exclude those tests.
-        if (RepeatTestFilter.isRepeatActionActive("webProfile")) {
-            props.put("excludedGroups","se_bootstrap,xml_binding");
-        } else if (RepeatTestFilter.isRepeatActionActive("coreProfile")) {
-            props.put("excludedGroups","se_bootstrap,xml_binding,servlet,security");
-        } else {
-            props.put("excludedGroups","se_bootstrap");
+        // Skip running on the windows platform when not running locally.
+        if (!(isWindows) || FATRunner.FAT_TEST_LOCALRUN) { 
+            HashMap<String, String> props = new HashMap<String, String>(); 
+            // The Java Se Bootstrap API added in EE10 is optional and not supported by Open Liberty.   So the 
+            // following property is being added to exclude those tests.
+            if (RepeatTestFilter.isRepeatActionActive("webProfile")) {
+                props.put("excludedGroups","se_bootstrap,xml_binding");
+            } else if (RepeatTestFilter.isRepeatActionActive("coreProfile")) {
+                props.put("excludedGroups","se_bootstrap,xml_binding,servlet,security");
+            } else {
+                props.put("excludedGroups","se_bootstrap");
+            }
+            
+            String bucketName = "io.openliberty.jakarta.rest.3.1.internal_fat_tck";
+            String testName = this.getClass() + ":testJakarta31RestTck";
+            Type type = Type.JAKARTA;
+            String specName = "Restful Web Services";
+            TCKRunner.runTCK(server, bucketName, testName, type, specName, props);
         }
-        
-        String bucketName = "io.openliberty.jakarta.rest.3.1.internal_fat_tck";
-        String testName = this.getClass() + ":testJakarta31RestTck";
-        Type type = Type.JAKARTA;
-        String specName = "Restful Web Services";
-        TCKRunner.runTCK(server, bucketName, testName, type, specName, props);
     }
 }

--- a/dev/io.openliberty.restfulWS.3.0.client_fat/fat/src/io/openliberty/restfulWS30/client/fat/ClientFeatureTest.java
+++ b/dev/io.openliberty.restfulWS.3.0.client_fat/fat/src/io/openliberty/restfulWS30/client/fat/ClientFeatureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -56,7 +56,7 @@ public class ClientFeatureTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWWKE1102W","CWWKE1107W");  //ignore server quiesce timeouts due to slow test machines
+        server.stopServer("CWWKE1102W","CWWKE1106W","CWWKE1107W");  //ignore server quiesce timeouts due to slow test machines
     }
 
 }

--- a/dev/io.openliberty.restfulWS.3.0.client_fat/fat/src/io/openliberty/restfulWS30/client/fat/RegisterRestClientTest.java
+++ b/dev/io.openliberty.restfulWS.3.0.client_fat/fat/src/io/openliberty/restfulWS30/client/fat/RegisterRestClientTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -63,7 +63,7 @@ public class RegisterRestClientTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWWKE1102W","CWWKE1107W");  //ignore server quiesce timeouts due to slow test machines
+        server.stopServer("CWWKE1102W","CWWKE1106W","CWWKE1107W");  //ignore server quiesce timeouts due to slow test machines
     }
 
 }

--- a/dev/io.openliberty.restfulWS.3.0.client_fat/fat/src/io/openliberty/restfulWS30/client/fat/SslTest.java
+++ b/dev/io.openliberty.restfulWS.3.0.client_fat/fat/src/io/openliberty/restfulWS30/client/fat/SslTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -57,7 +57,7 @@ public class SslTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWWKO0801E");
-    }
+        server.stopServer("CWWKO0801E","CWWKE1102W","CWWKE1106W","CWWKE1107W");  //ignore server quiesce timeouts due to slow test machines
+     }
 
 }

--- a/dev/io.openliberty.restfulWS.3.0.client_fat/fat/src/io/openliberty/restfulWS30/client/fat/test/PathParamTest.java
+++ b/dev/io.openliberty.restfulWS.3.0.client_fat/fat/src/io/openliberty/restfulWS30/client/fat/test/PathParamTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -64,7 +64,7 @@ public class PathParamTest extends AbstractTest {
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
+            server.stopServer("CWWKE1102W","CWWKE1106W","CWWKE1107W");  //ignore server quiesce timeouts due to slow test machines
         }
     }
 
@@ -143,7 +143,7 @@ public class PathParamTest extends AbstractTest {
 
     @Test
     public void testAllResources1() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKE1102W","CWWKE1106W","CWWKE1107W");  //ignore server quiesce timeouts due to slow test machines
         server.startServer(true);
         runGetMethod("/pathparam/resource/smallshort/" + shortVariable, 200, "ok", true);
         runGetMethod("/pathparam/resource/bigdouble/" + doubleVariable, 200, "ok", true);
@@ -153,7 +153,7 @@ public class PathParamTest extends AbstractTest {
 
     @Test
     public void testAllResources2() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKE1102W","CWWKE1106W","CWWKE1107W");  //ignore server quiesce timeouts due to slow test machines
         server.startServer(true);
         runGetMethod("/pathparam/resource/bigdouble/" + doubleVariable, 200, "ok", true);
         runGetMethod("/pathparam/resource/biglong/" + longVariable, 200, "ok", true);


### PR DESCRIPTION
The following are address in this PR:
- Add ignores for quiesce warnings to avoid bogus defects on slow test machines
- Change the Jakarta Rest internal TCK FAT to not run on Windows. 
- Change select clientProps FAT to an increase timeout tolerance on Windows. 
- Added timeouts to Future.get() and CompletableFuture.get() calls.  This will allow the tests to timeout and error without waiting for the 3 hour FAT timeout.  It also allows for better, more specific defect creation and allows testing to continue so we can see patterns or uncover additional failures (if any).

