### PR TITLE
Add back correct client-only feature detection.  Add back stable feature filter check.

### DIFF
--- a/dev/build.featureStart.base/resources/com/ibm/ws/test/featurestart/features/feature-stable.txt
+++ b/dev/build.featureStart.base/resources/com/ibm/ws/test/featurestart/features/feature-stable.txt
@@ -1,4 +1,4 @@
-### Open Liberty Stable Features for MVT Testing
+### Open Liberty Stable Features
 #
 ## Purpose of this file:
 #
@@ -7,7 +7,7 @@
 #
 # This file will likely be used in the future for other MVT testing.
 #
-# All current features Å\ including client, non-public, and test features Å\ should be listed,
+# All current features -- including client, non-public, and test features -- should be listed,
 # even though feature startup tests are not run on client, non-public, and test features.
 #
 # This file should be updated at major releases.  The current heuristic is to mark all but
@@ -47,6 +47,8 @@
 # list.
 
 # START START START
+
+# Open-Liberty:
 
 null acmeCA # 2.0                         #
 null adminCenter # 1.0                    #
@@ -103,17 +105,17 @@ null javaMail 1.5 # 1.6                   #
 null javaee 7.0  # 8.0                    #
 null javaeeClient 7.0 # 8.0               # isClient
 null jaxb # 2.2                           #
-null jaxrs 2.0 # 2.1                      #
+null jaxrs 1.1 2.0 # 2.1                  #
 null jaxrsClient 2.0 # 2.1                #
 null jaxws # 2.2                          #
-null jca # 1.7                            #
+null jca 1.6 # 1.7                        #
 null jcaInboundSecurity # 1.0             #
 null jcacheContainer # 1.1                #
 null jdbc 4.0 4.1 4.2 # 4.3               #
-null jms # 2.0                            #
-null jmsMdb # 3.2                         #
+null jms 1.1 # 2.0                        #
+null jmsMdb 3.1 # 3.2                     #
 null jndi # 1.0                           #
-null jpa 2.1 # 2.2                        #
+null jpa 2.0 2.1 # 2.2                    #
 null jpaContainer 2.1 # 2.2               #
 null jsf 2.2 # 2.3                        #
 null jsfContainer 2.2 # 2.3               #
@@ -131,7 +133,7 @@ null logstashCollector # 1.0              #
 null mail 2.0 # 2.1                       #
 null managedBeans # 1.0                   #
 null managedBeans # 2.0                   #
-null mdb 3.2 # 4.0                        #
+null mdb 3.1 3.2 # 4.0                    #
 null messaging 3.0 # 3.1                  #
 null messagingClient # 3.0                #
 null messagingSecurity # 3.0              #
@@ -158,7 +160,7 @@ null netty # 1.0                          #
 null noShip # 1.0                         #
 null nosql # 1.0                          #
 null oauth # 2.0                          #
-null openapi # 3.1                        #
+null openapi 2.0 3.0 # 3.1                #
 null openid # 2.0                         #
 null openidConnectClient # 1.0            #
 null openidConnectServer # 1.0            #
@@ -175,9 +177,9 @@ null restfulWS 3.0 # 3.1                  #
 null restfulWSClient 3.0 # 3.1            #
 null restfulWSLogging # 3.0               #
 null samlWeb # 2.0                        #
-null scim # 2.0                           #
+null scim 1.0 # 2.0                       #
 null serverConfig # 1.0                   # isPrivate
-null servlet 3.1 4.0 5.0 # 6.0            #
+null servlet 3.0 3.1 4.0 5.0 # 6.0        #
 null sessionCache # 1.0                   #
 null sessionDatabase # 1.0                #
 null sipServlet # 1.1                     #
@@ -187,11 +189,11 @@ null springBoot 1.5 # 2.0                 #
 null ssl # 1.0                            #
 null timedexit # 1.0                      # isTest
 null transportSecurity # 1.0              #
