### PR TITLE
Fix race condition with derby during tests

### DIFF
--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
@@ -748,7 +748,10 @@ public class DatabaseStoreImpl implements DatabaseStore {
      * @return the database product name.
      * @throws Exception if unable to obtain the database product name.
      */
-    private String getDatabaseProductName(WSDataSource dataSource) throws Exception {
+    private synchronized String getDatabaseProductName(WSDataSource dataSource) throws Exception {
+        //Synchronized to avoid a race condition in tests where attempting to boot two
+        //derby instances simultaneously causes tests to fail
+
         String dbProductName = dataSource.getDatabaseProductName();
         if (dbProductName == null) {
             // Query the metadata under a new transaction and commit right away


### PR DESCRIPTION
Fix for a test bug where booting two derby instances simultaneously causes an mbean error resulting in one of the derby instances not starting, and test failures.

