### PR TITLE
Improve serviceability of new transaction checkpoint hook

### DIFF
--- a/dev/com.ibm.tx.jta/resources/com/ibm/ws/Transaction/resources/TransactionMsgs.nlsprops
+++ b/dev/com.ibm.tx.jta/resources/com/ibm/ws/Transaction/resources/TransactionMsgs.nlsprops
@@ -858,7 +858,7 @@ WTRN0149_REC_XA_TRAN.useraction=No user action is required.
 # 1 - resource manager name
 # 2 - error code
 WTRN0150_REC_XA_ROLLEDBACK=WTRN0150I: Response from rolling back recovered xid {0} from {1} - {2}
-WTRN0150_REC_XA_ROLLEDBACK.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which does not correspond to a logged transaction.  The transaction service hass attempted to rollback the xid as part of recovery processing.
+WTRN0150_REC_XA_ROLLEDBACK.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which does not correspond to a logged transaction.  The transaction service has attempted to rollback the xid as part of recovery processing.
 WTRN0150_REC_XA_ROLLEDBACK.useraction=Examine the error code to determine if the rollback failed.
 
 # 0 - resource manager name

--- a/dev/com.ibm.tx.jta/resources/com/ibm/ws/Transaction/resources/TransactionMsgs.nlsprops
+++ b/dev/com.ibm.tx.jta/resources/com/ibm/ws/Transaction/resources/TransactionMsgs.nlsprops
@@ -843,7 +843,7 @@ WTRN0147_REC_XID_LATE.useraction=Examine the epoch value from this message and c
 # 0 - xid
 # 1 - resource manager name
 WTRN0148_REC_XA_ROLLBACK=WTRN0148I: Recovered xid {0} from {1} - xid has no associated transaction and will be rolled back
-WTRN0148_REC_XA_ROLLBACK.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which does not corrrespond to a logged transaction.  The transaction service will rollback the xid as part of recovery processing.
+WTRN0148_REC_XA_ROLLBACK.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which does not correspond to a logged transaction.  The transaction service will rollback the xid as part of recovery processing.
 WTRN0148_REC_XA_ROLLBACK.useraction=No user action is required.
 
 # 0 - xid
@@ -851,14 +851,14 @@ WTRN0148_REC_XA_ROLLBACK.useraction=No user action is required.
 # 2 - transaction id
 # 3 - transaction state
 WTRN0149_REC_XA_TRAN=WTRN0149I: Recovered xid {0} from {1} - xid has associated transaction (tid={2}) with logged state {3}
-WTRN0149_REC_XA_TRAN.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which corrresponds to a logged transaction.  The transaction service will complete the transaction as part of recovery processing.
+WTRN0149_REC_XA_TRAN.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which corresponds to a logged transaction.  The transaction service will complete the transaction as part of recovery processing.
 WTRN0149_REC_XA_TRAN.useraction=No user action is required.
 
 # 0 - xid
 # 1 - resource manager name
 # 2 - error code
 WTRN0150_REC_XA_ROLLEDBACK=WTRN0150I: Response from rolling back recovered xid {0} from {1} - {2}
-WTRN0150_REC_XA_ROLLEDBACK.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which does not corrrespond to a logged transaction.  The transaction service hass attempted to rollback the xid as part of recovery processing.
+WTRN0150_REC_XA_ROLLEDBACK.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which does not correspond to a logged transaction.  The transaction service hass attempted to rollback the xid as part of recovery processing.
 WTRN0150_REC_XA_ROLLEDBACK.useraction=Examine the error code to determine if the rollback failed.
 
 # 0 - resource manager name
@@ -877,6 +877,11 @@ WTRN0153_INVALID_LOG_AT_SHUTDOWN.useraction=Correct any conditions that are indi
 WTRN0154_ERROR_CHECKPOINT_NEW_TX=WTRN0154E: The server checkpoint request failed because the transaction service is unable to begin a transaction.
 WTRN0154_ERROR_CHECKPOINT_NEW_TX.explanation=Liberty does not support applications that begin or require a transaction while the application starts when a server checkpoint is requested.
 WTRN0154_ERROR_CHECKPOINT_NEW_TX.useraction=Use the server checkpoint at=deployment option or modify the application to begin transactions after it has started.