-null wasJmsClient # 2.0                   #
+null wasJmsClient 1.1 # 2.0               #
 null wasJmsSecurity # 1.0                 #
 null wasJmsServer # 1.0                   #
 null webCache # 1.0                       #
-null webProfile 7.0 8.0 9.1 # 10.0        #
+null webProfile 6.0 7.0 8.0 9.1 # 10.0    #
 null websocket 1.0 1.1 2.0 # 2.1          #
 null wsAtomicTransaction # 1.2            #
 null wsSecurity # 1.1                     #

--- a/dev/build.featureStart.base/resources/com/ibm/ws/test/featurestart/features/feature-stable.txt
+++ b/dev/build.featureStart.base/resources/com/ibm/ws/test/featurestart/features/feature-stable.txt
@@ -2,23 +2,25 @@
 #
 ## Purpose of this file:
 #
-# This file records stable feature versions.  Any feature version listed in this file are skipped during LITE mode testing when doing feature startup tests.
+# This file records stable feature versions.  Any feature version listed in this file are
+# skipped during LITE mode testing when doing feature startup tests.
 #
 # This file will likely be used in the future for other MVT testing.
 #
-# All current features Å\ including client, non-public, and test features Å\ should be listed, even though
-# feature startup tests are not run on client, non-public, and test features.
+# All current features Å\ including client, non-public, and test features Å\ should be listed,
+# even though feature startup tests are not run on client, non-public, and test features.
 #
-# This file should be updated at major releases.  The current heuristic is to mark all but the last version of each feature is stable, then adjust the
-# setting as appropriate based on the actual stability of each feature.
+# This file should be updated at major releases.  The current heuristic is to mark all but
+# the last version of each feature is stable, then adjust the setting as appropriate based
+# on the actual stability of each feature.
 #
 ## Overall formatting:
 #
 # Blank lines are ignored.  All white space characters collapse into either a
 # single character or a line end delimiter.
 #
-# The file supports comments delimited with a Åe#Åf character.  In the example,
-# the full list of available versions is present, with Åe#Åf placed after the
+# The file supports comments delimited with a '#' character.  In the example,
+# the full list of available versions is present, with '#' placed after the
 # last stable version.
 #
 ## Line formatting:
@@ -32,10 +34,10 @@
 # For example:
 #     null jdbc 4.0 4.1 # 4.2 4.3
 #
-# ÅgweightÅh is a currently unused cost weighing of the feature relative to other
+# "weight" is a currently unused cost weighing of the feature relative to other
 # features. Weight currently has a value of null in all cases.
 #
-# A feature which has no stable versions should be represented by placing the Åe#Åf
+# A feature which has no stable versions should be represented by placing the '#'
 # after the name.  For example:
 #     null ldapRegistry # 3.0
 #
@@ -50,7 +52,7 @@ null acmeCA # 2.0                         #
 null adminCenter # 1.0                    #
 null appAuthentication 2.0 # 3.0          #
 null appAuthorization 2.0 # 2.1           #
-null appClientSupport 1.0 # 2.0           # isClient
+null appClientSupport 1.0 # 2.0           #
 null appSecurity 1.0 2.0 3.0 4.0 # 5.0    #
 null appSecurityClient # 1.0              # isClient
 null arquillian-support # 1.0             # isTest
@@ -89,12 +91,12 @@ null faces 3.0 # 4.0                      #
 null facesContainer 3.0 # 4.0             #
 null federatedRegistry # 1.0              #
 null grpc # 1.0                           #
-null grpcClient # 1.0                     # isClient
-null http2clienttest # 1.0                # isClient isTest
+null grpcClient # 1.0                     #
+null http2clienttest # 1.0                # isTest
 null j2eeManagement # 1.1                 #
 null jacc # 1.5                           #
-null jakartaee 8.0 9.1 1# 0.0             #
-null jakartaeeClient 9.1 1# 0.0           # isClient
+null jakartaee 8.0 9.1 # 10.0             #
+null jakartaeeClient 9.1 # 10.0           # isClient
 null jaspic # 1.1                         #
 null javaBatch # 1.0                      # isPrivate
 null javaMail 1.5 # 1.6                   #
