### PR TITLE
JAX-WS: Prep CXF Bindings SOAP project source for CXF 3.5 

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/SoapBinding.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/SoapBinding.java
@@ -19,22 +19,17 @@
 
 package org.apache.cxf.binding.soap;
 
-import java.util.logging.Logger;
-
-import javax.xml.soap.SOAPMessage;
+import javax.xml.soap.SOAPMessage; // Liberty Change
 
 import org.apache.cxf.binding.Binding;
-import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.interceptor.AbstractBasicInterceptorProvider;
 import org.apache.cxf.message.Message;
-import org.apache.cxf.service.factory.AbstractServiceFactoryBean;
 import org.apache.cxf.service.model.BindingInfo;
 
-import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Sensitive; // Liberty Change
 
+// Liberty Changes - should try to commit back to CXF 
 public class SoapBinding extends AbstractBasicInterceptorProvider implements Binding {
-
-    private static final Logger LOG = LogUtils.getL7dLogger(SoapBinding.class);
 
     private SoapVersion version;
     private BindingInfo bindingInfo;
@@ -60,14 +55,14 @@ public class SoapBinding extends AbstractBasicInterceptorProvider implements Bin
         return version;
     }
 
-    @Sensitive
+    @Sensitive // Liberty Change
     public Message createMessage() {
         SoapMessage soapMessage = new SoapMessage(version);
         soapMessage.put(Message.CONTENT_TYPE, soapMessage.getVersion().getContentType());
         return soapMessage;
     }
 
