### PR TITLE
Remove hard-coded port in test app annotation

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/RedirectToOriginalResourceTruePromptNone.war/src/oidc/client/redirectToOriginalResourceTruePromptNone/servlets/RedirectToOriginalResourceTruePromptNoneServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/RedirectToOriginalResourceTruePromptNone.war/src/oidc/client/redirectToOriginalResourceTruePromptNone/servlets/RedirectToOriginalResourceTruePromptNoneServlet.java
@@ -22,7 +22,7 @@ import jakarta.servlet.annotation.WebServlet;
 import oidc.client.base.servlets.BaseServlet;
 
 @WebServlet("/RedirectToOriginalResourceTruePromptNoneServlet")
-@OpenIdAuthenticationMechanismDefinition(providerURI = "https://localhost:8920/oidc/endpoint/OP1",
+@OpenIdAuthenticationMechanismDefinition(providerURI = "${providerBean.providerSecureRoot}/oidc/endpoint/OP1",
                                          clientId = "client_1",
                                          clientSecret = "mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger",
                                          claimsDefinition = @ClaimsDefinition(callerNameClaim = "sub", callerGroupsClaim = "groupIds"),


### PR DESCRIPTION
The RedirectToOriginalResourceTruePromptNoneServlet app has a hard coded port in the @OpenIdAuthenticationMechanismDefinition annotation.  We can't guarantee the port that we'll get when the tests are running.  This instance of the annotation should use the variable value set by the test class at runtime.

There is a test that is using a hard coded value for the providerURI, but that test is skipped if we don't get the default port of 8920.  This test does not need a hard coded value.