### PR TITLE
Increase tx timout duration in testTransactionEnlistment

### DIFF
--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionServlet/server.xml
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionServlet/server.xml
@@ -59,5 +59,7 @@
     <javaPermission codebase="${server.config.dir}/apps/transactionservlet.war" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
     <javaPermission codebase="${server.config.dir}/apps/transactionservlet.war" className="java.util.PropertyPermission" name="java.util.concurrent.ForkJoinPool.*" actions="read"/>
 
+    <!--
     <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:*=info=enabled"/>
+    -->
 </server>

--- a/dev/io.openliberty.checkpoint_fat_transaction/test-applications/transactionservlet/src/servlets/simple/SimpleServlet.java
+++ b/dev/io.openliberty.checkpoint_fat_transaction/test-applications/transactionservlet/src/servlets/simple/SimpleServlet.java
@@ -276,6 +276,7 @@ public class SimpleServlet extends FATServlet {
             // UserTransaction Commit
             con.setAutoCommit(false);
             UserTransaction tran = (UserTransaction) context.lookup("java:comp/UserTransaction");
+            tran.setTransactionTimeout(3); // afford two more seconds to commit
             tran.begin();
             try {
                 stmt = con.createStatement();


### PR DESCRIPTION
Reduce trace and increase tx timeout duration to afford more time to commit user transactions in ServletTest.testTransactionEnlistment().