### PR TITLE
server version command now uses server.env of server

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1798,7 +1798,7 @@ case "$ACTION" in
   ;;
 
   version)
-    installEnv
+    serverEnv
     javaCmd '' --version
   ;;  
   

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -218,7 +218,7 @@ goto:eof
 goto:eof
 
 :version
-  call:installEnv
+  call:serverEnv
   !JAVA_CMD_QUOTED! !JAVA_PARAMS_QUOTED! --version
   set RC=%errorlevel%
   call:javaCmdResult
@@ -599,7 +599,7 @@ goto:eof
   call:readServerEnv "%WLP_INSTALL_DIR%\etc\server.env"
   call:installEnvDefaults
 
-  call:readServerEnv "%WLP_USER_DIR%/shared/server.env"
+  call:readServerEnv "%WLP_USER_DIR%\shared\server.env"
   call:readServerEnv "%SERVER_CONFIG_DIR%\server.env"
   call:serverEnvDefaults
 goto:eof

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerEnvTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerEnvTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.kernel.boot;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -50,6 +51,19 @@ public class ServerEnvTest {
 
     private static LibertyServer server;
 
+    // Describes the 3 locations for the server.env file
+    private enum ServerEnvType {
+        ETC("etc/server.env"),
+        SHARED("shared/server.env"),
+        SERVER("usr/servers/" + SERVER_NAME + "/server.env");
+
+        public final String path;
+
+        private ServerEnvType(String path) {
+            this.path = path;
+        }
+    }
+
     @Rule
     public TestName testName = new TestName();
 
@@ -73,7 +87,7 @@ public class ServerEnvTest {
     @After
     public void after() throws Exception {
         if (server.isStarted()) {
-            logDirectoryContents("after", new File(server.getLogsRoot())); // DEBUG
+            displayDirectoryContents("after", new File(server.getLogsRoot())); // DEBUG
             server.stopServer();
         }
     }
@@ -95,12 +109,12 @@ public class ServerEnvTest {
     @Test
     public void testVariableExpansionInServerEnv() throws Exception {
         final String METHOD_NAME = "testVariableExpansionInServerEnv";
-        Log.entering(c, METHOD_NAME);
+        Log.info(c, METHOD_NAME, "ENTER");
 
         if (OS.contains("os/390") || OS.contains("z/os") || OS.contains("zos")) {
             return;
         }
-        varsExpandInServerEnv(true);
+        varsExpandInServerEnv(true, ServerEnvType.ETC);
 
         Log.exiting(c, METHOD_NAME);
     }
@@ -124,57 +138,173 @@ public class ServerEnvTest {
     @Test
     public void testVariableExpansionInServerEnvWhenExpansionNotEnabled() throws Exception {
         final String METHOD_NAME = "testVariableExpansionInServerEnvWhenExpansionNotEnabled";
-        Log.entering(c, METHOD_NAME);
+        Log.info(c, METHOD_NAME, "ENTER");
         if (OS.contains("win") || OS.contains("os/390") || OS.contains("z/os") || OS.contains("zos")) {
             return;
         }
-        varsExpandInServerEnv(false);
+        varsExpandInServerEnv(false, ServerEnvType.ETC);
 
         Log.exiting(c, METHOD_NAME);
     }
 
     /**
-     * Set a variable in server.env using a pre-set environment
-     * variable as the value. In this case we set the LOG_FILE
-     * variable which provides a new name for "console.log".
-     * Then check whether the log file with the new name exists
-     * after starting the server.
+     * If server name is specified with the "server version" command. for example
+     * server version MyServer
+     * , the server.env file of the specified server should be read.
+     * The test creates a server.env file for the server, and adds an echo "hello world"
+     * statement in the file. On Linux systems the server.env is run as a script. So
+     * the hello world should be displayed in the output.
      *
-     * @param expansionEnabled if true, the new log file should exist, otherwise it should not
      * @throws Exception
      */
-    public void varsExpandInServerEnv(boolean expansionEnabled) throws Exception {
+    @Test
+    public void testVersionCommandReadsServerEnvOfServer() throws Exception {
+
+        final String METHOD_NAME = "testVersionCommandReadsServerEnvOfServer";
+        final boolean EXPANSION_ENABLED = true; // ensures server.env will be execute
+        Log.info(c, METHOD_NAME, "ENTER");
+
+        // Implementation will not work on Windows because server.env is not executed on Windows.
+        // There are some ASCII - EBCDIC issues that would have to be worked out for Z/OS.
+        if (!OS.contains("linux") && !OS.contains("mac os")) {
+            Log.info(c, METHOD_NAME, "Returning.  Test not valid on [{0}]", OS);
+            Log.exiting(c, METHOD_NAME);
+            return;
+        }
+
+        // Start the server passing null for the environment variable properties.
+        // We don't need the properties set for this test.
+        startServer(null);
+        assertTrue("the server should have been started", server.isStarted());
+
+        // Create file contents for server.env.   Contents will echo Hello World
+        final String HELLO_WORLD = "Hello World";
+        String fileContents = createFileContentsForServerEnv(EXPANSION_ENABLED, "echo " + HELLO_WORLD);
+
+        // Create server.env in the server directory.
+        File serverEnvFile = createServerEnvFile(fileContents, ServerEnvType.SERVER.path);
+        assertNotNull("The server.env file was not created. Null returned.", serverEnvFile);
+        assertTrue("The server.env file was not created.", serverEnvFile.exists());
+
+        // execute "server version <SERVER_MAME> and check output for hello world message
+        String output = executeServerVersionCommand();
+        assertTrue("The server's server.env did not get invoked as expected. "
+                   + HELLO_WORLD + "not found in output", output.contains(HELLO_WORLD));
+
+        testCleanUp(METHOD_NAME, serverEnvFile);
+        Log.exiting(c, METHOD_NAME);
+    }
+
+    /**
+     * Set the LOG_FILE variable in the server.env file.
+     * The value of the LOG_FILE will be a reference to an environment variable.
+     * For example:
+     * LOG_FILE=$CONSOLE_LOG_FILE_NAME (Linux)
+     * or
+     * LOG_FILE=%CONSOLE_LOG_FILE_NAME% (Windows)
+     *
+     * The liberty default for LOG_FILE is "console.log".
+     * If the variable gets resolved properly, the console.log file will have a
+     * new name.
+     * Check whether the log file with the new name exists (depending on whether
+     * expansion is enabled) after starting the server.
+     *
+     * @param expansionEnabled if true, the log file with the new name should exist, otherwise it should not.
+     * @param envType          Specifies which of the 3 server.env files to create
+     * @throws Exception
+     */
+    public void varsExpandInServerEnv(boolean expansionEnabled, ServerEnvType envType) throws Exception {
         final String METHOD_NAME = "varsExpandInServerEnv[" + expansionEnabled + "]";
         Log.entering(c, METHOD_NAME);
 
-        // The environment variable to be referenced in etc/server.env
-        final String consoleLogEnvVar = "CONSOLE_LOG_FILE_NAME";
-        String consoleLogEnvVarReference;
-        if (OS.contains("win")) {
-            consoleLogEnvVarReference = "!" + consoleLogEnvVar + "!";
-        } else {
-            consoleLogEnvVarReference = "${" + consoleLogEnvVar + "}";
-        }
+        String environmentVariableName = "LOG_FILE_NAME_VARIABLE";
 
-        // Create server.env with or without expansion enabled.
+        // Get the proper syntax !!, ${} for the environment variable to be referenced in .../server.env
+        final String consoleLogEnvVarReference = createReferenceSyntaxForVariableName(environmentVariableName);
+
+        // Create file contents for server.env with or without expansion enabled.
         // Sets the LOG_FILE variable to an environment variable reference.
         // This should cause the name of the "console.log" to be something different.
-        String fileContents;
-        if (expansionEnabled) {
-            fileContents = "#enable_variable_expansion\nLOG_FILE=" + consoleLogEnvVarReference;
-        } else {
-            fileContents = "LOG_FILE=" + consoleLogEnvVarReference;
-        }
-        Log.info(c, METHOD_NAME, "Creating /etc/server.env with contents:\n" + fileContents);
-        File wlpEtcDir = new File(server.getInstallRoot(), "etc");
-        String serverEnvCreate = createServerEnvFile(fileContents, wlpEtcDir);
-        Log.info(c, METHOD_NAME, "server.env location = " + serverEnvCreate);
-        assertTrue("The server.env file was not created.", serverEnvCreate.contains("server.env"));
+        String fileContents = createFileContentsForServerEnv(expansionEnabled, "LOG_FILE=" + consoleLogEnvVarReference);
+
+        File serverEnvFile = createServerEnvFile(fileContents, envType.path);
+        assertNotNull("The server.env file was not created. Null returned.", serverEnvFile);
+        assertTrue("The server.env file was not created.", serverEnvFile.exists());
 
         // Set the log file name in an environment variable
-        String logFileName = "GiveMeLibertyOrGiveMeDeath.log";
+        String newLogFileName = "GiveMeLibertyOrGiveMeDeath.log";
         Properties envVars = new Properties();
-        envVars.put(consoleLogEnvVar, logFileName);
+        envVars.put(environmentVariableName, newLogFileName);
+
+        startServer(envVars);
+        assertTrue("the server should have been started", server.isStarted());
+
+        displayDirectoryContents(METHOD_NAME, new File(server.getLogsRoot())); // DEBUG
+
+        // Finally, verify that the log file with the new name exists when expansion is enabled
+        String logFullPathName = server.getLogsRoot() + newLogFileName;
+        File logFile = new File(logFullPathName);
+        if (expansionEnabled) {
+            assertTrue("the log file with the new name [ " + logFullPathName + " ] does not exist", logFile.exists());
+        } else {
+            assertTrue("the log file with the new name [ " + logFullPathName + " ] exists, but it should not", !logFile.exists());
+        }
+
+        testCleanUp(METHOD_NAME, serverEnvFile);
+
+        Log.exiting(c, METHOD_NAME);
+    }
+
+    private void testCleanUp(String methodName, File serverEnvFile) {
+        // Test is complete, but create "console.log" file.
+        // Verification of server stop depends on the default name.
+        // Otherwise, we get FileNotFoundException in the test logs.
+        String defaultLogFullPathName = server.getLogsRoot() + "console.log";
+        Log.info(c, methodName, "Creating default console log: " + defaultLogFullPathName);
+        createFile(defaultLogFullPathName);
+
+        // Cleanup - If the server.env file is not deleted, it can cause other test cases to fail.
+        deleteServerEnvFile(serverEnvFile);
+    }
+
+    /**
+     * Prefixes contents with "#enable_variable_expansion" marker if expansionEnabled flag is set
+     *
+     * @param expansionEnabled
+     * @param contents
+     * @return
+     */
+    private String createFileContentsForServerEnv(boolean expansionEnabled, String contents) {
+        if (expansionEnabled) {
+            return "#enable_variable_expansion\n" + contents;
+        } else {
+            return contents;
+        }
+    }
+
+    /**
+     * Given a variable name, returns the appropriate reference syntax for
+     * the variable based on operating system; eg Windows !varName!; Linux ${varName}
+     *
+     * @param variableName
+     * @return
+     */
+    private String createReferenceSyntaxForVariableName(String variableName) {
+        if (OS.contains("win")) {
+            return "!" + variableName + "!";
+        } else {
+            return "${" + variableName + "}";
+        }
+    }
+
+    /**
+     * Start the server using server.getMachine().execute(<server start command>)
+     *
+     * @param envVars Properties containing environment variable names and values.
+     * @throws Exception
+     */
+    private void startServer(Properties envVars) throws Exception {
+        final String METHOD_NAME = "startServer";
 
         // Execute the server start command and display stdout and stderr
         String executionDir = server.getInstallRoot() + File.separator + "bin";
@@ -183,8 +313,8 @@ public class ServerEnvTest {
         parms[0] = "start";
         parms[1] = SERVER_NAME;
         ProgramOutput po = server.getMachine().execute(command, parms, executionDir, envVars);
-        Log.info(c, METHOD_NAME, "server start stdout = " + po.getStdout());
-        Log.info(c, METHOD_NAME, "server start stderr = " + po.getStderr());
+        Log.info(c, METHOD_NAME, "\nserver start stdout: \n[\n{0}\n]", po.getStdout());
+        Log.info(c, METHOD_NAME, "\nserver start stderr: \n[\n{0}\n]", po.getStderr());
 
         // Check for server ready
         String serverReady = server.waitForStringInLog("CWWKF0011I");
@@ -195,59 +325,67 @@ public class ServerEnvTest {
         // Because we didn't start the server using the LibertyServer APIs, we need
         // to have it detect its started state so it will stop and save logs properly
         server.resetStarted();
-        assertTrue("the server should have been started", server.isStarted());
-
-        logDirectoryContents(METHOD_NAME, new File(server.getLogsRoot())); // DEBUG
-
-        // Finally, verify that the log file with the new name exists when expansion is enabled
-        String logFullPathName = server.getLogsRoot() + logFileName;
-        File logFile = new File(logFullPathName);
-        if (expansionEnabled) {
-            assertTrue("the log file with the new name [ " + logFullPathName + " ] does not exist", logFile.exists());
-        } else {
-            assertTrue("the log file with the new name [ " + logFullPathName + " ] exists, but it should not", !logFile.exists());
-        }
-
-        // Test is complete, but create "console.log" file.
-        // Verification of server stop depends on the default name.
-        // Otherwise, we get FileNotFoundException in the test logs.
-        String defaultLogFullPathName = server.getLogsRoot() + "console.log";
-        Log.info(c, METHOD_NAME, "Creating default console log: " + defaultLogFullPathName);
-        createFile(defaultLogFullPathName);
-
-        // Cleanup - If the server.env file is not deleted, it can cause other test cases to fail.
-        deleteServerEnvFile(wlpEtcDir);
-        Log.exiting(c, METHOD_NAME);
     }
 
     /**
-     * Create the server.env file in the specified directory
+     * Execute the "server version <SERVER_NAME>" command and return the output of the command"
      *
-     * @param fileContents
-     * @param dir          directory for server.env
-     * @throws IOException
+     * @return
+     * @throws Exception
      */
-    private String createServerEnvFile(String fileContents, File dir) throws IOException {
+    private String executeServerVersionCommand() throws Exception {
+        final String METHOD_NAME = "executeServerVersionCommand";
 
-        File serverEnvFile = new File(dir, "server.env");
+        // Execute the server start command and display stdout and stderr
+        String executionDir = server.getInstallRoot() + File.separator + "bin";
+        String command = "." + File.separator + "server";
+        String[] parms = new String[2];
+        parms[0] = "version";
+        parms[1] = SERVER_NAME;
+        ProgramOutput po = server.getMachine().execute(command, parms, executionDir);
+        String stdoutAndstdErr = "\nStandard Out:\n" + po.getStdout() + "\nStandard Error:\n" + po.getStderr() + "\n";
+        Log.info(c, METHOD_NAME, stdoutAndstdErr);
 
-        String serverEnv = serverEnvFile.getAbsolutePath();
+        return stdoutAndstdErr;
+    }
 
-        if (!dir.exists()) {
-            dir.mkdirs();
+    /**
+     *
+     * @param fileContents          - contents to put in the newly created server.env file
+     * @param serverEnvRelativePath - relative path, below "wlp", to server.env file to create
+     * @return
+     */
+    private File createServerEnvFile(String fileContents, String serverEnvRelativePath) {
+        final String METHOD_NAME = "createServerEnvFile";
+        Log.info(c, METHOD_NAME, "ENTER serverEnvRelativePath [{0}]\n", serverEnvRelativePath);
+
+        String serverEnvPath = server.getInstallRoot() + "/" + serverEnvRelativePath;
+        File serverEnvFile = new File(serverEnvPath);
+        File parentDir = serverEnvFile.getParentFile();
+        String path = serverEnvFile.getAbsolutePath();
+        Log.info(c, METHOD_NAME, "Creating file [{0}] with contents \n[\n{1}\n]", new Object[] { path, fileContents });
+
+        if (!parentDir.exists()) {
+            parentDir.mkdirs();
         }
 
         FileOutputStream fos = null;
         try {
             fos = new FileOutputStream(serverEnvFile);
             fos.write(fileContents.getBytes());
+        } catch (IOException ioe) {
+            Log.info(c, METHOD_NAME, "Caught exception while writing the file " + path);
         } finally {
             if (fos != null) {
-                fos.close();
+                try {
+                    fos.close();
+                } catch (IOException ioe) {
+                    Log.info(c, METHOD_NAME, "Caught exception while closing the file " + path);
+                }
             }
         }
 
-        return serverEnv;
+        return serverEnvFile;
     }
 
     /**
@@ -277,68 +415,37 @@ public class ServerEnvTest {
      * Then check whether the log file with the new name exists
      * after starting the server.
      *
-     * @param expansionEnabled if true, the new log file should exist, otherwise it should not
      * @throws Exception
      */
     @Test
     public void testAlternateLocaleServerEnv() throws Exception {
         final String METHOD_NAME = "testAlternateLocaleServerEnv";
-        Log.entering(c, METHOD_NAME);
+        Log.info(c, METHOD_NAME, "ENTER");
         //Set Locale to turkish
         Locale.setDefault(new Locale("tr"));
 
-        // Create server.env
-        // Sets the LOG_FILE variable to an environment variable reference.
+        // Create server.env file.
+        // Sets the LOG_FILE variable to new log file name.
         // This should cause the name of the "console.log" to be something different.
         String fileContents;
         String logFileName = "default.log";
-
         fileContents = "LOG_FILE=" + logFileName;
+        File serverEnvFile = createServerEnvFile(fileContents, ServerEnvType.ETC.path);
+        assertNotNull("The server.env file was not created. Null returned.", serverEnvFile);
+        assertTrue("The server.env file was not created.", serverEnvFile.exists());
 
-        Log.info(c, METHOD_NAME, "Creating /etc/server.env with contents:\n" + fileContents);
-        File wlpEtcDir = new File(server.getInstallRoot(), "etc");
-        String serverEnvCreate = createServerEnvFile(fileContents, wlpEtcDir);
-        Log.info(c, METHOD_NAME, "server.env location = " + serverEnvCreate);
-        assertTrue("The server.env file was not created.", serverEnvCreate.contains("server.env"));
-
-        // Execute the server start command and display stdout and stderr
-        String executionDir = server.getInstallRoot() + File.separator + "bin";
-        String command = "." + File.separator + "server";
-        String[] parms = new String[2];
-        parms[0] = "start";
-        parms[1] = SERVER_NAME;
-        ProgramOutput po = server.getMachine().execute(command, parms, executionDir);
-        Log.info(c, METHOD_NAME, "server start stdout = " + po.getStdout());
-        Log.info(c, METHOD_NAME, "server start stderr = " + po.getStderr());
-
-        // Check for server ready
-        String serverReady = server.waitForStringInLog("CWWKF0011I");
-        if (serverReady == null) {
-            Log.info(c, METHOD_NAME, "Timed out waiting for server ready message, CWWKF0011I");
-        }
-
-        // Because we didn't start the server using the LibertyServer APIs, we need
-        // to have it detect its started state so it will stop and save logs properly
-        server.resetStarted();
+        startServer(null);
         assertTrue("the server should have been started", server.isStarted());
 
-        logDirectoryContents(METHOD_NAME, new File(server.getLogsRoot())); // DEBUG
+        displayDirectoryContents(METHOD_NAME, new File(server.getLogsRoot())); // DEBUG
 
-        // Finally, verify that the log file with the new name exists when expansion is enabled
+        // Finally, verify that the log file with the new name exists
         String logFullPathName = server.getLogsRoot() + logFileName;
         File logFile = new File(logFullPathName);
-
         assertTrue("the log file with the new name [ " + logFullPathName + " ] does not exist", logFile.exists());
 
-        // Test is complete, but create "console.log" file.
-        // Verification of server stop depends on the default name.
-        // Otherwise, we get FileNotFoundException in the test logs.
-        String defaultLogFullPathName = server.getLogsRoot() + "console.log";
-        Log.info(c, METHOD_NAME, "Creating default console log: " + defaultLogFullPathName);
-        createFile(defaultLogFullPathName);
+        testCleanUp(METHOD_NAME, serverEnvFile);
 
-        // Cleanup - If the server.env file is not deleted, it can cause other test cases to fail.
-        deleteServerEnvFile(wlpEtcDir);
         Log.exiting(c, METHOD_NAME);
     }
 
@@ -348,7 +455,7 @@ public class ServerEnvTest {
      * @param fileToCreate
      * @throws IOException
      */
-    public static void createFile(final String fileName) throws IOException {
+    public static void createFile(final String fileName) {
         String METHOD_NAME = "createFile";
         File fileToCreate = new File(fileName);
 
@@ -368,12 +475,16 @@ public class ServerEnvTest {
                 fileToCreate.createNewFile();
             }
 
-        } catch (Throwable t) {
-            Log.info(c, METHOD_NAME, "Caught exception:\n[\n" + t.toString() + "\n]");
+        } catch (Throwable ioe) {
+            Log.info(c, METHOD_NAME, "Caught exception while creating file [{0}]\n exception [{1}]\n", new String[] { fileName, ioe.toString() });
 
         } finally {
             if (fos != null) {
-                fos.close();
+                try {
+                    fos.close();
+                } catch (Throwable ioe) {
+                    Log.info(c, METHOD_NAME, "Caught exception while closing file [{0}]\n exception [{1}]\n", new String[] { fileName, ioe.toString() });
+                }
             }
         }
     }
@@ -382,19 +493,22 @@ public class ServerEnvTest {
      * @param methodName
      * @param folder
      */
-    public static void logDirectoryContents(final String methodName, File folder) {
+    public static void displayDirectoryContents(final String methodName, File folder) {
 
         File[] listOfFiles = folder.listFiles();
+        StringBuffer sb = new StringBuffer();
+        sb.append("Server 'logs' directory contents: \n[\n");
 
-        Log.info(c, methodName, "Server logs directory contents: ");
         if (listOfFiles != null) {
             for (int i = 0; i < listOfFiles.length; i++) {
                 if (listOfFiles[i].isFile()) {
-                    Log.info(c, methodName, "File: " + listOfFiles[i].getName());
+                    sb.append("File: " + listOfFiles[i].getName() + "\n");
                 } else if (listOfFiles[i].isDirectory()) {
-                    Log.info(c, methodName, "Directory: " + listOfFiles[i].getName());
+                    sb.append("Directory: " + listOfFiles[i].getName() + "\n");
                 }
             }
         }
+        sb.append("]\n");
+        Log.info(c, methodName, sb.toString());
     }
 }


### PR DESCRIPTION
Fixes #24981.  

The existing behavior is to only read the wlp/**etc**/server.env when executing the **server version** command, which is contrary to [the documentation](https://openliberty.io/docs/latest/reference/command/server-version.html).  The effect is that the server version output might not display the true version of java configured for the server.

The fix causes the the wlp/**shared/**server.env and **${server.config.dir}**/server.env to be read when executing the command:

`server version <SERVER_NAME>`

The server.env file of defaultServer is used when the server name is omitted: 

`server version`

If defaultServer does not exist the defaultServer is NOT created.   [The doc says it is](https://openliberty.io/docs/latest/reference/command/server-version.html).  I did not fix that.  This should either be fixed, or the doc should be updated to reflect the true behavior.  Creating defaultServer will not change the output of _server version_, since no server.env is created by default.

I believe the only effect of reading the additional server.env files is that JAVA_HOME might be set, in which case it will correctly show the Java level in use by the server.