### PR TITLE
Issue 21826: Add and read metatype for remaining OIDC Private Key JWT config attributes

### DIFF
--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/config/DiscoveryConfigUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/config/DiscoveryConfigUtils.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.common.config;
 
@@ -24,11 +21,12 @@ import com.ibm.ws.security.common.TraceConstants;
 import com.ibm.ws.security.common.crypto.HashUtils;
 
 public class DiscoveryConfigUtils {
-    
+
     public static final TraceComponent tc = Tr.register(DiscoveryConfigUtils.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
-    
+
     private JSONObject discoveryjson;
     private String tokenEndpointAuthMethod;
+    private String tokenEndpointAuthSigningAlgorithm;
     private String scope;
     private String signatureAlgorithm;
     private String id;
@@ -39,7 +37,7 @@ public class DiscoveryConfigUtils {
     private String discoveryDocumentHash;
 
     private long discoveryPollingRate;
-    
+
     public static final String OPDISCOVERY_AUTHZ_EP_URL = "authorization_endpoint";
     public static final String OPDISCOVERY_TOKEN_EP_URL = "token_endpoint";
     public static final String OPDISCOVERY_INTROSPECTION_EP_URL = "introspection_endpoint";
@@ -47,11 +45,13 @@ public class DiscoveryConfigUtils {
     public static final String OPDISCOVERY_USERINFO_EP_URL = "userinfo_endpoint";
     public static final String OPDISCOVERY_ISSUER = "issuer";
     public static final String OPDISCOVERY_TOKEN_EP_AUTH = "token_endpoint_auth_methods_supported";
+    public static final String OPDISCOVERY_TOKEN_EP_AUTH_SIGNING_ALGS_SUPPORTED = "token_endpoint_auth_signing_alg_values_supported";
     public static final String OPDISCOVERY_SCOPES = "scopes_supported";
     public static final String OPDISCOVERY_IDTOKEN_SIGN_ALG = "id_token_signing_alg_values_supported";
-    
+
     public static final String CFG_KEY_SCOPE = "scope";
     public static final String CFG_KEY_TOKEN_ENDPOINT_AUTH_METHOD = "tokenEndpointAuthMethod";
+    public static final String CFG_KEY_TOKEN_ENDPOINT_AUTH_SIGNING_ALGORITHM = "tokenEndpointAuthSigningAlgorithm";
     public static final String CFG_KEY_SIGNATURE_ALGORITHM = "signatureAlgorithm";
     public static final String KEY_authorizationEndpoint = "authorizationEndpoint";
     public static final String KEY_tokenEndpoint = "tokenEndpoint";
@@ -59,9 +59,9 @@ public class DiscoveryConfigUtils {
     public static final String KEY_jwksUri = "jwksUri";
     public static final String KEY_ISSUER = "issuer";
     public static final String KEY_DISCOVERY_ENDPOINT = "discoveryEndpoint";
-       
+
     public DiscoveryConfigUtils() {
-        
+
     }
 
     public DiscoveryConfigUtils initialConfig(String configId, String ep, long discoveryRate) {
@@ -70,42 +70,54 @@ public class DiscoveryConfigUtils {
         this.discoveryPollingRate = discoveryRate;
         return this;
     }
-    
-    public DiscoveryConfigUtils discoveredConfig(String alg, String tokenepAuthMethod, String scope) {
+
+    public DiscoveryConfigUtils discoveredConfig(String alg, String tokenepAuthMethod, String tokenEndpointAuthSigningAlgorithm, String scope) {
         this.signatureAlgorithm = alg;
         this.tokenEndpointAuthMethod = tokenepAuthMethod;
+        this.tokenEndpointAuthSigningAlgorithm = tokenEndpointAuthSigningAlgorithm;
         this.scope = scope;
         return this;
     }
-    
-    public DiscoveryConfigUtils discoveryDocumentHash(String discoveryHash) {    
+
+    public DiscoveryConfigUtils discoveryDocumentHash(String discoveryHash) {
         this.discoveryDocumentHash = discoveryHash;
         return this;
     }
-    
-    public DiscoveryConfigUtils discoveryDocumentResult(JSONObject json) {    
+
+    public DiscoveryConfigUtils discoveryDocumentResult(JSONObject json) {
         this.discoveryjson = json;
         return this;
     }
 
     public String adjustTokenEndpointAuthMethod() {
-        ArrayList<String> discoveryTokenepAuthMethod = discoverOPConfig(discoveryjson.get(OPDISCOVERY_TOKEN_EP_AUTH));
-        if (isSocialRPUsingDefault("authMethod") && !opHasSocialRPDefault("authMethod", discoveryTokenepAuthMethod)) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "See if we need to adjusted the token endpoint authmethod. The original is : " + tokenEndpointAuthMethod);
-            }
-            String supported  = socialRPSupportsOPConfig("authMethod", discoveryTokenepAuthMethod);
-            if (supported != null) {
-                Tr.info(tc,  "OIDC_CLIENT_DISCOVERY_OVERRIDE_DEFAULT", this.tokenEndpointAuthMethod, CFG_KEY_TOKEN_ENDPOINT_AUTH_METHOD, supported, getId());
-                this.tokenEndpointAuthMethod = supported;
-                if (tc.isDebugEnabled()) {
-                    Tr.debug(tc, "The adjusted value is : " + tokenEndpointAuthMethod);
-                }
-            }           
-        }
+        this.tokenEndpointAuthMethod = adjustConfigAttributeValueBasedOnListOfSupportedValues(OPDISCOVERY_TOKEN_EP_AUTH, CFG_KEY_TOKEN_ENDPOINT_AUTH_METHOD, tokenEndpointAuthMethod);
         return this.tokenEndpointAuthMethod;
     }
-    
+
+    public String adjustTokenEndpointAuthSigningAlgorithm() {
+        this.tokenEndpointAuthSigningAlgorithm = adjustConfigAttributeValueBasedOnListOfSupportedValues(OPDISCOVERY_TOKEN_EP_AUTH_SIGNING_ALGS_SUPPORTED, CFG_KEY_TOKEN_ENDPOINT_AUTH_SIGNING_ALGORITHM, tokenEndpointAuthSigningAlgorithm);
+        return this.tokenEndpointAuthSigningAlgorithm;
+    }
+
+    public String adjustConfigAttributeValueBasedOnListOfSupportedValues(String discoveryDocKey, String configAttributeName, String originalConfigValue) {
+        String overideValue = originalConfigValue;
+        ArrayList<String> opValuesSupported = discoverOPConfig(discoveryjson.get(discoveryDocKey));
+        if (isSocialRPUsingDefault(configAttributeName) && !opHasSocialRPDefault(configAttributeName, opValuesSupported)) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "See if we need to adjusted " + configAttributeName + ". The original is : " + originalConfigValue);
+            }
+            String supported  = socialRPSupportsOPConfig(configAttributeName, opValuesSupported);
+            if (supported != null) {
+                Tr.info(tc,  "OIDC_CLIENT_DISCOVERY_OVERRIDE_DEFAULT", originalConfigValue, configAttributeName, supported, getId());
+                overideValue = supported;
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "The adjusted value is : " + overideValue);
+                }
+            }
+        }
+        return overideValue;
+    }
+
     private String getId() {
         return id;
     }
@@ -116,28 +128,30 @@ public class DiscoveryConfigUtils {
      */
     public String adjustScopes() {
         ArrayList<String> discoveryScopes = discoverOPConfig(discoveryjson.get(OPDISCOVERY_SCOPES));
-        if (isSocialRPUsingDefault("scope") && !opHasSocialRPDefault("scope", discoveryScopes)) {
+        if (isSocialRPUsingDefault(CFG_KEY_SCOPE) && !opHasSocialRPDefault(CFG_KEY_SCOPE, discoveryScopes)) {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "See if we need to adjusted the scopes. The original is : " + this.scope);
             }
-            String supported  = socialRPSupportsOPConfig("scope", discoveryScopes);
+            String supported  = socialRPSupportsOPConfig(CFG_KEY_SCOPE, discoveryScopes);
             if (supported != null) {
                 Tr.info(tc,  "OIDC_CLIENT_DISCOVERY_OVERRIDE_DEFAULT", this.scope, CFG_KEY_SCOPE, supported, getId());
                 this.scope = supported;
                 if (tc.isDebugEnabled()) {
                     Tr.debug(tc, "The adjusted value is : " + this.scope);
                 }
-            }           
+            }
         }
         return this.scope;
     }
