### PR TITLE
Add @Trivial to ApplicationManager LogRecordContext inner class

### DIFF
--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/ApplicationManager.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/ApplicationManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Modified;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.websphere.logging.hpel.LogRecordContext;
 import com.ibm.ws.app.manager.internal.AppManagerConstants;
 
@@ -52,6 +53,7 @@ public class ApplicationManager {
     /* LogRecordContext callback to retrieve application name */
     private final static LogRecordContext.Extension APPNAME_CALLBACK = new LogRecordContext.Extension() {
         @Override
+        @Trivial
         public String getValue() {
             com.ibm.ws.runtime.metadata.ComponentMetaData metaData = com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
             if (metaData != null) {

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/TraceClassFileTransformer.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/TraceClassFileTransformer.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,18 +16,18 @@ import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.security.ProtectionDomain;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 
 /**
  * Wrapper around a ClassFileTransformer for tracing purposes.
  */
+@Trivial
 public class TraceClassFileTransformer implements ClassFileTransformer {
-    static final TraceComponent tc = Tr.register(TraceClassFileTransformer.class, "instrumentation");
 
     // Force tc to be initialized to avoid problems with the RAS
     // ClassFileTransformer.
-    public static void initialize() {}
+    public static void initialize() {
+    }
 
     /**
      * The delegate ClassFileTransformer.
@@ -49,13 +49,9 @@ public class TraceClassFileTransformer implements ClassFileTransformer {
                             Class<?> classBeingRedefined,
                             ProtectionDomain protectionDomain,
                             byte[] classfileBuffer) throws IllegalClassFormatException {
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
-            Tr.entry(tc, "transform", transformer, loader, className, classBeingRedefined, protectionDomain, classfileBuffer.length);
 
         byte[] bytes = transformer.transform(loader, className, classBeingRedefined, protectionDomain, classfileBuffer);
 
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
-            Tr.exit(tc, "transform", bytes == null ? null : bytes.length);
         return bytes;
     }
 }


### PR DESCRIPTION
fixes #24915
- If tracing is enabled for `com.ibm.ws.app.manager` or universally enabled for all packages (`com.ibm.ws.*=all`), the Entry/Exit tracing for the inner class of the `LogRecordContext Extension` is logged for every message, which might cause slowness or hang during server startup.
- Added the `@Trivial` annotation, so the instrumentation of the diagnostic tracing does not happen.
- Removed the tracing for the `TraceClassTransformer` class and added `@Trivial` to the class as well, since the transformer is adding trace to classes, while they are being loaded.