### PR TITLE
Updates for running unit tests and FATs on Java 17

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -28,7 +28,7 @@
     </dependency>
     <dependency>
       <groupId>cglib</groupId>
-      <artifactId>cglib-nodep</artifactId>
+      <artifactId>cglib</artifactId>
       <version>3.3.0</version>
     </dependency>
     <dependency>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -1,7 +1,7 @@
 biz.aQute.bnd:biz.aQute.bnd.annotation:6.3.0
 biz.aQute.bnd:biz.aQute.bnd.transform:6.3.0
 biz.aQute.bnd:biz.aQute.bnd:6.3.0
-cglib:cglib-nodep:3.3.0
+cglib:cglib:3.3.0
 ch.qos.logback:logback-classic:1.2.3
 com.beust:jcommander:1.72
 com.cloudant:cloudant-client:2.16.0

--- a/dev/com.ibm.jbatch.container/bnd.bnd
+++ b/dev/com.ibm.jbatch.container/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -133,7 +133,8 @@ instrument.classesExcludes: com/ibm/jbatch/container/internal/resources/*.class
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.mockito:mockito-all;version=1.9.5, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.logging;version=latest,\

--- a/dev/com.ibm.websphere.filetransfer/bnd.bnd
+++ b/dev/com.ibm.websphere.filetransfer/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2020 IBM Corporation and others.
+# Copyright (c) 2017,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -36,4 +36,5 @@ instrument.disabled: true
 	io.openliberty.org.apache.commons.logging;version=latest, \
 	io.openliberty.org.apache.commons.codec;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
-	cglib:cglib-nodep;version=3.3.0
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest

--- a/dev/com.ibm.websphere.security/bnd.bnd
+++ b/dev/com.ibm.websphere.security/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2020 IBM Corporation and others.
+# Copyright (c) 2017,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -97,4 +97,5 @@ Service-Component: \
   io.openliberty.org.apache.commons.logging;version=latest, \
   io.openliberty.org.apache.commons.codec;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
-	cglib:cglib-nodep;version=3.3.0
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest

--- a/dev/com.ibm.ws.adaptable.module/bnd.bnd
+++ b/dev/com.ibm.ws.adaptable.module/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -86,7 +86,8 @@ Service-Component: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.logging;version=latest, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.websphere.org.osgi.service.component;version=latest, \

--- a/dev/com.ibm.ws.appclient.boot/bnd.bnd
+++ b/dev/com.ibm.ws.appclient.boot/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -47,7 +47,8 @@ instrument.disabled: true
 	com.ibm.ws.junit.extensions;version=latest, \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	org.jmock:jmock-legacy;version=2.5.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.ws.logging;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest

--- a/dev/com.ibm.ws.artifact.loose/bnd.bnd
+++ b/dev/com.ibm.ws.artifact.loose/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -48,7 +48,8 @@ instrument.classesExcludes: com/ibm/ws/artifact/loose/internal/resources/*.class
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.logging;version=latest, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.websphere.org.osgi.service.component;version=latest, \

--- a/dev/com.ibm.ws.artifact.url/bnd.bnd
+++ b/dev/com.ibm.ws.artifact.url/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -53,7 +53,8 @@ Service-Component: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.logging;version=latest, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.websphere.org.osgi.service.component;version=latest, \

--- a/dev/com.ibm.ws.artifact.url/build.gradle
+++ b/dev/com.ibm.ws.artifact.url/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.net=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.artifact.url/test/com/ibm/ws/artifact/zip/internal/ZipFileContainerTest.java
+++ b/dev/com.ibm.ws.artifact.url/test/com/ibm/ws/artifact/zip/internal/ZipFileContainerTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014,2020 IBM Corporation and others.
+ * Copyright (c) 2014,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -107,7 +107,7 @@ public class ZipFileContainerTest {
                         m.setAccessible(true);
                         m.invoke(u, protocol, host, port, file, ref);
                     } catch (Throwable t) {
-                        throw new RuntimeException("unable to set fields on url");
+                        throw new RuntimeException("unable to set fields on url", t);
                     }
                 }
 
@@ -120,7 +120,7 @@ public class ZipFileContainerTest {
                         m.setAccessible(true);
                         m.invoke(u, protocol, host, port, authority, userInfo, path, query, ref);
                     } catch (Throwable t) {
-                        throw new RuntimeException("unable to set fields on url");
+                        throw new RuntimeException("unable to set fields on url", t);
                     }
                 }
             }, null, null, -1, -1);

--- a/dev/com.ibm.ws.channelfw/bnd.bnd
+++ b/dev/com.ibm.ws.channelfw/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -103,6 +103,7 @@ instrument.disabled: true
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.kernel.boot;version=latest

--- a/dev/com.ibm.ws.classloading_test/bnd.bnd
+++ b/dev/com.ibm.ws.classloading_test/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2018 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -37,7 +37,8 @@ test.project: true
 	com.ibm.ws.kernel.service;version=latest,\
 	com.ibm.ws.logging;version=latest,\
 	org.jmock:jmock-legacy;version=2.5.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.hamcrest:hamcrest-all;version=1.3, \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \

--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2022 IBM Corporation and others.
+    Copyright (c) 2017, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -103,12 +103,12 @@
 
 		<!-- In Java 16, the default enforcement of strong encapsulation (part of JPMS, which was introduced in Java 9) has changed from 
 			 <dash><dash>"illegal-access=permit" to <dash><dash>"illegal-access=deny".  This causes many of our FATs that use reflection to fail.  
-			 Setting up a gated property (illegal.access.permit) so that any builds that take place on Java 15+ use the JVM override 
+			 Setting up a gated property (illegal.access.permit.fat) so that any builds that take place on Java 15+ use the JVM override 
 			 <dash><dash>"add-opens java.base/java.lang=ALL-UNNAMED" which is needed for many of our FATs, but older versions will be skipped -->
-		<condition property="illegal.access.permit" value="--add-opens java.base/java.lang=ALL-UNNAMED">
+		<condition property="illegal.access.permit.fat" value="--add-opens java.base/java.lang=ALL-UNNAMED">
 			<istrue value="${is.java15.orHigher}"/>
 		</condition>
-		<property name="illegal.access.permit" value=""/>
+		<property name="illegal.access.permit.fat" value=""/>
 		
 		
 		<!-- Java 17 began the security manager's deprecation process (https://openjdk.java.net/jeps/411).
@@ -363,7 +363,7 @@
 					<jvmarg value="${framework.maxheap}" />
 					<!-- embedded trace conditionals -->
 					<jvmarg value="${framework.debug.embed.jvmarg1}" /> 
-					<jvmarg line="${illegal.access.permit}" />
+					<jvmarg line="${illegal.access.permit.fat}" />
 					<!-- Override default value of the security manager for Java 18+ -->
 					<jvmarg line="${use.java.security.manager}" />
 				</junit>

--- a/dev/com.ibm.ws.config/bnd.bnd
+++ b/dev/com.ibm.ws.config/bnd.bnd
@@ -91,7 +91,8 @@ instrument.classesExcludes: com/ibm/ws/config/internal/resources/*.class
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.service;version=latest, \
 	com.ibm.ws.logging;version=latest, \
 	com.ibm.ws.kernel.boot.logging;version=latest, \

--- a/dev/com.ibm.ws.container.service/bnd.bnd
+++ b/dev/com.ibm.ws.container.service/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2019 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -193,4 +193,5 @@ instrument.classesExcludes: com/ibm/ws/container/service/resources/*.class
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest

--- a/dev/com.ibm.ws.crypto.certificateutil/bnd.bnd
+++ b/dev/com.ibm.ws.crypto.certificateutil/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2020 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -36,4 +36,5 @@ instrument.disabled: true
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest

--- a/dev/com.ibm.ws.ejbcontainer.security/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.security/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -88,6 +88,7 @@ instrument.classesExcludes: com/ibm/ws/ejbcontainer/security/internal/resources/
 	org.jmock:jmock-legacy;version=2.5.0, \
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.mockito:mockito-all;version=1.9.5, \
 	org.hamcrest:hamcrest-all;version=1.3, \

--- a/dev/com.ibm.ws.install/bnd.bnd
+++ b/dev/com.ibm.ws.install/bnd.bnd
@@ -66,7 +66,8 @@ instrument.disabled: true
 	org.jmock:jmock;strategy=exact;version='2.5.1',\
 	org.jmock:jmock-legacy;version='2.5.0',\
 	com.ibm.ws.org.objenesis:objenesis;version='1.0',\
-	cglib:cglib-nodep;version='3.3.0',\
+	cglib:cglib;version='3.3.0',\
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	com.ibm.ws.logging;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.ws.logging.core;version=latest,\

--- a/dev/com.ibm.ws.jbatch.jms/bnd.bnd
+++ b/dev/com.ibm.ws.jbatch.jms/bnd.bnd
@@ -66,6 +66,7 @@ Include-Resource: \
     com.ibm.ws.junit.extensions;version=latest,\
     org.jmock:jmock-legacy;version=2.5.0,\
     com.ibm.ws.org.objenesis:objenesis;version=1.0,\
-    cglib:cglib-nodep;version=2.1.0.3
+    cglib:cglib;version=3.3.0,\
+    com.ibm.ws.org.objectweb.asm;version=latest
 
 instrument.classesExcludes: com/ibm/ws/jbatch/jms/internal/resources/BatchJmsMessages*.class

--- a/dev/com.ibm.ws.jmx.connector.server.rest/bnd.bnd
+++ b/dev/com.ibm.ws.jmx.connector.server.rest/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -105,7 +105,8 @@ instrument.classesExcludes: com/ibm/ws/jmx/connector/server/internal/resources/*
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.json4j;version=latest

--- a/dev/com.ibm.ws.jmx_fat/build.gradle
+++ b/dev/com.ibm.ws.jmx_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,15 +20,3 @@ task copyFeatureBundle(type: Copy) {
 autoFVT {
   dependsOn copyFeatureBundle
 }
-
-// Added copyOverrideLaunchIntoAutoFVT to copy the customized launch.xml from the override
-// directory to the autoFVT directory.  Doing so provides this FAT with the correct strong
-// encapsulation exceptions for Java 16+
-task copyOverrideLaunchIntoAutoFVT(type: Copy) {
-    mustRunAfter autoFVT
-    from project.file('override/autoFVT/src/ant')
-    into new File(autoFvtDir,"src/ant")
-    include '*.xml'
-}
-
-zipAutoFVT.dependsOn copyOverrideLaunchIntoAutoFVT

--- a/dev/com.ibm.ws.jndi.iiop/build.gradle
+++ b/dev/com.ibm.ws.jndi.iiop/build.gradle
@@ -1,5 +1,5 @@
 /* ***************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,9 @@ task stageEndorsed(type: Sync) {
 test {
     // subtests must only run as part of containing suites
     filter { excludeTestsMatching "com.ibm.ws.jndi.iiop.subtests.*" }
+
+    jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED", "--add-opens", "java.rmi/java.rmi=ALL-UNNAMED"]
+
     // pre Java 9: use the endorsed standards mechanism to override ORB API
     if (JavaVersion.current() < JavaVersion.VERSION_1_9) {
         dependsOn stageEndorsed                                      // populate endorsed dir

--- a/dev/com.ibm.ws.jndi/bnd.bnd
+++ b/dev/com.ibm.ws.jndi/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -63,7 +63,8 @@ instrument.classesExcludes: com/ibm/ws/jndi/internal/resources/*.class
     com.ibm.ws.org.objenesis:objenesis;version=1.0, \
 	org.hamcrest:hamcrest-all;version=1.3, \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.junit.extensions;version=latest, \
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.kernel.boot_fat/build.gradle
+++ b/dev/com.ibm.ws.kernel.boot_fat/build.gradle
@@ -12,21 +12,10 @@ task prebuild(type: Sync) {
 build.dependsOn 'prebuild'
 build.dependsOn ':wlp.lib.extract:assemble'
 
-// Added copyOverrideLaunchIntoAutoFVT to copy the customized launch.xml from the override
-// directory to the autoFVT directory.  Doing so provides this FAT with the correct strong
-// encapsulation exceptions for Java 16+
-task copyOverrideLaunchIntoAutoFVT(type: Copy) {
-    mustRunAfter autoFVT
-    from project.file('override/autoFVT/src/ant')
-    into new File(autoFvtDir,"src/ant")
-    include '*.xml'
-}
-
 task postrunfat(type: Delete) {
   dependsOn prebuild
   delete new File("test-applications/osgiEmbedManager/resources/WEB-INF/lib", "org.eclipse.osgi.jar")
 }
 
-zipAutoFVT.dependsOn copyOverrideLaunchIntoAutoFVT
 runfat.finalizedBy postrunfat
 

--- a/dev/com.ibm.ws.kernel.boot_test/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.boot_test/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -25,7 +25,8 @@ test.project: true
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.logging;version=latest, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.ws.logging.core;version=latest,\

--- a/dev/com.ibm.ws.kernel.boot_test/build.gradle
+++ b/dev/com.ibm.ws.kernel.boot_test/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.kernel.service/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.service/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -73,7 +73,8 @@ instrument.classesExcludes: com/ibm/ws/kernel/service/utils/resources/*.class, \
 	org.hamcrest:hamcrest-all;version=1.3, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
 	org.jmock:jmock-legacy;version=2.5.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.mockito:mockito-all;version=1.9.5, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.kernel.service/build.gradle
+++ b/dev/com.ibm.ws.kernel.service/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,6 @@
 test {
     dependsOn ':cnf:copyMavenLibs'
     doFirst {
-        jvmArgs '-javaagent:' + cnf.file('mavenlibs/jmockit-1.25.jar')
+        jvmArgs = ['-javaagent:' + cnf.file('mavenlibs/jmockit-1.25.jar'), '--add-opens', 'java.base/java.net=ALL-UNNAMED']
     }
 }

--- a/dev/com.ibm.ws.logging.osgi/bnd.bnd
+++ b/dev/com.ibm.ws.logging.osgi/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -65,7 +65,7 @@ instrument.disabled: true
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.websphere.org.osgi.service.cm;version=latest,\
 	org.eclipse.osgi;version=latest, \

--- a/dev/com.ibm.ws.logging_test/bnd.bnd
+++ b/dev/com.ibm.ws.logging_test/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@ test.project: true
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
 	org.eclipse.osgi;version=latest, \

--- a/dev/com.ibm.ws.management.security/bnd.bnd
+++ b/dev/com.ibm.ws.management.security/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -92,6 +92,7 @@ instrument.classesExcludes: com/ibm/ws/management/security/internal/resources/*.
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.websphere.security;version=latest

--- a/dev/com.ibm.ws.product.utility/bnd.bnd
+++ b/dev/com.ibm.ws.product.utility/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -43,7 +43,8 @@ instrument.disabled: true
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot.core;version=latest, \
 	com.ibm.ws.kernel.feature.core;version=latest, \
 	com.ibm.ws.kernel.boot.logging;version=latest, \

--- a/dev/com.ibm.ws.rest.handler/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -69,7 +69,8 @@ instrument.classesExcludes: com/ibm/ws/rest/handler/internal/resources/*.class
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.json4j;version=latest

--- a/dev/com.ibm.ws.rest.handler/build.gradle
+++ b/dev/com.ibm.ws.rest.handler/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.runtime.update/bnd.bnd
+++ b/dev/com.ibm.ws.runtime.update/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -54,7 +54,8 @@ instrument.classesExcludes: com/ibm/ws/runtime/update/internal/resources/*.class
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.threading;version=latest, \
 	com.ibm.ws.logging.core;version=latest, \
 	com.ibm.ws.logging;version=latest

--- a/dev/com.ibm.ws.security.auth.data.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.auth.data.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -52,7 +52,8 @@ instrument.classesExcludes: com/ibm/ws/security/auth/data/common/internal/resour
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.kernel.service;version=latest, \
 	com.ibm.ws.crypto.passwordutil;version=latest

--- a/dev/com.ibm.ws.security.auth.data/bnd.bnd
+++ b/dev/com.ibm.ws.security.auth.data/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -52,7 +52,8 @@ instrument.classesExcludes: com/ibm/ws/security/auth/data/internal/resources/*.c
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.kernel.service;version=latest, \
 	com.ibm.websphere.org.osgi.core;version=latest,\

--- a/dev/com.ibm.ws.security.authentication.builtin/bnd.bnd
+++ b/dev/com.ibm.ws.security.authentication.builtin/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -154,7 +154,8 @@ instrument.classesExcludes: com/ibm/ws/security/authentication/internal/resource
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.kernel.service;version=latest, \

--- a/dev/com.ibm.ws.security.authentication.builtin/build.gradle
+++ b/dev/com.ibm.ws.security.authentication.builtin/build.gradle
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/javax.security.auth.login=ALL-UNNAMED", 
+              "--add-opens", "java.base/java.security.cert=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.authentication.filter/bnd.bnd
+++ b/dev/com.ibm.ws.security.authentication.filter/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2022 IBM Corporation and others.
+# Copyright (c) 2018, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -49,7 +49,8 @@ instrument.classesExcludes: com/ibm/ws/security/authentication/filter/internal/r
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.authentication.tai/bnd.bnd
+++ b/dev/com.ibm.ws.security.authentication.tai/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -78,6 +78,7 @@ instrument.classesExcludes: com/ibm/ws/security/authentication/tai/internal/reso
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.kernel.boot;version=latest

--- a/dev/com.ibm.ws.security.authentication/bnd.bnd
+++ b/dev/com.ibm.ws.security.authentication/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -49,7 +49,8 @@ Service-Component:\
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.security.credentials;version=latest

--- a/dev/com.ibm.ws.security.authorization.builtin/bnd.bnd
+++ b/dev/com.ibm.ws.security.authorization.builtin/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -75,6 +75,7 @@ instrument.classesExcludes: com/ibm/ws/security/authorization/builtin/internal/r
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.security.credentials;version=latest

--- a/dev/com.ibm.ws.security.authorization.jacc.web/bnd.bnd
+++ b/dev/com.ibm.ws.security.authorization.jacc.web/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -54,7 +54,8 @@ Import-Package: \
 	org.jmock:jmock;strategy=exact;version=2.5.1,\
 	org.jmock:jmock-legacy;version=2.5.0,\
 	com.ibm.ws.org.objenesis:objenesis;version=1.0,\
-	cglib:cglib-nodep;version=3.3.0,\
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	com.ibm.ws.kernel.boot;version=latest,\
 	com.ibm.ws.logging;version=latest,\
 	com.ibm.websphere.org.osgi.core

--- a/dev/com.ibm.ws.security.client/bnd.bnd
+++ b/dev/com.ibm.ws.security.client/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2020 IBM Corporation and others.
+# Copyright (c) 2017,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -63,5 +63,6 @@ instrument.classesExcludes: com/ibm/ws/security/client/internal/resources/*.clas
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
 	org.jmock:jmock-legacy;version=2.5.0, \
-	cglib:cglib-nodep;version=3.3.0,\
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	com.ibm.ws.kernel.boot;version=latest

--- a/dev/com.ibm.ws.security.client/build.gradle
+++ b/dev/com.ibm.ws.security.client/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/javax.security.auth.login=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.common.jsonwebkey/bnd.bnd
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -64,7 +64,8 @@ instrument.classesExcludes: com/ibm/ws/security/common/jwk/internal/resources/*.
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.common/bnd.bnd
@@ -73,7 +73,8 @@ instrument.classesExcludes: com/ibm/ws/security/common/internal/resources/*.clas
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.credentials.ssotoken/bnd.bnd
+++ b/dev/com.ibm.ws.security.credentials.ssotoken/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -52,6 +52,7 @@ Service-Component: \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.logging;version=latest, \
 	com.ibm.ws.security;version=latest

--- a/dev/com.ibm.ws.security.csiv2.client/bnd.bnd
+++ b/dev/com.ibm.ws.security.csiv2.client/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -82,5 +82,6 @@ instrument.classesExcludes: com/ibm/ws/security/csiv2/client/internal/resources/
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.ssl;version=latest

--- a/dev/com.ibm.ws.security.csiv2.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.csiv2.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -114,5 +114,6 @@ instrument.classesExcludes: com/ibm/ws/security/csiv2/internal/resources/*.class
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.security.token;version=latest

--- a/dev/com.ibm.ws.security.csiv2/bnd.bnd
+++ b/dev/com.ibm.ws.security.csiv2/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -105,7 +105,8 @@ instrument.classesExcludes: com/ibm/ws/security/csiv2/server/internal/resources/
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.ws.security.credentials;version=latest, \

--- a/dev/com.ibm.ws.security.fat.common.social/bnd.bnd
+++ b/dev/com.ibm.ws.security.fat.common.social/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018,2020 IBM Corporation and others.
+# Copyright (c) 2018,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -63,7 +63,8 @@ generate.replacement: true
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.fat.common/bnd.bnd
@@ -73,7 +73,8 @@ generate.replacement: true
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.fat.common/build.gradle
+++ b/dev/com.ibm.ws.security.fat.common/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -54,4 +54,8 @@ assemble {
   dependsOn \
     formlogin,
     testmarker
+}
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED"]
 }

--- a/dev/com.ibm.ws.security.jaas.common_test/bnd.bnd
+++ b/dev/com.ibm.ws.security.jaas.common_test/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2022 IBM Corporation and others.
+# Copyright (c) 2017,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -23,7 +23,8 @@ test.project: true
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.ws.security.authentication;version=latest,\

--- a/dev/com.ibm.ws.security.jaas.common_test/build.gradle
+++ b/dev/com.ibm.ws.security.jaas.common_test/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.security.cert=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.jaspic/bnd.bnd
+++ b/dev/com.ibm.ws.security.jaspic/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -78,7 +78,8 @@ instrument.classesExcludes: com/ibm/ws/security/jaspi/internal/resources/*.class
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.container.service;version=latest, \
 	com.ibm.ws.security.registry;version=latest

--- a/dev/com.ibm.ws.security.javaeesec.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -93,7 +93,8 @@ Include-Resource: \
     org.jmock:jmock;strategy=exact;version=2.5.1, \
     org.jmock:jmock-legacy;version=2.5.0, \
     org.objenesis:objenesis;version=1.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     com.ibm.ws.cdi.interfaces;version=latest,\
     com.ibm.websphere.javaee.annotation.1.2;version=latest,\
     com.ibm.websphere.javaee.el.3.0;version=latest,\

--- a/dev/com.ibm.ws.security.javaeesec/bnd.bnd
+++ b/dev/com.ibm.ws.security.javaeesec/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -84,7 +84,8 @@ Include-Resource: \
     org.jmock:jmock;strategy=exact;version=2.5.1,\
     org.jmock:jmock-legacy;version=2.5.0,\
     org.objenesis:objenesis;version=1.0,\
-    cglib:cglib-nodep;version=3.3.0,\
+    cglib:cglib;version=3.3.0,\
+    com.ibm.ws.org.objectweb.asm;version=latest,\
     com.ibm.ws.kernel.boot;version=latest,\
     com.ibm.ws.container.service;version=latest,\
     com.ibm.ws.security.registry;version=latest,\

--- a/dev/com.ibm.ws.security.jca/bnd.bnd
+++ b/dev/com.ibm.ws.security.jca/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2022 IBM Corporation and others.
+# Copyright (c) 2017,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -88,5 +88,6 @@ Include-Resource: \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest

--- a/dev/com.ibm.ws.security.jca/build.gradle
+++ b/dev/com.ibm.ws.security.jca/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/javax.security.auth.login=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.jwt/bnd.bnd
+++ b/dev/com.ibm.ws.security.jwt/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -142,7 +142,8 @@ instrument.classesExcludes: com/ibm/ws/security/jwt/internal/resources/*.class
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.jwt/build.gradle
+++ b/dev/com.ibm.ws.security.jwt/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.security.cert=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.jwtsso.token/bnd.bnd
+++ b/dev/com.ibm.ws.security.jwtsso.token/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2021 IBM Corporation and others.
+# Copyright (c) 2017,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -60,7 +60,8 @@ Private-Package: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.jwtsso/bnd.bnd
+++ b/dev/com.ibm.ws.security.jwtsso/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2022 IBM Corporation and others.
+# Copyright (c) 2018, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -100,7 +100,8 @@ Include-Resource: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.mp.jwt.1.1.config/bnd.bnd
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1.config/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2022 IBM Corporation and others.
+# Copyright (c) 2018, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -68,7 +68,8 @@ Private-Package: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.mp.jwt.propagation/bnd.bnd
+++ b/dev/com.ibm.ws.security.mp.jwt.propagation/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -47,7 +47,8 @@ Import-Package: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.mp.jwt.proxy/bnd.bnd
+++ b/dev/com.ibm.ws.security.mp.jwt.proxy/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -44,7 +44,8 @@ Import-Package: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.mp.jwt/bnd.bnd
+++ b/dev/com.ibm.ws.security.mp.jwt/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -106,7 +106,8 @@ Include-Resource: \
     com.ibm.ws.junit.extensions;version=latest, \
     com.ibm.websphere.javaee.annotation.1.2;version=latest,\
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.oauth.jwt/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth.jwt/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -68,7 +68,8 @@ instrument.classesExcludes: com/ibm/ws/security/oauth20/jwt/resources/JwtServerM
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.2.10, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -81,7 +81,8 @@ test.project: true
 	com.ibm.ws.javaee.servlet.3.1;version='1.0.10'
     
 -testpath: \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     com.ibm.websphere.javaee.jsonp.1.1;version=latest, \
     com.ibm.ws.junit.extensions;version=latest, \
     com.ibm.ws.kernel.boot.logging;version=latest, \

--- a/dev/com.ibm.ws.security.oauth/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth/bnd.bnd
@@ -150,7 +150,8 @@ Include-Resource: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.oauth/build.gradle
+++ b/dev/com.ibm.ws.security.oauth/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.oauth_test.custom_servlets/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth_test.custom_servlets/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -30,7 +30,8 @@ test.project: true
     com.ibm.ws.security;version=latest,\
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
     org.jmock:jmock;strategy=exact;version=2.5.1,\
-    cglib:cglib-nodep;version=3.3.0,\
+    cglib:cglib;version=3.3.0,\
+    com.ibm.ws.org.objectweb.asm;version=latest,\
     org.jmock:jmock-legacy;version=2.5.0,\
     com.ibm.ws.org.objenesis:objenesis;version=1.0,\
     org.mongodb:mongo-java-driver;version=2.13.3,\

--- a/dev/com.ibm.ws.security.oauth_test.servlets/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth_test.servlets/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -28,7 +28,8 @@ test.project: true
     com.ibm.ws.security.registry;version=latest,\
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
     org.jmock:jmock;strategy=exact;version=2.5.1,\
-    cglib:cglib-nodep;version=3.3.0,\
+    cglib:cglib;version=3.3.0,\
+    com.ibm.ws.org.objectweb.asm;version=latest,\
     org.jmock:jmock-legacy;version=2.5.0,\
     com.ibm.ws.org.objenesis:objenesis;version=1.0,\
     com.ibm.websphere.javaee.transaction.1.1;version=latest,\

--- a/dev/com.ibm.ws.security.openidconnect.client/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.client/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -127,7 +127,8 @@ Include-Resource: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
 	com.ibm.ws.junit.extensions;version=latest,\
 	org.jmock:jmock-legacy;version='2.5.0',\
-	cglib:cglib-nodep;version='3.3.0',\
+	cglib:cglib;version='3.3.0',\
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	org.hamcrest:hamcrest-all;version='1.3',\
 	org.jmock:jmock-junit4;strategy=exact;version='2.5.1',\
 	org.jmock:jmock;strategy=exact;version='2.5.1',\

--- a/dev/com.ibm.ws.security.openidconnect.client/build.gradle
+++ b/dev/com.ibm.ws.security.openidconnect.client/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/bnd.bnd
@@ -91,7 +91,8 @@ Private-Package: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
 	com.ibm.ws.junit.extensions;version=latest,\
 	org.jmock:jmock-legacy;version='2.5.0',\
-	cglib:cglib-nodep;version='3.3.0',\
+	cglib:cglib;version='3.3.0',\
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	org.hamcrest:hamcrest-all;version='1.3',\
 	org.jmock:jmock-junit4;strategy=exact;version='2.5.1',\
 	org.jmock:jmock;strategy=exact;version='2.5.1',\

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/build.gradle
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/build.gradle
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/javax.net.ssl=ALL-UNNAMED",
+              "--add-opens", "java.base/java.io=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.openidconnect.server/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.server/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -171,7 +171,8 @@ Include-Resource: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
 	com.ibm.ws.junit.extensions;version=latest,\
 	org.jmock:jmock-legacy;version=2.5.0,\
-	cglib:cglib-nodep;version=3.3.0,\
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	org.hamcrest:hamcrest-all;version=1.3,\
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
 	org.jmock:jmock;strategy=exact;version=2.5.1,\

--- a/dev/com.ibm.ws.security.openidconnect.server/build.gradle
+++ b/dev/com.ibm.ws.security.openidconnect.server/build.gradle
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.security.cert=ALL-UNNAMED",
+              "--add-opens", "java.base/java.io=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.quickstart/bnd.bnd
+++ b/dev/com.ibm.ws.security.quickstart/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -51,6 +51,7 @@ instrument.classesExcludes: com/ibm/ws/security/quickstart/internal/resources/*.
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.crypto.passwordutil;version=latest

--- a/dev/com.ibm.ws.security.quickstart/build.gradle
+++ b/dev/com.ibm.ws.security.quickstart/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.security.cert=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.registry.basic/bnd.bnd
+++ b/dev/com.ibm.ws.security.registry.basic/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2018 IBM Corporation and others.
+# Copyright (c) 2017,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -62,7 +62,8 @@ instrument.classesExcludes: com/ibm/ws/security/registry/basic/internal/resource
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.kernel.service;version=latest, \
 	com.ibm.ws.crypto.passwordutil;version=latest

--- a/dev/com.ibm.ws.security.registry.basic/build.gradle
+++ b/dev/com.ibm.ws.security.registry.basic/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.security.cert=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.registry/bnd.bnd
+++ b/dev/com.ibm.ws.security.registry/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -62,6 +62,7 @@ instrument.classesExcludes: com/ibm/ws/security/registry/internal/resources/*.cl
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest
 

--- a/dev/com.ibm.ws.security.registry/build.gradle
+++ b/dev/com.ibm.ws.security.registry/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.security.cert=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.saml.wab/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.wab/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -76,7 +76,8 @@ instrument.classesExcludes: com/ibm/ws/security/saml/sso20/internal/resources/Sa
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.saml.websso.2.0/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2022 IBM Corporation and others.
+# Copyright (c) 2021, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -167,7 +167,8 @@ instrument.classesExcludes: com/ibm/ws/security/saml/sso20/internal/resources/Sa
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
 	com.ibm.ws.junit.extensions;version=latest,\
 	org.jmock:jmock-legacy;version='2.5.0',\
-	cglib:cglib-nodep;version='3.3.0',\
+	cglib:cglib;version='3.3.0',\
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	org.hamcrest:hamcrest-all;version='1.3',\
 	org.jmock:jmock-junit4;strategy=exact;version='2.5.1',\
 	org.jmock:jmock;strategy=exact;version='2.5.1',\

--- a/dev/com.ibm.ws.security.saml.websso.2.0/build.gradle
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.security.cert=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/metadata/MetadataHandlerTest.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/metadata/MetadataHandlerTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -482,6 +482,7 @@ public class MetadataHandlerTest {
                 one(servletOutputStream).write(with(any(byte[].class)), with(any(int.class)), with(any(int.class)));
                 one(servletOutputStream).flush();
                 one(servletOutputStream).close();
+                allowing(servletOutputStream).flush();  // In Java 17 close() calls flush()
 
             }
         });

--- a/dev/com.ibm.ws.security.social/bnd.bnd
+++ b/dev/com.ibm.ws.security.social/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -171,7 +171,8 @@ Include-Resource: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.social/build.gradle
+++ b/dev/com.ibm.ws.security.social/build.gradle
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED",
+              "--add-opens", "java.base/java.security.cert=ALL-UNNAMED",
+              "--add-opens", "java.base/java.net=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/internal/utils/OpenShiftUserApiUtilsTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/internal/utils/OpenShiftUserApiUtilsTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -524,6 +524,7 @@ public class OpenShiftUserApiUtilsTest extends CommonTestClass {
                     will(returnValue(serviceAccountToken));
                     one(outputStream).write(with(any(byte[].class)), with(any(int.class)), with(any(int.class)));
                     allowing(outputStream).close();
+                    allowing(outputStream).flush(); // In Java 17 close() calls flush()
                     one(httpUrlConnection).connect();
                 }
             });
@@ -553,6 +554,7 @@ public class OpenShiftUserApiUtilsTest extends CommonTestClass {
                     will(returnValue(serviceAccountToken));
                     one(outputStream).write(with(any(byte[].class)), with(any(int.class)), with(any(int.class)));
                     allowing(outputStream).close();
+                    allowing(outputStream).flush(); // In Java 17 close() calls flush()
                     one(httpUrlConnection).connect();
                 }
             });

--- a/dev/com.ibm.ws.security.spnego/bnd.bnd
+++ b/dev/com.ibm.ws.security.spnego/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -84,7 +84,8 @@ com.ibm.ws.security.spnego.internal.SpnegoHelperProxy
         org.jmock:jmock;version=2.5.1,\
         org.jmock:jmock-legacy;version=2.5.0,\
         com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-        cglib:cglib-nodep;version=3.3.0,\
+        cglib:cglib;version=3.3.0,\
+        com.ibm.ws.org.objectweb.asm;version=latest,\
         com.ibm.ws.kernel.boot.logging;version=latest,\
         com.ibm.ws.kernel.security.thread;version=latest,\
         org.mockito:mockito-all;version=1.9.5, \

--- a/dev/com.ibm.ws.security.spnego/build.gradle
+++ b/dev/com.ibm.ws.security.spnego/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.net=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.security.test.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.test.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -35,7 +35,8 @@ generate.replacement: true
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \
     com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \
@@ -46,7 +47,8 @@ generate.replacement: true
 -testpath: \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/com.ibm.ws.security.token.ltpa/bnd.bnd
+++ b/dev/com.ibm.ws.security.token.ltpa/bnd.bnd
@@ -102,7 +102,8 @@ instrument.classesExcludes: com/ibm/ws/security/token/ltpa/internal/resources/*.
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.crypto.passwordutil;version=latest

--- a/dev/com.ibm.ws.security.utility/bnd.bnd
+++ b/dev/com.ibm.ws.security.utility/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -44,7 +44,8 @@ instrument.disabled: true
 	org.jmock:jmock;strategy=exact;version=2.5.1,\
 	org.jmock:jmock-legacy;version=2.5.0,\
 	com.ibm.ws.org.objenesis:objenesis;version=1.0,\
-	cglib:cglib-nodep;version=3.3.0,\
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	com.ibm.ws.crypto.certificateutil;version=latest,\
 	com.ibm.ws.crypto.ltpakeyutil;version=latest, \
 	com.ibm.ws.kernel.service;version=latest, \

--- a/dev/com.ibm.ws.security.utility/build.gradle
+++ b/dev/com.ibm.ws.security.utility/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.springboot.utility/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.utility/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -36,7 +36,8 @@ instrument.disabled: true
 	org.jmock:jmock;strategy=exact;version=2.5.1,\
 	org.jmock:jmock-legacy;version=2.5.0,\
 	com.ibm.ws.org.objenesis:objenesis;version=1.0,\
-	cglib:cglib-nodep;version=3.3.0,\
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	com.ibm.ws.kernel.service;version=latest, \
 	com.ibm.ws.kernel.boot.core;version=latest, \
 	com.ibm.ws.logging;version=latest

--- a/dev/com.ibm.ws.springboot.utility/build.gradle
+++ b/dev/com.ibm.ws.springboot.utility/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.ssl/bnd.bnd
+++ b/dev/com.ibm.ws.ssl/bnd.bnd
@@ -87,5 +87,6 @@ instrument.disabled: true
 	com.ibm.ws.junit.extensions;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest

--- a/dev/com.ibm.ws.ssl/build.gradle
+++ b/dev/com.ibm.ws.ssl/build.gradle
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED",
+              "--add-opens", "java.base/java.security.cert=ALL-UNNAMED",
+              "--add-opens", "java.base/java.security=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.transaction/bnd.bnd
+++ b/dev/com.ibm.ws.transaction/bnd.bnd
@@ -132,7 +132,8 @@ instrument.classesExcludes: com/ibm/ws/transaction/services/TransactionMessages*
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\

--- a/dev/com.ibm.ws.transport.http/bnd.bnd
+++ b/dev/com.ibm.ws.transport.http/bnd.bnd
@@ -148,7 +148,8 @@ instrument.classesExcludes: \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
 	com.ibm.ws.logging;version=latest, \

--- a/dev/com.ibm.ws.transport.iiop.open_fat/build.gradle
+++ b/dev/com.ibm.ws.transport.iiop.open_fat/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 }
 
 task copyBundles {
+  dependsOn assemble
   enabled project.file('test-bundles').exists()
   doLast {
     new File(project.buildDir, 'buildfiles').eachLine { String line ->

--- a/dev/com.ibm.ws.transport.iiop.open_fat/override/autoFVT/src/ant/launch-overrides.xml
+++ b/dev/com.ibm.ws.transport.iiop.open_fat/override/autoFVT/src/ant/launch-overrides.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022 IBM Corporation and others.
+    Copyright (c) 2022, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
         IBM Corporation - initial API and implementation
  -->
 <project>
-    <condition property="illegal.access.permit" value="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED">
+    <condition property="illegal.access.permit.fat" value="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.rmi/java.rmi=ALL-UNNAMED">
         <not>
             <equals arg1="1.8" arg2="${java.specification.version}" />
         </not>

--- a/dev/com.ibm.ws.webcontainer.security.feature/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security.feature/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2020 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -87,7 +87,8 @@ instrument.classesExcludes: com/ibm/ws/webcontainer/security/feature/resources/*
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
 	org.jmock:jmock-legacy;version=2.5.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.container.service;version=latest, \
 	com.ibm.websphere.security;version=latest, \

--- a/dev/com.ibm.ws.webcontainer.security/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2022 IBM Corporation and others.
+# Copyright (c) 2017,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -115,7 +115,8 @@ instrument.classesExcludes: com/ibm/ws/webcontainer/security/resources/*.class
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.junit.extensions;version=latest, \
 	com.ibm.ws.org.apache.httpcomponents;version=latest, \
 	io.openliberty.org.apache.commons.logging;version=latest, \

--- a/dev/com.ibm.ws.webcontainer.security/build.gradle
+++ b/dev/com.ibm.ws.webcontainer.security/build.gradle
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED",
+              "--add-opens", "java.base/java.security.cert=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/bnd.bnd
@@ -122,7 +122,8 @@ instrument.disabled: true
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
     com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     com.ibm.ws.threading,\
     com.ibm.websphere.javaee.annotation.1.2;version=latest,\
     com.ibm.ws.javaee.dd.common;version=latest,\

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/bnd.bnd
@@ -86,7 +86,8 @@ Import-Package: \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
     com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     com.ibm.websphere.javaee.annotation.1.2;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\
     com.ibm.ws.javaee.dd.common;version=latest, \

--- a/dev/com.ibm.ws.webcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer/bnd.bnd
@@ -215,6 +215,7 @@ instrument.disabled: true
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
     com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     com.ibm.ws.kernel.boot;version=latest, \
     com.ibm.ws.javaee.ddmodel;version=latest

--- a/dev/com.ibm.ws.webcontainer/build.gradle
+++ b/dev/com.ibm.ws.webcontainer/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -29,4 +29,8 @@ compileJava {
             }
         }
     }
+}
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED"]
 }

--- a/dev/com.ibm.ws.webserver.plugin.utility/bnd.bnd
+++ b/dev/com.ibm.ws.webserver.plugin.utility/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2018 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -47,4 +47,5 @@ testsrc: test/src
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
     com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-    cglib:cglib-nodep;version=3.3.0
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest

--- a/dev/com.ibm.ws.webserver.plugin.utility/build.gradle
+++ b/dev/com.ibm.ws.webserver.plugin.utility/build.gradle
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.io=ALL-UNNAMED",
+              "--add-opens", "java.base/java.security.cert=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.wsbytebuffer/bnd.bnd
+++ b/dev/com.ibm.ws.wsbytebuffer/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -61,6 +61,7 @@ instrument.disabled: true
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
-	cglib:cglib-nodep;version=3.3.0, \
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest, \
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.kernel.boot;version=latest

--- a/dev/com.ibm.ws.wssecurity.3.4.1/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -143,7 +143,8 @@ instrument.classesExcludes: com/ibm/ws/wssecurity/resources/*.class
 	org.jmock:jmock-junit4;strategy=exact;version='2.5.1',\
 	org.jmock:jmock;strategy=exact;version='2.5.1',\
 	com.ibm.ws.org.objenesis:objenesis;version='1.0',\
-	cglib:cglib-nodep;version='3.3.0',\
+	cglib:cglib;version='3.3.0',\
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	org.hamcrest:hamcrest-all;version='1.3',\
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.componenttest.2.0,\

--- a/dev/fattest.simplicity/autoFVT-defaults/TestBuild.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/TestBuild.xml
@@ -22,6 +22,7 @@
 
 	<!-- Import standard launch tasks into this project -->
 	<import file="${basedir}/src/ant/properties.xml" />
+	<include file="${basedir}/src/ant/launch-overrides.xml" optional="true" />
 	<import file="${basedir}/src/ant/launch.xml" />
 
 	<!-- Executable targets -->

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2022 IBM Corporation and others.
+    Copyright (c) 2017, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
         IBM Corporation - initial API and implementation
  -->
 <project name="standard.launch.tasks">
-    <include file="./launch-overrides.xml" optional="true" />
 
 	<!-- This is needed for Moonstone autowas to work -->
 	<target name="init-test-tasks-autowas" unless="inited-test-tasks">
@@ -199,12 +198,12 @@
 		
 		<!-- In Java 16, the default enforcement of strong encapsulation (part of JPMS, which was introduced in Java 9) has changed from 
 			 <dash><dash>"illegal-access=permit" to <dash><dash>"illegal-access=deny".  This causes many of our FATs that use reflection to fail.  
-			 Setting up a gated property (illegal.access.permit) so that any builds that take place on Java 15+ use the JVM override 
+			 Setting up a gated property (illegal.access.permit.fat) so that any builds that take place on Java 15+ use the JVM override 
 			 <dash><dash>"add-opens java.base/java.lang=ALL-UNNAMED" which is needed for many of our FATs, but older versions will be skipped -->
-		<condition property="illegal.access.permit" value="--add-opens java.base/java.lang=ALL-UNNAMED">
+		<condition property="illegal.access.permit.fat" value="--add-opens java.base/java.lang=ALL-UNNAMED">
 			<istrue value="${is.java15.orHigher}"/>
 		</condition>
-		<property name="illegal.access.permit" value=""/>
+		<property name="illegal.access.permit.fat" value=""/>
 		
 		<!-- Java 17 began the security manager's deprecation process (https://openjdk.java.net/jeps/411).
 			     In Java 18, the `java.security.manager` system property's default changed from `allow` to `disallow`, which causes our build process to fail.  
@@ -544,7 +543,7 @@
 					<jvmarg value="${framework.debug.embed.jvmarg1}" />
 					<jvmarg line="${extra.vmargs}" />
 					<jvmarg line="${zos.extra.vmargs}" />
-					<jvmarg line="${illegal.access.permit}" />
+					<jvmarg line="${illegal.access.permit.fat}" />
 					<!-- Override default value of the security manager for Java 18+ -->
 					<jvmarg line="${use.java.security.manager}" />
 				</junit>

--- a/dev/io.openliberty.grpc.1.0.internal.client/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal.client/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -100,7 +100,8 @@ instrument.disabled: true
   org.jmock:jmock;strategy=exact;version=2.5.1, \
   ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
   com.ibm.ws.junit.extensions;version=latest, \
-  cglib:cglib-nodep;version=3.3.0, \
+  cglib:cglib;version=3.3.0, \
+  com.ibm.ws.org.objectweb.asm;version=latest, \
   org.jmock:jmock-legacy;version=2.5.0, \
   com.ibm.ws.org.objenesis:objenesis;version=1.0, \
   com.ibm.ws.logging;version=latest, \

--- a/dev/io.openliberty.grpc.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -80,7 +80,8 @@ Include-Resource: \
     org.jmock:jmock;strategy=exact;version=2.5.1, \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
     com.ibm.ws.org.objenesis:objenesis;version=1.0, \
     com.ibm.ws.logging;version=latest, \

--- a/dev/io.openliberty.netty.internal.impl/bnd.bnd
+++ b/dev/io.openliberty.netty.internal.impl/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -63,7 +63,8 @@ Private-Package: \
     org.jmock:jmock;strategy=exact;version=2.5.1, \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
     com.ibm.ws.org.objenesis:objenesis;version=1.0, \
     com.ibm.ws.logging;version=latest, \

--- a/dev/io.openliberty.security.common.jwt/bnd.bnd
+++ b/dev/io.openliberty.security.common.jwt/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -48,7 +48,8 @@ Private-Package: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file,\
     com.ibm.ws.junit.extensions;version=latest,\
     org.jmock:jmock-legacy;version=2.5.0,\
-    cglib:cglib-nodep;version=3.3.0,\
+    cglib:cglib;version=3.3.0,\
+    com.ibm.ws.org.objectweb.asm;version=latest,\
     org.hamcrest:hamcrest-all;version=1.3,\
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
     org.jmock:jmock;strategy=exact;version=2.5.1,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/bnd.bnd
@@ -74,7 +74,8 @@ src: src, resources
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
 	com.ibm.ws.junit.extensions;version=latest,\
 	org.jmock:jmock-legacy;version=2.5.0,\
-	cglib:cglib-nodep;version=3.3.0,\
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	org.hamcrest:hamcrest-all;version=1.3,\
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
 	org.jmock:jmock;strategy=exact;version=2.5.1,\

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/bnd.bnd
@@ -72,7 +72,8 @@ instrument.classesExcludes: io/openliberty/security/jakartasec/internal/resource
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
     org.jmock:jmock;strategy=exact;version=2.5.1,\
     com.ibm.ws.org.objenesis:objenesis;version=1.0,\
-    cglib:cglib-nodep;version=3.3.0,\
+    cglib:cglib;version=3.3.0,\
+    com.ibm.ws.org.objectweb.asm;version=latest,\
     org.hamcrest:hamcrest-all;version=1.3,\
     com.ibm.json4j;version=latest,\
     io.openliberty.jakarta.security.3.0;version=latest

--- a/dev/io.openliberty.security.mp.jwt.1.2.config/bnd.bnd
+++ b/dev/io.openliberty.security.mp.jwt.1.2.config/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -66,7 +66,8 @@ Private-Package: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/io.openliberty.security.mp.jwt.2.1.config/bnd.bnd
+++ b/dev/io.openliberty.security.mp.jwt.2.1.config/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -70,7 +70,8 @@ Private-Package: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -66,7 +66,8 @@ Export-Package: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
 	com.ibm.ws.junit.extensions;version=latest,\
 	org.jmock:jmock-legacy;version=2.5.0,\
-	cglib:cglib-nodep;version=3.3.0,\
+	cglib:cglib;version=3.3.0, \
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	org.hamcrest:hamcrest-all;version=1.3,\
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
 	org.jmock:jmock;strategy=exact;version=2.5.1,\

--- a/dev/io.openliberty.security.oidcclientcore.internal/build.gradle
+++ b/dev/io.openliberty.security.oidcclientcore.internal/build.gradle
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/javax.net.ssl=ALL-UNNAMED",
+              "--add-opens", "java.base/java.security=ALL-UNNAMED"]
+}

--- a/dev/io.openliberty.wssecurity/bnd.bnd
+++ b/dev/io.openliberty.wssecurity/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -45,7 +45,8 @@ Import-Package: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \
     org.jmock:jmock-legacy;version=2.5.0, \
-    cglib:cglib-nodep;version=3.3.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
     org.hamcrest:hamcrest-all;version=1.3, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -213,6 +213,13 @@ task autoFVT {
       from new File(project(':fattest.simplicity').buildDir, '/autoFVT-defaults')
       include '**/*'
       into autoFvtDir
+    }
+
+    // Copy override autoFVT files in the current project
+    copy {
+      from project.file('override/autoFVT/src/ant')
+      include '*.xml'
+      into new File(autoFvtDir,"src/ant")
     }
 
     // Create a fat.bnd.properties file that contains metadata about the FAT


### PR DESCRIPTION
- Change from using cglib-nodep to use cglib and adding latest asm version so that it works with Java 17.  This is needed for tests that use jmock
- Add --add-opens jvm arguments to unit test executions to be able to run with Java 17.  This is needed for jmock tests that end up mocking classes that end up needing to do reflection into JDK class and for tests that use reflection.
- Update test cases that fail on Java 17 because when calling close, flush is called on Java 17 where it isn't on Java 11.
- Make com.ibm.ws.transport.iiop.open_fat work with Java 17 by adding additional --add-opens to launch-overrides.xml and actually include it in the autoFVT directory so that it is used.