### PR TITLE
Do a resolveBundles call after installing all kernel bundles

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/ProvisionerImpl.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/ProvisionerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/launch/internal/ProvisionerTest.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/launch/internal/ProvisionerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2013 IBM Corporation and others.
+ * Copyright (c) 2010, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/launch/internal/ProvisionerTest.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/launch/internal/ProvisionerTest.java
@@ -240,6 +240,8 @@ public class ProvisionerTest {
             {
                 one(mockBundleContext).installBundle(with(any(String.class)), with(any(InputStream.class)));
                 will(returnValue(mockBundle));
+                allowing(mockBundle).getState();
+                will(returnValue(Bundle.INSTALLED));
 
                 one(mockBundle).adapt(BundleStartLevel.class);
                 will(returnValue(mockBundleStartLevel));
@@ -288,6 +290,8 @@ public class ProvisionerTest {
             {
                 one(mockBundleContext).installBundle(with(any(String.class)), with(any(InputStream.class)));
                 will(returnValue(mockBundle));
+                allowing(mockBundle).getState();
+                will(returnValue(Bundle.INSTALLED));
 
                 one(mockBundle).adapt(BundleStartLevel.class);
                 will(returnValue(mockBundleStartLevel));
@@ -358,6 +362,8 @@ public class ProvisionerTest {
             {
                 one(mockBundleContext).installBundle("kernel@" + locationString, null);
                 will(returnValue(mockBundle));
+                allowing(mockBundle).getState();
+                will(returnValue(Bundle.INSTALLED));
 
                 one(mockBundle).adapt(BundleRevision.class);
                 will(returnValue(mockBundleRevision));
@@ -461,6 +467,8 @@ public class ProvisionerTest {
             {
                 one(mockBundleContext).installBundle(with(any(String.class)), with(any(InputStream.class)));
                 will(returnValue(mockBundle));
+                allowing(mockBundle).getState();
+                will(returnValue(Bundle.INSTALLED));
 
                 one(mockBundle).adapt(BundleRevision.class);
                 will(returnValue(mockBundleRevision));


### PR DESCRIPTION
This avoids having to resolve bundles while starting the kernel bundles.  There is complications with resolving bundles in parallel from the start-level.  While that should work, it is a complication that we can easily avoid and this is better behavior anyway to resolve all the kernel bundles in one call.

