### PR TITLE
Define partial order for library change notifications

### DIFF
--- a/dev/com.ibm.ws.classloading.bells/src/com/ibm/ws/classloading/bells/internal/Bell.java
+++ b/dev/com.ibm.ws.classloading.bells/src/com/ibm/ws/classloading/bells/internal/Bell.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -41,6 +41,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
 import org.osgi.framework.Filter;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.PrototypeServiceFactory;
@@ -72,8 +73,10 @@ import com.ibm.wsspi.library.LibraryChangeListener;
  * meta-inf/services which are specified in the library as OSGi services.
  * This allows such services to be consumed by bundles in liberty features.
  */
-@Component(name = "com.ibm.ws.classloading.bell", configurationPolicy = ConfigurationPolicy.REQUIRE)
-public class Bell implements LibraryChangeListener {
+@Component(name = "com.ibm.ws.classloading.bell", configurationPolicy = ConfigurationPolicy.REQUIRE,
+           property = { Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE })
+ public class Bell implements LibraryChangeListener {
+
     private static final TraceComponent tc = Tr.register(Bell.class);
     private static final char COMMENT_CHAR = '#';
 

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/library/internal/SharedLibraryImpl.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/library/internal/SharedLibraryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -52,8 +52,6 @@ import com.ibm.wsspi.library.LibraryChangeListener;
  */
 public class SharedLibraryImpl implements Library, SpiLibrary {
     private static final TraceComponent tc = Tr.register(SharedLibraryImpl.class);
-
-    private static final LibraryChangeListener[] EMPTY_LIBRARY_LISTENERS = {};
 
     private volatile boolean deleted;
 
@@ -254,7 +252,12 @@ public class SharedLibraryImpl implements Library, SpiLibrary {
             return;
         }
 
-        for (LibraryChangeListener listener : ls.getServices(EMPTY_LIBRARY_LISTENERS)) {
+        // Call method getTracked() to obtain the map of listeners (ServiceReferences)
+        // sorted in order of {descending SERVICE_RANKING X ascending SERVICE_ID}.
+        // That is, the first entry is the service with the highest ranking and the
+        // lowest service id. Use SERVICE_RANKING to define a partial order for library
+        // change notifications.
+        for (LibraryChangeListener listener : ls.getTracked().values()) {
             if (deleted) {
                 return;
             }

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/publish/servers/com.ibm.ws.jpa.container.fat.modifyconfig/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/publish/servers/com.ibm.ws.jpa.container.fat.modifyconfig/bootstrap.properties
@@ -1,5 +1,5 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:Bell=all:JPA=all:ClassLoadingService=all:SharedLibrary=all
+com.ibm.ws.logging.trace.specification=*=info:Bell=all:JPA=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 # Exempt from java 2 security because this FAT does dynamic config


### PR DESCRIPTION
This PR establishes a partial order on library change notifications within method `SharedLIbraryImpl.notifyListeners()`, where the BELL library change listener will be notified last whenever the user updates a library's configuration or content.

The change fixes test `com.ibm.ws.jpaContainer.fat.JPAContainerModifyConfigTest.testModifyLibraryFiles()`, which fails with a NPE because the BELL feature runtime uses a stale library classloader to load the PersistenceProvider service impl class from the BELL's library after the library fileset (content) had been updated. Ultimately, the `ClassLoadingService` returns a stale loader via `getSharedLibraryClassloader()` because the BELL runtime processes the library change notification before the ClassLoadingService does.
