### PR TITLE
Issue 19029: Initial metatype for OIDC client PKCE support

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
@@ -1,14 +1,11 @@
 ###############################################################################
-# Copyright (c) 2013, 2021 IBM Corporation and others.
+# Copyright (c) 2013, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 #
 #NLS_ENCODING=UNICODE
@@ -276,3 +273,6 @@ accessTokenCacheEnabled.desc=Specifies whether authenticated subjects that are c
 
 accessTokenCacheTimeout=Access token cache timeout
 accessTokenCacheTimeout.desc=Specifies how long an authenticated subject that is created by using a propagated access token is cached.
+
+pkceCodeChallengeMethod.plain=Plain
+pkceCodeChallengeMethod.S256=S256

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2013, 2022 IBM Corporation and others.
+    Copyright (c) 2013, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
 -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0" 
                    xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
@@ -156,6 +153,10 @@
          <AD id="keyManagementKeyAlias" name="%keyManagementKeyAlias" description="%keyManagementKeyAlias.desc" required="false" type="String" />
          <AD id="accessTokenCacheEnabled" name="%accessTokenCacheEnabled" description="%accessTokenCacheEnabled.desc" required="false" type="Boolean" default="true" />
          <AD id="accessTokenCacheTimeout" name="%accessTokenCacheTimeout" description="%accessTokenCacheTimeout.desc" required="false" type="String" default="5m" ibm:type="duration" />
+         <AD id="pkceCodeChallengeMethod" name="internal" description="internal use only" required="false" type="String" ibm:beta="true" >
+                <Option label="%pkceCodeChallengeMethod.plain" value="plain" />
+                <Option label="%pkceCodeChallengeMethod.S256" value="S256" />
+         </AD>
      </OCD>
 
     <Designate factoryPid="com.ibm.ws.security.openidconnect.client.oidcClientConfig">

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.client.internal;
 
@@ -175,6 +172,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     public static final String CFG_KEY_KEY_MANAGEMENT_KEY_ALIAS = "keyManagementKeyAlias";
     public static final String CFG_KEY_ACCESS_TOKEN_CACHE_ENABLED = "accessTokenCacheEnabled";
     public static final String CFG_KEY_ACCESS_TOKEN_CACHE_TIMEOUT = "accessTokenCacheTimeout";
+    public static final String CFG_KEY_PKCE_CODE_CHALLENGE_METHOD = "pkceCodeChallengeMethod";
 
     public static final String OPDISCOVERY_AUTHZ_EP_URL = "authorization_endpoint";
     public static final String OPDISCOVERY_TOKEN_EP_URL = "token_endpoint";
@@ -270,6 +268,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     private String keyManagementKeyAlias;
     private boolean accessTokenCacheEnabled = true;
     private long accessTokenCacheTimeout = 1000 * 60 * 5;
+    private String pkceCodeChallengeMethod = null;
 
     private String oidcClientCookieName;
     private boolean authnSessionDisabled;
@@ -548,6 +547,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         keyManagementKeyAlias = configUtils.getConfigAttribute(props, CFG_KEY_KEY_MANAGEMENT_KEY_ALIAS);
         accessTokenCacheEnabled = configUtils.getBooleanConfigAttribute(props, CFG_KEY_ACCESS_TOKEN_CACHE_ENABLED, accessTokenCacheEnabled);
         accessTokenCacheTimeout = configUtils.getLongConfigAttribute(props, CFG_KEY_ACCESS_TOKEN_CACHE_TIMEOUT, accessTokenCacheTimeout);
+        pkceCodeChallengeMethod = configUtils.getConfigAttribute(props, CFG_KEY_PKCE_CODE_CHALLENGE_METHOD);
         // TODO - 3Q16: Check the validationEndpointUrl to make sure it is valid
         // before continuing to process this config
         // checkValidationEndpointUrl();
@@ -624,6 +624,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
             Tr.debug(tc, "forwardLoginParameter:" + forwardLoginParameter);
             Tr.debug(tc, "accessTokenCacheEnabled:" + accessTokenCacheEnabled);
             Tr.debug(tc, "accessTokenCacheTimeout:" + accessTokenCacheTimeout);
+            Tr.debug(tc, "pkceCodeChallengeMethod:" + pkceCodeChallengeMethod);
         }
     }
 
