### PR TITLE
LibertyServer debug and JPA Checkpoint FAT assertion

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/fat/src/com/ibm/ws/jpa/tests/container/checkpoint/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/fat/src/com/ibm/ws/jpa/tests/container/checkpoint/tests/AbstractFATSuite.java
@@ -13,21 +13,14 @@
 
 package com.ibm.ws.jpa.tests.container.checkpoint.tests;
 
-import org.junit.ClassRule;
-import org.testcontainers.containers.JdbcDatabaseContainer;
-
 import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 
 import componenttest.containers.TestContainerSuite;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 public class AbstractFATSuite extends TestContainerSuite {
     public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
                                                 "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
 
     public static String repeatPhase = "";
 

--- a/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/fat/src/com/ibm/ws/jpa/tests/container/checkpoint/tests/JPADataSourceCheckpointTest_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/fat/src/com/ibm/ws/jpa/tests/container/checkpoint/tests/JPADataSourceCheckpointTest_EJB.java
@@ -332,7 +332,7 @@ public class JPADataSourceCheckpointTest_EJB extends JPAFATServletClient {
         try {
             if (CheckpointPhase.INACTIVE.equals(checkpointPhase)) {
                 // Verify that the server application started
-                Assert.assertNotNull(appName + " was expected to start, but did not", server.waitForStringInTraceUsingMark(MSG_APP_START));
+                Assert.assertNotNull(appName + " was expected to start, but did not", server.waitForStringInLog(MSG_APP_START, server.getDefaultTraceFile()));
                 // Make sure that the checkpoint was not requested
                 Assert.assertTrue("Expected a server checkpoint to be requested, but it was not", server.findStringsInTrace(MSG_CHECKPOINT).isEmpty());
                 // Verify that the application didn't restart after checkpoint
@@ -359,7 +359,7 @@ public class JPADataSourceCheckpointTest_EJB extends JPAFATServletClient {
                 Assert.assertTrue("Application restarted unexpectedly", server.findStringsInLogsUsingMark(MSG_APP_RESTART, server.getDefaultTraceFile()).isEmpty());
             } else {
                 // Verify that the server application started
-                Assert.assertNotNull(appName + " was expected to start, but did not", server.waitForStringInTraceUsingMark(MSG_APP_START));
+                Assert.assertNotNull(appName + " was expected to start, but did not", server.waitForStringInLog(MSG_APP_START, server.getDefaultTraceFile()));
                 // Make sure that the checkpoint was requested
                 Assert.assertFalse("Expected a server checkpoint to be requested, but it was not", server.findStringsInTrace(MSG_CHECKPOINT).isEmpty());
                 // Verify that the application didn't restart after checkpoint

--- a/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/fat/src/com/ibm/ws/jpa/tests/container/checkpoint/tests/JPADataSourceCheckpointTest_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/fat/src/com/ibm/ws/jpa/tests/container/checkpoint/tests/JPADataSourceCheckpointTest_Web.java
@@ -241,7 +241,7 @@ public class JPADataSourceCheckpointTest_Web extends JPAFATServletClient {
         try {
             if (CheckpointPhase.INACTIVE.equals(checkpointPhase)) {
                 // Verify that the server application started
-                Assert.assertNotNull(appName + " was expected to start, but did not", server.waitForStringInTraceUsingMark(MSG_APP_START));
+                Assert.assertNotNull(appName + " was expected to start, but did not", server.waitForStringInLog(MSG_APP_START, server.getDefaultTraceFile()));
                 // Make sure that the checkpoint was not requested
                 Assert.assertTrue("Expected a server checkpoint to be requested, but it was not", server.findStringsInTrace(MSG_CHECKPOINT).isEmpty());
                 // Verify that the application didn't restart after checkpoint
@@ -268,7 +268,7 @@ public class JPADataSourceCheckpointTest_Web extends JPAFATServletClient {
                 Assert.assertTrue("Application restarted unexpectedly", server.findStringsInLogsUsingMark(MSG_APP_RESTART, server.getDefaultTraceFile()).isEmpty());
             } else {
                 // Verify that the server application started
-                Assert.assertNotNull(appName + " was expected to start, but did not", server.waitForStringInTraceUsingMark(MSG_APP_START));
+                Assert.assertNotNull(appName + " was expected to start, but did not", server.waitForStringInLog(MSG_APP_START, server.getDefaultTraceFile()));
                 // Make sure that the checkpoint was requested
                 Assert.assertFalse("Expected a server checkpoint to be requested, but it was not", server.findStringsInTrace(MSG_CHECKPOINT).isEmpty());
                 // Verify that the application didn't restart after checkpoint

--- a/dev/com.ibm.ws.jpa.tests.container.checkpoint_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.container.checkpoint_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0, checkpoint-1.0
+#tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0, checkpoint-1.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.jpa.tests.container.checkpoint_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.container.checkpoint_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0, checkpoint-1.0
+#tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0, checkpoint-1.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.jpa.tests.container.checkpoint_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.container.checkpoint_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0, checkpoint-1.0
+#tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0, checkpoint-1.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.jpa.tests.container.checkpoint_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.container.checkpoint_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0, checkpoint-1.0
+#tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0, checkpoint-1.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3782,6 +3782,7 @@ public class LibertyServer implements LogMonitorClient {
 
     public RemoteFile getMostRecentTraceFile() throws Exception {
         List<String> files = listDirectoryContents(logsRoot, DEFAULT_TRACE_FILE_PREFIX);
+        Log.debug(c, "Current list of trace logs: " + files);
 
         if (files == null || files.isEmpty()) {
             return null;
@@ -3789,10 +3790,14 @@ public class LibertyServer implements LogMonitorClient {
 
         RemoteFile rf = null;
         long maxLastModified = 0;
+        int nameLength = 0;
         for (int i = 0; i < files.size(); i++) {
             final RemoteFile f = getTraceFile(files.get(i));
-            if (f.lastModified() > maxLastModified) {
+            Log.debug(c, "Trace file " + f + "[modified: " + f.lastModified() + "]");
+            if (f.lastModified() > maxLastModified ||
+                f.lastModified() == maxLastModified && f.getName().length() < nameLength) {
                 maxLastModified = f.lastModified();
+                nameLength = f.getName().length();
                 rf = f;
             }
         }


### PR DESCRIPTION
Added some debug trace to `componenttest.topology.impl.LibertyServer.getMostRecentTraceFile()` because there may be a bug with `java.io.File.lastModified()` on DB2 iSeries.

Changed JPA checkpoint assertion to use `componenttest.topology.impl.LibertyServer.waitForStringInLog()`. It seems like there may be a bug as stated above when Checkpoint splits the trace.log. The assertion is really just wanting to look in `trace.log`, so I changed it to just look in the default trace file

https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions

