### PR TITLE
Objectclass in filter should be case insensitive

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapConfigManager.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapConfigManager.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -641,14 +641,14 @@ public class LdapConfigManager {
                 LdapEntity ldapEntity = getLdapEntity(SchemaConstants.DO_PERSON_ACCOUNT);
                 if (ldapEntity != null) {
                     Set<String> objClsSet = new HashSet<String>();
-                    int index = iUserFilter.indexOf(objectClassStr);
+                    int index = iUserFilter.toLowerCase().indexOf(objectClassStr);
                     while (index > -1) {
                         int endIndex = iUserFilter.indexOf(")", index);
                         String objectClass = iUserFilter.substring(index + length, endIndex);
                         objClsSet.add(objectClass);
 
                         index = endIndex + 1;
-                        index = iUserFilter.indexOf(objectClassStr, endIndex);
+                        index = iUserFilter.toLowerCase().indexOf(objectClassStr, endIndex);
                     }
                     if (objClsSet.size() > 0) {
                         ldapEntity.getObjectClasses().clear();
@@ -718,14 +718,14 @@ public class LdapConfigManager {
                 LdapEntity ldapEntity = getLdapEntity(SchemaConstants.DO_GROUP);
                 if (ldapEntity != null) {
                     Set<String> objClsSet = new HashSet<String>();
-                    int index = iGroupFilter.indexOf(objectClassStr);
+                    int index = iGroupFilter.toLowerCase().indexOf(objectClassStr);
                     while (index > -1) {
                         int endIndex = iGroupFilter.indexOf(")", index);
                         String objectClass = iGroupFilter.substring(index + length, endIndex);
                         objClsSet.add(objectClass);
 
                         index = endIndex + 1;
-                        index = iGroupFilter.indexOf(objectClassStr, endIndex);
+                        index = iGroupFilter.toLowerCase().indexOf(objectClassStr, endIndex);
                     }
                     if (objClsSet.size() > 0) {
                         ldapEntity.getObjectClasses().clear();

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.2/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPRegressionTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.2/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPRegressionTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -68,6 +68,8 @@ public class LDAPRegressionTest {
     private static final String USER_1_DN = "uid=" + USER_1 + "," + BASE_DN;
     private static final String USER_2 = "Bob (Contractor)";
     private static final String USER_2_DN = "uid=" + USER_2 + "," + BASE_DN;
+    private static final String USER_3 = "user3";
+    private static final String USER_3_DN = "cn=" + USER_3 + "," + BASE_DN;
 
     /**
      * Setup the test case.
@@ -185,6 +187,16 @@ public class LDAPRegressionTest {
         entry.addAttribute("sn", USER_2);
         entry.addAttribute("cn", USER_2);
         entry.addAttribute("nickName", USER_2 + " nick name");
+        entry.addAttribute("userPassword", "password");
+        ds.add(entry);
+
+        /*
+         * Create user3.
+         */
+        entry = new Entry(USER_3_DN);
+        entry.addAttribute("objectclass", "person");
+        entry.addAttribute("sn", USER_3);
+        entry.addAttribute("cn", USER_3);
         entry.addAttribute("userPassword", "password");
         ds.add(entry);
     }
@@ -408,5 +420,23 @@ public class LDAPRegressionTest {
         updateConfigDynamically(libertyServer, clone);
 
         assertFalse("Did not find CWIML4523E in log", libertyServer.waitForStringInLogUsingMark("CWIML4523E.*cn=somegroup.*groupFilter") == null);
+    }
+
+    /**
+     * Verify that "objectClass" in camelCase works in userFilter.
+     * If the object class is not read correctly, getUserDisplayName
+     * returns nothing because we don't have a PersonAccount.
+     */
+    @Test
+    public void testObjectClassCamelCase() throws Exception {
+        ServerConfiguration clone = basicConfiguration.clone();
+        LdapRegistry ldap = createLdapRegistry(clone);
+        ldap.getCustomFilters().setUserFilter("(&(objectClass=person)(cn=%v))");
+        updateConfigDynamically(libertyServer, clone);
+
+        String dName = urServlet.getUserDisplayName(USER_3);
+        assertNotNull("DisplayName should be non-null", dName);
+        assertEquals("DisplayName should be user3", USER_3, dName);
+
     }
 }


### PR DESCRIPTION
Using 'objectclass' in userFilter and groupFilter should be case insensitive. This is hard to diagnose as a user, but you may be hitting this issue if you are making user registry calls for display name and nothing is returned, but a user registry call for security name does return the user.
This is because the filters are parsed for objectclasses that are later used to identify entities as Groups and PersonAccounts.