### PR TITLE
Allow servers to be hit by a port scanner while tests are running

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestServer.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestServer.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -451,6 +451,9 @@ public class TestServer extends ExternalResource {
             // startserver automatically validates that any added apps have actually started
             server.startServer();
         }
+
+        server.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
+
     }
 
     protected boolean doesLogContainKnownIntermittentStartupFailures() throws Exception {

--- a/dev/com.ibm.ws.security.oauth_fat/fat/src/com/ibm/ws/security/oauth20/fat/OAuth20TestCommon.java
+++ b/dev/com.ibm.ws.security.oauth_fat/fat/src/com/ibm/ws/security/oauth20/fat/OAuth20TestCommon.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.net.UnknownHostException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.Random;
 
 import javax.net.ssl.HostnameVerifier;
@@ -46,6 +47,7 @@ import org.slf4j.LoggerFactory;
 import com.ibm.websphere.simplicity.config.MongoDBElement;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.mongo.fat.MongoServerSelector;
+import com.ibm.ws.security.fat.common.MessageConstants;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
 import com.meterware.httpunit.HttpUnitOptions;
 import com.meterware.httpunit.WebConversation;
@@ -278,6 +280,8 @@ public class OAuth20TestCommon {
         }
         assertNotNull("OAuth role configuration was not processed in time",
                       server.waitForStringInLog("OAuth roles configuration successfully processed"));
+
+        server.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0801E_UNABLE_TO_INIT_SSL));
 
         printTestStart();
         init();


### PR DESCRIPTION
The OAuth FAT project was running and a couple of the servers logged 

`[3/8/23, 13:38:15:752 PST] 0000002d com.ibm.ws.channel.ssl.internal.SSLHandshakeErrorTracker     E CWWKO0801E: The SSL connection cannot be initialized from the <host_a> host and 54,014 port on the remote client to the <host_b> host and 8,020 port on the local server. Exception: javax.net.ssl.SSLHandshakeException: Received fatal alert: bad_certificate
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:131)
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:117)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:339)
	at java.base/sun.security.ssl.Alert$AlertConsumer.consume(Alert.java:293)
	at java.base/sun.security.ssl.TransportContext.dispatch(TransportContext.java:185)
	at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:172)
	at java.base/sun.security.ssl.SSLEngineImpl.decode(SSLEngineImpl.java:681)
	at java.base/sun.security.ssl.SSLEngineImpl.readRecord(SSLEngineImpl.java:636)
	at java.base/sun.security.ssl.SSLEngineImpl.unwrap(SSLEngineImpl.java:454)
	at java.base/sun.security.ssl.SSLEngineImpl.unwrap(SSLEngineImpl.java:433)
	at java.base/javax.net.ssl.SSLEngine.unwrap(SSLEngine.java:637)
	at com.ibm.ws.channel.ssl.internal.SSLUtils.handleHandshake(SSLUtils.java:909)
	at com.ibm.ws.channel.ssl.internal.SSLConnectionLink.readyInbound(SSLConnectionLink.java:595)
	at com.ibm.ws.channel.ssl.internal.SSLConnectionLink.ready(SSLConnectionLink.java:342)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:169)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:77)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:516)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:586)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:970)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1059)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:247)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:866)`

This happens when a port scanner is running and hits our server instance.  The failure is recorded in the test server that is not making any outbound requests (just responding to requests from a test client)

I'm adding message CWWKO0801E to the list of errors that the test framework will ignore if located in the server log during shutdown.  The test framework fails the class if it finds any unaccounted for messages (or ffdcs).
Ignoring this should not affect any tests that are causing a handshake exception as they'll check the log during test case execution and use tooling that doesn't know about these ignored errors.
Tests should fail if this message is logged in a case where there really is a problem in the test env/setup.