### PR TITLE
add ability to run test buckets against different databases

### DIFF
--- a/dev/io.openliberty.data.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat/bnd.bnd
@@ -24,6 +24,14 @@ javac.target: 11
 
 fat.minimum.java.level: 11
 fat.project: true
+fat.test.databases: true
+
+# Uncomment to use remote docker host to simulate continuous build behavior.
+#fat.test.use.remote.docker: true
+
+# Uncomment to test against alternative databases
+# Options: Derby, Postgres, DB2, Oracle, SQLServer
+#fat.bucket.db.type: Postgres
 
 -sub: *.bnd
 
@@ -40,6 +48,7 @@ fat.project: true
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.persistence.jakarta;version=latest,\
   com.ibm.ws.tx.embeddable.jakarta;version=latest,\
+  fattest.simplicity;version=latest,\
   io.openliberty.jakarta.annotation.2.1,\
   io.openliberty.jakarta.cdi.4.0,\
   io.openliberty.jakarta.concurrency.3.0,\
@@ -47,4 +56,5 @@ fat.project: true
   io.openliberty.jakarta.interceptor.2.1,\
   io.openliberty.jakarta.persistence.3.1,\
   io.openliberty.jakarta.servlet.6.0;version=latest,\
-  io.openliberty.jakarta.transaction.2.0;version=latest
+  io.openliberty.jakarta.transaction.2.0;version=latest,\
+  io.openliberty.org.testcontainers;version=latest

--- a/dev/io.openliberty.data.internal_fat/build.gradle
+++ b/dev/io.openliberty.data.internal_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2022,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,15 @@
  *******************************************************************************/
 
 addRequiredLibraries.dependsOn addDerby
