### PR TITLE
Stop using SimpleDateFormat in CachedTime with CXF

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/interceptor/CachedTime.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/interceptor/CachedTime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,30 +13,22 @@
 // Liberty Change for CXF Begin
 package org.apache.cxf.jaxrs.interceptor;
 
-import java.text.FieldPosition;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
-import org.apache.cxf.jaxrs.utils.HttpUtils;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 class CachedTime {
+
     /** Stored formatter */
-    private SimpleDateFormat myFormat = null;
+    private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(ZoneId.of("GMT"));
 
     /** Last time we formatted a value */
     private long lastTimeCheck = 0L;
     /** The stored formatted time as a string */
     private String sTime = null;
-//    /** The stored formatted time as byte[] */
-//    private final byte[] baTime = new byte[0];
-//    /** The stored formatted time as a char[] */
-//    private final char[] caTime = new char[0];
-    /** Static date object used for all conversions */
-    private final Date myDate = new Date();
-    /** Buffer that the formatted puts output into */
-    private StringBuffer myBuffer = new StringBuffer(33);
 
-    private static CachedTime instance = new CachedTime(HttpUtils.getHttpDateFormat());
+    private static CachedTime instance = new CachedTime();
 
     protected static final long DEFAULT_TOLERANCE = 1000L;
 
@@ -47,21 +39,11 @@ class CachedTime {
      * @param format
      */
 
-    protected CachedTime(SimpleDateFormat format) {
-        this.myFormat = format;
+    protected CachedTime() {
     }
 
     public static CachedTime getCachedTime() {
         return instance;
-    }
-
-    /**
-     * Access the formatter for this particular cached time instance.
-     * 
-     * @return SimpleDateFormat
-     */
-    protected SimpleDateFormat getFormat() {
-        return this.myFormat;
     }
 
     /**
@@ -84,42 +66,10 @@ class CachedTime {
             }
         }
         // otherwise need to format the current time
-        this.myDate.setTime(now);
-        this.myBuffer.setLength(0);
-        this.myBuffer = this.myFormat.format(this.myDate, this.myBuffer, new FieldPosition(0));
-//        int len = this.myBuffer.length();
-//
-//        // extract the char[] of the time and save the byte[] equivalent
-//        if (this.caTime.length != len) {
-//            // both arrays will always have the same length
-//            this.caTime = new char[len];
-//            this.baTime = new byte[len];
-//        }
-//        this.myBuffer.getChars(0, len, this.caTime, 0);
-//        for (int i = 0; i < len; i++) {
-//            this.baTime[i] = (byte) this.caTime[i];
-//        }
-        // delay the string creation until it's actually needed
-        this.sTime = null;
+        sTime = dateFormatter.format(Instant.ofEpochMilli(now));
 
         this.lastTimeCheck = now;
     }
-
-    /**
-     * Get a formatted version of the time as a byte[]. The input range is
-     * the allowed difference in time from the cached snapshot that the
-     * caller is willing to use. If that range is exceeded, then a new
-     * snapshot is taken and formatted.
-     * <br>
-     * 
-     * @param tolerance -- milliseconds, -1 means use default 1000ms, a 0
-     *            means that this must be an exact match in time
-     * @return byte[]
-     */
-//    protected byte[] getTimeAsBytes(long tolerance) {
-//        updateTime(tolerance);
-//        return this.baTime;
-//    }
 
     /**
      * Get a formatted version of the time as a String. The input range is
@@ -134,10 +84,6 @@ class CachedTime {
      */
     protected synchronized String getTimeAsString(long tolerance) {
         updateTime(tolerance);
-        // see if we need the delayed string creation at this point
-        if (null == this.sTime) {
-            this.sTime = this.myBuffer.toString();
-        }
         return this.sTime;
     }
 }

--- a/dev/com.ibm.ws.jaxrs.2.0.common/test/com/ibm/ws/jaxrs/utils/test/JAXRSOutInterceptorTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/test/com/ibm/ws/jaxrs/utils/test/JAXRSOutInterceptorTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.utils.test;
+
+import static org.junit.Assert.*;
+
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Locale;
+
+import org.apache.cxf.jaxrs.utils.HttpUtils;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class JAXRSOutInterceptorTest {
+
+    /**
+     * This test validated that the HttpUtils.getHttpDateFormat previously used in CachedTime
+     * doesn't change its format.  We now use a DateTimeFormatter to avoid the overhead of
+     * SimpleDateFormat and we want the DateTimeFormatter settings to match any changes done
+     * in HttpUtils.getHttpDateFormat. So if this test fails, we need to update the DateTimeFormatter
+     * config in CachedTime.
+     */
+    @Test
+    public void testDateFormat() {
+        SimpleDateFormat sdf = HttpUtils.getHttpDateFormat();
+        long now = System.currentTimeMillis();
+        String expected = sdf.format(new Date(now));
+
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(ZoneId.of("GMT"));
+
+        assertEquals(expected, dateFormatter.format(Instant.ofEpochMilli(now)));
+    }
+
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/interceptor/CachedTime.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/interceptor/CachedTime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,30 +13,22 @@
 // Liberty Change for CXF Begin
 package org.apache.cxf.jaxrs.interceptor;
 
-import java.text.FieldPosition;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
-import org.apache.cxf.jaxrs.utils.HttpUtils;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 class CachedTime {
+
     /** Stored formatter */
-    private SimpleDateFormat myFormat = null;
+    private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(ZoneId.of("GMT"));
 
     /** Last time we formatted a value */
     private long lastTimeCheck = 0L;
     /** The stored formatted time as a string */
     private String sTime = null;
-//    /** The stored formatted time as byte[] */
-//    private final byte[] baTime = new byte[0];
-//    /** The stored formatted time as a char[] */
-//    private final char[] caTime = new char[0];
-    /** Static date object used for all conversions */
-    private final Date myDate = new Date();
-    /** Buffer that the formatted puts output into */
-    private StringBuffer myBuffer = new StringBuffer(33);
 
-    private static CachedTime instance = new CachedTime(HttpUtils.getHttpDateFormat());
+    private static CachedTime instance = new CachedTime();
 
     protected static final long DEFAULT_TOLERANCE = 1000L;
 
@@ -47,21 +39,11 @@ class CachedTime {
      * @param format
      */
 
-    protected CachedTime(SimpleDateFormat format) {
-        this.myFormat = format;
+    protected CachedTime() {
     }
 
     public static CachedTime getCachedTime() {
         return instance;
-    }
-
-    /**
-     * Access the formatter for this particular cached time instance.
-     * 
-     * @return SimpleDateFormat
-     */
-    protected SimpleDateFormat getFormat() {
-        return this.myFormat;
     }
 
     /**
@@ -84,42 +66,10 @@ class CachedTime {
             }
         }
         // otherwise need to format the current time
-        this.myDate.setTime(now);
-        this.myBuffer.setLength(0);
-        this.myBuffer = this.myFormat.format(this.myDate, this.myBuffer, new FieldPosition(0));
-//        int len = this.myBuffer.length();
-//
-//        // extract the char[] of the time and save the byte[] equivalent
-//        if (this.caTime.length != len) {
-//            // both arrays will always have the same length
-//            this.caTime = new char[len];
-//            this.baTime = new byte[len];
-//        }
-//        this.myBuffer.getChars(0, len, this.caTime, 0);
-//        for (int i = 0; i < len; i++) {
-//            this.baTime[i] = (byte) this.caTime[i];
-//        }
-        // delay the string creation until it's actually needed
-        this.sTime = null;
+        sTime = dateFormatter.format(Instant.ofEpochMilli(now));
 
         this.lastTimeCheck = now;
     }
-
-    /**
-     * Get a formatted version of the time as a byte[]. The input range is
-     * the allowed difference in time from the cached snapshot that the
-     * caller is willing to use. If that range is exceeded, then a new
-     * snapshot is taken and formatted.
-     * <br>
-     * 
-     * @param tolerance -- milliseconds, -1 means use default 1000ms, a 0
-     *            means that this must be an exact match in time
-     * @return byte[]
-     */
-//    protected byte[] getTimeAsBytes(long tolerance) {
-//        updateTime(tolerance);
-//        return this.baTime;
-//    }
 
     /**
      * Get a formatted version of the time as a String. The input range is
@@ -134,10 +84,6 @@ class CachedTime {
      */
     protected synchronized String getTimeAsString(long tolerance) {
         updateTime(tolerance);
-        // see if we need the delayed string creation at this point
-        if (null == this.sTime) {
-            this.sTime = this.myBuffer.toString();
-        }
         return this.sTime;
     }
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs/utils/test/JAXRSOutInterceptorTest.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs/utils/test/JAXRSOutInterceptorTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.utils.test;
+
+import static org.junit.Assert.*;
+
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Locale;
+
+import org.apache.cxf.jaxrs.utils.HttpUtils;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class JAXRSOutInterceptorTest {
+
+    /**
+     * This test validated that the HttpUtils.getHttpDateFormat previously used in CachedTime
+     * doesn't change its format.  We now use a DateTimeFormatter to avoid the overhead of
+     * SimpleDateFormat and we want the DateTimeFormatter settings to match any changes done
+     * in HttpUtils.getHttpDateFormat. So if this test fails, we need to update the DateTimeFormatter
+     * config in CachedTime.
+     */
+    @Test
+    public void testDateFormat() {
+        SimpleDateFormat sdf = HttpUtils.getHttpDateFormat();
+        long now = System.currentTimeMillis();
+        String expected = sdf.format(new Date(now));
+
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(ZoneId.of("GMT"));
+
+        assertEquals(expected, dateFormatter.format(Instant.ofEpochMilli(now)));
+    }
+
+}


### PR DESCRIPTION
- Use DateTimeFormatter instead of SimpleDateFormat.  This removes synchronization and use of StringBuffers which are also synchronized
- This change can avoid a Semeru locking bug seen with this code where some how locks get locked out of order.

Fixes #24651