### PR TITLE
Mail: Fix mapping files not found and add tests to dectect warnings

### DIFF
--- a/dev/io.openliberty.com.sun.mail.jakarta.mail.2.0/bnd.overrides
+++ b/dev/io.openliberty.com.sun.mail.jakarta.mail.2.0/bnd.overrides
@@ -4,6 +4,8 @@ bVersion=1.0
 Bundle-Name: JakartaMail 2.0 Implementation
 Bundle-SymbolicName: io.openliberty.com.sun.mail.jakarta.mail.2.0
 Bundle-Description: Private Jakarta Mail bundle
+
+Fragment-Host: io.openliberty.jakarta.mail.2.0
   
 Include-Resource: \
      @${repo;com.sun.mail:jakarta.mail;2.0.1;EXACT}!/META-INF/mailcap, \
@@ -12,32 +14,46 @@ Include-Resource: \
      @${repo;com.sun.mail:jakarta.mail;2.0.1;EXACT}!/META-INF/javamail.default.address.map, \
      @${repo;com.sun.mail:jakarta.mail;2.0.1;EXACT}!/META-INF/javamail.default.providers, \
      @${repo;com.sun.mail:jakarta.mail;2.0.1;EXACT}!/!(jakarta/mail/*|module-info.class)
+     
+Service-Component: \
+  io.openliberty.com.sun.mail.jakarta.mail_2_0_${replace;${bVersion};\\.;_}.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=ignore; \
+    properties:= "resources=${app-resources}"
+    
+app-resources= \
+  META-INF/services/jakarta.mail.Provider | \
+  META-INF/gfprobe-provider.xml | \
+  META-INF/javamail.default.address.map | \
+  META-INF/javamail.default.providers | \
+  META-INF/javamail.charset.map | \
+  META-INF/mailcap
 
 Import-Package: jakarta.mail;version="[2.0.0,3.0.0)",  \
-jakarta.mail.event;version="[2.0.0,3.0.0)", \
-jakarta.mail.internet;version="[2.0.0,3.0.0)", \
-jakarta.mail.search;version="[2.0.0,3.0.0)", \
-jakarta.mail.util;version="[2.0.0,3.0.0)", \
-com.sun.mail;version="[2.0.0,3.0.0)", \
-com.sun.mail.auth;version="[2.0.0,3.0.0)", \
-com.sun.mail.imap;version="[2.0.0,3.0.0)", \
-com.sun.mail.imap.protocol;version="[2.0.0,3.0.0)", \
-com.sun.mail.iap;version="[2.0.0,3.0.0)", \
-com.sun.mail.pop3;version="[2.0.0,3.0.0)", \
-com.sun.mail.smtp;version="[2.0.0,3.0.0)", \
-com.sun.mail.util;version="[2.0.0,3.0.0)", \
-com.sun.mail.util.logging;version="[2.0.0,3.0.0)", \
-com.sun.mail.handlers;version="[2.0.0,3.0.0)"
-
+  jakarta.mail.event;version="[2.0.0,3.0.0)", \
+  jakarta.mail.internet;version="[2.0.0,3.0.0)", \
+  jakarta.mail.search;version="[2.0.0,3.0.0)", \
+  jakarta.mail.util;version="[2.0.0,3.0.0)", \
+  com.sun.mail;version="[2.0.0,3.0.0)", \
+  com.sun.mail.auth;version="[2.0.0,3.0.0)", \
+  com.sun.mail.imap;version="[2.0.0,3.0.0)", \
+  com.sun.mail.imap.protocol;version="[2.0.0,3.0.0)", \
+  com.sun.mail.iap;version="[2.0.0,3.0.0)", \
+  com.sun.mail.pop3;version="[2.0.0,3.0.0)", \
+  com.sun.mail.smtp;version="[2.0.0,3.0.0)", \
+  com.sun.mail.util;version="[2.0.0,3.0.0)", \
+  com.sun.mail.util.logging;version="[2.0.0,3.0.0)", \
+  com.sun.mail.handlers;version="[2.0.0,3.0.0)"
 
 Export-Package: \
-com.sun.mail;version="2.0.1"; thread-context=true, \
-com.sun.mail.auth;version="2.0.1"; thread-context=true, \
-com.sun.mail.imap; thread-context=true, \
-com.sun.mail.imap.protocol; thread-context=true, \
-com.sun.mail.iap; thread-context=true, \
-com.sun.mail.pop3; thread-context=true, \
-com.sun.mail.smtp; thread-context=true, \
-com.sun.mail.util; thread-context=true, \
-com.sun.mail.util.logging; thread-context=true, \
-com.sun.mail.handlers; thread-context=true
+  com.sun.mail;version="2.0.1"; thread-context=true, \
+  com.sun.mail.auth;version="2.0.1"; thread-context=true, \
+  com.sun.mail.imap; thread-context=true, \
+  com.sun.mail.imap.protocol; thread-context=true, \
+  com.sun.mail.iap; thread-context=true, \
+  com.sun.mail.pop3; thread-context=true, \
+  com.sun.mail.smtp; thread-context=true, \
+  com.sun.mail.util; thread-context=true, \
+  com.sun.mail.util.logging; thread-context=true, \
+  com.sun.mail.handlers; thread-context=true

--- a/dev/io.openliberty.jakarta.mail.2.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.mail.2.0/bnd.bnd
@@ -7,8 +7,6 @@
 # 
 # SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0

--- a/dev/io.openliberty.mail.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.mail.2.0.internal/bnd.bnd
@@ -7,8 +7,6 @@
 # 
 # SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 
@@ -23,33 +21,9 @@ Bundle-Description: Openliberty mail 2.0 API; This feature allows applications t
 
 WS-TraceGroup: Mail
 
-
-## Resources that were moved from the original javax.mail.jar to
-## the new feature jar, included the mailcap file which is needed
-## for the app-resources header
-
-Include-Resource: \
-  @${repo;io.openliberty.com.sun.mail.jakarta.mail.2.0}!/META-INF/mailcap, \
-  @${repo;io.openliberty.com.sun.mail.jakarta.mail.2.0}!/META-INF/gfprobe-provider.xml, \
-  @${repo;io.openliberty.com.sun.mail.jakarta.mail.2.0}!/META-INF/javamail.charset.map, \
-  @${repo;io.openliberty.com.sun.mail.jakarta.mail.2.0}!/META-INF/javamail.default.address.map, \
-  @${repo;io.openliberty.com.sun.mail.jakarta.mail.2.0}!/META-INF/javamail.default.providers  
-
-Service-Component: \
-  io.openliberty.mail_2_0_internal${replace;${bVersion};\\.;_}.ResourceProvider; \
-    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
-    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
-    configuration-policy:=ignore; \
-    properties:= "resources=${app-resources}"
-
 -dsannotations=io.openliberty.mail.internal.MailSessionService, \
   io.openliberty.mail.internal.injection.MailSessionDefinitionInjectionProcessorProvider, \
   io.openliberty.mail.internal.injection.MailSessionResourceFactoryBuilder
-app-resources= \
-  META-INF/javamail.default.address.map | \
-  META-INF/javamail.default.providers | \
-  META-INF/javamail.charset.map | \
-  META-INF/mailcap 
 
 Private-Package: \
 	io.openliberty.mail.internal.injection,\

--- a/dev/io.openliberty.mail.2.0.internal_fat/fat/src/io/openliberty/mail/fat/IMAPTest.java
+++ b/dev/io.openliberty.mail.2.0.internal_fat/fat/src/io/openliberty/mail/fat/IMAPTest.java
@@ -1,18 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.mail.fat;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -215,6 +214,14 @@ public class IMAPTest {
         if (null != imapServer) {
             imapServer.stop();
         }
+
+        String resourceWarning = server.waitForStringInLog("expected resource not found:");
+
+        // If this assert fails its because the default mail cap files needed to set default encoding/decoding via
+        // the activation framework are missing are not visible to the mail-2.x spec. Check the bnd file configuration
+        // to ensure bundle has proper resources included
+        assertNull("FAIL: One of the Jakarta Mail resources in /META-INF/ directory is not availible to the application",
+                   resourceWarning);
 
         if (server != null && server.isStarted()) {
             server.stopServer("CWWKZ0013E");

--- a/dev/io.openliberty.mail.2.0.internal_fat/fat/src/io/openliberty/mail/fat/MailSessionInjectionTest.java
+++ b/dev/io.openliberty.mail.2.0.internal_fat/fat/src/io/openliberty/mail/fat/MailSessionInjectionTest.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.mail.fat;
+
+import static org.junit.Assert.assertNull;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -48,6 +48,15 @@ public class MailSessionInjectionTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
+
+        String resourceWarning = server.waitForStringInLog("expected resource not found:");
+
+        // If this assert fails its because the default mail cap files needed to set default encoding/decoding via
+        // the activation framework are missing are not visible to the mail-2.x spec. Check the bnd file configuration
+        // to ensure bundle has proper resources included
+        assertNull("FAIL: One of the Jakarta Mail resources in /META-INF/ directory is not availible to the application",
+                   resourceWarning);
+
         server.stopServer("J2CA0086W.*State:STATE_TRAN_WRAPPER_INUSE", // EXPECTED: One test intentionally leaves an open connection
                           "CWWKG0007W"); // let Nathan handle this : The system could not delete C:\Users\IBM_ADMIN\Documents\workspace\build.image/wlp/usr/servers\com.ibm.ws.jca.fat\workarea\org.eclipse.osgi\9\data\configs\com.ibm.ws.jca.jmsConnectionFactory.properties_83!-723947066
     }

--- a/dev/io.openliberty.mail.2.0.internal_fat/fat/src/io/openliberty/mail/fat/POP3Test.java
+++ b/dev/io.openliberty.mail.2.0.internal_fat/fat/src/io/openliberty/mail/fat/POP3Test.java
@@ -1,18 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.mail.fat;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -150,6 +149,15 @@ public class POP3Test {
     @AfterClass
     public static void stopGreenMail() throws Exception {
         pop3Server.quit();
+
+        String resourceWarning = server.waitForStringInLog("expected resource not found:");
+
+        // If this assert fails its because the default mail cap files needed to set default encoding/decoding via
+        // the activation framework are missing are not visible to the mail-2.x spec. Check the bnd file configuration
+        // to ensure bundle has proper resources included
+        assertNull("FAIL: One of the Jakarta Mail resources in /META-INF/ directory is not availible to the application",
+                   resourceWarning);
+
         if (server != null && server.isStarted()) {
             server.stopServer("CWWKZ0013E");
         }

--- a/dev/io.openliberty.mail.2.0.internal_fat/fat/src/io/openliberty/mail/fat/SMTPTest.java
+++ b/dev/io.openliberty.mail.2.0.internal_fat/fat/src/io/openliberty/mail/fat/SMTPTest.java
@@ -1,19 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.mail.fat;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -164,6 +163,14 @@ public class SMTPTest {
         if (null != smtpServer) {
             smtpServer.stop();
         }
+
+        String resourceWarning = server.waitForStringInLog("expected resource not found:");
+
+        // If this assert fails its because the default mail cap files needed to set default encoding/decoding via
+        // the activation framework are missing are not visible to the mail-2.x spec. Check the bnd file configuration
+        // to ensure bundle has proper resources included
+        assertNull("FAIL: One of the Jakarta Mail resources in /META-INF/ directory is not availible to the application",
+                   resourceWarning);
 
         if (server != null && server.isStarted()) {
             server.stopServer("CWWKZ0013E");

--- a/dev/io.openliberty.mail.2.1.internal_fat/fat/src/io/openliberty/mail/fat/StreamProviderTest.java
+++ b/dev/io.openliberty.mail.2.1.internal_fat/fat/src/io/openliberty/mail/fat/StreamProviderTest.java
@@ -1,17 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.mail.fat;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
@@ -58,6 +57,15 @@ public class StreamProviderTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
+
+        String resourceWarning = server.waitForStringInLog("expected resource not found:");
+
+        // If this assert fails its because the default mail cap files needed to set default encoding/decoding via
+        // the activation framework are missing are not visible to the mail-2.x spec. Check the bnd file configuration
+        // to ensure bundle has proper resources included
+        assertNull("FAIL: One of the Jakarta Mail resources in /META-INF/ directory is not availible to the application",
+                   resourceWarning);
+
         if (server != null && server.isStarted()) {
             server.stopServer("CWWKZ0013E");
         }

--- a/dev/io.openliberty.org.eclipse.angus.mail/bnd.bnd
+++ b/dev/io.openliberty.org.eclipse.angus.mail/bnd.bnd
@@ -33,7 +33,8 @@ Export-Package: \
   org.eclipse.angus.mail.pop3; version=${Export-Version}; thread-context=true, \
   org.eclipse.angus.mail.smtp; version=${Export-Version}; thread-context=true, \
   org.eclipse.angus.mail.util; version=${Export-Version}; thread-context=true, \
-  org.eclipse.angus.mail.util.logging; version=${Export-Version}; thread-context=true
+  org.eclipse.angus.mail.util.logging; version=${Export-Version}; thread-context=true, \
+  META-INF; version=${Export-Version}; thread-context=true
 
 Import-Package: \
   com.ibm.wsspi.classloading, \
@@ -44,25 +45,27 @@ Import-Package: \
   jakarta.mail.util;version=${Import-Version}, \
   *
 
-app-resources= \
+app-resources=\
   META-INF/services/jakarta.mail.util.StreamProvider | \
   META-INF/services/jakarta.mail.Provider | \
+  META-INF/gfprobe-provider.xml | \
+  META-INF/javamail.address.map | \
+  META-INF/javamail.charset.map | \
   META-INF/javamail.default.address.map | \
   META-INF/javamail.default.providers | \
-  META-INF/javamail.charset.map | \
+  META-INF/javamail.providers | \
   META-INF/mailcap
 
 Service-Component: \
-  io.openliberty.org.eclipse.angus.mail_${replace;${bVersion};\\.;_}.ResourceProvider; \
+  io.openliberty.org.eclipse.angus.mail_2_1_${replace;${bVersion};\\.;_}.ResourceProvider; \
     implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
     provide:=com.ibm.wsspi.classloading.ResourceProvider; \
     configuration-policy:=ignore; \
     properties:= "resources=${app-resources}"
-
+    
 -includeresource: \
   @${repo;org.eclipse.angus:angus-mail;${Implementation-Version};EXACT}!/!(module-info.class|META-INF/maven/*|META-INF/native-image/*|org/eclipse/angus/mail/nativeimage/*)
    
 -buildpath: \
   org.eclipse.angus:angus-mail;version=${Implementation-Version};strategy=exact, \
   io.openliberty.jakarta.mail.2.1;version=latest
-     


### PR DESCRIPTION
This pull request adds some bundle wiring to make mapping files available to the mail-2.0 and mail-2.1 features, as well as adds tests that check for the warning to prevent regression. 

Fixes #25018 