-    
+
     private boolean isSocialRPUsingDefault(String key) {
-        if ("authMethod".equals(key)) {
+        if (CFG_KEY_TOKEN_ENDPOINT_AUTH_METHOD.equals(key)) {
             return matches("client_secret_post", this.tokenEndpointAuthMethod);
-        } else if ("alg".equals(key)) {
+        } else if (CFG_KEY_TOKEN_ENDPOINT_AUTH_SIGNING_ALGORITHM.equals(key)) {
+            return matches("RS256", this.tokenEndpointAuthSigningAlgorithm);
+        } else if (CFG_KEY_SIGNATURE_ALGORITHM.equals(key)) {
             return matches("RS256", this.signatureAlgorithm);
-        } else if ("scope".equals(key)) {
+        } else if (CFG_KEY_SCOPE.equals(key)) {
             return (matchesMultipleValues("openid profile email", this.scope));
         }
         return false;
@@ -151,9 +165,10 @@ public class DiscoveryConfigUtils {
 
         String rpSupportedSignatureAlgorithms = "RS256";
         String rpSupportedTokenEndpointAuthMethods = "client_secret_post client_secret_basic";
+        String rpSupportedTokenEndpointAuthSigningAlgs = "RS256 RS384 RS512 ES256 ES384 ES512";
         String rpSupportedScopes = "openid profile email";
 
-        if ("alg".equals(key) && values != null) {
+        if (CFG_KEY_SIGNATURE_ALGORITHM.equals(key) && values != null) {
             for (String value : values) {
                 if (rpSupportedSignatureAlgorithms.contains(value)) {
                     return value;
@@ -161,7 +176,7 @@ public class DiscoveryConfigUtils {
             }
         }
 
-        if ("authMethod".equals(key) && values != null) {
+        if (CFG_KEY_TOKEN_ENDPOINT_AUTH_METHOD.equals(key) && values != null) {
             for (String value : values) {
                 if (rpSupportedTokenEndpointAuthMethods.contains(value)) {
                     return value;
@@ -169,7 +184,15 @@ public class DiscoveryConfigUtils {
             }
         }
 
-        if ("scope".equals(key) && values != null) {
+        if (CFG_KEY_TOKEN_ENDPOINT_AUTH_SIGNING_ALGORITHM.equals(key) && values != null) {
+            for (String value : values) {
+                if (rpSupportedTokenEndpointAuthSigningAlgs.contains(value)) {
+                    return value;
+                }
+            }
+        }
+
+        if (CFG_KEY_SCOPE.equals(key) && values != null) {
             String scopes = null;
             for (String value : values) {
                 if (rpSupportedScopes.contains(value)) {
@@ -185,7 +208,7 @@ public class DiscoveryConfigUtils {
         }
         return null;
     }
-    
+
     /**
      * @param object
      */
@@ -227,17 +250,19 @@ public class DiscoveryConfigUtils {
                 }
             }
         }
-       
+
         return jsonString;
     }
 
     private boolean opHasSocialRPDefault(String key, ArrayList<String> opconfig) {
 
-        if ("authMethod".equals(key)) {
+        if (CFG_KEY_TOKEN_ENDPOINT_AUTH_METHOD.equals(key)) {
             return matches("client_secret_post", opconfig);
-        } else if ("alg".equals(key)) {
+        } else if (CFG_KEY_TOKEN_ENDPOINT_AUTH_SIGNING_ALGORITHM.equals(key)) {
             return matches("RS256", opconfig);
-        } else if ("scope".equals(key)) {
+        } else if (CFG_KEY_SIGNATURE_ALGORITHM.equals(key)) {
+            return matches("RS256", opconfig);
+        } else if (CFG_KEY_SCOPE.equals(key)) {
             return matches("openid", opconfig) && matches("profile", opconfig) && matches("email", opconfig);
         }
         return false;
@@ -274,7 +299,7 @@ public class DiscoveryConfigUtils {
         }
         return true;
     }
-    
+
     /**
      * @param object
      * @return
@@ -304,24 +329,24 @@ public class DiscoveryConfigUtils {
         }
         if ((ep = configUtils.trim((String) props.get(KEY_jwksUri))) != null) {
             endpoints = buildDiscoveryWarning(endpoints, KEY_jwksUri);
-        } 
+        }
         if (!endpoints.isEmpty()) {
             logWarning("OIDC_CLIENT_DISCOVERY_OVERRIDE_EP", endpoints);
         }
-        
+
         if ((ep = configUtils.trim((String) props.get(KEY_ISSUER))) != null) {
             logWarning("OIDC_CLIENT_DISCOVERY_OVERRIDE_ISSUER", KEY_ISSUER);
         }
-        
+
     }
 
     /**
      * @param endpoints
      */
     private void logWarning(String key, String endpoints) {
-           
+
         Tr.warning(tc, key, this.discoveryURL, endpoints, getId());
-        
+
     }
 
     /**
@@ -329,10 +354,10 @@ public class DiscoveryConfigUtils {
      * @param ep
      * @return
      */
-    private String buildDiscoveryWarning(String endpoints, String ep) { 
+    private String buildDiscoveryWarning(String endpoints, String ep) {
         return endpoints.concat(ep).concat(", ");
     }
-    
+
     /**
      * @param string
      */
@@ -343,7 +368,7 @@ public class DiscoveryConfigUtils {
             Tr.info(tc, nlsMessage);
         } else {
             Tr.info(tc, getNlsMessage(key, defaultMessage));
-        }     
+        }
     }
 
     private String getNlsMessage(String key, String defaultMessage) {
@@ -352,7 +377,7 @@ public class DiscoveryConfigUtils {
         message = TraceNLS.getFormattedMessage(getClass(),
                 bundleName, key,
                 new Object[] { getId(), this.discoveryURL }, defaultMessage);
-             
+
         return message;
     }
 
@@ -372,9 +397,9 @@ public class DiscoveryConfigUtils {
         }
         return updated;
     }
-    
+
     public String getDiscoveryDocumentHash() {
         return this.discoveryDocumentHash;
     }
-    
+
 }

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
@@ -188,6 +188,19 @@ tokenEndpointAuthMethod.desc=The method to use for sending credentials to the to
 
 tokenEndpointAuthMethod.privateKeyJwt=Private key JWT client authentication.
 
+tokenEndpointAuthSigningAlgorithm=Token endpoint authentication signing algorithm
+tokenEndpointAuthSigningAlgorithm.desc=The signature algorithm to use to sign tokens that are used for client authentication.
+
+tokenEndpointAuthSigningAlgorithm.RS256=Use the RS256 signature algorithm to sign tokens that are used for client authentication
+tokenEndpointAuthSigningAlgorithm.RS384=Use the RS384 signature algorithm to sign tokens that are used for client authentication
+tokenEndpointAuthSigningAlgorithm.RS512=Use the RS512 signature algorithm to sign tokens that are used for client authentication
+tokenEndpointAuthSigningAlgorithm.ES256=Use the ES256 signature algorithm to sign tokens that are used for client authentication
+tokenEndpointAuthSigningAlgorithm.ES384=Use the ES384 signature algorithm to sign tokens that are used for client authentication
+tokenEndpointAuthSigningAlgorithm.ES512=Use the ES512 signature algorithm to sign tokens that are used for client authentication
+
+keyAliasName=Key alias name
+keyAliasName.desc=The alias for the private key that is used for signing tokens that are used for client authentication.
+
 authnSessionDisabled=Authentication session cookie disabled
 authnSessionDisabled.desc=An authentication session cookie will not be created for inbound propagation. The client is expected to send a valid OAuth token for every request.
 

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
@@ -93,6 +93,16 @@
                 <Option label="post"  value="post" />
                 <Option label="%tokenEndpointAuthMethod.privateKeyJwt" value="private_key_jwt" />
          </AD>
+         <AD id="tokenEndpointAuthSigningAlgorithm" name="%tokenEndpointAuthSigningAlgorithm" description="%tokenEndpointAuthSigningAlgorithm.desc" required="false"
+             type="String" default="RS256" ibm:beta="true" >
+                <Option label="%tokenEndpointAuthSigningAlgorithm.RS256" value="RS256" />
+                <Option label="%tokenEndpointAuthSigningAlgorithm.RS384" value="RS384" />
+                <Option label="%tokenEndpointAuthSigningAlgorithm.RS512" value="RS512" />
+                <Option label="%tokenEndpointAuthSigningAlgorithm.ES256" value="ES256" />
+                <Option label="%tokenEndpointAuthSigningAlgorithm.ES384" value="ES384" />
+                <Option label="%tokenEndpointAuthSigningAlgorithm.ES512" value="ES512" />
+         </AD>
+         <AD id="keyAliasName" name="%keyAliasName" description="%keyAliasName.desc" required="false" type="String" ibm:beta="true" />
          <AD id="jsonWebKey" name="internal" description="internal use only" required="false" type="String" />
          <AD id="prompt" name="internal" description="internal use only" required="false" type="String" />
           <AD id="jwt" name="internal" description="internal use only" ibm:type="pid" ibm:reference="com.ibm.ws.security.openidconnect.client.jwt"

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.client.internal;
@@ -106,6 +106,8 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     public static final String CFG_KEY_REALM_NAME = "realmName";
     public static final String CFG_KEY_UNIQUE_USER_IDENTIFIER = "uniqueUserIdentifier";
     public static final String CFG_KEY_TOKEN_ENDPOINT_AUTH_METHOD = "tokenEndpointAuthMethod";
+    public static final String CFG_KEY_TOKEN_ENDPOINT_AUTH_SIGNING_ALGORITHM = "tokenEndpointAuthSigningAlgorithm";
+    public static final String CFG_KEY_KEY_ALIAS_NAME = "keyAliasName";
     public static final String CFG_KEY_USER_IDENTITY_TO_CREATE_SUBJECT = "userIdentityToCreateSubject";
     public static final String CFG_KEY_MAP_IDENTITY_TO_REGISTRY_USER = "mapIdentityToRegistryUser";
     public static final String CFG_KEY_OidcclientRequestParameterSupported = "oidcclientRequestParameterSupported";
@@ -212,6 +214,8 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     private String realmName;
     private String uniqueUserIdentifier;
     private String tokenEndpointAuthMethod;
+    private String tokenEndpointAuthSigningAlgorithm;
+    private String keyAliasName;
     private String userIdentityToCreateSubject;
     private boolean mapIdentityToRegistryUser;
     private boolean oidcclientRequestParameterSupported;
@@ -431,6 +435,8 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         realmName = trimIt((String) props.get(CFG_KEY_REALM_NAME));
         uniqueUserIdentifier = trimIt((String) props.get(CFG_KEY_UNIQUE_USER_IDENTIFIER));
         tokenEndpointAuthMethod = trimIt((String) props.get(CFG_KEY_TOKEN_ENDPOINT_AUTH_METHOD));
+        tokenEndpointAuthSigningAlgorithm = trimIt((String) props.get(CFG_KEY_TOKEN_ENDPOINT_AUTH_SIGNING_ALGORITHM));
+        keyAliasName = trimIt((String) props.get(CFG_KEY_KEY_ALIAS_NAME));
 
         userIdentityToCreateSubject = trimIt((String) props.get(CFG_KEY_USER_IDENTITY_TO_CREATE_SUBJECT));
         checkForValidValue(userIdentityToCreateSubject);
@@ -577,6 +583,8 @@ public class OidcClientConfigImpl implements OidcClientConfig {
             Tr.debug(tc, "realmName: " + realmName);
             Tr.debug(tc, "uniqueUserIdentifier: " + uniqueUserIdentifier);
             Tr.debug(tc, "tokenEndpointAuthMethod: " + tokenEndpointAuthMethod);
+            Tr.debug(tc, "tokenEndpointAuthSigningAlgorithm: " + tokenEndpointAuthSigningAlgorithm);
+            Tr.debug(tc, "keyAliasName: " + keyAliasName);
             Tr.debug(tc, "userIdentityToCreateSubject: " + userIdentityToCreateSubject);
             Tr.debug(tc, "mapIdentityToRegistryUser: " + mapIdentityToRegistryUser);
             Tr.debug(tc, "oidcclientRequestParameterSupported: " + oidcclientRequestParameterSupported);
@@ -770,6 +778,10 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         }
     }
 
+    void adjustTokenEndpointAuthSigningAlgorithm() {
+        this.tokenEndpointAuthSigningAlgorithm = discoveryUtils.adjustTokenEndpointAuthSigningAlgorithm();
+    }
+
     void adjustSignatureAlgorithm() {
 
         ArrayList<String> discoverySigAlgorithm = discoveryUtils.discoverOPConfig(discoveryjson.get(OPDISCOVERY_IDTOKEN_SIGN_ALG));
@@ -952,6 +964,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     boolean discoverEndpointUrls(JSONObject json) {
 
         if (calculateDiscoveryDocumentHash(json)) {
+            discoveryUtils.discoveryDocumentResult(json);
             this.authorizationEndpointUrl = discoveryUtils.discoverOPConfigSingleValue(json.get(OPDISCOVERY_AUTHZ_EP_URL));
             this.tokenEndpointUrl = discoveryUtils.discoverOPConfigSingleValue(json.get(OPDISCOVERY_TOKEN_EP_URL));
             this.jwkEndpointUrl = discoveryUtils.discoverOPConfigSingleValue(json.get(OPDISCOVERY_JWKS_EP_URL));
@@ -963,6 +976,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
             }
             adjustSignatureAlgorithm();
             adjustTokenEndpointAuthMethod();
+            adjustTokenEndpointAuthSigningAlgorithm();
             adjustScopes();
         }
 
@@ -1223,6 +1237,18 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     @Override
     public String getTokenEndpointAuthMethod() {
         return tokenEndpointAuthMethod;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getTokenEndpointAuthSigningAlgorithm() {
+        return tokenEndpointAuthSigningAlgorithm;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKeyAliasName() {
+        return keyAliasName;
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ConvergedClientConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ConvergedClientConfig.java
@@ -61,6 +61,10 @@ public interface ConvergedClientConfig extends JwtConsumerConfig {
 
     public String getTokenEndpointAuthMethod();
 
+    public String getTokenEndpointAuthSigningAlgorithm();
+
+    public String getKeyAliasName();
+
     public String getRedirectUrlFromServerToClient();
 
     public String getRedirectUrlWithJunctionPath(String redirect_url);

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
@@ -96,6 +96,19 @@ tokenEndpointAuthMethod.desc=Specifies required authentication method.
 
 tokenEndpointAuthMethod.privateKeyJwt=Private key JWT client authentication.
 
+tokenEndpointAuthSigningAlgorithm=Token endpoint authentication signing algorithm
+tokenEndpointAuthSigningAlgorithm.desc=The signature algorithm to use to sign tokens that are used for client authentication.
+
+tokenEndpointAuthSigningAlgorithm.RS256=Use the RS256 signature algorithm to sign tokens that are used for client authentication
+tokenEndpointAuthSigningAlgorithm.RS384=Use the RS384 signature algorithm to sign tokens that are used for client authentication
+tokenEndpointAuthSigningAlgorithm.RS512=Use the RS512 signature algorithm to sign tokens that are used for client authentication
+tokenEndpointAuthSigningAlgorithm.ES256=Use the ES256 signature algorithm to sign tokens that are used for client authentication
+tokenEndpointAuthSigningAlgorithm.ES384=Use the ES384 signature algorithm to sign tokens that are used for client authentication
+tokenEndpointAuthSigningAlgorithm.ES512=Use the ES512 signature algorithm to sign tokens that are used for client authentication
+
+keyAliasName=Key alias name
+keyAliasName.desc=The alias for the private key that is used for signing tokens that are used for client authentication.
+
 redirectToRPHostAndPort=Callback host and port number
 redirectToRPHostAndPort.desc=Specifies a callback protocol, host, and port number. For example, https://myhost:8020.
 

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
@@ -420,6 +420,16 @@
                <Option label="client_secret_post"  value="client_secret_post" />
                <Option label="%tokenEndpointAuthMethod.privateKeyJwt" value="private_key_jwt" />
          </AD>
+        <AD id="tokenEndpointAuthSigningAlgorithm" name="%tokenEndpointAuthSigningAlgorithm" description="%tokenEndpointAuthSigningAlgorithm.desc" required="false"
+            type="String" default="RS256" ibm:beta="true" >
+               <Option label="%tokenEndpointAuthSigningAlgorithm.RS256" value="RS256" />
+               <Option label="%tokenEndpointAuthSigningAlgorithm.RS384" value="RS384" />
+               <Option label="%tokenEndpointAuthSigningAlgorithm.RS512" value="RS512" />
+               <Option label="%tokenEndpointAuthSigningAlgorithm.ES256" value="ES256" />
+               <Option label="%tokenEndpointAuthSigningAlgorithm.ES384" value="ES384" />
+               <Option label="%tokenEndpointAuthSigningAlgorithm.ES512" value="ES512" />
+        </AD>
+        <AD id="keyAliasName" name="%keyAliasName" description="%keyAliasName.desc" required="false" type="String" ibm:beta="true" />
         <AD id="redirectToRPHostAndPort" name="%redirectToRPHostAndPort" description="%redirectToRPHostAndPort.desc" required="false" type="String" />
         <AD id="hostNameVerificationEnabled" name="%hostNameVerificationEnabled" description="%hostNameVerificationEnabled.desc" required="false" type="Boolean" default="true"/>
         <AD id="responseType" name="%responseType" description="%responseType.desc" required="false" type="String" default="code">


### PR DESCRIPTION
- Adds the following attributes to the metatype for the `<openidConnectClient>` and `<oidcLogin>` elements:
    - `tokenEndpointAuthSigningAlgorithm`
    - `keyAliasName`

For #21826