### PR TITLE
add eviction task for oidc session cache

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
@@ -59,7 +59,6 @@ import com.ibm.wsspi.security.token.AttributeNameConstants;
 import com.ibm.wsspi.ssl.SSLSupport;
 
 import io.openliberty.security.common.jwt.JwtParsingUtils;
-import io.openliberty.security.oidcclientcore.utils.Utils;
 
 public class Jose4jUtil {
 
@@ -210,9 +209,9 @@ public class Jose4jUtil {
         String iss = jwtClaims.getIssuer();
         String sub = jwtClaims.getSubject();
         String sid = jwtClaims.getClaimValue("sid", String.class);
-        String timestamp = Utils.getTimeStamp();
+        String exp = String.valueOf(jwtClaims.getExpirationTime().getValueInMillis());
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, exp, clientConfig);
 
         OidcSessionCache oidcSessionCache = clientConfig.getOidcSessionCache();
         oidcSessionCache.insertSession(sessionInfo);

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionInfo.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionInfo.java
@@ -34,14 +34,14 @@ public class OidcSessionInfo {
     private final String iss;
     private final String sub;
     private final String sid;
-    private final String timestamp;
+    private final String exp;
 
-    public OidcSessionInfo(String configId, String iss, String sub, String sid, String timestamp, ConvergedClientConfig clientConfig) {
+    public OidcSessionInfo(String configId, String iss, String sub, String sid, String exp, ConvergedClientConfig clientConfig) {
         this.configId = configId != null ? configId : "";
         this.iss = iss != null ? iss : "";
         this.sub = sub != null ? sub : "";
         this.sid = sid != null ? sid : "";
-        this.timestamp = timestamp != null ? timestamp : "";
+        this.exp = exp != null ? exp : "";
 
         this.sessionId = createSessionId(clientConfig);
     }
@@ -49,7 +49,7 @@ public class OidcSessionInfo {
     /**
      * Gets the base64 encoded session id from the request cookies
      * and returns an OidcSessionInfo object which contains
-     * the config id, sub, sid, and timestamp embedded in the session id.
+     * the config id, sub, sid, and exp embedded in the session id.
      *
      * @param request The http servlet request.
      * @return An OidcSessionInfo object containing info parsed from the session id.
@@ -82,9 +82,9 @@ public class OidcSessionInfo {
         String iss = new String(Base64.decodeBase64(parts[1]));
         String sub = new String(Base64.decodeBase64(parts[2]));
         String sid = new String(Base64.decodeBase64(parts[3]));
-        String timestamp = new String(Base64.decodeBase64(parts[4]));
+        String exp = new String(Base64.decodeBase64(parts[4]));
 
-        return new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        return new OidcSessionInfo(configId, iss, sub, sid, exp, clientConfig);
     }
 
     private static String getSessionIdFromCookies(Cookie[] cookies) {
@@ -111,8 +111,8 @@ public class OidcSessionInfo {
         return this.sid;
     }
 
-    public String getTimestamp() {
-        return this.timestamp;
+    public String getExp() {
+        return this.exp;
     }
 
     @Override
@@ -121,27 +121,27 @@ public class OidcSessionInfo {
     }
 
     /**
-     * Generate a new session id using the config id, sub, sid, and timestamp in the
-     * format of 'Base64(configId):Base64(sub):Base64(sid):Base64(timestamp)'.
+     * Generate a new session id using the config id, sub, sid, and exp in the
+     * format of 'Base64(configId):Base64(sub):Base64(sid):Base64(exp)'.
      * A signature is then appended using a hash of the session id and the client secret.
      * It is assumed that the inputs have been validated before creating the session id.
      *
-     * @return A session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(timestamp)_Signature(SessionId, ClientSecret)'.
+     * @return A session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(exp)_Signature(SessionId, ClientSecret)'.
      */
     private String createSessionId(ConvergedClientConfig clientConfig) {
         String encodedConfigId = new String(Base64.encodeBase64(configId.getBytes()));
         String encodedIss = new String(Base64.encodeBase64(iss.getBytes()));
         String encodedSub = new String(Base64.encodeBase64(sub.getBytes()));
         String encodedSid = new String(Base64.encodeBase64(sid.getBytes()));
-        String encodedTimestamp = new String(Base64.encodeBase64(timestamp.getBytes()));
+        String encodedExp = new String(Base64.encodeBase64(exp.getBytes()));
 
-        String sessionId = String.join(DELIMITER, encodedConfigId, encodedIss, encodedSub, encodedSid, encodedTimestamp);
+        String sessionId = String.join(DELIMITER, encodedConfigId, encodedIss, encodedSub, encodedSid, encodedExp);
         return OidcClientUtil.addSignatureToStringValue(sessionId, clientConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(configId, iss, sid, sub, timestamp);
+        return Objects.hash(configId, iss, sid, sub, exp);
     }
 
     @Override
@@ -153,7 +153,7 @@ public class OidcSessionInfo {
         if (getClass() != obj.getClass())
             return false;
         OidcSessionInfo other = (OidcSessionInfo) obj;
-        return Objects.equals(configId, other.configId) && Objects.equals(iss, other.iss) && Objects.equals(sid, other.sid) && Objects.equals(sub, other.sub) && Objects.equals(timestamp, other.timestamp);
+        return Objects.equals(configId, other.configId) && Objects.equals(iss, other.iss) && Objects.equals(sid, other.sid) && Objects.equals(sub, other.sub) && Objects.equals(exp, other.exp);
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcSessionInfoTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcSessionInfoTest.java
@@ -50,12 +50,12 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String iss = "https://localhost";
         String sub = "testSub";
         String sid = "testSid";
-        String timestamp = "12345";
+        String exp = "12345";
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, exp, clientConfig);
         String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=_3ssUE3zEBGw4jK8MkAp6udTSo9PaqTVpJgoE4BwmqUs=";
 
-        assertEquals("Expected to return the session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(timestamp)_Signature(SessionId, ClientSecret)'.", expectedSesssionId, sessionInfo.getSessionId());
+        assertEquals("Expected to return the session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(exp)_Signature(SessionId, ClientSecret)'.", expectedSesssionId, sessionInfo.getSessionId());
     }
 
     @Test
@@ -64,12 +64,12 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String iss = "https://localhost";
         String sub = "testSub";
         String sid = "";
-        String timestamp = "12345";
+        String exp = "12345";
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, exp, clientConfig);
         String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==::MTIzNDU=_cPjhjKp9RSS1oESEIBaiK3x+GDs3Rft83urh4KaDYg8=";
 
-        assertEquals("Expected to the return the session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(timestamp)_Signature(SessionId, ClientSecret)'.", expectedSesssionId, sessionInfo.getSessionId());
+        assertEquals("Expected to the return the session id in the format 'Base64(configId):Base64(sub):Base64(sid):Base64(exp)_Signature(SessionId, ClientSecret)'.", expectedSesssionId, sessionInfo.getSessionId());
     }
 
     @Test
@@ -78,9 +78,9 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String iss = "https://localhost";
         String sub = "testSub";
         String sid = "testSid";
-        String timestamp = "12345";
+        String exp = "12345";
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, exp, clientConfig);
         String expectedSesssionId = ":aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=_hG1yWN/mOMMxzHGsS8KnpfXKP3e4C74BxDDJZtQQMzk=";
 
         assertEquals("Expected to replace the configId with an empty string.", expectedSesssionId, sessionInfo.getSessionId());
@@ -92,9 +92,9 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String iss = null;
         String sub = "testSub";
         String sid = "testSid";
-        String timestamp = "12345";
+        String exp = "12345";
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, exp, clientConfig);
         String expectedSesssionId = "dGVzdENvbmZpZ0lk::dGVzdFN1Yg==:dGVzdFNpZA==:MTIzNDU=_XViM+YzwC84l+DMxTjTqgaH8oVqkWMmjfsQP6kDgZKk=";
 
         assertEquals("Expected to replace the sub with an empty string.", expectedSesssionId, sessionInfo.getSessionId());
