### PR TITLE
Issue #20368: Stop pre-creating EJBs for Checkpoint

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/ContainerConfigConstants.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/ContainerConfigConstants.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2017 IBM Corporation and others.
+ * Copyright (c) 2002, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -1115,4 +1115,15 @@ public class ContainerConfigConstants {
      * <p><b>Property values:</b> true or false (default true)
      */
     public static final String createInstanceAtStartup = "com.ibm.websphere.ejbcontainer.createInstanceAtStart"; // PI23717
+
+    /**
+     * Property that allows the user to indicate that all Singleton beans should be
+     * started at application start, similar to using the <code>@Startup</code> annotation.
+     *
+     * Singleton beans without the <code>@Startup</code> annotation will be started after all
+     * startup beans have started and incoming work has been unblocked.
+     *
+     * <p><b>Property values:</b> true or false (default false)
+     */
+    public static final String startAllSingletons = "io.openliberty.ejb.startAllSingletons";
 }

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/ContainerProperties.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/ContainerProperties.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2017 IBM Corporation and others.
+ * Copyright (c) 2003, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -48,6 +48,7 @@ import static com.ibm.ejs.container.ContainerConfigConstants.persistentTimerSing
 import static com.ibm.ejs.container.ContainerConfigConstants.poolSizeSpecProp;
 import static com.ibm.ejs.container.ContainerConfigConstants.portableFinderProp;
 import static com.ibm.ejs.container.ContainerConfigConstants.portableProp;
+import static com.ibm.ejs.container.ContainerConfigConstants.startAllSingletons;
 import static com.ibm.ejs.container.ContainerConfigConstants.strictMaxCacheSize;
 import static com.ibm.ejs.container.ContainerConfigConstants.timerCancelTimeout;
 import static com.ibm.ejs.container.ContainerConfigConstants.timerQOSAtLeastOnceForRequired;
