### PR TITLE
Increased the test application start up time for MP Health FATs

### DIFF
--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat/fat/src/io/openliberty/microprofile/health30/fat/DefaultOverallReadinessStatusUpAppStartupTest.java
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat/fat/src/io/openliberty/microprofile/health30/fat/DefaultOverallReadinessStatusUpAppStartupTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -35,6 +35,8 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -106,7 +108,7 @@ public class DefaultOverallReadinessStatusUpAppStartupTest {
         List<String> lines = server1.findStringsInFileInLibertyServerRoot("CWMMH0053W:", MESSAGE_LOG);
         assertEquals("The CWMMH0053W warning should not appear in messages.log", 0, lines.size());
 
-        String line = server1.waitForStringInLogUsingMark("(CWWKZ0001I: Application DelayedHealthCheckApp started)+", 60000);
+        String line = server1.waitForStringInLogUsingMark("(CWWKZ0001I: Application DelayedHealthCheckApp started)+", 90000);
         log("testDefaultReadinessOverallStatusUpAtStartUpSingleApp", "Application Started message found: " + line);
         assertNotNull("The CWWKZ0001I Application started message did not appear in messages.log", line);
 
@@ -122,6 +124,7 @@ public class DefaultOverallReadinessStatusUpAppStartupTest {
     }
 
     @Test
+    @Mode(TestMode.FULL)
     public void testInvalidDefaultReadinessOverallStatusProperty() throws Exception {
         // Set the invalid value for the MpConfig property. e.g. "mp.health.default.readiness.empty.response=UPs", it should be default behaviour (DOWN)
         setupClass(server2, "testInvalidDefaultReadinessOverallStatusProperty");
@@ -143,7 +146,7 @@ public class DefaultOverallReadinessStatusUpAppStartupTest {
         List<String> lines = server2.findStringsInFileInLibertyServerRoot("CWMMH0053W:", MESSAGE_LOG);
         assertEquals("The CWMMH0053W warning did not appear in messages.log", 1, lines.size());
 
-        String line = server2.waitForStringInLogUsingMark("(CWWKZ0001I: Application DelayedHealthCheckApp started)+", 60000);
+        String line = server2.waitForStringInLogUsingMark("(CWWKZ0001I: Application DelayedHealthCheckApp started)+", 90000);
         log("testInvalidDefaultReadinessOverallStatusProperty", "Application Started message found: " + line);
         assertNotNull("The CWWKZ0001I Application started message did not appear in messages.log", line);
 

--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health30/delayed/health/check/app/DelayedServlet.java
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health30/delayed/health/check/app/DelayedServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -35,9 +35,9 @@ public class DelayedServlet extends HttpServlet {
 
     @Override
     public void init() {
-        System.out.println("Entering init function - Starting Thread.sleep for 65 seconds.");
+        System.out.println("Entering init function - Starting Thread.sleep for 95 seconds.");
         try {
-            Thread.sleep(65000); //65 seconds = 65000 ms
+            Thread.sleep(95000); // 95 seconds = 95000 ms
         } catch (InterruptedException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/DefaultOverallStartupStatusUpAppStartupTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/DefaultOverallStartupStatusUpAppStartupTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -35,6 +35,8 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -112,7 +114,7 @@ public class DefaultOverallStartupStatusUpAppStartupTest {
         List<String> lines = server1.findStringsInFileInLibertyServerRoot("CWMMH0054W:", MESSAGE_LOG);
         assertEquals("The CWMMH0054W warning should not appear in messages.log", 0, lines.size());
 
-        String line = server1.waitForStringInLogUsingMark("(CWWKZ0001I: Application DelayedHealthCheckApp started)+", 65000);
+        String line = server1.waitForStringInLogUsingMark("(CWWKZ0001I: Application DelayedHealthCheckApp started)+", 90000);
         log("testDefaultStartupOverallStatusUpAtStartUpSingleApp", "Application Started message found: " + line);
         assertNotNull("The CWWKZ0001I Application started message did not appear in messages.log", line);
 
@@ -131,6 +133,7 @@ public class DefaultOverallStartupStatusUpAppStartupTest {
      * Set the invalid value for the MpConfig property. e.g. "mp.health.default.startup.empty.response=UPs", it should be default behaviour (DOWN)
      */
     @Test
+    @Mode(TestMode.FULL)
     public void testInvalidDefaultStartupOverallStatusProperty() throws Exception {
         setupClass(server2, "testInvalidDefaultStartupOverallStatusProperty");
         log("testInvalidDefaultStartupOverallStatusProperty", "Testing the /health/started endpoint, before application has started.");
@@ -151,7 +154,7 @@ public class DefaultOverallStartupStatusUpAppStartupTest {
         List<String> lines = server2.findStringsInFileInLibertyServerRoot("CWMMH0054W:", MESSAGE_LOG);
         assertEquals("The CWMMH0054W warning did not appear in messages.log", 1, lines.size());
 
-        String line = server2.waitForStringInLogUsingMark("(CWWKZ0001I: Application DelayedHealthCheckApp started)+", 65000);
+        String line = server2.waitForStringInLogUsingMark("(CWWKZ0001I: Application DelayedHealthCheckApp started)+", 90000);
         log("testInvalidDefaultStartupOverallStatusProperty", "Application Started message found: " + line);
         assertNotNull("The CWWKZ0001I Application started message did not appear in messages.log", line);
 

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health31/delayed/health/check/app/DelayedServlet.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health31/delayed/health/check/app/DelayedServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -35,9 +35,9 @@ public class DelayedServlet extends HttpServlet {
 
     @Override
     public void init() {
-        System.out.println("Entering init function - Starting Thread.sleep for 65 seconds.");
+        System.out.println("Entering init function - Starting Thread.sleep for 95 seconds.");
         try {
-            Thread.sleep(65000); //65 seconds = 65000 ms
+            Thread.sleep(65000); // 95 seconds = 95000 ms
         } catch (InterruptedException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();


### PR DESCRIPTION
fixes #24580 
- When the MpHealth 3.0/3.1 FAT is run, sometimes the server takes over 1 minute to start up, due to infrastructure slowness. This causes the delayed applications in the test cases to start up right when the server starts up, which negates the tests that test for slow applications.
- Increased the startup delay in the test application, so it gives more time for the tests to run properly, if the server starts up slowly.
- Converted some tests to FULL mode, to save test time.