### PR TITLE
Switch to posix sed command for server.env

### DIFF
--- a/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
+++ b/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
@@ -480,7 +480,7 @@ readClientEnv()
       \#*);;
       *=*)
         # Only accept alphanumeric variable names to avoid eval complexities.
-        if var=`safeEcho "$line" | sed -e 's/^\([a-zA-Z0-9_][a-zA-Z0-9_]*\)=.*/\1/'`; then
+        if var=`safeEcho "$line" | sed -e 's/^\([_[:alnum:]][_[:alnum:]]*\)=.*/\1/'`; then
           extractValueAndEscapeForEval "${line}"
           eval "${var}=${escapeForEvalResult}; export ${var}"
         fi

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -830,7 +830,7 @@ readServerEnv()
            fi ;;
       *=*)
         # Only accept alphanumeric variable names to avoid eval complexities.
-        if var=`safeEcho "$line" | sed -e 's/^\([a-zA-Z0-9_][a-zA-Z0-9_]*\)=.*/\1/'`; then
+        if var=`safeEcho "$line" | sed -e 's/^\([_[:alnum:]][_[:alnum:]]*\)=.*/\1/'`; then
            case $var in
            *=*)
                SERVER_ENV_SETUP_FAILURE="${var} ${SERVER_ENV_SETUP_FAILURE}" ;;


### PR DESCRIPTION
On the Turkish language on RHEL8, the existing sed command that reads the variable values from the server.env file doesn't allow all characters it should.

moving from:
sed -e 's/^\([a-zA-Z0-9_][a-zA-Z0-9_]*\)=.*/\1/' 
to
sed -e 's/^\([_[:alnum:]][_[:alnum:]]*\)=.*/\1/'