### PR TITLE
Updates to OIDC back-channel logout token creation in line with the spec

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OAuth20TokenImpl.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OAuth20TokenImpl.java
@@ -1,18 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2008 IBM Corporation and others.
+ * Copyright (c) 1997, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.oauth20.plugins;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
@@ -284,26 +282,11 @@ public class OAuth20TokenImpl implements OAuth20Token, Serializable {
         sb.append(" _tokenString: " + _tokenString);
         sb.append(" _clientId: " + _clientId);
         sb.append(" _username: " + _username);
-        sb.append(" _scopes: " + arrayToString(_scopes));
+        sb.append(" _scopes: " + Arrays.toString(_scopes));
         sb.append(" _redirectUri: " + _redirectUri);
         sb.append(" _stateId: " + _stateId);
         sb.append(" _grantType: " + _grantType);
         sb.append(" _extensionProperties: " + JSONUtil.getJSONStrings(_extensionProperties));
-        sb.append("}");
-        return sb.toString();
-    }
-
-    String arrayToString(String[] strs) {
-        StringBuffer sb = new StringBuffer();
-        sb.append("{");
-        if (strs != null && strs.length > 0) {
-            for (int i = 0; i < strs.length; i++) {
-                sb.append(strs[i]);
-                if (i < (strs.length - 1)) {
-                    sb.append(",");
-                }
-            }
-        }
         sb.append("}");
         return sb.toString();
     }

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/jose4j/JWTData.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/jose4j/JWTData.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.oauth20.plugins.jose4j;
 
@@ -21,13 +18,8 @@ import com.ibm.ws.security.jwt.utils.JwtDataConfig;
 import com.ibm.ws.security.oauth20.TraceConstants;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
 
-/**
- *
- */
 public class JWTData {
 
-    private static final String SIGNATURE_ALG_HS256 = "HS256";
-    private static final String SIGNATURE_ALG_RS256 = "RS256";
     private static TraceComponent tc = Tr.register(JWTData.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     public static final String TYPE_ID_TOKEN = "ID Token";
@@ -41,6 +33,7 @@ public class JWTData {
 
     OidcServerConfig oidcServerConfig = null;
     String tokenType = TYPE_ID_TOKEN;
+    String typHeader = null;
 
     String signatureAlgorithm = null;
     JWTTokenException noKeyException = null;
@@ -107,6 +100,14 @@ public class JWTData {
      */
     public String getTokenType() {
         return tokenType;
+    }
+
+    public String getTypHeader() {
+        return typHeader;
+    }
+
+    public void setTypHeader(String typ) {
+        this.typHeader = typ;
     }
 
     public JWTTokenException getNoKeyException() {

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/jose4j/JwsSigner.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/jose4j/JwsSigner.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -66,6 +66,11 @@ public class JwsSigner {
         String keyId = jwtData.getKeyID();
         if (keyId != null) {
             jws.setKeyIdHeaderValue(keyId);
+        }
+
+        String typ = jwtData.getTypHeader();
+        if (typ != null) {
+            jws.setHeader("typ", typ);
         }
 
         // Set the signature algorithm on the JWT/JWS that will integrity protect the claims

--- a/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/jose4j/util/EcJwkTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/jose4j/util/EcJwkTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.client.jose4j.util;
 
@@ -187,6 +184,8 @@ public class EcJwkTest {
                 will(returnValue(issuerIdentifier));
                 one(oidcServerConfig).isCustomClaimsEnabled();
                 will(returnValue(false));
+                one(jwtData).getTypHeader();
+                will(returnValue(null));
                 one(jwtData).getSigningKey();
                 will(returnValue(jsonWebKey.getPrivateKey()));
                 one(jwtData).getKeyID();
@@ -516,6 +515,8 @@ public class EcJwkTest {
                 will(returnValue(issuerIdentifier));
                 one(oidcServerConfig).isCustomClaimsEnabled();
                 will(returnValue(false));
+                one(jwtData).getTypHeader();
+                will(returnValue(null));
                 one(jwtData).getSigningKey();
                 will(returnValue(rsJsonWebKey.getPrivateKey()));
                 one(jwtData).getKeyID();


### PR DESCRIPTION
- Adds the recommended `"typ"` header with value `"logout+jwt"` to the built logout token
- Ensures the logout token is created with at least a `"sub"` and/or `"sid"` claim; at least one of those must be present in the token
- Enhances some unit tests to verify the updated behavior