### PR TITLE
Increased the test application start up from for MP Health 3.1 FAT

### DIFF
--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/DefaultOverallStartupStatusUpAppStartupTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/DefaultOverallStartupStatusUpAppStartupTest.java
@@ -43,7 +43,7 @@ import componenttest.topology.utils.HttpUtils;
 @RunWith(FATRunner.class)
 public class DefaultOverallStartupStatusUpAppStartupTest {
 
-    private static final String[] EXPECTED_FAILURES = { "CWWKE1102W", "CWWKE1105W", "CWMMH0052W", "CWMMH0054W" };
+    private static final String[] EXPECTED_FAILURES = { "CWWKE1102W", "CWWKE1105W", "CWMMH0052W", "CWMMH0054W", "SRVE0302E" };
 
     public static final String APP_NAME = "DelayedHealthCheckApp";
     private static final String MESSAGE_LOG = "logs/messages.log";

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -52,7 +52,7 @@ import componenttest.topology.utils.HttpUtils;
 @RunWith(FATRunner.class)
 public class SlowAppStartupHealthCheckTest {
 
-    private static final String[] EXPECTED_FAILURES = { "CWWKE1102W", "CWWKE1105W", "CWMMH0052W", "CWMMH0054W" };
+    private static final String[] EXPECTED_FAILURES = { "CWWKE1102W", "CWWKE1105W", "CWMMH0052W", "CWMMH0054W", "SRVE0302E" };
 
     public static final String APP_NAME = "DelayedHealthCheckApp";
     private static final String MESSAGE_LOG = "logs/messages.log";

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health31/delayed/health/check/app/DelayedServlet.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health31/delayed/health/check/app/DelayedServlet.java
@@ -37,7 +37,7 @@ public class DelayedServlet extends HttpServlet {
     public void init() {
         System.out.println("Entering init function - Starting Thread.sleep for 95 seconds.");
         try {
-            Thread.sleep(65000); // 95 seconds = 95000 ms
+            Thread.sleep(95000); // 95 seconds = 95000 ms
         } catch (InterruptedException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();


### PR DESCRIPTION
#fixes https://github.com/OpenLiberty/open-liberty/issues/24580

- When the MpHealth 3.1 FAT is run, sometimes the server takes over 1 minute to start up, due to infrastructure slowness. This causes the delayed applications in the test cases to start up right when the server starts up, which negates the tests that test for slow applications.
- Increased the startup delay in the test application, so it gives more time for the tests to run properly, if the server starts up slowly.
