### PR TITLE
Avoid assertions of what is logged by Oracle JDBC driver

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleCustomTrace.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleCustomTrace.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -151,11 +150,9 @@ public class OracleCustomTrace extends FATServletClient {
         assertTrue("Expected to find oracle log file at: " + oracleLog1.getPath(), oracleLog1.isFile());
         assertTrue("Expected to find oracle log file at: " + oracleLog2.getPath(), oracleLog2.isFile());
 
-        //Read all bytes into string and ensure package name and trace level were set correctly
-        //TODO what if oracle retains lock on file? This did not happen when testing locally, but is possible.
-        String oracleLog1str = new String(Files.readAllBytes(oracleLog1.toPath()));
-        assertTrue("Expected oracle log file to be using the oracle.jdbc logger", oracleLog1str.contains("<logger>oracle.jdbc</logger>"));
-        assertTrue("Expected oracle log file to be using the FINE trace level", oracleLog1str.contains("<level>CONFIG</level>"));
+        //Ideally, we would want to make an assertion that this file contains logs.
+        //However, we have no guarantee that the Oracle driver has removed it's lock on the log file.
+        //Instead, assume if a log file was created, then the oracle driver is logging to it.
 
         //Use a second datasource and ensure we do not setup custom logging again
         server.setTraceMarkToEndOfDefaultTrace();


### PR DESCRIPTION
When creating the JDBCDriverService in Liberty each DataSource is processed asynchronously.
The Custom Oracle configuration is processed when the first JDBCDriverService.create() method is called. 

But, we are not guaranteed to have finished configuring the oracle logger before any other DataSource is created. 
Thus, we cannot assert that certain output will be contained in the first log where we would expect to see output from the first use of the JDBC driver. 

I thought I had made the test simple enough to make these assertions but over a large number of runs, we can expect this to fail. 