### PR TITLE
Update processing of containers in app classloader

### DIFF
--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -559,7 +559,7 @@ public class ZipFileContainerUtils {
      */
     @Trivial
     public static ZipEntryData[] collectZipEntries(ZipFile zipFile) {
-        final List<ZipEntryData> entriesList = new ArrayList<ZipEntryData>();
+        final List<ZipEntryData> entriesList = new ArrayList<>(zipFile.size());
 
         final Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
         while ( zipEntries.hasMoreElements() ) {

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoaderFactory.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoaderFactory.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -134,9 +134,8 @@ class ClassLoaderFactory extends GatewayBundleFactory {
         validate();
         inferParentLoader();
         AppClassLoader result = config.getDelegateToParentAfterCheckingLocalClasspath()
-                        ? new ParentLastClassLoader(parentClassLoader, config, classPath, access, redefiner, generator, globalConfig, systemTransformers)
-                        : new AppClassLoader(parentClassLoader, config, classPath, access, redefiner, generator, globalConfig, systemTransformers);
-        addSharedLibPaths(result);
+                        ? new ParentLastClassLoader(parentClassLoader, config, classPath, access, redefiner, generator, globalConfig, systemTransformers, sharedLibPath)
+                        : new AppClassLoader(parentClassLoader, config, classPath, access, redefiner, generator, globalConfig, systemTransformers, sharedLibPath);
         runPostCreateAction(result);
         return result;
     }
@@ -170,15 +169,6 @@ class ClassLoaderFactory extends GatewayBundleFactory {
             // DEAL WITH CHILD CLASSLOADER (if parent not already cached)
             ClassLoaderIdentity parentID = this.config.getParentId();
             setParent(ensureNotNull("Could not find parent classloader with id '" + parentID + "'.", store.retrieve(parentID)));
-        }
-    }
-
-    private void addSharedLibPaths(AppClassLoader result) {
-        //used by the bundle addon loader to add shared libs.. there has to be a better way!
-        if (this.sharedLibPath != null) {
-            for (File f : sharedLibPath) {
-                result.addLibraryFile(f);
-            }
         }
     }
 

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ParentLastClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ParentLastClassLoader.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2022 IBM Corporation and others.
+ * Copyright (c) 2010, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,6 +18,7 @@ import static com.ibm.ws.classloading.internal.AppClassLoader.SearchLocation.SEL
 import static com.ibm.ws.classloading.internal.Util.freeze;
 import static com.ibm.ws.classloading.internal.Util.list;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.instrument.ClassFileTransformer;
 import java.net.URL;
@@ -30,6 +31,7 @@ import com.ibm.ws.classloading.configuration.GlobalClassloadingConfiguration;
 import com.ibm.ws.classloading.internal.util.ClassRedefiner;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.wsspi.adaptable.module.Container;
+import com.ibm.wsspi.artifact.ArtifactContainer;
 import com.ibm.wsspi.classloading.ClassLoaderConfiguration;
 
 /**
@@ -40,8 +42,8 @@ class ParentLastClassLoader extends AppClassLoader {
     static {
         ClassLoader.registerAsParallelCapable();
     }
-    ParentLastClassLoader(ClassLoader parent, ClassLoaderConfiguration config, List<Container> urls, DeclaredApiAccess access, ClassRedefiner redefiner, ClassGenerator generator, GlobalClassloadingConfiguration globalConfig, List<ClassFileTransformer> systemTransformers) {
-        super(parent, config, urls, access, redefiner, generator, globalConfig, systemTransformers);
+    ParentLastClassLoader(ClassLoader parent, ClassLoaderConfiguration config, List<Container> urls, DeclaredApiAccess access, ClassRedefiner redefiner, ClassGenerator generator, GlobalClassloadingConfiguration globalConfig, List<ClassFileTransformer> systemTransformers, List<File> sharedLibPath) {
+        super(parent, config, urls, access, redefiner, generator, globalConfig, systemTransformers, sharedLibPath);
     }
 
     static final List<SearchLocation> PARENT_LAST_SEARCH_ORDER = freeze(list(SELF, DELEGATES, PARENT));

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -64,7 +64,7 @@ public class LibertyClassLoaderTest {
     public void testClassFormatError() throws Exception {
         Container c = buildMockContainer("testClasses", getOtherClassesURL(ClassSource.A));
 
-        loader = new AppClassLoader(loader.getParent(), loader.config, Arrays.asList(c), (DeclaredApiAccess) (loader.getParent()), null, null, new GlobalClassloadingConfiguration(), Collections.emptyList()) {
+        loader = new AppClassLoader(loader.getParent(), loader.config, Arrays.asList(c), (DeclaredApiAccess) (loader.getParent()), null, null, new GlobalClassloadingConfiguration(), Collections.emptyList(), Collections.emptyList()) {
             @Override
             protected com.ibm.ws.classloading.internal.AppClassLoader.ByteResourceInformation findClassBytes(String className, String resourceName,
                                                                                                              ClassLoaderHook hook) throws IOException {

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/ProtectionDomainTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/ProtectionDomainTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -88,7 +88,7 @@ public class ProtectionDomainTest {
                 return null;
             }
         };
-        AppClassLoader appClassLoader = new AppClassLoader(BOOTSTRAP_CLASS_LOADER, config, containers, access, null, null, new GlobalClassloadingConfiguration(), Collections.emptyList());
+        AppClassLoader appClassLoader = new AppClassLoader(BOOTSTRAP_CLASS_LOADER, config, containers, access, null, null, new GlobalClassloadingConfiguration(), Collections.emptyList(), Collections.emptyList());
 
         Class<?> testJarClass = appClassLoader.loadClass("test.StringReturner");
         String location = testJarClass.getProtectionDomain().getCodeSource().getLocation().toString();
@@ -127,7 +127,7 @@ public class ProtectionDomainTest {
                 return null;
             }
         };
-        AppClassLoader appClassLoader = new AppClassLoader(BOOTSTRAP_CLASS_LOADER, config, containers, access, null, null, new GlobalClassloadingConfiguration(), Collections.emptyList());
+        AppClassLoader appClassLoader = new AppClassLoader(BOOTSTRAP_CLASS_LOADER, config, containers, access, null, null, new GlobalClassloadingConfiguration(), Collections.emptyList(), Collections.emptyList());
 
         Class<?> testJarClass = appClassLoader.loadClass("test.StringReturner");
         String location = testJarClass.getProtectionDomain().getCodeSource().getLocation().toString();


### PR DESCRIPTION
- For checkpoint create the package map inline instead of using a thread
- Update to use less threads by having a thread do a collection of Containers instead of a thread per Container since each thread will just block the others.
- Set the size for the ArrayList when collecting zip entries since we know what the size will be.
