### PR TITLE
Update jwks read timeout in ProviderMetadata app

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/test-applications/ProviderMetadata.war/src/providerMetadata/servlets/ProviderMetadataServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/test-applications/ProviderMetadata.war/src/providerMetadata/servlets/ProviderMetadataServlet.java
@@ -26,6 +26,7 @@ import oidc.client.base.servlets.BaseServlet;
                                          clientId = "${openIdConfig.clientId}", clientSecret = "${openIdConfig.clientSecret}", redirectURI = "${openIdConfig.redirectURI}",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "${openIdConfig.callerNameClaim}",
                                                                               callerGroupsClaim = "${openIdConfig.callerGroupsClaim}"),
+                                         jwksReadTimeoutExpression = "${openIdConfig.jwksReadTimeoutExpression}",
                                          providerMetadata = @OpenIdProviderMetadata(authorizationEndpoint = "${openIdConfig.authorizationEndpoint}",
                                                                                     tokenEndpoint = "${openIdConfig.tokenEndpoint}",
                                                                                     userinfoEndpoint = "${openIdConfig.userinfoEndpoint}",


### PR DESCRIPTION
On slow test systems the jwks read can time out if the default timeout of 500 milliseconds is used.  Most of the test applications override the value.  This one instance did not have the update.  I just need to add jwksReadTimeoutExpression to the @OpenIdAuthenticationMechanismDefinition annotation.