### PR TITLE
remove synchronized from createSIPListenningConnection method to prevent deadlock

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transport/SIPConnectionsModel.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transport/SIPConnectionsModel.java
@@ -441,7 +441,8 @@ public class SIPConnectionsModel
 		return m_listeningConnections.values(); 
 	}
 
-	synchronized SIPListenningConnection createSIPListenningConnection( ListeningPointImpl lp ) throws IOException
+	//remove syncronized from createSIPListenningConnection method due to deadlock
+	SIPListenningConnection createSIPListenningConnection( ListeningPointImpl lp ) throws IOException
 	{
 		String transportFactoryKey = lp.getTransport().equals("tcp") && lp.isSecure() ? "tls" : lp.getTransport();
 		SIPConnectionFactory factory = getConnectionFactory(transportFactoryKey);


### PR DESCRIPTION
Custumer has reported a deadlock when starting up sipcontainer where the sipcontainer and the channel framework both placed a lock on the thread. 

Converting createSIPListenningConnection from synchronized to not syncronized should prevent this deadlock.
