### PR TITLE
add signature to oidc session cookie

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -451,15 +451,14 @@ public class OidcClientImpl implements OidcClient, UnprotectedResourceService {
             return;
         }
 
-        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(req);
+        OidcClientConfig oidcClientConfig = oidcClientConfigRef.getService(provider);
+        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(req, oidcClientConfig);
         if (sessionInfo == null) {
             if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Session info not found from client cookies.");
+                Tr.debug(tc, "Session info could not be retrieved from client cookies.");
             }
             return;
         }
-
-        OidcClientConfig oidcClientConfig = oidcClientConfigRef.getService(provider);
 
         OidcSessionUtils.logoutIfSessionInvalidated(req, sessionInfo, oidcClientConfig);
     }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -212,7 +212,7 @@ public class Jose4jUtil {
         String sid = jwtClaims.getClaimValue("sid", String.class);
         String timestamp = Utils.getTimeStamp();
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp);
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
 
         OidcSessionCache oidcSessionCache = clientConfig.getOidcSessionCache();
         oidcSessionCache.insertSession(sessionInfo);

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -386,7 +386,7 @@ public class OIDCClientAuthenticatorUtil {
             return null;
         }
         String encoded = cookieValue.substring(0, lastindex);
-        String testCookie = OidcClientUtil.calculateOidcCodeCookieValue(encoded, clientConfig);
+        String testCookie = OidcClientUtil.addSignatureToStringValue(encoded, clientConfig);
 
         if (!cookieValue.equals(testCookie)) {
             String cookieName = "WASOidcCode";

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtil.java
@@ -281,7 +281,7 @@ public class OidcClientUtil {
 
         String encodedHash = null;
         if (encodedReqParams != null) {
-            encodedHash = calculateOidcCodeCookieValue(encodedReqParams, clientCfg);
+            encodedHash = addSignatureToStringValue(encodedReqParams, clientCfg);
         }
         CookieBasedStorage store = new CookieBasedStorage(request, response, getReferrerURLCookieHandler());
         CookieStorageProperties cookieProps = new CookieStorageProperties();
@@ -291,7 +291,7 @@ public class OidcClientUtil {
         store.store(ClientConstants.WAS_OIDC_CODE, encodedHash, cookieProps);
     }
 
-    public static String calculateOidcCodeCookieValue(String encoded, ConvergedClientConfig clientCfg) {
+    public static String addSignatureToStringValue(String encoded, ConvergedClientConfig clientCfg) {
 
         String retVal = new String(encoded);
         String uniqueSecretValue = clientCfg.getClientSecret();

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionUtils.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -58,7 +58,7 @@ public class OidcSessionUtils {
             HttpServletRequest request,
             HttpServletResponse response,
             ConvergedClientConfig clientConfig) {
-        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request);
+        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request, clientConfig);
         if (sessionInfo == null) {
             return;
         }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcSessionInfoTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcSessionInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
 import org.jmock.Expectations;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.ibm.ws.security.test.common.CommonTestClass;
@@ -28,7 +29,20 @@ import com.ibm.ws.security.test.common.CommonTestClass;
  */
 public class OidcSessionInfoTest extends CommonTestClass {
 
+    private static final String CLIENT_SECRET = "myClientSecret";
+
     protected final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
+    protected final ConvergedClientConfig clientConfig = mockery.mock(ConvergedClientConfig.class);
+
+    @Before
+    public void before() {
+        mockery.checking(new Expectations() {
+            {
+                allowing(clientConfig).getClientSecret();
+                will(returnValue(CLIENT_SECRET));
+            }
+        });
+    }
 
     @Test
     public void test_createSessionId() {
@@ -38,10 +52,10 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String sid = "testSid";
         String timestamp = "12345";
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp);
-        String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=";
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=_3ssUE3zEBGw4jK8MkAp6udTSo9PaqTVpJgoE4BwmqUs=";
 
-        assertEquals("Expected to the return the session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(timestamp)'.", expectedSesssionId, sessionInfo.getSessionId());
+        assertEquals("Expected to return the session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(timestamp)_Signature(SessionId, ClientSecret)'.", expectedSesssionId, sessionInfo.getSessionId());
     }
 
     @Test
@@ -52,10 +66,10 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String sid = "";
         String timestamp = "12345";
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp);
-        String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==::MTIzNDU=";
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==::MTIzNDU=_cPjhjKp9RSS1oESEIBaiK3x+GDs3Rft83urh4KaDYg8=";
 
-        assertEquals("Expected to the return the session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(timestamp)'.", expectedSesssionId, sessionInfo.getSessionId());
+        assertEquals("Expected to the return the session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(timestamp)_Signature(SessionId, ClientSecret)'.", expectedSesssionId, sessionInfo.getSessionId());
     }
 
     @Test
@@ -66,8 +80,8 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String sid = "testSid";
         String timestamp = "12345";
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp);
-        String expectedSesssionId = ":aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=";
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        String expectedSesssionId = ":aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=_hG1yWN/mOMMxzHGsS8KnpfXKP3e4C74BxDDJZtQQMzk=";
 
         assertEquals("Expected to replace the configId with an empty string.", expectedSesssionId, sessionInfo.getSessionId());
     }
