### PR TITLE
 Debug if a request with session header is sent to /metrics

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/BaseMetricsRESTProxyServlet.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/BaseMetricsRESTProxyServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,14 +24,20 @@ import javax.servlet.http.HttpSession;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.rest.handler.helper.ServletRESTRequestImpl;
 import com.ibm.ws.rest.handler.helper.ServletRESTResponseImpl;
 import com.ibm.wsspi.rest.handler.RESTHandlerContainer;
 
+@Trivial
 public abstract class BaseMetricsRESTProxyServlet extends HttpServlet {
     private static final long serialVersionUID = 1L;
 
     private transient RESTHandlerContainer REST_HANDLER_CONTAINER = null;
+
+    private static final TraceComponent tc = Tr.register(BaseMetricsRESTProxyServlet.class);
 
     /** {@inheritDoc} */
     @Override
@@ -75,7 +81,14 @@ public abstract class BaseMetricsRESTProxyServlet extends HttpServlet {
      * @throws ServletException When the RESTHandlerContainer service is unavailable
      */
     private synchronized void getAndSetRESTHandlerContainer(HttpServletRequest request) throws ServletException {
+
         if (REST_HANDLER_CONTAINER == null) {
+
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Request Session ID [{0}], Thread [{1}]", request.getRequestedSessionId(),
+                         Thread.currentThread());
+            }
+
             // Get the bundle context
             HttpSession session = request.getSession();
             ServletContext sc = session.getServletContext();

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF5/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF5/bootstrap.properties
@@ -1,2 +1,2 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.metrics.monitor.*=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.metrics.monitor.*=all:com.ibm.ws.microprofile.metrics.BaseMetricsRESTProxyServlet=all

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF5/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF5/bootstrap.properties
@@ -1,2 +1,2 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.metrics.monitor.*=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.metrics.monitor.*=all:com.ibm.ws.microprofile.metrics.BaseMetricsRESTProxyServlet=all

--- a/dev/com.ibm.ws.microprofile.metrics/src/com/ibm/ws/microprofile/metrics/BaseMetricsRESTProxyServlet.java
+++ b/dev/com.ibm.ws.microprofile.metrics/src/com/ibm/ws/microprofile/metrics/BaseMetricsRESTProxyServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,12 +24,18 @@ import javax.servlet.http.HttpSession;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.rest.handler.helper.ServletRESTRequestImpl;
 import com.ibm.ws.rest.handler.helper.ServletRESTResponseImpl;
 import com.ibm.wsspi.rest.handler.RESTHandlerContainer;
 
+@Trivial
 public abstract class BaseMetricsRESTProxyServlet extends HttpServlet {
     private static final long serialVersionUID = 1L;
+
+    private static final TraceComponent tc = Tr.register(BaseMetricsRESTProxyServlet.class);
 
     private transient RESTHandlerContainer REST_HANDLER_CONTAINER = null;
 
@@ -75,7 +81,14 @@ public abstract class BaseMetricsRESTProxyServlet extends HttpServlet {
      * @throws ServletException When the RESTHandlerContainer service is unavailable
      */
     private synchronized void getAndSetRESTHandlerContainer(HttpServletRequest request) throws ServletException {
+
         if (REST_HANDLER_CONTAINER == null) {
+
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Request Session ID [{0}], Thread [{1}]", request.getRequestedSessionId(),
+                         Thread.currentThread());
+            }
+
             // Get the bundle context
             HttpSession session = request.getSession();
             ServletContext sc = session.getServletContext();

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/rest/BaseMetricsRESTProxyServlet.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/rest/BaseMetricsRESTProxyServlet.java
@@ -17,6 +17,9 @@ import java.io.IOException;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.rest.handler.helper.ServletRESTRequestImpl;
 import com.ibm.ws.rest.handler.helper.ServletRESTResponseImpl;
 import com.ibm.wsspi.rest.handler.RESTHandlerContainer;
@@ -28,8 +31,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
+@Trivial
 public abstract class BaseMetricsRESTProxyServlet extends HttpServlet {
     private static final long serialVersionUID = 1L;
+
+    private static final TraceComponent tc = Tr.register(BaseMetricsRESTProxyServlet.class);
 
     private transient RESTHandlerContainer REST_HANDLER_CONTAINER = null;
 
@@ -76,9 +82,17 @@ public abstract class BaseMetricsRESTProxyServlet extends HttpServlet {
      * @throws ServletException When the RESTHandlerContainer service is unavailable
      */
     private synchronized void getAndSetRESTHandlerContainer(HttpServletRequest request) throws ServletException {
+
         if (REST_HANDLER_CONTAINER == null) {
+
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Request Session ID [{0}], Thread [{1}]", request.getRequestedSessionId(),
+                        Thread.currentThread());
+            }
+
             // Get the bundle context
             HttpSession session = request.getSession();
+
             ServletContext sc = session.getServletContext();
             BundleContext ctxt = (BundleContext) sc.getAttribute("osgi-bundlecontext");
 

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF5/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF5/bootstrap.properties
@@ -1,2 +1,2 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:io.openliberty.microprofile.metrics.internal.monitor.*=all:com.ibm.ws.microprofile.metrics.monitor.*=all
+com.ibm.ws.logging.trace.specification=*=info:io.openliberty.microprofile.metrics.internal.monitor.*=all:com.ibm.ws.microprofile.metrics.monitor.*=all:com.ibm.ws.microprofile.metrics.BaseMetricsRESTProxyServlet=all

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF5/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF5/bootstrap.properties
@@ -1,2 +1,2 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:io.openliberty.microprofile.metrics.internal.monitor.*=all:com.ibm.ws.microprofile.metrics.monitor.*=all
+com.ibm.ws.logging.trace.specification=*=info:io.openliberty.microprofile.metrics.internal.monitor.*=all:com.ibm.ws.microprofile.metrics.monitor.*=all:com.ibm.ws.microprofile.metrics.BaseMetricsRESTProxyServlet=all

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF5/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF5/bootstrap.properties
@@ -1,2 +1,2 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:io.openliberty.microprofile.metrics.internal.monitor.*=all:com.ibm.ws.microprofile.metrics.monitor.*=all
+com.ibm.ws.logging.trace.specification=*=info:io.openliberty.microprofile.metrics.internal.monitor.*=all:com.ibm.ws.microprofile.metrics.monitor.*=all:io.openliberty.microprofile.metrics50.rest.*=all


### PR DESCRIPTION
#build

Debugging the metrics servlet to see if the request is passing in a sessions request.
This can potentially explain the failure as the FAT test is programmatically connecting to the metrics endpoint with no stateful information. However, this may bring up questions regarding about what is issuing the request.

Debug for #24590 