### PR TITLE
GraphQL updates for MP 6 support

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpGraphQL1.0-metrics2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpGraphQL1.0-metrics2.3.feature
@@ -2,8 +2,8 @@
 symbolicName=com.ibm.websphere.appserver.mpGraphQL1.0-metrics2.3
 visibility=private
 IBM-Provision-Capability: \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpGraphQL-1.0)(osgi.identity=io.openliberty.mpGraphQL-2.0)))", \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.3)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-3.0)(osgi.identity=io.openliberty.mpMetrics-4.0)))"
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpGraphQL-1.0))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.3))"
 -bundles=com.ibm.ws.microprofile.graphql.metrics.1.0
 IBM-Install-Policy: when-satisfied
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpGraphQL1.0-metrics3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpGraphQL1.0-metrics3.0.feature
@@ -1,0 +1,10 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.mpGraphQL1.0-metrics3.0
+visibility=private
+IBM-Provision-Capability: \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpGraphQL-1.0)(osgi.identity=io.openliberty.mpGraphQL-2.0)))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpMetrics-3.0)(osgi.identity=io.openliberty.mpMetrics-4.0)))"
+-bundles=io.openliberty.microprofile.graphql.internal.metrics.3.0
+IBM-Install-Policy: when-satisfied
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpGraphQL2.0-appSecurity4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpGraphQL2.0-appSecurity4.0.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.mpGraphQL2.0-appSecurity4.0
 visibility=private
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpGraphQL-2.0))", \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.appSecurity-4.0))"
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.appSecurity-4.0)(osgi.identity=io.openliberty.appSecurity-5.0)))"
 -bundles=com.ibm.ws.microprofile.graphql.authorization.jakarta,\
   com.ibm.ws.security.authorization.util.jakarta
 IBM-Install-Policy: when-satisfied

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpGraphQL2.0-metrics5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpGraphQL2.0-metrics5.0.feature
@@ -1,0 +1,10 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.mpGraphQL2.0-metrics5.0
+visibility=private
+IBM-Provision-Capability: \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpGraphQL-2.0))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpMetrics-5.0))"
+-bundles=io.openliberty.microprofile.graphql.internal.metrics.5.0
+IBM-Install-Policy: when-satisfied
+kind=ga
+edition=core

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@ fat.project: true
 
 
 tested.features: appsecurity-4.0, expressionlanguage-4.0, mpConfig-2.0, mpConfig-3.0, mpGraphQL-2.0, mpMetrics-2.0, mpMetrics-3.0, \
-  mpMetrics-4.0, mpRestClient-2.0, mpRestClient-3.0
+  mpMetrics-4.0, mpRestClient-2.0, mpRestClient-3.0, appsecurity-5.0, mpmetrics-5.0, restfulwsclient-3.1, concurrent-3.0, jsonb-3.0
 
 -buildpath: \
   io.smallrye:smallrye-graphql-client-api;strategy=exact;version=1.0.26,\

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/DefaultValueTest.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/DefaultValueTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -43,7 +43,6 @@ public class DefaultValueTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.dumpServer("deprecation");
         server.stopServer();
     }
 }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
