### PR TITLE
Update ToolboxPersistenceTest.java

### DIFF
--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/CatalogPersistenceTest.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/CatalogPersistenceTest.java
@@ -92,7 +92,8 @@ public class CatalogPersistenceTest extends CommonRESTTest implements APIConstan
             "CWWKX1002E:.*",
             "CWWKX1003E:.*",
             "CWWKX1009E:.*",
-            "CWWKX1010E:.*");
+            "CWWKX1010E:.*",
+            "SRVE8094W:.*");
     }
 
     /**

--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/CatalogPersistenceTest.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/CatalogPersistenceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/ToolboxPersistenceTest.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/ToolboxPersistenceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -129,7 +129,8 @@ public class ToolboxPersistenceTest extends CommonRESTTest implements APIConstan
             "CWWKX1010E:.*",
             "CWWKX1031E:.*",
             "CWWKX1009E:.*",
-            "CWWKX1030E:.*"
+            "CWWKX1030E:.*",
+            "SRVE8094W: WARNING: Cannot set header. Response already committed.*" 
         );
     }
 

--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/ToolboxPersistenceTest.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/ToolboxPersistenceTest.java
@@ -130,7 +130,7 @@ public class ToolboxPersistenceTest extends CommonRESTTest implements APIConstan
             "CWWKX1031E:.*",
             "CWWKX1009E:.*",
             "CWWKX1030E:.*",
-            "SRVE8094W: WARNING: Cannot set header. Response already committed.*" 
+            "SRVE8094W:.*"
         );
     }
 


### PR DESCRIPTION
Two multithreaded tests are finding this warning in the logs but it's not significant and should be ignored.