-    public Message createMessage(@Sensitive Message m) {
+    public Message createMessage(@Sensitive Message m) { // Liberty Change
        
         SoapMessage soapMessage = new SoapMessage(m);
         if (m.getExchange() != null) {
@@ -80,11 +75,13 @@ public class SoapBinding extends AbstractBasicInterceptorProvider implements Bin
             soapMessage.setVersion(version); 
         }
 
+	    // Liberty Change Start: If Message doesn't contain content-type add the SOAPMessage content-type
         if (!m.containsKey(Message.CONTENT_TYPE)) {
             m.put(Message.CONTENT_TYPE, soapMessage.getVersion().getContentType());
             SoapMessage newMessage = new SoapMessage(m);
             newMessage.setVersion(soapMessage.getVersion());
         }
+		// Liberty Change End
         
         if (!soapMessage.containsKey(Message.CONTENT_TYPE)) {
             soapMessage.put(Message.CONTENT_TYPE, soapMessage.getVersion().getContentType());

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/SoapBindingFactory.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/SoapBindingFactory.java
@@ -111,9 +111,13 @@ import org.apache.cxf.wsdl.interceptors.WrappedOutInterceptor;
 import org.apache.cxf.wsdl11.WSDLServiceBuilder;
 
 import static org.apache.cxf.helpers.CastUtils.cast;
-import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Sensitive; // Liberty Change
 
 
+// Liberty Change; This class has no Liberty specific changes other than the Sensitive annotation 
+// It is required as an overlay because of Liberty specific changes to MessageImpl.put(). Any call
+// to SoapMessage.put() will cause a NoSuchMethodException in the calling class if the class is not recompiled.
+// If a solution to this compilation issue can be found, this class should be removed as an overlay. 
 @NoJSR250Annotations(unlessNull = { "bus" })
 public class SoapBindingFactory extends AbstractWSDLBindingFactory {
     public static final Collection<String> DEFAULT_NAMESPACES = Collections.unmodifiableList(Arrays.asList(
@@ -179,7 +183,7 @@ public class SoapBindingFactory extends AbstractWSDLBindingFactory {
 
             BindingMessageInfo bInput = bop.getInput();
             if (bInput != null) {
-                MessageInfo input = null;
+                final MessageInfo input;
                 BindingMessageInfo unwrappedMsg = bInput;
                 if (bop.isUnwrappedCapable()) {
                     input = bop.getOperationInfo().getUnwrappedOperation().getInput();
@@ -192,7 +196,7 @@ public class SoapBindingFactory extends AbstractWSDLBindingFactory {
 
             BindingMessageInfo bOutput = bop.getOutput();
             if (bOutput != null) {
-                MessageInfo output = null;
+                final MessageInfo output;
                 BindingMessageInfo unwrappedMsg = bOutput;
                 if (bop.isUnwrappedCapable()) {
                     output = bop.getOperationInfo().getUnwrappedOperation().getOutput();
@@ -342,8 +346,8 @@ public class SoapBindingFactory extends AbstractWSDLBindingFactory {
 
         boolean hasWrapped = false;
 
-        org.apache.cxf.binding.soap.SoapBinding sb = null;
-        SoapVersion version = null;
+        final org.apache.cxf.binding.soap.SoapBinding sb;
+        final SoapVersion version;
         if (binding instanceof SoapBindingInfo) {
             SoapBindingInfo sbi = (SoapBindingInfo) binding;
             version = sbi.getSoapVersion();
@@ -465,7 +469,7 @@ public class SoapBindingFactory extends AbstractWSDLBindingFactory {
         // matter on such small messages anyway) to make sure we pickup those
         // namespaces that are declared there.
         p.getOutInterceptors().add(new AbstractSoapInterceptor(Phase.POST_LOGICAL) {
-            public void handleMessage(@Sensitive SoapMessage message) throws Fault {
+            public void handleMessage(@Sensitive SoapMessage message) throws Fault { // Liberty Change
                 AddressingProperties p = ContextUtils.retrieveMAPs(message, false, true);
                 if (p == null) {
                     return;
@@ -557,11 +561,10 @@ public class SoapBindingFactory extends AbstractWSDLBindingFactory {
     private void addOutOfBandParts(final BindingOperationInfo bop, final javax.wsdl.Message msg,
                                    final SchemaCollection schemas, boolean isInput,
                                    final String partName) {
-        MessageInfo minfo = null;
         MessageInfo.Type type;
 
         int nextId = 0;
-        minfo = bop.getOperationInfo().getInput();
+        MessageInfo minfo = bop.getOperationInfo().getInput();
         if (minfo != null) {
             for (MessagePartInfo part : minfo.getMessageParts()) {
                 if (part.getIndex() >= nextId) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/SoapMessage.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/SoapMessage.java
@@ -22,25 +22,22 @@ package org.apache.cxf.binding.soap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import javax.xml.namespace.QName;
 
-import org.apache.cxf.common.jaxb.JAXBUtils;
-import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.headers.Header;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 
+// Liberty Change; This class has no Liberty specific changes other
+// It is required as an overlay because of Liberty specific changes to MessageImpl.put(). Any call
+// to SoapMessage.put() will cause a NoSuchMethodException in the calling class if the class is not recompiled.
+// If a solution to this compilation issue can be found, this class should be removed as an overlay. 
 public class SoapMessage extends MessageImpl {
     private static final long serialVersionUID = 6310906412722265578L;
     private SoapVersion version;
 
-    // Liberty Change
-    private static final Logger LOG = LogUtils.getL7dLogger(SoapMessage.class);
-    // End Liberty Change
-    
     public SoapMessage(Message message) {
         super(message);
         setVersion(Soap11.getInstance());
@@ -64,7 +61,6 @@ public class SoapMessage extends MessageImpl {
         if (heads == null) {
             heads = new ArrayList<>();
             put(Header.HEADER_LIST, heads);
-            
         }
         return heads;
     }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/AbstractSoapInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/AbstractSoapInterceptor.java
@@ -22,8 +22,8 @@ package org.apache.cxf.binding.soap.interceptor;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.logging.Level;  // Liberty Change
+import java.util.logging.Logger; // Liberty Change
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
@@ -33,8 +33,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.Tr;   // Liberty Change
+import com.ibm.websphere.ras.TraceComponent;  // Liberty Change
 
 import org.apache.cxf.binding.soap.SoapFault;
 import org.apache.cxf.binding.soap.SoapMessage;
@@ -46,14 +46,11 @@ import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.staxutils.StaxUtils;
 
-import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.websphere.ras.Tr;
-
 public abstract class AbstractSoapInterceptor extends AbstractPhaseInterceptor<SoapMessage> implements SoapInterceptor {
 
     private static final Logger LOG = Logger.getLogger(AbstractSoapInterceptor.class.getName());
     
-    private static final TraceComponent tc = Tr.register(AbstractSoapInterceptor.class);
+    private static final TraceComponent tc = Tr.register(AbstractSoapInterceptor.class);   // Liberty Change
 
     public AbstractSoapInterceptor(String p) {
         super(p);
@@ -93,7 +90,7 @@ public abstract class AbstractSoapInterceptor extends AbstractPhaseInterceptor<S
 
     protected void prepareStackTrace(SoapMessage message, SoapFault fault) throws Exception {
         // Liberty Change Start: Reveals only the hidden stack trace. It does not repeat stack trace shown already in the log.
-        if (fault.getCause() != null && TraceComponent.isAnyTracingEnabled()) {
+        if (fault.getCause() != null && tc.isDebugEnabled()) {
             LOG.fine("Fault occured, printing Exception cause to trace.");
             String stackTraceString = buildStackTrace(fault);
             LOG.fine(stackTraceString);

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/MustUnderstandInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/MustUnderstandInterceptor.java
@@ -46,10 +46,14 @@ import org.apache.cxf.interceptor.Interceptor;
 import org.apache.cxf.interceptor.OneWayProcessorInterceptor;
 import org.apache.cxf.phase.Phase;
 
-import com.ibm.websphere.ras.annotation.Sensitive;
-import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.websphere.ras.annotation.Sensitive; // Liberty Change
+import com.ibm.websphere.ras.annotation.Trivial;   // Liberty Change
 
-@Trivial // Liberty Change
+@Trivial // Liberty Change 
+// Liberty Change; This class has no Liberty specific changes other than the Sensitive annotation 
+// It is required as an overlay because of Liberty specific changes to MessageImpl.put(). Any call
+// to SoapMessage.put() will cause a NoSuchMethodException in the calling class if the class is not recompiled.
+// If a solution to this compilation issue can be found, this class should be removed as an overlay. 
 public class MustUnderstandInterceptor extends AbstractSoapInterceptor {
     public static final String UNKNOWNS = "MustUnderstand.UNKNOWNS";
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/RPCInInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/RPCInInterceptor.java
@@ -52,6 +52,10 @@ import org.apache.cxf.staxutils.DepthXMLStreamReader;
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.cxf.wsdl.interceptors.BareInInterceptor;
 
+// Liberty Change; This class has no Liberty specific changes
+// It is required as an overlay because of Liberty specific changes to MessageImpl.put(). Any call
+// to SoapMessage.put() will cause a NoSuchMethodException in the calling class if the class is not recompiled.
+// If a solution to this compilation issue can be found, this class should be removed as an overlay. 
 public class RPCInInterceptor extends AbstractInDatabindingInterceptor {
     private static final QName SOAP12_RESULT = new QName("http://www.w3.org/2003/05/soap-rpc",
                                                          "result");

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/Soap11FaultOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/Soap11FaultOutInterceptor.java
@@ -40,7 +40,10 @@ import org.apache.cxf.staxutils.StaxUtils;
 
 
 import com.ibm.websphere.ras.annotation.Sensitive;
-
+// Liberty Change; This class has no Liberty specific changes other than the Sensitive annotation 
+// It is required as an overlay because of Liberty specific changes to MessageImpl.put(). Any call
+// to SoapMessage.put() will cause a NoSuchMethodException in the calling class if the class is not recompiled.
+// If a solution to this compilation issue can be found, this class should be removed as an overlay. 
 public class Soap11FaultOutInterceptor extends AbstractSoapInterceptor {
     private static final Logger LOG = LogUtils.getL7dLogger(Soap11FaultOutInterceptor.class);
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/Soap12FaultOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/Soap12FaultOutInterceptor.java
@@ -43,7 +43,10 @@ import org.apache.cxf.staxutils.StaxUtils;
 
 
 import com.ibm.websphere.ras.annotation.Sensitive;
-
+ // Liberty Change; This class has no Liberty specific changes other than the Sensitive annotation 
+// It is required as an overlay because of Liberty specific changes to MessageImpl.put(). Any call
+// to SoapMessage.put() will cause a NoSuchMethodException in the calling class if the class is not recompiled.
+// If a solution to this compilation issue can be found, this class should be removed as an overlay. 
 public class Soap12FaultOutInterceptor extends AbstractSoapInterceptor {
     private static final Logger LOG = LogUtils.getL7dLogger(Soap12FaultOutInterceptor.class);
 
@@ -66,8 +69,8 @@ public class Soap12FaultOutInterceptor extends AbstractSoapInterceptor {
         Soap12FaultOutInterceptorInternal() {
             super(Phase.MARSHAL);
         }
-        public void handleMessage(@Sensitive SoapMessage message) throws Fault { //Liberty Change
-            LOG.finest(getClass() + (String) message.get(Message.CONTENT_TYPE));
+        public void handleMessage(@Sensitive SoapMessage message) throws Fault { // Liberty Change
+            LOG.finest(getClass() + (String) message.get(Message.CONTENT_TYPE)); // Liberty Change
 
             XMLStreamWriter writer = message.getContent(XMLStreamWriter.class);
             Fault f = (Fault)message.getContent(Exception.class);

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/SoapActionInInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/SoapActionInInterceptor.java
@@ -47,6 +47,10 @@ import org.apache.cxf.ws.addressing.JAXWSAConstants;
 import com.ibm.websphere.ras.annotation.Trivial; // Liberty code change
 
 @Trivial // Liberty code change
+// Liberty Change; This class has no Liberty specific changes other than the Trivial annotation 
+// It is required as an overlay because of Liberty specific changes to MessageImpl.put(). Any call
+// to SoapMessage.put() will cause a NoSuchMethodException in the calling class if the class is not recompiled.
+// If a solution to this compilation issue can be found, this class should be removed as an overlay. 
 public class SoapActionInInterceptor extends AbstractSoapInterceptor {
 
     private static final Logger LOG = LogUtils.getL7dLogger(SoapActionInInterceptor.class);

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/SoapOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/SoapOutInterceptor.java
@@ -65,8 +65,8 @@ import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.cxf.staxutils.W3CDOMStreamWriter;
 import org.apache.cxf.ws.addressing.EndpointReferenceUtils;
 
-import com.ibm.websphere.ras.annotation.Sensitive;
-
+import com.ibm.websphere.ras.annotation.Sensitive; // Liberty Change
+ // Liberty Changes - Could potentially be removed when updating to CXF 3.5.5
 public class SoapOutInterceptor extends AbstractSoapInterceptor {
     public static final String WROTE_ENVELOPE_START = "wrote.envelope.start";
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/SoapPreProtocolOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/SoapPreProtocolOutInterceptor.java
@@ -39,7 +39,7 @@ import org.apache.cxf.service.model.BindingOperationInfo;
 
 import static org.apache.cxf.message.Message.MIME_HEADERS;
 
-import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Sensitive; // Liberty Change
 
 /**
  * This interceptor is responsible for setting up the SOAP version
@@ -58,7 +58,7 @@ public class SoapPreProtocolOutInterceptor extends AbstractSoapInterceptor {
      * @param message the current message
      * @throws Fault
      */
-    public void handleMessage(@Sensitive SoapMessage message) throws Fault {
+    public void handleMessage(@Sensitive SoapMessage message) throws Fault { // Liberty Change
         ensureVersion(message);
         ensureMimeHeaders(message);
         if (isRequestor(message)) {
@@ -85,7 +85,7 @@ public class SoapPreProtocolOutInterceptor extends AbstractSoapInterceptor {
             message.setVersion(soapVersion);
         }
 
-        message.put(Message.CONTENT_TYPE, (String) soapVersion.getContentType());
+        message.put(Message.CONTENT_TYPE, (String) soapVersion.getContentType()); // Libery Change
     }
 
     /**
@@ -152,7 +152,7 @@ public class SoapPreProtocolOutInterceptor extends AbstractSoapInterceptor {
         }
 
         if (!action.startsWith("\"")) {
-            action = new StringBuilder().append("\"").append(action).append("\"").toString();
+            action = '"' + action + '"';
         }
 
         return action;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/TibcoSoapActionInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/TibcoSoapActionInterceptor.java
@@ -27,11 +27,15 @@ import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
-import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Sensitive; // Liberty Change
 /**
  * Tibco Business Works uses SoapAction instead of the standard spelling SOAPAction.
  * So this interceptor adds a SoapAction header if SOAPAction is set in protocol header
  */
+ // Liberty Change; This class has no Liberty specific changes other than the Sensitive annotation 
+// It is required as an overlay because of Liberty specific changes to MessageImpl.put(). Any call
+// to SoapMessage.put() will cause a NoSuchMethodException in the calling class if the class is not recompiled.
+// If a solution to this compilation issue can be found, this class should be removed as an overlay. 
 public class TibcoSoapActionInterceptor extends AbstractPhaseInterceptor<SoapMessage> {
 
     private static final String SOAPACTION_TIBCO = "SoapAction";
@@ -41,7 +45,7 @@ public class TibcoSoapActionInterceptor extends AbstractPhaseInterceptor<SoapMes
     }
 
     @SuppressWarnings("unchecked")
-    public void handleMessage(@Sensitive SoapMessage soapMessage) throws Fault {
+    public void handleMessage(@Sensitive SoapMessage soapMessage) throws Fault { // Liberty Change
         Map<String, Object> headers = (Map<String, Object>)soapMessage.get(Message.PROTOCOL_HEADERS);
         if (headers != null && headers.containsKey(SoapBindingConstants.SOAP_ACTION)) {
             //need to flip to a case sensitive map.  The default

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/jms/interceptor/SoapFaultFactory.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/jms/interceptor/SoapFaultFactory.java
@@ -34,6 +34,7 @@ import org.apache.cxf.interceptor.Fault;
 /**
  *
  */
+ // Liberty Changes - Could potentially be removed when updating to CXF 3.5.5
 public class SoapFaultFactory  {
 
     private SoapVersion version;
@@ -43,7 +44,7 @@ public class SoapFaultFactory  {
     }
 
     public Fault createFault(JMSFault jmsFault) {
-        Fault f = null;
+        final Fault f;
         if (version == Soap11.getInstance()) {
             f = createSoap11Fault(jmsFault);
             // so we can encode the SequenceFault as header

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/saaj/SAAJInInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/saaj/SAAJInInterceptor.java
@@ -73,7 +73,7 @@ import org.apache.cxf.phase.Phase;
 import org.apache.cxf.phase.PhaseInterceptor;
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.cxf.staxutils.W3CDOMStreamWriter;
-import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Sensitive; // Liberty Change
 /**
  * Builds a SAAJ tree from the Document fragment inside the message which contains
  * the SOAP headers and from the XMLStreamReader.
@@ -114,7 +114,7 @@ public class SAAJInInterceptor extends AbstractSoapInterceptor {
             super(Phase.READ);
             addBefore(ReadHeadersInterceptor.class.getName());
         }
-        public void handleMessage(@Sensitive SoapMessage message) throws Fault {
+        public void handleMessage(@Sensitive SoapMessage message) throws Fault { // Liberty Change
             if (isGET(message)) {
                 return;
             }
@@ -145,7 +145,7 @@ public class SAAJInInterceptor extends AbstractSoapInterceptor {
                 throw new SoapFault("XML_STREAM_EXC", BUNDLE, e, message.getVersion().getSender());
             }
         }
-        public synchronized MessageFactory getFactory(@Sensitive SoapMessage message) throws SOAPException {
+        public synchronized MessageFactory getFactory(@Sensitive SoapMessage message) throws SOAPException { // Liberty Change
             if (message.getVersion() instanceof Soap11) {
                 if (factory11 == null) {
                     factory11 = SAAJFactoryResolver.createMessageFactory(message.getVersion());
@@ -165,7 +165,7 @@ public class SAAJInInterceptor extends AbstractSoapInterceptor {
 
 
     @SuppressWarnings("unchecked")
-    public void handleMessage(@Sensitive SoapMessage message) throws Fault {
+    public void handleMessage(@Sensitive SoapMessage message) throws Fault { // Liberty Change
         if (isGET(message)) {
             return;
         }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/saaj/SAAJOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/saaj/SAAJOutInterceptor.java
@@ -59,7 +59,7 @@ import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.cxf.staxutils.W3CDOMStreamReader;
 import org.apache.cxf.staxutils.W3CDOMStreamWriter;
 
-import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Sensitive;  // Liberty Change
 
 /**
  * Sets up the outgoing chain to build a SAAJ tree instead of writing
@@ -68,6 +68,10 @@ import com.ibm.websphere.ras.annotation.Sensitive;
  * at the end of the chain in the SEND phase which writes the resulting
  * SOAPMessage.
  */
+// Liberty Change; This class has no Liberty specific changes other than the Sensitive annotation 
+// It is required as an overlay because of Liberty specific changes to MessageImpl.put(). Any call
+// to SoapMessage.put() will cause a NoSuchMethodException in the calling class if the class is not recompiled.
+// If a solution to this compilation issue can be found, this class should be removed as an overlay. 
 @NoJSR250Annotations
 public class SAAJOutInterceptor extends AbstractSoapInterceptor {
     public static final String ORIGINAL_XML_WRITER
@@ -96,7 +100,7 @@ public class SAAJOutInterceptor extends AbstractSoapInterceptor {
         }
         return SAAJFactoryResolver.createMessageFactory(null);
     }
-    public void handleMessage(@Sensitive SoapMessage message) throws Fault {
+    public void handleMessage(@Sensitive SoapMessage message) throws Fault {  // Liberty Change
         SOAPMessage saaj = message.getContent(SOAPMessage.class);
 
         try {
@@ -158,7 +162,7 @@ public class SAAJOutInterceptor extends AbstractSoapInterceptor {
         message.getInterceptorChain().add(SAAJOutEndingInterceptor.INSTANCE);
     }
     @Override
-    public void handleFault(@Sensitive SoapMessage message) {
+    public void handleFault(@Sensitive SoapMessage message) {  // Liberty Change
         super.handleFault(message);
         //need to clear these so the fault writing will work correctly
         message.removeContent(SOAPMessage.class);
@@ -178,7 +182,7 @@ public class SAAJOutInterceptor extends AbstractSoapInterceptor {
             super(SAAJOutEndingInterceptor.class.getName(), Phase.PRE_PROTOCOL_ENDING);
         }
 
-        public void handleMessage(@Sensitive SoapMessage message) throws Fault {
+        public void handleMessage(@Sensitive SoapMessage message) throws Fault {  // Liberty Change
             SOAPMessage soapMessage = message.getContent(SOAPMessage.class);
 
             if (soapMessage != null) {


### PR DESCRIPTION


This PR does makes the following changes to the com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2 project:

    Brings in all non-conflicting changes to the sources overlays from the 3.5.5 version of CXF
    Properly notates all liberty specific changes to the overlays
    Indicates changes that could be committed back to CXF 3.5 in future releases
    Indicates what overlays could be removed once the 3.5.5 update is complete.