+
+// Copy bundle io.openliberty.org.testcontainers to AutoFVT/lib/
+// This bundle is required both at compiletime and runtime.
+addRequiredLibraries.dependsOn copyTestContainers
+
+// If you are preforming database testing use the copyJdbcDrivers
+// task to copy the common JDBC drivers into the
+// publish/shared/resources/jdbc directory
+addRequiredLibraries.dependsOn copyJdbcDrivers
 
 dependencies {
   requiredLibs project(':io.openliberty.jakarta.data.1.0')

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -59,7 +59,7 @@ public class DataTest extends FATServletClient {
         server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
 
         // Set up server DataSource properties
-        DatabaseContainerUtil.setupDataSourceProperties(server, testContainer);
+        DatabaseContainerUtil.setupDataSourceDatabaseProperties(server, testContainer);
 
         WebArchive war = ShrinkHelper.buildDefaultApp("DataTestApp", "test.jakarta.data.web");
         ShrinkHelper.exportAppToServer(server, war);

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -19,7 +19,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
@@ -28,6 +30,9 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.database.container.DatabaseContainerFactory;
+import componenttest.topology.database.container.DatabaseContainerType;
+import componenttest.topology.database.container.DatabaseContainerUtil;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import test.jakarta.data.inmemory.web.ProviderTestServlet;
@@ -37,6 +42,9 @@ import test.jakarta.data.web.DataTestServlet;
 @MinimumJavaLevel(javaLevel = 11) // TODO 17
 public class DataTest extends FATServletClient {
 
+    @ClassRule
+    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+
     @Server("io.openliberty.data.internal.fat")
     @TestServlets({ @TestServlet(servlet = DataTestServlet.class, contextRoot = "DataTestApp"),
                     @TestServlet(servlet = ProviderTestServlet.class, contextRoot = "ProviderTestApp") })
@@ -44,6 +52,14 @@ public class DataTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        // Get driver type
+        DatabaseContainerType type = DatabaseContainerType.valueOf(testContainer);
+        server.addEnvVar("DB_DRIVER", type.getDriverName());
+        server.addEnvVar("DB_USER", testContainer.getUsername());
+        server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
+
+        // Set up server DataSource properties
+        DatabaseContainerUtil.setupDataSourceProperties(server, testContainer);
 
         WebArchive war = ShrinkHelper.buildDefaultApp("DataTestApp", "test.jakarta.data.web");
         ShrinkHelper.exportAppToServer(server, war);

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/FATSuite.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 
 @RunWith(Suite.class)
@@ -23,5 +24,5 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
                 AlwaysPassesTest.class,
                 DataTest.class
 })
-public class FATSuite {
+public class FATSuite extends TestContainerSuite {
 }

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
@@ -28,15 +28,15 @@
 
   <application location="ProviderTestApp.war"/>
 
-  <dataSource id="DefaultDataSource">
-    <jdbcDriver libraryRef="DerbyLib"/>
+  <dataSource id="DefaultDataSource" fat.modify="true">
+    <jdbcDriver libraryRef="JDBCLibrary"/>
     <properties.derby.embedded createDatabase="create" databaseName="memory:testdb" user="dbuser1" password="dbpwd1"/>
   </dataSource>
 
-  <library id="DerbyLib">
-    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  <library id="JDBCLibrary">
+    <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
   </library>
 
-  <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codeBase="${shared.resource.dir}/jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
 
 </server>

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -2581,6 +2581,7 @@ public class DataTestServlet extends FATServlet {
                                              .map(r -> r.meetingID)
                                              .collect(Collectors.toList()));
 
+        // TODO This fails on SQL Server, with: 10030009L, 10030004L, 10030006L, 10030008L, considering 14:00-15:00 CDT a match for 9:00-10:00 CDT. Why is it off by 5 hours?
         assertIterableEquals(List.of(10030001L, 10030002L, 10030004L, 10030006L, 10030008L),
                              reservations.findByMeetingIDOrLocationLikeAndStartAndStopOrHost(10030006,
                                                                                              "050-2 %",

--- a/dev/io.openliberty.data.internal_fat_jpa/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat_jpa/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -23,6 +23,14 @@ javac.target: 11
 
 fat.minimum.java.level: 11
 fat.project: true
+fat.test.databases: true
+
+# Uncomment to use remote docker host to simulate continuous build behavior.
+#fat.test.use.remote.docker: true
+
+# Uncomment to test against alternative databases
+# Options: Derby, Postgres, DB2, Oracle, SQLServer
+#fat.bucket.db.type: Postgres
 
 -buildpath: \
   com.ibm.tx.jta.jakarta;version=latest,\
@@ -37,10 +45,12 @@ fat.project: true
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.persistence.jakarta;version=latest,\
   com.ibm.ws.tx.embeddable.jakarta;version=latest,\
+  fattest.simplicity;version=latest,\
   io.openliberty.jakarta.annotation.2.1,\
   io.openliberty.jakarta.cdi.4.0,\
   io.openliberty.jakarta.data.1.0,\
   io.openliberty.jakarta.interceptor.2.1,\
   io.openliberty.jakarta.persistence.3.1,\
   io.openliberty.jakarta.servlet.6.0;version=latest,\
-  io.openliberty.jakarta.transaction.2.0;version=latest
+  io.openliberty.jakarta.transaction.2.0;version=latest,\
+  io.openliberty.org.testcontainers;version=latest

--- a/dev/io.openliberty.data.internal_fat_jpa/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_jpa/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2022,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,15 @@
  *******************************************************************************/
 
 addRequiredLibraries.dependsOn addDerby
+
+// Copy bundle io.openliberty.org.testcontainers to AutoFVT/lib/
+// This bundle is required both at compiletime and runtime.
+addRequiredLibraries.dependsOn copyTestContainers
+
+// If you are preforming database testing use the copyJdbcDrivers
+// task to copy the common JDBC drivers into the
+// publish/shared/resources/jdbc directory
+addRequiredLibraries.dependsOn copyJdbcDrivers
 
 dependencies {
   requiredLibs project(':io.openliberty.jakarta.data.1.0')

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,7 +15,9 @@ package test.jakarta.data.jpa;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
@@ -23,6 +25,9 @@ import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.database.container.DatabaseContainerFactory;
+import componenttest.topology.database.container.DatabaseContainerType;
+import componenttest.topology.database.container.DatabaseContainerUtil;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import test.jakarta.data.jpa.web.DataJPATestServlet;
@@ -31,12 +36,24 @@ import test.jakarta.data.jpa.web.DataJPATestServlet;
 @MinimumJavaLevel(javaLevel = 11) // TODO 17
 public class DataJPATest extends FATServletClient {
 
+    @ClassRule
+    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+
     @Server("io.openliberty.data.internal.fat.jpa")
     @TestServlet(servlet = DataJPATestServlet.class, contextRoot = "DataJPATestApp")
     public static LibertyServer server;
 
     @BeforeClass
     public static void setUp() throws Exception {
+        // Get driver type
+        DatabaseContainerType type = DatabaseContainerType.valueOf(testContainer);
+        server.addEnvVar("DB_DRIVER", type.getDriverName());
+        server.addEnvVar("DB_USER", testContainer.getUsername());
+        server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
+
+        // Set up server DataSource properties
+        DatabaseContainerUtil.setupDataSourceProperties(server, testContainer);
+
         WebArchive war = ShrinkHelper.buildDefaultApp("DataJPATestApp", "test.jakarta.data.jpa.web");
         ShrinkHelper.exportAppToServer(server, war);
         server.startServer();

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
@@ -52,7 +52,7 @@ public class DataJPATest extends FATServletClient {
         server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
 
         // Set up server DataSource properties
-        DatabaseContainerUtil.setupDataSourceProperties(server, testContainer);
+        DatabaseContainerUtil.setupDataSourceDatabaseProperties(server, testContainer);
 
         WebArchive war = ShrinkHelper.buildDefaultApp("DataJPATestApp", "test.jakarta.data.jpa.web");
         ShrinkHelper.exportAppToServer(server, war);

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/FATSuite.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 
 @RunWith(Suite.class)
@@ -23,5 +24,5 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
                 AlwaysPassesTest.class,
                 DataJPATest.class
 })
-public class FATSuite {
+public class FATSuite extends TestContainerSuite {
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.fat.jpa/server.xml
+++ b/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.fat.jpa/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022 IBM Corporation and others.
+    Copyright (c) 2022,2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -24,9 +24,23 @@
 
   <application location="DataJPATestApp.war"/>
 
-  <dataSource id="DefaultDataSource">
-    <jdbcDriver libraryRef="DerbyLib"/>
+  <dataSource id="DefaultDataSource" fat.modify="true">
+    <jdbcDriver libraryRef="JDBCLibrary"/>
     <properties.derby.embedded createDatabase="create" databaseName="memory:testdb" user="dbuser1" password="dbpwd1"/>
+  </dataSource>
+
+  <library id="JDBCLibrary">
+    <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
+  </library>
+
+  <!-- TODO for tests that will be hard-coded to use Derby -->
+  <databaseStore id="DerbyDatabaseStore" createTables="true" tablePrefix="DATA" dataSourceRef="DerbyDataSource">
+    <authData user="dbuser1" password="dbpwd1"/>
+  </databaseStore>
+
+  <dataSource id="DerbyDataSource">
+    <jdbcDriver libraryRef="DerbyLib"/>
+    <properties.derby.embedded createDatabase="create" databaseName="memory:testdb"/>
   </dataSource>
 
   <library id="DerbyLib">
@@ -34,5 +48,6 @@
   </library>
 
   <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codeBase="${shared.resource.dir}/jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
 
 </server>

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
@@ -28,6 +28,7 @@ import test.jakarta.data.jpa.web.CreditCard.Issuer;
  * Repository for testing ManyToOne relationship between CreditCard and Customer entities.
  */
 @Repository
+//TODO always use Derby for this repository in order to guarantee case sensitive comparisons, which are required by some tests
 public interface CreditCards extends DataRepository<CreditCard, CardId> {
     @OrderBy("debtor.phone")
     @OrderBy("issuer")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Customers.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Customers.java
@@ -26,6 +26,7 @@ import test.jakarta.data.jpa.web.CreditCard.Issuer;
 /**
  * Repository for testing OneToMany relationship between Customer and CreditCard entities.
  */
+// TODO always use Derby for this repository in order to guarantee case sensitive comparisons, which are required by some tests
 @Repository
 public interface Customers extends DataRepository<Customer, Integer> {
 


### PR DESCRIPTION
Give the main Jakarta Data test bucket and the Jakarta Data JPA test bucket the ability to run against different databases.  The intention here is to enable for running locally, not to automate these buckets to run with other databases in builds yet.  Most of the combinations with other databases have at least a couple of issues that would need to be resolved before that happens.