### PR TITLE
Add new VisibilityTest for tolerated public / protected features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,7 +14,9 @@
 package com.ibm.ws.feature.tests;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -26,6 +28,8 @@ import org.junit.Test;
 import com.ibm.ws.feature.utils.FeatureInfo;
 import com.ibm.ws.feature.utils.FeatureMapFactory;
 import com.ibm.ws.feature.utils.FeatureVerifier;
+
+import aQute.bnd.header.Attrs;
 
 public class VisibilityTest {
 
@@ -47,7 +51,7 @@ public class VisibilityTest {
             FeatureInfo featureInfo = entry.getValue();
 
             Set<String> dependentAutoFeatures = null;
-            for (String dependentFeature : featureInfo.getDependentFeatures()) {
+            for (String dependentFeature : featureInfo.getDependentFeatures().keySet()) {
                 FeatureInfo depFeatureInfo = features.get(dependentFeature);
                 if (depFeatureInfo != null && depFeatureInfo.isAutoFeature()) {
                     if (dependentAutoFeatures == null) {
@@ -86,7 +90,7 @@ public class VisibilityTest {
             }
 
             Set<String> dependentActivationMismatch = null;
-            for (String dependentFeature : featureInfo.getDependentFeatures()) {
+            for (String dependentFeature : featureInfo.getDependentFeatures().keySet()) {
                 FeatureInfo depFeatureInfo = features.get(dependentFeature);
                 if (depFeatureInfo != null && !depFeatureInfo.isParallelActivationEnabled()) {
                     if (dependentActivationMismatch == null) {
@@ -126,7 +130,7 @@ public class VisibilityTest {
             }
 
             Set<String> dependentDisableOnConflictMismatch = null;
-            for (String dependentFeature : featureInfo.getDependentFeatures()) {
+            for (String dependentFeature : featureInfo.getDependentFeatures().keySet()) {
                 FeatureInfo depFeatureInfo = features.get(dependentFeature);
                 if (depFeatureInfo != null && depFeatureInfo.isDisableOnConflictEnabled()) {
                     if (dependentDisableOnConflictMismatch == null) {
@@ -405,7 +409,7 @@ public class VisibilityTest {
                 if (!featureInfo.isAutoFeature()) {
                     boolean containsNoShipFeature = false;
                     boolean containsBetaFeature = false;
-                    for (String depFeatureName : featureInfo.getDependentFeatures()) {
+                    for (String depFeatureName : featureInfo.getDependentFeatures().keySet()) {
                         FeatureInfo depFeature = features.get(depFeatureName);
                         if (depFeature == null) {
                             continue;
@@ -434,5 +438,237 @@ public class VisibilityTest {
                         +
                         errorMessage.toString());
         }
+    }
+
+    /**
+     * Tests to make sure that public and protected features are correctly referenced in a feature
+     * when a dependent feature includes a public or protected feature with a tolerates attribute.
+     */
+    @Test
+    public void testNonTransitiveTolerates() {
+        StringBuilder errorMessage = new StringBuilder();
+        // javaeePlatform and appSecurity are special because they have dependencies on each other.
+        Set<String> nonSingletonToleratedFeatures = new HashSet<>();
+        nonSingletonToleratedFeatures.add("io.openliberty.jakartaeePlatform-");
+        nonSingletonToleratedFeatures.add("com.ibm.websphere.appserver.javaeePlatform-");
+        nonSingletonToleratedFeatures.add("com.ibm.websphere.appserver.appSecurity-");
+        Map<String, String> visibilityMap = new HashMap<>();
+        for (Entry<String, FeatureInfo> entry : features.entrySet()) {
+            String feature = entry.getKey();
+            int lastIndex = feature.indexOf('-');
+            if (lastIndex == -1) {
+                continue;
+            }
+            String baseFeatureName = feature.substring(0, lastIndex + 1);
+            visibilityMap.put(baseFeatureName, entry.getValue().getVisibility());
+
+        }
+        for (Entry<String, FeatureInfo> entry : features.entrySet()) {
+            String featureName = entry.getKey();
+
+            FeatureInfo featureInfo = entry.getValue();
+            if (featureInfo.isAutoFeature()) {
+                continue;
+            }
+            Set<String> processedFeatures = new HashSet<>();
+            Map<String, Attrs> depFeatures = featureInfo.getDependentFeatures();
+            Set<String> rootDepFeatureWithoutTolerates = new HashSet<>();
+            for (Map.Entry<String, Attrs> depEntry : depFeatures.entrySet()) {
+                Attrs attrs = depEntry.getValue();
+                if (!attrs.containsKey("ibm.tolerates:")) {
+                    rootDepFeatureWithoutTolerates.add(depEntry.getKey());
+                }
+            }
+
+            Map<String, Set<String>> featureErrors = new HashMap<>();
+            Map<String, Set<String>> toleratedFeatures = new HashMap<>();
+            for (Map.Entry<String, Attrs> depFeature : depFeatures.entrySet()) {
+                String depFeatureName = depFeature.getKey();
+                FeatureInfo depFeatureInfo = features.get(depFeatureName);
+                if (depFeatureInfo != null) {
+                    for (Map.Entry<String, Attrs> depEntry2 : depFeatureInfo.getDependentFeatures().entrySet()) {
+                        Map<String, Set<String>> tolFeatures = processIncludedFeature(featureName, rootDepFeatureWithoutTolerates,
+                                                                                      depEntry2.getKey(), featureName + " -> " + depFeatureName, featureErrors, processedFeatures,
+                                                                                      depEntry2.getValue().containsKey("ibm.tolerates:"),
+                                                                                      depFeature.getValue().containsKey("ibm.tolerates:"));
+                        if (tolFeatures != null) {
+                            for (Entry<String, Set<String>> entry2 : tolFeatures.entrySet()) {
+                                String key = entry2.getKey();
+                                Set<String> existing = toleratedFeatures.get(key);
+                                if (existing == null) {
+                                    toleratedFeatures.put(key, entry2.getValue());
+                                } else {
+                                    existing.addAll(entry2.getValue());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (!toleratedFeatures.isEmpty()) {
+                for (String depFeature : depFeatures.keySet()) {
+                    String baseFeatureName = depFeature.substring(0, depFeature.lastIndexOf('-') + 1);
+                    toleratedFeatures.remove(baseFeatureName);
+                }
+                if (!toleratedFeatures.isEmpty()) {
+                    for (Iterator<String> i = toleratedFeatures.keySet().iterator(); i.hasNext();) {
+                        String featureBase = i.next();
+                        if (nonSingletonToleratedFeatures.contains(featureBase) || "private".equals(visibilityMap.get(featureBase))) {
+                            i.remove();
+                        }
+                    }
+                    if (!toleratedFeatures.isEmpty()) {
+                        for (Entry<String, Set<String>> tolEntry : toleratedFeatures.entrySet()) {
+                            errorMessage.append(featureName)
+                                        .append(" must have a dependency on tolerated feature that start with ").append(tolEntry.getKey()).append(" in features ")
+                                        .append(tolEntry.getValue()).append("\n\n");
+                        }
+                    }
+                }
+            }
+        }
+
+        if (errorMessage.length() != 0) {
+            Assert.fail("Found features missing feature due to tolerates not being transitive for public and protected features: " + '\n' + errorMessage.toString());
+        }
+    }
+
+    /**
+     * Finds dependent features that are redundant because other dependent features already bring in those features.
+     */
+    //@Test
+    public void testFeatureDependenciesRedundancy() {
+        StringBuilder errorMessage = new StringBuilder();
+        // javaeePlatform and appSecurity are special because they have dependencies on each other.
+        Set<String> nonSingletonToleratedFeatures = new HashSet<>();
+        nonSingletonToleratedFeatures.add("io.openliberty.jakartaeePlatform-");
+        nonSingletonToleratedFeatures.add("com.ibm.websphere.appserver.javaeePlatform-");
+        nonSingletonToleratedFeatures.add("com.ibm.websphere.appserver.appSecurity-");
+        Map<String, String> visibilityMap = new HashMap<>();
+        for (Entry<String, FeatureInfo> entry : features.entrySet()) {
+            String feature = entry.getKey();
+            int lastIndex = feature.indexOf('-');
+            if (lastIndex == -1) {
+                continue;
+            }
+            String baseFeatureName = feature.substring(0, lastIndex + 1);
+            visibilityMap.put(baseFeatureName, entry.getValue().getVisibility());
+
+        }
+        for (Entry<String, FeatureInfo> entry : features.entrySet()) {
+            String featureName = entry.getKey();
+
+            FeatureInfo featureInfo = entry.getValue();
+            if (featureInfo.isAutoFeature()) {
+                continue;
+            }
+            Set<String> processedFeatures = new HashSet<>();
+            Map<String, Attrs> depFeatures = featureInfo.getDependentFeatures();
+            Set<String> rootDepFeatureWithoutTolerates = new HashSet<>();
+            for (Map.Entry<String, Attrs> depEntry : depFeatures.entrySet()) {
+                Attrs attrs = depEntry.getValue();
+                if (!attrs.containsKey("ibm.tolerates:")) {
+                    rootDepFeatureWithoutTolerates.add(depEntry.getKey());
+                }
+            }
+
+            Map<String, Set<String>> featureErrors = new HashMap<>();
+            Set<String> toleratedFeatures = new HashSet<>();
+            for (Map.Entry<String, Attrs> depFeature : depFeatures.entrySet()) {
+                String depFeatureName = depFeature.getKey();
+                FeatureInfo depFeatureInfo = features.get(depFeatureName);
+                if (depFeatureInfo != null) {
+                    for (Map.Entry<String, Attrs> depEntry2 : depFeatureInfo.getDependentFeatures().entrySet()) {
+                        Map<String, Set<String>> tolFeatures = processIncludedFeatureAndChildren(featureName, rootDepFeatureWithoutTolerates,
+                                                                                                 depEntry2.getKey(), featureName + " -> " + depFeatureName, featureErrors,
+                                                                                                 processedFeatures,
+                                                                                                 depEntry2.getValue().containsKey("ibm.tolerates:"),
+                                                                                                 depFeature.getValue().containsKey("ibm.tolerates:"));
+                        if (tolFeatures != null) {
+                            toleratedFeatures.addAll(tolFeatures.keySet());
+                        }
+                    }
+                }
+            }
+            for (Map.Entry<String, Set<String>> errorEntry : featureErrors.entrySet()) {
+                String depFeature = errorEntry.getKey();
+                String baseFeatureName = depFeature.substring(0, depFeature.lastIndexOf('-') + 1);
+                if (toleratedFeatures.contains(baseFeatureName)) {
+                    continue;
+                }
+                errorMessage.append(featureName).append(" contains redundant feature ").append(depFeature)
+                            .append(" because it is already in an included feature(s):\n");
+                for (String errorPath : errorEntry.getValue()) {
+                    errorMessage.append("    ").append(errorPath).append('\n');
+                }
+                errorMessage.append('\n');
+            }
+        }
+
+        if (errorMessage.length() != 0) {
+            Assert.fail("Found features contains redundant included features: " + '\n' + errorMessage.toString());
+        }
+    }
+
+    private Map<String, Set<String>> processIncludedFeatureAndChildren(String rootFeature, Set<String> rootDepFeatures, String feature,
+                                                                       String parentFeature, Map<String, Set<String>> featureErrors, Set<String> processedFeatures,
+                                                                       boolean isTolerates, boolean hasToleratesAncestor) {
+        Map<String, Set<String>> toleratedFeatures = processIncludedFeature(rootFeature, rootDepFeatures, feature, parentFeature, featureErrors,
+                                                                            processedFeatures, isTolerates, hasToleratesAncestor);
+        if (toleratedFeatures != null) {
+            FeatureInfo featureInfo = features.get(feature);
+            if (featureInfo != null) {
+                for (Map.Entry<String, Attrs> depEntry : featureInfo.getDependentFeatures().entrySet()) {
+                    Map<String, Set<String>> includeTolerates = processIncludedFeatureAndChildren(rootFeature, rootDepFeatures, depEntry.getKey(),
+                                                                                                  parentFeature + " -> " + feature, featureErrors, processedFeatures,
+                                                                                                  depEntry.getValue().containsKey("ibm.tolerates:"),
+                                                                                                  isTolerates || hasToleratesAncestor);
+                    if (includeTolerates != null) {
+                        if (toleratedFeatures == null) {
+                            toleratedFeatures = new HashMap<>(includeTolerates);
+                        } else {
+                            for (Entry<String, Set<String>> entry : includeTolerates.entrySet()) {
+                                String key = entry.getKey();
+                                Set<String> existing = toleratedFeatures.get(key);
+                                if (existing == null) {
+                                    toleratedFeatures.put(key, entry.getValue());
+                                } else {
+                                    existing.addAll(entry.getValue());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return toleratedFeatures;
+    }
+
+    private Map<String, Set<String>> processIncludedFeature(String rootFeature, Set<String> rootDepFeatures, String feature,
+                                                            String parentFeature, Map<String, Set<String>> featureErrors, Set<String> processedFeatures,
+                                                            boolean isTolerates, boolean hasToleratesAncestor) {
+        if (!isTolerates && processedFeatures.contains(feature)) {
+            return null;
+        }
+        Map<String, Set<String>> toleratedFeatures = null;
+        if (isTolerates) {
+            toleratedFeatures = new HashMap<>();
+            HashSet<String> depFeatureWithTolerate = new HashSet<>();
+            depFeatureWithTolerate.add(parentFeature);
+            toleratedFeatures.put(feature.substring(0, feature.lastIndexOf('-') + 1), depFeatureWithTolerate);
+            processedFeatures.add(feature);
+        } else if (!hasToleratesAncestor && rootDepFeatures.contains(feature) && !feature.startsWith("com.ibm.websphere.appserver.eeCompatible-")
+                   && !feature.startsWith("io.openliberty.mpCompatible-")) {
+            Set<String> errors = featureErrors.get(feature);
+            if (errors == null) {
+                errors = new HashSet<String>();
+                featureErrors.put(feature, errors);
+            }
+            errors.add(parentFeature);
+        } else {
+            processedFeatures.add(feature);
+        }
+        return toleratedFeatures;
     }
 }

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,6 +15,8 @@ package com.ibm.ws.feature.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -27,11 +29,11 @@ import aQute.bnd.header.Attrs;
 public class FeatureInfo {
 
     private String[] lockedAutoFeatures;
-    private String[] lockedDependentFeatures;
+    private Map<String, Attrs> lockedDependentFeatures;
     private String[] lockedActivatingAutoFeature;
 
     private Set<String> autoFeatures = new LinkedHashSet<String>();
-    private Set<String> dependentFeatures = new LinkedHashSet<String>();
+    private Map<String, Attrs> dependentFeatures = new LinkedHashMap<String, Attrs>();
     private Set<String> activatingAutoFeature = new LinkedHashSet<String>();
 
     private String edition;
@@ -149,7 +151,7 @@ public class FeatureInfo {
         activatingAutoFeature = null;
     }
 
-    public String[] getDependentFeatures() {
+    public Map<String, Attrs> getDependentFeatures() {
         if (!isInit)
             populateInfo();
 
@@ -214,11 +216,10 @@ public class FeatureInfo {
             this.lockedAutoFeatures = this.autoFeatures.toArray(new String[this.autoFeatures.size()]);
 
             for (Map.Entry<String, Attrs> feature : builder.getFeatures()) {
-                String item = feature.getKey().toString();
-                this.dependentFeatures.add(item);
+                this.dependentFeatures.put(feature.getKey(), feature.getValue());
             }
 
-            this.lockedDependentFeatures = this.dependentFeatures.toArray(new String[this.dependentFeatures.size()]);
+            this.lockedDependentFeatures = Collections.unmodifiableMap(new LinkedHashMap<String, Attrs>(this.dependentFeatures));
 
             this.autoFeatures = null;
             this.dependentFeatures = null;

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureVerifier.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureVerifier.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -67,7 +67,7 @@ public class FeatureVerifier {
             featuresLessVisible.add(featureName);
         }
 
-        for (String depFeature : omni.get(featureName).getDependentFeatures()) {
+        for (String depFeature : omni.get(featureName).getDependentFeatures().keySet()) {
             featuresLessVisible.addAll(findViolatingFeatures(seen, depFeature, featureVisibility, classification));
         }
 

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-9.1/io.openliberty.jakartaeeClient-9.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-9.1/io.openliberty.jakartaeeClient-9.1.feature
@@ -21,6 +21,7 @@ Subsystem-Name: Jakarta EE 9.1 Application Client
   io.openliberty.appclient.appClient-2.0, \
   io.openliberty.xmlWSClient-3.0, \
   com.ibm.websphere.appserver.transaction-2.0, \
-  io.openliberty.jsonp-2.0
+  io.openliberty.jsonp-2.0, \
+  io.openliberty.expressionLanguage-4.0
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-5.0/io.openliberty.microProfile-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-5.0/io.openliberty.microProfile-5.0.feature
@@ -11,6 +11,7 @@ Subsystem-Name: MicroProfile 5.0
   io.openliberty.jsonb-2.0, \
   io.openliberty.jsonp-2.0, \
   io.openliberty.restfulWS-3.0, \
+  io.openliberty.restfulWSClient-3.0, \
   com.ibm.websphere.appserver.servlet-5.0, \
   io.openliberty.servlet.internal-5.0, \
   io.openliberty.mpCompatible-5.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-1.2/com.ibm.websphere.appserver.mpOpenTracing-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-1.2/com.ibm.websphere.appserver.mpOpenTracing-1.2.feature
@@ -10,6 +10,7 @@ Subsystem-Name: MicroProfile OpenTracing 1.2
 IBM-API-Package: \
   org.eclipse.microprofile.opentracing; type="stable"
 -features=com.ibm.websphere.appserver.opentracing-1.2, \
+  com.ibm.websphere.appserver.mpConfig-1.3, \
   io.openliberty.mpCompatible-0.0, \
   com.ibm.websphere.appserver.org.eclipse.microprofile.opentracing-1.2, \
   com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/openapi-3.1/com.ibm.websphere.appserver.openapi-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/openapi-3.1/com.ibm.websphere.appserver.openapi-3.1.feature
@@ -15,6 +15,7 @@ Subsystem-Name: OpenAPI 3.1
   com.ibm.websphere.appserver.adminSecurity-1.0, \
   io.openliberty.securityAPI.javaee-1.0, \
   com.ibm.websphere.appserver.mpOpenAPI-1.0, \
+  com.ibm.websphere.appserver.mpConfig-1.2; ibm.tolerates:="1.3,1.4", \
   com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1"
 
 -bundles= \


### PR DESCRIPTION
- Add test to make sure that if a feature depends on another feature and that dependent feature has tolerated public or protected features, that the depending feature references that tolerated feature.
- Update features that were found to be missing features for tolerated public / protected features in their dependent features.
- A new commented out test is also added that will be enabled later with additional feature changes for the redundancy it finds with dependent features.

fixes #15061