### PR TITLE
Switch webAppSecurity-2.0 auto feature to a private feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webAppSecurity-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webAppSecurity-2.0.feature
@@ -3,9 +3,6 @@ symbolicName=io.openliberty.webAppSecurity-2.0
 IBM-App-ForceRestart: install, \
  uninstall
 IBM-API-Package: com.ibm.websphere.security.web; type="ibm-api"
-IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.servlet-5.0)(osgi.identity=io.openliberty.servlet.internal-6.0)))", \
- osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.appSecurity-4.0)(osgi.identity=io.openliberty.appSecurity-5.0)(osgi.identity=io.openliberty.mpJwt-2.1)))"
-IBM-Install-Policy: when-satisfied
 -features=com.ibm.websphere.appserver.containerServices-1.0, \
   com.ibm.websphere.appserver.distributedMap-1.0
 -bundles=com.ibm.ws.webcontainer.security.app, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-4.0/io.openliberty.appSecurity-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-4.0/io.openliberty.appSecurity-4.0.feature
@@ -21,7 +21,8 @@ Subsystem-Name: Application Security 4.0 (Jakarta Security 2.0)
   com.ibm.websphere.appserver.security-1.0, \
   io.openliberty.securityAPI.jakarta-1.0, \
   io.openliberty.jakarta.security.enterprise-2.0, \
-  io.openliberty.expressionLanguage-4.0
+  io.openliberty.expressionLanguage-4.0, \
+  io.openliberty.webAppSecurity-2.0
 -bundles=\
   io.openliberty.security.jakartasec.2.0.internal, \
   io.openliberty.security.jakartasec.2.0.internal.cdi, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-5.0/io.openliberty.appSecurity-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-5.0/io.openliberty.appSecurity-5.0.feature
@@ -23,7 +23,8 @@ Subsystem-Name: Application Security 5.0 (Jakarta Security 3.0)
   io.openliberty.securityAPI.jakarta-1.0, \
   io.openliberty.jakarta.security.enterprise-3.0, \
   io.openliberty.expressionLanguage-5.0, \
-  io.openliberty.jsonp-2.1
+  io.openliberty.jsonp-2.1, \
+  io.openliberty.webAppSecurity-2.0
 -bundles=\
   com.ibm.json4j, \
   com.ibm.ws.org.apache.commons.lang3, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-2.1/io.openliberty.mpJwt-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-2.1/io.openliberty.mpJwt-2.1.feature
@@ -17,7 +17,9 @@ Subsystem-Name: MicroProfile JSON Web Token 2.1
   io.openliberty.cdi-4.0
 -bundles=io.openliberty.security.mp.jwt.internal,\
   io.openliberty.security.mp.jwt.cdi.internal,\
-  io.openliberty.security.mp.jwt.2.1.config
+  io.openliberty.security.mp.jwt.2.1.config, \
+  com.ibm.ws.webcontainer.security.app, \
+  com.ibm.ws.security.appbnd
 kind=ga
 edition=core
 WLP-Activation-Type: parallel


### PR DESCRIPTION
- appSecurity-4.0 and 5.0 already depend on servlet, so the auto feature is always satisfied.
- mpJwt-2.1 already depends on servlet-internal, but don't want to expose the servlet dependency in the APIs
- Change the auto feature to a private feature and have appSecurity-4.0 and appSecurity-5.0 depend on the private feature.
- Have mpJwt-2.1 include the two missing bundles from the feature.  We do not want to have mpJwt-2.1 expose the APIs from webAppSecurity-2.0 since they depend on servlet APIs.
