### PR TITLE
Issue 19029: Initial drop of data structures for PKCE support

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/oauth/core/internal/oauth20/OAuth20Constants.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/oauth/core/internal/oauth20/OAuth20Constants.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.oauth.core.internal.oauth20;
 
@@ -76,12 +73,7 @@ public interface OAuth20Constants extends OAuthConstants {
     public static final String CODE_CHALLENGE = "code_challenge";
     public static final String CODE_CHALLENGE_METHOD = "code_challenge_method";
     public static final String CODE_VERIFIER = "code_verifier";
-    public static final String CODE_CHALLENGE_METHOD_PLAIN = "plain";
-    public static final String CODE_CHALLENGE_METHOD_S256 = "S256";
-    public static final String CODE_CHALLENGE_ALG_METHOD_SHA256 = "SHA-256";
     public static final String CODE_VERIFIER_ASCCI = "US-ASCII";
-    public static final int CODE_VERIFIER_MIN_LENGTH = 43;
-    public static final int CODE_VERIFIER_MAX_LENGTH = 128;
 
     public static final String ISSUER_IDENTIFIER = "issuerIdentifier";
     public static final String REFRESH_TOKEN_KEY = "refresh_key";

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/PkceMethodPlain.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/PkceMethodPlain.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.oauth20.pkce;
+
+import com.ibm.oauth.core.api.error.oauth20.InvalidGrantException;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * Class to use for generating and validating PKCE code challenges using the "plain" code challenge method.
+ */
+public class PkceMethodPlain extends ProofKeyForCodeExchangeMethod {
+
+    private static final TraceComponent tc = Tr.register(PkceMethodS256.class);
+
+    public static String CHALLENGE_METHOD = "plain";
+
+    @Override
+    public String getCodeChallengeMethod() {
+        return CHALLENGE_METHOD;
+    }
+
+    /**
+     * Note: Plain performs no operations on the code verifier and simply returns the value as-is.
+     */
+    @Override
+    public String generateCodeChallenge(String codeVerifier) {
+        return codeVerifier;
+    }
+
+    @Override
+    public void validate(String codeVerifier, String codeChallenge) throws InvalidGrantException {
+        if (codeVerifier == null && codeChallenge == null) {
+            return;
+        }
+        if ((codeChallenge == null && codeVerifier != null) || !codeChallenge.equals(codeVerifier)) {
+            String message = Tr.formatMessage(tc, "security.oauth20.pkce.error.mismatch.codeverifier", codeChallenge, codeVerifier);
+            throw new InvalidGrantException(message, null);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/PkceMethodS256.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/PkceMethodS256.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.oauth20.pkce;
+
+import com.ibm.oauth.core.api.error.oauth20.InvalidGrantException;
+import com.ibm.oauth.core.internal.oauth20.OAuth20Constants;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.security.oauth20.util.HashUtils;
+
+/**
+ * Class to use for generating and validating PKCE code challenges using the "S256" code challenge method.
+ */
+public class PkceMethodS256 extends ProofKeyForCodeExchangeMethod {
+
+    private static final TraceComponent tc = Tr.register(PkceMethodS256.class);
+
+    public static String CHALLENGE_METHOD = "S256";
+    public static String CODE_CHALLENGE_ALG_METHOD = "SHA-256";
+
+    @Override
+    public String getCodeChallengeMethod() {
+        return CHALLENGE_METHOD;
+    }
+
+    @Override
+    public String generateCodeChallenge(String codeVerifier) {
+        return HashUtils.encodedDigest(codeVerifier, CODE_CHALLENGE_ALG_METHOD, OAuth20Constants.CODE_VERIFIER_ASCCI);
+    }
+
+    @Override
+    public void validate(String codeVerifier, String codeChallenge) throws InvalidGrantException {
+        if (codeVerifier == null && codeChallenge == null) {
+            return;
+        }
+        String derivedCodeChallenge = generateCodeChallenge(codeVerifier);
+        if ((codeChallenge == null && codeVerifier != null) || !codeChallenge.equals(derivedCodeChallenge)) {
+            String message = Tr.formatMessage(tc, "security.oauth20.pkce.error.mismatch.codeverifier", codeChallenge, codeVerifier);
+            throw new InvalidGrantException(message, null);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/ProofKeyForCodeExchange.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/ProofKeyForCodeExchange.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.oauth20.pkce;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import com.ibm.oauth.core.api.error.oauth20.InvalidGrantException;
+import com.ibm.oauth.core.api.error.oauth20.OAuth20MissingParameterException;
+import com.ibm.oauth.core.internal.oauth20.TraceConstants;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+/**
+ * Class to contain Proof Key for Code Exchange values consistent with RFC 7636.
+ */
+public class ProofKeyForCodeExchange {
+
+    private static final TraceComponent tc = Tr.register(ProofKeyForCodeExchange.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
+
+    public static final int CODE_VERIFIER_MIN_LENGTH = 43;
+    public static final int CODE_VERIFIER_MAX_LENGTH = 128;
+
+    /**
+     * Generates a code verifier value per Section 4.1 of RFC 7636: It is RECOMMENDED that the output of a suitable random number
+     * generator be used to create a 32-octet sequence. The octet sequence is then base64url-encoded to produce a 43-octet URL
+     * safe string to use as the code verifier. Per Section 3 of RFC 7636, all trailing '=' characters are omitted.
+     */
+    @Sensitive
+    @FFDCIgnore(NoSuchAlgorithmException.class)
+    public static String generateCodeVerifier() {
+        SecureRandom random;
+        try {
+            random = SecureRandom.getInstanceStrong();
+        } catch (NoSuchAlgorithmException e) {
+            random = new SecureRandom();
+        }
+        byte verifierBytes[] = new byte[32];
+        random.nextBytes(verifierBytes);
+        String codeVerifier = new String(Base64.getUrlEncoder().encode(verifierBytes));
+        codeVerifier = codeVerifier.replaceAll("[=]+$", "");
+        return codeVerifier;
+    }
+
+    /**
+     * Verifies the provided code challenge based on the verifier and challenge method provided.
+     */
+    public static void verifyCodeChallenge(String codeVerifier, String codeChallenge, String codeChallengeMethod) throws OAuth20MissingParameterException, InvalidGrantException {
+        if (codeVerifier == null) {
+            throw new OAuth20MissingParameterException("security.oauth20.error.missing.parameter", "code_verifier", null);
+        }
+        if (!isCodeVerifierLengthAcceptable(codeVerifier)) {
+            String message = Tr.formatMessage(tc, "security.oauth20.pkce.codeverifier.length.error", codeVerifier.length());
+            throw new InvalidGrantException(message, null);
+        }
+        ProofKeyForCodeExchangeMethod pkceMethod = ProofKeyForCodeExchangeMethod.getInstance(codeChallengeMethod);
+        if (pkceMethod == null) {
+            String message = Tr.formatMessage(tc, "security.oauth20.pkce.invalid.method.error", codeChallengeMethod);
+            throw new InvalidGrantException(message, null);
+        }
+        pkceMethod.validate(codeVerifier, codeChallenge);
+    }
+
+    static boolean isCodeVerifierLengthAcceptable(String codeVerifier) {
+        if (codeVerifier != null && (codeVerifier.length() >= CODE_VERIFIER_MIN_LENGTH && codeVerifier.length() <= CODE_VERIFIER_MAX_LENGTH)) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/ProofKeyForCodeExchangeMethod.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/ProofKeyForCodeExchangeMethod.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.oauth20.pkce;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.ibm.oauth.core.api.error.oauth20.InvalidGrantException;
+
+public abstract class ProofKeyForCodeExchangeMethod {
+
+    public static final Set<String> SUPPORTED_CODE_CHALLENGE_METHODS;
+    static {
+        Set<String> supportedCodeChallengeMethods = new HashSet<>();
+        supportedCodeChallengeMethods.add("plain");
+        supportedCodeChallengeMethods.add("S256");
+        SUPPORTED_CODE_CHALLENGE_METHODS = Collections.unmodifiableSet(supportedCodeChallengeMethods);
+    };
+
+    public static ProofKeyForCodeExchangeMethod getInstance(String challengeMethod) {
+        if (challengeMethod == null || challengeMethod.isEmpty()) {
+            return null;
+        }
+        if (PkceMethodS256.CHALLENGE_METHOD.equals(challengeMethod)) {
+            return new PkceMethodS256();
+        }
+        if (PkceMethodPlain.CHALLENGE_METHOD.equals(challengeMethod)) {
+            return new PkceMethodPlain();
+        }
+        return null;
+    }
+
+    public static boolean isValidCodeChallengeMethod(String codeChallengeMethod) {
+        if (codeChallengeMethod == null) {
+            return false;
+        }
+        return SUPPORTED_CODE_CHALLENGE_METHODS.contains(codeChallengeMethod);
+    }
+
+    public abstract String getCodeChallengeMethod();
+
+    public abstract String generateCodeChallenge(String codeVerifier);
+
+    public abstract void validate(String codeVerifier, String codeChallenge) throws InvalidGrantException;
+
+}

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/package-info.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = "OAUTH", messageBundle = "com.ibm.ws.security.oauth20.resources.ProviderMsgs")
+package com.ibm.ws.security.oauth20.pkce;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/pkce/PkceMethodPlainTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/pkce/PkceMethodPlainTest.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.oauth20.pkce;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.oauth.core.api.error.oauth20.InvalidGrantException;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class PkceMethodPlainTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    private static final String CWOAU0081E_CODE_CHALLENGE_DOES_NOT_MATCH_VERIFIER = "CWOAU0081E";
+
+    PkceMethodPlain pkceMethod = new PkceMethodPlain();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println("Entering test: " + testName.getMethodName());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_generateCodeChallenge_nullVerifier() {
+        String codeVerifier = null;
+        String codeChallenge = pkceMethod.generateCodeChallenge(codeVerifier);
+        assertEquals("Generated code challenge should have matched the input.", codeVerifier, codeChallenge);
+    }
+
+    @Test
+    public void test_generateCodeChallenge_emptyVerifier() {
+        String codeVerifier = "";
+        String codeChallenge = pkceMethod.generateCodeChallenge(codeVerifier);
+        assertEquals("Generated code challenge should have matched the input.", codeVerifier, codeChallenge);
+    }
+
+    @Test
+    public void test_generateCodeChallenge_nonEmptyVerifier() {
+        String codeVerifier = "this is my code verifier";
+        String codeChallenge = pkceMethod.generateCodeChallenge(codeVerifier);
+        assertEquals("Generated code challenge should have matched the input.", codeVerifier, codeChallenge);
+    }
+
+    @Test
+    public void test_validate_bothNull() {
+        String codeVerifier = null;
+        String codeChallenge = null;
+        try {
+            pkceMethod.validate(codeVerifier, codeChallenge);
+        } catch (InvalidGrantException e) {
+            fail("Should not have thrown an exception but got " + e);
+        }
+    }
+
+    @Test
+    public void test_validate_verifierNonNull_challengeNull() {
+        String codeVerifier = "not null";
+        String codeChallenge = null;
+        try {
+            pkceMethod.validate(codeVerifier, codeChallenge);
+            fail("Should have thrown an exception but didn't.");
+        } catch (InvalidGrantException e) {
+            // Expected
+            verifyException(e, CWOAU0081E_CODE_CHALLENGE_DOES_NOT_MATCH_VERIFIER);
+        }
+    }
+
+    @Test
+    public void test_validate_verifierNull_challengeNonNull() {
+        String codeVerifier = null;
+        String codeChallenge = "not null";
+        try {
+            pkceMethod.validate(codeVerifier, codeChallenge);
+            fail("Should have thrown an exception but didn't.");
+        } catch (InvalidGrantException e) {
+            // Expected
+            verifyException(e, CWOAU0081E_CODE_CHALLENGE_DOES_NOT_MATCH_VERIFIER);
+        }
+    }
+
+    @Test
+    public void test_validate_mismatch() {
+        String codeVerifier = "value1";
+        String codeChallenge = "value2";
+        try {
+            pkceMethod.validate(codeVerifier, codeChallenge);
+            fail("Should have thrown an exception but didn't.");
+        } catch (InvalidGrantException e) {
+            // Expected
+            verifyException(e, CWOAU0081E_CODE_CHALLENGE_DOES_NOT_MATCH_VERIFIER);
+        }
+    }
+
+    @Test
+    public void test_validate_match() {
+        String codeVerifier = "value1";
+        String codeChallenge = codeVerifier;
+        try {
+            pkceMethod.validate(codeVerifier, codeChallenge);
+        } catch (InvalidGrantException e) {
+            fail("Should not have thrown an exception but got " + e);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/pkce/PkceMethodS256Test.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/pkce/PkceMethodS256Test.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.oauth20.pkce;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.oauth.core.api.error.oauth20.InvalidGrantException;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class PkceMethodS256Test extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    private static final String CWOAU0081E_CODE_CHALLENGE_DOES_NOT_MATCH_VERIFIER = "CWOAU0081E";
+
+    PkceMethodS256 pkceMethod = new PkceMethodS256();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println("Entering test: " + testName.getMethodName());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_generateCodeChallenge_nullVerifier() {
+        String codeVerifier = null;
+        String codeChallenge = pkceMethod.generateCodeChallenge(codeVerifier);
+        assertEquals("A null input did not generated the expected code challenge value.", null, codeChallenge);
+    }
+
+    @Test
+    public void test_generateCodeChallenge_emptyVerifier() {
+        String codeVerifier = "";
+        String codeChallenge = pkceMethod.generateCodeChallenge(codeVerifier);
+        assertEquals("An empty input did not generated the expected code challenge value.", null, codeChallenge);
+    }
+
+    @Test
+    public void test_generateCodeChallenge_nonEmptyVerifier() {
+        String codeVerifier = "this is my code verifier";
+        String expectedCodeChallenge = "f0oC0rbBvUUCblldL8CRG0DjcW1U83A73O1yKlUktgQ";
+        String codeChallenge = pkceMethod.generateCodeChallenge(codeVerifier);
+        assertEquals("Generated code challenge did not match the expected value.", expectedCodeChallenge, codeChallenge);
+    }
+
+    @Test
+    public void test_validate_bothNull() {
+        String codeVerifier = null;
+        String codeChallenge = null;
+        try {
+            pkceMethod.validate(codeVerifier, codeChallenge);
+        } catch (InvalidGrantException e) {
+            fail("Should not have thrown an exception but got " + e);
+        }
+    }
+
+    @Test
+    public void test_validate_verifierNonNull_challengeNull() {
+        String codeVerifier = "not null";
+        String codeChallenge = null;
+        try {
+            pkceMethod.validate(codeVerifier, codeChallenge);
+            fail("Should have thrown an exception but didn't.");
+        } catch (InvalidGrantException e) {
+            // Expected
+            verifyException(e, CWOAU0081E_CODE_CHALLENGE_DOES_NOT_MATCH_VERIFIER);
+        }
+    }
+
+    @Test
+    public void test_validate_verifierNull_challengeNonNull() {
+        String codeVerifier = null;
+        String codeChallenge = "not null";
+        try {
+            pkceMethod.validate(codeVerifier, codeChallenge);
+            fail("Should have thrown an exception but didn't.");
+        } catch (InvalidGrantException e) {
+            // Expected
+            verifyException(e, CWOAU0081E_CODE_CHALLENGE_DOES_NOT_MATCH_VERIFIER);
+        }
+    }
+
+    @Test
+    public void test_validate_mismatch() {
+        String codeVerifier = "value1";
+        String codeChallenge = "value2";
+        try {
+            pkceMethod.validate(codeVerifier, codeChallenge);
+            fail("Should have thrown an exception but didn't.");
+        } catch (InvalidGrantException e) {
+            // Expected
+            verifyException(e, CWOAU0081E_CODE_CHALLENGE_DOES_NOT_MATCH_VERIFIER);
+        }
+    }
+
+    @Test
+    public void test_validate_match() {
+        String codeVerifier = "this is my code verifier";
+        String codeChallenge = "f0oC0rbBvUUCblldL8CRG0DjcW1U83A73O1yKlUktgQ";
+        try {
+            pkceMethod.validate(codeVerifier, codeChallenge);
+        } catch (InvalidGrantException e) {
+            fail("Should not have thrown an exception but got " + e);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/pkce/ProofKeyForCodeExchangeMethodTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/pkce/ProofKeyForCodeExchangeMethodTest.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.oauth20.pkce;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class ProofKeyForCodeExchangeMethodTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println("Entering test: " + testName.getMethodName());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_getInstance_codeChallengeMethodNull() {
+        String codeChallengeMethod = null;
+        ProofKeyForCodeExchangeMethod instance = ProofKeyForCodeExchangeMethod.getInstance(codeChallengeMethod);
+        assertEquals("Null code challenge method should not have produced a PKCE method instance.", null, instance);
+    }
+
+    @Test
+    public void test_getInstance_codeChallengeMethodEmpty() {
+        String codeChallengeMethod = "";
+        ProofKeyForCodeExchangeMethod instance = ProofKeyForCodeExchangeMethod.getInstance(codeChallengeMethod);
+        assertEquals("Empty code challenge method should not have produced a PKCE method instance.", null, instance);
+    }
+
+    @Test
+    public void test_getInstance_codeChallengeMethodUnknown() {
+        String codeChallengeMethod = "RS256";
+        ProofKeyForCodeExchangeMethod instance = ProofKeyForCodeExchangeMethod.getInstance(codeChallengeMethod);
+        assertEquals("Unsupported/unknown code challenge method should not have produced a PKCE method instance.", null, instance);
+    }
+
+    @Test
+    public void test_getInstance_codeChallengeMethodPlain() {
+        String codeChallengeMethod = "plain";
+        ProofKeyForCodeExchangeMethod instance = ProofKeyForCodeExchangeMethod.getInstance(codeChallengeMethod);
+        assertNotNull("Should have created a valid PKCE method based on " + codeChallengeMethod + " code challenge method.", instance);
+        assertEquals("Did not get the expected code challenge method type from the PKCE instance.", "plain", instance.getCodeChallengeMethod());
+    }
+
+    @Test
+    public void test_getInstance_codeChallengeMethodS256() {
+        String codeChallengeMethod = "S256";
+        ProofKeyForCodeExchangeMethod instance = ProofKeyForCodeExchangeMethod.getInstance(codeChallengeMethod);
+        assertNotNull("Should have created a valid PKCE method based on " + codeChallengeMethod + " code challenge method.", instance);
+        assertEquals("Did not get the expected code challenge method type from the PKCE instance.", "S256", instance.getCodeChallengeMethod());
+    }
+
+    @Test
+    public void test_isValidCodeChallengeMethod_null() {
+        String codeChallengeMethod = null;
+        assertFalse("Null code challenge method should not be considered a valid method.", ProofKeyForCodeExchangeMethod.isValidCodeChallengeMethod(codeChallengeMethod));
+    }
+
+    @Test
+    public void test_isValidCodeChallengeMethod_empty() {
+        String codeChallengeMethod = "";
+        assertFalse("Empty code challenge method should not be considered a valid method.", ProofKeyForCodeExchangeMethod.isValidCodeChallengeMethod(codeChallengeMethod));
+    }
+
+    @Test
+    public void test_isValidCodeChallengeMethod_unknown() {
+        String codeChallengeMethod = "unknown";
+        assertFalse("Unknown code challenge method should not be considered a valid method.", ProofKeyForCodeExchangeMethod.isValidCodeChallengeMethod(codeChallengeMethod));
+    }
+
+    @Test
+    public void test_isValidCodeChallengeMethod_plain() {
+        String codeChallengeMethod = "plain";
+        assertTrue("Plain code challenge method should be considered a valid method.", ProofKeyForCodeExchangeMethod.isValidCodeChallengeMethod(codeChallengeMethod));
+    }
+
+    @Test
+    public void test_isValidCodeChallengeMethod_S256() {
+        String codeChallengeMethod = "S256";
+        assertTrue("S256 code challenge method should be considered a valid method.", ProofKeyForCodeExchangeMethod.isValidCodeChallengeMethod(codeChallengeMethod));
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/pkce/ProofKeyForCodeExchangeTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/pkce/ProofKeyForCodeExchangeTest.java
@@ -1,0 +1,204 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.oauth20.pkce;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.oauth.core.api.error.oauth20.InvalidGrantException;
+import com.ibm.oauth.core.api.error.oauth20.OAuth20MissingParameterException;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class ProofKeyForCodeExchangeTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    private static final String ALLOWED_CHARS_REGEX = "[a-zA-Z0-9._~-]";
+
+    private static final String CWOAU0033E_MISSING_PARAMETER = "CWOAU0033E";
+    private static final String CWOAU0079E_INVALID_CHALLENGE_METHOD = "CWOAU0079E";
+    private static final String CWOAU0080E_CODE_VERIFIER_LENGTH_ERROR = "CWOAU0080E";
+    private static final String CWOAU0081E_CODE_CHALLENGE_DOES_NOT_MATCH_VERIFIER = "CWOAU0081E";
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println("Entering test: " + testName.getMethodName());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_generateCodeVerifier() {
+        String codeVerifier = ProofKeyForCodeExchange.generateCodeVerifier();
+        assertNotNull("Code verifier should not have been null.", codeVerifier);
+
+        assertTrue("Code verifier contained a character outside the allowed set " + ALLOWED_CHARS_REGEX, codeVerifier.matches(ALLOWED_CHARS_REGEX + "+"));
+        assertEquals("Code verifier did not have the expected length. Code verifier was [" + codeVerifier + "].", 43, codeVerifier.length());
+
+        String codeVerifier2 = ProofKeyForCodeExchange.generateCodeVerifier();
+        assertFalse("Two calls to generate code verifiers should not have produced the same value.", codeVerifier2.equals(codeVerifier));
+    }
+
+    @Test
+    public void test_verifyCodeChallenge_nullVerifier() {
+        String codeVerifier = null;
+        String codeChallenge = "codechallenge";
+        String codeChallengeMethod = PkceMethodS256.CHALLENGE_METHOD;
+        try {
+            ProofKeyForCodeExchange.verifyCodeChallenge(codeVerifier, codeChallenge, codeChallengeMethod);
+            fail("Should have thrown an exception but didn't.");
+        } catch (OAuth20MissingParameterException e) {
+            // Expected
+            verifyException(e, CWOAU0033E_MISSING_PARAMETER + ".*" + "code_verifier");
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Caught unexpected exception: " + e);
+        }
+    }
+
+    @Test
+    public void test_verifyCodeChallenge_emptyVerifier() {
+        String codeVerifier = "";
+        String codeChallenge = "codechallenge";
+        String codeChallengeMethod = PkceMethodS256.CHALLENGE_METHOD;
+        try {
+            ProofKeyForCodeExchange.verifyCodeChallenge(codeVerifier, codeChallenge, codeChallengeMethod);
+            fail("Should have thrown an exception but didn't.");
+        } catch (InvalidGrantException e) {
+            // Expected
+            verifyException(e, CWOAU0080E_CODE_VERIFIER_LENGTH_ERROR);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Caught unexpected exception: " + e);
+        }
+    }
+
+    @Test
+    public void test_verifyCodeChallenge_unknownChallengeMethod() {
+        String codeVerifier = getStringOfLength(ProofKeyForCodeExchange.CODE_VERIFIER_MIN_LENGTH);
+        String codeChallenge = "codechallenge";
+        String codeChallengeMethod = "42";
+        try {
+            ProofKeyForCodeExchange.verifyCodeChallenge(codeVerifier, codeChallenge, codeChallengeMethod);
+            fail("Should have thrown an exception but didn't.");
+        } catch (InvalidGrantException e) {
+            // Expected
+            verifyException(e, CWOAU0079E_INVALID_CHALLENGE_METHOD);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Caught unexpected exception: " + e);
+        }
+    }
+
+    @Test
+    public void test_verifyCodeChallenge_invalidChallenge() {
+        String codeVerifier = getStringOfLength(ProofKeyForCodeExchange.CODE_VERIFIER_MIN_LENGTH);
+        String codeChallenge = "codechallenge";
+        String codeChallengeMethod = PkceMethodS256.CHALLENGE_METHOD;
+        try {
+            ProofKeyForCodeExchange.verifyCodeChallenge(codeVerifier, codeChallenge, codeChallengeMethod);
+            fail("Should have thrown an exception but didn't.");
+        } catch (InvalidGrantException e) {
+            // Expected
+            verifyException(e, CWOAU0081E_CODE_CHALLENGE_DOES_NOT_MATCH_VERIFIER);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Caught unexpected exception: " + e);
+        }
+    }
+
+    @Test
+    public void test_verifyCodeChallenge_validChallenge() {
+        String codeVerifier = getStringOfLength(ProofKeyForCodeExchange.CODE_VERIFIER_MIN_LENGTH);
+        ProofKeyForCodeExchangeMethod pkceMethod = new PkceMethodS256();
+        String codeChallenge = pkceMethod.generateCodeChallenge(codeVerifier);
+        String codeChallengeMethod = PkceMethodS256.CHALLENGE_METHOD;
+        try {
+            ProofKeyForCodeExchange.verifyCodeChallenge(codeVerifier, codeChallenge, codeChallengeMethod);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Caught unexpected exception: " + e);
+        }
+    }
+
+    @Test
+    public void test_isCodeVerifierLengthAcceptable_null() {
+        String codeVerifier = null;
+        assertFalse("Code verifier [" + codeVerifier + "] should not be considered to have an acceptable length.", ProofKeyForCodeExchange.isCodeVerifierLengthAcceptable(codeVerifier));
+    }
+
+    @Test
+    public void test_isCodeVerifierLengthAcceptable_emptyString() {
+        String codeVerifier = "";
+        assertFalse("Code verifier [" + codeVerifier + "] (length " + codeVerifier.length() + ") should not be considered to have an acceptable length.", ProofKeyForCodeExchange.isCodeVerifierLengthAcceptable(codeVerifier));
+    }
+
+    @Test
+    public void test_isCodeVerifierLengthAcceptable_minMinus1() {
+        String codeVerifier = getStringOfLength(ProofKeyForCodeExchange.CODE_VERIFIER_MIN_LENGTH - 1);
+        assertFalse("Code verifier [" + codeVerifier + "] (length " + codeVerifier.length() + ") should not be considered to have an acceptable length.", ProofKeyForCodeExchange.isCodeVerifierLengthAcceptable(codeVerifier));
+    }
+
+    @Test
+    public void test_isCodeVerifierLengthAcceptable_min() {
+        String codeVerifier = getStringOfLength(ProofKeyForCodeExchange.CODE_VERIFIER_MIN_LENGTH);
+        assertTrue("Code verifier [" + codeVerifier + "] (length " + codeVerifier.length() + ") should be considered to have an acceptable length.", ProofKeyForCodeExchange.isCodeVerifierLengthAcceptable(codeVerifier));
+    }
+
+    @Test
+    public void test_isCodeVerifierLengthAcceptable_max() {
+        String codeVerifier = getStringOfLength(ProofKeyForCodeExchange.CODE_VERIFIER_MAX_LENGTH);
+        assertTrue("Code verifier [" + codeVerifier + "] (length " + codeVerifier.length() + ") should be considered to have an acceptable length.", ProofKeyForCodeExchange.isCodeVerifierLengthAcceptable(codeVerifier));
+    }
+
+    @Test
+    public void test_isCodeVerifierLengthAcceptable_maxPlus1() {
+        String codeVerifier = getStringOfLength(ProofKeyForCodeExchange.CODE_VERIFIER_MAX_LENGTH + 1);
+        assertFalse("Code verifier [" + codeVerifier + "] (length " + codeVerifier.length() + ") should not be considered to have an acceptable length.", ProofKeyForCodeExchange.isCodeVerifierLengthAcceptable(codeVerifier));
+    }
+
+    private String getStringOfLength(int length) {
+        String result = "";
+        for (int i = 1; i <= length; i++) {
+            result += "a";
+        }
+        return result;
+    }
+
+}

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandler.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandler.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- * IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
@@ -16,6 +13,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.MalformedURLException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.net.ssl.SSLSocketFactory;
@@ -153,7 +151,7 @@ public class AuthorizationCodeHandler {
         tokenRequestBuilder.isHostnameVerification(clientConfig.isHostNameVerificationEnabled());
         tokenRequestBuilder.authMethod(clientConfig.getTokenEndpointAuthMethod());
         tokenRequestBuilder.resources(OIDCClientAuthenticatorUtil.getResources(clientConfig));
-        tokenRequestBuilder.customParams(clientConfig.getTokenRequestParams());
+        tokenRequestBuilder.customParams(getTokenRequestCustomParameters());
         tokenRequestBuilder.useSystemPropertiesForHttpClientConnections(clientConfig.getUseSystemPropertiesForHttpClientConnections());
         TokenRequestor tokenRequestor = tokenRequestBuilder.build();
 
@@ -171,6 +169,20 @@ public class AuthorizationCodeHandler {
         addAuthCodeToUsedList(authzCode);
 
         return oidcResult;
+    }
+
+    HashMap<String, String> getTokenRequestCustomParameters() {
+        HashMap<String, String> customParams = clientConfig.getTokenRequestParams();
+        String pkceChallengeMethod = clientConfig.getPkceCodeChallengeMethod();
+        if (pkceChallengeMethod != null) {
+            customParams = addPkceParameters(customParams);
+        }
+        return customParams;
+    }
+
+    HashMap<String, String> addPkceParameters(HashMap<String, String> parameters) {
+        // TODO
+        return parameters;
     }
 
     // refactored from Oauth SendErrorJson.  Only usable for sending an http400.


### PR DESCRIPTION
Adds standalone classes for handling PKCE methods:
- `ProofKeyForCodeExchangeMethod`: Abstract class that can be extended to support arbitrary PKCE code challenge methods
- `PkceMethodPlain`: Class for supporting the `plain` PKCE code challenge method
- `PkceMethodS256`: Class for supporting the `S256` PKCE code challenge method
- `ProofKeyForCodeExchange`: General methods for PKCE support like generating a code verifier and validating a code challenge

For #19029