### PR TITLE
Clarify polling option does not apply to SAF keyrings

### DIFF
--- a/dev/com.ibm.ws.ssl/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.ssl/resources/OSGI-INF/l10n/metatype.properties
@@ -74,7 +74,7 @@ keystore.fileBased=File based keystore
 keystore.fileBased.desc=Specify true if the keystore is file based and false if the keystore is a SAF keyring or hardware keystore type.  
 keystore.trigger.name=Keystore file update trigger
 keystore.trigger.desc=Keystore file update method or trigger.
-keystore.trigger.timed=Server will scan for keystore file changes at the polling interval and update if the keystore file has detectable changes. Polling interval do not apply to non file-based keystores such as SAF keyrings. 
+keystore.trigger.timed=Server will scan for keystore file changes at the polling interval and update if the keystore file has detectable changes. Polled do not apply to non file-based keystores such as SAF keyrings. 
 keystore.trigger.external=Server will only update the keystore when prompted by the FileNotificationMbean. The FileNotificationMbean is typically called by an external program such as an integrated development environment or a management application.
 keystore.trigger.disabled=Disables all update monitoring. Changes to the keystore file will not be applied while the server is running.
 

--- a/dev/com.ibm.ws.ssl/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.ssl/resources/OSGI-INF/l10n/metatype.properties
@@ -74,7 +74,7 @@ keystore.fileBased=File based keystore
 keystore.fileBased.desc=Specify true if the keystore is file based and false if the keystore is a SAF keyring or hardware keystore type.  
 keystore.trigger.name=Keystore file update trigger
 keystore.trigger.desc=Keystore file update method or trigger.
-keystore.trigger.timed=Server will scan for keystore file changes at the polling interval and update if the keystore file has detectable changes.
+keystore.trigger.timed=Server will scan for keystore file changes at the polling interval and update if the keystore file has detectable changes. Polling interval do not apply to non file-based keystores such as SAF keyrings. 
 keystore.trigger.external=Server will only update the keystore when prompted by the FileNotificationMbean. The FileNotificationMbean is typically called by an external program such as an integrated development environment or a management application.
 keystore.trigger.disabled=Disables all update monitoring. Changes to the keystore file will not be applied while the server is running.
 

--- a/dev/com.ibm.ws.ssl/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.ssl/resources/OSGI-INF/l10n/metatype.properties
@@ -74,7 +74,7 @@ keystore.fileBased=File based keystore
 keystore.fileBased.desc=Specify true if the keystore is file based and false if the keystore is a SAF keyring or hardware keystore type.  
 keystore.trigger.name=Keystore file update trigger
 keystore.trigger.desc=Keystore file update method or trigger.
-keystore.trigger.timed=Server will scan for keystore file changes at the polling interval and update if the keystore file has detectable changes. Polled do not apply to non file-based keystores such as SAF keyrings. 
+keystore.trigger.timed=Server will scan for keystore file changes at the polling interval and update if the keystore file has detectable changes. Polled does not apply to non file-based keystores such as SAF keyrings. 
 keystore.trigger.external=Server will only update the keystore when prompted by the FileNotificationMbean. The FileNotificationMbean is typically called by an external program such as an integrated development environment or a management application.
 keystore.trigger.disabled=Disables all update monitoring. Changes to the keystore file will not be applied while the server is running.
 

--- a/dev/com.ibm.ws.ssl/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.ssl/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 IBM Corporation and others.
+# Copyright (c) 2011, 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at


### PR DESCRIPTION
In the following documentation, "updateTrigger - polled" options are not applicable to non file-based keystore such as SAF keyrings. https://www.ibm.com/docs/en/was-liberty/nd?topic=configuration-ssl#keyStore

The documentation is auto-generated from the metatype file. This PR is to clarify the documentation.
**Current:** Polled: Server will scan for keystore file changes at the polling interval and update if the keystore file has detectable changes.
**After this PR:** Polled: Server will scan for keystore file changes at the polling interval and update if the keystore file has detectable changes. **Polling intervals do not apply to non file-based keystores such as SAF keyrings.** 