@@ -438,6 +439,15 @@ public final class ContainerProperties {
     public static final int RMICCompatible = JITDeploy.RMICCompatible; // PM46698
 
     /**
+     * Property that allows the user to indicate that all Singleton beans should be
+     * started at application start, similar to using the <code>@Startup</code> annotation.
+     *
+     * Singleton beans without the <code>@Startup</code> annotation will be started after all
+     * startup beans have started and incoming work has been unblocked.
+     */
+    public static final boolean StartAllSingletons;
+
+    /**
      * Property that allows the user to specify that the EJB max cache size
      * should be strictly enforced.
      */
@@ -631,6 +641,8 @@ public final class ContainerProperties {
 
         PortableFinder = System.getProperty(portableFinderProp);
 
+        StartAllSingletons = Boolean.getBoolean(startAllSingletons);
+
         StrictMaxCacheSize = Boolean.getBoolean(strictMaxCacheSize);
 
         TimerCancelTimeout = Integer.getInteger(timerCancelTimeout, 60) * 1000; // d703086
@@ -746,6 +758,7 @@ public final class ContainerProperties {
         writer.println("Property: Portable                = " + Portable);
         writer.println("Property: PortableFinder          = " + PortableFinder);
         writer.println("Property: RMICCompatible          = " + RMICCompatible);
+        writer.println("Property: StartAllSingletons      = " + StartAllSingletons);
         writer.println("Property: StrictMaxCacheSize      = " + StrictMaxCacheSize);
         writer.println("Property: TimerCancelTimeout      = " + TimerCancelTimeout);
         writer.println("Property: TimerQOSAtLeastOnceForRequired = " + TimerQOSAtLeastOnceForRequired);

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/EJBMDOrchestrator.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/EJBMDOrchestrator.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2022 IBM Corporation and others.
+ * Copyright (c) 2006, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,6 +22,7 @@ import static com.ibm.ejs.container.ContainerProperties.FbpkAlwaysReadOnly;
 import static com.ibm.ejs.container.ContainerProperties.LimitSetRollbackOnlyBehaviorToInstanceFor;
 import static com.ibm.ejs.container.ContainerProperties.NoEJBPool;
 import static com.ibm.ejs.container.ContainerProperties.PoolSize;
+import static com.ibm.ejs.container.ContainerProperties.StartAllSingletons;
 import static com.ibm.ws.ejbcontainer.jitdeploy.EJBWrapper.LOCAL_BEAN_WRAPPER_FIELD;
 import static com.ibm.ws.ejbcontainer.jitdeploy.EJBWrapper.MANAGED_BEAN_BEANO_FIELD;
 import static com.ibm.ws.ejbcontainer.jitdeploy.EJBWrapper.MESSAGE_ENDPOINT_BASE_FIELD;
@@ -498,7 +499,8 @@ public abstract class EJBMDOrchestrator {
                 // homes, so it is only important to check the individual flags when the global flag is not
                 // set.
                 if (!initAtStartupSet) {
-                    isStartEJBAtApplicationStart = bmd.wccm.isStartEJBAtApplicationStart(initAtStartup);
+                    boolean initAtStartupDefault = (StartAllSingletons && bmd.type == InternalConstants.TYPE_SINGLETON_SESSION) ? true : initAtStartup;
+                    isStartEJBAtApplicationStart = bmd.wccm.isStartEJBAtApplicationStart(initAtStartupDefault);
                 } // !initAtStartupSet
             } //!isStartupBean
         } // !isMessageDriven

--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBRuntimeImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBRuntimeImpl.java
@@ -1722,7 +1722,7 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
      */
     @Override
     public boolean isCheckpointDeployment() {
-        return CheckpointPhase.DEPLOYMENT == checkpointPhase;
+        return CheckpointPhase.DEPLOYMENT == checkpointPhase && !checkpointPhase.restored();
     }
 
     /**
@@ -1733,7 +1733,7 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
      */
     @Override
     public boolean isCheckpointApplications() {
-        return CheckpointPhase.APPLICATIONS == checkpointPhase;
+        return CheckpointPhase.APPLICATIONS == checkpointPhase && !checkpointPhase.restored();
     }
 
     @Override

--- a/dev/io.openliberty.ejbcontainer.checkpoint_fat/test-applications/CheckpointWeb.war/src/io/openliberty/ejbcontainer/fat/checkpoint/web/EjbStartCheckpointServlet.java
+++ b/dev/io.openliberty.ejbcontainer.checkpoint_fat/test-applications/CheckpointWeb.war/src/io/openliberty/ejbcontainer/fat/checkpoint/web/EjbStartCheckpointServlet.java
@@ -50,6 +50,29 @@ public class EjbStartCheckpointServlet extends FATServlet {
         assert_24_StatelessClassInstancesCreated();
     }
 
+    public void testEjbStartCheckpointInactiveStartAllSingletons() throws Exception {
+        // All Singleton that don't disable StartAtAppStart bean classes should be initialized
+        assertEquals("Wrong number of classes initialized", 16, CheckpointStatistics.getInitializedClassListSize());
+        assert_16_SingletonClassesInitialized();
+
+        // All beans from above should be fully created; 1 each
+        assertEquals("Wrong number of classes created", 16, CheckpointStatistics.getInstanceCountMapSize());
+        assert_16_SingletonClassInstancesCreated();
+
+        // Access all beans and verify they are functional
+        verifyAllBeans();
+
+        // All bean classes should now be initialized
+        assertEquals("Wrong number of classes initialized", 44, CheckpointStatistics.getInitializedClassListSize());
+        assert_20_SingletonClassesInitialized();
+        assert_24_StatelessClassesInitialized();
+
+        // At least one instance per bean should now be created; more for those with a hard minimum poolSize
+        assertEquals("Wrong number of classes created", 44, CheckpointStatistics.getInstanceCountMapSize());
+        assert_20_SingletonClassInstancesCreated();
+        assert_24_StatelessClassInstancesCreated();
+    }
+
     public void testEjbStartCheckpointDeployment() throws Exception {
         // Only the @Startup Singleton bean classes should be initialized
         assertEquals("Wrong number of classes initialized", 8, CheckpointStatistics.getInitializedClassListSize());


### PR DESCRIPTION
To avoid global transactions during checkpoint, the following changes will be made to "undo" changes originally intended to improve checkpoint performance:

1 - Non-startup Singleton beans will no longer be pre-created. They will be created
    on first use, which has always been the normal behavior prior to checkpoint.
    Singleton bean postConstruct methods will use a global transaction by default.

2 - Stateless bean pool will not be automatically pre-loaded for checkpoint.
    Stateless bean postConstruct method may use a global transaction. Also,
    preloading the Stateless pools is blocked until after @Startup beans are
    created, so in the future preloading the bean pools would occur on restore.

Basically, both options are reverted to their normal behavior without checkpoint and both behaviors could still be enabled via other configuration options, though enabling them would likely cause the checkpoint to fail due to use of transactions.

for #20368 