### PR TITLE
JAX-WS: Prep CXF Databinding JAXB project source for CXF 3.5

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/src/org/apache/cxf/jaxb/JAXBContextInitializer.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/src/org/apache/cxf/jaxb/JAXBContextInitializer.java
@@ -324,7 +324,7 @@ class JAXBContextInitializer extends ServiceModelVisitor {
                 && ReflectionUtil.getDeclaredConstructors(claz).length > 0
                 && !Modifier.isAbstract(claz.getModifiers())) {
                 if (LOG.isLoggable(Level.FINEST)) {
-                    LOG.finest("Class " + claz.getName() + " does not have a default constructor which JAXB requires.");
+                    LOG.finest("Class " + claz.getName() + " does not have a default constructor which JAXB requires."); // Liberty Change: Finest Log Level
                 }
                 Object factory = createFactory(claz);
                 unmarshallerProperties.put("com.sun.xml.bind.ObjectFactory", factory);

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/src/org/apache/cxf/jaxb/attachment/JAXBAttachmentSchemaValidationHack.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/src/org/apache/cxf/jaxb/attachment/JAXBAttachmentSchemaValidationHack.java
@@ -37,6 +37,7 @@ import org.apache.cxf.phase.Phase;
 /**
  *
  */
+ // Liberty Changes - Could potentially be removed when updating to CXF 3.5.5
 public final class JAXBAttachmentSchemaValidationHack extends AbstractPhaseInterceptor<Message> {
     public static final JAXBAttachmentSchemaValidationHack INSTANCE
         = new JAXBAttachmentSchemaValidationHack();

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/src/org/apache/cxf/jaxb/io/DataReaderImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/src/org/apache/cxf/jaxb/io/DataReaderImpl.java
@@ -48,7 +48,7 @@ import org.apache.cxf.service.model.MessagePartInfo;
 public class DataReaderImpl<T> extends JAXBDataBase implements DataReader<T> {
     private static final Logger LOG = LogUtils.getLogger(JAXBDataBinding.class);
     JAXBDataBinding databinding;
-    boolean unwrapJAXBElement = true;
+    boolean unwrapJAXBElement;
     ValidationEventHandler veventHandler;
     boolean setEventHandler = true;
 
@@ -109,10 +109,9 @@ public class DataReaderImpl<T> extends JAXBDataBase implements DataReader<T> {
 
     private Unmarshaller createUnmarshaller() {
         try {
-            Unmarshaller um = null;
             // Liberty change begin
             // Move the logic that is 
-            um = databinding.getJAXBUnmarshaller(setEventHandler, setEventHandler ? new WSUIDValidationHandler(veventHandler) : null);
+            Unmarshaller um = databinding.getJAXBUnmarshaller(setEventHandler, setEventHandler ? new WSUIDValidationHandler(veventHandler) : null);
             /*if (databinding.getUnmarshallerListener() != null) {
                 um.setListener(databinding.getUnmarshallerListener());
             }
@@ -146,9 +145,8 @@ public class DataReaderImpl<T> extends JAXBDataBase implements DataReader<T> {
 
     public Object read(MessagePartInfo part, T reader) {
         boolean honorJaxbAnnotation = honorJAXBAnnotations(part);
-        Annotation[] anns = null;
         if (honorJaxbAnnotation) {
-            anns = getJAXBAnnotation(part);
+            Annotation[] anns = getJAXBAnnotation(part);
             if (anns.length > 0) {
                 // RpcLit will use the JAXB Bridge to unmarshall part message when it is
                 // annotated with @XmlList,@XmlAttachmentRef,@XmlJavaTypeAdapter

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/src/org/apache/cxf/jaxb/io/DataWriterImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/src/org/apache/cxf/jaxb/io/DataWriterImpl.java
@@ -21,7 +21,7 @@ package org.apache.cxf.jaxb.io;
 
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Array;
+import java.lang.reflect.Array; // Liberty Change
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -117,19 +117,19 @@ public class DataWriterImpl<T> extends JAXBDataBase implements DataWriter<T> {
     }
 
     public Marshaller createMarshaller(Object elValue, MessagePartInfo part) {
-        Class<?> cls = null;
-        if (part != null) {
-            cls = part.getTypeClass();
-        }
-
-        if (cls == null) {
-            cls = null != elValue ? elValue.getClass() : null;
-        }
-
-        if (cls != null && cls.isArray() && elValue instanceof Collection) {
-            Collection<?> col = (Collection<?>)elValue;
-            elValue = col.toArray((Object[])Array.newInstance(cls.getComponentType(), col.size()));
-        }
+        //Class<?> cls = null;
+        //if (part != null) {
+        //    cls = part.getTypeClass();
+        //}
+        //
+        //if (cls == null) {
+        //    cls = null != elValue ? elValue.getClass() : null;
+        //}
+        //
+        //if (cls != null && cls.isArray() && elValue instanceof Collection) {
+        //    Collection<?> col = (Collection<?>)elValue;
+        //    elValue = col.toArray((Object[])Array.newInstance(cls.getComponentType(), col.size()));
+        //}
         Marshaller marshaller;
         try {
             // Liberty change begin


### PR DESCRIPTION
This PR makes the following changes to the `com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2`project:

- Brings in all non-conflicting changes to the sources overlays from the 3.5.5 version of CXF
- Properly notates all liberty specific changes to the overlays
- Indicates changes that could be committed back to CXF 3.5 in future releases
- Indicates what overlays could be removed once the 3.5.5 update is complete.
