### PR TITLE
Upgrade to commons-io:2.11.0 and commons-fileupload:1.5

### DIFF
--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     binaries "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     binaries "org.osgi:org.osgi.core:6.0.0"
     binaries "org.apache.aries:org.apache.aries.util:1.1.3"
-    binaries "commons-io:commons-io:2.8.0"
+    binaries "commons-io:commons-io:2.11.0"
     binaries "commons-lang:commons-lang:2.4"
     binaries "org.apache.commons:commons-math:2.2"
     binaries "org.eclipse.jdt:ecj:3.22.0"

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -384,7 +384,12 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.4</version>
+      <version>1.5</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
@@ -4070,11 +4075,6 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.6</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>io.jaegertracing</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -72,7 +72,8 @@ com.unboundid:unboundid-ldapsdk:5.1.0
 commons-cli:commons-cli:1.4
 commons-codec:commons-codec:1.15
 commons-collections:commons-collections:3.2.2
-commons-fileupload:commons-fileupload:1.4
+commons-fileupload:commons-fileupload:1.5
+commons-io:commons-io:2.11.0
 commons-lang:commons-lang:2.4
 commons-logging:commons-logging:1.2
 commons-net:commons-net:3.6

--- a/dev/cnf/oss_source_dependencies.maven
+++ b/dev/cnf/oss_source_dependencies.maven
@@ -18,7 +18,6 @@ commons-digester:commons-digester:1.8
 commons-discovery:commons-discovery:0.2
 commons-httpclient:commons-httpclient:3.1
 commons-io:commons-io:2.6
-commons-io:commons-io:2.8.0
 io.jaegertracing:jaeger-core:0.34.0
 io.opencensus:opencensus-api:0.28.0
 io.opencensus:opencensus-contrib-grpc-metrics:0.28.0

--- a/dev/cnf/resources/bnd/anttaskdefs.bnd
+++ b/dev/cnf/resources/bnd/anttaskdefs.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ repo.generateChecksums.path: ${path;\
     ${repo;com.ibm.websphere.org.osgi.core}}
     
 repo.nlsTasks.path: ${path;\
-    ${repo;commons-io:commons-io;2.8.0},\
+    ${repo;commons-io:commons-io;2.11.0},\
     ${repo;commons-lang:commons-lang;2.4},\
     ${repo;org.apache.commons:commons-math;2.2},\
     ${repo;com.ibm.ws.componenttest:mantis-collections;2.5.0},\
@@ -71,7 +71,7 @@ repo.repositoryGenerator.path: ${path;\
 repo.mavenRepoTasks.path: ${path;\
     ${repo;wlp-mavenRepoTasks},\
     ${repo;com.ibm.ws.org.apache.ant},\
-    ${repo;commons-io:commons-io;2.8.0},\
+    ${repo;commons-io:commons-io;2.11.0},\
     ${repo;commons-lang:commons-lang;2.4},\
     ${repo;javax.json:javax.json-api;1.1.2},\
     ${repo;org.glassfish:javax.json;1.1.2},\

--- a/dev/com.ibm.ws.org.apache.commons.fileupload/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.commons.fileupload/bnd.bnd
@@ -10,7 +10,7 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;commons-fileupload:commons-fileupload;1.4;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;commons-fileupload:commons-fileupload;1.5;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
 -sub: *.bnd
 
@@ -19,5 +19,5 @@ instrument.disabled: true
 
 
 -buildpath: \
-	commons-fileupload:commons-fileupload;strategy=exact;version=1.4,\
+	commons-fileupload:commons-fileupload;strategy=exact;version=1.5,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest

--- a/dev/com.ibm.ws.org.apache.commons.fileupload/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.commons.fileupload/bnd.overrides
@@ -5,5 +5,5 @@ bVersion=1.0
 
 Private-Package: org.apache.commons.fileupload.portlet
 
-Include-Resource: @${repo;org.apache.commons.commons-fileupload;1.4;EXACT}!/!META-INF/MANIFEST.MF|META-INF/maven/*
+Include-Resource: @${repo;org.apache.commons.commons-fileupload;1.5;EXACT}!/!META-INF/MANIFEST.MF|META-INF/maven/*
 

--- a/dev/com.ibm.ws.org.apache.commons.io/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.commons.io/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -10,6 +10,6 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;commons-io:commons-io;2.8.0;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;commons-io:commons-io;2.11.0;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
--buildpath: commons-io:commons-io;strategy=exact;version=2.8.0
+-buildpath: commons-io:commons-io;strategy=exact;version=2.11.0

--- a/dev/com.ibm.ws.org.apache.commons.io/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.commons.io/bnd.overrides
@@ -3,17 +3,22 @@ bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.apache.commons.io
 
-Import-Package: !org.apache.commons.io.*, *
+Dynamic-Import: \
+sun.misc, \
+sun.nio.ch
+
+Import-Package: \
+!sun.misc, \
+!sun.nio.ch, \
+!org.apache.commons.io.*, *
 
 Export-Package: \
-org.apache.commons.io;version="1.4.9999",org.apache.commons.io.comparator;version="1.4.9999", \
-org.apache.commons.io.comparator;version="2.8.0",org.apache.commons.io.file;version="2.8.0", \
-org.apache.commons.io.filefilter;version="1.4.9999",org.apache.commons.io.filefilter;version="2.8.0", \
-org.apache.commons.io.function;version="2.8.0",org.apache.commons.io.input;version="1.4.9999", \
-org.apache.commons.io.input.buffer;version="2.8.0",org.apache.commons.io.input;version="2.8.0", \
-org.apache.commons.io.monitor;version="2.8.0",org.apache.commons.io.output;version="1.4.9999", \
-org.apache.commons.io.output;version="2.8.0",org.apache.commons.io.serialization;version="2.8.0", \
-org.apache.commons.io;version="2.8.0"
+org.apache.commons.io;version="2.11.0",org.apache.commons.io.comparator;version="2.11.0", \
+org.apache.commons.io.file;version="2.11.0",org.apache.commons.io.file.spi;version="2.11.0", \
+org.apache.commons.io.filefilter;version="2.11.0",org.apache.commons.io.function;version="2.11.0", \
+org.apache.commons.io.input;version="2.11.0",org.apache.commons.io.input.buffer;version="2.11.0", \
+org.apache.commons.io.monitor;version="2.11.0",org.apache.commons.io.output;version="2.11.0", \
+org.apache.commons.io.serialization;version="2.11.0"
 
-Include-Resource: @${repo;commons-io:commons-io;2.8.0;EXACT}!/!META-INF/MANIFEST.MF|META-INF/maven/*
+Include-Resource: @${repo;commons-io:commons-io;2.11.0;EXACT}!/!META-INF/MANIFEST.MF|META-INF/maven/*
 


### PR DESCRIPTION
commons-fileupload:1.5  requires commons-io:2.11.0