### PR TITLE
Add classloading trace to the JPA container ModifyConfig FAT

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/publish/servers/com.ibm.ws.jpa.container.fat.modifyconfig/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/publish/servers/com.ibm.ws.jpa.container.fat.modifyconfig/bootstrap.properties
@@ -1,5 +1,5 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:Bell=all:JPA=all
+com.ibm.ws.logging.trace.specification=*=info:Bell=all:JPA=all:ClassLoadingService=all:SharedLibrary=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 # Exempt from java 2 security because this FAT does dynamic config


### PR DESCRIPTION
For RTC-295221.  Get classloading trace to help determine whether the updated fileset reference used by the new library classloader supplies the expected classpath entries or was not injected.

Problem: During the library update (i.e. after the test replaces the `fileset` jar of the library referenced by the BELL), the BELL runtime registers the javax...PersistenceProvider service, and immediately, the persistence runtime consumes the service (i.e. triggers OSGi to invoke the service’s factory to get the service instance). Nothing strange about that behavior. The service factory attempts to load the PersistenceProvider service impl class using the new library classloader, which fails unexpectedly with a CNFE indicating the class is not visible on its classpath. Typically, a faulty or unavailable fileset reference(s) will cause a library classloader to malfunction in this manner.

