### PR TITLE
Rtc293555 jsp osgi

### DIFF
--- a/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdi12JSFServer/server.xml
+++ b/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdi12JSFServer/server.xml
@@ -10,9 +10,4 @@
         <feature>servlet-3.1</feature>
     </featureManager>
 
-    <logging traceSpecification="*=info:logservice=all:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HTTPChannel=all:GenericBNF=all:com.ibm.ws.jsf*=all:com.sun.faces*=all:com.ibm.ws.webcontainer*=all:com.ibm.ws.jsp=all:com.ibm.ws.jsf*=all:org.apache.myfaces*=all:com.ibm.ws.webcontainer*=all:com.ibm.ws.jsp=all"
-		traceFileName="trace.log"
-		maxFileSize="2000"
-		maxFiles="20"/>
-
 </server>

--- a/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdi12JSFWithSharedLibServer/server.xml
+++ b/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdi12JSFWithSharedLibServer/server.xml
@@ -17,9 +17,4 @@
         <fileset dir="${server.config.dir}/InjectionSharedLibrary" includes="sharedLibrary.jar" />
     </library> 
 
-    <logging traceSpecification="*=info:logservice=all:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HTTPChannel=all:GenericBNF=all:com.ibm.ws.jsf*=all:com.sun.faces*=all:com.ibm.ws.webcontainer*=all:com.ibm.ws.jsp=all:com.ibm.ws.jsf*=all:org.apache.myfaces*=all:com.ibm.ws.webcontainer*=all:com.ibm.ws.jsp=all"
-		traceFileName="trace.log"
-		maxFileSize="2000"
-		maxFiles="20"/>
-
 </server>

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webcontainerext/JSPExtensionFactory.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webcontainerext/JSPExtensionFactory.java
@@ -123,7 +123,7 @@ public class JSPExtensionFactory extends AbstractJSPExtensionFactory implements 
      * @param expressionFactoryService
      *            an expressionFactory service to wrap the default ExpressionFactory
      */
-    @Reference(cardinality=ReferenceCardinality.OPTIONAL, policyOption=ReferencePolicyOption.GREEDY)
+    @Reference(cardinality=ReferenceCardinality.OPTIONAL, policyOption=ReferencePolicyOption.GREEDY, policy=ReferencePolicy.DYNAMIC)
     protected void setExpressionFactoryService(ServiceReference<ELFactoryWrapperForCDI> expressionFactoryService) {
         this.expressionFactoryService.setReference(expressionFactoryService);
     }


### PR DESCRIPTION
Should hopefully fix 

https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=293555

and

https://wasrtc.hursley.ibm.com:9443/jazz/resource/itemName/com.ibm.team.workitem.WorkItem/295088

By making the reference dynamic, we stop JSP shutting down. If JSP stays up the app wont wait indefinitely for JSP to start. If the app starts, the test will pass. 