### PR TITLE
Revert "mpTelemetry-1.0 supersedes all open tracing features"

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-1.0/com.ibm.websphere.appserver.mpOpenTracing-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-1.0/com.ibm.websphere.appserver.mpOpenTracing-1.0.feature
@@ -19,4 +19,3 @@ IBM-API-Package: \
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
-superseded-by=mpTelemetry-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-1.1/com.ibm.websphere.appserver.mpOpenTracing-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-1.1/com.ibm.websphere.appserver.mpOpenTracing-1.1.feature
@@ -19,4 +19,3 @@ IBM-API-Package: \
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
-superseded-by=mpTelemetry-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-1.2/com.ibm.websphere.appserver.mpOpenTracing-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-1.2/com.ibm.websphere.appserver.mpOpenTracing-1.2.feature
@@ -19,4 +19,3 @@ IBM-API-Package: \
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
-superseded-by=mpTelemetry-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-1.3/com.ibm.websphere.appserver.mpOpenTracing-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-1.3/com.ibm.websphere.appserver.mpOpenTracing-1.3.feature
@@ -18,4 +18,3 @@ IBM-API-Package: \
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
-superseded-by=mpTelemetry-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-2.0/com.ibm.websphere.appserver.mpOpenTracing-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-2.0/com.ibm.websphere.appserver.mpOpenTracing-2.0.feature
@@ -18,4 +18,3 @@ kind=ga
 edition=core
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
-superseded-by=mpTelemetry-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-3.0/io.openliberty.mpOpenTracing-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-3.0/io.openliberty.mpOpenTracing-3.0.feature
@@ -37,4 +37,3 @@ kind=ga
 edition=core
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
-superseded-by=mpTelemetry-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.0/com.ibm.websphere.appserver.opentracing-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.0/com.ibm.websphere.appserver.opentracing-1.0.feature
@@ -24,4 +24,3 @@ IBM-API-Package: io.opentracing;  type="third-party",\
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
-superseded-by=mpTelemetry-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.1/com.ibm.websphere.appserver.opentracing-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.1/com.ibm.websphere.appserver.opentracing-1.1.feature
@@ -25,4 +25,3 @@ IBM-API-Package: io.opentracing;  type="third-party",\
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
-superseded-by=mpTelemetry-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.2/com.ibm.websphere.appserver.opentracing-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.2/com.ibm.websphere.appserver.opentracing-1.2.feature
@@ -26,4 +26,3 @@ IBM-API-Package: io.opentracing;  type="third-party",\
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
-superseded-by=mpTelemetry-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.3/com.ibm.websphere.appserver.opentracing-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.3/com.ibm.websphere.appserver.opentracing-1.3.feature
@@ -29,4 +29,3 @@ IBM-API-Package: io.opentracing;  type="third-party",\
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
-superseded-by=mpTelemetry-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-2.0/com.ibm.websphere.appserver.opentracing-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-2.0/com.ibm.websphere.appserver.opentracing-2.0.feature
@@ -30,4 +30,3 @@ kind=ga
 edition=core
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
-superseded-by=mpTelemetry-1.0


### PR DESCRIPTION
We decided that the open tracing features would not be superseded, only stabilized.
