### PR TITLE
Invalid messages will hog thread

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/parser/MessageParser.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/parser/MessageParser.java
@@ -1077,7 +1077,7 @@ public abstract class MessageParser
 			else {
 				dstChar = srcChar;
 			}
-					dest.append(dstChar);
+			dest.append(dstChar);
 		}
 		return 0;
 	}

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/parser/MessageParser.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/parser/MessageParser.java
@@ -959,8 +959,7 @@ public abstract class MessageParser
 	 */
 	private int readLine(byte[] source, int offset, int length, CharsBuffer dest) {
 		final int end = offset + length; // index to one-past source array
-		boolean parsingErrorInReadLine = false;
-		//readlineloop:
+		
 		for (int i = offset; i < end; i++) {
 			byte b = source[i];
 			char srcChar;
@@ -975,13 +974,15 @@ public abstract class MessageParser
 						s_logger.traceFailure(this, "readLine", "Illegal byte value ["
 							+ (int)(b & 255) + ']');
 					}
-					if (!s_acceptNonUtf8ByteSequences) {
-						setError(Response.BAD_REQUEST, "Bad Message. Illegal Character.");
-						break;
-						//return 1000;
-					}
+					
 					value = (int)(b & 255); // 8-bit ascii - not standard
 					size = 1;
+					
+					if (!s_acceptNonUtf8ByteSequences) {
+						setError(Response.BAD_REQUEST, "Bad Message. Illegal Character.");
+						return 1;
+					}
+					
 				}
 				else {
 					value = utf8(source, i, end-i, size);
@@ -994,8 +995,7 @@ public abstract class MessageParser
 						}
 						if (!s_acceptNonUtf8ByteSequences) {
 							setError(Response.BAD_REQUEST, "Bad Message. Illegal Character.");
-							break;
-							//return 1000;
+							return 1;
 						}
 						value = (int)(b & 255); // 8-bit ascii - not standard
 						size = 1;
@@ -1079,11 +1079,7 @@ public abstract class MessageParser
 			}
 					dest.append(dstChar);
 		}
-		//if (parsingErrorInReadLine) {
-		//return 1000;	
-		//} else {
 		return 0;
