### PR TITLE
Only validate header name once (attempt #2)

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
@@ -388,7 +388,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (this.bHeaderValidation) {
             checkHeaderValue(value, 0, value.length);
         }
-        HeaderElement elem = getElement(findKey(header));
+        HeaderElement elem = getElement(findKey(header, false));
         elem.setByteArrayValue(value);
         addHeader(elem, FILTER_YES);
     }
@@ -407,7 +407,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (this.bHeaderValidation) {
             checkHeaderValue(value, offset, length);
         }
-        HeaderElement elem = getElement(findKey(header));
+        HeaderElement elem = getElement(findKey(header, false));
         elem.setByteArrayValue(value, offset, length);
         addHeader(elem, FILTER_YES);
     }
@@ -426,7 +426,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (this.bHeaderValidation) {
             checkHeaderValue(value, 0, value.length);
         }
-        HeaderElement elem = getElement(findKey(header));
+        HeaderElement elem = getElement(findKey(header, false));
         elem.setByteArrayValue(value);
         addHeader(elem, FILTER_YES);
     }
@@ -445,7 +445,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (this.bHeaderValidation) {
             checkHeaderValue(value, offset, length);
         }
-        HeaderElement elem = getElement(findKey(header));
+        HeaderElement elem = getElement(findKey(header, false));
         elem.setByteArrayValue(value, offset, length);
         addHeader(elem, FILTER_YES);
     }
@@ -505,7 +505,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             else
                 checkHeaderValue(value);
         }
-        HeaderElement elem = getElement(findKey(header));
+        HeaderElement elem = getElement(findKey(header, false));
         elem.setStringValue(value);
         addHeader(elem, FILTER_YES);
     }
@@ -527,7 +527,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             else
                 checkHeaderValue(value);
         }
-        HeaderElement elem = getElement(findKey(header));
+        HeaderElement elem = getElement(findKey(header, false));
         elem.setStringValue(value);
         addHeader(elem, FILTER_YES);
     }
@@ -930,7 +930,8 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (null == header) {
             throw new IllegalArgumentException("Null input provided");
         }
-        HeaderElement elem = findHeader(findKey(header));
+        HeaderKeys key = findKey(header, true);
+        HeaderElement elem = key == null ? null : findHeader(key);
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "getHeader(s): " + header + " " + elem);
         }
@@ -948,10 +949,10 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (null == header) {
             throw new IllegalArgumentException("Null input provided");
         }
-        HeaderKeys key = findKey(header);
-        HeaderElement elem = findHeader(key);
+        HeaderKeys key = findKey(header, true);
+        HeaderElement elem = key == null ? null : findHeader(key);
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "getHeader(b): " + key.getName() + " " + elem);
+            Tr.debug(tc, "getHeader(b): " + new String(header) + " " + elem);
         }
         if (null == elem) {
             return NULL_HEADER;
@@ -968,8 +969,8 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             throw new IllegalArgumentException("Null input provided");
         }
         List<HeaderField> list = new ArrayList<HeaderField>();
-        HeaderKeys key = findKey(header);
-        HeaderElement elem = findHeader(key);
+        HeaderKeys key = findKey(header, true);
+        HeaderElement elem = key == null ? null : findHeader(key);
         while (null != elem) {
             if (!elem.wasRemoved()) {
                 list.add(elem);
@@ -977,7 +978,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             elem = elem.nextInstance;
         }
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "getHeaders(b): " + key.getName() + " " + list.size());
+            Tr.debug(tc, "getHeaders(b): " + new String(header) + " " + list.size());
         }
         return list;
     }
@@ -1017,7 +1018,8 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             throw new IllegalArgumentException("Null input provided");
         }
         List<HeaderField> list;
