### PR TITLE
Issue 21826: Initial data structures and metatype for OIDC Private Key JWT client authn

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
@@ -186,6 +186,8 @@ validationEndpointUrl.desc=The endpoint URL for validating the token inbound pro
 tokenEndpointAuthMethod=Authentication method of token endpoint
 tokenEndpointAuthMethod.desc=The method to use for sending credentials to the token endpoint of the OpenID Connect provider in order to authenticate the client.
 
+tokenEndpointAuthMethod.privateKeyJwt=Private key JWT client authentication.
+
 authnSessionDisabled=Authentication session cookie disabled
 authnSessionDisabled.desc=An authentication session cookie will not be created for inbound propagation. The client is expected to send a valid OAuth token for every request.
 

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
@@ -17,7 +17,7 @@
          name="%openidConnectClient" description="%openidConnectClient.desc">
          <AD id="scope" name="%scope" description="%scope.desc" required="true" type="String"  default="openid profile"  ibm:type="token"/>
          <AD id="clientId" name="%clientId" description="%clientId.desc" required="false" type="String" />
-  		 <AD id="clientSecret" name="%clientSecret" description="%clientSecret.desc" required="false" type="String" ibm:type="password"/>		 
+  		 <AD id="clientSecret" name="%clientSecret" description="%clientSecret.desc" required="false" type="String" ibm:type="password"/>
 		 <AD id="redirectToRPHostAndPort" name="%redirectToRPHostAndPort" description="%redirectToRPHostAndPort.desc" required="false" type="String" />
 		 <AD id="redirectJunctionPath" name="%redirectJunctionPath" description="%redirectJunctionPath.desc" required="false" type="String" />
 		 <AD id="isClientSideRedirectSupported" name="%isClientSideRedirectSupported" description="%isClientSideRedirectSupported.desc" required="false" type="Boolean" default="true" />
@@ -28,17 +28,15 @@
 	     <AD id="trustStoreRef" name="%trustStoreRef" description="%trustStoreRef.desc" required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.keystore" />
 	     <AD id="trustAliasName" name="%trustAliasName" description="%trustAliasName.desc" required="false" type="String" />
 		 <AD id="httpsRequired" name="%httpsRequired" description="%httpsRequired.desc" required="true" type="Boolean" default="true"/>
-  		 <AD id="nonceEnabled" name="%nonceEnabled" description="%nonceEnabled.desc" required="false" type="Boolean" default="false"/> 
+  		 <AD id="nonceEnabled" name="%nonceEnabled" description="%nonceEnabled.desc" required="false" type="Boolean" default="false"/>
   		 <AD id="realmName" name="%realmName" description="%realmName.desc" required="false" type="String" />
-  		         		 
-  		         		 
+
          <!--<AD id="sslRef" name="%sslRef" description="%sslRef.desc" required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.repertoire" />-->
          <AD id="sslRef" name="%sslRef" description="%sslRef.desc" required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.ssl.repertoire" ibmui:uiReference="com.ibm.ws.ssl.repertoire" />
-         <!-- following lines are supposed to make sure ssl is fully activated before we are --> 
+         <!-- following lines are supposed to make sure ssl is fully activated before we are -->
          <AD id="SSLSupport.cardinality.minimum" name="internal" description="internal use only" type="String" default="${count(sslRef)}"/>
-         <AD id="SSLSupport.target" name="internal" description="internal use only"  type="String" default="(repertoirePIDs=${sslRef})"/>  
-         
-         
+         <AD id="SSLSupport.target" name="internal" description="internal use only"  type="String" default="(repertoirePIDs=${sslRef})"/>
+
          <AD id="signatureAlgorithm" required="false" type="String" name="%signatureAlgorithm" description="%signatureAlgorithm.desc" default="HS256">
              <Option label="%tokenSignAlgorithm.NONE" value="none" />
              <Option label="%tokenSignAlgorithm.RS256" value="RS256" />
@@ -51,10 +49,10 @@
              <Option label="%tokenSignAlgorithm.ES384" value="ES384" />
              <Option label="%tokenSignAlgorithm.ES512" value="ES512" />
          </AD>
-  		 
+
   		 <AD id="includeIdTokenInSubject" name="%includeIdTokenInSubject" description="%includeIdTokenInSubject.desc"  required="false" type="Boolean" default="true"/>
   		 <AD id="accessTokenInLtpaCookie" name="%accessTokenInLtpaCookie" description="%accessTokenInLtpaCookie.desc"  required="false" type="Boolean" default="false"/>
-         <AD id="initialStateCacheCapacity" name="%initialStateCacheCapacity" description="%initialStateCacheCapacity.desc" required="false" type="Integer" min="0" default="3000" />             
+         <AD id="initialStateCacheCapacity" name="%initialStateCacheCapacity" description="%initialStateCacheCapacity.desc" required="false" type="Integer" min="0" default="3000" />
          <AD id="hostNameVerificationEnabled" name="%hostNameVerificationEnabled" description="%hostNameVerificationEnabled.desc" required="false" type="Boolean" default="false"/>
          <AD id="discoveryEndpointUrl" name="%discoveryEndpointUrl" description="%discoveryEndpointUrl.desc" required="false" type="String" />
          <AD id="authorizationEndpointUrl" name="%authorizationEndpointUrl" description="%authorizationEndpointUrl.desc" required="false" type="String" />
@@ -63,7 +61,7 @@
      	 		<Option label="access_token" value="access_token" />
 		 </AD>
          <AD id="userInfoEndpointUrl" name="%userInfoEndpointUrl" description="%userInfoEndpointUrl.desc"
-            required="false" type="String" />  
+            required="false" type="String" />
          <AD id="userInfoEndpointEnabled" name="%userInfoEndpointEnabled" description="%userInfoEndpointEnabled.desc"
             required="false" type="Boolean" default="false" />
          <AD id="jwkEndpointUrl" name="%jwkEndpointUrl" description="%jwkEndpointUrl.desc" required="false"  type="String" />
@@ -75,7 +73,7 @@
          		<Option label="%grantType.authorization_code" value="authorization_code" />
             	<Option label="%grantType.implicit" value="implicit" />
          </AD>
-         
+
          <!--  sent by the browser to tell the OP what kind of response it wants.  Preferred to grantType -->
          <AD id="responseType" name="%responseType" description="%responseType.desc" required="false" type="String">
                 <!--  code is an authorization code flow, the other three are implicit code flows. -->
@@ -83,25 +81,21 @@
             	<Option label="%responseType.idToken" value="id_token" />
             	<Option label="%responseType.idTokenToken" value="id_token token" />
             	<Option label="%responseType.Token" value="token" />
-         </AD> 
+         </AD>
          <AD id="userIdentifier" name="%userIdentifier" description="%userIdentifier.desc"
             required="false" type="String"/>
          <AD id="groupIdentifier" name="%groupIdentifier" description="%groupIdentifier.desc" required="false" type="String" default="groupIds" />
          <AD id="realmIdentifier" name="%realmIdentifier" description="%realmIdentifier.desc" required="false" type="String" default="realmName" />
          <AD id="uniqueUserIdentifier" name="%userUniqueIdentifier" description="%userUniqueIdentifier.desc" required="false" type="String" default="uniqueSecurityName" />
