### PR TITLE
PR for Issue 22634: Jakarta Security 3.0: Suppress FFDC for provider metadata not found

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.security.jakartasec.identitystore;
 
@@ -250,6 +247,7 @@ public class OidcIdentityStore implements IdentityStore {
         return new CredentialValidationResult(issuer, caller, null, caller, groups);
     }
 
+    @FFDCIgnore(OidcDiscoveryException.class)
     private JsonObject getProviderMetadataAsJsonObject(OidcClientConfig oidcClientConfig) {
         try {
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTests.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.security.jakartasec.fat.config.tests;
 
@@ -288,7 +285,6 @@ public class ConfigurationTests extends CommonAnnotatedSecurityTests {
      * @throws Exception
      */
     @Mode(TestMode.LITE)
-    @ExpectedFFDC({ "io.openliberty.security.oidcclientcore.exceptions.OidcClientConfigurationException" })
     @Test
     public void ConfigurationTests_noProviderURI_withProviderMetadata() throws Exception {
 


### PR DESCRIPTION
Resolves #22634