### PR TITLE
Update SAML tests for changes due to RFC 9110

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTestHelpers.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTestHelpers.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -1579,23 +1579,23 @@ public class SAMLCommonTestHelpers extends TestHelpers {
                 if (samlNameForHeader != null) {
                     if (settings.getRSSettings().getHeaderFormat().equals(SAMLConstants.SAML_HEADER_1)) {
                         con.setRequestProperty("saml_name", authString);
-                        con.setRequestProperty(authString, settings.getRSSettings().getHeaderName() + "=" + samlValue);
-                        Log.info(thisClass, thisMethod, "Header format 1: " + authString + "=" + settings.getRSSettings().getHeaderName() + "=" + samlValue);
+                        con.setRequestProperty(authString, samlNameForHeader + "=" + samlValue);
+                        Log.info(thisClass, thisMethod, "Header format 1: " + authString + "=" + samlNameForHeader + "=" + samlValue);
                     }
                     if (settings.getRSSettings().getHeaderFormat().equals(SAMLConstants.SAML_HEADER_2)) {
                         con.setRequestProperty("saml_name", authString);
-                        con.setRequestProperty(authString, settings.getRSSettings().getHeaderName() + "=\"" + samlValue + "\"");
-                        Log.info(thisClass, thisMethod, "Header format 2: " + authString + "=" + settings.getRSSettings().getHeaderName() + "=\"" + samlValue + "\"");
+                        con.setRequestProperty(authString, samlNameForHeader + "=\"" + samlValue + "\"");
+                        Log.info(thisClass, thisMethod, "Header format 2: " + authString + "=" + samlNameForHeader + "=\"" + samlValue + "\"");
                     }
                     if (settings.getRSSettings().getHeaderFormat().equals(SAMLConstants.SAML_HEADER_3)) {
                         con.setRequestProperty("saml_name", authString);
-                        con.setRequestProperty(authString, settings.getRSSettings().getHeaderName() + " " + samlValue);
-                        Log.info(thisClass, thisMethod, "Header format 3: " + authString + "=" + settings.getRSSettings().getHeaderName() + " " + samlValue);
+                        con.setRequestProperty(authString, samlNameForHeader + " " + samlValue);
+                        Log.info(thisClass, thisMethod, "Header format 3: " + authString + "=" + samlNameForHeader + " " + samlValue);
                     }
                     if (settings.getRSSettings().getHeaderFormat().equals(SAMLConstants.SAML_HEADER_4)) {
-                        con.setRequestProperty("saml_name", settings.getRSSettings().getHeaderName());
-                        con.setRequestProperty(settings.getRSSettings().getHeaderName(), samlValue);
-                        Log.info(thisClass, thisMethod, "Header format 4: " + settings.getRSSettings().getHeaderName() + "=" + samlValue);
+                        con.setRequestProperty("saml_name", samlNameForHeader);
+                        con.setRequestProperty(samlNameForHeader, samlValue);
+                        Log.info(thisClass, thisMethod, "Header format 4: " + samlNameForHeader + "=" + samlValue);
                     }
                 } else {
                     Log.info(thisClass, thisMethod, "NOT Passing SAML Assertion on call");
@@ -1768,7 +1768,7 @@ public class SAMLCommonTestHelpers extends TestHelpers {
      * server exceptions for this particular server.
      *
      * @param theServer
-     *                           - the server to register the allowed excpetion to.
+     *            - the server to register the allowed excpetion to.
      * @param expected
      * @param step
      * @param log

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTestHelpers.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTestHelpers.java
@@ -1577,22 +1577,22 @@ public class SAMLCommonTestHelpers extends TestHelpers {
             if ((settings.getRSSettings() != null) && (startPage != null)) {
                 String samlNameForHeader = settings.getRSSettings().getHeaderName();
                 if (samlNameForHeader != null) {
-                    if (settings.getRSSettings().getHeaderFormat().equals(SAMLConstants.SAML_HEADER_1)) {
+                    if (settings.getRSSettings().getHeaderFormat().equals(SAMLConstants.HEADER_FORMAT_AUTHZ_NAME_EQUALS_VALUE)) {
                         con.setRequestProperty("saml_name", authString);
                         con.setRequestProperty(authString, samlNameForHeader + "=" + samlValue);
                         Log.info(thisClass, thisMethod, "Header format 1: " + authString + "=" + samlNameForHeader + "=" + samlValue);
                     }
-                    if (settings.getRSSettings().getHeaderFormat().equals(SAMLConstants.SAML_HEADER_2)) {
+                    if (settings.getRSSettings().getHeaderFormat().equals(SAMLConstants.HEADER_FORMAT_AUTHZ_NAME_EQUALS_QUOTED_VALUE)) {
                         con.setRequestProperty("saml_name", authString);
                         con.setRequestProperty(authString, samlNameForHeader + "=\"" + samlValue + "\"");
                         Log.info(thisClass, thisMethod, "Header format 2: " + authString + "=" + samlNameForHeader + "=\"" + samlValue + "\"");
                     }
-                    if (settings.getRSSettings().getHeaderFormat().equals(SAMLConstants.SAML_HEADER_3)) {
+                    if (settings.getRSSettings().getHeaderFormat().equals(SAMLConstants.HEADER_FORMAT_AUTHZ_NAME_SPACE_VALUE)) {
                         con.setRequestProperty("saml_name", authString);
                         con.setRequestProperty(authString, samlNameForHeader + " " + samlValue);
                         Log.info(thisClass, thisMethod, "Header format 3: " + authString + "=" + samlNameForHeader + " " + samlValue);
                     }
-                    if (settings.getRSSettings().getHeaderFormat().equals(SAMLConstants.SAML_HEADER_4)) {
+                    if (settings.getRSSettings().getHeaderFormat().equals(SAMLConstants.HEADER_FORMAT_NAME_EQUALS_VALUE)) {
                         con.setRequestProperty("saml_name", samlNameForHeader);
                         con.setRequestProperty(samlNameForHeader, samlValue);
                         Log.info(thisClass, thisMethod, "Header format 4: " + samlNameForHeader + "=" + samlValue);

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLConstants.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLConstants.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -511,15 +511,16 @@ public class SAMLConstants extends Constants {
     //    public static final String[] SAML_TOKEN_FORMATS = new String[] { ASSERTION_TEXT_ONLY, ASSERTION_ENCODED, ASSERTION_COMPRESSED_ENCODED };
     public static final String[] SAML_TOKEN_FORMATS = new String[] { ASSERTION_ENCODED, ASSERTION_COMPRESSED_ENCODED };
 
-    public static final String SAML_HEADER_1 = "auth_header_saml_with_equals";
-    public static final String SAML_HEADER_2 = "auth_header_saml_with_equals_and_quotes";
-    public static final String SAML_HEADER_3 = "auth_header_saml_no_equals";
-    public static final String SAML_HEADER_4 = "header_saml_with_equals";
-    public static final String SAML_HEADER_5t = "propagate_token_string_true";
-    public static final String SAML_HEADER_5f = "propagate_token_string_false";
-    public static final String SAML_HEADER_6t = "propagate_token_boolean_true";
-    public static final String SAML_HEADER_6f = "propagate_token_boolean_false";
-    public static final String[] SAML_HEADER_FORMATS = new String[] { SAML_HEADER_1, SAML_HEADER_2, SAML_HEADER_3, SAML_HEADER_4 };
+    public static final String HEADER_FORMAT_AUTHZ_NAME_EQUALS_VALUE = "auth_header_saml_with_equals";
+    public static final String HEADER_FORMAT_AUTHZ_NAME_EQUALS_QUOTED_VALUE = "auth_header_saml_with_equals_and_quotes";
+    public static final String HEADER_FORMAT_AUTHZ_NAME_SPACE_VALUE = "auth_header_saml_no_equals";
+    public static final String HEADER_FORMAT_NAME_EQUALS_VALUE = "header_saml_with_equals";
+    public static final String HEADER_FORMAT_PROPAGATE_TOKEN_STRING_TRUE = "propagate_token_string_true";
+    public static final String HEADER_FORMAT_PROPAGATE_TOKEN_STRING_FALSE = "propagate_token_string_false";
+    public static final String HEADER_FORMAT_PROPAGATE_TOKEN_BOOLEAN_TRUE = "propagate_token_boolean_true";
+    public static final String HEADER_FORMAT_PROPAGATE_TOKEN_BOOLEAN_FALSE = "propagate_token_boolean_false";
+    public static final String[] SAML_HEADER_FORMATS = new String[] { HEADER_FORMAT_AUTHZ_NAME_EQUALS_VALUE, HEADER_FORMAT_AUTHZ_NAME_EQUALS_QUOTED_VALUE, HEADER_FORMAT_AUTHZ_NAME_SPACE_VALUE,
+                                                                      HEADER_FORMAT_NAME_EQUALS_VALUE };
 
     /* SAML IDPs */
     public static final String[] IDP_SERVER_LIST = { "localhost:8019:8029" };

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLTestSettings.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLTestSettings.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -440,8 +440,9 @@ public class SAMLTestSettings extends TestSettings {
         public RSSettings() {
             headerName = "saml_token";
             headerFormat = cttools
-                            .chooseRandomEntry(new String[] { SAMLConstants.SAML_HEADER_1, SAMLConstants.SAML_HEADER_2, SAMLConstants.SAML_HEADER_3, SAMLConstants.SAML_HEADER_4 });
-            //			this.headerFormat = cttools.chooseRandomEntry(new String[] {SAMLConstants.SAML_HEADER_2}) ;
+                            .chooseRandomEntry(new String[] { SAMLConstants.HEADER_FORMAT_AUTHZ_NAME_EQUALS_VALUE, SAMLConstants.HEADER_FORMAT_AUTHZ_NAME_SPACE_VALUE,
+                                                              SAMLConstants.HEADER_FORMAT_AUTHZ_NAME_SPACE_VALUE, SAMLConstants.HEADER_FORMAT_NAME_EQUALS_VALUE });
+            //			this.headerFormat = cttools.chooseRandomEntry(new String[] {SAMLConstants.HEADER_FORMAT_AUTHZ_NAME_SPACE_VALUE}) ;
             // randomly choose if SAML should be  encoded, compressed and encoded, or left as a string (when it is passed on the invoke of the app)
             // duplicate 3 items in the list so we get a better "random" sampling...
             //			this.samlTokenFormat = cttools.chooseRandomEntry(new String[] {SAMLConstants.ASSERTION_TEXT_ONLY, SAMLConstants.ASSERTION_ENCODED, SAMLConstants.ASSERTION_COMPRESSED_ENCODED, SAMLConstants.TOKEN_TEXT_ONLY, SAMLConstants.ASSERTION_TEXT_ONLY, SAMLConstants.ASSERTION_ENCODED, SAMLConstants.ASSERTION_COMPRESSED_ENCODED, SAMLConstants.TOKEN_TEXT_ONLY});
@@ -685,9 +686,9 @@ public class SAMLTestSettings extends TestSettings {
     /**
      *
      * @param httpStart
-     *                       prefix Url string (ie: http://localhost:DefaultPort)
+     *            prefix Url string (ie: http://localhost:DefaultPort)
      * @param httpsStart
-     *                       prefix Url string (ie: https://localhost:DefaultSSLPort)
+     *            prefix Url string (ie: https://localhost:DefaultSSLPort)
      * @return
      *         returns a TestSettings object with the default values set
      */
@@ -734,7 +735,7 @@ public class SAMLTestSettings extends TestSettings {
      * Using the currently chosen TFIM server, return the IDP challenge provider requested
      *
      * @param provider
-     *                     - index of requested provider
+     *            - index of requested provider
      * @return
      * @throws Exception
      */
@@ -1219,7 +1220,7 @@ public class SAMLTestSettings extends TestSettings {
     public RSSettings overWriteRSSettings(RSSettings orig, String inHeaderName, String inHeaderFormat, String inSamlTokenFormat) {
 
         String headerName = "saml_token";
-        String headerFormat = SAMLConstants.SAML_HEADER_4;
+        String headerFormat = SAMLConstants.HEADER_FORMAT_NAME_EQUALS_VALUE;
         String samlTokenFormat = SAMLConstants.ASSERTION_ENCODED;
         if (orig != null) {
             if (orig.getHeaderName() != null) {

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/IDPInitiated/RSSamlIDPInitiatedMiscConfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/IDPInitiated/RSSamlIDPInitiatedMiscConfigTests.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -155,22 +155,79 @@ public class RSSamlIDPInitiatedMiscConfigTests extends RSSamlIDPInitiatedConfigC
      *
      * @throws Exception
      */
-    @Test
-    public void RSSamlIDPInitiatedConfigTests_headerName_nonEmptyWithSpaces() throws Exception {
+    /**
+     * Update test as runtime was updated to honor
+     * RFC 9110 - disallow spaces
+     *
+     * @throws Exception
+     */
+    public void common_headerName_withSpaces(String format, String headerName, int status) throws Exception {
 
         RSSamlConfigSettings updatedRsSamlSettings = rsConfigSettings.copyConfigSettings();
         RSSamlProviderSettings updatedProviderSettings = updatedRsSamlSettings.getDefaultRSSamlProviderSettings();
-        String headerName = "Some value with  spaces.";
         updatedProviderSettings.setHeaderName(headerName);
 
         // Update the header name in the test settings
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         RSSettings rsSettings = updatedTestSettings.getRSSettings();
         rsSettings.setHeaderName(headerName);
+        rsSettings.setHeaderFormat(format);
 
-        List<validationData> expectations = commonUtils.getGoodExpectationsForJaxrsGet(flowType, updatedTestSettings);
+        List<validationData> expectations = null;
+        if (status == SAMLConstants.BAD_REQUEST_STATUS) {
+            expectations = vData.addSuccessStatusCodes(null, SAMLConstants.INVOKE_JAXRS_GET);
+            expectations = vData.addResponseStatusExpectation(expectations, SAMLConstants.INVOKE_JAXRS_GET, status);
+            expectations = vData.addExpectation(expectations, SAMLConstants.INVOKE_JAXRS_GET, SAMLConstants.RESPONSE_MESSAGE, SAMLConstants.STRING_CONTAINS, "Did not get a failure because the header name contained spaces.", null, SAMLConstants.BAD_REQUEST);
+        } else {
+            commonUtils.getGoodExpectationsForJaxrsGet(flowType, updatedTestSettings);
+        }
 
         generalConfigTest(updatedRsSamlSettings, expectations, updatedTestSettings);
+    }
+
+    /**
+     * Pass header as Authorization=<header>=<value>
+     *
+     * @throws Exception
+     */
+    @Test
+    public void RSSamlIDPInitiatedConfigTests_headerName_nonEmptyWithSpaces_formatHeaderEqualsValue() throws Exception {
+
+        common_headerName_withSpaces(SAMLConstants.SAML_HEADER_1, "Some value with  spaces.", SAMLConstants.OK_STATUS);
+    }
+
+    /**
+     * Pass header as Authorization=<header>="<value>"
+     *
+     * @throws Exception
+     */
+    @Test
+    public void RSSamlIDPInitiatedConfigTests_headerName_nonEmptyWithSpaces_formatHeaderEqualsQuotedValue() throws Exception {
+
+        common_headerName_withSpaces(SAMLConstants.SAML_HEADER_2, "Some value with  spaces.", SAMLConstants.OK_STATUS);
+    }
+
+     /**
+     * Pass header as Authorization=<header> <value>
+     *
+     * @throws Exception
+     */
+   @Test
+    public void RSSamlIDPInitiatedConfigTests_headerName_nonEmptyWithSpaces_formatHeaderSpaceValue() throws Exception {
+
+        common_headerName_withSpaces(SAMLConstants.SAML_HEADER_3, "Some value with  spaces.", SAMLConstants.OK_STATUS);
+    }
+
+    /**
+     * Pass header as <header>=<value>
+     *
+     * @throws Exception
+     */
+    @ExpectedFFDC({ "java.lang.IllegalArgumentException" })
+    @Test
+    public void RSSamlIDPInitiatedConfigTests_headerName_nonEmptyWithSpaces_formatNoAuthHeaderEqualsValue() throws Exception {
+
+        common_headerName_withSpaces(SAMLConstants.SAML_HEADER_4, "Some value with  spaces.", SAMLConstants.BAD_REQUEST_STATUS);
     }
 
     /**************************************

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/IDPInitiated/RSSamlIDPInitiatedMiscConfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/IDPInitiated/RSSamlIDPInitiatedMiscConfigTests.java
@@ -193,7 +193,7 @@ public class RSSamlIDPInitiatedMiscConfigTests extends RSSamlIDPInitiatedConfigC
     @Test
     public void RSSamlIDPInitiatedConfigTests_headerName_nonEmptyWithSpaces_formatHeaderEqualsValue() throws Exception {
 
-        common_headerName_withSpaces(SAMLConstants.SAML_HEADER_1, "Some value with  spaces.", SAMLConstants.OK_STATUS);
+        common_headerName_withSpaces(SAMLConstants.HEADER_FORMAT_AUTHZ_NAME_EQUALS_VALUE, "Some value with  spaces.", SAMLConstants.OK_STATUS);
     }
 
     /**
@@ -204,18 +204,18 @@ public class RSSamlIDPInitiatedMiscConfigTests extends RSSamlIDPInitiatedConfigC
     @Test
     public void RSSamlIDPInitiatedConfigTests_headerName_nonEmptyWithSpaces_formatHeaderEqualsQuotedValue() throws Exception {
 
-        common_headerName_withSpaces(SAMLConstants.SAML_HEADER_2, "Some value with  spaces.", SAMLConstants.OK_STATUS);
+        common_headerName_withSpaces(SAMLConstants.HEADER_FORMAT_AUTHZ_NAME_EQUALS_QUOTED_VALUE, "Some value with  spaces.", SAMLConstants.OK_STATUS);
     }
 
-     /**
+    /**
      * Pass header as Authorization=<header> <value>
      *
      * @throws Exception
      */
-   @Test
+    @Test
     public void RSSamlIDPInitiatedConfigTests_headerName_nonEmptyWithSpaces_formatHeaderSpaceValue() throws Exception {
 
-        common_headerName_withSpaces(SAMLConstants.SAML_HEADER_3, "Some value with  spaces.", SAMLConstants.OK_STATUS);
+        common_headerName_withSpaces(SAMLConstants.HEADER_FORMAT_AUTHZ_NAME_SPACE_VALUE, "Some value with  spaces.", SAMLConstants.OK_STATUS);
     }
 
     /**
@@ -227,7 +227,7 @@ public class RSSamlIDPInitiatedMiscConfigTests extends RSSamlIDPInitiatedConfigC
     @Test
     public void RSSamlIDPInitiatedConfigTests_headerName_nonEmptyWithSpaces_formatNoAuthHeaderEqualsValue() throws Exception {
 
-        common_headerName_withSpaces(SAMLConstants.SAML_HEADER_4, "Some value with  spaces.", SAMLConstants.BAD_REQUEST_STATUS);
+        common_headerName_withSpaces(SAMLConstants.HEADER_FORMAT_NAME_EQUALS_VALUE, "Some value with  spaces.", SAMLConstants.BAD_REQUEST_STATUS);
     }
 
     /**************************************

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlAPITests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlAPITests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -230,7 +230,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
         WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.setRSSettings("Authorization", SAMLConstants.SAML_HEADER_5t, SAMLConstants.ASSERTION_ENCODED);
+        updatedTestSettings.setRSSettings("Authorization", SAMLConstants.HEADER_FORMAT_PROPAGATE_TOKEN_STRING_TRUE, SAMLConstants.ASSERTION_ENCODED);
 
         List<validationData> expectations = null;
         if (flowType.equals(SAMLConstants.IDP_INITIATED)) {
@@ -266,7 +266,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
         WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.setRSSettings("Authorization", SAMLConstants.SAML_HEADER_6t, SAMLConstants.ASSERTION_ENCODED);
+        updatedTestSettings.setRSSettings("Authorization", SAMLConstants.HEADER_FORMAT_PROPAGATE_TOKEN_BOOLEAN_TRUE, SAMLConstants.ASSERTION_ENCODED);
 
         List<validationData> expectations = null;
         if (flowType.equals(SAMLConstants.IDP_INITIATED)) {
@@ -300,7 +300,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
         WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.setRSSettings("Authorization", SAMLConstants.SAML_HEADER_5f, SAMLConstants.ASSERTION_ENCODED);
+        updatedTestSettings.setRSSettings("Authorization", SAMLConstants.HEADER_FORMAT_PROPAGATE_TOKEN_STRING_FALSE, SAMLConstants.ASSERTION_ENCODED);
 
         List<validationData> expectations = null;
         expectations = vData.addSuccessStatusCodes(null, endAction);
@@ -332,7 +332,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
         WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
-        updatedTestSettings.setRSSettings("Authorization", SAMLConstants.SAML_HEADER_6f, SAMLConstants.ASSERTION_ENCODED);
+        updatedTestSettings.setRSSettings("Authorization", SAMLConstants.HEADER_FORMAT_PROPAGATE_TOKEN_BOOLEAN_FALSE, SAMLConstants.ASSERTION_ENCODED);
 
         List<validationData> expectations = null;
         expectations = vData.addSuccessStatusCodes(null, endAction);


### PR DESCRIPTION
Update expected behavior for tests using embedded spaces in the saml header name.