### PR TITLE
Update filter tests to allow LdapAdapter activation

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.2/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPRegressionTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.2/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPRegressionTest.java
@@ -401,6 +401,11 @@ public class LDAPRegressionTest {
     public void testUserFilterWithoutPercentV() throws Exception {
         ServerConfiguration clone = basicConfiguration.clone();
         LdapRegistry ldap = createLdapRegistry(clone);
+
+        // Update config to working server first. This is necessary in case the two filter tests
+        // are run first. We need LdapAdapter to activate successfully before we modify the config.
+        updateConfigDynamically(libertyServer, clone);
+
         ldap.getCustomFilters().setUserFilter("(uid=someuser)");
 
         updateConfigDynamically(libertyServer, clone);
@@ -415,6 +420,11 @@ public class LDAPRegressionTest {
     public void testGroupFilterWithoutPercentV() throws Exception {
         ServerConfiguration clone = basicConfiguration.clone();
         LdapRegistry ldap = createLdapRegistry(clone);
+
+        // Update config to working server first. This is necessary in case the two filter tests
+        // are run first. We need LdapAdapter to activate successfully before we modify the config.
+        updateConfigDynamically(libertyServer, clone);
+
         ldap.getCustomFilters().setGroupFilter("(cn=somegroup)");
 
         updateConfigDynamically(libertyServer, clone);


### PR DESCRIPTION
testUserFilterWithoutPercentV:junit.framework.AssertionFailedError: 2023-02-24-08:26:28:125 Did not find CWIML4523E in log

This error occurs when the filter tests are run first. They both use invalid config to test for error messages, but this is stopping LdapAdapter activation from completing. If activation is not complete, modify is not triggered upon config updates. Thus the second test to run never has its config validated. Other tests will pass because they contain user registry calls which trigger config validation. When the tests are run in order, activation occurs before these filter tests are run and they pass without issue.