### PR TITLE
Update short token lifetime tests to avoid tokens expiring too soon

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/utils/ShortTokenLifetimePrep.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/utils/ShortTokenLifetimePrep.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package oidc.client.base.utils;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.fat.common.Constants;
+import com.ibm.ws.security.fat.common.expectations.Expectations;
+
+import io.openliberty.security.jakartasec.fat.commonTests.CommonAnnotatedSecurityTests;
+
+public class ShortTokenLifetimePrep extends CommonAnnotatedSecurityTests {
+
+    /**
+     * Try to access a protected app to have the OP issue tokens - issuing the first token after starting
+     * the server is taking too long for tests that use tokens with short lifetimes. The tokens are expired
+     * before the client gets them back from the OP. We're not seeing the problem after the first tokens are
+     * issued.
+     *
+     * @param httpsBase - Base of the url of the app to invoke https://localhost:<port>/
+     * @param appName - unique name of the app to invoke
+     * @throws Exception
+     */
+    public void shortTokenLifetimePrep(String httpsBase, String appName) throws Exception {
+
+        try {
+
+            String thisMethod = "shortTokenLifetimePrep";
+            loggingUtils.printMethodName(thisMethod);
+
+            // sleep and give apps a little more time to get ready
+            actions.testLogAndSleep(30);
+
+            WebClient webClient = getAndSaveWebClient();
+
+            initResponseValues();
+
+            String url = httpsBase + "/" + appName;
+
+            Page response = invokeAppReturnLoginPage(webClient, url);
+
+            response = actions.doFormLogin(response, Constants.TESTUSER, Constants.TESTUSERPWD);
+            // confirm protected resource was accessed
+            // Just check for a good status code - on faster machines, we'll land on the test app, on
+            // slow machines, we'll land on the logout page (since the token will be expired by the time it's returned
+            Expectations expectations = new Expectations();
+            expectations.addSuccessCodeForCurrentAction();
+            validationUtils.validateResult(response, expectations);
+
+        } catch (Exception e) {
+            Log.info(thisClass, "shortTokenLifetimePrep",
+                     "A failure occurred trying to \"warm up\" the OP (meaning it takes a long time to issue the very first token and short token lifetime tests will time out)");
+            Log.info(thisClass, "shortTokenLifetimePrep", e.getMessage());
+        }
+
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTokenMinValidityTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTokenMinValidityTests.java
@@ -43,6 +43,7 @@ import io.openliberty.security.jakartasec.fat.utils.MessageConstants;
 import io.openliberty.security.jakartasec.fat.utils.ServletMessageConstants;
 import io.openliberty.security.jakartasec.fat.utils.ShrinkWrapHelpers;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant;
+import oidc.client.base.utils.ShortTokenLifetimePrep;
 
 /**
  * Tests @OpenIdAuthenticationMechanismDefinition tokenMinValidity and tokenMinValidityExpression
@@ -105,6 +106,9 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
         rpHttpsBase = "https://localhost:" + rpServer.getBvtSecurePort();
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
+
+        ShortTokenLifetimePrep s = new ShortTokenLifetimePrep();
+        s.shortTokenLifetimePrep(rpHttpsBase, "TokenMinValidity5s/TokenMinValidity5sServlet");
 
     }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/fat/src/io/openliberty/security/jakartasec/fat/logout/tests/BasicLogoutTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/fat/src/io/openliberty/security/jakartasec/fat/logout/tests/BasicLogoutTests.java
@@ -46,6 +46,7 @@ import io.openliberty.security.jakartasec.fat.utils.Constants;
 import io.openliberty.security.jakartasec.fat.utils.MessageConstants;
 import io.openliberty.security.jakartasec.fat.utils.ShrinkWrapHelpers;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.PromptType;
+import oidc.client.base.utils.ShortTokenLifetimePrep;
 
 /**
  * Tests various logout flows.  Make sure that we logout when we should and do NOT logout when we should not.
@@ -111,6 +112,10 @@ public class BasicLogoutTests extends CommonLogoutAndRefreshTests {
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
         baseAppName = "BasicLogoutServlet";
+
+        ShortTokenLifetimePrep s = new ShortTokenLifetimePrep();
+        s.shortTokenLifetimePrep(rpHttpsBase,
+                                 getShortAppName(NotifyProvider, IDTokenHonorExpiry, AccessTokenHonorExpiry, IDTokenShortLifetime, AccessTokenShortLifetime) + "/" + baseAppName);
 
     }
 
@@ -442,12 +447,12 @@ public class BasicLogoutTests extends CommonLogoutAndRefreshTests {
      * @return - returns the short app name of the app that has the parm values specified in the openIdConfig.properties file
      * @throws Exception
      */
-    public String getShortAppName(boolean notifyProvider, boolean idTokenExpiry, boolean accessTokenExpiry, boolean idTokenLifetimeShort,
-                                  boolean accessTokenLifetimeShort) throws Exception {
+    public static String getShortAppName(boolean notifyProvider, boolean idTokenExpiry, boolean accessTokenExpiry, boolean idTokenLifetimeShort,
+                                         boolean accessTokenLifetimeShort) throws Exception {
 
         String appName = buildAppName(notifyProvider, idTokenExpiry, accessTokenExpiry, idTokenLifetimeShort, accessTokenLifetimeShort);
         String shortAppName = appMap.get(appName);
-        Log.info(thisClass, _testName, "Using app: " + shortAppName + " which maps to an app with settings: " + appName);
+        Log.info(thisClass, "getShortAppName", "Using app: " + shortAppName + " which maps to an app with settings: " + appName);
         return shortAppName;
 
     }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/fat/src/io/openliberty/security/jakartasec/fat/refresh/tests/BasicRefreshTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/fat/src/io/openliberty/security/jakartasec/fat/refresh/tests/BasicRefreshTests.java
@@ -41,6 +41,7 @@ import io.openliberty.security.jakartasec.fat.commonTests.CommonLogoutAndRefresh
 import io.openliberty.security.jakartasec.fat.configs.TestConfigMaps;
 import io.openliberty.security.jakartasec.fat.utils.Constants;
 import io.openliberty.security.jakartasec.fat.utils.ShrinkWrapHelpers;
+import oidc.client.base.utils.ShortTokenLifetimePrep;
 
 /**
  * Tests various flows using refresh.  Make sure that we refresh tokens when we should and do NOT refresh tokens when we should not.
@@ -108,6 +109,11 @@ public class BasicRefreshTests extends CommonLogoutAndRefreshTests {
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
         baseAppName = "BasicRefreshServlet";
+
+        ShortTokenLifetimePrep s = new ShortTokenLifetimePrep();
+        s.shortTokenLifetimePrep(rpHttpsBase,
+                                 getShortAppName(TokenAutoRefresh, ProvderAllowsRefresh, NotifyProvider, IDTokenHonorExpiry, AccessTokenHonorExpiry) + "/" + baseAppName);
+
     }
 
     /**
@@ -318,8 +324,8 @@ public class BasicRefreshTests extends CommonLogoutAndRefreshTests {
      * @return - returns the short app name of the app that has the parm values specified in the openIdConfig.properties file
      * @throws Exception
      */
-    public String getShortAppName(boolean tokenAutoRefresh, boolean providerAllowsRefresh, boolean notifyProvider, boolean idTokenExpiry,
-                                  boolean accessTokenExpiry) throws Exception {
+    public static String getShortAppName(boolean tokenAutoRefresh, boolean providerAllowsRefresh, boolean notifyProvider, boolean idTokenExpiry,
+                                         boolean accessTokenExpiry) throws Exception {
 
         String appName = buildAppName(tokenAutoRefresh, providerAllowsRefresh, notifyProvider, idTokenExpiry, accessTokenExpiry);
         return appMap.get(appName);


### PR DESCRIPTION
Update Jakartasec FAT that use tokens with short lifetimes.
The OP is taking extra time to issue the first token after the server starts.
Adding a request from the test class @BeforeClass method to make a request of the OP - that should get the OP moving.
We've only seen a problem with the first request to the OP - this should resolve the test problem and I've opened issue 
#24589 to investigate the runtime further.

#build
#spawn.fullfat.buckets=io.openliberty.security.jakartasec.3.0.internal_fat,io.openliberty.security.jakartasec.3.0.internal_fat.config,io.openliberty.security.jakartasec.3.0.internal_fat.config.1,io.openliberty.security.jakartasec.3.0.internal_fat.config.2,io.openliberty.security.jakartasec.3.0.internal_fat.logout,io.openliberty.security.jakartasec.3.0.internal_fat.refresh