-        HeaderElement elem = findHeader(findKey(header));
+        HeaderKeys key = findKey(header, true);
+        HeaderElement elem = key == null ? null : findHeader(key);
         if (null == elem) {
             list = Collections.emptyList();
         } else if (elem.nextInstance == null) {
@@ -1049,7 +1051,8 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (null == header) {
             throw new IllegalArgumentException("Null input provided");
         }
-        return countInstances(findHeader(findKey(header)));
+        HeaderKeys key = findKey(header, true);
+        return key == null ? 0 : countInstances(findHeader(key));
     }
 
     /**
@@ -1060,7 +1063,8 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (null == header) {
             throw new IllegalArgumentException("Null input provided");
         }
-        return countInstances(findHeader(findKey(header)));
+        HeaderKeys key = findKey(header, true);
+        return key == null ? 0 : countInstances(findHeader(key));
     }
 
     /**
@@ -1087,7 +1091,8 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (null == header) {
             throw new IllegalArgumentException("Null input provided");
         }
-        return (null != findHeader(findKey(header)));
+        HeaderKeys key = findKey(header, true);
+        return (key != null && null != findHeader(key));
     }
 
     /**
@@ -1098,7 +1103,8 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (null == header) {
             throw new IllegalArgumentException("Null input provided");
         }
-        return (null != findHeader(findKey(header)));
+        HeaderKeys key = findKey(header, true);
+        return key != null && (null != findHeader(key));
     }
 
     /**
@@ -1596,7 +1602,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
 
                 case GenericConstants.PARSING_HDR_NAME_VALUE:
                     // parse the unknown header name
-                    this.currentElem = getElement(findKey(this.parsedToken));
+                    this.currentElem = getElement(findKey(this.parsedToken, false));
                     this.binaryParsingState = GenericConstants.PARSING_HDR_VALUE_LEN;
                     resetCacheToken(4);
                     break;
@@ -1796,7 +1802,10 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "removeHeader(s): " + header);
         }
-        removeHdrInstances(findHeader(findKey(header)), FILTER_YES);
+        HeaderKeys key = findKey(header, true);
+        if (key != null) {
+            removeHdrInstances(findHeader(key), FILTER_YES);
+        }
     }
 
     /**
@@ -1807,11 +1816,13 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (null == header) {
             throw new IllegalArgumentException("Null input provided");
         }
-        HeaderKeys key = findKey(header);
+        HeaderKeys key = findKey(header, true);
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "removeHeader(b): " + key.getName());
+            Tr.debug(tc, "removeHeader(b): " + new String(header));
         }
-        removeHdrInstances(findHeader(key), FILTER_YES);
+        if (key != null) {
+            removeHdrInstances(findHeader(key), FILTER_YES);
+        }
     }
 
     /**
@@ -1839,7 +1850,10 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "removeHeader(s,i): " + header + " " + instance);
         }
-        removeHdr(findHeader(findKey(header), instance));
+        HeaderKeys key = findKey(header, true);
+        if (key != null) {
+            removeHdr(findHeader(key, instance));
+        }
     }
 
     /**
@@ -1850,11 +1864,13 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (null == header) {
             throw new IllegalArgumentException("Null input provided");
         }
-        HeaderKeys key = findKey(header);
+        HeaderKeys key = findKey(header, true);
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "removeHeader(b,i): " + key.getName() + " " + instance);
+            Tr.debug(tc, "removeHeader(b,i): " + new String(header) + " " + instance);
         }
-        removeHdr(findHeader(key, instance));
+        if (key != null) {
+            removeHdr(findHeader(key, instance));
+        }
     }
 
     /**
@@ -1896,7 +1912,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setHeader(s,b): " + header);
         }
-        setHeader(findKey(header), value);
+        setHeader(findKey(header, false), value);
     }
 
     /**
@@ -1910,7 +1926,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setHeader(s,b,i,i): " + header);
         }
-        setHeader(findKey(header), value, offset, length);
+        setHeader(findKey(header, false), value, offset, length);
     }
 
     /**
@@ -1921,7 +1937,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (null == header || null == value) {
             throw new IllegalArgumentException("Null input provided");
         }
-        HeaderKeys key = findKey(header);
+        HeaderKeys key = findKey(header, false);
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setHeader(b,b): " + key.getName());
         }
@@ -1936,7 +1952,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (null == header || null == value) {
             throw new IllegalArgumentException("Null input provided");
         }
-        HeaderKeys key = findKey(header);
+        HeaderKeys key = findKey(header, false);
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setHeader(b,b,i,i): " + key.getName());
         }
@@ -2179,7 +2195,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setHeader(s,s): " + header);
         }
-        setHeader(findKey(header), value);
+        setHeader(findKey(header, false), value);
     }
 
     /**
@@ -2190,7 +2206,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (null == header || null == value) {
             throw new IllegalArgumentException("Null input provided");
         }
-        HeaderKeys key = findKey(header);
+        HeaderKeys key = findKey(header, false);
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setHeader(b,s): " + key.getName());
         }
@@ -2333,7 +2349,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
      * @param name
      * @return HeaderKeys
      */
-    protected abstract HeaderKeys findKey(String name);
+    protected abstract HeaderKeys findKey(String name, boolean returnNullForInvalidName);
 
     /**
      * Subclasses will provide the match of the input name against a defined key.
@@ -2342,7 +2358,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
      * @param name
      * @return HeaderKeys
      */
-    protected abstract HeaderKeys findKey(byte[] name);
+    protected abstract HeaderKeys findKey(byte[] name, boolean returnNullForInvalidName);
 
     /**
      * Subclasses will provide the match of the input name against a defined key.
@@ -2353,7 +2369,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
      * @param length - length from that offset
      * @return HeaderKeys
      */
