### PR TITLE
IBM API/SPI should not generate pom dependencies

### DIFF
--- a/dev/com.ibm.websphere.appserver.api.authData/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.authData/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.crypto,com.ibm.websphere.security.auth.data,co
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.authData/pom.xml=com.ibm.websphere.appserver.api.authData.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.basics/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.basics/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.application,com.ibm.websphere.filemonitor,com.
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.basics/pom.xml=com.ibm.websphere.appserver.api.basics.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.config/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.config/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.config.mbeans
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.config/pom.xml=com.ibm.websphere.appserver.api.config.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.connectionmanager/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.connectionmanager/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.ws.jca.cm.mbean
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.connectionmanager/pom.xml=com.ibm.websphere.appserver.api.connectionmanager.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.connectionpool/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.connectionpool/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.connectionpool.monitor
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.connectionpool/pom.xml=com.ibm.websphere.appserver.api.connectionpool.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.constrainedDelegation/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.constrainedDelegation/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.security.s4u2proxy
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.constrainedDelegation/pom.xml=com.ibm.websphere.appserver.api.constrainedDelegation.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.data/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.data/bnd.bnd
@@ -25,6 +25,8 @@ Export-Package: io.openliberty.data.repository
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/io.openliberty.data/pom.xml=io.openliberty.data.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.distributedMap/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.distributedMap/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.cache,com.ibm.websphere.cache.exception,com.ib
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.distributedMap/pom.xml=com.ibm.websphere.appserver.api.distributedMap.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.ejbcontainer/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.ejbcontainer/bnd.bnd
@@ -26,6 +26,8 @@ Export-Package: \
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.ejbcontainer/pom.xml=com.ibm.websphere.appserver.api.ejbcontainer.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.endpoint/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.endpoint/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.endpoint
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.endpoint/pom.xml=com.ibm.websphere.appserver.api.endpoint.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.hpel/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.hpel/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.logging.hpel,com.ibm.websphere.logging.hpel.re
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.hpel/pom.xml=com.ibm.websphere.appserver.api.hpel.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.j2eemanagement/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.j2eemanagement/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.management.j2ee
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.j2eemanagement/pom.xml=com.ibm.websphere.appserver.api.j2eemanagement.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.jacc/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.jacc/bnd.bnd
@@ -22,6 +22,8 @@ Export-Package: com.ibm.wsspi.security.authorization.jacc
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.jacc/pom.xml=com.ibm.websphere.appserver.api.jacc.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.jaxrs20/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.jaxrs20/bnd.bnd
@@ -41,6 +41,8 @@ Export-Package: \
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.jaxrs20/pom.xml=com.ibm.websphere.appserver.api.jaxrs20.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.json/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.json/bnd.bnd
@@ -23,6 +23,8 @@ Import-Package: com.ibm.json.java,com.ibm.json.xml
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.json/pom.xml=com.ibm.websphere.appserver.api.json.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.jwt/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.jwt/bnd.bnd
@@ -22,6 +22,8 @@ Export-Package: com.ibm.websphere.security.jwt
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.jwt/pom.xml=com.ibm.websphere.appserver.api.jwt.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.kernel.service/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.kernel.service/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.kernel.server
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.kernel.service/pom.xml=com.ibm.websphere.appserver.api.kernel.service.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.messaging/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.messaging/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.messaging.mbean
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.messaging/pom.xml=com.ibm.websphere.appserver.api.messaging.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.monitor/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.monitor/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.monitor.jmx
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.monitor/pom.xml=com.ibm.websphere.appserver.api.monitor.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 instrument.disabled: true

