### PR TITLE
Fixes #24565 - handle exception for getUserRegistry api call

### DIFF
--- a/dev/com.ibm.websphere.security.impl/src/com/ibm/ws/security/intfc/internal/WSSecurityServiceImpl.java
+++ b/dev/com.ibm.websphere.security.impl/src/com/ibm/ws/security/intfc/internal/WSSecurityServiceImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -117,7 +117,7 @@ public class WSSecurityServiceImpl implements WSSecurityService {
      */
     @Override
     public boolean isRealmInboundTrusted(String inboundRealm, String localRealm) {
-        final String METHOD = "getInboundTrustedRealms";
+        final String METHOD = "isRealmInboundTrusted";
         if (inboundRealm == null)
             return false;
         boolean trusted = true;
@@ -156,7 +156,7 @@ public class WSSecurityServiceImpl implements WSSecurityService {
      * @throws WSSecurityException
      */
     private UserRegistry getActiveUserRegistry() throws WSSecurityException {
-        final String METHOD = "getUserRegistry";
+        final String METHOD = "getActiveUserRegistry";
         UserRegistry activeUserRegistry = null;
         try {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -185,7 +185,13 @@ public class WSSecurityServiceImpl implements WSSecurityService {
                 }
             }
         } catch (RegistryException e) {
-            String msg = "getUserRegistryWrapper failed due to an internal error: " + e.getMessage();
+            String msg = METHOD + " failed due to an internal error: " + e.getMessage();
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, msg, e);
+            }
+            throw new WSSecurityException(msg, e);
+        } catch (IllegalStateException e) {
+            String msg = METHOD + " failed due to an internal error: " + e.getMessage();
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, msg, e);
             }

--- a/dev/com.ibm.websphere.security.impl/test/com/ibm/wsspi/security/registry/RegistryHelperTest.java
+++ b/dev/com.ibm.websphere.security.impl/test/com/ibm/wsspi/security/registry/RegistryHelperTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -99,6 +99,21 @@ public class RegistryHelperTest {
             }
         });
         RegistryHelper.getUserRegistry(null);
+    }
+
+    /**
+     * Test method for {@link com.ibm.wsspi.security.registry.RegistryHelper#getUserRegistry(java.lang.String)}.
+     */
+    @Test
+    public void getUserRegistry_null() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(wsSecurityService).getUserRegistry(null);
+                will(returnValue(null));
+            }
+        });
+        assertNull("Null is expected when a userRegistry is not configured",
+                   RegistryHelper.getUserRegistry(null));
     }
 
     /**

--- a/dev/com.ibm.ws.security.registry/src/com/ibm/ws/security/registry/internal/UserRegistryServiceImpl.java
+++ b/dev/com.ibm.ws.security.registry/src/com/ibm/ws/security/registry/internal/UserRegistryServiceImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -398,7 +398,7 @@ public class UserRegistryServiceImpl implements UserRegistryService, ServiceProp
      */
     private UserRegistry autoDetectUserRegistry(boolean exceptionOnError) throws RegistryException {
         // Determine if there is a federation registry configured.
-        UserRegistry ur = getFederationRegistry(exceptionOnError);
+        UserRegistry ur = getFederationRegistry();
         synchronized (userRegistrySync) {
             if (ur != null) {
                 setRegistriesToBeFederated((FederationRegistry) ur, exceptionOnError);
@@ -441,7 +441,7 @@ public class UserRegistryServiceImpl implements UserRegistryService, ServiceProp
      * @throws RegistryException
      *
      */
-    private UserRegistry getFederationRegistry(boolean exceptionOnError) throws RegistryException {
+    private UserRegistry getFederationRegistry() throws RegistryException {
         return federationRegistryServiceRef.getService();
     }
 

--- a/dev/com.ibm.ws.security/src/com/ibm/ws/security/internal/SecurityServiceImpl.java
+++ b/dev/com.ibm.ws.security/src/com/ibm/ws/security/internal/SecurityServiceImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -399,6 +399,8 @@ public class SecurityServiceImpl implements SecurityService, ServicePropertySupp
      * @param serviceName name of the service
      * @param map         ConcurrentServiceReferenceMap of registered services
      * @return id of the single service registered in map. Will not return null.
+     *
+     * @throws IllegalStateException
      */
     private <V> V autoDetectService(String serviceName, ConcurrentServiceReferenceMap<String, V> map) {
         Iterator<V> services = map.getServices();
@@ -534,7 +536,11 @@ public class SecurityServiceImpl implements SecurityService, ServicePropertySupp
         return service;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalStateException
+     */
     @Override
     public UserRegistryService getUserRegistryService() {
         UserRegistryService service = userRegistryService.get();


### PR DESCRIPTION
Fixes #24565 

In rare circumstances the following API call `RegistryHelper.getUserRegistry(null)` can throw an `IllegalStateException`.  

 According to the javadoc for the api method, throwing an `IllegalStateException` is not valid. Instead it should be cast as a `WSSecurityException` to indicate there has been an internal error.
 
 ## Javadoc:
 > ### public static UserRegistry getUserRegistry​(java.lang.String realmName) throws WSSecurityException
> 
> Gets the UserRegistry object for the given realm. If the realm name is null returns the active registry. If the realm is not valid, or security is not enabled, or no registry is configured, returns null.
>
> **Parameters:** realmName - 
> **Returns:** UserRegistry object
> **Throws:** WSSecurityException - if there is an internal error
