### PR TITLE
Avoid inferring datasources where not needed and skip tests not valid on IBM i

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_db2/build.gradle
@@ -24,6 +24,7 @@ task copyDB2(type: Copy) {
   shouldRunAfter jar
   from configurations.db2
   into new File(autoFvtDir, 'publish/shared/resources/db2')
+  rename 'jcc.*.jar', 'jcc.jar'
 }
 
 addRequiredLibraries.dependsOn copyDB2

--- a/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.jdbc.fat.db2/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.jdbc.fat.db2/server.xml
@@ -16,6 +16,7 @@
     <feature>jdbc-4.2</feature>
     <feature>servlet-3.1</feature>
     <feature>ssl-1.0</feature>
+    <feature>jndi-1.0</feature>
   </featureManager>
     
   <include location="../fatTestPorts.xml"/>
@@ -32,10 +33,14 @@
     <fileset dir="${shared.resource.dir}/db2"/>
   </library>
   
+  <library id="DB2LibJar">
+    <file name="${shared.resource.dir}/db2/jcc-11.1.4.4.jar"/>
+  </library>
+  
   <keyStore id="defaultKeyStore" location="security/db2-keystore.p12" password="db2test" />
     
   <dataSource id="DefaultDataSource">
-    <jdbcDriver libraryRef="DB2Lib"/>
+    <jdbcDriver libraryRef="DB2LibJar"/>
     <properties.db2.jcc
       databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"
       downgradeHoldCursorsUnderXa="true"/>
@@ -52,8 +57,17 @@
       commandTimeout="2m30s" connectionTimeout="90s" memberConnectTimeout="100000ms"/>
   </dataSource>
   
+    <dataSource jndiName="jdbc/db2jar">
+    <jdbcDriver libraryRef="DB2LibJar"/>
+    <properties.db2.jcc
+      databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"
+      user="${DB2_USER}" password="${DB2_PASS}"
+      affinityFailbackInterval="1h20m30s" allowNullResultSetForExecuteQuery="1"
+      commandTimeout="2m30s" connectionTimeout="90s" memberConnectTimeout="100000ms"/>
+  </dataSource>
+  
   <dataSource jndiName="jdbc/db2-secure">
-    <jdbcDriver libraryRef="DB2Lib"/>
+    <jdbcDriver libraryRef="DB2LibJar"/>
     <properties.db2.jcc
       databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT_SECURE}"
       user="${DB2_USER}" password="${DB2_PASS}"
@@ -67,7 +81,7 @@
   </dataSource>
   
   <dataSource jndiName="jdbc/db2-using-driver-type" type="java.sql.Driver">
-  	<jdbcDriver libraryRef="DB2Lib"/>
+  	<jdbcDriver libraryRef="DB2LibJar"/>
   	<properties.db2.jcc url="jdbc:db2://${DB2_HOSTNAME}:${DB2_PORT}/${DB2_DBNAME}"
       user="${DB2_USER}" password="${DB2_PASS}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"/>
   </dataSource>

--- a/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.jdbc.fat.db2/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.jdbc.fat.db2/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017,2021 IBM Corporation and others.
+    Copyright (c) 2017,2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -30,17 +30,13 @@
   </application>
     
   <library id="DB2Lib">
-    <fileset dir="${shared.resource.dir}/db2"/>
-  </library>
-  
-  <library id="DB2LibJar">
-    <file name="${shared.resource.dir}/db2/jcc-11.1.4.4.jar"/>
+    <fileset dir="${shared.resource.dir}/db2" includes="jcc.jar"/>
   </library>
   
   <keyStore id="defaultKeyStore" location="security/db2-keystore.p12" password="db2test" />
     
   <dataSource id="DefaultDataSource">
-    <jdbcDriver libraryRef="DB2LibJar"/>
+    <jdbcDriver libraryRef="DB2Lib"/> 
     <properties.db2.jcc
       databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"
       downgradeHoldCursorsUnderXa="true"/>
@@ -57,17 +53,8 @@
       commandTimeout="2m30s" connectionTimeout="90s" memberConnectTimeout="100000ms"/>
   </dataSource>
   
-    <dataSource jndiName="jdbc/db2jar">
-    <jdbcDriver libraryRef="DB2LibJar"/>
-    <properties.db2.jcc
-      databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"
-      user="${DB2_USER}" password="${DB2_PASS}"
-      affinityFailbackInterval="1h20m30s" allowNullResultSetForExecuteQuery="1"
-      commandTimeout="2m30s" connectionTimeout="90s" memberConnectTimeout="100000ms"/>
-  </dataSource>
-  
   <dataSource jndiName="jdbc/db2-secure">
