### PR TITLE
ignore logging ffdc when securerandom with the SHA1PRNG algorithm fails

### DIFF
--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/random/RandomUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/random/RandomUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import java.util.UUID;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.TraceConstants;
 
 public class RandomUtils {
@@ -64,6 +65,7 @@ public class RandomUtils {
         return result.toString();
     }
 
+    @FFDCIgnore({ Exception.class })
     public static Random getRandom() {
         Random result = null;
         try {
@@ -73,7 +75,10 @@ public class RandomUtils {
                 result = SecureRandom.getInstance(SECRANDOM_SHA1PRNG);
             }
         } catch (Exception e) {
-            result = new Random();
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "OLGH24469 - encountered exception : " + e.getMessage() + ", try without algorithm ");
+            }
+            result = new SecureRandom();
         }
         return result;
     }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtUtils.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -399,6 +399,7 @@ public class JwtUtils {
         return result.toString();
     }
 
+    @FFDCIgnore({ Exception.class })
     static Random getRandom() {
         Random result = null;
         try {
@@ -408,7 +409,10 @@ public class JwtUtils {
                 result = SecureRandom.getInstance(SECRANDOM_SHA1PRNG);
             }
         } catch (Exception e) {
-            result = new Random();
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "OLGH24469 - encountered exception : " + e.getMessage() + ", try without algorithm ");
+            }
+            result = new SecureRandom();
         }
         return result;
     }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ import javax.security.auth.Subject;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.openidconnect.common.Constants;
 import com.ibm.ws.webcontainer.security.CookieHelper;
 
@@ -95,6 +96,7 @@ public class OidcUtil {
     }
 
     @Trivial
+    @FFDCIgnore({ Exception.class })
     static Random getRandom() {
         Random result = null;
         try {
@@ -104,7 +106,10 @@ public class OidcUtil {
                 result = SecureRandom.getInstance(SECRANDOM_SHA1PRNG);
             }
         } catch (Exception e) {
-            result = new Random();
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "OLGH24469 - encountered exception : " + e.getMessage() + ", try without algorithm ");
+            }
+            result = new SecureRandom();
         }
         return result;
     }


### PR DESCRIPTION
SHA1PRNG SecureRandom  is not available when FIPS (with IBM Semeru runtime) is enabled.
Update the utilities to not log ffdc , invoke securerandom instead of random without specifying algorithm
fixes #24469
