### PR TITLE
Increase threshold for EE10 to avoid build-break under load.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/restmetrics/src/com/ibm/ws/jaxrs/fat/restmetrics/RestMetricsResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/restmetrics/src/com/ibm/ws/jaxrs/fat/restmetrics/RestMetricsResource.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -406,6 +406,12 @@ public class RestMetricsResource {
 
         if (responseTime >= 0) {
             double threshold = 100;
+            // With EE10 MP Metrics had to change to a dual filter approach that caused an intermittent increase in
+            // recorded response times.  The threshold will be increased to account for this with issue
+            // https://github.com/OpenLiberty/open-liberty/issues/24693 written to potentially investigate alternatives.
+            if (isEE10OrGreater()) {
+                threshold = 200;
+            }
             monitorResponseTime /= 1000000;
             if (Math.abs(monitorResponseTime - responseTime) > threshold) {
 
@@ -448,5 +454,15 @@ public class RestMetricsResource {
             return "Failed: Expected exeption not received: " + e +", causedBy " + e2;
         }
     }
+
+    private boolean isEE10OrGreater() {
+        try {
+            Class.forName("jakarta.ws.rs.core.EntityPart");
+        } catch (Throwable t){
+            return false;
+        }
+        return true;
+    }
+
 
 }


### PR DESCRIPTION
This is needed do to a design change in MP Metrics for EE10 that introduced a dual-filter approach.  Issue #24693 was written to investigate potential alternative approaches.