+
+# 0 - Stack trace of call to create new tx
+WTRN0155_CHECKPOINT_NEW_TX_STACK=WTRN0155W: A new transaction was created during the server checkpoint request. Here is the stack trace of this thread when the transaction was created: {0}.
+WTRN0155_CHECKPOINT_NEW_TX_STACK.explanation=The stack, captured when the transaction was created, is provided to help determine which applications begin transactions during application startup and cause the checkpoint request to fail.
+WTRN0155_CHECKPOINT_NEW_TX_STACK.useraction=Examine the stack trace to determine which application began a new transaction during the server checkpoint request.
 
 # --------------------------------
 # WTRN9xxx Range reserved for zSeries-specific transaction messages - only used for releases prior to v5.1

--- a/dev/com.ibm.tx.jta/resources/com/ibm/ws/Transaction/resources/TransactionMsgs.nlsprops
+++ b/dev/com.ibm.tx.jta/resources/com/ibm/ws/Transaction/resources/TransactionMsgs.nlsprops
@@ -843,7 +843,7 @@ WTRN0147_REC_XID_LATE.useraction=Examine the epoch value from this message and c
 # 0 - xid
 # 1 - resource manager name
 WTRN0148_REC_XA_ROLLBACK=WTRN0148I: Recovered xid {0} from {1} - xid has no associated transaction and will be rolled back
-WTRN0148_REC_XA_ROLLBACK.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which does not correspond to a logged transaction.  The transaction service will rollback the xid as part of recovery processing.
+WTRN0148_REC_XA_ROLLBACK.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which does not correspond to a logged transaction. The transaction service rolls back the xid as part of recovery processing.
 WTRN0148_REC_XA_ROLLBACK.useraction=No user action is required.
 
 # 0 - xid
@@ -851,14 +851,14 @@ WTRN0148_REC_XA_ROLLBACK.useraction=No user action is required.
 # 2 - transaction id
 # 3 - transaction state
 WTRN0149_REC_XA_TRAN=WTRN0149I: Recovered xid {0} from {1} - xid has associated transaction (tid={2}) with logged state {3}
-WTRN0149_REC_XA_TRAN.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which corresponds to a logged transaction.  The transaction service will complete the transaction as part of recovery processing.
+WTRN0149_REC_XA_TRAN.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which corresponds to a logged transaction. The transaction service completes the transaction as part of recovery processing.
 WTRN0149_REC_XA_TRAN.useraction=No user action is required.
 
 # 0 - xid
 # 1 - resource manager name
 # 2 - error code
 WTRN0150_REC_XA_ROLLEDBACK=WTRN0150I: Response from rolling back recovered xid {0} from {1} - {2}
-WTRN0150_REC_XA_ROLLEDBACK.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which does not correspond to a logged transaction.  The transaction service has attempted to rollback the xid as part of recovery processing.
+WTRN0150_REC_XA_ROLLEDBACK.explanation=The transaction service successfully issued xa recover on a logged resource manager and obtained an xid which does not correspond to a logged transaction. The transaction service attempted to rollback the xid as part of recovery processing.
 WTRN0150_REC_XA_ROLLEDBACK.useraction=Examine the error code to determine if the rollback failed.
 
 # 0 - resource manager name
@@ -879,8 +879,8 @@ WTRN0154_ERROR_CHECKPOINT_NEW_TX.explanation=Liberty does not support applicatio
 WTRN0154_ERROR_CHECKPOINT_NEW_TX.useraction=Use the server checkpoint at=deployment option or modify the application to begin transactions after it has started.
 
 # 0 - Stack trace of call to create new tx
