### PR TITLE
Use HTTP 302 redirect instead of JavaScript for most OIDC FATs

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/OidcEndpointServicesTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/OidcEndpointServicesTest.java
@@ -1065,8 +1065,6 @@ public class OidcEndpointServicesTest {
         assertEquals("Returned key should have matched the expected client, but didn't.", clientSecret, key);
     }
 
-    // TODO
-
     @Test
     public void test_getSharedKey_missingAud() throws Exception {
         context.checking(new Expectations() {

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_adjustDefaults_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_adjustDefaults_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -18,13 +15,13 @@
          id="oidcLogin_autoAdjust"
          enabled="true"
          signatureAlgorithm="RS256"
-         scope="profile email openid"
          userNameAttribute="sub"
          clientId="client03"
          clientSecret="secret"
          discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_autoAdjust/.well-known/openid-configuration"
          authFilterRef="authFilter_autoAdjust"
-         hostNameVerificationEnabled="false" 
+         hostNameVerificationEnabled="false"
+         isClientSideRedirectSupported="false"
          >
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_badIssuer_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_badIssuer_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -18,14 +15,14 @@
          id="oidcLogin_badIssuer"
          enabled="true"
          signatureAlgorithm="RS256"
-         scope="profile email openid"
          userNameAttribute="sub"
          clientId="client01"
          clientSecret="secret"
          discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		 issuer="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/badIssuer"
          authFilterRef="authFilter_badIssuer"
-         hostNameVerificationEnabled="false" 
+         hostNameVerificationEnabled="false"
+         isClientSideRedirectSupported="false"
          >
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_badTrust_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_badTrust_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,7 +14,6 @@
 	<oidcLogin
 		id="oidcLogin_badTrust"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -25,6 +21,7 @@
 		authFilterRef="authFilter_badTrust"
 		sslRef="EmptyTrustSSLSettings"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basicConfig_oauth_SocialConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basicConfig_oauth_SocialConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -21,6 +18,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -36,6 +34,7 @@
 		userNameAttribute="sub"
 		clientId="client09"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -51,6 +50,7 @@
 		userNameAttribute="sub"
 		clientId=" "
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -66,6 +66,7 @@
 		userNameAttribute="sub"
 		clientId=""
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -81,6 +82,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="badSecret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -96,6 +98,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret=" "
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -111,6 +114,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret=""
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -126,6 +130,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -141,6 +146,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}PT47DDo8LTor"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -157,6 +163,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -173,6 +180,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -188,6 +196,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -203,6 +212,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -219,6 +229,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -235,6 +246,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -251,6 +263,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -267,6 +280,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorizeIt"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -282,6 +296,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="someString"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -297,6 +312,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint=" "
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -312,6 +328,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint=""
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -327,6 +344,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://somehost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -342,6 +360,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint=" "
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -357,6 +376,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint=""
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -372,6 +392,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -388,6 +409,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -404,6 +426,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -420,6 +443,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -435,6 +459,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/myinfo"
@@ -449,6 +474,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi=" "
@@ -463,6 +489,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi=""
@@ -477,6 +504,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -492,6 +520,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -507,6 +536,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -522,6 +552,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -530,7 +561,7 @@
 		authFilterRef="authFilter_good_userApiToken"
 	>
 	</oauth2Login>
-	
+
 	<oauth2Login
 		id="oidcLogin_badUserApiToken"
 		signatureAlgorithm="RS256"
@@ -538,6 +569,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -546,7 +578,7 @@
 		authFilterRef="authFilter_bad_userApiToken"
 	>
 	</oauth2Login>
-	
+
 	<oauth2Login
 		id="oidcLogin_blankUserApiToken"
 		signatureAlgorithm="RS256"
@@ -554,6 +586,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -562,7 +595,7 @@
 		authFilterRef="authFilter_blank_userApiToken"
 	>
 	</oauth2Login>
-	
+
 	<oauth2Login
 		id="oidcLogin_emptyUserApiToken"
 		signatureAlgorithm="RS256"
@@ -570,6 +603,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -578,7 +612,7 @@
 		authFilterRef="authFilter_empty_userApiToken"
 	>
 	</oauth2Login>
-				
+
 	<oauth2Login
 		id="oidcLogin_realmName"
 		signatureAlgorithm="RS256"
@@ -586,6 +620,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -602,6 +637,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -618,6 +654,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -634,6 +671,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -650,6 +688,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -666,6 +705,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -682,6 +722,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -698,6 +739,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -714,6 +756,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -730,6 +773,7 @@
 		userNameAttribute="sub"
 		clientId="client06"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_JWT_JWK/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_JWT_JWK/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_JWT_JWK/${oAuthOidcRSValidationEndpoint}"
@@ -746,6 +790,7 @@
 		userNameAttribute="sub"
 		clientId="client06"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_JWT_JWK/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_JWT_JWK/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_JWT_JWK/${oAuthOidcRSValidationEndpoint}"
@@ -794,6 +839,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -809,6 +855,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -824,6 +871,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -839,6 +887,7 @@
 		userNameAttribute="sub"
 		clientId="client02"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_limitedScope/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_limitedScope/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_limitedScope/${oAuthOidcRSValidationEndpoint}"
@@ -853,6 +902,7 @@
 		scope="profile email"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -868,6 +918,7 @@
 		scope="profile email"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -883,6 +934,7 @@
 		scope="profile email"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -898,6 +950,7 @@
 		scope="profile email"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -914,6 +967,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -930,6 +984,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -946,6 +1001,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -962,6 +1018,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -978,6 +1035,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -994,6 +1052,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1010,6 +1069,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1026,6 +1086,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1042,6 +1103,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1058,6 +1120,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1074,6 +1137,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1090,6 +1154,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1106,6 +1171,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1122,6 +1188,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1138,6 +1205,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1154,6 +1222,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1170,6 +1239,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1178,7 +1248,7 @@
 		authFilterRef="authFilter_codeResponseType"
 	>
 	</oauth2Login>
-		
+
 	<oauth2Login
 		id="oidcLogin_tokenResponseType"
 		signatureAlgorithm="RS256"
@@ -1186,6 +1256,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1202,6 +1273,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1211,7 +1283,7 @@
 		authFilterRef="authFilter_responseModeFormPost_codeResponseType"
 	>
 	</oauth2Login>
-		
+
 	<oauth2Login
 		id="oidcLogin_responseModeFormPost_tokenResponseType"
 		signatureAlgorithm="RS256"
@@ -1219,6 +1291,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1236,6 +1309,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_missingAuthCodeGrantType/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_missingAuthCodeGrantType/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_missingAuthCodeGrantType/${oAuthOidcRSValidationEndpoint}"
@@ -1244,14 +1318,15 @@
 		authFilterRef="authFilter_opMissingAuthCodeGrantType_codeResponseType"
 	>
 	</oauth2Login>
-	
- 	<oauth2Login
+
+	<oauth2Login
 		id="oidcLogin_opMissingImplicitGrantType_tokenResponseType"
 		signatureAlgorithm="RS256"
 		scope="profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_missingImplicitGrantType/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_missingImplicitGrantType/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_missingImplicitGrantType/${oAuthOidcRSValidationEndpoint}"
@@ -1260,12 +1335,13 @@
 		authFilterRef="authFilter_opMissingImplicitGrantType_tokenResponseType"
 	>
 	</oauth2Login>
-	
+
 	<oauth2Login
 		id="oidcLogin_accessTokenRequiredTrue"
 		signatureAlgorithm="RS256"
 		scope="profile email"
 		userNameAttribute="sub"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
 		userApiType="${userApiType}"
@@ -1273,7 +1349,7 @@
 		accessTokenRequired="true"
 	>
 	</oauth2Login>
-	
+
 	<oauth2Login
 		id="oidcLogin_accessTokenRequiredTrue_withIntrospectRequiredAttrs"
 		signatureAlgorithm="RS256"
@@ -1281,6 +1357,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
 		userApiType="${userApiType}"
@@ -1288,7 +1365,7 @@
 		accessTokenRequired="true"
 	>
 	</oauth2Login>
-	
+
 	<oauth2Login
 		id="oidcLogin_accessTokenRequiredFalse"
 		signatureAlgorithm="RS256"
@@ -1296,6 +1373,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1304,13 +1382,13 @@
 		accessTokenRequired="false"
 	>
 	</oauth2Login>
-	
-	
+
 	<oauth2Login
 		id="oidcLogin_accessTokenSupportedTrue_optionalParmsOmitted"
 		signatureAlgorithm="RS256"
 		scope="profile email"
 		userNameAttribute="sub"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
 		userApiType="${userApiType}"
@@ -1318,7 +1396,7 @@
 		accessTokenSupported="true"
 	>
 	</oauth2Login>
-	
+
 	<oauth2Login
 		id="oidcLogin_accessTokenSupportedTrue_optionalParmsOmitted_withIntrospectRequiredAttrs"
 		signatureAlgorithm="RS256"
@@ -1326,6 +1404,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
 		userApiType="${userApiType}"
@@ -1333,7 +1412,7 @@
 		accessTokenSupported="true"
 	>
 	</oauth2Login>
-	
+
 	<oauth2Login
 		id="oidcLogin_accessTokenSupportedTrue_optionalParmsIncluded"
 		signatureAlgorithm="RS256"
@@ -1341,6 +1420,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1349,7 +1429,7 @@
 		accessTokenSupported="true"
 	>
 	</oauth2Login>
-	
+
 	<oauth2Login
 		id="oidcLogin_accessTokenSupportedFalse"
 		signatureAlgorithm="RS256"
@@ -1357,6 +1437,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
@@ -1365,7 +1446,7 @@
 		accessTokenSupported="false"
 	>
 	</oauth2Login>
-	
+
 	<oauth2Login
 		id="oidcLogin_accessTokenRequiredTrue_accessTokenSupportedTrue"
 		signatureAlgorithm="RS256"
@@ -1373,6 +1454,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
 		userApiType="${userApiType}"
@@ -1381,7 +1463,7 @@
 		accessTokenSupported="true"
 	>
 	</oauth2Login>
-	
+
 	<oauth2Login
 		id="oidcLogin_accessTokenHeaderNameBearer"
 		signatureAlgorithm="RS256"
@@ -1389,15 +1471,16 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
 		userApiType="${userApiType}"
 		authFilterRef="authFilter_accessTokenHeaderNameBearer"
 		accessTokenRequired="true"
- 		accessTokenHeaderName="Authorization"
+		accessTokenHeaderName="Authorization"
 	>
 	</oauth2Login>
-	
+
 	<oauth2Login
 		id="oidcLogin_accessTokenHeaderNameXForwardedAccessToken"
 		signatureAlgorithm="RS256"
@@ -1405,6 +1488,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
 		userApiType="${userApiType}"
@@ -1421,13 +1505,14 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"
 		userApiType="${userApiType}"
 		authFilterRef="authFilter_accessTokenHeaderNameUserDefined"
 		accessTokenRequired="true"
- 		accessTokenHeaderName="UserDefinedHeader"
+		accessTokenHeaderName="UserDefinedHeader"
 	>
-	</oauth2Login>	
-	
+	</oauth2Login>
+
 </server>

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basicConfig_oauth_SocialConfig_noServerSSL.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basicConfig_oauth_SocialConfig_noServerSSL.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -21,6 +18,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://3.4.5.6:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://4.5.6.7:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/userinfo"
@@ -29,14 +27,15 @@
 		useSystemPropertiesForHttpClientConnections="true"
 	>
 	</oauth2Login>
-	
-		<oauth2Login
+
+	<oauth2Login
 		id="oidcLogin_goodTrust"
 		signatureAlgorithm="RS256"
 		scope="profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/userinfo"
@@ -52,6 +51,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/userinfo"
@@ -60,14 +60,13 @@
 	>
 	</oauth2Login>
 
-
 	<authFilter id="authFilter_goodTrust">
 		<requestUrl
 			id="myRequestUrlc"
 			urlPattern="helloworld_goodTrust"
 			matchType="contains" />
 	</authFilter>
-	
+
 		<authFilter id="authFilter_jvmprops_goodTrust">
 		<requestUrl
 			id="myRequestUrlc"

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basicConfig_oidc_SocialConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basicConfig_oidc_SocialConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,7 +14,6 @@
 	<oidcLogin
 		id="oidcLogin1"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -25,13 +21,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter1"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_badClientId"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client09"
 		clientSecret="secret"
@@ -39,13 +35,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_badClientId"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_blankClientId"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId=" "
 		clientSecret="secret"
@@ -53,13 +49,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_blankClientId"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_emptyClientId"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId=""
 		clientSecret="secret"
@@ -67,13 +63,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_emptyClientId"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_badClientSecret"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="badSecret"
@@ -81,13 +77,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_badClientSecret"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_blankClientSecret"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret=" "
@@ -95,13 +91,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_blankClientSecret"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_emptyClientSecret"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret=""
@@ -109,13 +105,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_emptyClientSecret"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_XOR_Secret"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
@@ -123,13 +119,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_xorSecret"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_bad_XOR_Secret"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}PT47DDo8LTor"
@@ -137,6 +133,7 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_bad_xorSecret"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -144,7 +141,6 @@
 		id="oidcLogin_enabledTrue"
 		enabled="true"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -152,6 +148,7 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_enabledTrue"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -159,7 +156,6 @@
 		id="oidcLogin_enabledFalse"
 		enabled="false"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -167,13 +163,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_enabledFalse"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_badAuthFilterRef"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -181,13 +177,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_badAuthFilterRef"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_goodTrust"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -196,13 +192,13 @@
 		authFilterRef="authFilter_goodTrust"
 		sslRef="DefaultSSLSettings"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_badTrust"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -211,13 +207,13 @@
 		authFilterRef="authFilter_badTrust"
 		sslRef="BadTrustSSLSettings"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_blankTrust"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -225,6 +221,7 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_blankTrust"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		sslRef=" "
 	>
 	</oidcLogin>
@@ -232,7 +229,6 @@
 	<oidcLogin
 		id="oidcLogin_emptyTrust"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -241,13 +237,13 @@
 		authFilterRef="authFilter_emptyTrust"
 		sslRef=""
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_badAuthEndpoint"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -255,13 +251,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_badAuthEndpoint"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_reallyBadAuthEndpoint"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -269,13 +265,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_reallyBadAuthEndpoint"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_blankAuthEndpoint"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -283,13 +279,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_blankAuthEndpoint"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_emptyAuthEndpoint"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -297,13 +293,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_emptyAuthEndpoint"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_httpAuthEndpoint"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -311,13 +307,13 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_httpAuthEndpoint"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_badTokenEndpoint"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -325,13 +321,13 @@
 		tokenEndpoint="https://somehost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_badTokenEndpoint"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_blankTokenEndpoint"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -339,13 +335,13 @@
 		tokenEndpoint=" "
 		authFilterRef="authFilter_blankTokenEndpoint"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_emptyTokenEndpoint"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -353,13 +349,13 @@
 		tokenEndpoint=""
 		authFilterRef="authFilter_emptyTokenEndpoint"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_tEAM_clientSecretBasic"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -368,13 +364,13 @@
 		tokenEndpointAuthMethod="client_secret_basic"
 		authFilterRef="authFilter_tEAM_clientSecretBasic"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_tEAM_clientSecretPost"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -383,13 +379,13 @@
 		tokenEndpointAuthMethod="client_secret_post"
 		authFilterRef="authFilter_tEAM_clientSecretPost"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_tEAM_clientSecretBad"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -398,13 +394,13 @@
 		tokenEndpointAuthMethod="client_secret_bad"
 		authFilterRef="authFilter_tEAM_clientSecretBad"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_realmName"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -413,13 +409,13 @@
 		realmName="myLibertyOPRealm"
 		authFilterRef="authFilter_realmName"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_blankRealmName"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -428,13 +424,13 @@
 		realmName=" "
 		authFilterRef="authFilter_blankRealmName"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_emptyRealmName"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -443,13 +439,13 @@
 		realmName=""
 		authFilterRef="authFilter_emptyRealmName"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_mapToUserRegistryFalse"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -458,13 +454,13 @@
 		mapToUserRegistry="false"
 		authFilterRef="authFilter_mapToUserRegistryFalse"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_mapToUserRegistryTrue"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -473,13 +469,13 @@
 		mapToUserRegistry="true"
 		authFilterRef="authFilter_mapToUserRegistryTrue"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_goodjwt_builder"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -487,6 +483,7 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_good_jwt_builder"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 		<jwt builder="goodJwtBuilder" />
 	</oidcLogin>
@@ -494,7 +491,6 @@
 	<oidcLogin
 		id="oidcLogin_blankjwt_builder"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -502,6 +498,7 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_blank_jwt_builder"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 		<jwt builder=" " />
 	</oidcLogin>
@@ -509,7 +506,6 @@
 	<oidcLogin
 		id="oidcLogin_emptyjwt_builder"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -517,6 +513,7 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_empty_jwt_builder"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 		<jwt builder="" />
 	</oidcLogin>
@@ -524,7 +521,6 @@
 	<oidcLogin
 		id="oidcLogin_jwt_builder_HS256"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -532,6 +528,7 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_jwt_builder_HS256"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 		<jwt builder="goodJwtBuilder_HS256" />
 	</oidcLogin>
@@ -539,7 +536,6 @@
 	<oidcLogin
 		id="oidcLogin_goodJwksUri"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client06"
 		clientSecret="secret"
@@ -548,13 +544,13 @@
 		authFilterRef="authFilter_goodJwksUri"
 		jwksUri="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_JWT_JWK/jwk"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_badJwksUri"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client06"
 		clientSecret="secret"
@@ -563,13 +559,13 @@
 		authFilterRef="authFilter_badJwksUri"
 		jwksUri="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_JWT_JWK/jwt"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_blankJwksUri"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client06"
 		clientSecret="secret"
@@ -578,13 +574,13 @@
 		authFilterRef="authFilter_blankJwksUri"
 		jwksUri=" "
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_emptyJwksUri"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client06"
 		clientSecret="secret"
@@ -593,13 +589,13 @@
 		authFilterRef="authFilter_emptyJwksUri"
 		jwksUri=""
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_jwksUri_jwkDisabledInOP"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -608,13 +604,13 @@
 		authFilterRef="authFilter_jwksUri_jwkDisabledInOP"
 		jwksUri="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/jwk"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_badIssuer"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -623,13 +619,13 @@
 		authFilterRef="authFilter_badIssuer"
 		issuer="https://somebadName.com"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_blankIssuer"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -638,13 +634,13 @@
 		authFilterRef="authFilter_blankIssuer"
 		issuer=" "
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_emptyIssuer"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -653,13 +649,13 @@
 		authFilterRef="authFilter_emptyIssuer"
 		issuer=""
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_isClientSideRedirectSupported_true"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -674,7 +670,6 @@
 	<oidcLogin
 		id="oidcLogin_isClientSideRedirectSupported_false"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -697,6 +692,7 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_badScope"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -711,6 +707,7 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_blankScope"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -725,6 +722,7 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_emptyScope"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -739,19 +737,20 @@
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_limitedScope/token"
 		authFilterRef="authFilter_badScope_limitedOPScope"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_goodUserNameAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_goodUserNameAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		userNameAttribute="sub"
 	>
 	</oidcLogin>
@@ -759,13 +758,13 @@
 	<oidcLogin
 		id="oidcLogin_badUserNameAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_badUserNameAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		userNameAttribute="someBadName"
 	>
 	</oidcLogin>
@@ -773,13 +772,13 @@
 	<oidcLogin
 		id="oidcLogin_blankUserNameAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_blankUserNameAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		userNameAttribute=" "
 	>
 	</oidcLogin>
@@ -787,13 +786,13 @@
 	<oidcLogin
 		id="oidcLogin_emptyUserNameAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_emptyUserNameAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		userNameAttribute=""
 	>
 	</oidcLogin>
@@ -801,13 +800,13 @@
 	<oidcLogin
 		id="oidcLogin_goodGroupNameAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_goodGroupNameAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		groupNameAttribute="sub"
 	>
 	</oidcLogin>
@@ -815,13 +814,13 @@
 	<oidcLogin
 		id="oidcLogin_badGroupNameAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_badGroupNameAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		groupNameAttribute="someBadName"
 	>
 	</oidcLogin>
@@ -829,13 +828,13 @@
 	<oidcLogin
 		id="oidcLogin_blankGroupNameAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_blankGroupNameAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		groupNameAttribute=" "
 	>
 	</oidcLogin>
@@ -843,13 +842,13 @@
 	<oidcLogin
 		id="oidcLogin_emptyGroupNameAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_emptyGroupNameAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		groupNameAttribute=""
 	>
 	</oidcLogin>
@@ -857,13 +856,13 @@
 	<oidcLogin
 		id="oidcLogin_goodRealmNameAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_goodRealmNameAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		realmNameAttribute="sub"
 	>
 	</oidcLogin>
@@ -871,13 +870,13 @@
 	<oidcLogin
 		id="oidcLogin_badRealmNameAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_badRealmNameAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		realmNameAttribute="someBadName"
 	>
 	</oidcLogin>
@@ -885,13 +884,13 @@
 	<oidcLogin
 		id="oidcLogin_blankRealmNameAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_blankRealmNameAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		realmNameAttribute=" "
 	>
 	</oidcLogin>
@@ -899,13 +898,13 @@
 	<oidcLogin
 		id="oidcLogin_emptyRealmNameAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_emptyRealmNameAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		realmNameAttribute=""
 	>
 	</oidcLogin>
@@ -913,13 +912,13 @@
 	<oidcLogin
 		id="oidcLogin_goodUserUniqueIdAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_goodUserUniqueIdAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		userUniqueIdAttribute="sub"
 	>
 	</oidcLogin>
@@ -927,13 +926,13 @@
 	<oidcLogin
 		id="oidcLogin_badUserUniqueIdAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_badUserUniqueIdAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		userUniqueIdAttribute="someBadName"
 	>
 	</oidcLogin>
@@ -941,13 +940,13 @@
 	<oidcLogin
 		id="oidcLogin_blankUserUniqueIdAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_blankUserUniqueIdAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		userUniqueIdAttribute=" "
 	>
 	</oidcLogin>
@@ -955,13 +954,13 @@
 	<oidcLogin
 		id="oidcLogin_emptyUserUniqueIdAttribute"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_emptyUserUniqueIdAttribute"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		userUniqueIdAttribute=""
 	>
 	</oidcLogin>
@@ -969,13 +968,13 @@
 	<oidcLogin
 		id="oidcLogin_goodRedirectToRPHostAndPort"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_goodRedirectToRPHostAndPort"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		redirectToRPHostAndPort="https://localhost:${bvt.prop.security_2_HTTP_default.secure}"
 	>
 	</oidcLogin>
@@ -983,13 +982,13 @@
 	<oidcLogin
 		id="oidcLogin_badRedirectToRPHostAndPort"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_badRedirectToRPHostAndPort"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		redirectToRPHostAndPort="https://myBogusMachine.austin.ibm.com:${bvt.prop.security_2_HTTP_default.secure}"
 	>
 	</oidcLogin>
@@ -997,13 +996,13 @@
 	<oidcLogin
 		id="oidcLogin_blankRedirectToRPHostAndPort"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_blankRedirectToRPHostAndPort"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		redirectToRPHostAndPort=" "
 	>
 	</oidcLogin>
@@ -1011,13 +1010,13 @@
 	<oidcLogin
 		id="oidcLogin_emptyRedirectToRPHostAndPort"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		clientId="client01"
 		clientSecret="secret"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		authFilterRef="authFilter_emptyRedirectToRPHostAndPort"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		redirectToRPHostAndPort=""
 	>
 	</oidcLogin>
@@ -1025,7 +1024,6 @@
 	<oidcLogin
 		id="oidcLogin_hostNameVerificationEnabledTrue"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client06"
 		clientSecret="secret"
@@ -1034,14 +1032,14 @@
 		jwksUri="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_JWT_JWK/jwk"
 		authFilterRef="authFilter_hostNameVerificationEnabledTrue"
 		hostNameVerificationEnabled="true"
+		isClientSideRedirectSupported="false"
 		goo="someString"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_codeResponseType"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
@@ -1050,15 +1048,15 @@
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/userinfo"
 		userInfoEndpointEnabled="true"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		responseType="code"
 		authFilterRef="authFilter_codeResponseType"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_idTokenTokenResponseType"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
@@ -1067,15 +1065,15 @@
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/userinfo"
 		userInfoEndpointEnabled="true"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		responseType="id_token token"
 		authFilterRef="authFilter_idTokenTokenResponseType"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_idTokenResponseType"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
@@ -1084,6 +1082,7 @@
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/userinfo"
 		userInfoEndpointEnabled="true"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		responseType="id_token"
 		authFilterRef="authFilter_idTokenResponseType"
 	>
@@ -1092,7 +1091,6 @@
 	<oidcLogin
 		id="oidcLogin_responseModeFormPost_codeResponseType"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
@@ -1101,16 +1099,16 @@
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/userinfo"
 		userInfoEndpointEnabled="true"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		responseType="code"
 		responseMode="form_post"
 		authFilterRef="authFilter_responseModeFormPost_codeResponseType"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_responseModeFormPost_idTokenTokenResponseType"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
@@ -1119,16 +1117,16 @@
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/userinfo"
 		userInfoEndpointEnabled="true"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		responseType="id_token token"
 		responseMode="form_post"
 		authFilterRef="authFilter_responseModeFormPost_idTokenTokenResponseType"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_responseModeFormPost_idTokenResponseType"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
@@ -1137,6 +1135,7 @@
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/userinfo"
 		userInfoEndpointEnabled="true"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		responseMode="form_post"
 		responseType="id_token"
 		authFilterRef="authFilter_responseModeFormPost_idTokenResponseType"
@@ -1146,7 +1145,6 @@
 	<oidcLogin
 		id="oidcLogin_opMissingAuthCodeGrantType_codeResponseType"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
@@ -1155,15 +1153,15 @@
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_missingAuthCodeGrantType/userinfo"
 		userInfoEndpointEnabled="true"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		responseType="code"
 		authFilterRef="authFilter_opMissingAuthCodeGrantType_codeResponseType"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_opMissingImplicitGrantType_idTokenTokenResponseType"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
@@ -1172,15 +1170,15 @@
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_missingImplicitGrantType/userinfo"
 		userInfoEndpointEnabled="true"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		responseType="id_token token"
 		authFilterRef="authFilter_opMissingImplicitGrantType_idTokenTokenResponseType"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_opMissingImplicitGrantType_idTokenResponseType"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
@@ -1189,15 +1187,15 @@
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_missingImplicitGrantType/userinfo"
 		userInfoEndpointEnabled="true"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 		responseType="id_token"
 		authFilterRef="authFilter_opMissingImplicitGrantType_idTokenResponseType"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_forwardLoginParameter"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -1206,6 +1204,7 @@
 		authFilterRef="authFilter_forwardLoginParameter"
 		forwardLoginParameter="login_hint,ui_locales"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 		<authzParameter name="mq_authz1" value="mqa1234" />
 	</oidcLogin>

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basicConfig_oidc_SocialConfig_noServerSSL.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basicConfig_oidc_SocialConfig_noServerSSL.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,7 +14,6 @@
 	<oidcLogin
 		id="oidcLogin_goodTrust"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -26,13 +22,13 @@
 		authFilterRef="authFilter_goodTrust"
 		sslRef="SpecificSSLSettings"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_goodJwksUri_goodTrust"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client06"
 		clientSecret="secret"
@@ -42,13 +38,13 @@
 		authFilterRef="authFilter_goodJwksUri_goodTrust"
 		sslRef="SpecificSSLSettings"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_badTrust"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -57,6 +53,7 @@
 		authFilterRef="authFilter_badTrust"
 		sslRef="DefaultSSLSettings"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basicConfig_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basicConfig_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,53 +14,53 @@
 	<oidcLogin
 		id="oidcLogin1"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter1"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_badClientId"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client09"
 		clientSecret="secret"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter_badClientId"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_blankClientSecret"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret=" "
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter_blankClientSecret"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
-		<oidcLogin
+
+	<oidcLogin
 		id="oidcLogin_enabledTrue"
 		enabled="true"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter_enabledTrue"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -71,33 +68,32 @@
 		id="oidcLogin_enabledFalse"
 		enabled="false"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter_enabledFalse"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
-		<oidcLogin
+
+	<oidcLogin
 		id="oidcLogin_badAuthFilterRef"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter_badAuthFilterRef"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
-		<oidcLogin
+
+	<oidcLogin
 		id="oidcLogin_tEAM_clientSecretBasic"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -105,13 +101,13 @@
 		tokenEndpointAuthMethod="client_secret_basic"
 		authFilterRef="authFilter_tEAM_clientSecretBasic"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_tEAM_clientSecretPost"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -119,13 +115,13 @@
 		tokenEndpointAuthMethod="client_secret_post"
 		authFilterRef="authFilter_tEAM_clientSecretPost"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_realmName"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -133,13 +129,13 @@
 		realmName="myLibertyOPRealm"
 		authFilterRef="authFilter_realmName"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_mapToUserRegistryFalse"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -147,13 +143,13 @@
 		mapToUserRegistry="false"
 		authFilterRef="authFilter_mapToUserRegistryFalse"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
 	<oidcLogin
 		id="oidcLogin_mapToUserRegistryTrue"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -161,19 +157,20 @@
 		mapToUserRegistry="true"
 		authFilterRef="authFilter_mapToUserRegistryTrue"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_goodjwt_builder"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter_good_jwt_builder"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 		<jwt builder="goodJwtBuilder" />
 	</oidcLogin>
@@ -181,17 +178,16 @@
 	<oidcLogin
 		id="oidcLogin_jwt_builder_HS256"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter_jwt_builder_HS256"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 		<jwt builder="goodJwtBuilder_HS256" />
 	</oidcLogin>
-	
 
 	<oidcLogin
 		id="oidcLogin_badScope"
@@ -203,46 +199,46 @@
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter_badScope"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_addParms"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter_addParms"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
-	    <authzParameter name="mq_authz1" value="mqa1234" />
-        <tokenParameter name="mq_token1" value="mqt1234" />
-        <authzParameter name="mq_authz2" value="mqa_5678" />
-        <tokenParameter name="mq_token2" value="mqt_5678" />
+		<authzParameter name="mq_authz1" value="mqa1234" />
+		<tokenParameter name="mq_token1" value="mqt1234" />
+		<authzParameter name="mq_authz2" value="mqa_5678" />
+		<tokenParameter name="mq_token2" value="mqt_5678" />
 	</oidcLogin>
-	
+
 
 	<oidcLogin
 		id="oidcLogin_addBadParms"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter_addBadParms"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 		<authzParameter  value="mqa1234" />
-        <tokenParameter name="mq_token1" value="" />
+		<tokenParameter name="mq_token1" value="" />
 	</oidcLogin>
-	
+
 	<oidcLogin
 		id="oidcLogin_forwardLoginParameter"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
@@ -250,6 +246,7 @@
 		authFilterRef="authFilter_forwardLoginParameter"
 		forwardLoginParameter="login_hint,ui_locales"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 		<authzParameter name="mq_authz1" value="mqa1234" />
 	</oidcLogin>

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basic_oauth_SocialConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basic_oauth_SocialConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -20,6 +17,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basic_oauth_SocialConfig_samesite.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basic_oauth_SocialConfig_samesite.xml
@@ -1,6 +1,6 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
+		isClientSideRedirectSupported="false"
 		authorizationEndpoint="${authorizationHost}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="${tokenHost}/oidc/endpoint/OidcConfigSample/token"
 		userApi="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/${oAuthOidcRSValidationEndpoint}"

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basic_oidc_SocialConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basic_oidc_SocialConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,7 +14,6 @@
 	<oidcLogin
 		id="oidcLogin1"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
@@ -26,6 +22,7 @@
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/userinfo"
 		userInfoEndpointEnabled="true"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basic_oidc_SocialConfig_samesite.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basic_oidc_SocialConfig_samesite.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,7 +14,6 @@
 	<oidcLogin
 		id="oidcLogin1"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
@@ -27,6 +23,7 @@
 		userInfoEndpointEnabled="true"
 		hostNameVerificationEnabled="false"
 		redirectToRPHostAndPort="${redirectHost}"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basic_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_basic_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,13 +14,13 @@
 	<oidcLogin
 		id="oidcLogin1"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		userInfoEndpointEnabled="true"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_blankDiscoveryUrl_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_blankDiscoveryUrl_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,13 +14,13 @@
 	<oidcLogin
 		id="oidcLogin1"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint=" "
 		authFilterRef="authFilter1"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_configuredEndpoints_oidc_SocialConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_configuredEndpoints_oidc_SocialConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -21,6 +18,7 @@
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
 		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_emptyDiscoveryUrl_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_emptyDiscoveryUrl_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,13 +14,13 @@
 	<oidcLogin
 		id="oidcLogin1"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint=""
 		authFilterRef="authFilter1"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_hostNameVerify_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_hostNameVerify_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,13 +14,13 @@
 	<oidcLogin
 		id="oidcLogin_hostNameVerificationEnabledTrue"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client06"
 		clientSecret="secret"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_JWT_JWK/.well-known/openid-configuration"
 		authFilterRef="authFilter_hostNameVerificationEnabledTrue"
 		hostNameVerificationEnabled="true"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_malFormedUrl_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_malFormedUrl_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,13 +14,13 @@
 	<oidcLogin
 		id="oidcLogin1"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.mal-formed/openid-configuration"
 		authFilterRef="authFilter1"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_minimalConfig_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_minimalConfig_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_nonHttpsUrl_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_nonHttpsUrl_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,13 +14,13 @@
 	<oidcLogin
 		id="oidcLogin1"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint="http://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter1"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_orig_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_orig_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -17,13 +14,13 @@
 	<oidcLogin
 		id="oidcLogin1"
 		signatureAlgorithm="RS256"
-		scope="profile email openid"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="secret"
 		discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/.well-known/openid-configuration"
 		authFilterRef="authFilter1"
 		hostNameVerificationEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_overrideEndpts_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_overrideEndpts_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -26,7 +23,8 @@
          authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/bad/authorize"
 		 tokenEndpoint="http://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
          authFilterRef="authFilter_overrideEndpts"
-         hostNameVerificationEnabled="false" 
+         hostNameVerificationEnabled="false"
+         isClientSideRedirectSupported="false"
          >
 	</oidcLogin>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_overrideJwksUri_oidc_SocialDiscoveryConfig.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/LibertyOP_overrideJwksUri_oidc_SocialDiscoveryConfig.xml
@@ -1,15 +1,12 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
@@ -24,6 +21,7 @@
          discoveryEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_JWT_JWK/.well-known/openid-configuration"
          authFilterRef="authFilter_goodJwksUri"
          jwksUri="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample_JWT_JWK/jwk"
-         hostNameVerificationEnabled="false" />
+         hostNameVerificationEnabled="false"
+         isClientSideRedirectSupported="false" />
 
 </server>

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/oidcSigningEncryptingSocialClients.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/oidcSigningEncryptingSocialClients.xml
@@ -1,19 +1,16 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 
 <server>
 
-<!--  RS encryption variations -->	
+<!--  RS encryption variations -->
 
 	<authFilter id="authFilterHS256RS256">
 		<requestUrl
@@ -24,23 +21,22 @@
 
 	<oidcLogin
 		id="SignHS256EncryptRS256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS256RS256"
-		signatureAlgorithm="HS256"		
+		signatureAlgorithm="HS256"
 		keyManagementKeyAlias="rs256"
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -53,14 +49,13 @@
 
 	<oidcLogin
 		id="SignHS384EncryptRS256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS384RS256"
@@ -69,7 +64,7 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -82,14 +77,13 @@
 
 	<oidcLogin
 		id="SignHS512EncryptRS256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS512RS256"
@@ -98,11 +92,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
-	
+
 	<authFilter id="authFilterRS256RS256">
 		<requestUrl
 			id="requestUrlRS256RS256"
@@ -112,12 +105,11 @@
 
 	<oidcLogin
 		id="SignRS256EncryptRS256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"   
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS256RS256"
@@ -128,9 +120,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS384RS256">
 		<requestUrl
 			id="requestUrlRS384RS256"
@@ -140,13 +133,12 @@
 
 	<oidcLogin
 		id="SignRS384EncryptRS256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS384RS256"
@@ -157,10 +149,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS512RS256">
 		<requestUrl
 			id="requestUrlRS512RS256"
@@ -170,13 +162,12 @@
 
 	<oidcLogin
 		id="SignRS512EncryptRS256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS512RS256"
@@ -187,10 +178,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES256RS256">
 		<requestUrl
 			id="requestUrlES256RS256"
@@ -200,13 +191,12 @@
 
 	<oidcLogin
 		id="SignES256EncryptRS256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES256RS256"
@@ -217,10 +207,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES384RS256">
 		<requestUrl
 			id="requestUrlES384RS256"
@@ -230,13 +220,12 @@
 
 	<oidcLogin
 		id="SignES384EncryptRS256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES384RS256"
@@ -247,10 +236,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES512RS256">
 		<requestUrl
 			id="requestUrlES512RS256"
@@ -260,13 +249,12 @@
 
 	<oidcLogin
 		id="SignES512EncryptRS256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES512RS256"
@@ -277,9 +265,9 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
+	</oidcLogin>
 
 	<authFilter id="authFilterHS256RS384">
 		<requestUrl
@@ -290,23 +278,22 @@
 
 	<oidcLogin
 		id="SignHS256EncryptRS384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS256RS384"
-		signatureAlgorithm="HS256"		
+		signatureAlgorithm="HS256"
 		keyManagementKeyAlias="rs384"
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -319,14 +306,13 @@
 
 	<oidcLogin
 		id="SignHS384EncryptRS384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS384RS384"
@@ -335,7 +321,7 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -348,14 +334,13 @@
 
 	<oidcLogin
 		id="SignHS512EncryptRS384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS512RS384"
@@ -364,11 +349,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
-	
+
 	<authFilter id="authFilterRS256RS384">
 		<requestUrl
 			id="requestUrlRS256RS384"
@@ -378,13 +362,12 @@
 
 	<oidcLogin
 		id="SignRS256EncryptRS384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS256RS384"
@@ -395,10 +378,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS384RS384">
 		<requestUrl
 			id="requestUrlRS384RS384"
@@ -408,13 +391,12 @@
 
 	<oidcLogin
 		id="SignRS384EncryptRS384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS384RS384"
@@ -425,10 +407,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS512RS384">
 		<requestUrl
 			id="requestUrlRS512RS384"
@@ -438,13 +420,12 @@
 
 	<oidcLogin
 		id="SignRS512EncryptRS384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS512RS384"
@@ -455,10 +436,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES256RS384">
 		<requestUrl
 			id="requestUrlES256RS384"
@@ -468,13 +449,12 @@
 
 	<oidcLogin
 		id="SignES256EncryptRS384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES256RS384"
@@ -485,10 +465,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES384RS384">
 		<requestUrl
 			id="requestUrlES384RS384"
@@ -498,13 +478,12 @@
 
 	<oidcLogin
 		id="SignES384EncryptRS384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES384RS384"
@@ -515,10 +494,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES512RS384">
 		<requestUrl
 			id="requestUrlES512RS384"
@@ -528,13 +507,12 @@
 
 	<oidcLogin
 		id="SignES512EncryptRS384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES512RS384"
@@ -545,9 +523,9 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
+	</oidcLogin>
 
 	<authFilter id="authFilterHS256RS512">
 		<requestUrl
@@ -558,23 +536,22 @@
 
 	<oidcLogin
 		id="SignHS256EncryptRS512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS256RS512"
-		signatureAlgorithm="HS256"		
+		signatureAlgorithm="HS256"
 		keyManagementKeyAlias="rs512"
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -587,14 +564,13 @@
 
 	<oidcLogin
 		id="SignHS384EncryptRS512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS384RS512"
@@ -603,7 +579,7 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -616,14 +592,13 @@
 
 	<oidcLogin
 		id="SignHS512EncryptRS512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS512RS512"
@@ -632,11 +607,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
-	
+
 	<authFilter id="authFilterRS256RS512">
 		<requestUrl
 			id="requestUrlRS256RS512"
@@ -646,13 +620,12 @@
 
 	<oidcLogin
 		id="SignRS256EncryptRS512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS256RS512"
@@ -663,10 +636,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS384RS512">
 		<requestUrl
 			id="requestUrlRS384RS512"
@@ -676,13 +649,12 @@
 
 	<oidcLogin
 		id="SignRS384EncryptRS512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS384RS512"
@@ -693,10 +665,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS512RS512">
 		<requestUrl
 			id="requestUrlRS512RS512"
@@ -706,13 +678,12 @@
 
 	<oidcLogin
 		id="SignRS512EncryptRS512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS512RS512"
@@ -723,10 +694,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES256RS512">
 		<requestUrl
 			id="requestUrlES256RS512"
@@ -736,13 +707,12 @@
 
 	<oidcLogin
 		id="SignES256EncryptRS512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES256RS512"
@@ -753,10 +723,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES384RS512">
 		<requestUrl
 			id="requestUrlES384RS512"
@@ -766,13 +736,12 @@
 
 	<oidcLogin
 		id="SignES384EncryptRS512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES384RS512"
@@ -783,10 +752,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES512RS512">
 		<requestUrl
 			id="requestUrlES512RS512"
@@ -796,13 +765,12 @@
 
 	<oidcLogin
 		id="SignES512EncryptRS512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES512RS512"
@@ -813,11 +781,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-				
-	
+	</oidcLogin>
+
 <!-- ES encryption variations -->
 	<authFilter id="authFilterHS256ES256">
 		<requestUrl
@@ -828,23 +795,22 @@
 
 	<oidcLogin
 		id="SignHS256EncryptES256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS256ES256"
-		signatureAlgorithm="HS256"		
+		signatureAlgorithm="HS256"
 		keyManagementKeyAlias="es256"
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -857,14 +823,13 @@
 
 	<oidcLogin
 		id="SignHS384EncryptES256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS384ES256"
@@ -873,7 +838,7 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -886,14 +851,13 @@
 
 	<oidcLogin
 		id="SignHS512EncryptES256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS512ES256"
@@ -902,11 +866,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
-	
+
 	<authFilter id="authFilterRS256ES256">
 		<requestUrl
 			id="requestUrlRS256ES256"
@@ -916,13 +879,12 @@
 
 	<oidcLogin
 		id="SignRS256EncryptES256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS256ES256"
@@ -933,10 +895,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS384ES256">
 		<requestUrl
 			id="requestUrlRS384ES256"
@@ -946,13 +908,12 @@
 
 	<oidcLogin
 		id="SignRS384EncryptES256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS384ES256"
@@ -963,10 +924,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS512ES256">
 		<requestUrl
 			id="requestUrlRS512ES256"
@@ -976,13 +937,12 @@
 
 	<oidcLogin
 		id="SignRS512EncryptES256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS512ES256"
@@ -993,10 +953,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES256ES256">
 		<requestUrl
 			id="requestUrlES256ES256"
@@ -1006,13 +966,12 @@
 
 	<oidcLogin
 		id="SignES256EncryptES256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES256ES256"
@@ -1023,10 +982,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES384ES256">
 		<requestUrl
 			id="requestUrlES384ES256"
@@ -1036,13 +995,12 @@
 
 	<oidcLogin
 		id="SignES384EncryptES256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES384ES256"
@@ -1053,10 +1011,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES512ES256">
 		<requestUrl
 			id="requestUrlES512ES256"
@@ -1066,13 +1024,12 @@
 
 	<oidcLogin
 		id="SignES512EncryptES256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES512ES256"
@@ -1083,9 +1040,9 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
+	</oidcLogin>
 
 	<authFilter id="authFilterHS256ES384">
 		<requestUrl
@@ -1096,23 +1053,22 @@
 
 	<oidcLogin
 		id="SignHS256EncryptES384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS256ES384"
-		signatureAlgorithm="HS256"		
+		signatureAlgorithm="HS256"
 		keyManagementKeyAlias="es384"
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -1125,14 +1081,13 @@
 
 	<oidcLogin
 		id="SignHS384EncryptES384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS384ES384"
@@ -1141,7 +1096,7 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -1154,14 +1109,13 @@
 
 	<oidcLogin
 		id="SignHS512EncryptES384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS512ES384"
@@ -1170,11 +1124,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
-	
+
 	<authFilter id="authFilterRS256ES384">
 		<requestUrl
 			id="requestUrlRS256ES384"
@@ -1184,13 +1137,12 @@
 
 	<oidcLogin
 		id="SignRS256EncryptES384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS256ES384"
@@ -1201,10 +1153,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS384ES384">
 		<requestUrl
 			id="requestUrlRS384ES384"
@@ -1214,13 +1166,12 @@
 
 	<oidcLogin
 		id="SignRS384EncryptES384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS384ES384"
@@ -1231,10 +1182,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS512ES384">
 		<requestUrl
 			id="requestUrlRS512ES384"
@@ -1244,13 +1195,12 @@
 
 	<oidcLogin
 		id="SignRS512EncryptES384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS512ES384"
@@ -1261,10 +1211,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES256ES384">
 		<requestUrl
 			id="requestUrlES256ES384"
@@ -1274,13 +1224,12 @@
 
 	<oidcLogin
 		id="SignES256EncryptES384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES256ES384"
@@ -1291,10 +1240,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES384ES384">
 		<requestUrl
 			id="requestUrlES384ES384"
@@ -1304,13 +1253,12 @@
 
 	<oidcLogin
 		id="SignES384EncryptES384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES384ES384"
@@ -1321,10 +1269,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES512ES384">
 		<requestUrl
 			id="requestUrlES512ES384"
@@ -1334,13 +1282,12 @@
 
 	<oidcLogin
 		id="SignES512EncryptES384"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES512ES384"
@@ -1351,9 +1298,9 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
+	</oidcLogin>
 
 	<authFilter id="authFilterHS256ES512">
 		<requestUrl
@@ -1364,23 +1311,22 @@
 
 	<oidcLogin
 		id="SignHS256EncryptES512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS256ES512"
-		signatureAlgorithm="HS256"		
+		signatureAlgorithm="HS256"
 		keyManagementKeyAlias="es512"
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -1393,14 +1339,13 @@
 
 	<oidcLogin
 		id="SignHS384EncryptES512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS384ES512"
@@ -1409,7 +1354,7 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -1422,14 +1367,13 @@
 
 	<oidcLogin
 		id="SignHS512EncryptES512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		sharedKey="secret"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS512ES512"
@@ -1438,11 +1382,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
-	
+
 	<authFilter id="authFilterRS256ES512">
 		<requestUrl
 			id="requestUrlRS256ES512"
@@ -1452,13 +1395,12 @@
 
 	<oidcLogin
 		id="SignRS256EncryptES512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS256ES512"
@@ -1469,10 +1411,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS384ES512">
 		<requestUrl
 			id="requestUrlRS384ES512"
@@ -1482,13 +1424,12 @@
 
 	<oidcLogin
 		id="SignRS384EncryptES512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS384ES512"
@@ -1499,10 +1440,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS512ES512">
 		<requestUrl
 			id="requestUrlRS512ES512"
@@ -1512,13 +1453,12 @@
 
 	<oidcLogin
 		id="SignRS512EncryptES512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS512ES512"
@@ -1529,10 +1469,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES256ES512">
 		<requestUrl
 			id="requestUrlES256ES512"
@@ -1542,13 +1482,12 @@
 
 	<oidcLogin
 		id="SignES256EncryptES512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES256ES512"
@@ -1559,10 +1498,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES384ES512">
 		<requestUrl
 			id="requestUrlES384ES512"
@@ -1572,13 +1511,12 @@
 
 	<oidcLogin
 		id="SignES384EncryptES512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES384ES512"
@@ -1589,10 +1527,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES512ES512">
 		<requestUrl
 			id="requestUrlES512ES512"
@@ -1602,13 +1540,12 @@
 
 	<oidcLogin
 		id="SignES512EncryptES512"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES512ES512"
@@ -1619,11 +1556,11 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>		
-		
-<!-- Other -->						
+	</oidcLogin>
+
+<!-- Other -->
 	<authFilter id="authFilterInvalidKeyManagementKeyAlias">
 		<requestUrl
 			id="requestUrlInvalidKeyManagementKeyAlias"
@@ -1633,13 +1570,12 @@
 
 	<oidcLogin
 		id="invalidKeyManagementKeyAlias"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterInvalidKeyManagementKeyAlias"
@@ -1650,10 +1586,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterNonExistantKeyManagementKeyAlias">
 		<requestUrl
 			id="requestUrNonExistantKeyManagementKeyAlias"
@@ -1663,13 +1599,12 @@
 
 	<oidcLogin
 		id="nonExistantKeyManagementKeyAlias"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterNonExistantKeyManagementKeyAlias"
@@ -1680,10 +1615,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>		
-			
+	</oidcLogin>
+
 	<authFilter id="authFilterOmittedKeyManagementKeyAlias">
 		<requestUrl
 			id="requestUrlOmittedKeyManagementKeyAlias"
@@ -1693,13 +1628,12 @@
 
 	<oidcLogin
 		id="omittedKeyManagementKeyAlias"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterOmittedKeyManagementKeyAlias"
@@ -1709,9 +1643,9 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>		
+	</oidcLogin>
 
 	<authFilter id="authFilterRS256none">
 		<requestUrl
@@ -1722,13 +1656,12 @@
 
 	<oidcLogin
 		id="SignRS256Encryptnone"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS256none"
@@ -1738,10 +1671,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>		
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS384none">
 		<requestUrl
 			id="requestUrlRS384none"
@@ -1751,13 +1684,12 @@
 
 	<oidcLogin
 		id="SignRS384Encryptnone"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS384none"
@@ -1767,9 +1699,9 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>					
+	</oidcLogin>
 
 	<authFilter id="authFilterRS512none">
 		<requestUrl
@@ -1780,13 +1712,12 @@
 
 	<oidcLogin
 		id="SignRS512Encryptnone"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS512none"
@@ -1796,9 +1727,9 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>					
+	</oidcLogin>
 
 	<authFilter id="authFilterES256none">
 		<requestUrl
@@ -1809,13 +1740,12 @@
 
 	<oidcLogin
 		id="SignES256Encryptnone"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES256none"
@@ -1825,10 +1755,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>		
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES384none">
 		<requestUrl
 			id="requestUrlES384none"
@@ -1838,13 +1768,12 @@
 
 	<oidcLogin
 		id="SignES384Encryptnone"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES384none"
@@ -1854,9 +1783,9 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>					
+	</oidcLogin>
 
 	<authFilter id="authFilterES512none">
 		<requestUrl
@@ -1867,13 +1796,12 @@
 
 	<oidcLogin
 		id="SignES512Encryptnone"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES512none"
@@ -1883,10 +1811,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS256ShortRS256">
 		<requestUrl
 			id="requestUrlRS256ShortRS256"
@@ -1896,13 +1824,12 @@
 
 	<oidcLogin
 		id="SignRS256EncryptShortRS256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS256ShortRS256"
@@ -1913,10 +1840,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-		
+	</oidcLogin>
+
 	<authFilter id="authFilterRS256PublicRS256">
 		<requestUrl
 			id="requestUrlRS256PublicRS256"
@@ -1926,13 +1853,12 @@
 
 	<oidcLogin
 		id="SignRS256EncryptPublicRS256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS256PublicRS256"
@@ -1941,8 +1867,9 @@
 		trustAliasName="rs256"
 		keyManagementKeyAlias="rs256"
 		sslRef="ssl_allSigAlg_badKeyStore"
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>		
+	</oidcLogin>
 
 	<authFilter id="authFilterRP_trustStoreRefOmitted">
 		<requestUrl
@@ -1953,13 +1880,12 @@
 
 	<oidcLogin
 		id="RP_trustStoreRefOmitted"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRP_trustStoreRefOmitted"
@@ -1969,10 +1895,10 @@
 		sslRef="ssl_allSigAlg"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
-
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>		
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRP_sslRefOmitted">
 		<requestUrl
 			id="requestUrlRP_sslRefOmitted"
@@ -1982,20 +1908,20 @@
 
 	<oidcLogin
 		id="RP_sslRefOmitted"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		mapIdentityToRegistryUser="true"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigningEncrypting/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"  
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRP_sslRefOmitted"
 		signatureAlgorithm="RS256"
 		trustAliasName="rs256"
 		keyManagementKeyAlias="rs256"
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>		
-		
+	</oidcLogin>
+
 </server>

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/oidcSigningSocialClients.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/oidcSigningSocialClients.xml
@@ -1,14 +1,11 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 
 <server>
@@ -22,11 +19,10 @@
 
 	<oidcLogin
 		id="hs256"
-		scope="openid profile email"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigning/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"   
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS256"
@@ -35,6 +31,7 @@
 		hostNameVerificationEnabled="false"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -47,11 +44,10 @@
 
 	<oidcLogin
 		id="hs384"
-		scope="openid profile email"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigning/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"   
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS384"
@@ -60,6 +56,7 @@
 		hostNameVerificationEnabled="false"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
 
@@ -72,11 +69,10 @@
 
 	<oidcLogin
 		id="hs512"
-		scope="openid profile email"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigning/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"   
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterHS512"
@@ -85,10 +81,10 @@
 		hostNameVerificationEnabled="false"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
 	</oidcLogin>
-	
-	
+
 	<authFilter id="authFilterRS256">
 		<requestUrl
 			id="requestUrlRS256"
@@ -98,12 +94,11 @@
 
 	<oidcLogin
 		id="rs256"
-		scope="openid profile email"
 		userNameAttribute="sub"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigning/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"   
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS256"
@@ -112,9 +107,10 @@
 		hostNameVerificationEnabled="false"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS384">
 		<requestUrl
 			id="requestUrlRS384"
@@ -124,11 +120,10 @@
 
 	<oidcLogin
 		id="rs384"
-		scope="openid profile email"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigning/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"   
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS384"
@@ -138,9 +133,10 @@
 		hostNameVerificationEnabled="false"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterRS512">
 		<requestUrl
 			id="requestUrlRS512"
@@ -150,11 +146,10 @@
 
 	<oidcLogin
 		id="rs512"
-		scope="openid profile email"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigning/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"   
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterRS512"
@@ -164,9 +159,10 @@
 		hostNameVerificationEnabled="false"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES256">
 		<requestUrl
 			id="requestUrlES256"
@@ -176,11 +172,10 @@
 
 	<oidcLogin
 		id="es256"
-		scope="openid profile email"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigning/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"   
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES256"
@@ -190,9 +185,10 @@
 		hostNameVerificationEnabled="false"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES384">
 		<requestUrl
 			id="requestUrlES384"
@@ -202,11 +198,10 @@
 
 	<oidcLogin
 		id="es384"
-		scope="openid profile email"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigning/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"   
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES384"
@@ -216,9 +211,10 @@
 		hostNameVerificationEnabled="false"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-	
+	</oidcLogin>
+
 	<authFilter id="authFilterES512">
 		<requestUrl
 			id="requestUrlES512"
@@ -228,11 +224,10 @@
 
 	<oidcLogin
 		id="es512"
-		scope="openid profile email"
 		clientId="client01"
 		clientSecret="{xor}LDo8LTor"
 		authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSigning/authorize"
-		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"   
+		tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/TokenEndpointServlet/getToken"
 		userInfoEndpointEnabled="true"
 		authFilterRef="authFilterES512"
@@ -242,8 +237,9 @@
 		hostNameVerificationEnabled="false"
 		issuer="http://localhost:${bvt.prop.security_1_HTTP_default}/TokenEndpointServlet"
 		nonceEnabled="false"
+		isClientSideRedirectSupported="false"
 	>
-	</oidcLogin>	
-						
+	</oidcLogin>
+
 </server>
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/servers/com.ibm.ws.security.social_fat.LibertyOP.social/configs/server_LibertyOP_cookieVerificationTests.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/servers/com.ibm.ws.security.social_fat.LibertyOP.social/configs/server_LibertyOP_cookieVerificationTests.xml
@@ -1,33 +1,30 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
 <server>
 
-	<include location="${server.config.dir}/imports/socialLoginRunableFeatures.xml" />
+    <include location="${server.config.dir}/imports/socialLoginRunableFeatures.xml" />
 
-	<include location="${server.config.dir}/imports/misc.xml" />
-	<include location="${server.config.dir}/imports/helloworldApplication.xml" />
-	<include location="${server.config.dir}/imports/goodBasicRegistry.xml" />
-	<include location="${server.config.dir}/imports/socialSSLSettings.xml" />
+    <include location="${server.config.dir}/imports/misc.xml" />
+    <include location="${server.config.dir}/imports/helloworldApplication.xml" />
+    <include location="${server.config.dir}/imports/goodBasicRegistry.xml" />
+    <include location="${server.config.dir}/imports/socialSSLSettings.xml" />
 
     <oidcLogin
         id="oidcLogin1"
         signatureAlgorithm="RS256"
-        scope="profile email openid"
         userNameAttribute="sub"
         clientId="client01"
         clientSecret="secret"
+        isClientSideRedirectSupported="false"
         authorizationEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/authorize"
         tokenEndpoint="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OidcConfigSample/token"
         authFilterRef="authFilter1"


### PR DESCRIPTION
Adds `isClientSideRedirectSupported="false"` to most of our FAT configs to avoid some cases where JavaScript inexplicably doesn't fire when running tests.