### PR TITLE
Update the JPA 3.1 FAT's QueryTimeFunction to skip if too close to mi…

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_31_fat/test-applications/jpa31/src/io/openliberty/jpa/tests/jpa31/web/TestNewQueryTimeFunctionsServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_31_fat/test-applications/jpa31/src/io/openliberty/jpa/tests/jpa31/web/TestNewQueryTimeFunctionsServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -208,7 +208,7 @@ public class TestNewQueryTimeFunctionsServlet extends JPADBTestServlet {
         // decently synchronized clocks.  Best if the database is on the same machine as the liberty server.
 
         final int graceTime = 60; // the min amount of time before midnight or noon to run this test, otherwise wait until that time mark
-                                  // has passed.  This is to avoid reasonable race conditions for slow test systems.
+                                  // has passed.  This is to avoid reasonable race conditions for slow test systems.  In seconds.
 
         try {
             LocalTime now = getDatabaseServerLocalTime(); // LocalTime.now();
@@ -217,23 +217,18 @@ public class TestNewQueryTimeFunctionsServlet extends JPADBTestServlet {
                 now = LocalTime.now();
             }
             int nowSecondOfDay = now.toSecondOfDay();
-            final int twelveZeroSecondOfDay = LocalTime.of(12, 0).toSecondOfDay();
             final int secondsPerDay = 60 * 60 * 24;
 
-            int secToTwelve = twelveZeroSecondOfDay - nowSecondOfDay;
+            int secToTwelve = LocalTime.NOON.toSecondOfDay() - nowSecondOfDay;
             int secToMidnight = secondsPerDay - nowSecondOfDay;
-            if ((secToTwelve > 0 && secToTwelve < graceTime) && (secToMidnight < graceTime)) {
-                // If the current time is within (graceTime) seconds of either of the time markers, then it's better to wait until current time
-                // elapses past the time marker.  This is to eliminate race conditions.  30 seconds window for slow test systems.
-                long waitTime = (secToTwelve > secToTwelve) ? (long) (secToTwelve + 1) * 1000 : (long) (secToMidnight + 1) * 1000;
-                Thread.sleep(waitTime);
 
-                // After sleeping, recalculate now.
-                now = getDatabaseServerLocalTime(); // LocalTime.now();
-                if (now == null) {
-                    System.out.println("Failed to get a recalculated LocalTime from the database, falling back to LocalTime.now()");
-                    now = LocalTime.now();
-                }
+            // If the test is running too close to midnight or noon, then just skip the test.  Trying elaborate sleep times have proven too unreliable.
+            if (secToMidnight <= graceTime) {
+                System.out.println("Determined current time is too close to midnight, skipping test.");
+                return;
+            } else if (!(secToTwelve < 0) && secToTwelve <= graceTime) {
+                System.out.println("Determined current time is too close to noon, skipping test.");
+                return;
             }
 
             tx.begin();


### PR DESCRIPTION
Updating testLocalTimeFunction_JPQL test to skip if too close (60s) to midnight or noon. 