@@ -102,7 +104,7 @@ null javaee 7.0  # 8.0                    #
 null javaeeClient 7.0 # 8.0               # isClient
 null jaxb # 2.2                           #
 null jaxrs 2.0 # 2.1                      #
-null jaxrsClient 2.0 # 2.1                # isClient
+null jaxrsClient 2.0 # 2.1                #
 null jaxws # 2.2                          #
 null jca # 1.7                            #
 null jcaInboundSecurity # 1.0             #
@@ -131,7 +133,7 @@ null managedBeans # 1.0                   #
 null managedBeans # 2.0                   #
 null mdb 3.2 # 4.0                        #
 null messaging 3.0 # 3.1                  #
-null messagingClient # 3.0                # isClient
+null messagingClient # 3.0                #
 null messagingSecurity # 3.0              #
 null messagingServer # 3.0                #
 null microProfile 1.0 1.2 1.3 1.4 2.0 2.1 2.2 3.0 3.2 3.3 4.0 4.1 5.0 # 6.0 #
@@ -139,18 +141,18 @@ null mongodb # 2.0                        #
 null monitor # 1.0                        #
 null mpConfig 1.1 1.2 1.3 1.4 2.0 # 3.0   #
 null mpContextPropagation 1.0 1.2 # 1.3   #
-null mpFaultTolerance 1.0 1.1 2.0 2.1 3.0 # 4.0 #  
+null mpFaultTolerance 1.0 1.1 2.0 2.1 3.0 # 4.0 #
 null mpGraphQL 1.0 # 2.0                  #
-null mpHealth 1.0 2.0 2.1 2.2 3.0 3.1 # 4.0 #  
+null mpHealth 1.0 2.0 2.1 2.2 3.0 3.1 # 4.0 #
 null mpJwt 1.0 1.1 1.2 2.0 # 2.1          #
 null mpLRA # 1.0                          #
 null mpLRACoordinator # 1.0               #
-null mpMetrics 1.0 1.1 2.0 2.2 2.3 3.0 4.0 # 5.0 #  
+null mpMetrics 1.0 1.1 2.0 2.2 2.3 3.0 4.0 # 5.0 #
 null mpOpenAPI 1.0 1.1 2.0 3.0 # 3.1      #
-null mpOpenTracing 1.0 1.1 1.2 1.3 2.0 # 3.0 #  
+null mpOpenTracing 1.0 1.1 1.2 1.3 2.0 # 3.0 #
 null mpReactiveMessaging # 1.0            #
 null mpReactiveStreams # 1.0              #
-null mpRestClient 1.0 1.1 1.2 1.31. 2.0 # 3.0 # isClient 
+null mpRestClient 1.0 1.1 1.2 1.31. 2.0 # 3.0 #
 null mpTelemetry # 1.0                    #
 null netty # 1.0                          #
 null noShip # 1.0                         #
@@ -158,7 +160,7 @@ null nosql # 1.0                          #
 null oauth # 2.0                          #
 null openapi # 3.1                        #
 null openid # 2.0                         #
-null openidConnectClient # 1.0            # isClient
+null openidConnectClient # 1.0            #
 null openidConnectServer # 1.0            #
 null opentracing 1.0 1.1 1.2 1.3 # 2.0    #
 null osgiConsole # 1.0                    #
@@ -170,7 +172,7 @@ null persistentExecutor # 1.0             #
 null requestTiming # 1.0                  #
 null restConnector # 2.0                  #
 null restfulWS 3.0 # 3.1                  #
-null restfulWSClient 3.0 # 3.1            # isClient
+null restfulWSClient 3.0 # 3.1            #
 null restfulWSLogging # 3.0               #
 null samlWeb # 2.0                        #
 null scim # 2.0                           #
@@ -185,11 +187,11 @@ null springBoot 1.5 # 2.0                 #
 null ssl # 1.0                            #
 null timedexit # 1.0                      # isTest
 null transportSecurity # 1.0              #
