### PR TITLE
remove as alias for delete

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -959,7 +959,7 @@ public class RepositoryImpl<R, E> implements InvocationHandler {
             if (orderBy >= c)
                 parseOrderBy(queryInfo, orderBy, q);
             queryInfo.type = QueryInfo.Type.SELECT;
-        } else if (methodName.startsWith("delete")) {
+        } else if (methodName.startsWith("delete") || methodName.startsWith("remove")) {
             int by = methodName.indexOf("By", 6);
             int c = by < 0 ? 6 : by + 2;
             if (by > 6) {

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -2024,7 +2024,7 @@ public class DataTestServlet extends FATServlet {
     public void testMixedEntitiesInTransaction() throws HeuristicMixedException, HeuristicRollbackException, //
                     IllegalStateException, NotSupportedException, RollbackException, SecurityException, SystemException {
         houses.deleteAll();
-        vehicles.deleteAll();
+        vehicles.removeAll();
 
         House h1 = new House();
         h1.area = 1900;
@@ -2093,7 +2093,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals(26000f, v.price, 0.001f);
 
         houses.deleteAll();
-        vehicles.deleteAll();
+        vehicles.removeAll();
     }
 
     /**
@@ -2487,7 +2487,7 @@ public class DataTestServlet extends FATServlet {
         ZoneOffset CDT = ZoneOffset.ofHours(-5);
 
         // remove data that other tests previously inserted to the same table
-        reservations.deleteByHostNotIn(Set.of("never-ever-used@example.org"));
+        reservations.removeByHostNotIn(Set.of("never-ever-used@example.org"));
 
         assertEquals(0, reservations.count());
 
@@ -3214,7 +3214,7 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testSaveMultipleAndUpdate() {
-        vehicles.deleteAll();
+        vehicles.removeAll();
 
         Vehicle v1 = new Vehicle();
         v1.make = "Honda";
@@ -3249,7 +3249,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals(false, i.hasNext());
 
         // delete
-        assertEquals(true, vehicles.deleteById(v1.vinId));
+        assertEquals(true, vehicles.removeById(v1.vinId));
 
         // find none
         Optional<Vehicle> found = vehicles.findById(v1.vinId);
@@ -3263,7 +3263,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals(true, found.isPresent());
         assertEquals(25500f, found.get().price, 0.001f);
 
-        vehicles.deleteAll();
+        vehicles.removeAll();
     }
 
     /**
@@ -3274,7 +3274,7 @@ public class DataTestServlet extends FATServlet {
         ZoneOffset CDT = ZoneOffset.ofHours(-5);
 
         // remove data that other tests previously inserted to the same table
-        reservations.deleteByHostNotIn(Set.of("never-ever-used@example.org"));
+        reservations.removeByHostNotIn(Set.of("never-ever-used@example.org"));
 
         assertEquals(0, reservations.count());
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
@@ -46,8 +46,6 @@ public interface Reservations extends CrudRepository<Reservation, Long> {
 
     long deleteByHostNot(String host);
 
-    int deleteByHostNotIn(Collection<String> hosts);
-
     Iterable<Reservation> findByHost(String host);
 
     Collection<Reservation> findByLocationContainsOrderByMeetingID(String locationSubstring);
@@ -101,6 +99,8 @@ public interface Reservations extends CrudRepository<Reservation, Long> {
     ArrayDeque<Reservation> findByLocationStartsWith(String locationPrefix);
 
     CopyOnWriteArrayList<Reservation> findByHostIgnoreCaseEndsWith(String hostPostfix);
+
+    int removeByHostNotIn(Collection<String> hosts);
 
     int updateByHostAndLocationSetLocation(String host, String currentLocation, String newLocation);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
@@ -23,11 +23,12 @@ import jakarta.data.repository.Repository;
  */
 @Repository(dataStore = "java:module/jdbc/env/DerbyDataSourceRef")
 public interface Vehicles {
-    long deleteAll();
-
-    boolean deleteById(String vin);
 
     Optional<Vehicle> findById(String vin);
+
+    long removeAll();
+
+    boolean removeById(String vin);
 
     Iterable<Vehicle> save(Iterable<Vehicle> v);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Accounts.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Accounts.java
@@ -22,8 +22,6 @@ import jakarta.data.repository.Repository;
 @Repository
 public interface Accounts {
 
-    void delete(Account account); // copied from CrudRepository
-
     // "IN" (which is needed for this) is not supported for embeddables, but EclipseLink generates SQL
     // that leads to an SQLSyntaxErrorException rather than rejecting it outright
     void deleteAll(Iterable<Account> list); // copied from CrudRepository
@@ -74,6 +72,8 @@ public interface Accounts {
     // Mapping: org.eclipse.persistence.mappings.AggregateObjectMapping[accountId]
     // Descriptor: RelationalDescriptor(test.jakarta.data.jpa.web.Account --> [DatabaseTable(WLPAccount)])
     List<Account> findByIdTrue();
+
+    void remove(Account account);
 
     void save(Account a);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -536,7 +536,7 @@ public class DataJPATestServlet extends FATServlet {
             // expected
         }
 
-        accounts.delete(new Account(1005380, 70081, "Think Bank", true, 552.18, "Ellen TestEmbeddedId"));
+        accounts.remove(new Account(1005380, 70081, "Think Bank", true, 552.18, "Ellen TestEmbeddedId"));
 
         // JPQL with "IN", which this needs, is not supported by EclipseLink for embeddables
         // accounts.deleteAll(List.of(new Account(1004470, 70081, "Think Bank", true, 443.94, "Erin TestEmbeddedId")));


### PR DESCRIPTION
This is a simple/trivial change to be more flexible. While writing tests we have often accidentally written "remove" rather than "delete", which is also supported by some vendors.