### PR TITLE
Allow additional ssl handshake error messages in negative test

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorBadOpTrustStoreTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientDiscoveryErrorBadOpTrustStoreTests.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -79,6 +79,8 @@ public class OidcClientDiscoveryErrorBadOpTrustStoreTests extends CommonTest {
         testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from sigAlgMismatch2 - message is not always logged
         testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from endpoint
         testRPServer.addIgnoredServerException("CWWKS1525E"); // Ignore message indicating discovery failed
+        testRPServer.addIgnoredServerException("CWWKO0801E"); // Ignore message indicating connection failure
+        testRPServer.addIgnoredServerException("CWPKI0022E"); // Ignore message indicating Handshake failure
 
         // try to wait for discovery to have populated the RP config
         // Don't stop if this fails (there is a chance it could be ready by the time the tests actually run


### PR DESCRIPTION
A negative test case of Discovery has mismatched key/trust between the OP and RP.
We're getting some new error messages.  Update the test to allow these.
We currently allow:
        testRPServer.addIgnoredServerException("CWWKS1859E"); // Ignore exceptions from bad client secret test
        testRPServer.addIgnoredServerException("CWWKS1741W"); // Ignore from sigAlgMismatch2 - message is not always logged
        testRPServer.addIgnoredServerException("CWWKS1524E"); // Ignore message indicating unsuccessful response from endpoint
        testRPServer.addIgnoredServerException("CWWKS1525E"); // Ignore message indicating discovery failed

Adding:
        testRPServer.addIgnoredServerException("CWWKO0801E"); // Ignore message indicating connection failure
        testRPServer.addIgnoredServerException("CWPKI0022E"); // Ignore message indicating Handshake failure