-null wasJmsClient # 2.0                   # isClient
+null wasJmsClient # 2.0                   #
 null wasJmsSecurity # 1.0                 #
 null wasJmsServer # 1.0                   #
 null webCache # 1.0                       #
-null webProfile 7.0 8.0 9.1 1# 0.0        #
+null webProfile 7.0 8.0 9.1 # 10.0        #
 null websocket 1.0 1.1 2.0 # 2.1          #
 null wsAtomicTransaction # 1.2            #
 null wsSecurity # 1.1                     #

--- a/dev/build.featureStart.base/src/com/ibm/ws/test/featurestart/FeaturesStartTestBase.java
+++ b/dev/build.featureStart.base/src/com/ibm/ws/test/featurestart/FeaturesStartTestBase.java
@@ -39,6 +39,8 @@ import com.ibm.ws.test.featurestart.features.FeatureLevels;
 import com.ibm.ws.test.featurestart.features.FeatureReports;
 import com.ibm.ws.test.featurestart.features.FeatureStability;
 
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.TestModeFilter;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -548,12 +550,11 @@ public class FeaturesStartTestBase {
             } else if (!featureData.isPublic()) {
                 nonPublicFeatures.add(name);
                 continue;
-            }
 
-            // } else if ((TestModeFilter.FRAMEWORK_TEST_MODE == TestMode.LITE) && isStable(name)) {
-            //     stableFeatures.add(name);
-            //     continue;
-            // }
+            } else if ((TestModeFilter.FRAMEWORK_TEST_MODE == TestMode.LITE) && isStable(name)) {
+                stableFeatures.add(name);
+                continue;
+            }
 
             String filterReason = isFiltered(name);
             if (filterReason != null) {

--- a/dev/build.featureStart.base/src/com/ibm/ws/test/featurestart/features/FeatureData.java
+++ b/dev/build.featureStart.base/src/com/ibm/ws/test/featurestart/features/FeatureData.java
@@ -112,7 +112,7 @@ public class FeatureData {
                 String line = scanner.nextLine();
                 if (line.startsWith("IBM-ShortName:")) {
                     shortName = line.substring(SHORT_PREFIX_LEN).trim();
-                    if (shortName.toLowerCase().contains("client")) {
+                    if (FeatureFilter.isClient(shortName)) {
                         isClientOnly = true;
                     }
 

--- a/dev/build.featureStart.base/src/com/ibm/ws/test/featurestart/features/FeatureFilter.java
+++ b/dev/build.featureStart.base/src/com/ibm/ws/test/featurestart/features/FeatureFilter.java
@@ -73,7 +73,7 @@ public class FeatureFilter {
     }
 
     /**
-     * if a feature is not to be run depending on whether the test environment
+     * Tell if a feature is not to be run depending on whether the test environment
      * is ZOS.
      *
      * Irrespective of the value returned by this method, other tests may cause
@@ -100,4 +100,22 @@ public class FeatureFilter {
             }
         }
     }
+
+    /**
+     * Tell if a feature is a client-only feature.  Currently,
+     * features which have names which contain 'eeClient' or 'securityClient'
+     * are client-only features.  Those are 'jakartaeeClient' and
+     * 'securityClient'.
+     *
+     * Previously, the test was against 'client', but that was incorrect.
+     *
+     * @param shortName The short name of the feature which is to be tested.
+     * @return True or false telling if the feature is a client-only feature.
+     */
+    public static boolean isClient(String shortName) {
+        String upperShortName = shortName.toUpperCase();
+        return ( upperShortName.contains("EECLIENT") ||
+                 upperShortName.contains("SECURITYCLIENT") );
+    }
 }
+


### PR DESCRIPTION
The refactoring of featureStart test code removed a correction to client-only feature testing.

Also, the initial check-in of the featureStart refactored code had the stable features check disabled.

This PR adds the correct client-only feature test and re-enables stable feature filtering.