### PR TITLE
add dynamic config change to max connections limit pmi test

### DIFF
--- a/dev/com.ibm.ws.jca_fat_mbean/publish/servers/com.ibm.ws.jca.jdbc.mbean.fat.app.connPool/server.xml
+++ b/dev/com.ibm.ws.jca_fat_mbean/publish/servers/com.ibm.ws.jca.jdbc.mbean.fat.app.connPool/server.xml
@@ -22,6 +22,13 @@
     <dataSource id="ds1" jndiName="jdbc/ds1" jdbcDriverRef="FATJDBCDriver">
     	<properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
+
+    <connectionManager id="maxconlimitConnectionManager" maxPoolSize="50"/>
+    
+    <dataSource id="ds1_maxconlimit" jndiName="jdbc/ds1_maxconlimit" jdbcDriverRef="FATJDBCDriver" connectionManagerRef="maxconlimitConnectionManager">
+    	<properties.derby.embedded databaseName="memory:ds1_maxconlimit" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
     
     <!-- Note that this datasource should only by used by the testBasicGetWaitTime test -->
     <dataSource id="waitTimeDS" jndiName="jdbc/waitTimeDS" jdbcDriverRef="FATJDBCDriver">


### PR DESCRIPTION
Adding an additional test for dynamic server configuration change to maximum connections that will change the maximum connections limit value in pmi.

Added minor fix to getConnPoolStatsMBeanObjName, wild carding the front of the name is mostly ok and should have a low risk of run into duplicate names, but wild carding the end, increases the chances of getting the wrong object for the object name being used.

