### PR TITLE
Cipher suite updates

### DIFF
--- a/dev/com.ibm.ws.ssl/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.ssl/resources/OSGI-INF/metatype/metatype.xml
@@ -101,15 +101,7 @@
             
         <AD id="clientAuthenticationSupported" name="%repertoire.clientAuthenticationSupported" description="%repertoire.clientAuthenticationSupported.desc" 
             required="false" type="Boolean" default="false" />
-            
-        <AD id="securityLevel" name="%repertoire.securityLevel" description="%repertoire.securityLevel.desc" 
-            required="false" type="String" default="HIGH" >
-            <Option label="%repertoire.HIGH" value="HIGH"/>
-            <Option label="%repertoire.MEDIUM" value="MEDIUM"/>
-            <Option label="%repertoire.LOW" value="LOW"/>
-            <Option label="%repertoire.CUSTOM" value="CUSTOM"/>
-        </AD> 
-            
+                        
         <AD id="clientKeyAlias" name="%repertoire.clientKeyAlias" description="%repertoire.clientKeyAlias.desc" 
             required="false" type="String" />
             

--- a/dev/com.ibm.ws.ssl/src/com/ibm/websphere/ssl/Constants.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/websphere/ssl/Constants.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2022 IBM Corporation and others.
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -405,7 +405,10 @@ public class Constants {
                         && supportedCiphers[i].indexOf("_RC4") == -1
                         && supportedCiphers[i].indexOf("_EXPORT_") == -1
                         && supportedCiphers[i].indexOf("_FIPS_") == -1
-                        && supportedCiphers[i].indexOf("_3DES_") == -1) {
+                        && supportedCiphers[i].indexOf("_3DES_") == -1
+                        && supportedCiphers[i].indexOf("_ECDH_") == -1
+                        && supportedCiphers[i].indexOf("SSL_RSA") == -1
+                        && supportedCiphers[i].indexOf("TLS_RSA") == -1) {
                         newCipherList.add(supportedCiphers[i]);
                     }
                 }

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/SSLConfigManager.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/SSLConfigManager.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -382,10 +382,6 @@ public class SSLConfigManager {
         if (clientAuthenticationSupported != null && !clientAuthenticationSupported.equals(""))
             sslprops.setProperty(Constants.SSLPROP_CLIENT_AUTHENTICATION_SUPPORTED, clientAuthenticationSupported);
 
-        String securityLevel = getSystemProperty(Constants.SSLPROP_SECURITY_LEVEL);
-        if (securityLevel != null && !securityLevel.equals(""))
-            sslprops.setProperty(Constants.SSLPROP_SECURITY_LEVEL, securityLevel);
-
         String clientKeyAlias = getSystemProperty(Constants.SSLPROP_KEY_STORE_CLIENT_ALIAS);
         if (clientKeyAlias != null && !clientKeyAlias.equals(""))
             sslprops.setProperty(Constants.SSLPROP_KEY_STORE_CLIENT_ALIAS, clientKeyAlias);
@@ -509,12 +505,7 @@ public class SSLConfigManager {
             sslprops.setProperty(Constants.SSLPROP_CLIENT_AUTHENTICATION_SUPPORTED, clientAuthSup.toString());
         }
 
-        String prop = (String) map.get("securityLevel");
-        if (null != prop && !prop.isEmpty()) {
-            sslprops.setProperty(Constants.SSLPROP_SECURITY_LEVEL, prop);
-        }
-
-        prop = (String) map.get("clientKeyAlias");
+        String prop = (String) map.get("clientKeyAlias");
         if (null != prop && !prop.isEmpty()) {
             sslprops.setProperty(Constants.SSLPROP_KEY_STORE_CLIENT_ALIAS, prop);
         }
@@ -1395,14 +1386,9 @@ public class SSLConfigManager {
             if (cipherString != null) {
                 ciphers = cipherString.split("\\s+");
             } else {
-                String securityLevel = props.getProperty(Constants.SSLPROP_SECURITY_LEVEL);
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "securityLevel from properties is " + securityLevel);
-                if (securityLevel == null)
-                    securityLevel = "HIGH";
+                String securityLevel = "HIGH";
 
                 ciphers = adjustSupportedCiphersToSecurityLevel(socket.getSupportedCipherSuites(), securityLevel);
-
             }
         } catch (Exception e) {
             if (tc.isDebugEnabled())


### PR DESCRIPTION
For Epic 24601.  Stop using the RSA key exchange ciphers and ECDH cipher suites by default.   Removing the securityLevel attribute from the ssl element.