### PR TITLE
Avoid resource injection for inferred datasources on IBMi

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2018,2019 IBM Corporation and others.
+    Copyright (c) 2018, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -86,6 +86,9 @@
     
     <application location="jdbcapp.war" >
         <classloader commonLibraryRef="FATDriverLib"/>
+        <application-bnd>
+        	<resource-ref id="jdbc/fatDataSourceRef" name="jdbc/fatDataSourceRef" binding-name="jdbc/fatDataSource" />
+        </application-bnd>
     </application>
 
 </server>

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/resources/WEB-INF/web.xml
@@ -24,5 +24,12 @@
       <value>1m16s</value>
     </property>
   </data-source>
+  
+  <resource-ref>
+    <res-ref-name>jdbc/fatDataSourceRef</res-ref-name>
+    <res-type>javax.sql.DataSource</res-type>
+    <res-auth>Application</res-auth>
+    <res-sharing-scope>Unshareable</res-sharing-scope>
+  </resource-ref>
 
 </web-app>

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,6 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 
 import javax.annotation.Resource;
-import javax.annotation.Resource.AuthenticationType;
 import javax.annotation.sql.DataSourceDefinition;
 import javax.annotation.sql.DataSourceDefinitions;
 import javax.naming.InitialContext;
@@ -89,9 +88,6 @@ import jdbc.fat.driver.derby.FATVendorSpecificSomething;
 @SuppressWarnings("serial")
 @WebServlet("/JDBCDriverManagerServlet")
 public class JDBCDriverManagerServlet extends FATServlet {
-
-    @Resource(name = "jdbc/fatDataSource", shareable = false, authenticationType = AuthenticationType.APPLICATION)
-    DataSource ds;
 
     @Resource
     DataSource xads;
@@ -150,6 +146,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
     public void testBasicConnection() throws Exception {
         InitialContext context = new InitialContext();
         UserTransaction tran = (UserTransaction) context.lookup("java:comp/UserTransaction");
+        DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/fatDataSourceRef");
         Connection con = ds.getConnection();
         try {
             DatabaseMetaData metadata = con.getMetaData();
@@ -388,6 +385,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
     @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testTransactionEnlistment() throws Exception {
         InitialContext context = new InitialContext();
+        DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/fatDataSourceRef");
         Connection con = ds.getConnection();
         try {
             // Set up table
@@ -594,6 +592,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
     //Test that setting the LoginTimeout via URL or properties for DataSources using Driver is rejected and that getLoginTimeout always returns 0.
     @Test
     @ExpectedFFDC({ "java.sql.SQLNonTransientException" })
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testGetSetLoginTimeout() throws Exception {
         InitialContext ctx = new InitialContext();
         //Ensure URL with loginTimeout specified is not allowed when using Driver

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -89,9 +89,6 @@ import jdbc.fat.driver.derby.FATVendorSpecificSomething;
 @WebServlet("/JDBCDriverManagerServlet")
 public class JDBCDriverManagerServlet extends FATServlet {
 
-    @Resource
-    DataSource xads;
-
     @Resource(name = "jdbc/fatDriver")
     DataSource fatDriverDS;
 
@@ -386,6 +383,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
     public void testTransactionEnlistment() throws Exception {
         InitialContext context = new InitialContext();
         DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/fatDataSourceRef");
+        DataSource xads = (DataSource) context.lookup("java:comp/DefaultDataSource");
         Connection con = ds.getConnection();
         try {
             // Set up table
@@ -543,6 +541,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
     @Test
     @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testUnwrapToVendorSpecificInterface() throws Exception {
+        DataSource xads = InitialContext.doLookup("java:comp/DefaultDataSource");
         FATJDBCSpecialOps vendorApi = xads.unwrap(FATJDBCSpecialOps.class);
         assertNotNull(vendorApi);
 

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerTest.java
@@ -27,7 +27,6 @@ import org.testcontainers.containers.MSSQLServerContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipIfSysProp;
 import componenttest.annotation.TestServlet;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
@@ -94,7 +93,6 @@ public class SQLServerTest extends FATServletClient {
     }
 
     @Test
-    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDKs
     public void testAuthenticationSchemeNTLM() throws Exception {
         server.setTraceMarkToEndOfDefaultTrace();
         runTest(server, APP_NAME + "/SQLServerTestServlet", testName);

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/publish/servers/com.ibm.ws.jdbc.fat.sqlserver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/publish/servers/com.ibm.ws.jdbc.fat.sqlserver/server.xml
@@ -15,6 +15,7 @@
     <feature>componenttest-1.0</feature>
     <feature>concurrent-1.0</feature>
     <feature>jdbc-4.1</feature>
+    <feature>jndi-1.0</feature>
     <feature>servlet-3.1</feature>
   </featureManager>
     
@@ -69,7 +70,7 @@
   
   <dataSource jndiName="jdbc/ntlm">
     <jdbcDriver libraryRef="SQLServerLibAnon"/>
-    <properties user="${env.SQL_USER}" password="${env.SQL_PASSWORD}"
+    <properties.microsoft.sqlserver user="${env.SQL_USER}" password="${env.SQL_PASSWORD}"
       databaseName="${env.SQL_DBNAME}" serverName="${env.SQL_HOST}" portNumber="${env.SQL_PORT}" authenticationScheme="NTLM" />
   </dataSource>
 


### PR DESCRIPTION
When running tests on IBMi we cannot use resource injection when a DataSource configuration depends on inferred data source classes.  
This is because IBMi systems have a version of the Java JDK that includes the DB2 driver on the classpath.  
Therefore, if we use another driver with a nondescript driver name, and generic `properties` we have no way of deciding which DataSource classes to use. 

