### PR TITLE
Wait for endpoint initialization in JAX-RS SSL FAT

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/SecuritySSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/SecuritySSLTest.java
@@ -61,6 +61,13 @@ public class SecuritySSLTest {
             assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
             assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
             assertNotNull("The defaultHttpEndpoint-ssl endpoint should report it is ready", server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl"));
+            // Wait for /security endpoints to be initialized
+            assertNotNull("/security com.ibm.ws.jaxrs.fat.security.ssl.SSLApplication was not initialized (SRVE0242I not found)",
+                          server.waitForStringInLog("SRVE0242I.*/security.*com.ibm.ws.jaxrs.fat.security.ssl.SSLApplication"));
+            assertNotNull("/security com.ibm.ws.jaxrs.fat.security.annotations.SecurityAnnotationsApplication was not initialized (SRVE0242I not found)",
+                          server.waitForStringInLog("SRVE0242I.*/security.*com.ibm.ws.jaxrs.fat.security.annotations.SecurityAnnotationsApplication"));
+            assertNotNull("/security SecurityContextApp was not initialized (SRVE0242I not found)",
+                          server.waitForStringInLog("SRVE0242I.*/security.*SecurityContextApp"));
         } catch (Exception e) {
             System.out.println(e.toString());
         }

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/JAXRS21SecuritySSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/JAXRS21SecuritySSLTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -71,6 +71,14 @@ public class JAXRS21SecuritySSLTest {
         // wait for LTPA key to be available to avoid CWWKS4000E
         assertNotNull("CWWKS4105I.* not received on server",
                       server.waitForStringInLog("CWWKS4105I.*"));
+
+        // Wait for /jaxrs21security endpoints to be initialized
+        assertNotNull("/jaxrs21security com.ibm.ws.jaxrs21.fat.security.ssl.SSLApplication was not initialized (SRVE0242I not found)",
+                      server.waitForStringInLog("SRVE0242I.*/jaxrs21security.*com.ibm.ws.jaxrs21.fat.security.ssl.SSLApplication"));
+        assertNotNull("/jaxrs21security com.ibm.ws.jaxrs21.fat.security.annotations.SecurityAnnotationsApplication was not initialized (SRVE0242I not found)",
+                      server.waitForStringInLog("SRVE0242I.*/jaxrs21security.*com.ibm.ws.jaxrs21.fat.security.annotations.SecurityAnnotationsApplication"));
+        assertNotNull("/jaxrs21security SecurityContextApp was not initialized (SRVE0242I not found)",
+                      server.waitForStringInLog("SRVE0242I.*/jaxrs21security.*SecurityContextApp"));
     }
 
     @AfterClass


### PR DESCRIPTION
Test client is attempting to access the JAX-RS endpoints before initialization complete and failing intermittently; add a wait.
