### PR TITLE
Add RESTEASY 3283 fix to liberty's RestEasy code

### DIFF
--- a/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ bVersion=1.0
 src: \
 	fat/src
 
-tested.features=webprofile-10.0
+tested.features=webprofile-10.0, microprofile-6.0
 
 fat.project: true
 

--- a/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/fat/src/io/openliberty/jakarta/rest31/tck/JakartaRest31TckPackageTest.java
+++ b/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/fat/src/io/openliberty/jakarta/rest31/tck/JakartaRest31TckPackageTest.java
@@ -56,7 +56,8 @@ public class JakartaRest31TckPackageTest {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification().
         andWith(new FeatureReplacementAction().removeFeatures(featuresToRemove).addFeature("webProfile-10.0").withID("webProfile").fullFATOnly()).
-        andWith(new FeatureReplacementAction().removeFeatures(featuresToRemove).withID("coreProfile").fullFATOnly());
+        andWith(new FeatureReplacementAction().removeFeatures(featuresToRemove).withID("coreProfile").fullFATOnly()).
+        andWith(new FeatureReplacementAction().removeFeatures(featuresToRemove).addFeature("microProfile-6.0").withID("microProfile").fullFATOnly());
 
     @Server("FATServer")
     public static LibertyServer server;
@@ -87,7 +88,7 @@ public class JakartaRest31TckPackageTest {
             // following property is being added to exclude those tests.
             if (RepeatTestFilter.isRepeatActionActive("webProfile")) {
                 props.put("excludedGroups","se_bootstrap,xml_binding");
-            } else if (RepeatTestFilter.isRepeatActionActive("coreProfile")) {
+            } else if (RepeatTestFilter.isRepeatActionActive("coreProfile") || RepeatTestFilter.isRepeatActionActive("microProfile")) {
                 props.put("excludedGroups","se_bootstrap,xml_binding,servlet,security");
             } else {
                 props.put("excludedGroups","se_bootstrap");

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/ResourceLocatorInvoker.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/ResourceLocatorInvoker.java
@@ -186,11 +186,15 @@ public class ResourceLocatorInvoker implements ResourceInvoker
             methodStatisticsLogger.duration(timeStamp);
          }
       }
-      else
+      else if (invoker instanceof ResourceMethodInvoker) // Liberty change
       {
          ResourceMethodInvoker method = (ResourceMethodInvoker) invoker;
          return method.invoke(request, response, target);
       }
+      else // Liberty change begin
+      {
+          return (BuiltResponse) invoker.invoke(request, response, target);
+      } // Liberty change end
    }
 
    public void setMethodStatisticsLogger(MethodStatisticsLogger msLogger) {

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/ResourceLocatorInvoker.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/ResourceLocatorInvoker.java
@@ -1,0 +1,203 @@
+package org.jboss.resteasy.core;
+
+import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.specimpl.BuiltResponse;
+import org.jboss.resteasy.specimpl.ResteasyUriInfo;
+import org.jboss.resteasy.spi.ApplicationException;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.InjectorFactory;
+import org.jboss.resteasy.spi.InternalServerErrorException;
+import org.jboss.resteasy.spi.MethodInjector;
+import org.jboss.resteasy.spi.ResourceFactory;
+import org.jboss.resteasy.spi.ResourceInvoker;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.metadata.ResourceLocator;
+import org.jboss.resteasy.spi.statistics.MethodStatisticsLogger;
+import org.jboss.resteasy.statistics.StatisticsControllerImpl;
+import org.jboss.resteasy.util.GetRestful;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Produces;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class ResourceLocatorInvoker implements ResourceInvoker
+{
+   protected InjectorFactory injector;
+   protected MethodInjector methodInjector;
+   protected ResourceFactory resource;
+   protected ResteasyProviderFactory providerFactory;
+   protected ResourceLocator method;
+   protected ConcurrentHashMap<Class<?>, LocatorRegistry> cachedSubresources = new ConcurrentHashMap<Class<?>, LocatorRegistry>();
+   protected final boolean hasProduces;
+   protected MethodStatisticsLogger methodStatisticsLogger;
+
+   public ResourceLocatorInvoker(final ResourceFactory resource, final InjectorFactory injector, final ResteasyProviderFactory providerFactory, final ResourceLocator locator)
+   {
+      this.resource = resource;
+      this.injector = injector;
+      this.providerFactory = providerFactory;
+      this.method = locator;
+      this.methodInjector = injector.createMethodInjector(locator, providerFactory);
+      hasProduces = method.getMethod().isAnnotationPresent(Produces.class) || method.getMethod().getClass().isAnnotationPresent(Produces.class);
+      methodStatisticsLogger = StatisticsControllerImpl.EMPTY;
+   }
+
+   @Override
+   public boolean hasProduces() {
+      return hasProduces;
+   }
+
+
+   @SuppressWarnings("unchecked")
+   protected Object resolveTarget(HttpRequest request, HttpResponse response)
+   {
+      Object locatorResource = this.resource.createResource(request, response, providerFactory);
+      if (locatorResource instanceof CompletionStage) {
+         CompletionStage<Object> locatorStage = (CompletionStage<Object>)locatorResource;
+         return locatorStage
+                 .thenCompose(resource -> {
+                    Object located = resolveTargetFromLocator(request, response, resource);
+                    if (located instanceof CompletionStage) {
+                       return (CompletionStage<Object>)located;
+                    } else {
+                       return CompletableFuture.completedFuture(located);
+                    }
+                 });
+      } else {
+         return resolveTargetFromLocator(request, response, locatorResource);
+
+      }
+   }
+
+   protected Object resolveTargetFromLocator(HttpRequest request, HttpResponse response, Object locator)
+   {
+      ResteasyUriInfo uriInfo = (ResteasyUriInfo)request.getUri();
+      RuntimeException lastException = (RuntimeException)request.getAttribute(ResourceMethodRegistry.REGISTRY_MATCHING_EXCEPTION);
+      Object obj = methodInjector.injectArguments(request, response);
+      if (obj == null || !(obj instanceof CompletionStage)) {
+         return constructLocator(locator, uriInfo, (Object[])obj);
+      }
+      @SuppressWarnings("unchecked")
+      CompletionStage<Object[]> stagedArgs = (CompletionStage<Object[]>)obj;
+
+      return stagedArgs.exceptionally(t -> {
+            if(t.getCause() instanceof NotFoundException && lastException != null)
+               throw lastException;
+            SynchronousDispatcher.rethrow(t);
+            // never reached
+            return null;
+         }).thenApply(args -> {
+         return constructLocator(locator, uriInfo, args);
+      });
+   }
+
+   private Object constructLocator(Object locator, ResteasyUriInfo uriInfo, Object[] args) {
+      try
+      {
+         uriInfo.pushCurrentResource(locator);
+         Object subResource = method.getMethod().invoke(locator, args);
+         if (subResource instanceof Class)
+         {
+            subResource = this.providerFactory.injectedInstance((Class<?>)subResource);
+         }
+         return subResource;
+
+      }
+      catch (IllegalAccessException e)
+      {
+         throw new InternalServerErrorException(e);
+      }
+      catch (InvocationTargetException e)
+      {
+         throw new ApplicationException(e.getCause());
+      }
+      catch (SecurityException e)
+      {
+         throw new ApplicationException(e.getCause());
+      }
+   }
+
+   public Method getMethod()
+   {
+      return method.getMethod();
+   }
+
+   @SuppressWarnings("unchecked")
+   public BuiltResponse invoke(HttpRequest request, HttpResponse response)
+   {
+      Object resource = resolveTarget(request, response);
+      if (resource instanceof CompletionStage) {
+         return ((CompletionStage<Object>)resource).thenApply(target -> invokeOnTargetObject(request, response, target)).toCompletableFuture().getNow(null);
+      }
+      return invokeOnTargetObject(request, response, resource);
+
+   }
+
+   @SuppressWarnings("unchecked")
+   public BuiltResponse invoke(HttpRequest request, HttpResponse response, Object locator)
+   {
+      Object resource = resolveTargetFromLocator(request, response, locator);
+      if (resource instanceof CompletionStage) {
+         return ((CompletionStage<Object>)resource).thenApply(target -> invokeOnTargetObject(request, response, target)).toCompletableFuture().getNow(null);
+      }
+      return invokeOnTargetObject(request, response, resource);
+
+   }
+
+   protected BuiltResponse invokeOnTargetObject(HttpRequest request, HttpResponse response, Object target)
+   {
+      if (target == null)
+      {
+         NotFoundException notFound = new NotFoundException(Messages.MESSAGES.nullSubresource(request.getUri().getAbsolutePath()));
+         throw notFound;
+      }
+      Class<? extends Object> clazz = target.getClass();
+      LocatorRegistry registry = cachedSubresources.get(clazz);
+      if (registry == null)
+      {
+         if (!GetRestful.isSubResourceClass(clazz))
+         {
+            String msg = Messages.MESSAGES.subresourceHasNoJaxRsAnnotations(clazz.getName());
+            throw new InternalServerErrorException(msg);
+         }
+         registry = new LocatorRegistry(clazz, providerFactory);
+         cachedSubresources.putIfAbsent(clazz, registry);
+      }
+      ResourceInvoker invoker = registry.getResourceInvoker(request);
+      if (invoker instanceof ResourceLocatorInvoker)
+      {
+         ResourceLocatorInvoker locator = (ResourceLocatorInvoker) invoker;
+         final long timeStamp = methodStatisticsLogger.timestamp();
+
+         try
+         {
+            return locator.invoke(request, response, target);
+         } finally
+         {
+            methodStatisticsLogger.duration(timeStamp);
+         }
+      }
+      else
+      {
+         ResourceMethodInvoker method = (ResourceMethodInvoker) invoker;
+         return method.invoke(request, response, target);
+      }
+   }
+
+   public void setMethodStatisticsLogger(MethodStatisticsLogger msLogger) {
+      methodStatisticsLogger = msLogger;
+   }
+
+   public MethodStatisticsLogger getMethodStatisticsLogger() {
+      return methodStatisticsLogger;
+   }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/registry/ConstantResourceInvoker.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/registry/ConstantResourceInvoker.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.core.registry;
+
+import java.lang.reflect.Method;
+
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.ResourceInvoker;
+import org.jboss.resteasy.spi.statistics.MethodStatisticsLogger;
+
+/**
+ * A resource invoker which simply returns the given response.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class ConstantResourceInvoker implements ResourceInvoker {
+    private final Response response;
+    private volatile MethodStatisticsLogger logger;
+
+    ConstantResourceInvoker(final Response response) {
+        this.response = response;
+    }
+
+    @Override
+    public Response invoke(final HttpRequest request, final HttpResponse response) {
+        return this.response;
+    }
+
+    @Override
+    public Response invoke(final HttpRequest request, final HttpResponse response, final Object target) {
+        return this.response;
+    }
+
+    @Override
+    public Method getMethod() {
+        return null;
+    }
+
+    @Override
+    public boolean hasProduces() {
+        return false;
+    }
+
+    @Override
+    public void setMethodStatisticsLogger(final MethodStatisticsLogger msLogger) {
+        this.logger = msLogger;
+    }
+
+    @Override
+    public MethodStatisticsLogger getMethodStatisticsLogger() {
+        return logger;
+    }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/registry/SegmentNode.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/registry/SegmentNode.java
@@ -1,0 +1,574 @@
+package org.jboss.resteasy.core.registry;
+
+import org.jboss.resteasy.core.ResourceLocatorInvoker;
+import org.jboss.resteasy.core.ResourceMethodInvoker;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.specimpl.ResteasyUriInfo;
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
+import org.jboss.resteasy.spi.DefaultOptionsMethodException;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponseCodes;
+import org.jboss.resteasy.spi.ResourceInvoker;
+import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
+import org.jboss.resteasy.util.HttpHeaderNames;
+import org.jboss.resteasy.util.WeightedMediaType;
+
+import jakarta.ws.rs.NotAcceptableException;
+import jakarta.ws.rs.NotAllowedException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class SegmentNode
+{
+   public static final String RESTEASY_CHOSEN_ACCEPT = "RESTEASY_CHOSEN_ACCEPT";
+   public static final String RESTEASY_SERVER_HAS_PRODUCES = "RESTEASY-SERVER-HAS-PRODUCES";
+   public static final String RESTEASY_SERVER_HAS_PRODUCES_LC = RESTEASY_SERVER_HAS_PRODUCES.toLowerCase();
+   public static final MediaType[] WILDCARD_ARRAY = {MediaType.WILDCARD_TYPE};
+   public static final List<MediaType> DEFAULT_ACCEPTS = new ArrayList<MediaType>();
+
+   static
+   {
+      DEFAULT_ACCEPTS.add(MediaType.WILDCARD_TYPE);
+   }
+   protected String segment;
+   protected Map<String, SegmentNode> children = new HashMap<String, SegmentNode>();
+   protected List<MethodExpression> targets = new ArrayList<MethodExpression>();
+
+   public SegmentNode(final String segment)
+   {
+      this.segment = segment;
+   }
+
+   protected static class Match
+   {
+      MethodExpression expression;
+      Matcher matcher;
+
+      public Match(final MethodExpression expression, final Matcher matcher)
+      {
+         this.expression = expression;
+         this.matcher = matcher;
+      }
+   }
+
+   public MatchCache match(HttpRequest request, int start)
+   {
+      String path = ((ResteasyUriInfo) request.getUri()).getMatchingPath();
+      RESTEasyTracingLogger logger = RESTEasyTracingLogger.getInstance(request);
+      logger.log("MATCH_PATH_FIND", ((ResteasyUriInfo)request.getUri()).getMatchingPath());
+
+      if (start < path.length() && path.charAt(start) == '/') start++;
+      List<MethodExpression> potentials = new ArrayList<MethodExpression>();
+      potentials(path, start, potentials);
+      Collections.sort(potentials);
+
+      boolean expressionMatched = false;
+      List<Match> matches = new ArrayList<Match>();
+      for (MethodExpression expression : potentials)
+      {
+         // We ignore locators if the first match was a resource method as per the spec Section 3, Step 2(h)
+         if (expressionMatched && expression.isLocator()) {
+            logger.log("MATCH_PATH_SKIPPED", expression.getRegex());
+            continue;
+         }
+
+         Pattern pattern = expression.getPattern();
+         Matcher matcher = pattern.matcher(path);
+         matcher.region(start, path.length());
+
+         if (matcher.matches())
+         {
+            expressionMatched = true;
+            ResourceInvoker invoker = expression.getInvoker();
+            if (invoker instanceof ResourceLocatorInvoker)
+            {
+               MatchCache ctx = new MatchCache();
+               ctx.invoker = invoker;
+               ResteasyUriInfo uriInfo = (ResteasyUriInfo) request.getUri();
+               int length = matcher.start(expression.getNumGroups() + 1);
+               if (length == -1)
+               {
+                  uriInfo.pushMatchedPath(path);
+                  uriInfo.pushMatchedURI(path);
+               }
+               else
+               {
+                  // must find the end of the matched pattern
+                  // and get the substring from 1st char thru end
+                  // of matched chars
+                  Pattern p = expression.getPattern();
+                  Matcher m = p.matcher(path);
+                  m.region(start, path.length());
+                  String substring = path;
+                  while(m.find()) {
+                     String endText = m.group(m.groupCount());
+                     if (endText != null && !endText.isEmpty()) {
+                        int indx = path.indexOf(endText, length);
+                        if (indx > -1) {
+                           substring = path.substring(0, indx);
+                        }
+                     }
+                  }
+
+                  uriInfo.pushMatchedPath(substring);
+                  uriInfo.pushMatchedURI(substring);
+               }
+               expression.populatePathParams(request, matcher, path);
+               logger.log("MATCH_LOCATOR", invoker.getMethod());
+               return ctx;
+            }
+            else
+            {
+
+               matches.add(new Match(expression, matcher));
+            }
+         } else {
+            logger.log("MATCH_PATH_NOT_MATCHED", expression.getRegex());
+         }
+      }
+      if (matches.size() == 0)
+      {
+         throw new NotFoundException(Messages.MESSAGES.couldNotFindResourceForFullPath(request.getUri().getRequestUri()));
+      }
+      MatchCache match = match(matches, request.getHttpMethod(), request);
+      match.match.expression.populatePathParams(request, match.match.matcher, path);
+      logger.log("MATCH_PATH_SELECTED", match.match.expression.getRegex());
+      return match;
+
+   }
+
+   public void potentials(String path, int start, List<MethodExpression> matches)
+   {
+      if (start == path.length()) // we've reached end of string
+      {
+         matches.addAll(targets);
+         return;
+      }
+
+      if (start < path.length())
+      {
+         String simpleSegment = null;
+         int endOfSegmentIndex = path.indexOf('/', start);
+         if (endOfSegmentIndex > -1) simpleSegment = path.substring(start, endOfSegmentIndex);
+         else simpleSegment = path.substring(start);
+         SegmentNode child = children.get(simpleSegment);
+         if (child != null)
+         {
+            int next = start + simpleSegment.length();
+            if (endOfSegmentIndex > -1) next++; // go past '/'
+            child.potentials(path, next, matches);
+         }
+      }
+      for (MethodExpression exp : targets)
+      {
+         // skip any static matches as they will not match anyways
+         if (exp.getNumGroups() > 0 || exp.getInvoker() instanceof ResourceLocatorInvoker)
+         {
+            matches.add(exp);
+         }
+      }
+   }
+
+   public static class SortFactor
+   {
+      public float q = 1.0f;
+      public float qs = 1.0f;
+      public int d;
+      public int dm;
+      public String type;
+      public String subtype;
+      public Map<String, String> params;
+
+      public boolean isWildcardType()
+      {
+         return type.equals(MediaType.MEDIA_TYPE_WILDCARD);
+      }
+      public boolean isWildcardSubtype()
+      {
+         return subtype.equals(MediaType.MEDIA_TYPE_WILDCARD);
+      }
+
+   }
+
+   public static SortFactor createSortFactor(MediaType client, MediaType server)
+   {
+      SortFactor sortFactor = new SortFactor();
+      if (client.isWildcardType() != server.isWildcardType())
+      {
+         sortFactor.type = (client.isWildcardType()) ? server.getType() : client.getType();
+         sortFactor.d++;
+      }
+      else
+      {
+         sortFactor.type = client.getType();
+      }
+      if (client.isWildcardSubtype() != server.isWildcardSubtype())
+      {
+         sortFactor.subtype = (client.isWildcardSubtype()) ? server.getSubtype() : client.getSubtype();
+         sortFactor.d++;
+      }
+      else
+      {
+         sortFactor.subtype = client.getSubtype();
+      }
+      String q = client.getParameters().get("q");
+      if (q != null) sortFactor.q = Float.parseFloat(q);
+      String qs = server.getParameters().get("qs");
+      if (qs != null) sortFactor.qs = Float.parseFloat(qs);
+
+      sortFactor.dm = 0;
+      for (Map.Entry<String, String> entry : client.getParameters().entrySet())
+      {
+         String name = entry.getKey();
+         if ("q".equals(name)
+                 || "qs".equals(name)) continue;
+         String val = server.getParameters().get(name);
+         if (val == null)
+         {
+            sortFactor.dm++;
+            continue;
+         }
+         if (!val.equals(entry.getValue()))
+         {
+            sortFactor.dm++;
+            continue;
+         }
+      }
+
+      for (Map.Entry<String, String> entry : server.getParameters().entrySet())
+      {
+         String name = entry.getKey();
+         if ("q".equals(name)
+                 || "qs".equals(name)) continue;
+         String val = client.getParameters().get(name);
+         if (val == null)
+         {
+            sortFactor.dm++;
+            continue;
+         }
+         if (!val.equals(entry.getValue()))
+         {
+            sortFactor.dm++;
+            continue;
+         }
+      }
+      return sortFactor;
+   }
+
+   protected class SortEntry implements Comparable<SortEntry>
+   {
+      Match match;
+      MediaType serverProduce;
+      SortFactor consumes;
+      SortFactor produces;
+
+      public SortEntry(final Match match, final SortFactor consumes, final SortFactor produces, final MediaType serverProduce)
+      {
+         this.serverProduce = serverProduce;
+         this.match = match;
+         this.consumes = consumes;
+         this.produces = produces;
+      }
+
+      public MediaType getAcceptType()
+      {
+         // take params from produce and type and subtype from sort factor
+         // to define the returned media type
+         Map<String, String> params = new HashMap<String, String>();
+         for (Map.Entry<String, String> entry : serverProduce.getParameters().entrySet())
+         {
+            String name = entry.getKey();
+            if ("q".equals(name)
+               || "qs".equals(name)) continue;
+            params.put(name, entry.getValue());
+         }
+         if (match.expression.invoker.hasProduces())
+         {
+            params.put(RESTEASY_SERVER_HAS_PRODUCES, "true");
+         }
+         return new MediaType(produces.type, produces.subtype, params);
+      }
+
+
+      @Override
+      public int compareTo(SortEntry o)
+      {
+         if (consumes.isWildcardType() && !o.consumes.isWildcardType()) return 1;
+         if (!consumes.isWildcardType() && o.consumes.isWildcardType()) return -1;
+         if (consumes.isWildcardSubtype() && !o.consumes.isWildcardSubtype()) return 1;
+         if (!consumes.isWildcardSubtype() && o.consumes.isWildcardSubtype()) return -1;
+
+         if (consumes.q > o.consumes.q) return -1;
+         if (consumes.q < o.consumes.q) return 1;
+
+         if (consumes.qs > o.consumes.qs) return -1;
+         if (consumes.qs < o.consumes.qs) return 1;
+
+         if (consumes.d < o.consumes.d) return -1;
+         if (consumes.d > o.consumes.d) return 1;
+
+         if (consumes.dm < o.consumes.dm) return -1;
+         if (consumes.dm > o.consumes.dm) return 1;
+
+         if (produces.isWildcardType() && !o.produces.isWildcardType()) return 1;
+         if (!produces.isWildcardType() && o.produces.isWildcardType()) return -1;
+         if (produces.isWildcardSubtype() && !o.produces.isWildcardSubtype()) return 1;
+         if (!produces.isWildcardSubtype() && o.produces.isWildcardSubtype()) return -1;
+
+         if (produces.q > o.produces.q) return -1;
+         if (produces.q < o.produces.q) return 1;
+
+         if (produces.qs > o.produces.qs) return -1;
+         if (produces.qs < o.produces.qs) return 1;
+
+         if (produces.d < o.produces.d) return -1;
+         if (produces.d > o.produces.d) return 1;
+
+         if (produces.dm < o.produces.dm) return -1;
+         if (produces.dm > o.produces.dm) return 1;
+
+         return match.expression.compareTo(o.match.expression);
+      }
+   }
+
+   public MatchCache match(List<Match> matches, String httpMethod, HttpRequest request)
+   {
+      MediaType contentType = request.getHttpHeaders().getMediaType();
+
+      List<MediaType> requestAccepts = request.getHttpHeaders().getAcceptableMediaTypes();
+      List<WeightedMediaType> weightedAccepts = new ArrayList<WeightedMediaType>();
+      for (MediaType accept : requestAccepts) weightedAccepts.add(WeightedMediaType.parse(accept));
+
+      List<Match> list = new ArrayList<Match>();
+      boolean methodMatch = false;
+      boolean consumeMatch = false;
+
+      // make a list of all compatible ResourceMethods
+      for (Match match : matches)
+      {
+
+         ResourceMethodInvoker invoker = (ResourceMethodInvoker) match.expression.getInvoker();
+         if (invoker.getHttpMethods().contains(httpMethod.toUpperCase()))
+         {
+            methodMatch = true;
+            if (invoker.doesConsume(contentType))
+            {
+               consumeMatch = true;
+               if (invoker.doesProduce(weightedAccepts))
+               {
+                  list.add(match);
+               }
+            }
+
+         }
+      }
+
+      if (list.size() == 0)
+      {
+         if (!methodMatch)
+         {
+            HashSet<String> allowed = new HashSet<String>();
+            for (Match match : matches)
+            {
+               allowed.addAll(((ResourceMethodInvoker) match.expression.getInvoker()).getHttpMethods());
+            }
+
+            if (httpMethod.equalsIgnoreCase("HEAD") && allowed.contains("GET"))
+            {
+               return match(matches, "GET", request);
+            }
+
+            if (allowed.contains("GET")) allowed.add("HEAD");
+            allowed.add("OPTIONS");
+            StringBuilder allowHeaders = new StringBuilder("");
+            boolean first = true;
+            for (String allow : allowed)
+            {
+               if (first) first = false;
+               else allowHeaders.append(", ");
+               allowHeaders.append(allow);
+            }
+            String allowHeaderValue = allowHeaders.toString();
+
+            if (httpMethod.equals("OPTIONS"))
+            {
+
+               ResponseBuilder resBuilder =  Response.ok(allowHeaderValue.toString(),  MediaType.TEXT_PLAIN_TYPE).header(HttpHeaderNames.ALLOW, allowHeaderValue.toString());
+
+               if (allowed.contains("PATCH"))
+               {
+                  Set<MediaType> patchAccepts = new HashSet<MediaType>(8);
+                  for (Match match : matches)
+                  {
+                     if (((ResourceMethodInvoker) match.expression.getInvoker()).getHttpMethods().contains("PATCH"))
+                     {
+                        patchAccepts.addAll(Arrays.asList(((ResourceMethodInvoker) match.expression.getInvoker())
+                              .getConsumes()));
+                     }
+                  }
+                  StringBuilder acceptPatch = new StringBuilder("");
+                  first = true;
+                  for (MediaType mediaType : patchAccepts)
+                  {
+                     if (first)
+                        first = false;
+                     else
+                        acceptPatch.append(", ");
+                     acceptPatch.append(mediaType.toString());
+                  }
+                  resBuilder.header(HttpHeaderNames.ACCEPT_PATCH, acceptPatch.toString());
+               }
+               throw new DefaultOptionsMethodException(Messages.MESSAGES.noResourceMethodFoundForOptions(), resBuilder.build());
+            }
+            else
+            {
+               Response res = Response.status(HttpResponseCodes.SC_METHOD_NOT_ALLOWED).header(HttpHeaderNames.ALLOW, allowHeaderValue).build();
+               throw new NotAllowedException(Messages.MESSAGES.noResourceMethodFoundForHttpMethod(httpMethod), res);
+            }
+         }
+         else if (!consumeMatch)
+         {
+            throw new NotSupportedException(Messages.MESSAGES.cannotConsumeContentType());
+         }
+         throw new NotAcceptableException(Messages.MESSAGES.noMatchForAcceptHeader());
+      }
+      //if (list.size() == 1) return list.get(0); //don't do this optimization as we need to set chosen accept
+      List<SortEntry> sortList = new ArrayList<SortEntry>();
+      for (Match match : list)
+      {
+         ResourceMethodInvoker invoker = (ResourceMethodInvoker) match.expression.getInvoker();
+         if (contentType == null) contentType = MediaType.WILDCARD_TYPE;
+
+         MediaType[] consumes = invoker.getConsumes();
+         if (consumes.length == 0)
+         {
+            consumes = WILDCARD_ARRAY;
+         }
+         MediaType[] produces = invoker.getProduces();
+         if (produces.length == 0)
+         {
+            produces = WILDCARD_ARRAY;
+         }
+         List<SortFactor> consumeCombo = new ArrayList<SortFactor>();
+         for (MediaType consume : consumes)
+         {
+            consumeCombo.add(createSortFactor(contentType, consume));
+         }
+         for (MediaType produce : produces)
+         {
+            List<MediaType> acceptableMediaTypes = requestAccepts;
+            if (acceptableMediaTypes.size() == 0)
+            {
+               acceptableMediaTypes = DEFAULT_ACCEPTS;
+            }
+            for (MediaType accept : acceptableMediaTypes)
+            {
+               if (accept.isCompatible(produce))
+               {
+                  SortFactor sortFactor = createSortFactor(accept, produce);
+
+                  for (SortFactor consume : consumeCombo)
+                  {
+                     sortList.add(new SortEntry(match, consume, sortFactor, produce));
+                  }
+               }
+
+            }
+         }
+      }
+      Collections.sort(sortList);
+
+      SortEntry sortEntry = sortList.get(0);
+
+      String[] mm = matchingMethods(sortList);
+      if (mm != null)
+      {
+         boolean isFailFast = ConfigurationFactory.getInstance().getConfiguration().getOptionalValue(
+                 ResteasyContextParameters.RESTEASY_FAIL_FAST_ON_MULTIPLE_RESOURCES_MATCHING, boolean.class)
+                 .orElse(false);
+         if(isFailFast) {
+            throw new RuntimeException(Messages.MESSAGES
+                    .multipleMethodsMatchFailFast(requestToString(request), mm));
+         } else {
+            LogMessages.LOGGER.multipleMethodsMatch(requestToString(request), mm);
+         }
+      }
+      MediaType acceptType = sortEntry.getAcceptType();
+      request.setAttribute(RESTEASY_CHOSEN_ACCEPT, acceptType);
+      MatchCache ctx =  new MatchCache();
+      ctx.chosen = acceptType;
+      ctx.match = sortEntry.match;
+      ctx.invoker = sortEntry.match.expression.invoker;
+      return ctx;
+   }
+
+   protected void addExpression(MethodExpression expression)
+   {
+      targets.add(expression);
+      Collections.sort(targets);
+
+   }
+
+   private String requestToString(HttpRequest request) {
+      return "\"" + request.getHttpMethod() + " " + request.getUri().getPath() + "\"";
+   }
+
+   private String[] matchingMethods(List<SortEntry> sortList)
+   {
+      Set<Method> s = null;
+      Iterator<SortEntry> it = sortList.iterator();
+      SortEntry a;
+      SortEntry b = it.next();
+      Method first = b.match.expression.getInvoker().getMethod();
+      while (it.hasNext())
+      {
+         a = b;
+         b = it.next();
+         if (a.compareTo(b) == 0)
+         {
+            if (s == null) {
+               s = new HashSet<>();
+               s.add(first);
+            }
+            s.add(b.match.expression.getInvoker().getMethod());
+         }
+         else
+         {
+            break;
+         }
+      }
+      if (s != null && s.size() > 1) {
+         String[] names = new String[s.size()];
+         Iterator<Method> iterator = s.iterator();
+         int i = 0;
+         while (iterator.hasNext())
+         {
+            names[i++] = iterator.next().toString();
+         }
+         return names;
+      }
+      return null;
+   }
+}
+


### PR DESCRIPTION
- Add fix for [RESTEASY 3283](https://issues.redhat.com/browse/RESTEASY-3283) to not throw exception when receiving OPTIONS request with no OPTIONS method on the resource
- Update REST TCK to have a repeat with microProfile-6.0 feature.

https://github.com/resteasy/resteasy/pull/3406/files is the PR I used to get the changes.