### PR TITLE
rename the jaxrs + jaxws interop test

### DIFF
--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/.classpath
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="src" path="test-applications/jaxrs-prototype/src"/>
+	<classpathentry kind="src" path="test-applications/jaxrs-interop/src"/>
 	<classpathentry kind="src" path="test-applications/jaxws-peopleservice/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>

--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/bnd.bnd
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -15,7 +15,7 @@ bVersion=1.0
 
 src: \
   fat/src,\
-  test-applications/jaxrs-prototype/src,\
+  test-applications/jaxrs-interop/src,\
   test-applications/jaxws-peopleservice/src
 
 fat.project: true
@@ -26,4 +26,4 @@ fat.project: true
   com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
   com.ibm.websphere.javaee.jaxrs.2.0,\
   fattest.simplicity
-	
+

--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/fat/src/com/ibm/ws/fat/WebServicesInteroperabilityTest.java
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/fat/src/com/ibm/ws/fat/WebServicesInteroperabilityTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,13 +19,13 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
-import com.ibm.ws.jaxrs.fat.prototype.InteropStartClientTestServlet;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
+import io.openliberty.interop.InteropStartClientTestServlet;
 
 /*
  * The purpose of this test is to check interoperability between JAX-RS and JAX-WS
@@ -36,7 +36,7 @@ import componenttest.topology.utils.FATServletClient;
 @RunWith(FATRunner.class)
 public class WebServicesInteroperabilityTest extends FATServletClient {
 
-    private static final String appName = "prototype";
+    private static final String appName = "interop";
 
     @Server("WebServicesInteroperabilityServer")
     @TestServlet(servlet = InteropStartClientTestServlet.class, contextRoot = appName)
@@ -45,7 +45,7 @@ public class WebServicesInteroperabilityTest extends FATServletClient {
     @BeforeClass
     public static void setup() throws Exception {
         // Build an application and export it to the dropins directory
-        ShrinkHelper.defaultDropinApp(server, appName, "com.ibm.ws.jaxrs.fat.prototype",
+        ShrinkHelper.defaultDropinApp(server, appName, "io.openliberty.interop",
                                       "com.ibm.ws.jaxws.test.wsr.server.stub",
                                       "com.ibm.ws.jaxws.fat.util");
 

--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/InteropStartClientTestServlet.java
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/InteropStartClientTestServlet.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs.fat.prototype;
+package io.openliberty.interop;
 
 import static org.junit.Assert.assertEquals;
 
@@ -29,7 +29,7 @@ import componenttest.app.FATServlet;
 @WebServlet(urlPatterns = "/JaxrsInteropStartClientTestServlet")
 public class InteropStartClientTestServlet extends FATServlet {
 
-    private static final String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/prototype/ep1";
+    private static final String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/interop/ep1";
 
     private Client client;
 

--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/InteropStartJaxrsApplication.java
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/InteropStartJaxrsApplication.java
@@ -1,22 +1,22 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs.fat.prototype;
+package io.openliberty.interop;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 @ApplicationPath("/")
-public class PrototypeApplication extends Application {
+public class InteropStartJaxrsApplication extends Application {
 
 //    @Override
 //    public Set<Class<?>> getClasses() {

--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/InteropStartJaxrsClientTestServlet.java
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/InteropStartJaxrsClientTestServlet.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs.fat.prototype;
+package io.openliberty.interop;
 
 import static org.junit.Assert.assertEquals;
 
@@ -27,9 +27,9 @@ import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/JaxrsPrototypeClientTestServlet")
-public class PrototypeClientTestServlet extends FATServlet {
+public class InteropStartJaxrsClientTestServlet extends FATServlet {
 
-    private static final String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/prototype/ep2";
+    private static final String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/interop/ep2";
 
     private Client client;
 

--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/InteropStartJaxrsResource.java
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/InteropStartJaxrsResource.java
@@ -1,22 +1,22 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs.fat.prototype;
+package io.openliberty.interop;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 @Path("/ep2")
-public class PrototypeResource {
+public class InteropStartJaxrsResource {
 
     @GET
     @Path("jaxwsEP2")

--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/InteropStartResource.java
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/InteropStartResource.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs.fat.prototype;
+package io.openliberty.interop;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxws-peopleservice/src/com/ibm/ws/jaxws/test/wsr/server/impl/Bill.java
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxws-peopleservice/src/com/ibm/ws/jaxws/test/wsr/server/impl/Bill.java
@@ -23,7 +23,7 @@ import com.ibm.ws.jaxws.test.wsr.server.People;
 @WebService(serviceName = "PeopleService", portName = "BillPort", endpointInterface = "com.ibm.ws.jaxws.test.wsr.server.People",
             targetNamespace = "http://server.wsr.test.jaxws.ws.ibm.com")
 public class Bill implements People {
-    private static final String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/prototype/ep2";
+    private static final String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/interop/ep2";
 
     @Override
     public String hello() {


### PR DESCRIPTION
The JAX-RS portion of this test was copied from the PrototypeTest in `com.ibm.ws.jaxrs.2.0_fat` and not renamed. I use this test all the time, so the naming collision is causing confusion in my workflow.