### PR TITLE
Remove unnecessary defaultKeyStore and avoid keytool issue

### DIFF
--- a/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/LDAPRegistry_customClaims.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/LDAPRegistry_customClaims.xml
@@ -63,9 +63,6 @@
 	>
 	</idsLdapFilterProperties>
 
-	<keyStore
-		id="defaultKeyStore"
-		password="keyspass" />
 
 	<authorization-roles id="com.ibm.ws.security.oidc10">
 		<security-role name="authenticated">

--- a/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/goodSSLSettings3.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/goodSSLSettings3.xml
@@ -1,9 +1,6 @@
 <server>
 
 	<sslDefault outboundSSLRef="outboundSSLSettings" />
-	<keyStore
-		id="defaultKeyStore"
-		password="Liberty" />
 	<ssl
 		id="outboundSSLSettings"
 		keyStoreRef="rsa_key"


### PR DESCRIPTION
keytool gives the error:
`Unable to create SSL key file: /home/jazz_build/Build/jbe/build/dev/image/output/wlp/usr/servers/com.ibm.ws.security.jwt_fat.builder/resources/security/key.p12`
That is being investigated, but, in the meantime, we don't need that keystore, so, I'll just remove it.