@@ -1899,6 +1900,11 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     @Override
     public OidcSessionCache getOidcSessionCache() {
         return oidcSessionCache;
+    }
+
+    @Override
+    public String getPkceCodeChallengeMethod() {
+        return pkceCodeChallengeMethod;
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ConvergedClientConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ConvergedClientConfig.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- * IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
@@ -136,5 +133,7 @@ public interface ConvergedClientConfig extends JwtConsumerConfig {
     String getIntrospectionTokenTypeHint();
 
     public OidcSessionCache getOidcSessionCache();
+
+    public String getPkceCodeChallengeMethod();
 
 }

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
@@ -1,14 +1,11 @@
 ###############################################################################
-# Copyright (c) 2016, 2021 IBM Corporation and others.
+# Copyright (c) 2016, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 #
 # -------------------------------------------------------------------------------------------------
@@ -276,3 +273,6 @@ createSession.desc=Specifies whether to create an HttpSession if the current Htt
 # Do not translate "Content Encryption Key", "JSON Web Encryption"
 keyManagementKeyAlias=Key management key alias
 keyManagementKeyAlias.desc=Private key alias of the key management key that is used to decrypt the Content Encryption Key of a JSON Web Encryption (JWE) token.
+
+pkceCodeChallengeMethod.plain=Plain
+pkceCodeChallengeMethod.S256=S256

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2021 IBM Corporation and others.
+    Copyright (c) 2016, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0" 
                    xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
@@ -450,6 +447,10 @@
         <AD id="forwardLoginParameter" name="internal" description="internal use only" required="false" type="String" cardinality="2147483647" />
         <AD id="createSession" name="%createSession" description="%createSession.desc" required="false" type="Boolean" default="false" />
         <AD id="keyManagementKeyAlias" name="%keyManagementKeyAlias" description="%keyManagementKeyAlias.desc" required="false" type="String" />
+        <AD id="pkceCodeChallengeMethod" name="internal" description="internal use only" required="false" type="String" ibm:beta="true" >
+            <Option label="%pkceCodeChallengeMethod.plain" value="plain" />
+            <Option label="%pkceCodeChallengeMethod.S256" value="S256" />
+        </AD>
     </OCD>
     
      <OCD id="com.ibm.ws.security.social.client.param.metatype" name="%oidcClientCustomRequestParam" description="%oidcClientCustomRequestParam.desc" 

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
@@ -138,6 +138,8 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
     private List<String> forwardLoginParameter = null;
     public static final String CFG_KEY_KEY_MANAGEMENT_KEY_ALIAS = "keyManagementKeyAlias";
     private String keyManagementKeyAlias = null;
+    public static final String CFG_KEY_PKCE_CODE_CHALLENGE_METHOD = "pkceCodeChallengeMethod";
+    private String pkceCodeChallengeMethod = null;
 
     HttpUtils httputils = new HttpUtils();
     ConfigUtils oidcConfigUtils = new ConfigUtils(null);
@@ -218,6 +220,7 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
 
         forwardLoginParameter = oidcConfigUtils.readAndSanitizeForwardLoginParameter(props, uniqueId, CFG_KEY_FORWARD_LOGIN_PARAMETER);
         keyManagementKeyAlias = configUtils.getConfigAttribute(props, CFG_KEY_KEY_MANAGEMENT_KEY_ALIAS);
+        pkceCodeChallengeMethod = configUtils.getConfigAttribute(props, CFG_KEY_PKCE_CODE_CHALLENGE_METHOD);
 
         if (discovery) {
             String OIDC_CLIENT_DISCOVERY_COMPLETE = "CWWKS6110I: The client [{" + getId() + "}] configuration has been established with the information from the discovery endpoint URL [{" + discoveryEndpointUrl + "}]. This information enables the client to interact with the OpenID Connect provider to process the requests such as authorization and token.";
@@ -943,6 +946,11 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
     @Override
     public OidcSessionCache getOidcSessionCache() {
     	return this.oidcSessionCache;
+    }
+
+    @Override
+    public String getPkceCodeChallengeMethod() {
+        return pkceCodeChallengeMethod;
     }
 
 }


### PR DESCRIPTION
Adds the first pass of metatype for PKCE support for the openidConnectClient-1.0 and socialLogin-1.0 features. Attribute name and approach is subject to change, but currently designed as a `pkceCodeChallengeMethod` attribute with two options:
- `plain`
- `S256`

For #19029