### PR TITLE
Cleanup any asyncServlet non-daemon threads at the server shutdown

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/WebContainer.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/WebContainer.java
@@ -65,6 +65,7 @@ import com.ibm.ws.threading.FutureMonitor;
 import com.ibm.ws.threading.listeners.CompletionListener;
 import com.ibm.ws.webcontainer.SessionRegistry;
 import com.ibm.ws.webcontainer.async.AsyncContextFactory;
+import com.ibm.ws.webcontainer.async.AsyncContextImpl;
 import com.ibm.ws.webcontainer.collaborator.CollaboratorService;
 import com.ibm.ws.webcontainer.exception.WebAppHostNotFoundException;
 import com.ibm.ws.webcontainer.osgi.container.DeployedModule;
@@ -389,6 +390,14 @@ public class WebContainer extends com.ibm.ws.webcontainer.WebContainer implement
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(tc, "Deactivating the WebContainer bundle");
+        }
+       
+        //issue#24461
+        if (AsyncContextImpl.executorRetrieved.get() && !AsyncContextImpl.ExecutorFieldHolder.field.isShutdown()) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, methodName, "shutting down now async servlet thread pool executor");
+            }
+            AsyncContextImpl.ExecutorFieldHolder.field.shutdownNow();
         }
         
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {


### PR DESCRIPTION
fixes https://github.com/OpenLiberty/open-liberty/issues/24461

When Liberty server is created/started within another existing JVM (parent) and within that parent process/server/stack 's own address space (i.e CICS), non-daemon threads from Liberty can prevent the shutdown of the parent JVM. This happens particularly when any of the AsynServlet was used by any deployed application in Liberty.

The Liberty server is updated to explicitly call ThreadPoolExecutor shutdownNow() for any of called AsyncServlet threads before the server is completely stopped.

