### PR TITLE
Remove restConnector from jakarta ee 10 convenience feature.

### DIFF
--- a/dev/build.image/profiles/jakartaee10/features.xml
+++ b/dev/build.image/profiles/jakartaee10/features.xml
@@ -4,6 +4,7 @@
 <feature>monitor-1.0</feature>
 <feature>ldapRegistry-3.0</feature>
 <feature>localConnector-1.0</feature>
+<feature>restConnector-2.0</feature>
 <feature>transportSecurity-1.0</feature>
 <feature>sessionCache-1.0</feature>
 <feature>sessionDatabase-1.0</feature>

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-10.0/io.openliberty.jakartaee-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-10.0/io.openliberty.jakartaee-10.0.feature
@@ -7,7 +7,6 @@ IBM-ShortName: jakartaee-10.0
 Subsystem-Version: 10.0.0
 Subsystem-Name: Jakarta EE Platform 10.0
 -features=io.openliberty.mail-2.1, \
-  com.ibm.websphere.appserver.restConnector-2.0, \
   io.openliberty.messagingClient-3.0, \
   io.openliberty.connectors-2.1, \
   com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \


### PR DESCRIPTION
Someone erroneously added restConnector-2.0 to the jakartaee-9.1 convenience feature and that got carried over into jakartaee-10.0 feature as well.  This fixes jakartaee-10.0 convenience feature.  It cannot be changed in jakartaee-9.1 because it would break zero migration.


#build