### PR TITLE
Update FeatureList and EsaResourceImpl for Java 20

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -91,7 +91,7 @@ public class FeatureList {
             addJVM(possibleJavaVersions, "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
-            addJVM(possibleJavaVersions, "19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
+            addJVM(possibleJavaVersions, "20", "19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
 
             List<GenericMetadata> mostGeneralRange = ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=1.7))\"");
 
@@ -104,7 +104,7 @@ public class FeatureList {
             eeToCapability.put("JavaSE-1.8", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=1.8))\""));
             eeToCapability.put("JavaSE-11", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=11))\""));
             eeToCapability.put("JavaSE-17", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=17))\""));
-            eeToCapability.put("JavaSE-19", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=19))\""));
+            eeToCapability.put("JavaSE-20", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=20))\""));
         }
 
         gaBuild = isGABuild();

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
@@ -234,9 +234,9 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
             return;
         }
 
-        String minJava17 = "Java SE 17, Java SE 19";
-        String minJava11 = "Java SE 11, Java SE 17, Java SE 19";
-        String minJava8 = "Java SE 8, Java SE 11, Java SE 17, Java SE 19";
+        String minJava17 = "Java SE 17, Java SE 20";
+        String minJava11 = "Java SE 11, Java SE 17, Java SE 20";
+        String minJava8 = "Java SE 8, Java SE 11, Java SE 17, Java SE 20";
 
         // The min version should have been validated when the ESA was constructed
         // so checking for the version string should be safe


### PR DESCRIPTION
Update `FeatureList` and `EsaResourceImpl` to replace the previously supported non-LTS (non-long term support) release of Java 19 with the current release of Java 20 (also non-LTS).

Previous request for Java 19 -> https://github.com/OpenLiberty/open-liberty/pull/22038