@@ -106,9 +106,9 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String iss = "https://localhost";
         String sub = null;
         String sid = "testSid";
-        String timestamp = "12345";
+        String exp = "12345";
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, exp, clientConfig);
         String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=::dGVzdFNpZA==:MTIzNDU=_JTmRlEJgi/mUGSFs3Jg8j1BOcc/faLKDIxdBE5XlFV4=";
 
         assertEquals("Expected to replace the sub with an empty string.", expectedSesssionId, sessionInfo.getSessionId());
@@ -120,26 +120,26 @@ public class OidcSessionInfoTest extends CommonTestClass {
         String iss = "https://localhost";
         String sub = "testSub";
         String sid = null;
-        String timestamp = "12345";
+        String exp = "12345";
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, exp, clientConfig);
         String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==::MTIzNDU=_cPjhjKp9RSS1oESEIBaiK3x+GDs3Rft83urh4KaDYg8=";
 
         assertEquals("Expected to replace the sid with an empty string.", expectedSesssionId, sessionInfo.getSessionId());
     }
 
     @Test
-    public void test_createSessionId_timestampIsNull() {
+    public void test_createSessionId_expIsNull() {
         String configId = "testConfigId";
         String iss = "https://localhost";
         String sub = "testSub";
         String sid = "testSid";
-        String timestamp = null;
+        String exp = null;
 
-        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, timestamp, clientConfig);
+        OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, exp, clientConfig);
         String expectedSesssionId = "dGVzdENvbmZpZ0lk:aHR0cHM6Ly9sb2NhbGhvc3Q=:dGVzdFN1Yg==:dGVzdFNpZA==:_vb86W5kVUmHqMfboDo/jG491Zk5axpk0UqNVPqk5oR4=";
 
-        assertEquals("Expected to replace the timestamp with an empty string.", expectedSesssionId, sessionInfo.getSessionId());
+        assertEquals("Expected to replace the exp with an empty string.", expectedSesssionId, sessionInfo.getSessionId());
     }
 
     @Test
@@ -153,7 +153,7 @@ public class OidcSessionInfoTest extends CommonTestClass {
         assertEquals("https://localhost", sessionInfo.getIss());
         assertEquals("testSub", sessionInfo.getSub());
         assertEquals("testSid", sessionInfo.getSid());
-        assertEquals("12345", sessionInfo.getTimestamp());
+        assertEquals("12345", sessionInfo.getExp());
     }
 
     @Test
@@ -167,7 +167,7 @@ public class OidcSessionInfoTest extends CommonTestClass {
         assertEquals("https://localhost", sessionInfo.getIss());
         assertEquals("testSub", sessionInfo.getSub());
         assertEquals("", sessionInfo.getSid());
-        assertEquals("12345", sessionInfo.getTimestamp());
+        assertEquals("12345", sessionInfo.getExp());
     }
 
     @Test


### PR DESCRIPTION
for #20360

- updates the timestamp in the oidc session cookie to be the `exp` of the id token
- adds an eviction task that runs every 10 mins to the `InMemoryOidcSessionCache` to remove expired sessions