-WTRN0155_CHECKPOINT_NEW_TX_STACK=WTRN0155W: A new transaction was created during the server checkpoint request. Here is the stack trace of this thread when the transaction was created: {0}.
-WTRN0155_CHECKPOINT_NEW_TX_STACK.explanation=The stack, captured when the transaction was created, is provided to help determine which applications begin transactions during application startup and cause the checkpoint request to fail.
+WTRN0155_CHECKPOINT_NEW_TX_STACK=WTRN0155W: An application began or required a transaction during the server checkpoint request. The following stack trace for this thread was captured when the transaction was created: {0}
+WTRN0155_CHECKPOINT_NEW_TX_STACK.explanation=The stack trace was captured when the transaction was created. The stack trace helps users determine which applications begin transactions during application startup and then cause the checkpoint request to fail.
 WTRN0155_CHECKPOINT_NEW_TX_STACK.useraction=Examine the stack trace to determine which application began a new transaction during the server checkpoint request.
 
 # --------------------------------

--- a/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/ServletStartupTest.java
+++ b/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/ServletStartupTest.java
@@ -118,9 +118,12 @@ public class ServletStartupTest extends FATServletClient {
         // Request a server checkpoint
         ProgramOutput output = server.startServer(getTestMethodNameOnly(testName) + ".log");
         int returnCode = output.getReturnCode();
-        assertEquals("The server checkpoint request should have returned failure code 72, but did not.", 72, returnCode);
+        assertEquals("The server checkpoint request should return failure code 72, but did not.", 72, returnCode);
 
-        assertNotNull("The transaction manager should report it is unable to begin a transaction during a checkpoint request, but did not.",
+        assertNotNull("The transaction manager should log the stack trace of thread that begins a transaction during checkpoint, but did not.",
+                      server.waitForStringInLogUsingMark("WTRN0155"));
+
+        assertNotNull("The transaction manager should log it is unable to begin a transaction during checkpoint, but did not.",
                       server.waitForStringInLogUsingMark("WTRN0154"));
     }
 

--- a/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/StartupBeanTest.java
+++ b/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/StartupBeanTest.java
@@ -137,9 +137,12 @@ public class StartupBeanTest extends FATServletClient {
     public void testStartupBeanRequiresNewAtApplications() throws Exception {
         ProgramOutput output = server.startServer(getTestMethodNameOnly(testName) + ".log");
         int returnCode = output.getReturnCode();
-        assertEquals("The server checkpoint request should have returned failure code 72, but did not.", 72, returnCode);
+        assertEquals("The server checkpoint request should return failure code 72, but did not.", 72, returnCode);
 
-        assertNotNull("The transaction manager should report it is unable to begin a transaction during a checkpoint request, but did not.",
+        assertNotNull("The transaction manager should log the stack trace of thread that begins a transaction during checkpoint, but did not.",
+                      server.waitForStringInLogUsingMark("WTRN0155"));
+
+        assertNotNull("The transaction manager should log it is unable to begin a transaction during checkpoint, but did not.",
                       server.waitForStringInLogUsingMark("WTRN0154"));
     }
 
@@ -152,9 +155,9 @@ public class StartupBeanTest extends FATServletClient {
     public void testStartupBeanUserTranAtApplications() throws Exception {
         ProgramOutput output = server.startServer(getTestMethodNameOnly(testName) + ".log");
         int returnCode = output.getReturnCode();
-        assertEquals("The server checkpoint request should have returned failure code 72, but did not.", 72, returnCode);
+        assertEquals("The server checkpoint request should return failure code 72, but did not.", 72, returnCode);
 
-        assertNotNull("The transaction manager should report it is unable to begin a transaction during a checkpoint request, but did not.",
+        assertNotNull("The transaction manager should log it is unable to begin a transaction during checkpoint, but did not.",
                       server.waitForStringInLogUsingMark("WTRN0154"));
     }
 


### PR DESCRIPTION
For issue https://github.com/OpenLiberty/open-liberty/issues/21198

Improve the serviceability of the `NewTransactionCheckpointHook` by logging a warning message that provides the stack trace of the thread which created the transaction before setting the hook.  The hook will eventually cause checkpoint to fail, which requires subsequent user action to either run checkpoint `--at=deployment` or to modify the application.  The warning is intended to help determine which applications begin or require a new transaction when started during a server checkpoint request.

The checkpoint transaction fat contains new assertions to verify the new warning, WTRN0155W, logs when user and container-managed transactions begin during checkpoint `--at=applications`.

The message resource contains a few spelling corrections in addition to the new warning message: 
* `corrrespond` --> `correspond`
* `hass` --> `has`.