### PR TITLE
Allow OpenLiberty to run without the java.security.Identity class in the JRE

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/BeanO.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/BeanO.java
@@ -36,7 +36,6 @@ import javax.transaction.UserTransaction;
 
 import com.ibm.ejs.container.activator.ActivationStrategy;
 import com.ibm.ejs.container.util.EJSPlatformHelper;
-import com.ibm.ejs.csi.NullSecurityCollaborator;
 import com.ibm.ejs.j2c.HandleList;
 import com.ibm.ejs.j2c.HandleListInterface;
 import com.ibm.websphere.csi.BeanInstanceInfo;
@@ -89,7 +88,7 @@ public abstract class BeanO implements EJBContextExtension, // LI3492-2
 {
     private static final String CLASS_NAME = BeanO.class.getName();
     private static final TraceComponent tc = Tr.register(BeanO.class, "EJBContainer", "com.ibm.ejs.container.container");
-
+    public static final java.security.Principal UNAUTHENTICATED_PRINCIPAL = new UnauthenticatedPrincipal();
     // LIDB2775-23.1 ASV60
     protected static final boolean isZOS = EJSPlatformHelper.isZOS(); // LIDB2775-23.7
 
@@ -669,7 +668,7 @@ public abstract class BeanO implements EJBContextExtension, // LI3492-2
     public Principal getCallerPrincipal() {
         EJBSecurityCollaborator<?> securityCollaborator = container.ivSecurityCollaborator;
         if (securityCollaborator == null) {
-            return NullSecurityCollaborator.UNAUTHENTICATED;
+            return UNAUTHENTICATED_PRINCIPAL;
         }
 
         return getCallerPrincipal(securityCollaborator, EJSContainer.getMethodContext());
@@ -2207,6 +2206,13 @@ public abstract class BeanO implements EJBContextExtension, // LI3492-2
 
         return timer;
 
+    }
+
+    private static class UnauthenticatedPrincipal implements java.security.Principal {
+        @Override
+        public String getName() {
+            return "UNAUTHENTICATED";
+        }
     }
 
 } // BeanO

--- a/dev/com.ibm.ws.ejbcontainer.security/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.security/bnd.bnd
@@ -33,9 +33,10 @@ Include-Resource: \
 
 Service-Component: \
   com.ibm.ws.ejbcontainer.security.internal.EJBSecurityCollaboratorImpl; \
-    implementation:=com.ibm.ws.ejbcontainer.security.internal.EJBSecurityCollaboratorImpl; \
+    implementation:=com.ibm.ws.ejbcontainer.security.internal.EJBSecurityCollaboratorImplServiceFactory; \
     provide:='com.ibm.ws.ejbcontainer.EJBSecurityCollaborator,\
               com.ibm.ws.container.service.metadata.ComponentMetaDataListener'; \
+    servicefactory:=true; \
     activate:=activate; \
     deactivate:=deactivate; \
     modified:='modified'; \

--- a/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/EJBSecurityCollaboratorImplServiceFactory.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/EJBSecurityCollaboratorImplServiceFactory.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.security.internal;
+
+import com.ibm.ws.security.SecurityService;
+import com.ibm.ws.security.authentication.UnauthenticatedSubjectService;
+import com.ibm.ws.security.authorization.jacc.JaccService;
+import com.ibm.ws.security.context.SubjectManager;
+import com.ibm.ws.security.credentials.CredentialsService;
+import com.ibm.ws.security.ready.SecurityReadyService;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceFactory;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Reference;
+
+import java.util.Map;
+
+/**
+ * ServiceFactory which constructs EJBSecurityCollaboratorImpl directly
+ * instead of constructing it via OSGi reflection. Reflection will
+ * cause a NoClassDefFound error if optional deprecated classes like
+ * java.security.Identity are not present in the JRE
+ */
+public class EJBSecurityCollaboratorImplServiceFactory implements ServiceFactory {
+
+    private final EJBSecurityCollaboratorImpl service;
+
+    public EJBSecurityCollaboratorImplServiceFactory(SubjectManager subjectManager) {
+        service = new EJBSecurityCollaboratorImpl(subjectManager);
+    }
+
+    @Override
+    public Object getService(Bundle bundle, ServiceRegistration registration) {
+        return service;
+    }
+
+    @Override
+    public void ungetService(Bundle bundle, ServiceRegistration registration, Object service) {
+
+    }
+
+    protected void activate(ComponentContext cc, Map<String, Object> props) {
+        service.activate(cc, props);
+    }
+
+    protected void modified(Map<String, Object> newProperties) {
+        service.modified(newProperties);
+    }
+
+    protected void deactivate(ComponentContext cc) {
+        service.deactivate(cc);
+    }
+
+    protected void setCredentialService(ServiceReference<CredentialsService> ref) {
+        service.setCredentialService(ref);
+    }
+
+    protected void unsetCredentialService(ServiceReference<CredentialsService> ref) {
+        service.unsetCredentialService(ref);
+    }
+
+    protected void setSecurityService(ServiceReference<SecurityService> ref) {
+        service.setSecurityService(ref);
+    }
+
+    protected void unsetSecurityService(ServiceReference<SecurityService> ref) {
+        service.unsetSecurityService(ref);
+    }
+
+    @Reference
+    protected void setSecurityReadyService(SecurityReadyService ref) {
+        service.setSecurityReadyService(ref);
+    }
+
+    protected void unsetSecurityReadyService(SecurityReadyService ref) {
+        service.unsetSecurityReadyService(ref);
+    }
+
+    protected void setUnauthenticatedSubjectService(ServiceReference<UnauthenticatedSubjectService> ref) {
+        service.setUnauthenticatedSubjectService(ref);
+    }
+
+    protected void unsetUnauthenticatedSubjectService(ServiceReference<UnauthenticatedSubjectService> ref) {
+        service.unsetUnauthenticatedSubjectService(ref);
+    }
+
+    protected void setJaccService(ServiceReference<JaccService> reference) {
+        service.setJaccService(reference);
+    }
+
+    protected void unsetJaccService(ServiceReference<JaccService> reference) {
+        service.unsetJaccService(reference);
+    }
+}


### PR DESCRIPTION
Efforts are underway in OpenJDK to remove the long deprecated class `java.security.Identity`:

https://bugs.openjdk.org/browse/JDK-8191136

While it is not yet clear when this removal will happen, it would be good for the wider ecosystem and OpenLiberty in particular to prepare and accomodate for this change. 

This PR suggests to fix two separate issues which currently prevents OpenLiberty from running on a JRE where the `java.security.Identity` class has been removed:

- The implementation of `EJBContext.getCallerPrincipal()` method in `BeanO.java` currently returns an implementation of `java.security.Identity` for the `UNAUTHENTICATED` user. This should return an implementation of `java.security.Principal` instead, such that no loading of `java.security.Identity` will be needed for this method.
- `EJBSecurityCollaboratorImpl` is currently constructed using reflection via OSGi. The `Class.getConstructor` reflection call fails if the `java.security.Identity` class cannot be found. This can be fixed by loading the service via a `ServiceFactory` instead which directly creates the instance of the `EJBSecurityCollaboratorImpl` class. 

CLA has been signed and sent in for processing.