### PR TITLE
Fixed #28239 and #28200 on Bookmark Violation

### DIFF
--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/js/toolbox/views/toolbox.js
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/js/toolbox/views/toolbox.js
@@ -307,6 +307,9 @@ define(["dojo/parser",
         // allow the close button to be tabbable
         registry.byId("addBookmarkDialogId").closeButtonNode.setAttribute("tabindex", "0");
 
+        // add aria-level of 1 to meet accessibility requirements
+        registry.byId("addBookmarkDialogId").titleNode.setAttribute("aria-level", "1");
+
         handleSkipToContentButton();
 
       });

--- a/dev/com.ibm.ws.ui/resources/WEB-CONTENT/js/toolbox/views/toolbox.js
+++ b/dev/com.ibm.ws.ui/resources/WEB-CONTENT/js/toolbox/views/toolbox.js
@@ -304,6 +304,9 @@ define(["dojo/parser",
           registry.byId("bookmarkURL").reset();
         };
 
+        // allow the close button to be tabbable
+        registry.byId("addBookmarkDialogId").closeButtonNode.setAttribute("tabindex", "0");
+
         handleSkipToContentButton();
 
       });


### PR DESCRIPTION
Updated the "tabindex" of the closeButtonNode element and "aria-level" of titleNode element. Both of the elements are included under addBookmarkDialogId, and they were in violation of a11y checkpoint 4.1.2 based on IBM Accessibility Checker.  