### PR TITLE
OneToOne entities

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -48,7 +48,8 @@ class EntityInfo {
     final PersistenceServiceUnit persister;
     final Class<?> type;
 
-    EntityInfo(String entityName, Class<?> entityClass,
+    EntityInfo(String entityName,
+               Class<?> entityClass,
                Map<String, List<Member>> attributeAccessors,
                Map<String, String> attributeNames,
                SortedMap<String, Class<?>> attributeTypes,

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -36,7 +36,6 @@ import jakarta.data.repository.Pageable;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
-import jakarta.data.repository.Select;
 import jakarta.data.repository.Slice;
 import jakarta.data.repository.Sort;
 import jakarta.data.repository.Streamable;
@@ -188,7 +187,6 @@ public interface Primes {
     @Filter(by = "romanNumeral", ignoreCase = true, op = Compare.Like, value = "%v%")
     @Filter(by = "name", op = Compare.Contains)
     @OrderBy(value = "number", descending = true)
-    @Select("number")
     List<Long> inRangeHavingVNumeralAndSubstringOfName(long min, long max, String nameSuffix);
 
     @Filter(by = "number", op = Compare.LessThan)
@@ -237,7 +235,6 @@ public interface Primes {
     @Filter(by = "number", op = Compare.NotBetween)
     @Filter(by = "number", op = Compare.LessThan)
     @OrderBy("number")
-    @Select("number")
     List<Long> notWithinButBelow(int rangeMin, int rangeMax, int below);
 
     @Query("SELECT DISTINCT LENGTH(p.romanNumeral) FROM Prime p WHERE p.number <= ?1 ORDER BY LENGTH(p.romanNumeral) DESC")

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/ShippingAddresses.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/ShippingAddresses.java
@@ -17,7 +17,6 @@ import java.util.List;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
-import jakarta.data.repository.Select;
 
 /**
  *
@@ -26,7 +25,6 @@ import jakarta.data.repository.Select;
 public interface ShippingAddresses {
     long countByRecipientInfoEmpty();
 
-    @Select({ "houseNumber", "streetName" })
     StreetAddress[] findByHouseNumberBetweenOrderByStreetNameAscHouseNumber(int minHouseNumber, int maxHouseNumber);
 
     List<ShippingAddress> findByRecipientInfoNotEmpty();

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -810,19 +810,26 @@ public class DataJPATestServlet extends FATServlet {
         Driver d1 = new Driver("Owen TestOneToOne", 100101000, LocalDate.of(2000, 1, 1), 71, 210, //
                         "T121-100-100-100", "Minnesota", LocalDate.of(2021, 1, 1), LocalDate.of(2025, 1, 1));
 
-        Driver d2 = new Driver("Oliver TestOneToOne", 100202000, LocalDate.of(2000, 2, 2), 72, 220, //
+        Driver d2 = new Driver("Oliver TestOneToOne", 100202000, LocalDate.of(2002, 2, 2), 72, 220, //
                         "T121-200-200-200", "Wisconsin", LocalDate.of(2022, 2, 2), LocalDate.of(2026, 2, 2));
 
         Driver d3 = new Driver("Olivia TestOneToOne", 100303000, LocalDate.of(2000, 3, 3), 63, 130, //
                         "T121-300-300-300", "Minnesota", LocalDate.of(2023, 3, 3), LocalDate.of(2027, 3, 3));
 
-        Driver d4 = new Driver("Oscar TestOneToOne", 100404000, LocalDate.of(2000, 4, 4), 74, 240, //
+        Driver d4 = new Driver("Oscar TestOneToOne", 100404000, LocalDate.of(2004, 4, 4), 74, 240, //
                         "T121-400-400-400", "Iowa", LocalDate.of(2020, 4, 4), LocalDate.of(2024, 4, 4));
 
         Driver d5 = new Driver("Ozzy TestOneToOne", 100505000, LocalDate.of(2000, 5, 5), 65, 150, //
                         "T121-500-500-500", "Wisconsin", LocalDate.of(2021, 5, 5), LocalDate.of(2025, 5, 5));
 
         drivers.saveAll(List.of(d1, d2, d3, d4, d5));
+
+        assertIterableEquals(List.of("Minnesota T121-100-100-100", "Minnesota T121-300-300-300",
+                                     "Wisconsin T121-500-500-500", "Wisconsin T121-200-200-200",
+                                     "Iowa T121-400-400-400"),
+                             drivers.findByFullNameEndsWith(" TestOneToOne")
+                                             .map(license -> license.stateName + " " + license.licenseNum)
+                                             .collect(Collectors.toList()));
 
         drivers.deleteByFullNameEndsWith(" TestOneToOne");
     }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -15,6 +15,7 @@ package test.jakarta.data.jpa.web;
 import static org.junit.Assert.assertEquals;
 import static test.jakarta.data.jpa.web.Assertions.assertIterableEquals;
 
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -50,6 +51,9 @@ public class DataJPATestServlet extends FATServlet {
 
     @Inject
     Cities cities;
+
+    @Inject
+    Drivers drivers;
 
     @Inject
     Employees employees;
@@ -794,5 +798,32 @@ public class DataJPATestServlet extends FATServlet {
                                              .collect(Collectors.toList()));
 
         employees.deleteByLastName("TestIdOnEmbeddable");
+    }
+
+    /**
+     * One-to-one entity mapping.
+     */
+    @Test
+    public void testOneToOne() {
+        drivers.deleteByFullNameEndsWith(" TestOneToOne");
+
+        Driver d1 = new Driver("Owen TestOneToOne", 100101000, LocalDate.of(2000, 1, 1), 71, 210, //
+                        "T121-100-100-100", "Minnesota", LocalDate.of(2021, 1, 1), LocalDate.of(2025, 1, 1));
+
+        Driver d2 = new Driver("Oliver TestOneToOne", 100202000, LocalDate.of(2000, 2, 2), 72, 220, //
+                        "T121-200-200-200", "Wisconsin", LocalDate.of(2022, 2, 2), LocalDate.of(2026, 2, 2));
+
+        Driver d3 = new Driver("Olivia TestOneToOne", 100303000, LocalDate.of(2000, 3, 3), 63, 130, //
+                        "T121-300-300-300", "Minnesota", LocalDate.of(2023, 3, 3), LocalDate.of(2027, 3, 3));
+
+        Driver d4 = new Driver("Oscar TestOneToOne", 100404000, LocalDate.of(2000, 4, 4), 74, 240, //
+                        "T121-400-400-400", "Iowa", LocalDate.of(2020, 4, 4), LocalDate.of(2024, 4, 4));
+
+        Driver d5 = new Driver("Ozzy TestOneToOne", 100505000, LocalDate.of(2000, 5, 5), 65, 150, //
+                        "T121-500-500-500", "Wisconsin", LocalDate.of(2021, 5, 5), LocalDate.of(2025, 5, 5));
+
+        drivers.saveAll(List.of(d1, d2, d3, d4, d5));
+
+        drivers.deleteByFullNameEndsWith(" TestOneToOne");
     }
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Driver.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Driver.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+
+/**
+ * Entity that has one-to-one mapping with the DriversLicense entity.
+ */
+@Entity
+public class Driver {
+
+    @Column
+    public LocalDate birthday;
+
+    @Column
+    public String fullName;
+
+    @Column
+    public int heightInInches;
+
+    @OneToOne
+    @JoinColumn
+    public DriversLicense license;
+
+    @Id
+    public int ssn;
+
+    @Column
+    public int weightInPounds;
+
+    public Driver() {
+    }
+
+    public Driver(String fullName, int ssn, LocalDate birthday, int height, int weight,
+                  String licenseNum, String stateName, LocalDate issuedOn, LocalDate expiresOn) {
+        this.fullName = fullName;
+        this.ssn = ssn;
+        this.birthday = birthday;
+        this.heightInInches = height;
+        this.weightInPounds = weight;
+        this.license = new DriversLicense();
+        license.licenseNum = licenseNum;
+        license.stateName = stateName;
+        license.issuedOn = issuedOn;
+        license.expiresOn = expiresOn;
+    }
+
+    @Override
+    public String toString() {
+        return "Driver SSN#" + ssn + " " + fullName + " born " + birthday + " " +
+               heightInInches + " inches " + weightInPounds + " lbs with license #" + (license == null ? null : license.licenseNum);
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Drivers.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Drivers.java
@@ -12,7 +12,10 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import java.util.stream.Stream;
+
 import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Repository;
 
 /**
@@ -23,4 +26,6 @@ public interface Drivers extends CrudRepository<Driver, Integer> {
 
     int deleteByFullNameEndsWith(String ending);
 
+    @OrderBy("birthday")
+    Stream<DriversLicense> findByFullNameEndsWith(String ending);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Drivers.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Drivers.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for testing OneToOne relationship between Driver and DriversLicense entities.
+ */
+@Repository
+public interface Drivers extends CrudRepository<Driver, Integer> {
+
+    int deleteByFullNameEndsWith(String ending);
+
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DriversLicense.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DriversLicense.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+/**
+ * Entity that has one-to-one mapping with the Driver entity.
+ */
+@Entity
+public class DriversLicense {
+
+    @OneToOne(mappedBy = "license")
+    public Driver driver;
+
+    @Column
+    public LocalDate expiresOn;
+
+    @Column
+    public LocalDate issuedOn;
+
+    @Id
+    public String licenseNum;
+
+    @Column
+    public String stateName;
+
+    public DriversLicense() {
+    }
+
+    @Override
+    public String toString() {
+        return stateName + " license #" + licenseNum + " for " + (driver == null ? null : driver.fullName) +
+               " valid from " + issuedOn + " to " + expiresOn;
+    }
+}


### PR DESCRIPTION
Initial set of updates to allow OneToOne entity mappings.
At this point, you can define a OneToOne mapping and not otherwise have to declare the entity that it maps to, and you can have a repository method return type be an entity that was mapped as OneToOne.