-		//}
 	}
 
 	/**

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/parser/MessageParser.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/parser/MessageParser.java
@@ -544,6 +544,7 @@ public abstract class MessageParser
 	{
 		line.reset();
 		while (readLine(source, line)) {
+			
 			if (line.getCharCount() == 0) {
 				return true; // found empty line that ends the headers section
 			}
@@ -937,6 +938,7 @@ public abstract class MessageParser
 			// fast-forward source buffer to the end of the line
 			source.rewind(offset + read);
 		}
+		
 		return complete;
 	}
 	
@@ -957,6 +959,8 @@ public abstract class MessageParser
 	 */
 	private int readLine(byte[] source, int offset, int length, CharsBuffer dest) {
 		final int end = offset + length; // index to one-past source array
+		boolean parsingErrorInReadLine = false;
+		//readlineloop:
 		for (int i = offset; i < end; i++) {
 			byte b = source[i];
 			char srcChar;
@@ -968,11 +972,13 @@ public abstract class MessageParser
 				if (size == -1) {
 					// neither utf-8 or 7-bit-ascii
 					if (s_logger.isTraceFailureEnabled()) {
-						s_logger.traceFailure(this, "readLine", "Illgal byte value ["
+						s_logger.traceFailure(this, "readLine", "Illegal byte value ["
 							+ (int)(b & 255) + ']');
 					}
 					if (!s_acceptNonUtf8ByteSequences) {
 						setError(Response.BAD_REQUEST, "Bad Message. Illegal Character.");
+						break;
+						//return 1000;
 					}
 					value = (int)(b & 255); // 8-bit ascii - not standard
 					size = 1;
@@ -983,11 +989,13 @@ public abstract class MessageParser
 						// utf-8 lead byte with no utf-8 trail byte.
 						if (s_logger.isTraceFailureEnabled()) {
 							s_logger.traceFailure(this, "readLine",
-								"Illgal byte value, expected utf-8 trail byte following utf-8 lead byte ["
+								"Illegal byte value, expected utf-8 trail byte following utf-8 lead byte ["
 									+ (int)(b & 255) + ']');
 						}
 						if (!s_acceptNonUtf8ByteSequences) {
 							setError(Response.BAD_REQUEST, "Bad Message. Illegal Character.");
+							break;
+							//return 1000;
 						}
 						value = (int)(b & 255); // 8-bit ascii - not standard
 						size = 1;
@@ -1069,9 +1077,13 @@ public abstract class MessageParser
 			else {
 				dstChar = srcChar;
 			}
-			dest.append(dstChar);
+					dest.append(dstChar);
 		}
+		//if (parsingErrorInReadLine) {
+		//return 1000;	
+		//} else {
 		return 0;
+		//}
 	}
 
 	/**

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transport/connections/SIPConnectionAdapter.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transport/connections/SIPConnectionAdapter.java
@@ -495,18 +495,18 @@ public abstract class SIPConnectionAdapter
 	public boolean shouldDropConnection() {
 		if (m_maxParseErrorsAllowed == NEVER_CLOSE_CONNECTION_ON_A_PARSE_ERROR) {
 			if (c_logger.isTraceDebugEnabled()) {
-				c_logger.traceDebug(this, " shouldDropConnection ", " EYECATCHER: maxParseErrorsAllowed is set to -1, shouldDropConnection will return false" );
+				c_logger.traceDebug(this, " shouldDropConnection ", "maxParseErrorsAllowed is set to -1, shouldDropConnection will return false" );
 			}
 			return false;
 			
 		} else if (m_maxParseErrorsAllowed > NEVER_CLOSE_CONNECTION_ON_A_PARSE_ERROR) {
 			if (c_logger.isTraceDebugEnabled()) {
-				c_logger.traceDebug(this, " shouldDropConnection ", " EYECATCHER: maxParseErrorsAllowed is set to " + m_maxParseErrorsAllowed);
+				c_logger.traceDebug(this, " shouldDropConnection ", "maxParseErrorsAllowed is set to " + m_maxParseErrorsAllowed);
 			}
 	    	synchronized (m_parseErrorsSynchronizer) {
 	    		if (m_numberOfParseErrors > m_maxParseErrorsAllowed) {
 	    			if (c_logger.isTraceDebugEnabled()) {
-	    				c_logger.traceDebug(this, " shouldDropConnection ", " EYECATCHER: number of parse errors is higher than maxParseErrorsAllowed, shouldDropConnection will return true" );
+	    				c_logger.traceDebug(this, " shouldDropConnection ", "number of parse errors is higher than maxParseErrorsAllowed, shouldDropConnection will return true" );
 	    			}
 	    			return true;
 	    		}
@@ -522,13 +522,13 @@ public abstract class SIPConnectionAdapter
 		if (m_maxParseErrorsAllowed == -1 || 
 				m_maxParseErrorsAllowed > 0) {
 			if (c_logger.isTraceDebugEnabled()) {
-				c_logger.traceDebug(this, " isAParseErrorAllowed ", " EYECATCHER: parsing errors are allowed" );
+				c_logger.traceDebug(this, " isAParseErrorAllowed ", "parsing errors are allowed" );
 			}
 			return true;
 		}
 		
 		if (c_logger.isTraceDebugEnabled()) {
-			c_logger.traceDebug(this, " isAParseErrorAllowed ", " EYECATCHER: parsing errors are not allowed" );
+			c_logger.traceDebug(this, " isAParseErrorAllowed ", "parsing errors are not allowed" );
 		}
 		return false;
 	}

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transport/connections/SIPConnectionAdapter.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transport/connections/SIPConnectionAdapter.java
@@ -494,11 +494,20 @@ public abstract class SIPConnectionAdapter
 	 */
 	public boolean shouldDropConnection() {
 		if (m_maxParseErrorsAllowed == NEVER_CLOSE_CONNECTION_ON_A_PARSE_ERROR) {
+			if (c_logger.isTraceDebugEnabled()) {
+				c_logger.traceDebug(this, " shouldDropConnection ", " EYECATCHER: maxParseErrorsAllowed is set to -1, shouldDropConnection will return false" );
+			}
 			return false;
 			
 		} else if (m_maxParseErrorsAllowed > NEVER_CLOSE_CONNECTION_ON_A_PARSE_ERROR) {
+			if (c_logger.isTraceDebugEnabled()) {
+				c_logger.traceDebug(this, " shouldDropConnection ", " EYECATCHER: maxParseErrorsAllowed is set to " + m_maxParseErrorsAllowed);
+			}
 	    	synchronized (m_parseErrorsSynchronizer) {
 	    		if (m_numberOfParseErrors > m_maxParseErrorsAllowed) {
+	    			if (c_logger.isTraceDebugEnabled()) {
+	    				c_logger.traceDebug(this, " shouldDropConnection ", " EYECATCHER: number of parse errors is higher than maxParseErrorsAllowed, shouldDropConnection will return true" );
+	    			}
 	    			return true;
 	    		}
 	    	}
@@ -512,7 +521,14 @@ public abstract class SIPConnectionAdapter
 	public boolean isAParseErrorAllowed() {
 		if (m_maxParseErrorsAllowed == -1 || 
 				m_maxParseErrorsAllowed > 0) {
+			if (c_logger.isTraceDebugEnabled()) {
+				c_logger.traceDebug(this, " isAParseErrorAllowed ", " EYECATCHER: parsing errors are allowed" );
+			}
 			return true;
+		}
+		
+		if (c_logger.isTraceDebugEnabled()) {
+			c_logger.traceDebug(this, " isAParseErrorAllowed ", " EYECATCHER: parsing errors are not allowed" );
 		}
 		return false;
 	}


### PR DESCRIPTION
In case the sipcontainer receives a junk message which contains nonutf8 characters, the message processing code could get in an infinite loop, hogging the thread.