-    <jdbcDriver libraryRef="DB2LibJar"/>
+    <jdbcDriver libraryRef="DB2Lib"/> 
     <properties.db2.jcc
       databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT_SECURE}"
       user="${DB2_USER}" password="${DB2_PASS}"
@@ -75,13 +62,13 @@
   </dataSource>
   
   <dataSource jndiName="jdbc/db2-using-driver">
-  	<jdbcDriver libraryRef="DB2Lib"/>
+    <jdbcDriver libraryRef="DB2Lib"/> 
   	<properties url="jdbc:db2://${DB2_HOSTNAME}:${DB2_PORT}/${DB2_DBNAME}"
       user="${DB2_USER}" password="${DB2_PASS}" driverType="4"/>
   </dataSource>
   
   <dataSource jndiName="jdbc/db2-using-driver-type" type="java.sql.Driver">
-  	<jdbcDriver libraryRef="DB2LibJar"/>
+    <jdbcDriver libraryRef="DB2Lib"/> 
   	<properties.db2.jcc url="jdbc:db2://${DB2_HOSTNAME}:${DB2_PORT}/${DB2_DBNAME}"
       user="${DB2_USER}" password="${DB2_PASS}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"/>
   </dataSource>

--- a/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
@@ -50,8 +50,8 @@ public class DB2TestServlet extends FATServlet {
     @Resource(shareable = false)
     private DataSource ds;
 
-    @Resource(lookup = "jdbc/db2jar", authenticationType = Resource.AuthenticationType.APPLICATION)
-    private DataSource ds_db2_jar;
+    @Resource(lookup = "jdbc/db2", authenticationType = Resource.AuthenticationType.APPLICATION)
+    private DataSource ds_db2;
 
     @Resource(lookup = "jdbc/db2-using-driver")
     private DataSource db2_using_driver;
@@ -112,7 +112,7 @@ public class DB2TestServlet extends FATServlet {
             tran.begin();
             try {
                 // ensure two-phase commit
-                Connection c2 = ds_db2_jar.getConnection();
+                Connection c2 = ds_db2.getConnection();
                 c2.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (3, 'third')");
                 c2.close();
 
@@ -141,7 +141,7 @@ public class DB2TestServlet extends FATServlet {
     // Verify that properties which represent durations of time are set properly on the data source.
     @Test
     public void testDurationProperties() throws Exception {
-        Referenceable referenceable = ds_db2_jar.unwrap(javax.naming.Referenceable.class);
+        Referenceable referenceable = ds_db2.unwrap(javax.naming.Referenceable.class);
         Reference ref = referenceable.getReference();
 
         RefAddr affinityFailbackInterval = ref.get("affinityFailbackInterval");
@@ -161,7 +161,7 @@ public class DB2TestServlet extends FATServlet {
     // Verify that WAS JDBC statement wrappers can properly handle the NULL result set.
     @Test
     public void testNullResultOfExecuteQuery() throws Exception {
-        Connection con = ds_db2_jar.getConnection();
+        Connection con = ds_db2.getConnection();
         try {
             con.createStatement()
                             .execute("CREATE OR REPLACE PROCEDURE insertNewEntry (IN NEWID SMALLINT, IN NEWVAL NVARCHAR(40))"
@@ -220,7 +220,6 @@ public class DB2TestServlet extends FATServlet {
     public void testInferDB2DataSource() throws Exception {
         //Lookup instead of resource injection so this datasource is not looked up when running on IBMi
         DataSource db2_inferred_ds = InitialContext.doLookup("jdbc/db2-inferred");
-        DataSource ds_db2 = InitialContext.doLookup("jdbc/db2");
 
         //The default datasource should continue to be inferred as an XADataSource, since it has properties.db2.jcc configured
         assertTrue("default datasource should wrap XADataSource", ds.isWrapperFor(XADataSource.class));

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
@@ -32,8 +32,17 @@
     	<fileset dir="${shared.resource.dir}/oracle"/>
     </library>
     
+    <library id="DBLibJar">
+    	<file name="${shared.resource.dir}/oracle/oracleunknown.jar"/>
+    </library>
+    
     <dataSource id="DefaultDataSource">
     	<jdbcDriver libraryRef="DBLib"/>
+    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
+    </dataSource>
+    
+    <dataSource id="df-ds-jar" jndiName="jdbc/df-ds-jar">
+    	<jdbcDriver libraryRef="DBLibJar"/>
     	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
     </dataSource>
 
@@ -47,12 +56,12 @@
     
     <dataSource id="driver-ds" jndiName="jdbc/driver-ds" type="java.sql.Driver">
     	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
-    	<jdbcDriver libraryRef="DBLib"/>
+    	<jdbcDriver libraryRef="DBLibJar"/>
     </dataSource>
     
     <dataSource id="generic-driver-ds" jndiName="jdbc/generic-driver-ds">
     	<properties URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
-    	<jdbcDriver libraryRef="DBLib"/>
+    	<jdbcDriver libraryRef="DBLibJar"/>
     </dataSource>
     
     <dataSource id="inferred-ds" jndiName="jdbc/inferred-ds">

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
@@ -29,20 +29,11 @@
     </application>
 
     <library id="DBLib">
-    	<fileset dir="${shared.resource.dir}/oracle"/>
-    </library>
-    
-    <library id="DBLibJar">
-    	<file name="${shared.resource.dir}/oracle/oracleunknown.jar"/>
+    	<fileset dir="${shared.resource.dir}/oracle" includes="oracleunknown.jar"/>
     </library>
     
     <dataSource id="DefaultDataSource">
     	<jdbcDriver libraryRef="DBLib"/>
-    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
-    </dataSource>
-    
-    <dataSource id="df-ds-jar" jndiName="jdbc/df-ds-jar">
-    	<jdbcDriver libraryRef="DBLibJar"/>
     	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
     </dataSource>
 
@@ -56,12 +47,12 @@
     
     <dataSource id="driver-ds" jndiName="jdbc/driver-ds" type="java.sql.Driver">
     	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
-    	<jdbcDriver libraryRef="DBLibJar"/>
+    	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
     <dataSource id="generic-driver-ds" jndiName="jdbc/generic-driver-ds">
     	<properties URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
-    	<jdbcDriver libraryRef="DBLibJar"/>
+    	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
     <dataSource id="inferred-ds" jndiName="jdbc/inferred-ds">

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
@@ -51,8 +51,8 @@ import oracle.jdbc.datasource.OracleXADataSource;
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/OracleTestServlet")
 public class OracleTestServlet extends FATServlet {
-    @Resource(lookup = "jdbc/df-ds-jar")
-    private DataSource df_ds_jar;
+    @Resource
+    private DataSource ds;
 
     @Resource(lookup = "jdbc/driver-ds")
     private DataSource driver_ds;
@@ -71,7 +71,6 @@ public class OracleTestServlet extends FATServlet {
 
     // Verify that connections are/are not castable to OracleConnection based on whether enableConnectionCasting=true/false.
     @Test
-    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testConnectionCasting() throws Exception {
         //Lookup instead of resource injection so this datasource is not looked up when running on IBMi
         DataSource ds_casting = InitialContext.doLookup("jdbc/casting-ds");
@@ -112,7 +111,6 @@ public class OracleTestServlet extends FATServlet {
     // Test for oracle.jdbc.OracleCallableStatement.getCursor.  Should be able to execute a procedure that returns a cursor
     // and use getCursor to obtain a result set.  The parent statement of the result set should be the WAS statement wrapper.
     @Test
-    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testCursor() throws Exception {
         DataSource ds = InitialContext.doLookup("java:comp/DefaultDataSource");
         Connection con = ds.getConnection();
@@ -144,7 +142,6 @@ public class OracleTestServlet extends FATServlet {
     // In this test we cover specifying multiple onConnect SQL commands on a single data source,
     // the use of transactional onConnect commands, as well as the use of Liberty variables in the onConnect SQL.
     @Test
-    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testOnConnectSQL() throws Exception {
         DataSource ds_casting = InitialContext.doLookup("jdbc/casting-ds");
         Connection con = ds_casting.getConnection();
@@ -172,7 +169,7 @@ public class OracleTestServlet extends FATServlet {
     @Test
     @ExpectedFFDC({ "java.sql.SQLException" })
     public void testReadOnlyException() throws Exception {
-        try (Connection con = df_ds_jar.getConnection(); PreparedStatement ps = con.prepareStatement("INSERT INTO MYTABLE VALUES(?,?)");) {
+        try (Connection con = ds.getConnection(); PreparedStatement ps = con.prepareStatement("INSERT INTO MYTABLE VALUES(?,?)");) {
             con.setReadOnly(true);
             ps.setInt(1, 4);
             ps.setString(2, "four");
@@ -189,7 +186,7 @@ public class OracleTestServlet extends FATServlet {
     // and use getObject to obtain a result set.  The parent statement of the result set should be the WAS statement wrapper.
     @Test
     public void testRefCursor() throws Exception {
-        Connection con = df_ds_jar.getConnection();
+        Connection con = ds.getConnection();
         try {
             assertTrue(con.getMetaData().supportsRefCursors());
 
@@ -221,7 +218,6 @@ public class OracleTestServlet extends FATServlet {
     // that returns values, obtain the return result set and use it.  The parent statement of the result set should
     // be the WAS statement wrapper.
     @Test
-    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testReturnResultSet() throws Exception {
         DataSource ds = InitialContext.doLookup("java:comp/DefaultDataSource");
         Connection con = ds.getConnection();
@@ -251,7 +247,6 @@ public class OracleTestServlet extends FATServlet {
 
     // Test configured value of newly supported roleName data source property for Oracle.
     @Test
-    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testRoleName() throws Exception {
         // First determine if we can run this test. Oracle driver for JDBC 4.2 is not compatible with Java 9+
         boolean atLeastJava9;
@@ -419,7 +414,7 @@ public class OracleTestServlet extends FATServlet {
         try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("/data/myDataFile.txt");) {
 
             //First try to use setBlob
-            try (Connection con1 = df_ds_jar.getConnection();
+            try (Connection con1 = ds.getConnection();
                             PreparedStatement ps = con1.prepareStatement("INSERT INTO BLOBTABLE VALUES (?, ?)");) {
 
                 byte[] byteData = new byte[inputStream.available()];
@@ -436,7 +431,7 @@ public class OracleTestServlet extends FATServlet {
             }
 
             //Next try to use setBinaryStream
-            try (Connection con1 = df_ds_jar.getConnection();
+            try (Connection con1 = ds.getConnection();
                             PreparedStatement ps = con1.prepareStatement("INSERT INTO BLOBTABLE VALUES (?, ?)");) {
 
                 ps.setInt(1, 2);

--- a/dev/com.ibm.ws.jdbc_fat_postgresql/publish/servers/postgresql-test-server/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/publish/servers/postgresql-test-server/server.xml
@@ -12,13 +12,17 @@
     </application>
     
     <dataSource jndiName="jdbc/postgres/genericprops">
-      <jdbcDriver libraryRef="PostgresLib" />
+      <jdbcDriver libraryRef="PostgresLibJar" />
       <properties serverName="${env.POSTGRES_HOST}" portNumber="${env.POSTGRES_PORT}" databaseName="${env.POSTGRES_DB}" user="${env.POSTGRES_USER}" password="${env.POSTGRES_PASS}"/>
     </dataSource>
 
     <!-- Uses an anonymously named postgres JDBC driver, so that the file name heuristic doesn't discover the driver type -->    
     <library id="PostgresLib">
         <fileset dir="${server.config.dir}/jdbc"/>
+    </library>
+    
+    <library id="PostgresLibJar">
+        <file name="${shared.resource.dir}/postgres/postgresql.jar"/>
     </library>
     
     <!-- datasource type auto-detection should locate the java.sql.Driver in the driver.jar -->
@@ -33,8 +37,14 @@
                   defaultRowFetchSize="5" applicationName="postgresqlApp"/>
     </dataSource>
     
+    <dataSource jndiName="jdbc/postgres/XADataSource" type="javax.sql.XADataSource">
+      <jdbcDriver libraryRef="PostgresLibJar" />
+      <properties serverName="${env.POSTGRES_HOST}" portNumber="${env.POSTGRES_PORT}" databaseName="${env.POSTGRES_DB}" user="${env.POSTGRES_USER}" password="${env.POSTGRES_PASS}"
+                  defaultRowFetchSize="5" applicationName="postgresqlApp"/>
+    </dataSource>
+    
     <dataSource jndiName="jdbc/postgres/minimal">
-      <jdbcDriver libraryRef="PostgresLib" />
+      <jdbcDriver libraryRef="PostgresLibJar" />
       <properties.postgresql serverName="${env.POSTGRES_HOST}" portNumber="${env.POSTGRES_PORT}" databaseName="${env.POSTGRES_DB}" user="${env.POSTGRES_USER}" password="${env.POSTGRES_PASS}"/>
     </dataSource>
     
@@ -52,36 +62,36 @@
     </dataSource>
     
     <dataSource jndiName="jdbc/postgres/ConnectionPoolDataSource" type="javax.sql.ConnectionPoolDataSource">
-      <jdbcDriver libraryRef="PostgresLib" />
+      <jdbcDriver libraryRef="PostgresLibJar" />
       <properties.postgresql serverName="${env.POSTGRES_HOST}" portNumber="${env.POSTGRES_PORT}" databaseName="${env.POSTGRES_DB}" user="${env.POSTGRES_USER}" password="${env.POSTGRES_PASS}"/>
     </dataSource>
     
     <dataSource jndiName="jdbc/postgres/DataSource" type="javax.sql.DataSource">
-      <jdbcDriver libraryRef="PostgresLib" />
+      <jdbcDriver libraryRef="PostgresLibJar" />
       <properties.postgresql serverName="${env.POSTGRES_HOST}" portNumber="${env.POSTGRES_PORT}" databaseName="${env.POSTGRES_DB}" user="${env.POSTGRES_USER}" password="${env.POSTGRES_PASS}"/>
     </dataSource>
     
     <dataSource jndiName="jdbc/postgres/readOnly">
-      <jdbcDriver libraryRef="PostgresLib" />
+      <jdbcDriver libraryRef="PostgresLibJar" />
       <properties.postgresql serverName="${env.POSTGRES_HOST}" portNumber="${env.POSTGRES_PORT}" databaseName="${env.POSTGRES_DB}" user="${env.POSTGRES_USER}" password="${env.POSTGRES_PASS}"
                              readOnly="true" readOnlyMode="always"/>
     </dataSource>
     
     <dataSource jndiName="jdbc/postgres/defaultAutoCommit" type="javax.sql.ConnectionPoolDataSource">
-      <jdbcDriver libraryRef="PostgresLib" />
+      <jdbcDriver libraryRef="PostgresLibJar" />
       <properties.postgresql serverName="${env.POSTGRES_HOST}" portNumber="${env.POSTGRES_PORT}" databaseName="${env.POSTGRES_DB}" user="${env.POSTGRES_USER}" password="${env.POSTGRES_PASS}"
                              defaultAutoCommit="true" connectTimeout="10s"/>
     </dataSource>
     
     <dataSource jndiName="jdbc/postgres/defaultAutoCommitOff" type="javax.sql.ConnectionPoolDataSource">
-      <jdbcDriver libraryRef="PostgresLib" />
+      <jdbcDriver libraryRef="PostgresLibJar" />
       <connectionManager enableSharingForDirectLookups="false"/>
       <properties.postgresql serverName="${env.POSTGRES_HOST}" portNumber="${env.POSTGRES_PORT}" databaseName="${env.POSTGRES_DB}" user="${env.POSTGRES_USER}" password="${env.POSTGRES_PASS}"
                              defaultAutoCommit="false"/>
     </dataSource>
     
     <dataSource jndiName="jdbc/postgres/urlOnly">
-      <jdbcDriver libraryRef="PostgresLib" />
+      <jdbcDriver libraryRef="PostgresLibJar" />
       <properties.postgresql URL="${env.POSTGRES_URL}"/>
     </dataSource>
     

--- a/dev/com.ibm.ws.jdbc_fat_postgresql/test-applications/postgresqlApp/src/jdbc/fat/postgresql/web/PostgreSQLTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/test-applications/postgresqlApp/src/jdbc/fat/postgresql/web/PostgreSQLTestServlet.java
@@ -60,7 +60,6 @@ public class PostgreSQLTestServlet extends FATServlet {
 
     // Test that we can obtain a Connection from a datasource that uses the generic <properties> element with PostgreSQL
     @Test
-    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testPostgresGenericProps() throws Exception {
         DataSource ds = InitialContext.doLookup("jdbc/postgres/genericprops");
         ds.getConnection().close();
@@ -93,7 +92,6 @@ public class PostgreSQLTestServlet extends FATServlet {
 
     // Verify that we can configure a <properties.postgresql> element by specifying only the 'URL' property
     @Test
-    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testPostgresURLOnly() throws Exception {
         DataSource ds = InitialContext.doLookup("jdbc/postgres/urlOnly");
         ds.getConnection().close();
@@ -102,7 +100,7 @@ public class PostgreSQLTestServlet extends FATServlet {
     // Verify that basic unwrap patterns work for the 3 DataSource types: reg, CP, and XA
     @Test
     public void testUnwrapDS() throws Exception {
-        DataSource ds = InitialContext.doLookup("jdbc/anonymous/XADataSource");
+        DataSource ds = InitialContext.doLookup("jdbc/postgres/XADataSource");
         assertTrue("Class " + ds.getClass() + " was not marked as a wrapper for XADataSource",
                    ds.isWrapperFor(XADataSource.class));
         // There isn't any PosgreSQL specific interface we can unwrap to,
@@ -128,6 +126,7 @@ public class PostgreSQLTestServlet extends FATServlet {
     }
 
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testUnwrapConnection() throws Exception {
         DataSource ds = InitialContext.doLookup("jdbc/postgres/xa");
         try (Connection con = ds.getConnection()) {
@@ -145,9 +144,8 @@ public class PostgreSQLTestServlet extends FATServlet {
 
     // Test that a basic PostgreSQL-only bean property (defaultFetchSize) gets set on a DataSource when configured in server.xml
     @Test
-    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testBasicPostgreSpecificProp() throws Exception {
-        DataSource ds = InitialContext.doLookup("jdbc/anonymous/XADataSource");
+        DataSource ds = InitialContext.doLookup("jdbc/postgres/XADataSource");
 
         // Insert 6 rows into the DB. Uses ID's 0, 1, 2, 3, 4, and 5
         try (Connection con = ds.getConnection()) {
@@ -172,10 +170,9 @@ public class PostgreSQLTestServlet extends FATServlet {
 
     // Verify behavior of the defaultReadOnly setting on <properties.postgresql>
     @Test
-    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testReadOnly() throws Exception {
         // On a regular DS, should be able to write data
-        DataSource regularDS = InitialContext.doLookup("jdbc/anonymous/XADataSource");
+        DataSource regularDS = InitialContext.doLookup("jdbc/postgres/XADataSource");
         try (Connection con = regularDS.getConnection()) {
             assertFalse("JDBC connection should not be marked read-only by default.", con.isReadOnly());
             Statement stmt = con.createStatement();
@@ -207,10 +204,9 @@ public class PostgreSQLTestServlet extends FATServlet {
     // Verify that the defaultAutoCommit setting defaults to true, and when it is set to false
     // connections obtained from these DataSources have autoCommit=false when initially obtained
     @Test
-    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testDefaultAutoCommit() throws Exception {
         // On a regular DS, default AC should be true in an LTC, or false in a global tran
-        DataSource writingDS = InitialContext.doLookup("jdbc/anonymous/XADataSource");
+        DataSource writingDS = InitialContext.doLookup("jdbc/postgres/XADataSource");
         DataSource regularDS = InitialContext.doLookup("jdbc/postgres/ConnectionPoolDataSource");
 
         try (Connection writingConn = writingDS.getConnection();
@@ -265,6 +261,7 @@ public class PostgreSQLTestServlet extends FATServlet {
     // Ensure defaultAutoCommit=false behaves properly across global transaction boundaries.
     // Insert/read data with two different DataSources, expect writes to auto-commit
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testDefaultAutoCommitOffGlobalTran() throws Exception {
         DataSource regularDS = InitialContext.doLookup("jdbc/postgres/xa");
         DataSource autoCommitDS = InitialContext.doLookup("jdbc/postgres/defaultAutoCommitOff");
@@ -479,6 +476,7 @@ public class PostgreSQLTestServlet extends FATServlet {
     }
 
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testPostgresCopyApiUsability() throws Exception {
         DataSource ds = InitialContext.doLookup("jdbc/postgres/xa");
         try (Connection con = ds.getConnection()) {
@@ -490,6 +488,7 @@ public class PostgreSQLTestServlet extends FATServlet {
     }
 
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testPostgresLargeObjectApiUsability() throws Exception {
         DataSource ds = InitialContext.doLookup("jdbc/postgres/xa");
         try (Connection con = ds.getConnection()) {


### PR DESCRIPTION
IBM i has a native jdbc driver that is always on the classpath so if you don't specify the specific jdbc driver jar you want to use, liberty will just search for one in the classpath, and on IBM i, it always finds the native driver. Other platforms just find the driver that is placed in the classpath. So needed to update our tests to point to a specific jar for the tests that didn't need the inferring capability, and skipping the inferring tests on IBM i.