### PR TITLE
Fix conditional rules for jakartasec

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/commonTests/CommonAnnotatedSecurityTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/commonTests/CommonAnnotatedSecurityTests.java
@@ -103,10 +103,10 @@ public class CommonAnnotatedSecurityTests extends CommonSecurityFat {
             try {
                 currentOS = Machine.getLocalMachine().getOperatingSystem();
             } catch (Exception e) {
-                Log.info(thisClass, "isEnabled", "Encountered and exception trying to determine OS type - assume we'll need to run: " + e.getMessage());
+                Log.info(thisClass, "skipIfWindows", "Encountered an exception trying to determine OS type - assume we'll need to run: " + e.getMessage());
             }
             Log.info(thisClass, "isEnabled", "OS: " + currentOS.toString());
-            if (OperatingSystem.WINDOWS != currentOS) {
+            if (OperatingSystem.WINDOWS == currentOS) {
 
                 Log.info(thisClass, "skipIfWindows", "Running on Windows - skip test");
                 testSkipped();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationSigningTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationSigningTests.java
@@ -17,7 +17,9 @@ import java.util.Map;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.Page;
@@ -59,6 +61,9 @@ import io.openliberty.security.jakartasec.fat.utils.ShrinkWrapHelpers;
 public class ConfigurationSigningTests extends CommonAnnotatedSecurityTests {
 
     protected static Class<?> thisClass = ConfigurationSigningTests.class;
+
+    @Rule
+    public static final TestRule conditIgnoreRule = new ConditionalIgnoreRule();
 
     @Server("jakartasec-3.0_fat.config.op")
     public static LibertyServer opServer;

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/sharedTests/BasicOIDCAnnotationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/sharedTests/BasicOIDCAnnotationTests.java
@@ -17,7 +17,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.Page;
@@ -53,6 +55,9 @@ public class BasicOIDCAnnotationTests extends CommonAnnotatedSecurityTests {
     protected static Class<?> thisClass = BasicOIDCAnnotationTests.class;
 
     protected static ShrinkWrapHelpers swh = null;
+
+    @Rule
+    public static final TestRule conditIgnoreRule = new ConditionalIgnoreRule();
 
     @Server("jakartasec-3.0_fat.op")
     public static LibertyServer opServer;


### PR DESCRIPTION
Skip rules are not firing in the jakartasec FATs in all cases.  Some of the test classes were missing 
    @Rule
    public static final TestRule conditIgnoreRule = new ConditionalIgnoreRule();
The skip rules aren't firing and tests aren't being skipped when they should.