--- a/dev/com.ibm.websphere.appserver.api.oauth/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.oauth/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.oauth.core.api.attributes,com.ibm.oauth.core.api.config,
 -includeresource: \
     {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.oauth/pom.xml=com.ibm.websphere.appserver.api.oauth.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.oidc/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.oidc/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.security.openidconnect
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.oidc/pom.xml=com.ibm.websphere.appserver.api.oidc.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.passwordUtil/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.passwordUtil/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.crypto
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.passwordUtil/pom.xml=com.ibm.websphere.appserver.api.passwordUtil.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.persistence/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.persistence/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.persistence.mbean
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.persistence/pom.xml=com.ibm.websphere.appserver.api.persistence.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.requestTimingMonitor/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.requestTimingMonitor/bnd.bnd
@@ -23,6 +23,8 @@ Import-Package: com.ibm.websphere.request.timing
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.requestTimingMonitor/pom.xml=com.ibm.websphere.appserver.api.requestTimingMonitor.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.restConnector/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.restConnector/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.filetransfer,com.ibm.websphere.jmx.connector.r
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.restConnector/pom.xml=com.ibm.websphere.appserver.api.restConnector.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.saml20/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.saml20/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.security.saml2
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.saml20/pom.xml=com.ibm.websphere.appserver.api.saml20.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.security.spnego/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.security.spnego/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.security.token
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.security.spnego/pom.xml=com.ibm.websphere.appserver.api.security.spnego.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.security/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.security/bnd.bnd
@@ -22,6 +22,8 @@ Export-Package: com.ibm.websphere.security.auth.callback,com.ibm.wsspi.security.
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.security/pom.xml=com.ibm.websphere.appserver.api.security.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.securityClient/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.securityClient/bnd.bnd
@@ -22,6 +22,8 @@ Export-Package: com.ibm.websphere.security,com.ibm.websphere.security.auth.callb
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.securityClient/pom.xml=com.ibm.websphere.appserver.api.securityClient.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.servlet/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.servlet/bnd.bnd
@@ -22,6 +22,8 @@ Export-Package: com.ibm.websphere.servlet.container,com.ibm.websphere.servlet.co
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.servlet/pom.xml=com.ibm.websphere.appserver.api.servlet.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.sessionstats/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.sessionstats/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.session.monitor
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.sessionstats/pom.xml=com.ibm.websphere.appserver.api.sessionstats.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.sipServlet.1.1/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.sipServlet.1.1/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.sip,com.ibm.websphere.sip.resolver,com.ibm.web
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.sipServlet.1.1/pom.xml=com.ibm.websphere.appserver.api.sipServlet.1.1.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.sipServletSecurity.1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.sipServletSecurity.1.0/bnd.bnd
@@ -24,6 +24,8 @@ Export-Package: com.ibm.websphere.security.tai.extension,com.ibm.wsspi.security.
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.sipServletSecurity.1.0/pom.xml=com.ibm.websphere.appserver.api.sipServletSecurity.1.0.pom}
 
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.social/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.social/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.security.social
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.social/pom.xml=com.ibm.websphere.appserver.api.social.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.ssl/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.ssl/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.ssl
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.ssl/pom.xml=com.ibm.websphere.appserver.api.ssl.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.transaction/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.transaction/bnd.bnd
@@ -22,6 +22,8 @@ Export-Package: com.ibm.tx.jta,com.ibm.websphere.jtaextensions,com.ibm.websphere
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.transaction/pom.xml=com.ibm.websphere.appserver.api.transaction.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.webCache/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.webCache/bnd.bnd
@@ -22,6 +22,8 @@ Export-Package: com.ibm.websphere.command,com.ibm.websphere.command.web,com.ibm.
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.webCache/pom.xml=com.ibm.websphere.appserver.api.webCache.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.webcontainer.security.app/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.webcontainer.security.app/bnd.bnd
@@ -22,6 +22,8 @@ Export-Package: com.ibm.websphere.security.web
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.webcontainer.security.app/pom.xml=com.ibm.websphere.appserver.api.webcontainer.security.app.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.api.wsoc/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.wsoc/bnd.bnd
@@ -22,6 +22,8 @@ Export-Package: com.ibm.websphere.wsoc
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.wsoc/pom.xml=com.ibm.websphere.appserver.api.wsoc.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.application/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.application/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.application,com.ibm.wsspi.application.handler
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.application/pom.xml=com.ibm.websphere.appserver.spi.application.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.artifact/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.artifact/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.ws.adaptable.module.structure,com.ibm.wsspi.adaptable.mo
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.artifact/pom.xml=com.ibm.websphere.appserver.spi.artifact.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.cdi/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.cdi/bnd.bnd
@@ -20,6 +20,8 @@ Import-Package: io.openliberty.cdi.spi,*
 
 Export-Package: io.openliberty.cdi.spi
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.classloading/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.classloading/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.classloading,com.ibm.wsspi.library
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.classloading/pom.xml=com.ibm.websphere.appserver.spi.classloading.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.federatedRepository/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.federatedRepository/bnd.bnd
@@ -22,6 +22,8 @@ Export-Package: com.ibm.wsspi.security.wim,com.ibm.wsspi.security.wim.exception,
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.federatedRepository/pom.xml=com.ibm.websphere.appserver.spi.federatedRepository.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.globalhandler/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.globalhandler/bnd.bnd
@@ -22,6 +22,8 @@ Export-Package: com.ibm.wsspi.webservices.handler
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.globalhandler/pom.xml=com.ibm.websphere.appserver.spi.globalhandler.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.httptransport/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.httptransport/bnd.bnd
@@ -25,6 +25,8 @@ com.ibm.wsspi.http.ee8
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.httptransport/pom.xml=com.ibm.websphere.appserver.spi.httptransport.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.jaspic/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.jaspic/bnd.bnd
@@ -22,6 +22,8 @@ Export-Package: com.ibm.wsspi.security.jaspi
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.jaspic/pom.xml=com.ibm.websphere.appserver.spi.jaspic.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.javaeedd/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.javaeedd/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.ws.javaee.dd.appbnd,com.ibm.ws.javaee.dd.common,com.ibm.
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.javaeedd/pom.xml=com.ibm.websphere.appserver.spi.javaeedd.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.jsp/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.jsp/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.jsp.taglib.config
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.jsp/pom.xml=com.ibm.websphere.appserver.spi.jsp.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.kernel.embeddable/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.kernel.embeddable/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.kernel.embeddable,com.ibm.wsspi.kernel.security.th
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.kernel.embeddable/pom.xml=com.ibm.websphere.appserver.spi.kernel.embeddable.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.kernel.filemonitor/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.kernel.filemonitor/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.kernel.filemonitor
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.kernel.filemonitor/pom.xml=com.ibm.websphere.appserver.spi.kernel.filemonitor.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.kernel.metatype/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.kernel.metatype/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.config
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.kernel.metatype/pom.xml=com.ibm.websphere.appserver.spi.kernel.metatype.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.kernel.service/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.kernel.service/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.crypto,com.ibm.wsspi.kernel.service.location,c
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.kernel.service/pom.xml=com.ibm.websphere.appserver.spi.kernel.service.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.logging/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.logging/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.websphere.ras,com.ibm.websphere.ras.annotation,com.ibm.w
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.logging/pom.xml=com.ibm.websphere.appserver.spi.logging.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.oauth/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.oauth/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.security.oauth20,com.ibm.wsspi.security.openidconn
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.oauth/pom.xml=com.ibm.websphere.appserver.spi.oauth.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.openapi.3.1/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.openapi.3.1/bnd.bnd
@@ -25,6 +25,8 @@ Export-Package: com.ibm.wsspi.openapi31
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.openapi.3.1/pom.xml=com.ibm.websphere.appserver.spi.openapi.3.1.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.opentracing.1.1/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.opentracing.1.1/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.ws.opentracing.tracer;version=1.1
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.opentracing.1.1/pom.xml=com.ibm.websphere.appserver.spi.opentracing.1.1.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.opentracing.1.2/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.opentracing.1.2/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.ws.opentracing.tracer;version=1.2
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.opentracing.1.2/pom.xml=com.ibm.websphere.appserver.spi.opentracing.1.2.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.opentracing.1.3/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.opentracing.1.3/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.ws.opentracing.tracer;version=1.3
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.opentracing.1.3/pom.xml=com.ibm.websphere.appserver.spi.opentracing.1.3.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.opentracing/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.opentracing/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.ws.opentracing.tracer
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.opentracing/pom.xml=com.ibm.websphere.appserver.spi.opentracing.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.restHandler/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.restHandler/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.rest.handler,com.ibm.wsspi.rest.handler.helper
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.restHandler/pom.xml=com.ibm.websphere.appserver.spi.restHandler.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.saml20/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.saml20/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.security.saml2
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.saml20/pom.xml=com.ibm.websphere.appserver.spi.saml20.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.servlet/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.servlet/bnd.bnd
@@ -32,6 +32,8 @@ Export-Package: com.ibm.wsspi.webcontainer.extension, \
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.servlet/pom.xml=com.ibm.websphere.appserver.spi.servlet.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.ssl/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.ssl/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.ssl
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.ssl/pom.xml=com.ibm.websphere.appserver.spi.ssl.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.threading/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.threading/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.threading
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.threading/pom.xml=com.ibm.websphere.appserver.spi.threading.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.transaction/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.transaction/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.tx
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.transaction/pom.xml=com.ibm.websphere.appserver.spi.transaction.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.wab.configure/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.wab.configure/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.wab.configure
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.wab.configure/pom.xml=com.ibm.websphere.appserver.spi.wab.configure.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.webCache/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.webCache/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: com.ibm.wsspi.cache.web
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.webCache/pom.xml=com.ibm.websphere.appserver.spi.webCache.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/com.ibm.websphere.appserver.spi.wsat/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.wsat/bnd.bnd
@@ -10,6 +10,8 @@ Export-Package: com.ibm.wsspi.webservices.wsat
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/com.ibm.websphere.appserver.spi.wsat/pom.xml=com.ibm.websphere.appserver.spi.wsat.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/io.openliberty.data/bnd.bnd
+++ b/dev/io.openliberty.data/bnd.bnd
@@ -27,6 +27,8 @@ Export-Package: \
 
 instrument.classesExcludes: io/openliberty/data/repository/*.class
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/io.openliberty.grpc.1.0/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0/bnd.bnd
@@ -26,6 +26,8 @@ Export-Package: \
 
 -includeresource: {META-INF/maven/io.openliberty.api/io.openliberty.grpc/pom.xml=io.openliberty.grpc.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/io.openliberty.jaxrs30/bnd.bnd
+++ b/dev/io.openliberty.jaxrs30/bnd.bnd
@@ -39,6 +39,8 @@ Export-Package: \
 
 -includeresource: {META-INF/maven/io.openliberty.api/io.openliberty.jaxrs30/pom.xml=io.openliberty.jaxrs30.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \

--- a/dev/io.openliberty.opentracing.2.0.spi/bnd.bnd
+++ b/dev/io.openliberty.opentracing.2.0.spi/bnd.bnd
@@ -23,6 +23,8 @@ Export-Package: io.openliberty.opentracing.spi.tracer;version=2.0
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.spi/io.openliberty.opentracing.2.0.spi/pom.xml=io.openliberty.opentracing.2.0.spi.pom}
 
+-maven-dependencies:
+ 
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \

--- a/dev/wlp-updatePom/src/io/openliberty/build/update/pom/UpdatePom.java
+++ b/dev/wlp-updatePom/src/io/openliberty/build/update/pom/UpdatePom.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 
 import io.openliberty.build.update.Update;
@@ -123,7 +124,7 @@ public class UpdatePom extends UpdateFile {
     }
 
     protected Model readPomFromTarget() throws Exception {
-        try ( FileInputStream fileInputStream = new FileInputStream(getTargetFile()) ) {
+        try (FileInputStream fileInputStream = new FileInputStream(getTargetFile())) {
             return PomUtils.readPom(fileInputStream);
         }
     }
@@ -137,8 +138,9 @@ public class UpdatePom extends UpdateFile {
         byte[] transferBuffer = new byte[32 * 1024];
         FileUtils.write(pomInput, outputFile, transferBuffer);
 
-        Path inputPath = Paths.get(inputFile.getPath());
-        Path outputPath = Paths.get(outputFile.getPath());
+        // The target is now the original input
+        Path inputPath = Paths.get(outputFile.getPath());
+        Path outputPath = Paths.get(inputFile.getPath());
 
         // TODO: Should this include 'StandardCopyOption.ATOMIC_MOVE'?
         // We want to be sure to never leave the target in a broken state.

--- a/dev/wlp-updatePom/src/io/openliberty/build/update/pom/UpdatePomFiles.java
+++ b/dev/wlp-updatePom/src/io/openliberty/build/update/pom/UpdatePomFiles.java
@@ -78,13 +78,13 @@ public class UpdatePomFiles extends UpdateDirectory {
      */
     @Override
     public String getCriteria() {
-        return "**/pom.xml";
+        return "**/*.pom";
     }
 
     @Override
     public boolean select(String targetPath) {
         // DO NOT USE 'endsWith', which would match "someDir/junkPom.xml".
-        return targetPath.equals("pom.xml") || targetPath.endsWith("/pom.xml");
+        return targetPath.endsWith(".pom");
     }
 
     @Override


### PR DESCRIPTION
Although the jar's do go through a "cleanup" routine...  these jar's shouldn't create the pom dependencies in any case - they will never contain 3rd party resources...   And the pom's are extracted for the maven repo zip prior to the cleanup task - Stopping these from being created in the first place...