### PR TITLE
Disable CRIU HW breakpoints for restore

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -867,6 +867,9 @@ criuEnvDefaults() {
   fi
   export GLIBC_TUNABLES
   export LD_BIND_NOT=on
+  # Disable CRIU's use of HW breakpoints on restore.
+  # HW breakpoints are slower in some environments.
+  export CRIU_FAULT=130 # 130=FI_NO_BREAKPOINTS
 }
 
 ##


### PR DESCRIPTION
HW breakpoints allow CRIU to stop process threads at arbitrary locations but are slower to initialize. The first thread that is stopped will take much longer than subsequent threads, due to HW and kernel setup. Setting CRIU_FAULT=130 disables HW breakpoints on x86 and ARM and falls back to stopping threads at syscall transitions instead.