-    protected abstract HeaderKeys findKey(byte[] data, int offset, int length);
+    protected abstract HeaderKeys findKey(byte[] data, int offset, int length, boolean returnNullForInvalidName);
 
     /**
      * Find the specific instance of this header in storage.
@@ -3968,7 +3984,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             length = data.length;
         }
         // otherwise we found the entire length of the name
-        this.currentElem = getElement(findKey(data, start, length));
+        this.currentElem = getElement(findKey(data, start, length, false));
 
         // Reset all the global variables once HeaderElement has been instantiated
         if (HeaderStorage.NOTSET != this.headerChangeLimit) {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
@@ -499,7 +499,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "appendHeader(s,s): " + header);
         }
-        validateHeaderName(header);
         if (this.bHeaderValidation) {
             if (getCharacterValidation()) //PI45266
                 value = getValidatedCharacters(value); //PI57228
@@ -522,7 +521,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "appendHeader(b,s): " + GenericUtils.getEnglishString(header));
         }
-        validateHeaderName(header.toString());
         if (this.bHeaderValidation) {
             if (getCharacterValidation()) //PI45266
                 value = getValidatedCharacters(value); //PI57228
@@ -545,7 +543,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "appendHeader(h,s): " + key.getName());
         }
-        validateHeaderName(key.getName());
         if (this.bHeaderValidation) {
             if (getCharacterValidation()) //PI45266
                 value = getValidatedCharacters(value); //PI57228
@@ -1957,7 +1954,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setHeader(h,b): " + key.getName());
         }
-        validateHeaderName(key.getName());
         if (this.bHeaderValidation) {
             checkHeaderValue(value, 0, value.length);
         }
@@ -1995,7 +1991,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setHeader(h,b,i,i): " + key.getName());
         }
-        validateHeaderName(key.getName());
         if (this.bHeaderValidation) {
             checkHeaderValue(value, offset, length);
         }
@@ -2036,7 +2031,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "setHeader(h,s): " + key.getName());
         }
-        validateHeaderName(key.getName());
         if (this.bHeaderValidation) {
             if (getCharacterValidation()) //PI45266
                 value = getValidatedCharacters(value); //PI57228
@@ -2113,7 +2107,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
         if (elem != null && elem.asString() != null) {
             return elem;
         }
-        validateHeaderName(key.getName());
         if (this.bHeaderValidation) {
             if (getCharacterValidation()) //PI45266
                 value = getValidatedCharacters(value); //PI57228
@@ -3892,7 +3885,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
                 }
 
                 // PH52074 Check for other invalid chars
-                if (!isValidTchar((char) (b & 0xFF))) {
+                if (!HttpHeaderKeys.isValidTchar((char) (b & 0xFF))) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
                         final int maskedCodePoint = b & 0xFF;
                         Tr.debug(tc, "Invalid character found in http header name.  The Unicode is: " + String.format("%04x", maskedCodePoint));
@@ -4772,66 +4765,6 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
             }
         }
         return nodename;
-
-    }
-
-    /*
-     * A valid header name is "!" / "#" / "$" / "%" / "&" / "'" /
-     * "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
-     *
-     * The information about valid chars in a header name comes from
-     * RCF 9110 section 5.6.2 tchars
-     * https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2
-     *
-     * PH52074
-     */
-
-    private void validateHeaderName(String name) {
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-            Tr.entry(tc, "validateHeaderName, name is " + name);
-        }
-        char[] a = name.toCharArray();
-        char c;
-        boolean valid = true;
-
-        for (int i = 0; i < a.length; i++) {
-            c = a[i];
-            valid = isValidTchar(c);
-            if (!valid) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-                    Tr.debug(tc, "validateHeaderName invalid char " + String.format("%04x", (int) c));
-                }
-                break;
-            }
-        }
-
-        // if we found an error, throw the exception now
-        if (!valid) {
-            IllegalArgumentException iae = new IllegalArgumentException("Header name contained an invalid character");
-            FFDCFilter.processException(iae, getClass().getName() + ".validateHeaderName(String)", "1", this);
-            throw iae;
-        }
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-            Tr.exit(tc, "validateHeaderName");
-        }
-
-    }
-
-    private boolean isValidTchar(char c) {
-        boolean valid = ((c >= 'a') && (c <= 'z')) ||
-                        ((c >= 'A') && (c <= 'Z')) ||
-                        ((c >= '0') && (c <= '9')) ||
-                        (c == '!') || (c == '#') ||
-                        (c == '$') || (c == '%') ||
-                        (c == '&') || (c == '\'') ||
-                        (c == '*') || (c == '+') ||
-                        (c == '-') || (c == '.') ||
-                        (c == '^') || (c == '_') ||
-                        (c == '`') || (c == '|') ||
-                        (c == '~');
-
-        return valid;
-
     }
 
     private void processForwardedErrorState() {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpBaseMessageImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpBaseMessageImpl.java
@@ -232,28 +232,28 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
 
     /*
      * @see com.ibm.ws.genericbnf.internal.BNFHeadersImpl#findKey(byte[], int,
-     * int)
+     * int, boolean)
      */
     @Override
-    protected HeaderKeys findKey(byte[] data, int offset, int length) {
-        return HttpHeaderKeys.find(data, offset, length);
+    protected HeaderKeys findKey(byte[] data, int offset, int length, boolean returnNullForInvalidName) {
+        return HttpHeaderKeys.find(data, offset, length, returnNullForInvalidName);
     }
 
     /*
-     * see com.ibm.ws.genericbnf.impl.BNFHeadersImpl#findKey(byte[])
+     * see com.ibm.ws.genericbnf.impl.BNFHeadersImpl#findKey(byte[], boolean)
      */
     @Override
-    protected HeaderKeys findKey(byte[] name) {
-        return HttpHeaderKeys.find(name, 0, name.length);
+    protected HeaderKeys findKey(byte[] name, boolean returnNullForInvalidName) {
+        return HttpHeaderKeys.find(name, 0, name.length, returnNullForInvalidName);
     }
 
     /*
      * @see
-     * com.ibm.ws.genericbnf.internal.BNFHeadersImpl#findKey(java.lang.String)
+     * com.ibm.ws.genericbnf.internal.BNFHeadersImpl#findKey(java.lang.String, boolean)
      */
     @Override
-    protected HeaderKeys findKey(String name) {
-        return HttpHeaderKeys.find(name);
+    protected HeaderKeys findKey(String name, boolean returnNullForInvalidName) {
+        return HttpHeaderKeys.find(name, returnNullForInvalidName);
     }
 
     /*

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpTrailerGeneratorImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpTrailerGeneratorImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -64,9 +64,9 @@ public class HttpTrailerGeneratorImpl implements HttpTrailerGenerator {
     @Override
     public byte[] generateTrailerValue(String hdr, HttpTrailers message) {
 
-        HeaderKeys key = HttpHeaderKeys.find(hdr);
+        HeaderKeys key = HttpHeaderKeys.find(hdr, true);
 
-        if (key != null && hdr.equals(_key)) {
+        if (key != null && key.equals(_key)) {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "generateTrailerValue(String,HttpTrailers): hdr = " + hdr + ", value = " + _value);
             }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpTrailersImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpTrailersImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2009 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -92,7 +92,8 @@ public class HttpTrailersImpl extends BNFHeadersImpl implements HttpTrailers {
      * @return boolean (true if exists)
      */
     public boolean containsDeferredTrailer(String target) {
-        return containsDeferredTrailer(findKey(target));
+        HeaderKeys key = findKey(target, true);
+        return key != null && containsDeferredTrailer(key);
     }
 
     /**
@@ -172,7 +173,7 @@ public class HttpTrailersImpl extends BNFHeadersImpl implements HttpTrailers {
         if (null == htg) {
             throw new IllegalArgumentException("Null value generator");
         }
-        this.knownTGs.put(findKey(hdr), htg);
+        this.knownTGs.put(findKey(hdr, false), htg);
     }
 
     /**
@@ -196,7 +197,10 @@ public class HttpTrailersImpl extends BNFHeadersImpl implements HttpTrailers {
         if (null == hdr) {
             throw new IllegalArgumentException("Null header name");
         }
-        this.knownTGs.remove(findKey(hdr));
+        HeaderKeys key = findKey(hdr, true);
+        if (key != null) {
+            this.knownTGs.remove(key);
+        }
     }
 
     /**
@@ -314,24 +318,24 @@ public class HttpTrailersImpl extends BNFHeadersImpl implements HttpTrailers {
     }
 
     /**
-     * @see com.ibm.ws.genericbnf.internal.BNFHeadersImpl#findKey(byte[], int, int)
+     * @see com.ibm.ws.genericbnf.internal.BNFHeadersImpl#findKey(byte[], int, int, boolean)
      */
-    protected HeaderKeys findKey(byte[] data, int offset, int length) {
-        return HttpHeaderKeys.find(data, offset, length);
+    protected HeaderKeys findKey(byte[] data, int offset, int length, boolean returnNullForInvalidName) {
+        return HttpHeaderKeys.find(data, offset, length, returnNullForInvalidName);
     }
 
     /**
-     * see com.ibm.ws.genericbnf.impl.BNFHeadersImpl#findKey(byte[])
+     * see com.ibm.ws.genericbnf.impl.BNFHeadersImpl#findKey(byte[], boolean)
      */
-    protected HeaderKeys findKey(byte[] name) {
-        return HttpHeaderKeys.find(name, 0, name.length);
+    protected HeaderKeys findKey(byte[] name, boolean returnNullForInvalidName) {
+        return HttpHeaderKeys.find(name, 0, name.length, returnNullForInvalidName);
     }
 
     /**
      * @see com.ibm.ws.genericbnf.internal.BNFHeadersImpl#findKey(java.lang.String)
      */
-    protected HeaderKeys findKey(String name) {
-        return HttpHeaderKeys.find(name);
+    protected HeaderKeys findKey(String name, boolean returnNullForInvalidName) {
+        return HttpHeaderKeys.find(name, returnNullForInvalidName);
     }
 
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpResponseImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpResponseImpl.java
@@ -339,7 +339,7 @@ public class HttpResponseImpl implements HttpResponse, HttpResponseExt {
     public void setTrailer(String name, String value) {
 
         HttpTrailers trailers = message.createTrailers();
-        HeaderKeys key = HttpHeaderKeys.find(name);
+        HeaderKeys key = HttpHeaderKeys.find(name, false);
 
         if (trailers.containsDeferredTrailer(key)) {
             trailers.removeDeferredTrailer(key);

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.wsspi.genericbnf.BNFHeaders;
 import com.ibm.wsspi.genericbnf.HeaderKeys;
 import com.ibm.wsspi.genericbnf.KeyMatcher;
@@ -240,7 +241,7 @@ public class HttpHeaderKeys extends HeaderKeys {
      *
      * @param name
      */
-    public HttpHeaderKeys(String name) {
+    private HttpHeaderKeys(String name) {
         super(name, generateNextOrdinal());
         if (NEXT_ORDINAL.get() <= ORD_MAX) {
 
@@ -275,7 +276,7 @@ public class HttpHeaderKeys extends HeaderKeys {
      * @param shouldLog
      * @param shouldFilter
      */
-    public HttpHeaderKeys(String name, boolean shouldLog, boolean shouldFilter) {
+    private HttpHeaderKeys(String name, boolean shouldLog, boolean shouldFilter) {
         super(name, generateNextOrdinal());
         super.setShouldLogValue(shouldLog);
         super.setUseFilters(shouldFilter);
@@ -353,13 +354,10 @@ public class HttpHeaderKeys extends HeaderKeys {
                 // testing again inside a sync block
                 key = (HttpHeaderKeys) myMatcher.match(name, offset, length);
                 if (null == key) {
+                    String headerName = new String(name, offset, length);
                     // make sure the name is valid
-                    for (int i = offset; i < length; i++) {
-                        if (BNFHeaders.CR == name[i] || BNFHeaders.LF == name[i]) {
-                            throw new IllegalArgumentException("Invalid CRLF in name: " + i);
-                        }
-                    }
-                    key = new HttpHeaderKeys(new String(name, offset, length), true);
+                    validateHeaderName(headerName);
+                    key = new HttpHeaderKeys(headerName, true);
                 }
             } // end-sync
 
@@ -387,17 +385,53 @@ public class HttpHeaderKeys extends HeaderKeys {
                 key = (HttpHeaderKeys) myMatcher.match(name, 0, name.length());
                 if (null == key) {
                     // make sure the name is valid
-                    for (int i = 0, size = name.length(); i < size; i++) {
-                        char c = name.charAt(i);
-                        if (BNFHeaders.CR == c || BNFHeaders.LF == c) {
-                            throw new IllegalArgumentException("Invalid CRLF in name: " + i);
-                        }
-                    }
+                    validateHeaderName(name);
                     key = new HttpHeaderKeys(name, true);
                 }
             } // end-sync
         }
         return key;
+    }
+
+    /*
+     * A valid header name is "!" / "#" / "$" / "%" / "&" / "'" /
+     * "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+     *
+     * The information about valid chars in a header name comes from
+     * RCF 9110 section 5.6.2 tchars
+     * https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2
+     *
+     * PH52074
+     */
+    private static void validateHeaderName(String name) {
+        for (int i = 0, size = name.length(); i < size; i++) {
+            char c = name.charAt(i);
+            if (BNFHeaders.CR == c || BNFHeaders.LF == c) {
+                throw new IllegalArgumentException("Invalid CRLF in name: " + i);
+            }
+            // if we found an error, throw the exception now
+            if (!isValidTchar(c)) {
+                IllegalArgumentException iae = new IllegalArgumentException("Header name contained an invalid character " + i);
+                FFDCFilter.processException(iae, HttpHeaderKeys.class.getName() + ".validateHeaderName(String)", "1", name);
+                throw iae;
+            }
+        }
+    }
+
+    public static boolean isValidTchar(char c) {
+        boolean valid = ((c >= 'a') && (c <= 'z')) ||
+                        ((c >= 'A') && (c <= 'Z')) ||
+                        ((c >= '0') && (c <= '9')) ||
+                        (c == '!') || (c == '#') ||
+                        (c == '$') || (c == '%') ||
+                        (c == '&') || (c == '\'') ||
+                        (c == '*') || (c == '+') ||
+                        (c == '-') || (c == '.') ||
+                        (c == '^') || (c == '_') ||
+                        (c == '`') || (c == '|') ||
+                        (c == '~');
+
+        return valid;
     }
 
     /**

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/channel/test/api/HttpRequestMessageImplTest.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/channel/test/api/HttpRequestMessageImplTest.java
@@ -1597,6 +1597,139 @@ public class HttpRequestMessageImplTest {
     }
 
     /**
+     * This test validates that for an invalid header name we get IllegalArgumentException for
+     * set and append operations. get, remove and contains methods should just no-op meaning
+     * that they should NOT populate the HeaderStorage with a HeaderKeys object. If it would then
+     * we would no longer get IllegalArgumentExceptions because once a HeaderKeys object is created
+     * we know that it was a valid headerName.
+     */
+    @Test
+    public void testInvalidHeaderName() {
+
+        // loop twice to make sure that nothing gets added to make it not throw an exception
+        String[] invalidHeaderNames = new String[] { "(0)", "2\n3", "4\r5" };
+        String valueString = "value";
+        byte[] valueBytes = valueString.getBytes();
+        HttpRequestMessageImpl r = getRequest();
+        for (String invalidHeaderName : invalidHeaderNames) {
+            byte[] invalidHeaderNameBytes = invalidHeaderName.getBytes();
+            for (int i = 0; i < 2; ++i) {
+                try {
+                    r.appendHeader(invalidHeaderNameBytes, valueBytes);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderNameBytes, valueString);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderName, valueBytes);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderName, valueString);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderNameBytes, valueBytes, 0, invalidHeaderNameBytes.length);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderName, valueBytes, 0, invalidHeaderName.length());
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                assertFalse(r.containsHeader(invalidHeaderNameBytes));
+
+                assertFalse(r.containsHeader(invalidHeaderName));
+
+                assertEquals(0, r.getAllHeaderNames().size());
+
+                assertNull(r.getHeader(invalidHeaderNameBytes).getKey());
+
+                assertNull(r.getHeader(invalidHeaderName).getKey());
+
+                assertEquals(0, r.getHeaders(invalidHeaderNameBytes).size());
+
+                assertEquals(0, r.getHeaders(invalidHeaderName).size());
+
+                assertEquals(0, r.getNumberOfHeaderInstances(invalidHeaderNameBytes));
+
+                assertEquals(0, r.getNumberOfHeaderInstances(invalidHeaderName));
+
+                assertEquals(0, r.getNumberOfHeaders());
+
+                r.removeHeader(invalidHeaderNameBytes);
+
+                r.removeHeader(invalidHeaderNameBytes, 1);
+
+                r.removeHeader(invalidHeaderName);
+
+                r.removeHeader(invalidHeaderName, 1);
+
+                try {
+                    r.setHeader(invalidHeaderNameBytes, valueBytes);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderNameBytes, valueString);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderName, valueBytes);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderName, valueString);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderNameBytes, valueBytes, 0, invalidHeaderNameBytes.length);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderName, valueBytes, 0, invalidHeaderName.length());
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+            }
+        }
+    }
+
+    /**
      * Utility method for verifying the connection information
      *
      * @param ords

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/channel/test/api/HttpResponseMessageImplTest.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/channel/test/api/HttpResponseMessageImplTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -28,8 +29,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import test.common.SharedOutputManager;
 
 import com.ibm.ws.channelfw.internal.ChannelDataImpl;
 import com.ibm.ws.channelfw.internal.InboundVirtualConnectionFactoryImpl;
@@ -44,6 +43,8 @@ import com.ibm.wsspi.http.HttpCookie;
 import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.http.channel.values.StatusCodes;
 import com.ibm.wsspi.http.channel.values.VersionValues;
+
+import test.common.SharedOutputManager;
 
 /**
  * The methods common to HttpBaseMessage and lower are tested by the
@@ -60,7 +61,7 @@ public class HttpResponseMessageImplTest {
 
     /**
      * Capture stdout/stderr output to the manager.
-     * 
+     *
      * @throws Exception
      */
     @BeforeClass
@@ -71,7 +72,7 @@ public class HttpResponseMessageImplTest {
 
     /**
      * Final teardown work when class is exiting.
-     * 
+     *
      * @throws Exception
      */
     @AfterClass
@@ -82,7 +83,7 @@ public class HttpResponseMessageImplTest {
 
     /**
      * Individual teardown after each test.
-     * 
+     *
      * @throws Exception
      */
     @After
@@ -96,7 +97,7 @@ public class HttpResponseMessageImplTest {
     /**
      * Create a new message for use and update the chain with the input
      * configuration key/value pair.
-     * 
+     *
      * @param key
      * @param value
      */
@@ -118,8 +119,7 @@ public class HttpResponseMessageImplTest {
      */
     @Before
     public void setUp() {
-        this.cdi = new ChannelDataImpl("HTTP", null, new HashMap<Object, Object>(), 10,
-                        ChannelFrameworkFactory.getChannelFramework());
+        this.cdi = new ChannelDataImpl("HTTP", null, new HashMap<Object, Object>(), 10, ChannelFrameworkFactory.getChannelFramework());
         this.config = new HttpChannelConfig(this.cdi);
         MockInboundSC sc = new MockInboundSC(new InboundVirtualConnectionFactoryImpl().createConnection(), this.config);
         this.response = new MockResponseMessage(sc);
@@ -138,7 +138,7 @@ public class HttpResponseMessageImplTest {
 
     /**
      * Get access to the response message.
-     * 
+     *
      * @return HttpResponseMessageImpl
      */
     private HttpResponseMessageImpl getResponse() {
@@ -196,8 +196,7 @@ public class HttpResponseMessageImplTest {
             getResponse().setHeader("Test", "TestValue");
 
             // @ Tested API - duplicate()
-            HttpResponseMessageImpl duplicate =
-                            (HttpResponseMessageImpl) getResponse().duplicate();
+            HttpResponseMessageImpl duplicate = (HttpResponseMessageImpl) getResponse().duplicate();
             assertNotNull(duplicate);
 
             // @ Tested API - marshallHeaders()
@@ -292,9 +291,9 @@ public class HttpResponseMessageImplTest {
             getResponse().clear();
             getResponse().setHeader(HttpHeaderKeys.HDR_SET_COOKIE,
                                     "TestCookie1=TestCookieValue1;"
-                                                    + "TestCookie2=TestCookieValue2;"
-                                                    + "TestCookie3=TestCookieValue3;"
-                                                    + "TestCookie4=TestCookieValue4");
+                                                                   + "TestCookie2=TestCookieValue2;"
+                                                                   + "TestCookie3=TestCookieValue3;"
+                                                                   + "TestCookie4=TestCookieValue4");
             cookieList = getResponse().getAllCookies();
             assertNotNull(cookieList);
             assertEquals(4, cookieList.size());
@@ -654,7 +653,7 @@ public class HttpResponseMessageImplTest {
             assertTrue(getResponse().containsHeader("split-header1"));
             assertEquals("split_appendHeader_BEGIN1_?_END1:it",
                          getResponse().getHeader("split-header1").asString());
-            
+
             getResponse().clear();
             getResponse().appendHeader("split-header2", "split_\r\n \n appendHeader_BEGIN2_\u570A_END2:it");
             mData = duplicateBuffers(getResponse().marshallMessage());
@@ -665,7 +664,7 @@ public class HttpResponseMessageImplTest {
             assertTrue(getResponse().containsHeader("split-header2"));
             assertEquals("split_     appendHeader_BEGIN2_?_END2:it",
                          getResponse().getHeader("split-header2").asString());
-            
+
             // test not adding the headers
             createNewMessage(HttpConfigConstants.PROPNAME_COOKIES_CONFIGURE_NOCACHE, "false");
             getResponse().setHeader("Set-Cookie", "jsessionid=nocache_false");
@@ -699,7 +698,7 @@ public class HttpResponseMessageImplTest {
             getResponse().setContentLength(0);
             assertEquals(0, getResponse().getContentLength());
 
-            // Test setting long values                     
+            // Test setting long values
             getResponse().clear();
             getResponse().setContentLength(Integer.MAX_VALUE + 1L);
             assertEquals(Integer.MAX_VALUE + 1L, getResponse().getContentLength());
@@ -827,4 +826,136 @@ public class HttpResponseMessageImplTest {
         }
     }
 
+    /**
+     * This test validates that for an invalid header name we get IllegalArgumentException for
+     * set and append operations. get, remove and contains methods should just no-op meaning
+     * that they should NOT populate the HeaderStorage with a HeaderKeys object. If it would then
+     * we would no longer get IllegalArgumentExceptions because once a HeaderKeys object is created
+     * we know that it was a valid headerName.
+     */
+    @Test
+    public void testInvalidHeaderName() {
+
+        // loop twice to make sure that nothing gets added to make it not throw an exception
+        String[] invalidHeaderNames = new String[] { "(0)", "2\n3", "4\r5" };
+        String valueString = "value";
+        byte[] valueBytes = valueString.getBytes();
+        HttpResponseMessageImpl r = getResponse();
+        for (String invalidHeaderName : invalidHeaderNames) {
+            byte[] invalidHeaderNameBytes = invalidHeaderName.getBytes();
+            for (int i = 0; i < 2; ++i) {
+                try {
+                    r.appendHeader(invalidHeaderNameBytes, valueBytes);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderNameBytes, valueString);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderName, valueBytes);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderName, valueString);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderNameBytes, valueBytes, 0, invalidHeaderNameBytes.length);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderName, valueBytes, 0, invalidHeaderName.length());
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                assertFalse(r.containsHeader(invalidHeaderNameBytes));
+
+                assertFalse(r.containsHeader(invalidHeaderName));
+
+                assertEquals(0, r.getAllHeaderNames().size());
+
+                assertNull(r.getHeader(invalidHeaderNameBytes).getKey());
+
+                assertNull(r.getHeader(invalidHeaderName).getKey());
+
+                assertEquals(0, r.getHeaders(invalidHeaderNameBytes).size());
+
+                assertEquals(0, r.getHeaders(invalidHeaderName).size());
+
+                assertEquals(0, r.getNumberOfHeaderInstances(invalidHeaderNameBytes));
+
+                assertEquals(0, r.getNumberOfHeaderInstances(invalidHeaderName));
+
+                assertEquals(0, r.getNumberOfHeaders());
+
+                r.removeHeader(invalidHeaderNameBytes);
+
+                r.removeHeader(invalidHeaderNameBytes, 1);
+
+                r.removeHeader(invalidHeaderName);
+
+                r.removeHeader(invalidHeaderName, 1);
+
+                try {
+                    r.setHeader(invalidHeaderNameBytes, valueBytes);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderNameBytes, valueString);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderName, valueBytes);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderName, valueString);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderNameBytes, valueBytes, 0, invalidHeaderNameBytes.length);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderName, valueBytes, 0, invalidHeaderName.length());
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+            }
+        }
+    }
 }

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/channel/test/api/HttpTrailersImplTest.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/channel/test/api/HttpTrailersImplTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,8 +12,11 @@
  *******************************************************************************/
 package com.ibm.ws.http.channel.test.api;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -21,14 +24,14 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.ws.http.channel.internal.HttpObjectFactory;
 import com.ibm.ws.http.channel.internal.HttpTrailersImpl;
 import com.ibm.wsspi.genericbnf.HeaderKeys;
 import com.ibm.wsspi.http.channel.HttpTrailerGenerator;
 import com.ibm.wsspi.http.channel.HttpTrailers;
 import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
+
+import test.common.SharedOutputManager;
 
 /**
  * Test the HTTP trailers class.
@@ -46,7 +49,7 @@ public class HttpTrailersImplTest {
 
     /**
      * Capture stdout/stderr output to the manager.
-     * 
+     *
      * @throws Exception
      */
     @BeforeClass
@@ -57,7 +60,7 @@ public class HttpTrailersImplTest {
 
     /**
      * Final teardown work when class is exiting.
-     * 
+     *
      * @throws Exception
      */
     @AfterClass
@@ -68,7 +71,7 @@ public class HttpTrailersImplTest {
 
     /**
      * Individual teardown after each test.
-     * 
+     *
      * @throws Exception
      */
     @After
@@ -92,7 +95,7 @@ public class HttpTrailersImplTest {
 
     /**
      * Get access to the trailer header object itself.
-     * 
+     *
      * @return HttpTrailersImpl
      */
     private HttpTrailersImpl getTrailers() {
@@ -101,7 +104,7 @@ public class HttpTrailersImplTest {
 
     /**
      * Get access to the Content-Language generator
-     * 
+     *
      * @return HttpContentLanguageGenerator
      */
     private HttpContentLanguageGenerator getLangGen() {
@@ -249,7 +252,7 @@ public class HttpTrailersImplTest {
 
         /**
          * Create an object which will return the current date.
-         * 
+         *
          */
         public HttpContentLanguageGenerator() {
             // nothing to do
@@ -257,11 +260,11 @@ public class HttpTrailersImplTest {
 
         /**
          * Return a HDR_CONTENT_LANGUAGE Http header value
-         * 
+         *
          * @param hdr
-         *            the HTTP header to generate as a trailer.
+         *                    the HTTP header to generate as a trailer.
          * @param message
-         *            the message to append the trailer to.
+         *                    the message to append the trailer to.
          * @return the bytes comprising the value of the trailer.
          */
         @Override
@@ -271,16 +274,161 @@ public class HttpTrailersImplTest {
 
         /**
          * Return a HDR_CONTENT_LANGUAGE Http header value
-         * 
+         *
          * @param hdr
-         *            the HTTP header to generate as a trailer.
+         *                    the HTTP header to generate as a trailer.
          * @param message
-         *            the message to append the trailer to.
+         *                    the message to append the trailer to.
          * @return the bytes comprising the value of the trailer.
          */
         @Override
         public byte[] generateTrailerValue(String hdr, HttpTrailers message) {
             return ("en-US".getBytes());
+        }
+    }
+
+    /**
+     * This test validates that for an invalid header name we get IllegalArgumentException for
+     * set and append operations. get, remove and contains methods should just no-op meaning
+     * that they should NOT populate the HeaderStorage with a HeaderKeys object. If it would then
+     * we would no longer get IllegalArgumentExceptions because once a HeaderKeys object is created
+     * we know that it was a valid headerName.
+     */
+    @Test
+    public void testInvalidHeaderName() {
+
+        // loop twice to make sure that nothing gets added to make it not throw an exception
+        String[] invalidHeaderNames = new String[] { "(0)", "2\n3", "4\r5" };
+        String valueString = "value";
+        byte[] valueBytes = valueString.getBytes();
+        HttpTrailersImpl r = getTrailers();
+        for (String invalidHeaderName : invalidHeaderNames) {
+            byte[] invalidHeaderNameBytes = invalidHeaderName.getBytes();
+            for (int i = 0; i < 2; ++i) {
+                try {
+                    r.appendHeader(invalidHeaderNameBytes, valueBytes);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderNameBytes, valueString);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderName, valueBytes);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderName, valueString);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderNameBytes, valueBytes, 0, invalidHeaderNameBytes.length);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.appendHeader(invalidHeaderName, valueBytes, 0, invalidHeaderName.length());
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                assertFalse(r.containsHeader(invalidHeaderNameBytes));
+
+                assertFalse(r.containsHeader(invalidHeaderName));
+
+                assertEquals(0, r.getAllHeaderNames().size());
+
+                assertNull(r.getHeader(invalidHeaderNameBytes).getKey());
+
+                assertNull(r.getHeader(invalidHeaderName).getKey());
+
+                assertEquals(0, r.getHeaders(invalidHeaderNameBytes).size());
+
+                assertEquals(0, r.getHeaders(invalidHeaderName).size());
+
+                assertEquals(0, r.getNumberOfHeaderInstances(invalidHeaderNameBytes));
+
+                assertEquals(0, r.getNumberOfHeaderInstances(invalidHeaderName));
+
+                assertEquals(0, r.getNumberOfHeaders());
+
+                r.removeHeader(invalidHeaderNameBytes);
+
+                r.removeHeader(invalidHeaderNameBytes, 1);
+
+                r.removeHeader(invalidHeaderName);
+
+                r.removeHeader(invalidHeaderName, 1);
+
+                try {
+                    r.setHeader(invalidHeaderNameBytes, valueBytes);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderNameBytes, valueString);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderName, valueBytes);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderName, valueString);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderNameBytes, valueBytes, 0, invalidHeaderNameBytes.length);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                try {
+                    r.setHeader(invalidHeaderName, valueBytes, 0, invalidHeaderName.length());
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                // HttpTrailer specific APIs
+                assertFalse(r.containsDeferredTrailer(invalidHeaderName));
+
+                try {
+                    r.setDeferredTrailer(invalidHeaderName, null);
+                    fail("Expected IllegalArgumentException");
+                } catch (IllegalArgumentException iae) {
+                    // expected
+                }
+
+                r.removeDeferredTrailer(invalidHeaderName);
+            }
         }
     }
 }


### PR DESCRIPTION
- Only validate header name when creating HttpHeaderKeys the first time.
- Correctly validate byte[] header names.  byte[].toString doesn't give you a String of the byte[] contents.
- Make all HttpHeaderKeys constructors private to prevent anyone creating one without validation.
- For get, contains, and remove do not throw IllegalArgumentException when the header name is invalid.  Just ignore the header and do not created a HttpHeaderKeys object.  Do the same for CR and LF characters.
- Update HttpTrailerGeneratorImpl to do the correct equals.  The code never would work as it was written.
- Add test case for invalidate header names and make sure that each operation does what it is supposed to do.

Fixes #24427

This pull request is redo of PR #24382.  It is a performance improvement for the changes done in #24157. Also going to tag #24187 since that is the PR associated with #24157.