-         <AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false" 
+         <AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="post" >
-                <!-- support basic or post -->
                 <Option label="basic" value="basic" />
-            	<Option label="post"  value="post" />
-            	<!-- future maybe exclusive or, bad, adding cardinality to 3 or 4.  
-            	<Option label="jwt"   value="jwt" />
-            	<Option label="saml"  value="saml" />
-            	-->
+                <Option label="post"  value="post" />
+                <Option label="%tokenEndpointAuthMethod.privateKeyJwt" value="private_key_jwt" />
          </AD>
          <AD id="jsonWebKey" name="internal" description="internal use only" required="false" type="String" />
          <AD id="prompt" name="internal" description="internal use only" required="false" type="String" />
-          <AD id="jwt" name="internal" description="internal use only" ibm:type="pid" ibm:reference="com.ibm.ws.security.openidconnect.client.jwt" 
+          <AD id="jwt" name="internal" description="internal use only" ibm:type="pid" ibm:reference="com.ibm.ws.security.openidconnect.client.jwt"
              required="false" type="String"  />
          <AD id="inboundPropagation" name="%inboundPropagation" description="%inboundPropagation.desc" required="false" type="String" default="none" >
                 <Option label="%inboundPropagation.supported" value="supported" />
@@ -131,7 +125,7 @@
          <AD id="useSystemPropertiesForHttpClientConnections" name ="%useSystemPropertiesForHttpClientConnections" description="%useSystemPropertiesForHttpClientConnections.desc"
             required="false" type="Boolean" default="false"/>
          <AD id="reAuthnOnAccessTokenExpire" name="%reAuthnOnAccessTokenExpire" description="%reAuthnOnAccessTokenExpire.desc" required="false" type="Boolean" default="true" />
-         <AD id="reAuthnCushion" name="%reAuthnCushion" description="%reAuthnCushion.desc" required="false" type="String" ibm:type="duration" default="0s"/>            
+         <AD id="reAuthnCushion" name="%reAuthnCushion" description="%reAuthnCushion.desc" required="false" type="String" ibm:type="duration" default="0s"/>
 		 <AD id="validateAccessTokenLocally" name="internal" description="internal use only" required="false" type="Boolean" default="true"/>
 		 <AD id="sharedKey" name="internal" description="internal use only" required="false" type="String" ibm:type="password" />
          <AD id="includeCustomCacheKeyInSubject" name="internal" description="internal use only"  required="false" type="Boolean" default="true"/>
@@ -142,9 +136,9 @@
          <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid" ibm:reference="com.ibm.ws.security.authentication.filter" required="false" type="String"  />
          <AD id="createSession" name ="%createSession" description="%createSession.desc"
             required="false" type="Boolean" default="true"/>
-         <AD id="resource" name="%resource" description="%resource.desc" required="false" type="String" cardinality="2147483647" /> 
+         <AD id="resource" name="%resource" description="%resource.desc" required="false" type="String" cardinality="2147483647" />
          <AD id="authenticationTimeLimit" name="%authenticationTimeLimit" description="%authenticationTimeLimit.desc" required="false" type="String" default="420s" ibm:type="duration" />
-         <AD id="discoveryPollingRate" name="%discoveryPollingRate" description="%discoveryPollingRate.desc" required="false" type="String" default="300s" ibm:type="duration" /> 
+         <AD id="discoveryPollingRate" name="%discoveryPollingRate" description="%discoveryPollingRate.desc" required="false" type="String" default="300s" ibm:type="duration" />
          <AD id="useAccessTokenAsIdToken" name="internal" description="internal use only" required="false" type="Boolean" default="false"/>
          <AD id="tokenReuse" name="%tokenReuse" description="%tokenReuse.desc" required="false" type="Boolean" default="false" />
          <AD id="forwardLoginParameter" name="%forwardLoginParameter" description="%forwardLoginParameter.desc" required="false" type="String" cardinality="2147483647" />
@@ -162,8 +156,8 @@
     <Designate factoryPid="com.ibm.ws.security.openidconnect.client.oidcClientConfig">
                 <Object ocdref="com.ibm.ws.security.openidconnect.client.oidcClientConfig.metatype" />
     </Designate>
-    
-     <OCD id="com.ibm.ws.security.openidconnect.client.jwt.metatype" name="internal" description="internal use only" 
+
+     <OCD id="com.ibm.ws.security.openidconnect.client.jwt.metatype" name="internal" description="internal use only"
          ibmui:localization="OSGI-INF/l10n/metatype" >
      	 <AD id="builder" name="internal" description="internal use only" required="false" type="String" />
          <AD id="claims" name="internal" description="internal use only" required="false" type="String" cardinality="400" />
@@ -172,8 +166,8 @@
     <Designate factoryPid="com.ibm.ws.security.openidconnect.client.jwt">
         <Object ocdref="com.ibm.ws.security.openidconnect.client.jwt.metatype" />
     </Designate>
-    
-    <OCD id="com.ibm.ws.security.openidconnect.client.param.metatype" name="%oidcClientCustomRequestParam" description="%oidcClientCustomRequestParam.desc" 
+
+    <OCD id="com.ibm.ws.security.openidconnect.client.param.metatype" name="%oidcClientCustomRequestParam" description="%oidcClientCustomRequestParam.desc"
          ibmui:localization="OSGI-INF/l10n/metatype" >
      	 <AD id="name" name="%oidcClientCustomRequestParamName" description="%oidcClientCustomRequestParamName.desc" required="false" type="String" />
          <AD id="value" name="%oidcClientCustomRequestParamValue" description="%oidcClientCustomRequestParamValue.desc" required="false" type="String" />
@@ -182,14 +176,14 @@
     <Designate factoryPid="com.ibm.ws.security.openidconnect.client.param">
         <Object ocdref="com.ibm.ws.security.openidconnect.client.param.metatype" />
     </Designate>
-    
-    <OCD description="%oidcClientWebapp.desc" name="%oidcClientWebapp.name" 
-         id="com.ibm.ws.security.openidconnect.client.webapp" 
-         ibm:alias="oidcClientWebapp" ibmui:localization="OSGI-INF/l10n/metatype">   
-         <!--    <AD  name="%contextPath" description="%contextPath.desc" id="contextPath" required="false" type="String" default="/oidcclient" /> -->                 
+
+    <OCD description="%oidcClientWebapp.desc" name="%oidcClientWebapp.name"
+         id="com.ibm.ws.security.openidconnect.client.webapp"
+         ibm:alias="oidcClientWebapp" ibmui:localization="OSGI-INF/l10n/metatype">
+         <!--    <AD  name="%contextPath" description="%contextPath.desc" id="contextPath" required="false" type="String" default="/oidcclient" /> -->
          <AD  name="%oidcClientWebapp.contextPath.name" description="%oidcClientWebapp.desc" id="contextPath" required="true" type="String" default="/oidcclient" />
          <AD name="internal" id="contextName" ibm:final="true" type="String"   description="internal" default="oidcClientWebapp" />
