### PR TITLE
281155 Batch CDI FAT: Increase DB tran timeout

### DIFF
--- a/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/resources/TranTimeoutCleanupBefore.xml
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/resources/TranTimeoutCleanupBefore.xml
@@ -19,7 +19,7 @@
 	<step id="step1"> 
 		<properties>
 			<!--  Long enough that we never timeout just because the DB is slow -->
-			<property name="javax.transaction.global.timeout" value="#{jobParameters['chunkTimeSeconds']}?:2;" />
+			<property name="javax.transaction.global.timeout" value="#{jobParameters['chunkTimeSeconds']}?:3;" />
 		</properties>
 		<chunk item-count="3">
 			<reader ref="TranTimeoutCleanupReader" />

--- a/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/resources/TranTimeoutCleanupBeforePartition.xml
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/resources/TranTimeoutCleanupBeforePartition.xml
@@ -19,7 +19,7 @@
 	<step id="step1"> 
 		<properties>
 			<!--  Long enough that we never timeout just because the DB is slow -->
-			<property name="javax.transaction.global.timeout" value="#{jobParameters['chunkTimeSeconds']}?:2;" />
+			<property name="javax.transaction.global.timeout" value="#{jobParameters['chunkTimeSeconds']}?:3;" />
 		</properties>
 		<chunk item-count="3">
 			<reader ref="TranTimeoutCleanupReader" />

--- a/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/resources/TranTimeoutCleanupBeforeSplitFlow.xml
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/resources/TranTimeoutCleanupBeforeSplitFlow.xml
@@ -34,7 +34,7 @@
 			<step id="step2">
 				<properties>
 					<!-- Long enough that we never timeout just because the DB is slow -->
-					<property name="javax.transaction.global.timeout" value="#{jobParameters['chunkTimeSeconds']}?:2;"/>
+					<property name="javax.transaction.global.timeout" value="#{jobParameters['chunkTimeSeconds']}?:3;"/>
 				</properties>
 				<chunk item-count="3">
 					<reader ref="TranTimeoutCleanupReader" />


### PR DESCRIPTION
We set the DB tran timeout to 2 seconds, with a note of "Long enough that we never timeout because the DB is slow." Well...

[2/23/23, 21:36:52:454 PST] 000000f4 com.ibm.tx.jta.embeddable.impl.EmbeddableTimeoutManager      I WTRN0006W: Transaction 0000018681EC92A90000000107B0BD3C5B16219163CCAB763B318B33BBF2114023226FEE0000018681EC92A90000000107B0BD3C5B16219163CCAB763B318B33BBF2114023226FEE00000001 has timed out after 2 seconds.