### PR TITLE
PR for Issue 17842: Add asymmetric algorithm support to OIDC RP-initiated logout

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/OidcEndpointServicesTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/OidcEndpointServicesTest.java
@@ -862,6 +862,8 @@ public class OidcEndpointServicesTest {
                     will(returnValue(oauth20tokencache));
                     one(oauth20tokencache).get(with(HashUtils.digest(idTokenHint)));
                     will(returnValue(null));
+                    one(oidcServerConfig).getIdTokenSigningAlgValuesSupported();
+                    will(returnValue("HS256"));
                     one(oauth20Provider).getClientProvider();
                     will(returnValue(oidcoauth20clientprovider));
                     one(oidcoauth20clientprovider).get(with(clientId));
@@ -904,6 +906,8 @@ public class OidcEndpointServicesTest {
                     will(returnValue(oauth20tokencache));
                     one(oauth20tokencache).get(with(HashUtils.digest(idTokenHint)));
                     will(returnValue(null));
+                    one(oidcServerConfig).getIdTokenSigningAlgValuesSupported();
+                    will(returnValue("HS256"));
                     one(oauth20Provider).getClientProvider();
                     will(returnValue(oidcoauth20clientprovider));
                     one(oidcoauth20clientprovider).get(with(clientId));

--- a/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/OidcRpInitiatedLogoutTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/OidcRpInitiatedLogoutTest.java
@@ -346,6 +346,8 @@ public class OidcRpInitiatedLogoutTest {
                     will(returnValue(oauth20clientprovider));
                     one(oauth20tokencache).get(with(HashUtils.digest(idTokenHint)));
                     will(returnValue(null));
+                    one(oidcServerConfig).getIdTokenSigningAlgValuesSupported();
+                    will(returnValue("HS256"));
                     allowing(principal).getName();
                     will(returnValue(IDTokenUtil.KEY_STRING));
                     one(oauth20Provider).isTrackOAuthClients();


### PR DESCRIPTION
Adds support for verifying ID tokens signed using asymmetric algorithms that are passed in the `id_token_hint` parameter for end_session and authorization endpoint requests.

For #17842