-    </OCD>    
+    </OCD>
     <Designate pid="com.ibm.ws.security.openidconnect.client.webapp"> <!--  needs to match pid in WabConfiguration impl -->
         <!--  just needs to ref the id in the OCD element.  -->
         <Object ocdref="com.ibm.ws.security.openidconnect.client.webapp"/>

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtil.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- * IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
@@ -113,17 +110,6 @@ public class OidcClientUtil {
         // oidcHttpUtil.extractTokensFromResponse(getResponseMap);
 
         // return userinfoResponse;
-    }
-
-    Map<String, Object> postToTokenEndpoint(String tokenEnpoint,
-            @Sensitive List<NameValuePair> params,
-            String baUsername,
-            @Sensitive String baPassword,
-            SSLSocketFactory sslSocketFactory,
-            boolean isHostnameVerification,
-            String authMethod, boolean useSystemPropertiesForHttpClientConnections)
-            throws Exception {
-        return oidcHttpUtil.postToEndpoint(tokenEnpoint, params, baUsername, baPassword, null, sslSocketFactory, isHostnameVerification, authMethod, useSystemPropertiesForHttpClientConnections);
     }
 
     Map<String, Object> postToCheckTokenEndpoint(String tokenEnpoint,

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtilTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- * IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
@@ -16,23 +13,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.message.BasicNameValuePair;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
@@ -41,7 +34,6 @@ import org.junit.After;
 import org.junit.Test;
 
 import com.ibm.ws.security.common.http.HttpUtils;
-import com.ibm.ws.security.openidconnect.common.Constants;
 import com.ibm.ws.security.test.common.CommonTestClass;
 
 import io.openliberty.security.oidcclientcore.http.HttpConstants;
@@ -250,96 +242,6 @@ public class OidcClientUtilTest extends CommonTestClass {
             });
             Map<String, Object> tokenResponse = oicu.checkToken(strTokenEndpoint, strClientId, strClientSecret, access_token_content, false, authMethod, sslSocketFactory, false);
             assertEquals("token response = ", tokenResponse.get(access_token), "qOuZdH6Anmxclul5d71AXoDbFVmRG2dPnHn9moaw");
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testPostToTokenEndpoint() {
-        try {
-            final String strTokenEndpoint = "https://unknown.ibm.com:8020/openidserver/token";
-            final String strClientId = "client01";
-            final String strClientSecret = "secret";
-            final String strRedirectUri = "https://client.ibm.com:8020/oidcclient/redirect";
-            final String strCode = "xabceyfghil";
-            final String strGrantType = "autoiztion_code";
-            OidcClientUtil oicu = new OidcClientUtil();
-            assertNotNull("Expected to get an instance of OidcClientutil but none", oicu);
-            oicu.oidcHttpUtil = oidcHttpUtil;
-            final Map<String, Object> postResponseMap = new HashMap<String, Object>();
-            // {"access_token":"qOuZdH6Anmxclul5d71AXoDbFVmRG2dPnHn9moaw","token_type":"bearer","expires_in":3599,"scope":"openid profile","refresh_token":"QGCYpfziPZY2saAagbsf5jxbMucqcF3743euknBxzkUlof7uSv","id_token":"eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOi8vaGFybW9uaWM6ODAxMS9vYXV0aDIvZW5kcG9pbnQvT0F1dGhDb25maWdTYW1wbGUvdG9rZW4iLCJpYXQiOjEzODczODM5NTMsInN1YiI6InRlc3R1c2VyIiwiZXhwIjoxMzg3Mzg3NTUzLCJhdWQiOiJjbGllbnQwMSJ9.ottD3eYa6qrnItRpL_Q9UaKumAyo14LnlvwnyF3Kojk"}
-            postResponseMap.put(access_token, "qOuZdH6Anmxclul5d71AXoDbFVmRG2dPnHn9moaw");
-            postResponseMap.put(token_type, "bearer");
-            postResponseMap.put(expires_in, new Long(3599));
-            postResponseMap.put(scope, "openid profile");
-            postResponseMap.put(refresh_token, "QGCYpfziPZY2saAagbsf5jxbMucqcF3743euknBxzkUlof7uSv");
-            postResponseMap.put(
-                    id_token,
-                    "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOi8vaGFybW9uaWM6ODAxMS9vYXV0aDIvZW5kcG9pbnQvT0F1dGhDb25maWdTYW1wbGUvdG9rZW4iLCJpYXQiOjEzODczODM5NTMsInN1YiI6InRlc3R1c2VyIiwiZXhwIjoxMzg3Mzg3NTUzLCJhdWQiOiJjbGllbnQwMSJ9.ottD3eYa6qrnItRpL_Q9UaKumAyo14LnlvwnyF3Kojk");
-            mock.checking(new Expectations() {
-                {
-                    one(oidcHttpUtil).postToEndpoint(with(any(String.class)), //strTokenEndpoint
-                            with(any(List.class)), // params
-                            with(any(String.class)), // strClientId,
-                            with(any(String.class)), // strClientSecret,
-                            with(any(String.class)), // (String) null,
-                            with(any(SSLSocketFactory.class)), // sslContext,
-                            with(any(Boolean.class)), //isHostnameVerification
-                            with(any(String.class)),
-                            with(any(Boolean.class)));
-                    will(returnValue(postResponseMap));
-                }
-            });
-            List<NameValuePair> params = new ArrayList<NameValuePair>();
-            params.add(new BasicNameValuePair(ClientConstants.GRANT_TYPE, strGrantType));
-            params.add(new BasicNameValuePair(ClientConstants.REDIRECT_URI, strRedirectUri));
-            params.add(new BasicNameValuePair(Constants.CODE, strCode));
-
-            Map<String, Object> results = oicu.postToTokenEndpoint(strTokenEndpoint,
-                    params,
-                    strClientId,
-                    strClientSecret,
-                    sslSocketFactory,
-                    false,
-                    authMethod,
-                    false);
-            Set<String> keys = results.keySet();
-            boolean bAccessToken = false;
-            boolean bTokenType = false;
-            boolean bExpiresIn = false;
-            boolean bScope = false;
-            boolean bRefreshToken = false;
-            boolean bIdToken = false;
-            for (String key : keys) {
-                Object obj = results.get(key);
-                String value = null;
-                if (obj instanceof String)
-                    value = (String) obj;
-                else
-                    value = obj.toString();
-                System.out.println("**" + key + ":" + value);
-                if (key.equalsIgnoreCase(access_token))
-                    bAccessToken = true;
-                if (key.equalsIgnoreCase(token_type))
-                    bTokenType = true;
-                if (key.equalsIgnoreCase(expires_in))
-                    bExpiresIn = true;
-                if (key.equalsIgnoreCase(scope))
-                    bScope = true;
-                if (key.equalsIgnoreCase(refresh_token))
-                    bRefreshToken = true;
-                if (key.equalsIgnoreCase(id_token))
-                    bIdToken = true;
-            }
-            assertNotNull("Expect to get an instance of Tokens but none returned", results);
-            assertTrue("access_token not found", bAccessToken);
-            assertTrue("token_type not found", bTokenType);
-            assertTrue("expires_in not found", bExpiresIn);
-            assertTrue("scope not found", bScope);
-            assertTrue("refresh_token not found", bRefreshToken);
-            assertTrue("id_token not found", bIdToken);
         } catch (Throwable t) {
             outputMgr.failWithThrowable(testName.getMethodName(), t);
         }

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
@@ -94,6 +94,8 @@ responseType.desc=Specifies the OAuth response type.
 tokenEndpointAuthMethod=Authentication method
 tokenEndpointAuthMethod.desc=Specifies required authentication method.
 
+tokenEndpointAuthMethod.privateKeyJwt=Private key JWT client authentication.
+
 redirectToRPHostAndPort=Callback host and port number
 redirectToRPHostAndPort.desc=Specifies a callback protocol, host, and port number. For example, https://myhost:8020.
 

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
@@ -12,20 +12,20 @@
                    xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
                    xmlns:ibmui="http://www.ibm.com/xmlns/appservers/osgi/metatype/ui/v1.0.0"
                    localization="OSGI-INF/l10n/metatype">
-    <!-- if you add to or change this, consider changing oidc conf too --> 
-    <OCD id="com.ibm.ws.security.social.google.metatype" name="%social.google.conf" description="%social.google.conf.desc" 
+    <!-- if you add to or change this, consider changing oidc conf too -->
+    <OCD id="com.ibm.ws.security.social.google.metatype" name="%social.google.conf" description="%social.google.conf.desc"
          ibm:alias="googleLogin">
         <AD id="id" name="internal" description="internal use only"
             required="false" type="String" default="googleLogin" ibm:final="true" ibm:unique="uniqueId"/>
         <AD id="clientId" name="%clientId" description="%clientId.desc"
-            required="true" type="String" /> 
+            required="true" type="String" />
         <AD id="clientSecret" name="%clientSecret" description="%clientSecret.desc"
-            required="true" type="String" ibm:type="password" /> 
-        <!-- AD id="userApi" required="false" type="String" not defined --> 
+            required="true" type="String" ibm:type="password" />
+        <!-- AD id="userApi" required="false" type="String" not defined -->
         <AD id="authorizationEndpoint" name="%authorizationEndpoint" description="%authorizationEndpoint.desc"
             required="false" type="String" default="https://accounts.google.com/o/oauth2/v2/auth"/>
         <AD id="tokenEndpoint" name="%tokenEndpoint" description="%tokenEndpoint.desc"
-            required="false" type="String" default="https://www.googleapis.com/oauth2/v4/token"/>  
+            required="false" type="String" default="https://www.googleapis.com/oauth2/v4/token"/>
         <AD id="jwksUri" name="%jwksUri" description="%jwksUri.desc"
             required="false" type="String" default="https://www.googleapis.com/oauth2/v3/certs"/>
         <AD id="scope" name="%scope" description="%scope.desc"
@@ -34,11 +34,11 @@
             required="false" type="String" default="email"/>
         <AD id="mapToUserRegistry" name="%mapToUserRegistry" description="%mapToUserRegistry.desc"
             required="false" type="Boolean" default="false" />
-        <AD id="sslRef" name="%sslRef" description="%sslRef.desc" 
+        <AD id="sslRef" name="%sslRef" description="%sslRef.desc"
             required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.repertoire" />
-        <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid" 
+        <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid"
              ibm:reference="com.ibm.ws.security.authentication.filter" required="false" type="String"  />
-        <AD id="jwt" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.login.jwt" 
+        <AD id="jwt" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.login.jwt"
              required="false" type="String" />
         <AD id="isClientSideRedirectSupported" name="%isClientSideRedirectSupported" description="%isClientSideRedirectSupported.desc"
             required="false" type="Boolean" default="true" />
@@ -48,12 +48,12 @@
         <AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="client_secret_post" >
                <Option label="client_secret_basic" value="client_secret_basic" />
-               <Option label="client_secret_post"  value="client_secret_post" /> 
+               <Option label="client_secret_post"  value="client_secret_post" />
         </AD>
         <AD id="redirectToRPHostAndPort" name="%redirectToRPHostAndPort" description="%redirectToRPHostAndPort.desc" required="false" type="String" />
-        
+
         <AD id="issuer" name="%issuer" description="%issuer.desc" required="false" type="String"
-            default="https://accounts.google.com" />            
+            default="https://accounts.google.com" />
         <AD id="realmNameAttribute" name="%realmNameAttribute" description="%realmNameAttribute.desc"
             required="false" type="String" default="iss" />
         <AD id="groupNameAttribute" name="%groupNameAttribute" description="%groupNameAttribute.desc"
@@ -63,7 +63,7 @@
         <AD id="clockSkew" name="%clockSkew" description="%clockSkew.desc"
             required="false" type="Integer" default="300000" />
         <AD id="signatureAlgorithm" name="%signatureAlgorithm"  description="%signatureAlgorithm.desc"
-            required="false" type="String" default="RS256" /> 
+            required="false" type="String" default="RS256" />
         <AD id="responseType" name="%responseType" description="%responseType.desc" required="false" type="String" default="code">
             <Option label="%responseType.code" value="code" />
             <Option label="%responseType.idTokenToken" value="id_token token" />
@@ -84,38 +84,38 @@
 
     <Designate pid="com.ibm.ws.security.social.google">
         <Object ocdref="com.ibm.ws.security.social.google.metatype" />
-    </Designate> 
-    
-    <OCD id="com.ibm.ws.security.social.twitter.metatype" name="%social.twitter.conf" description="%social.twitter.conf.desc" 
+    </Designate>
+
+    <OCD id="com.ibm.ws.security.social.twitter.metatype" name="%social.twitter.conf" description="%social.twitter.conf.desc"
          ibm:alias="twitterLogin">
         <AD id="id" name="internal" description="internal use only"
             required="false" type="String" default="twitterLogin" ibm:final="true" ibm:unique="uniqueId"/>
         <AD id="consumerKey" name="%consumerKey" description="%consumerKey.desc"
-            required="true" type="String" /> 
+            required="true" type="String" />
         <AD id="consumerSecret" name="%consumerSecret" description="%consumerSecret.desc"
             required="true" type="String" ibm:type="password" />
         <AD id="requestTokenUrl" name="%requestTokenUrl" description="%requestTokenUrl.desc"
-            required="false" type="String" default="https://api.twitter.com/oauth/request_token"/>             
+            required="false" type="String" default="https://api.twitter.com/oauth/request_token"/>
         <AD id="userAuthorizationUrl" name="%userAuthorizationUrl" description="%userAuthorizationUrl.desc"
             required="false" type="String" default="https://api.twitter.com/oauth/authenticate"/>
         <AD id="accessTokenUrl" name="%accessTokenUrl" description="%accessTokenUrl.desc"
             required="false" type="String" default="https://api.twitter.com/oauth/access_token"/>
         <AD id="userApi" name="%userApi" description="%userApi.desc"
-            required="false" type="String" default="https://api.twitter.com/1.1/account/verify_credentials.json"/>                                
+            required="false" type="String" default="https://api.twitter.com/1.1/account/verify_credentials.json"/>
         <!-- not defined AD id="scope" name="%scope" description="%scope.desc"
             required="false" type="String" default="openid profile email" / -->
         <AD id="userNameAttribute" name="%userNameAttribute" description="%userNameAttribute.desc"
             required="false" type="String" default="email"/>
         <AD id="mapToUserRegistry" name="%mapToUserRegistry" description="%mapToUserRegistry.desc"
             required="false" type="Boolean" default="false" />
-        <AD id="sslRef" name="%sslRef" description="%sslRef.desc" 
+        <AD id="sslRef" name="%sslRef" description="%sslRef.desc"
             required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.repertoire" />
-        <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid" 
-             ibm:reference="com.ibm.ws.security.authentication.filter" required="false" type="String"  />            
-        <AD id="jwt" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.login.jwt" 
+        <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid"
+             ibm:reference="com.ibm.ws.security.authentication.filter" required="false" type="String"  />
+        <AD id="jwt" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.login.jwt"
              required="false" type="String" />
         <AD id="isClientSideRedirectSupported" name="%isClientSideRedirectSupported" description="%isClientSideRedirectSupported.desc"
-            required="false" type="Boolean" default="true" />                                                         
+            required="false" type="Boolean" default="true" />
         <AD id="displayName" name="%displayName" description="%displayName.desc"
             required="false" type="String" default="Twitter" />
         <AD id="website" name="%website" description="%website.desc" required="false" type="String" ibm:type="token" default="https://twitter.com" />
@@ -125,14 +125,14 @@
 
     <Designate pid="com.ibm.ws.security.social.twitter">
         <Object ocdref="com.ibm.ws.security.social.twitter.metatype" />
-    </Designate>   
+    </Designate>
 
-    <OCD id="com.ibm.ws.security.social.facebook.metatype" name="%social.facebook.conf" description="%social.facebook.conf.desc" 
+    <OCD id="com.ibm.ws.security.social.facebook.metatype" name="%social.facebook.conf" description="%social.facebook.conf.desc"
          ibm:alias="facebookLogin">
         <AD id="id" name="internal" description="internal use only"
             required="false" type="String" default="facebookLogin" ibm:final="true"  ibm:unique="uniqueId"/>
         <AD id="clientId" name="%clientId" description="%clientId.desc"
-            required="true" type="String" /> 
+            required="true" type="String" />
         <AD id="clientSecret" name="%clientSecret" description="%clientSecret.desc"
             required="true" type="String" ibm:type="password" />
         <AD id="loginDialogEndpoint" name="%loginDialogEndpoint" description="%loginDialogEndpoint.desc"
@@ -140,31 +140,31 @@
         <AD id="tokenEndpoint" name="%tokenEndpoint" description="%tokenEndpoint.desc"
             required="false" type="String" default="https://graph.facebook.com/v2.8/oauth/access_token"/>
         <AD id="userApi" name="%userApi" description="%userApi.desc"
-            required="false" type="String" default="https://graph.facebook.com/v2.8/me?fields=id\,name\,email"/>                 
+            required="false" type="String" default="https://graph.facebook.com/v2.8/me?fields=id\,name\,email"/>
         <AD id="permissions" name="%permissions" description="%permissions.desc"
             required="false" type="String" default="public_profile email" />
         <AD id="userNameAttribute" name="%userNameAttribute" description="%userNameAttribute.desc"
             required="false" type="String" default="email"/>
         <AD id="mapToUserRegistry" name="%mapToUserRegistry" description="%mapToUserRegistry.desc"
             required="false" type="Boolean" default="false" />
-        <AD id="sslRef" name="%sslRef" description="%sslRef.desc" 
+        <AD id="sslRef" name="%sslRef" description="%sslRef.desc"
             required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.repertoire" />
-        <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid" 
-             ibm:reference="com.ibm.ws.security.authentication.filter" required="false" type="String"  />            
-        <AD id="jwt" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.login.jwt" 
+        <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid"
+             ibm:reference="com.ibm.ws.security.authentication.filter" required="false" type="String"  />
+        <AD id="jwt" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.login.jwt"
              required="false" type="String" />
         <AD id="isClientSideRedirectSupported" name="%isClientSideRedirectSupported" description="%isClientSideRedirectSupported.desc"
-            required="false" type="Boolean" default="true" />                                                  
+            required="false" type="Boolean" default="true" />
         <AD id="displayName" name="%displayName" description="%displayName.desc"
-            required="false" type="String" default="Facebook" /> 
+            required="false" type="String" default="Facebook" />
         <AD id="website" name="%website" description="%website.desc" required="false" type="String" ibm:type="token" default="https://www.facebook.com" />
         <AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="client_secret_post" >
                 <Option label="client_secret_basic" value="client_secret_basic" />
-                <Option label="client_secret_post"  value="client_secret_post" /> 
-        </AD>        
+                <Option label="client_secret_post"  value="client_secret_post" />
+        </AD>
         <AD id="redirectToRPHostAndPort" name="%redirectToRPHostAndPort" description="%redirectToRPHostAndPort.desc" required="false" type="String" />
-        <AD id="useSystemPropertiesForHttpClientConnections" name="%useSystemPropertiesForHttpClientConnections" description="%useSystemPropertiesForHttpClientConnections.desc" required="false" type="Boolean" default="false"/>                     
+        <AD id="useSystemPropertiesForHttpClientConnections" name="%useSystemPropertiesForHttpClientConnections" description="%useSystemPropertiesForHttpClientConnections.desc" required="false" type="Boolean" default="false"/>
         <AD id="responseType" name="%responseType" description="%responseType.desc" required="false" type="String" default="code">
                 <Option label="%responseType.code" value="code" />
             <!-- future
@@ -175,48 +175,48 @@
 
     <Designate pid="com.ibm.ws.security.social.facebook">
         <Object ocdref="com.ibm.ws.security.social.facebook.metatype" />
-    </Designate> 
+    </Designate>
 
-    <OCD id="com.ibm.ws.security.social.github.metatype" name="%social.github.conf" description="%social.github.conf.desc" 
+    <OCD id="com.ibm.ws.security.social.github.metatype" name="%social.github.conf" description="%social.github.conf.desc"
          ibm:alias="githubLogin">
         <AD id="id" name="internal" description="internal use only"
             required="false" type="String" default="githubLogin" ibm:final="true"  ibm:unique="uniqueId"/>
         <AD id="clientId" name="%clientId" description="%clientId.desc"
-            required="true" type="String" /> 
+            required="true" type="String" />
         <AD id="clientSecret" name="%clientSecret" description="%clientSecret.desc"
             required="true" type="String" ibm:type="password" />
         <AD id="authorizationEndpoint" name="%authorizationEndpoint" description="%authorizationEndpoint.desc"
             required="false" type="String" default="https://github.com/login/oauth/authorize"/>
         <AD id="tokenEndpoint" name="%tokenEndpoint" description="%tokenEndpoint.desc"
-            required="false" type="String" default="https://github.com/login/oauth/access_token"/>  
+            required="false" type="String" default="https://github.com/login/oauth/access_token"/>
         <AD id="userApi" name="%userApi" description="%userApi.desc"
-            required="false" type="String" default="https://api.github.com/user/emails"/>                    
+            required="false" type="String" default="https://api.github.com/user/emails"/>
         <AD id="scope" name="%scope" description="%scope.desc"
             required="false" type="String" default="user" />
         <AD id="userNameAttribute" name="%userNameAttribute" description="%userNameAttribute.desc"
             required="false" type="String" default="email"/>
         <AD id="mapToUserRegistry" name="%mapToUserRegistry" description="%mapToUserRegistry.desc"
             required="false" type="Boolean" default="false" />
-        <AD id="sslRef" name="%sslRef" description="%sslRef.desc" 
+        <AD id="sslRef" name="%sslRef" description="%sslRef.desc"
             required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.repertoire" />
-        <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid" 
-             ibm:reference="com.ibm.ws.security.authentication.filter" required="false" type="String"  />            
-        <AD id="jwt" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.login.jwt" 
+        <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid"
+             ibm:reference="com.ibm.ws.security.authentication.filter" required="false" type="String"  />
+        <AD id="jwt" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.login.jwt"
              required="false" type="String" />
         <AD id="isClientSideRedirectSupported" name="%isClientSideRedirectSupported" description="%isClientSideRedirectSupported.desc"
             required="false" type="Boolean" default="true" />
         <AD id="displayName" name="%displayName" description="%displayName.desc"
-            required="false" type="String" default="GitHub" /> 
+            required="false" type="String" default="GitHub" />
         <AD id="website" name="%website" description="%website.desc" required="false" type="String" ibm:type="token" default="https://github.com" />
-        <AD id="userApiNeedsSpecialHeader" name="internal" description="internal use only" required="false" 
+        <AD id="userApiNeedsSpecialHeader" name="internal" description="internal use only" required="false"
              type="Boolean" default="true" />
 	<AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="client_secret_post" >
                <Option label="client_secret_basic" value="client_secret_basic" />
                <Option label="client_secret_post"  value="client_secret_post" />
-        </AD>        
+        </AD>
         <AD id="redirectToRPHostAndPort" name="%redirectToRPHostAndPort" description="%redirectToRPHostAndPort.desc" required="false" type="String" />
-        <AD id="useSystemPropertiesForHttpClientConnections" name="%useSystemPropertiesForHttpClientConnections" description="%useSystemPropertiesForHttpClientConnections.desc" required="false" type="Boolean" default="false"/>                                                                  
+        <AD id="useSystemPropertiesForHttpClientConnections" name="%useSystemPropertiesForHttpClientConnections" description="%useSystemPropertiesForHttpClientConnections.desc" required="false" type="Boolean" default="false"/>
         <AD id="responseType" name="%responseType" description="%responseType.desc" required="false" type="String" default="code">
                 <Option label="%responseType.code" value="code" />
             <!-- future
@@ -228,47 +228,47 @@
     <Designate pid="com.ibm.ws.security.social.github">
         <Object ocdref="com.ibm.ws.security.social.github.metatype" />
     </Designate>
-     
-    <OCD id="com.ibm.ws.security.social.linkedin.metatype" name="%social.linkedin.conf" description="%social.linkedin.conf.desc" 
+
+    <OCD id="com.ibm.ws.security.social.linkedin.metatype" name="%social.linkedin.conf" description="%social.linkedin.conf.desc"
          ibm:alias="linkedinLogin">
         <AD id="id" name="internal" description="internal use only"
             required="false" type="String" default="linkedinLogin" ibm:final="true"  ibm:unique="uniqueId"/>
         <AD id="clientId" name="%clientId" description="%clientId.desc"
-            required="true" type="String" /> 
+            required="true" type="String" />
         <AD id="clientSecret" name="%clientSecret" description="%clientSecret.desc"
             required="true" type="String" ibm:type="password" />
         <AD id="authorizationEndpoint" name="%authorizationEndpoint" description="%authorizationEndpoint.desc"
             required="false" type="String" default="https://www.linkedin.com/oauth/v2/authorization"/>
         <AD id="tokenEndpoint" name="%tokenEndpoint" description="%tokenEndpoint.desc"
-            required="false" type="String" default="https://www.linkedin.com/oauth/v2/accessToken"/>  
+            required="false" type="String" default="https://www.linkedin.com/oauth/v2/accessToken"/>
         <AD id="userApi" name="%userApi" description="%userApi.desc"
-            required="false" type="String" default="https://api.linkedin.com/v2/emailAddress?q=members&amp;projection=(elements*(handle~))"/>                    
-        <AD id="scope" name="%scope" description="%scope.desc" 
+            required="false" type="String" default="https://api.linkedin.com/v2/emailAddress?q=members&amp;projection=(elements*(handle~))"/>
+        <AD id="scope" name="%scope" description="%scope.desc"
             required="false" type="String" default="r_emailaddress r_liteprofile" />
         <AD id="userNameAttribute" name="%userNameAttribute" description="%userNameAttribute.desc"
             required="false" type="String" default="emailAddress"/>
         <AD id="mapToUserRegistry" name="%mapToUserRegistry" description="%mapToUserRegistry.desc"
             required="false" type="Boolean" default="false" />
-        <AD id="sslRef" name="%sslRef" description="%sslRef.desc" 
+        <AD id="sslRef" name="%sslRef" description="%sslRef.desc"
             required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.repertoire" />
-        <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid" 
-             ibm:reference="com.ibm.ws.security.authentication.filter" required="false" type="String"  />            
-        <AD id="jwt" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.login.jwt" 
+        <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid"
+             ibm:reference="com.ibm.ws.security.authentication.filter" required="false" type="String"  />
+        <AD id="jwt" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.login.jwt"
              required="false" type="String" />
         <AD id="isClientSideRedirectSupported" name="%isClientSideRedirectSupported" description="%isClientSideRedirectSupported.desc"
-            required="false" type="Boolean" default="true" />                                 
+            required="false" type="Boolean" default="true" />
         <AD id="displayName" name="%displayName" description="%displayName.desc"
-            required="false" type="String" default="Linkedin" /> 
+            required="false" type="String" default="Linkedin" />
         <AD id="website" name="%website" description="%website.desc" required="false" type="String" ibm:type="token" default="https://www.linkednin.com" />
         <AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="client_secret_post" >
                 <Option label="client_secret_basic" value="client_secret_basic" />
                 <Option label="client_secret_post"  value="client_secret_post" />
-        </AD> 
-        <AD id="userApiNeedsSpecialHeader" name="internal" description="internal use only" required="false" 
+        </AD>
+        <AD id="userApiNeedsSpecialHeader" name="internal" description="internal use only" required="false"
              type="Boolean" default="true" />
         <AD id="redirectToRPHostAndPort" name="%redirectToRPHostAndPort" description="%redirectToRPHostAndPort.desc" required="false" type="String" />
-        <AD id="useSystemPropertiesForHttpClientConnections" name="%useSystemPropertiesForHttpClientConnections" description="%useSystemPropertiesForHttpClientConnections.desc" required="false" type="Boolean" default="false"/>                                     
+        <AD id="useSystemPropertiesForHttpClientConnections" name="%useSystemPropertiesForHttpClientConnections" description="%useSystemPropertiesForHttpClientConnections.desc" required="false" type="Boolean" default="false"/>
         <AD id="responseType" name="%responseType" description="%responseType.desc" required="false" type="String" default="code">
                 <Option label="%responseType.code" value="code" />
             <!-- future
@@ -281,7 +281,7 @@
         <Object ocdref="com.ibm.ws.security.social.linkedin.metatype" />
     </Designate>
 
-    <OCD id="com.ibm.ws.security.social.oauth2login.metatype" name="%social.oauth2login.conf" description="%social.oauth2login.conf.desc" 
+    <OCD id="com.ibm.ws.security.social.oauth2login.metatype" name="%social.oauth2login.conf" description="%social.oauth2login.conf.desc"
          ibm:alias="oauth2Login">
         <AD id="id" name="%uniqueId" description="%uniqueId.desc"
             required="true" type="String" ibm:unique="uniqueId"/>
@@ -355,32 +355,32 @@
     </Designate>
 
       <!-- Default for use with other OIDC services.  Like google except most of the defaults
-           have been removed. If you add to or change this, consider changing google conf too -->                             
+           have been removed. If you add to or change this, consider changing google conf too -->
      <Designate factoryPid="com.ibm.ws.security.social.oidclogin">
         <Object ocdref="com.ibm.ws.security.social.oidc.metatype" />
-     </Designate>           
-     <OCD id="com.ibm.ws.security.social.oidc.metatype" name="%social.oidc.conf" description="%social.oidc.conf.desc" 
-         ibm:alias="oidcLogin">    
+     </Designate>
+     <OCD id="com.ibm.ws.security.social.oidc.metatype" name="%social.oidc.conf" description="%social.oidc.conf.desc"
+         ibm:alias="oidcLogin">
          <AD id="id" name="%uniqueId" description="%uniqueId.desc"
-            required="true" type="String" ibm:unique="uniqueId"/>   
+            required="true" type="String" ibm:unique="uniqueId"/>
         <!--
         <AD id="id" name="internal" description="internal use only"
             required="false" type="String" default="oidcLogin" ibm:final="true" ibm:unique="uniqueId"/>
-        --> 
+        -->
         <AD id="clientId" name="%clientId" description="%clientId.desc"
-            required="true" type="String" /> 
+            required="true" type="String" />
         <AD id="clientSecret" name="%clientSecret" description="%clientSecret.desc"
-            required="true" type="String" ibm:type="password" /> 
-        <!-- AD id="userApi" required="false" type="String" not defined --> 
+            required="true" type="String" ibm:type="password" />
+        <!-- AD id="userApi" required="false" type="String" not defined -->
         <AD id="authorizationEndpoint" name="%authorizationEndpoint" description="%authorizationEndpoint.desc"
             required="false" type="String" />
         <AD id="tokenEndpoint" name="%tokenEndpoint" description="%tokenEndpoint.desc"
             required="false" type="String" />
         <!--  userInfoEndpoint is not required, but if used successfully, results are available in an api.  -->
         <AD id="userInfoEndpoint" name="%userInfoEndpoint" description="%userInfoEndpoint.desc"
-            required="false" type="String" />  
+            required="false" type="String" />
         <AD id="userInfoEndpointEnabled" name="%userInfoEndpointEnabled" description="%userInfoEndpointEnabled.desc"
-            required="false" type="Boolean" default="false" />            
+            required="false" type="Boolean" default="false" />
         <AD id="jwksUri" name="%jwksUri" description="%jwksUri.desc"
             required="false" type="String" />
         <AD id="scope" name="%scope" description="%scope.desc"
@@ -389,20 +389,20 @@
             required="false" type="String" default="sub" />
         <AD id="mapToUserRegistry" name="%mapToUserRegistry" description="%mapToUserRegistry.desc"
             required="false" type="Boolean" default="false" />
-        <AD id="sslRef" name="%sslRef" description="%sslRef.desc" 
+        <AD id="sslRef" name="%sslRef" description="%sslRef.desc"
             required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.repertoire" />
-        <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid" 
+        <AD id="authFilterRef" name="%authFilterRef" description="%authFilterRef.desc" ibm:type="pid"
              ibm:reference="com.ibm.ws.security.authentication.filter" required="false" type="String"  />
         <AD id="trustAliasName" name="%trustAliasName" description="%trustAliasName.desc" required="false" type="String" />
-        <AD id="jwt" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.login.jwt" 
+        <AD id="jwt" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.login.jwt"
              required="false" type="String" />
         <AD id="isClientSideRedirectSupported" name="%isClientSideRedirectSupported" description="%isClientSideRedirectSupported.desc"
             required="false" type="Boolean" default="true" />
         <AD id="displayName" name="%displayName" description="%displayName.desc"
             required="false" type="String" default="oidcLogin" />
-        <AD id="website" name="%website" description="%website.desc" required="false" type="String" ibm:type="token" />         
-         
-        <AD id="issuer" name="%issuer" description="%issuer.desc" required="false" type="String" />            
+        <AD id="website" name="%website" description="%website.desc" required="false" type="String" ibm:type="token" />
+
+        <AD id="issuer" name="%issuer" description="%issuer.desc" required="false" type="String" />
         <AD id="realmNameAttribute" name="%realmNameAttribute" description="%realmNameAttribute.desc"
             required="false" type="String" default="iss" />
         <AD id="groupNameAttribute" name="%groupNameAttribute" description="%groupNameAttribute.desc"
@@ -412,12 +412,13 @@
         <AD id="clockSkew" name="%clockSkew" description="%clockSkew.desc"
             required="false"  type="Integer" default="300000" />
         <AD id="signatureAlgorithm" name="%signatureAlgorithm"  description="%signatureAlgorithm.desc"
-            required="false" type="String"  default="RS256" /> 
-        <!-- todo: might need a name for this next one in metatype.properties after 2q --> 
+            required="false" type="String"  default="RS256" />
+        <!-- todo: might need a name for this next one in metatype.properties after 2q -->
         <AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="client_secret_post" >
                <Option label="client_secret_basic" value="client_secret_basic" />
-               <Option label="client_secret_post"  value="client_secret_post" /> 
+               <Option label="client_secret_post"  value="client_secret_post" />
+               <Option label="%tokenEndpointAuthMethod.privateKeyJwt" value="private_key_jwt" />
          </AD>
         <AD id="redirectToRPHostAndPort" name="%redirectToRPHostAndPort" description="%redirectToRPHostAndPort.desc" required="false" type="String" />
         <AD id="hostNameVerificationEnabled" name="%hostNameVerificationEnabled" description="%hostNameVerificationEnabled.desc" required="false" type="Boolean" default="true"/>
@@ -452,8 +453,8 @@
             <Option label="%pkceCodeChallengeMethod.S256" value="S256" />
         </AD>
     </OCD>
-    
-     <OCD id="com.ibm.ws.security.social.client.param.metatype" name="%oidcClientCustomRequestParam" description="%oidcClientCustomRequestParam.desc" 
+
+     <OCD id="com.ibm.ws.security.social.client.param.metatype" name="%oidcClientCustomRequestParam" description="%oidcClientCustomRequestParam.desc"
          ibmui:localization="OSGI-INF/l10n/metatype" >
          <AD id="name" name="%oidcClientCustomRequestParamName" description="%oidcClientCustomRequestParamName.desc" required="false" type="String" />
          <AD id="value" name="%oidcClientCustomRequestParamValue" description="%oidcClientCustomRequestParamValue.desc" required="false" type="String" />
@@ -477,13 +478,13 @@
     </OCD>
 
      <!-- 238750, configurable context root.
-          The alias or name is the name of the element in server.xml. 
+          The alias or name is the name of the element in server.xml.
           contextPath is the attribute that will define the context root, ex:
           <socialLoginWebapp contextPath="/some/place" />
       -->
-     <OCD description="%socialLoginWebapp.desc" name="%socialLoginWebapp.name" 
-         id="com.ibm.ws.security.social.webapp" 
-         ibm:alias="socialLoginWebapp" ibmui:localization="OSGI-INF/l10n/metatype">   <!-- alias has to match bnd file -->                         
+     <OCD description="%socialLoginWebapp.desc" name="%socialLoginWebapp.name"
+         id="com.ibm.ws.security.social.webapp"
+         ibm:alias="socialLoginWebapp" ibmui:localization="OSGI-INF/l10n/metatype">   <!-- alias has to match bnd file -->
          <AD id="contextPath" name="%socialLoginWebapp.contextPath.name" description="%socialLoginWebapp.contextPath.desc"
             required="true" type="String" default="/ibm/api/social-login" />
          <AD id="contextName" name="internal" description="internal use only"
@@ -491,12 +492,12 @@
         <AD id="socialMediaSelectionPageUrl" name="%socialMediaSelectionPageUrl" description="%socialMediaSelectionPageUrl.desc"
             required="false" type="String" ibm:type="token" /> <!-- trim the beginning and ending spaces-->
          <AD id="enableLocalAuthentication" name="%enableLocalAuthentication" description="%enableLocalAuthentication.desc" type="Boolean" default="false" />
-    </OCD>    
-    <Designate pid="com.ibm.ws.security.social.webapp"> <!--  needs to match pid in WabConfiguration impl -->        
+    </OCD>
+    <Designate pid="com.ibm.ws.security.social.webapp"> <!--  needs to match pid in WabConfiguration impl -->
         <Object ocdref="com.ibm.ws.security.social.webapp"/> <!--  just needs to ref the id in the OCD element. -->
     </Designate>
     <!--  see also WABConfiguration javadoc -->
-    <OCD id="com.ibm.ws.security.social.login.jwt.metatype" name="%jwtBuilder" description="%jwtBuilder.desc" 
+    <OCD id="com.ibm.ws.security.social.login.jwt.metatype" name="%jwtBuilder" description="%jwtBuilder.desc"
          ibmui:localization="OSGI-INF/l10n/metatype" >
          <AD id="builder" name="%jwtRef"    description="%jwtRef.desc"     required="false" type="String" ibm:type="token" />
          <AD id="claims"  name="%jwtClaims" description="%jwtClaims.desc"  required="false" type="String" cardinality="400" />
@@ -504,5 +505,5 @@
     <Designate factoryPid="com.ibm.ws.security.social.login.jwt">
         <Object ocdref="com.ibm.ws.security.social.login.jwt.metatype" />
     </Designate>
-               
+
 </metatype:MetaData>

--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -59,7 +59,8 @@ Export-Package: \
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.org.jose4j;version=latest,\
 	com.ibm.ws.security.common.jsonwebkey;version=latest,\
-	io.openliberty.security.common.jwt;version=latest
+	io.openliberty.security.common.jwt;version=latest,\
+	com.ibm.ws.kernel.boot.core;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -1,14 +1,11 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 
@@ -36,6 +33,7 @@ Export-Package: \
 	io.openliberty.security.oidcclientcore.logout, \
 	io.openliberty.security.oidcclientcore.storage, \
 	io.openliberty.security.oidcclientcore.token, \
+	io.openliberty.security.oidcclientcore.token.auth, \
 	io.openliberty.security.oidcclientcore.userinfo, \
 	io.openliberty.security.oidcclientcore.utils
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenConstants.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenConstants.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.token;
 
@@ -21,11 +18,15 @@ public class TokenConstants {
     public static final String CLIENT_SECRET = "client_secret";
     public static final String GRANT_TYPE = "grant_type";
     public static final String REDIRECT_URI = "redirect_uri";
+    public static final String CLIENT_ASSERTION_TYPE = "client_assertion_type";
+    public static final String CLIENT_ASSERTION = "client_assertion";
+    public static final String CLIENT_ASSERTION_TYPE_JWT_BEARER = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
     public static final String RESOURCE = "resource";
     public static final String METHOD_BASIC = "basic";
     public static final String METHOD_POST = "post";
     public static final String METHOD_CLIENT_SECRET_POST = "client_secret_post";
+    public static final String METHOD_PRIVATE_KEY_JWT = "private_key_jwt";
 
     public static final String SCOPE = "scope";
     public static final String EXPIRES_IN = "expires_in";

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/auth/PrivateKeyJwtAuthMethod.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/auth/PrivateKeyJwtAuthMethod.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.token.auth;
+
+public class PrivateKeyJwtAuthMethod {
+
+    private final String clientId;
+    private final String tokenEndpoint;
+
+    public PrivateKeyJwtAuthMethod(String clientId, String tokenEndpoint) {
+        this.clientId = clientId;
+        this.tokenEndpoint = tokenEndpoint;
+    }
+
+    public String createPrivateKeyJwt() {
+        // TODO
+        return null;
+    }
+
+}

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/auth/package-info.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/auth/package-info.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
+package io.openliberty.security.oidcclientcore.token.auth;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+
+import io.openliberty.security.oidcclientcore.TraceConstants;

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/auth/PrivateKeyJwtAuthMethodTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/auth/PrivateKeyJwtAuthMethodTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.oidcclientcore.token.auth;
+
+import static org.junit.Assert.assertNull;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class PrivateKeyJwtAuthMethodTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    private String clientId;
+    private final String tokenEndpointUrl = "https://somehost/path/to/token";
+
+    PrivateKeyJwtAuthMethod authMethod;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() {
+        clientId = testName.getMethodName();
+        authMethod = new PrivateKeyJwtAuthMethod(clientId, tokenEndpointUrl);
+    }
+
+    @After
+    public void tearDown() {
+        mockery.assertIsSatisfied();
+        outputMgr.resetStreams();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_createPrivateKeyJwt() {
+        assertNull("Result should be null until this method is implemented.", authMethod.createPrivateKeyJwt());
+    }
+
+}


### PR DESCRIPTION
- Adds a `private_key_jwt` option to the `tokenEndpointAuthMethod` attributes in `<openidConnectClient>` and `<oidcLogin>`. **Note: ** This is still strictly beta-level code and remains incomplete.
- Adds a new `PrivateKeyJwtAuthMethod` class to encapsulate the logic for creating JWTs to use for client authentication.

For #21826