### PR TITLE
oidc client code updates

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtilTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -931,22 +931,35 @@ public class OIDCClientAuthenticatorUtilTest {
         try {
             final String originalState = TEST_ORIGINAL_STATE;
             final String cookieName = OidcStorageUtils.getStateStorageKey("notA" + originalState);
+            final Cookie[] cookies = new Cookie[] { cookie1 };
+            final ReferrerURLCookieHandler referrerURLCookieHandlerTwo = mock.mock(ReferrerURLCookieHandler.class, "referrerURLCookieHandlerTwo");
             mock.checking(new Expectations() {
                 {
                     allowing(convClientConfig).getClientId();
                     will(returnValue(CLIENT01));
                     one(req).getCookies();
                     will(returnValue(cookies));
+                    one(cookie1).getName();
+                    will(returnValue(cookieName));
+                    one(cookie1).getValue();
+                    will(returnValue(originalState));
                     one(convClientConfig).getClientSecret();
                     will(returnValue("clientsecret"));
                     one(convClientConfig).getClockSkewInSeconds();
                     will(returnValue(TEST_CLOCK_SKEW_IN_SECONDS));
                     one(convClientConfig).getAuthenticationTimeLimitInSeconds();
-                    will(returnValue(420L));
-                    one(referrerURLCookieHandler).invalidateCookie(req, res, cookieName, true);
+                    will(returnValue(420L));                   
+                    one(req).getRequestURL();
+                    will(returnValue(new StringBuffer(TEST_URL)));
+                    one(referrerURLCookieHandlerTwo).createCookie(with(any(String.class)), with(any(String.class)), with(any(HttpServletRequest.class)));
+                    will(returnValue(cookie1));
+                    one(cookie1).setMaxAge(0);
+                    one(res).addCookie(cookie1);
+                    
                 }
             });
-            OidcClientUtil.setReferrerURLCookieHandler(referrerURLCookieHandler);
+            
+            OidcClientUtil.setReferrerURLCookieHandler(referrerURLCookieHandlerTwo);
 
             ProviderAuthenticationResult result = oidcCAUtil.verifyResponseState(req, res, "notA" + originalState, convClientConfig);
             assertNotNull("Did not get an expecyted result", result);

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieBasedStorage.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/storage/CookieBasedStorage.java
@@ -86,7 +86,13 @@ public class CookieBasedStorage implements Storage {
             }
             return;
         }
-        referrerURLCookieHandler.invalidateCookie(request, response, name, true);
+        Cookie c = referrerURLCookieHandler.createCookie(name, "", request);
+        String domainName = webSsoUtils.getSsoDomain(request);
+        if (domainName != null && !domainName.isEmpty()) {
+            c.setDomain(domainName);
+        }
+        c.setMaxAge(0);
+        response.addCookie(c);
     }
 
     private void setAdditionalCookieProperties(Cookie cookie, CookieStorageProperties cookieProps) {

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/storage/CookieBasedStorageTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/storage/CookieBasedStorageTest.java
@@ -181,7 +181,14 @@ public class CookieBasedStorageTest extends CommonTestClass {
     public void test_remove() {
         mockery.checking(new Expectations() {
             {
-                one(referrerURLCookieHandler).invalidateCookie(request, response, testCookieName, true);
+                one(referrerURLCookieHandler).createCookie(testCookieName, "", request);
+                will(returnValue(cookie));
+                one(webSSOUtils).getSsoDomain(request);
+                will(returnValue(null));              
+                one(cookie).setSecure(true);
+                one(cookie).setHttpOnly(true);
+                one(cookie).setMaxAge(0);
+                one(response).addCookie(cookie);
             }
         });
 


### PR DESCRIPTION
- when removing cookies , make sure to add domain information (so, they match the original cookie)
- fix another regression involving access token in ltpa cookie

fixes #24543 