### PR TITLE
JAX-WS and JAX-RS 2.1: Prep CXF Core project source for CXF 3.5

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/attachment/AttachmentUtil.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/attachment/AttachmentUtil.java
@@ -63,6 +63,7 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
 
 // Liberty Change - Backport https://github.com/apache/cxf/pull/960
+// Liberty Changes - Could potentially be removed when updating to CXF 3.5.5
 public final class AttachmentUtil {
     // Liberty Change - Start
     // The xop:include "href" attribute (https://www.w3.org/TR/xop10/#xop_href) may include

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/bus/osgi/CXFExtensionBundleListener.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/bus/osgi/CXFExtensionBundleListener.java
@@ -18,7 +18,6 @@
  */
 package org.apache.cxf.bus.osgi;
 
-import java.io.IOException;
 import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
@@ -56,7 +55,7 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
         this.id = bundleId;
     }
 
-    public void registerExistingBundles(BundleContext context) throws IOException {
+    public void registerExistingBundles(BundleContext context) {
         for (Bundle bundle : context.getBundles()) {
             if ((bundle.getState() == Bundle.RESOLVED
                 || bundle.getState() == Bundle.STARTING
@@ -101,7 +100,7 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
         for (Extension ext : orig) {
             names.add(ext.getName());
         }
-        LOG.finest("Adding the extensions from bundle " + bundle.getSymbolicName()
+        LOG.finest("Adding the extensions from bundle " + bundle.getSymbolicName() // Liberty Change: Log at finest
                  + " (" + bundle.getBundleId() + ") " + names);
         List<OSGiExtension> list = extensions.get(bundle.getBundleId());
         if (list == null) {
@@ -121,7 +120,7 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
     protected void unregister(final long bundleId) {
         List<OSGiExtension> list = extensions.remove(bundleId);
         if (list != null) {
-            LOG.finest("Removing the extensions for bundle " + bundleId);
+            LOG.finest("Removing the extensions for bundle " + bundleId);  // Liberty Change: Log at finest
             ExtensionRegistry.removeExtensions(list);
         }
     }
@@ -183,6 +182,8 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
 
             return super.load(cl, b);
         }
+        
+        @Override
         protected Class<?> tryClass(String name, ClassLoader cl) {
             Class<?> c = null;
 
@@ -223,6 +224,7 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
             return c;
         }
 
+        @Override
         public Extension cloneNoObject() {
             OSGiExtension ext = new OSGiExtension(this, bundle);
             ext.obj = serviceObject;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/bus/osgi/OSGiBeanLocator.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/bus/osgi/OSGiBeanLocator.java
@@ -18,9 +18,12 @@
  */
 package org.apache.cxf.bus.osgi;
 
+// Liberty Change Start
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+// Liberty Change End
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/logging/LogUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/logging/LogUtils.java
@@ -19,12 +19,15 @@
 
 package org.apache.cxf.common.logging;
 
+// import java.io.BufferedReader; Liberty Change
+// import java.io.InputStream; Liberty Change
+// import java.io.InputStreamReader; Liberty Change
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
+import java.security.PrivilegedActionException; // Liberty Change
+import java.security.PrivilegedExceptionAction; // Liberty Change
 import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
@@ -33,8 +36,8 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import org.apache.cxf.common.i18n.BundleUtils;
-
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+// import org.apache.cxf.common.util.StringUtils; Liberty Change
+import com.ibm.ws.ffdc.annotation.FFDCIgnore; // Liberty Change
 
 /**
  * A container for static utility methods related to logging.
@@ -51,11 +54,11 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
  */
 
 public final class LogUtils {
-    public static final String KEY = "org.apache.cxf.Logger";
+    private static final String KEY = "org.apache.cxf.Logger";
 
     private static final Object[] NO_PARAMETERS = new Object[0];
 
-    private static Class<?> loggerClass = null;
+    private static Class<?> loggerClass;
 
     /**
      * Prevents instantiation.
@@ -236,7 +239,7 @@ public final class LogUtils {
     /**
      * Create a logger
      */
-    @FFDCIgnore({ MissingResourceException.class, IllegalArgumentException.class })
+    @FFDCIgnore({ MissingResourceException.class, IllegalArgumentException.class }) // Liberty Change
     protected static Logger createLogger(final Class<?> cls,
                                          String name,
                                          String loggerName) {
@@ -247,7 +250,6 @@ public final class LogUtils {
         }
         String bundleName = name;
         try {
-            Logger logger = null;
             ResourceBundle b = null;
             if (bundleName == null) {
                 //grab the bundle prior to the call to Logger.getLogger(...) so the
@@ -296,15 +298,12 @@ public final class LogUtils {
                 }
             }
 
+            Logger logger;
             try {
                 logger = Logger.getLogger(loggerName, bundleName); //NOPMD
-            } catch (IllegalArgumentException iae) {
+            } catch (IllegalArgumentException | MissingResourceException ex) {
                 //likely a mismatch on the bundle name, just return the default
                 logger = Logger.getLogger(loggerName); //NOPMD
-            } catch (MissingResourceException rex) {
-                logger = Logger.getLogger(loggerName); //NOPMD
-            } finally {
-                b = null;
             }
             return logger;
         } finally {
@@ -318,7 +317,6 @@ public final class LogUtils {
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             AccessController.doPrivileged(new PrivilegedAction<Object>() {
-               @Override
                 public Object run() {
                     Thread.currentThread().setContextClassLoader(classLoader);
                     return null;
@@ -473,7 +471,7 @@ public final class LogUtils {
 
         //try to get the right class name/method name - just trace
         //back the stack till we get out of this class
-        StackTraceElement stack[] = (new Throwable()).getStackTrace();
+        StackTraceElement[] stack = (new Throwable()).getStackTrace();
         String cname = LogUtils.class.getName();
         for (int x = 0; x < stack.length; x++) {
             StackTraceElement frame = stack[x];

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/util/ProxyHelper.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/util/ProxyHelper.java
@@ -34,8 +34,18 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
  *
  */
 public class ProxyHelper {
-    static final ProxyHelper HELPER = new ProxyHelper(); //Liberty change
-
+    // Liberty Change Start: 
+	// Dont use CglibProxyHelper as default
+    static final ProxyHelper HELPER = new ProxyHelper(); 
+    // static {
+    //     ProxyHelper theHelper;
+    //     try {
+    //         theHelper = new CglibProxyHelper();
+    //     } catch (Throwable ex) {
+    //          theHelper = new ProxyHelper();
+    //     }
+    //    HELPER = theHelper;
+    // }
     private static final Logger LOG = LogUtils.getL7dLogger(ProxyHelper.class);
     
     protected ProxyClassLoaderCache proxyClassLoaderCache = 
@@ -89,7 +99,7 @@ public class ProxyHelper {
     }
     
     private String getSortedNameFromInterfaceArray(Class<?>[] interfaces) {
-        SortedArraySet<String> arraySet = new SortedArraySet<String>();
+        SortedArraySet<String> arraySet = new SortedArraySet<>();
         for (Class<?> currentInterface : interfaces) {
             arraySet.add(currentInterface.getName() + ClassLoaderUtils.getClassLoaderName(currentInterface));
         }
@@ -97,7 +107,7 @@ public class ProxyHelper {
     }
 
 
-    @FFDCIgnore({ClassNotFoundException.class})
+    @FFDCIgnore({ClassNotFoundException.class}) // Liberty Change Start
     private boolean canSeeAllInterfaces(ClassLoader loader, Class<?>[] interfaces) {
         for (Class<?> currentInterface : interfaces) {
             String ifName = currentInterface.getName();

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/message/MessageImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/message/MessageImpl.java
@@ -51,6 +51,7 @@ public class MessageImpl extends StringMapImpl implements Message {
     private Object[] contents = new Object[20];
     private int index;
 
+    // private Map<String, Object> contextCache; Liberty code Change
 
 
     public MessageImpl() {
@@ -70,6 +71,7 @@ public class MessageImpl extends StringMapImpl implements Message {
             interceptorChain = impl.interceptorChain;
             contents = impl.contents;
             index = impl.index;
+            // contextCache = impl.contextCache; Liberty code Change
         } else {
             throw new RuntimeException("Not a MessageImpl! " + m.getClass());
         }
@@ -106,7 +108,7 @@ public class MessageImpl extends StringMapImpl implements Message {
 
     @SuppressWarnings("unchecked")
     public <T> T getContent(Class<T> format) {
-        // Liberty code change start
+        // Liberty code change start - Add logging statments
         LOG.entering("MessageImpl", "getContent");
         for (int x = 0; x < index; x += 2) {
             if (contents[x] == format) {
@@ -183,7 +185,7 @@ public class MessageImpl extends StringMapImpl implements Message {
         this.interceptorChain = ic;
     }
 
-    //Liberty code change start
+    // Liberty code change start
     // Since these maps can have null value, use the getOrDefault API
     // to prevent calling get twice under the covers
     private static final Object NOT_FOUND = new Object();

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/phase/PhaseInterceptorChain.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/phase/PhaseInterceptorChain.java
@@ -206,7 +206,6 @@ public class PhaseInterceptorChain implements InterceptorChain {
         if (iterator == null) {
             iterator = new PhaseInterceptorIterator(heads);
             outputChainToLog(false);
-            //System.out.println(toString());
         }
     }
 
@@ -395,8 +394,8 @@ public class PhaseInterceptorChain implements InterceptorChain {
     }
 
     private void doDefaultLogging(Message message, Exception ex, String description) {
-        FaultMode mode = (FaultMode) message.get(FaultMode.class);
-        //Liberty Change Start
+        FaultMode mode = message.get(FaultMode.class);
+        //Liberty Change Start - Prevent logging from ending up in message.log
         if (mode == FaultMode.CHECKED_APPLICATION_FAULT && this.isFineLogging) {
             Throwable t = ex;
             if (ex instanceof Fault && ex.getCause() != null) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/service/model/EndpointInfo.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/service/model/EndpointInfo.java
@@ -26,6 +26,8 @@ import org.apache.cxf.ws.addressing.EndpointReferenceType;
 
 /**
  * The EndpointInfo contains the information for a web service 'port' inside of a service.
+ * 
+ * Liberty Changes - should try to commit back to CXF 
  */
 public class EndpointInfo extends AbstractDescriptionElement implements NamedItem {
     String transportId;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxSource.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxSource.java
@@ -38,6 +38,8 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.AttributesImpl;
 
+
+// Liberty Changes - should try to commit back to CXF 
 public class StaxSource extends SAXSource implements XMLReader {
 
     private XMLStreamReader streamReader;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxUtils.java
@@ -87,6 +87,7 @@ import org.w3c.dom.UserDataHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 
+// Liberty Change
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
@@ -99,7 +100,8 @@ import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.message.Message;
 
 // Liberty change -- must be trivial to avoid StackOverflow when tracing methods like createXMLStreamReader -
-//                   which creates/logs the W3CDOMStreamReader class that can print a stack trace.
+//                   which creates/logs the W3CDOMStreamReader class that can print a stack trace. (Could have instrumentation disabled)
+// Liberty Changes - Could potentially be removed when updating to CXF 3.5.5
 @Trivial
 public final class StaxUtils {
     // System properties for defaults, but also contextual properties usable
@@ -207,7 +209,6 @@ public final class StaxUtils {
             }
         } catch (Throwable t) {
             //ignore, can always drop down to the pooled factories
-            xif = null;
         }
         SAFE_INPUT_FACTORY = xif;
 
@@ -303,6 +304,7 @@ public final class StaxUtils {
      * @param nsAware
      * @throws XMLStreamException
      */
+	 // Liberty Change
     @FFDCIgnore(Throwable.class)
     public static XMLInputFactory createXMLInputFactory(boolean nsAware) {
         XMLInputFactory factory = null;
@@ -312,7 +314,6 @@ public final class StaxUtils {
             if (LOG.isLoggable(Level.FINE)) {
                 LOG.log(Level.FINE, "XMLInputFactory.newInstance() failed with: ", t);
             }
-            factory = null;
         }
         if (factory == null || !setRestrictionProperties(factory)) {
             try {
@@ -320,8 +321,10 @@ public final class StaxUtils {
             } catch (Throwable t) {
                 if (LOG.isLoggable(Level.FINE)) {
                     LOG.log(Level.FINE, "Cannot create Woodstox XMLInputFactory ");
+					// Liberty Change Start:
                     if(t instanceof NoClassDefFoundError)
                         LOG.log(Level.FINE, "The WoodStox API is not availible on the classpath");
+				    // Liberty Change End
                 }
             }
 
@@ -378,6 +381,7 @@ public final class StaxUtils {
             && setProperty(factory, P_MIN_TEXT_SEGMENT, MIN_TEXT_SEGMENT_VAL);
     }
 
+    // Liberty Change
     @FFDCIgnore(Throwable.class)
     private static boolean setProperty(XMLInputFactory f, String p, Object o) {
         try {
@@ -1930,6 +1934,7 @@ public final class StaxUtils {
             } finally {
                 StaxUtils.close(writer);
             }
+			// Liberty Change - Prevent from going to message logs
             LOG.finest(sw.toString());
         } catch (XMLStreamException e) {
             LOG.severe(e.getMessage());


### PR DESCRIPTION
This PR does makes the following changes to the `com.ibm.ws.org.apache.cxf.cxf.core.3.2` project:

- Brings in all non-conflicting changes to the sources overlays from the 3.5.5 version of CXF
- Properly notates all liberty specific changes to the overlays
- Indicates changes that could be committed back to CXF 3.5 in future releases
- Indicates what overlays could be removed once the 3.5.5 update is complete. 