### PR TITLE
Added Title for All Search Icons

### DIFF
--- a/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/utils/imgUtils.js
+++ b/dev/com.ibm.ws.ui.shared/resources/WEB-CONTENT/jsShared/utils/imgUtils.js
@@ -62,6 +62,10 @@
     svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
     svg.setAttribute('viewBox', '0 0 64 64');
     svg.setAttribute('role', 'img');
+    // need to include title for all search icons in order to comply with accessibility checker
+    if (name === "search") {
+      svg.setAttribute("title", "searchIcon");
+    }
     if (ariaLabelledBy) {
       svg.setAttribute('aria-labelledby', ariaLabelledBy);
     } else if (ariaLabel) {


### PR DESCRIPTION
A component with an "img" role can contain important information as well as multiple image files. Element with an "img" must have aria label, or it must contain title.