### PR TITLE
Update tests due to 3hrs limit on Fyre Windows

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/FATSuite.java
@@ -20,6 +20,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.websphere.simplicity.config.Logging;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.fat.util.FatLogHandler;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.AsyncReadListenerHttpUnit;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.AsyncWriteListenerHttpUnit;
@@ -49,6 +51,7 @@ import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.JavaInfo;
+import componenttest.topology.impl.LibertyServer;
 
 /**
  * Servlet 3.1 Tests with repeat for Servlet 4.0
@@ -91,7 +94,7 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests repeat;
 
-    private static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
+    public static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
 
     static {
         // EE10 requires Java 11.  If we only specify EE10 for lite mode it will cause no tests to run which causes an error.
@@ -114,6 +117,18 @@ public class FATSuite {
                             .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly())
                             .andWith(FeatureReplacementAction.EE9_FEATURES());
         }
+    }
+
+    //Due to Fyre performance on Windows, use this method to set the server trace to the mininum
+    public static void setDynamicTrace(LibertyServer server, String trace) throws Exception {
+        Logging loggingObj;
+        ServerConfiguration serverConfig = server.getServerConfiguration();
+        loggingObj = serverConfig.getLogging();
+        loggingObj.setTraceSpecification(trace);
+
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(serverConfig);
+        server.waitForConfigUpdateInLogUsingMark(null);
     }
 
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/AsyncReadListenerHttpUnit.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/AsyncReadListenerHttpUnit.java
@@ -4,11 +4,8 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -35,6 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -81,6 +79,10 @@ public class AsyncReadListenerHttpUnit {
 
         // Start the server and use the class name so we can find logs easily.
         server.startServer(AsyncReadListenerHttpUnit.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(server, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/AsyncWriteListenerHttpUnit.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/AsyncWriteListenerHttpUnit.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -33,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -94,6 +92,10 @@ public class AsyncWriteListenerHttpUnit {
 
         // Start the server and use the class name so we can find logs easily.
         server.startServer(AsyncWriteListenerHttpUnit.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(server, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/CDINoInjectionTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/CDINoInjectionTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -25,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 import com.meterware.httpunit.GetMethodWebRequest;
 import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
@@ -69,6 +67,10 @@ public class CDINoInjectionTest {
 
         // Start the server and use the class name so we can find logs easily.
         server.startServer(CDINoInjectionTest.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(server, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/CDITests.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/CDITests.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -25,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 import com.meterware.httpunit.GetMethodWebRequest;
 import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
@@ -87,6 +85,10 @@ public class CDITests {
 
         // Start the server and use the class name so we can find logs easily.
         server.startServer(CDITests.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(server, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/FormLoginReadListenerTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/FormLoginReadListenerTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -38,6 +35,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.webcontainer.security.test.servlets.PostParamsClient;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -77,6 +75,9 @@ public class FormLoginReadListenerTest {
         assertNotNull("CWWKS4105I LTPA configuration message not found.",
                       server.waitForStringInLogUsingMark("CWWKS4105I.*"));
 
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(server, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/HttpSessionAttListenerHttpUnit.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/HttpSessionAttListenerHttpUnit.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -25,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -57,6 +55,10 @@ public class HttpSessionAttListenerHttpUnit {
 
         // Start the server and use the class name so we can find logs easily.
         server.startServer(HttpSessionAttListenerHttpUnit.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(server, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/JSPServerHttpUnit.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/JSPServerHttpUnit.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -27,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 import com.meterware.httpunit.PostMethodWebRequest;
 import com.meterware.httpunit.UploadFileSpec;
 import com.meterware.httpunit.WebConversation;
@@ -75,6 +73,10 @@ public class JSPServerHttpUnit {
 
         // Start the server and use the class name so we can find logs easily.
         jspServer.startServer(JSPServerHttpUnit.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(jspServer, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/NBMultiReadTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/NBMultiReadTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -30,6 +27,7 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -65,6 +63,10 @@ public class NBMultiReadTest {
 
         // Start the server and use the class name so we can find logs easily.
         server.startServer(NBMultiReadTest.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(server, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/PrivateHeaderTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/PrivateHeaderTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -26,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -69,6 +67,10 @@ public class PrivateHeaderTest {
 
         // Start the server and use the class name so we can find logs easily.
         server.startServer(PrivateHeaderTest.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(server, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/UpgradeReadListenerHttpUnit.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/UpgradeReadListenerHttpUnit.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -34,6 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -69,6 +67,10 @@ public class UpgradeReadListenerHttpUnit {
 
         // Start the server and use the class name so we can find logs easily.
         server.startServer(UpgradeReadListenerHttpUnit.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(server, "*=info=enabled");
+        }
     }
 
     //After each test is complete it will add it's connection to the list of connections to close. Then when the tests are all done it will close them all at once

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/UpgradeReadWriteTimeoutHttpUnit.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/UpgradeReadWriteTimeoutHttpUnit.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -30,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -72,6 +70,10 @@ public class UpgradeReadWriteTimeoutHttpUnit {
 
         // Start the server and use the class name so we can find logs easily.
         readWriteUpgradeTimeoutServer.startServer(UpgradeReadWriteTimeoutHttpUnit.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(readWriteUpgradeTimeoutServer, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/UpgradeWriteListenerHttpUnit.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/UpgradeWriteListenerHttpUnit.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -31,6 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -65,6 +63,10 @@ public class UpgradeWriteListenerHttpUnit {
 
         // Start the server and use the class name so we can find logs easily.
         server.startServer(UpgradeWriteListenerHttpUnit.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(server, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/VHServerHttpUnit.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/VHServerHttpUnit.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -26,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 import com.meterware.httpunit.GetMethodWebRequest;
 import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
@@ -82,6 +80,10 @@ public class VHServerHttpUnit {
 
         // Start the server and use the class name so we can find logs easily.
         altHostServer.startServer(VHServerHttpUnit.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(altHostServer, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServerHttpUnit.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServerHttpUnit.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -29,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 import com.meterware.httpunit.GetMethodWebRequest;
 import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
@@ -76,6 +74,10 @@ public class WCServerHttpUnit {
 
         // Start the server and use the class name so we can find logs easily.
         server.startServer(WCServerHttpUnit.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(server, "*=info=enabled");
+        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServerTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServerTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServletContextUnsupportedOperationExceptionTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServletContextUnsupportedOperationExceptionTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
@@ -25,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
@@ -61,6 +59,10 @@ public class WCServletContextUnsupportedOperationExceptionTest {
         ShrinkHelper.exportDropinAppToServer(server, TestProgrammaticListenerApp);
 
         server.startServer(WCServletContextUnsupportedOperationExceptionTest.class.getSimpleName() + ".log");
+
+        if (FATSuite.isWindows) {
+            FATSuite.setDynamicTrace(server, "*=info=enabled");
+        }
     }
 
     @AfterClass


### PR DESCRIPTION
bb causes by Fyre performance on Windows > 3hrs allowance.

Strategy : set the trace to just `*info=enabled` and hopefully it will improve the execution time on Windows.