### PR TITLE
Reduce frequency of scheduled test pipelines and revert unittest step

### DIFF
--- a/.ci-orchestrator/personalbuild.yml
+++ b/.ci-orchestrator/personalbuild.yml
@@ -74,7 +74,7 @@ steps:
     awaitOutputProperties: true
   timeoutInMinutes: 1440
   properties:
-    build.stub.target: build.CachedWSCD.CompileImage
+    build.stub.target: build.CachedWSCD.Combined
     run.packaging.verification: ${pr-changes:run.packaging.verification}
     fat.buckets.to.run: ${pr-changes:fat.buckets.to.run}
     disable.run.runBvtTests: ${pr-changes:disable.run.runBvtTests}
@@ -88,22 +88,6 @@ steps:
     skip.open.liberty.build.if.possible: ${pr-changes:skip.open.liberty.build.if.possible}
     skip.open.liberty.fats.if.possible: ${pr-changes:skip.open.liberty.fats.if.possible}
     spawn.fullfat.buckets: ${pr-changes:spawn.fullfat.buckets}
-  includeProperties:
-  - file: compilePersonal.properties
-  - file: compile.properties
-
-- stepName: unittest
-  workType: RTC
-  projectName: "Liberty Personal Build CI Orchestrator - EBC"
-  dependsOn:
-  - stepName: pr-changes
-    awaitOutputProperties: true
-  timeoutInMinutes: 1440
-  properties:
-    build.stub.target: build.CachedWSCD.OLTest
-    disable.run.runUnitTests: ${pr-changes:disable.run.runUnitTests}
-    skip.open.liberty.build.if.possible: ${pr-changes:skip.open.liberty.build.if.possible}
-    skip.open.liberty.fats.if.possible: ${pr-changes:skip.open.liberty.fats.if.possible}
   includeProperties:
   - file: compilePersonal.properties
   - file: compile.properties

--- a/.ci-orchestrator/scheduledPersonalBuilds.yml
+++ b/.ci-orchestrator/scheduledPersonalBuilds.yml
@@ -159,7 +159,7 @@ steps:
     awaitOutputProperties: true
   timeoutInMinutes: 1440
   properties:
-    build.stub.target: build.CachedWSCD.CompileImage
+    build.stub.target: build.CachedWSCD.Combined
     run.packaging.verification: ${pr-changes:run.packaging.verification}
     fat.buckets.to.run: ${pr-changes:fat.buckets.to.run}
     disable.run.runBvtTests: ${pr-changes:disable.run.runBvtTests}
@@ -173,22 +173,6 @@ steps:
     skip.open.liberty.build.if.possible: ${pr-changes:skip.open.liberty.build.if.possible}
     skip.open.liberty.fats.if.possible: ${pr-changes:skip.open.liberty.fats.if.possible}
     spawn.fullfat.buckets: ${pr-changes:spawn.fullfat.buckets}
-  includeProperties:
-  - file: compilePersonal.properties
-  - file: compile.properties
-
-- stepName: unittest
-  workType: RTC
-  projectName: "Liberty Personal Build CI Orchestrator - EBC"
-  dependsOn:
-  - stepName: pr-changes
-    awaitOutputProperties: true
-  timeoutInMinutes: 1440
-  properties:
-    build.stub.target: build.CachedWSCD.OLTest
-    disable.run.runUnitTests: ${pr-changes:disable.run.runUnitTests}
-    skip.open.liberty.build.if.possible: ${pr-changes:skip.open.liberty.build.if.possible}
-    skip.open.liberty.fats.if.possible: ${pr-changes:skip.open.liberty.fats.if.possible}
   includeProperties:
   - file: compilePersonal.properties
   - file: compile.properties

--- a/.ci-orchestrator/scheduledPersonalBuilds.yml
+++ b/.ci-orchestrator/scheduledPersonalBuilds.yml
@@ -9,7 +9,7 @@ triggers:
   triggerMonitored: false
   triggerThreshold: 100
   every:
-    hours: 24
+    hours: 168
   propertyDefinitions:
   - name: git.laos.clone.repository.username
     defaultValue: "fritze2"
@@ -37,7 +37,7 @@ triggers:
   triggerMonitored: false
   triggerThreshold: 100
   every:
-    hours: 24
+    hours: 168
   propertyDefinitions:
   - name: git.laos.clone.repository.username
     defaultValue: "fritze2"
@@ -65,7 +65,7 @@ triggers:
   triggerMonitored: false
   triggerThreshold: 100
   every:
-    hours: 24
+    hours: 168
   propertyDefinitions:
   - name: git.laos.clone.repository.username
     defaultValue: "fritze2"
@@ -93,7 +93,7 @@ triggers:
   triggerMonitored: false
   triggerThreshold: 100
   every:
-    hours: 24
+    hours: 168
   propertyDefinitions:
   - name: git.laos.clone.repository.username
     defaultValue: "fritze2"
@@ -121,7 +121,7 @@ triggers:
   triggerMonitored: false
   triggerThreshold: 100
   every:
-    hours: 24
+    hours: 168
   propertyDefinitions:
   - name: git.laos.clone.repository.username
     defaultValue: "fritze2"


### PR DESCRIPTION
- Lowering frequency of scheduled pipelines from daily to weekly.
- Revert parallel unittest step until we fix a defect with the new compile step target.