@@ -80,8 +94,8 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String sid = "testSid";
         String timestamp = "12345";
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp);
-        String expectedSesssionId = "dGVzdENvbmZpZ0lk::dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=";
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        String expectedSesssionId = "dGVzdENvbmZpZ0lk::dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=_XViM+YzwC84l+DMxTjTqgaH8oVqkWMmjfsQP6kDgZKk=";
 
         assertEquals("Expected to replace the sub with an empty string.", expectedSesssionId, sessionInfo.getSessionId());
     }
@@ -94,8 +108,8 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String sid = "testSid";
         String timestamp = "12345";
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp);
-        String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=::dGVzdFNpZA==:MTIzNDU=";
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=::dGVzdFNpZA==:MTIzNDU=_JTmRlEJgi/mUGSFs3Jg8j1BOcc/faLKDIxdBE5XlFV4=";
 
         assertEquals("Expected to replace the sub with an empty string.", expectedSesssionId, sessionInfo.getSessionId());
     }
@@ -108,8 +122,8 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String sid = null;
         String timestamp = "12345";
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp);
-        String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==::MTIzNDU=";
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==::MTIzNDU=_cPjhjKp9RSS1oESEIBaiK3x+GDs3Rft83urh4KaDYg8=";
 
         assertEquals("Expected to replace the sid with an empty string.", expectedSesssionId, sessionInfo.getSessionId());
     }
@@ -122,18 +136,18 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String sid = "testSid";
         String timestamp = null;
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp);
-        String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==:dGVzdFNpZA==:";
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==:dGVzdFNpZA==:_vb86W5kVUmHqMfboDo/jG491Zk5axpk0UqNVPqk5oR4=";
 
         assertEquals("Expected to replace the timestamp with an empty string.", expectedSesssionId, sessionInfo.getSessionId());
     }
 
     @Test
     public void test_getSessionInfo() {
-        String sessionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=";
+        String sessionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=_3ssUE3zEBGw4jK8MkAp6udTSo9PaqTVpJgoE4BwmqUs=";
         setupRequestExpectations(sessionId);
 
-        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request);
+        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request, clientConfig);
 
         assertEquals("testConfigId", sessionInfo.getConfigId());
         assertEquals("https://localhost", sessionInfo.getIss());
@@ -144,10 +158,10 @@ public class OidcSessionInfoTest extends CommonTestClass {
 
     @Test
     public void test_getSessinoInfo_sidWasEmptyOrNull() {
-        String sessionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==::MTIzNDU=";
+        String sessionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==::MTIzNDU=_cPjhjKp9RSS1oESEIBaiK3x+GDs3Rft83urh4KaDYg8=";
         setupRequestExpectations(sessionId);
 
-        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request);
+        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request, clientConfig);
 
         assertEquals("testConfigId", sessionInfo.getConfigId());
         assertEquals("https://localhost", sessionInfo.getIss());
@@ -161,7 +175,7 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String sessionId = null;
         setupRequestExpectations(sessionId);
 
-        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request);
+        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request, clientConfig);
 
         assertNull("Expected the sessionInfo to be null, since the sessionId was invalid.", sessionInfo);
     }
@@ -171,7 +185,7 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String sessionId = "";
         setupRequestExpectations(sessionId);
 
-        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request);
+        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request, clientConfig);
 
         assertNull("Expected the sessionInfo to be null, since the sessionId was invalid.", sessionInfo);
     }
@@ -181,7 +195,7 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String sessionId = "dGVzdENvbmZpZ0lk:dGVzdFN1Yg==";
         setupRequestExpectations(sessionId);
 
-        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request);
+        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request, clientConfig);
 
         assertNull("Expected the sessionInfo to be null, since the sessionId was invalid.", sessionInfo);
     }
@@ -191,7 +205,7 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String sessionId = "invalidSessionId";
         setupRequestExpectations(sessionId);
 
-        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request);
+        OidcSessionInfo sessionInfo = OidcSessionInfo.getSessionInfo(request, clientConfig);
 
         assertNull("Expected the sessionInfo to be null, since the sessionId was invalid.", sessionInfo);
     }


### PR DESCRIPTION
for #20360

appends a signature to the `WASOidcSession` cookie to ensure that it has not been tampered with. the signature is the digest of the oidc session cookie value and the client secret / client specific value. this is done by reusing the `calculateOidcCodeCookieValue` method (now renamed to `addSignatureToStringValue`) from `OidcClientUtil`. this method works for both confidential clients (by using the client secret) and public clients (by using the client config `toString` result).