@@ -49,17 +50,23 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
+    public static RepeatTests r = RepeatTests.withoutModificationInFullMode()
                                              .andWith(new FeatureReplacementAction("mpConfig-1.4", "mpConfig-2.0")
                                                       .addFeature("mpMetrics-3.0").removeFeature("mpMetrics-2.3")
                                                       .addFeature("mpRestClient-2.0").removeFeature("mpRestClient-1.4")
-                                                      .withID("mp4.0"))
+                                                      .withID("mp4.0").fullFATOnly())
                                              .andWith(new JakartaEE9Action()
                                                       .removeFeatures(setOf("mpConfig-1.4", "mpConfig-2.0")).addFeature("mpConfig-3.0")
                                                       .removeFeatures(setOf("mpMetrics-3.0", "mpMetrics-2.3")).addFeature("mpMetrics-4.0")
                                                       .removeFeatures(setOf("mpRestClient-2.0", "mpRestClient-1.4")).addFeature("mpRestClient-3.0")
                                                       .removeFeature("mpGraphQL-1.0").addFeature("mpGraphQL-2.0")
-                                                      .withID(MicroProfileActions.STANDALONE9_ID));
+                                                      .withID(MicroProfileActions.STANDALONE9_ID).conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                                             .andWith(new JakartaEE10Action()
+                                                      .removeFeatures(setOf("mpConfig-1.4", "mpConfig-2.0")).addFeature("mpConfig-3.0")
+                                                      .removeFeatures(setOf("mpMetrics-3.0", "mpMetrics-2.3", "mpMetrics-4.0")).addFeature("mpMetrics-5.0")
+                                                      .removeFeatures(setOf("mpRestClient-2.0", "mpRestClient-1.4")).addFeature("mpRestClient-3.0")
+                                                      .removeFeature("mpGraphQL-1.0").addFeature("mpGraphQL-2.0").alwaysAddFeature("servlet-6.0")
+                                                      .withID(MicroProfileActions.STANDALONE10_ID));
 
     private static Set<String> setOf(String... strings) {
         // basically does what Java 11's Set.of(...) does

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.metrics/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.metrics/server.xml
@@ -15,5 +15,6 @@
 
   <!--  Required to read the server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+  <javaPermission className="java.security.AllPermission"/> <!-- TODO replace with URLPermission once it permits wildcards-->
 
 </server>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicQueryApp/src/mpGraphQL10/basicQuery/Error.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicQueryApp/src/mpGraphQL10/basicQuery/Error.java
@@ -1,13 +1,22 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
  * 
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package mpGraphQL10.basicQuery;
 
 public class Error {
 
     private String message;
     private Object[] path;
-    private String extensions;
+    private Extensions extensions;
 
     public String getMessage() {
         return message;
@@ -25,11 +34,11 @@ public class Error {
         this.path = path;
     }
 
-    public String getExtensions() {
+    public Extensions getExtensions() {
         return extensions;
     }
 
-    public void setExtensions(String extensions) {
+    public void setExtensions(Extensions extensions) {
         this.extensions = extensions;
     }
 }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicQueryApp/src/mpGraphQL10/basicQuery/Extensions.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicQueryApp/src/mpGraphQL10/basicQuery/Extensions.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.basicQuery;
+
+public class Extensions {
+
+    private String exception;
+    private String classification;
+    private String code;
+
+    public String getException() {
+        return exception;
+    }
+
+    public void setException(String exception) {
+        this.exception = exception;
+    }
+
+    public String getClassification() {
+        return classification;
+    }
+
+    public void setClassification(String classification) {
+        this.classification = classification;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setcode(String code) {
+        this.code = code;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicQueryApp/src/mpGraphQL10/basicQuery/WidgetQueryResponse.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicQueryApp/src/mpGraphQL10/basicQuery/WidgetQueryResponse.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package mpGraphQL10.basicQuery;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class WidgetQueryResponse {
@@ -50,10 +51,16 @@ public class WidgetQueryResponse {
         if (errors != null) {
             sb.append(System.lineSeparator()).append("  errors [");
             for (Error e : errors) {
+                Extensions ext = e.getExtensions();
                 sb.append("    {").append(System.lineSeparator());
                 sb.append("      message : ").append(e.getMessage()).append(System.lineSeparator());
-                sb.append("      path : ").append(e.getPath()).append(System.lineSeparator());
-                sb.append("      extensions : ").append(e.getExtensions()).append(System.lineSeparator());
+                sb.append("      path : ").append(Arrays.toString(e.getPath())).append(System.lineSeparator());
+                sb.append("      extensions : ").append(System.lineSeparator());
+                sb.append("        {").append(System.lineSeparator());
+                sb.append("          exception : ").append(ext.getException()).append(System.lineSeparator());
+                sb.append("          classification : ").append(ext.getClassification()).append(System.lineSeparator());
+                sb.append("          code : ").append(ext.getCode()).append(System.lineSeparator());
+                sb.append("        }").append(System.lineSeparator());
                 sb.append("    }").append(System.lineSeparator());
             }
             sb.append("]");

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ifaceApp/src/mpGraphQL10/iface/InterfaceTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ifaceApp/src/mpGraphQL10/iface/InterfaceTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -39,7 +39,9 @@ import javax.ws.rs.core.Response;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.junit.Test;
 
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
+import componenttest.rules.repeater.MicroProfileActions;
 
 
 @SuppressWarnings("serial")
@@ -78,6 +80,7 @@ public class InterfaceTestServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat(MicroProfileActions.STANDALONE10_ID) // Looks to be a yasson 3.0 bug
     public void testMutationUsingInterfaceType(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         long timeStampAtStart = System.currentTimeMillis();
         GraphQLClient client = builder.build(GraphQLClient.class);

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/MetricsTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/MetricsTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,30 +14,26 @@ package mpGraphQL10.metrics;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.net.MalformedURLException;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.junit.Test;
@@ -50,6 +46,19 @@ import mpGraphQL10.metrics.Stats.SimpleTimerStat;
 public class MetricsTestServlet extends FATServlet {
     private static final Logger LOG = Logger.getLogger(MetricsTestServlet.class.getName());
     private static final long PADDING_TIME = 5000; //milliseconds
+
+    private static final String METRICS_URL_STRING_PREFIX = "/metrics/vendor/";
+    private static final String METRICS5_URL_STRING_PREFIX = "/metrics?scope=vendor&name=";
+
+    private static boolean ee10;
+    static {
+       try {
+           Class.forName("jakarta.ws.rs.core.EntityPart");
+           ee10 = true;
+       } catch(Throwable t) {
+           ee10 = false;
+       }
+    }
 
     private RestClientBuilder builder;
     private RestClientBuilder statsBuilder;
@@ -113,12 +122,33 @@ public class MetricsTestServlet extends FATServlet {
         assertEquals("Count", widget.getName());
         assertEquals(3, widget.getCount());
         
-        Stats stats = statsBuilder.register(LoggingFilter.class).build(StatsClient.class).getVendorStats();
-        assertNotNull(stats);
-        SimpleTimerStat stat = stats.getCount();
-        if (stat != null) {
+        // MP Metrics 5.0 removed the JSON format for metrics
+        if (!ee10) {
+            Stats stats = statsBuilder.register(LoggingFilter.class).build(StatsClient.class).getVendorStats();
+            assertNotNull(stats);
+            SimpleTimerStat stat = stats.getCount();
             assertEquals(3, stat.getCount());
-        } //stat will be null when using MP 4.0, so only check it in MP 3.3
+        }
+
+        // Check also with the normal text metrics format as well so can test EE 10 where JSON format isn't enabled any longer.
+        List<String> metrics = getMetricsStrings(200, (ee10 ? METRICS5_URL_STRING_PREFIX : METRICS_URL_STRING_PREFIX) 
+                                                 + "mp_graphql_QUERY_getCountWidget");
+        int count = -1;
+
+        for (String metric : metrics) {
+            if (metric.startsWith("#")) {
+                continue;
+            }
+            if (ee10 ? metric.contains("mp_graphql_QUERY_getCountWidget_seconds_count") : 
+                metric.contains("mp_graphql_QUERY_getCountWidget_total")) {
+                count = Float.valueOf(metric.substring(metric.indexOf(' ') +1)).intValue();
+                break;
+            }
+        }
+
+        assertTrue("Count statistic not found", count != -1);
+
+        assertEquals(3, count);
     }
 
     @Test
@@ -164,16 +194,94 @@ public class MetricsTestServlet extends FATServlet {
         runningDuration = runningDuration.plus(duration);
         assertTrue( duration.compareTo(HALF_SECOND.multipliedBy(3)) >=0 );
         
-        //TODO: check mpMetrics shows that (1.5s + someBuffer) >= time_from_mpMetrics >= time_from_widget 
-        Stats stats = statsBuilder.build(StatsClient.class).getVendorStats();
-        assertNotNull(stats);
-        SimpleTimerStat stat = stats.getTime();
-        if (stat != null) {
+        //TODO: check mpMetrics shows that (1.5s + someBuffer) >= time_from_mpMetrics >= time_from_widget
+        // MP Metrics 5.0 removed the JSON format for metrics
+        if (!ee10) {
+            Stats stats = statsBuilder.build(StatsClient.class).getVendorStats();
+            assertNotNull(stats);
+            SimpleTimerStat stat = stats.getTime();
+
             assertEquals(3, stat.getCount());
             Duration metricsDuration = Duration.ofNanos((long)stat.getElapsedTime());
             Duration maxTimeDuration = Duration.ofMillis(1500 + PADDING_TIME);
             assertTrue( maxTimeDuration.compareTo(metricsDuration) >= 0 );
             assertTrue( Math.abs(metricsDuration.minus(runningDuration).toMillis()) <= PADDING_TIME);
-        } //stat will be null when using MP 4.0, so only check it in MP 3.3
+        }
+
+        // Check also with the normal text metrics format as well so can test EE 10 where JSON format isn't enabled any longer.
+        List<String> metrics = getMetricsStrings(200, (ee10 ? METRICS5_URL_STRING_PREFIX : METRICS_URL_STRING_PREFIX) 
+                                                 + "mp_graphql_QUERY_getTimeWidget");
+        int count = -1;
+        float seconds = -1;
+
+        for (String metric : metrics) {
+            if (metric.startsWith("#")) {
+                continue;
+            }
+            if (ee10 ? metric.contains("mp_graphql_QUERY_getTimeWidget_seconds_count") : 
+                metric.contains("mp_graphql_QUERY_getTimeWidget_total")) {
+                count = Float.valueOf(metric.substring(metric.indexOf(' ') +1)).intValue();
+            } else if (ee10 ? metric.contains("mp_graphql_QUERY_getTimeWidget_seconds_sum") : 
+                metric.contains("mp_graphql_QUERY_getTimeWidget_elapsedTime_seconds")) {
+                seconds = Float.parseFloat(metric.substring(metric.indexOf(' ') +1));
+            }
+        }
+
+        assertTrue("Count statistic not found", count != -1);
+        assertTrue("Elapsed Time statistic not found", seconds != -1);
+
+        assertEquals(3, count);
+        Duration metricsDuration = Duration.ofNanos((long)(seconds * 1000000));
+        Duration maxTimeDuration = Duration.ofMillis(1500 + PADDING_TIME);
+        assertTrue( maxTimeDuration.compareTo(metricsDuration) >= 0 );
+        assertTrue( Math.abs(metricsDuration.minus(runningDuration).toMillis()) <= PADDING_TIME);
+    }
+
+    private ArrayList<String> getMetricsStrings(int expectedRc, String metricString) {
+        HttpURLConnection con = null;
+        try {
+            URL url = new URL("http://localhost:" + getSysProp("bvt.prop.HTTP_default", "8010") + metricString);
+            int retcode;
+            con = (HttpURLConnection) url.openConnection();
+            con.setDoInput(true);
+            con.setDoOutput(true);
+            con.setUseCaches(false);
+            con.setRequestMethod("GET");
+
+            retcode = con.getResponseCode();
+            // Since these tests an run asynchronously it is possible that a testcase that does not expect metrics to be
+            // collected (for example testAbort) may run first or be specified as the only test to run.  In
+            // this case a 404 is expected.
+            if (retcode != expectedRc){
+
+                fail("Bad return Code from Metrics method call. Expected " + expectedRc + ": Received "
+                     + retcode + ", URL = " + url.toString());
+
+                return null;
+            }
+
+            if (retcode == 200) {
+                InputStream is = con.getInputStream();
+                InputStreamReader isr = new InputStreamReader(is);
+
+                BufferedReader br = new BufferedReader(isr);
+
+                ArrayList<String> lines = new ArrayList<String>();
+                for (String line = br.readLine(); line != null; line = br.readLine()) {
+                    lines.add(line);
+                }
+                return lines;
+            }
+            return null;
+
+        } catch (Exception e) {
+            fail("Caught unexpected exception: " + e);
+            return null;
+        } finally {
+            if (con != null) {
+                con.disconnect();
+            }
+        }
+
     }
 }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/Stats.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/Stats.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,9 +34,9 @@ public class Stats {
         }
     }
 
-    @JsonbProperty("mp_graphql_Query_getCountWidget")
+    @JsonbProperty("mp_graphql_QUERY_getCountWidget")
     private SimpleTimerStat count;
-    @JsonbProperty("mp_graphql_Query_getTimeWidget")
+    @JsonbProperty("mp_graphql_QUERY_getTimeWidget")
     private SimpleTimerStat time;
 
     public SimpleTimerStat getCount() {

--- a/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/src/com/ibm/ws/microprofile/graphql/metrics/component/MetricsServiceComponent.java
+++ b/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/src/com/ibm/ws/microprofile/graphql/metrics/component/MetricsServiceComponent.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.graphql.metrics.component;
+
+import static org.osgi.service.component.annotations.ConfigurationPolicy.IGNORE;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import com.ibm.ws.microprofile.metrics.impl.SharedMetricRegistries;
+
+@Component(configurationPolicy = IGNORE)
+public class MetricsServiceComponent {
+
+    private static SharedMetricRegistries sharedRegistries;
+
+    public static SharedMetricRegistries getSharedMetricRegistries() {
+        return sharedRegistries;
+    }
+
+    @Reference
+    protected void setSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistries) {
+        sharedRegistries = sharedMetricRegistries;
+    }
+
+    protected void unsetSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistries) {
+        if (sharedRegistries == sharedMetricRegistries) {
+            sharedRegistries = null;
+        }
+    }
+}

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/.classpath
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/.project
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.microprofile.graphql.internal.metrics.3.0</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/bnd.bnd
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/bnd.bnd
@@ -1,32 +1,28 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2023 IBM Corporation and others.
+# Copyright (c) 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
 Bundle-Name: MicroProfile Metrics Support for MP GraphQL
-Bundle-SymbolicName: com.ibm.ws.microprofile.graphql.metrics.1.0
+Bundle-SymbolicName: io.openliberty.microprofile.graphql.internal.metrics.3.0
 Bundle-Description: MicroProfile Metrics Support for MP GraphQL
 
-Export-Package: \
-  com.ibm.ws.microprofile.graphql.metrics.component;thread-context=true
+Export-Package: io.openliberty.microprofile.graphql.internal.metrics.component;thread-context=true
 
 Import-Package: \
-  org.eclipse.microprofile.metrics;version="[2.3,3.0)",\
+  org.eclipse.microprofile.metrics;version="[3.0,4.1)",\
   *
 
 -dsannotations: \
-  com.ibm.ws.microprofile.graphql.metrics.component.MetricsServiceComponent
+  io.openliberty.microprofile.graphql.internal.metrics.component.MetricsServiceComponent
 
 Include-Resource: \
   META-INF=resources/META-INF
@@ -42,9 +38,9 @@ Service-Component: \
     properties:="resources=META-INF/services/io.smallrye.graphql.spi.EventingService"
 
 -buildpath: \
-  com.ibm.ws.io.smallrye.graphql;version=latest,\
-  com.ibm.websphere.org.eclipse.microprofile.metrics.2.3;version=latest,\
-  com.ibm.ws.logging;version=latest,\
-  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-  com.ibm.wsspi.org.osgi.service.component.annotations,\
-  com.ibm.ws.microprofile.metrics
+	com.ibm.ws.io.smallrye.graphql;version=latest,\
+	io.openliberty.org.eclipse.microprofile.metrics.3.0;version=latest,\
+	com.ibm.ws.logging;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations,\
+	io.openliberty.microprofile.metrics.internal.3.0

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/resources/META-INF/services/io.smallrye.graphql.spi.EventingService
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/resources/META-INF/services/io.smallrye.graphql.spi.EventingService
@@ -1,0 +1,1 @@
+io.openliberty.microprofile.graphql.internal.metrics.component.MetricsService

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/src/io/openliberty/microprofile/graphql/internal/metrics/component/MetricsService.java
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/src/io/openliberty/microprofile/graphql/internal/metrics/component/MetricsService.java
@@ -7,7 +7,7 @@
  * 
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package com.ibm.ws.microprofile.graphql.metrics.component;
+package io.openliberty.microprofile.graphql.internal.metrics.component;
 
 import java.time.Duration;
 import java.util.Collections;

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/src/io/openliberty/microprofile/graphql/internal/metrics/component/MetricsServiceComponent.java
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/src/io/openliberty/microprofile/graphql/internal/metrics/component/MetricsServiceComponent.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.graphql.internal.metrics.component;
+
+import static org.osgi.service.component.annotations.ConfigurationPolicy.IGNORE;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import com.ibm.ws.microprofile.metrics.impl.SharedMetricRegistries;
+
+@Component(configurationPolicy = IGNORE)
+public class MetricsServiceComponent {
+
+    private static SharedMetricRegistries sharedRegistries;
+
+    public static SharedMetricRegistries getSharedMetricRegistries() {
+        return sharedRegistries;
+    }
+
+    @Reference
+    protected void setSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistries) {
+        sharedRegistries = sharedMetricRegistries;
+    }
+
+    protected void unsetSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistries) {
+        if (sharedRegistries == sharedMetricRegistries) {
+            sharedRegistries = null;
+        }
+    }
+}

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/src/io/openliberty/microprofile/graphql/internal/metrics/component/package-info.java
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.3.0/src/io/openliberty/microprofile/graphql/internal/metrics/component/package-info.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "GraphQL")
+package io.openliberty.microprofile.graphql.internal.metrics.component;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/.classpath
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/.project
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.microprofile.graphql.internal.metrics.5.0</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=11

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/bnd.bnd
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/bnd.bnd
@@ -1,38 +1,35 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2023 IBM Corporation and others.
+# Copyright (c) 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+javac.source: 11
+javac.target: 11
+
+Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
+
 Bundle-Name: MicroProfile Metrics Support for MP GraphQL
-Bundle-SymbolicName: com.ibm.ws.microprofile.graphql.metrics.1.0
+Bundle-SymbolicName: io.openliberty.microprofile.graphql.internal.metrics.5.0
 Bundle-Description: MicroProfile Metrics Support for MP GraphQL
 
 Export-Package: \
-  com.ibm.ws.microprofile.graphql.metrics.component;thread-context=true
-
-Import-Package: \
-  org.eclipse.microprofile.metrics;version="[2.3,3.0)",\
-  *
+  io.openliberty.microprofile.graphql.internal.metrics.component;thread-context=true
 
 -dsannotations: \
-  com.ibm.ws.microprofile.graphql.metrics.component.MetricsServiceComponent
+  io.openliberty.microprofile.graphql.internal.metrics.component.MetricsServiceComponent
 
 Include-Resource: \
   META-INF=resources/META-INF
 
 src: src/
-
 
 Service-Component: \
   com.ibm.ws.io.smallrye.graphql.ResourceProvider; \
@@ -42,9 +39,9 @@ Service-Component: \
     properties:="resources=META-INF/services/io.smallrye.graphql.spi.EventingService"
 
 -buildpath: \
-  com.ibm.ws.io.smallrye.graphql;version=latest,\
-  com.ibm.websphere.org.eclipse.microprofile.metrics.2.3;version=latest,\
-  com.ibm.ws.logging;version=latest,\
-  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-  com.ibm.wsspi.org.osgi.service.component.annotations,\
-  com.ibm.ws.microprofile.metrics
+	com.ibm.ws.io.smallrye.graphql;version=latest,\
+	io.openliberty.org.eclipse.microprofile.metrics.5.0;version=latest,\
+	com.ibm.ws.logging;version=latest,\
+	io.openliberty.microprofile.metrics.5.0.internal,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/resources/META-INF/services/io.smallrye.graphql.spi.EventingService
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/resources/META-INF/services/io.smallrye.graphql.spi.EventingService
@@ -1,0 +1,1 @@
+io.openliberty.microprofile.graphql.internal.metrics.component.MetricsService

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/src/io/openliberty/microprofile/graphql/internal/metrics/component/MetricsServiceComponent.java
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/src/io/openliberty/microprofile/graphql/internal/metrics/component/MetricsServiceComponent.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.graphql.internal.metrics.component;
+
+import static org.osgi.service.component.annotations.ConfigurationPolicy.IGNORE;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import io.openliberty.microprofile.metrics50.SharedMetricRegistries;
+
+
+@Component(configurationPolicy = IGNORE)
+public class MetricsServiceComponent {
+
+    private static SharedMetricRegistries sharedRegistries;
+
+    public static SharedMetricRegistries getSharedMetricRegistries() {
+        return sharedRegistries;
+    }
+
+    @Reference
+    protected void setSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistries) {
+        sharedRegistries = sharedMetricRegistries;
+    }
+
+    protected void unsetSharedMetricRegistries(SharedMetricRegistries sharedMetricRegistries) {
+        if (sharedRegistries == sharedMetricRegistries) {
+            sharedRegistries = null;
+        }
+    }
+}

--- a/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/src/io/openliberty/microprofile/graphql/internal/metrics/component/package-info.java
+++ b/dev/io.openliberty.microprofile.graphql.internal.metrics.5.0/src/io/openliberty/microprofile/graphql/internal/metrics/component/package-info.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "GraphQL")
+package io.openliberty.microprofile.graphql.internal.metrics.component;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;


### PR DESCRIPTION
- Update metrics integration to be specific for different metrics levels.  mpMetrics 5.0 has breaking changes that need to be handled.
- Update Metrics test to skip the JSON testing since mpMetrics 5.0 doesn't include JSON any longer.
- Add a non JSON test for metrics with mpGraphQL
- Update security mpGraphQL auto feature to include EE 10 security feature.
- Add repeat for MP 6 in the GraphQL FAT bucket.
