### PR TITLE
Revert "Remove extendedHandshake property from Plugin autogeneration"

### DIFF
--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype-mbeans.properties
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype-mbeans.properties
@@ -1,11 +1,14 @@
 ###############################################################################
-# Copyright (c) 2011, 2023 IBM Corporation and others.
+# Copyright (c) 2011, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
 ###############################################################################
 #
 #CMVCPATHNAME com.ibm.ws.webcontainer-8.0/resources/OSGI-INF/l10n/metatype-mbeans.properties
@@ -58,6 +61,9 @@ plugin.wsServerIOTimeout.desc=Identifies the maximum amount of time that the web
 
 plugin.wsServerIdleTimeout.name=Websocket idle connection timeout
 plugin.wsServerIdleTimeout.desc=Identifies the maximum amount of time that the web server plugin waits to terminate an idle websocket connection.
+
+plugin.extendedHandshake.name=Use extended handshake
+plugin.extendedHandshake.desc=If true, the web server plugin uses an extended handshake to determine if the application server is running.
 
 plugin.waitForContinue.name=Always use "Expect: 100-continue" headers
 plugin.waitForContinue.desc=If false (the default value), the web server plugin sends the "Expect: 100-continue" header with HTTP requests that have a message body. When set to true, the web server plugin sends the "Expect: 100-continue" header with every HTTP request. Consider setting this value to true if you have a firewall between the web server and the application server, and are sensitive to requests retries with no request body.

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype-mbeans.xml
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype-mbeans.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2012, 2023 IBM Corporation and others.
+    Copyright (c) 2012, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
  -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0" 
     xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0" 
@@ -42,6 +45,8 @@
             id="wsServerIOTimeout" required="false" type="String" ibm:type="duration(s)" />
         <AD name="%plugin.wsServerIdleTimeout.name" description="%plugin.wsServerIdleTimeout.desc" 
             id="wsServerIdleTimeout" required="false" type="String" ibm:type="duration(s)" />
+        <AD name="%plugin.extendedHandshake.name" description="%plugin.extendedHandshake.desc"
+            id="extendedHandshake" required="false" type="Boolean" default="false" />
         <AD name="%plugin.waitForContinue.name" description="%plugin.waitForContinue.desc" 
             id="waitForContinue" required="false" type="Boolean" default="false" />
         <AD name="%plugin.logFileName.name" description="%plugin.logFileName.desc" 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
@@ -1,11 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2023 IBM Corporation and others.
+ * Copyright (c) 2009, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.webcontainer.osgi.mbeans;
 
@@ -504,6 +507,7 @@ public class PluginGenerator {
                         serverElem.setAttribute("wsServerIdleTimeout", sd.wsServerIdleTimeout.toString());
                     serverElem.setAttribute("WaitForContinue", sd.waitForContinue.toString());
                     serverElem.setAttribute("MaxConnections", sd.maxConnections.toString());
+                    serverElem.setAttribute("ExtendedHandshake", sd.extendedHandshake.toString());
 
                     sgElem.appendChild(serverElem);
 
@@ -1757,6 +1761,7 @@ protected class XMLRootHandler extends DefaultHandler implements LexicalHandler 
         protected Long wsServerIOTimeout = null; //optional
         protected Long wsServerIdleTimeout = null; //optional
         public Long connectTimeout = null;
+        public Boolean extendedHandshake = null;
         public Boolean waitForContinue = null;
         protected String LogFileName = null;
         protected String LogDirLocation = null; //142740
@@ -1790,6 +1795,7 @@ protected class XMLRootHandler extends DefaultHandler implements LexicalHandler 
             wsServerIOTimeout = (Long) config.get("wsServerIOTimeout");
             wsServerIdleTimeout = (Long) config.get("wsServerIdleTimeout");
             connectTimeout = (Long) config.get("connectTimeout");
+            extendedHandshake = (Boolean) config.get("extendedHandshake");
             waitForContinue = (Boolean) config.get("waitForContinue");
             LogFileName = (String) config.get("logFileName");
             LogDirLocation = (String) config.get("logDirLocation"); //142740
@@ -2012,6 +2018,7 @@ protected class XMLRootHandler extends DefaultHandler implements LexicalHandler 
         protected Long wsServerIdleTimeout = null;//optional
         protected Boolean waitForContinue = Boolean.FALSE;
         protected Integer maxConnections = Integer.valueOf(-1);
+        protected Boolean extendedHandshake = Boolean.FALSE;
         protected Role roleKind = Role.PRIMARY;
         protected String sessionManagerCookieName = "JSESSIONID";
         protected String sessionURLIdentifier = "jsessionid";
@@ -2037,6 +2044,7 @@ protected class XMLRootHandler extends DefaultHandler implements LexicalHandler 
             this.connectTimeout = pcd.connectTimeout;
             this.waitForContinue = pcd.waitForContinue;
             this.maxConnections = pcd.maxConnections;
+            this.extendedHandshake = pcd.extendedHandshake;
             this.loadBalanceWeight = pcd.loadBalanceWeight;
             this.roleKind = pcd.roleKind;
         }
@@ -2067,6 +2075,7 @@ protected class XMLRootHandler extends DefaultHandler implements LexicalHandler 
                 Tr.debug(trace, "   wsServerIdleTimeout             : " + wsServerIdleTimeout);
                 Tr.debug(trace, "   waitForContinue                 : " + waitForContinue);
                 Tr.debug(trace, "   maxConnections                  : " + maxConnections);
+                Tr.debug(trace, "   extendedHandshake               : " + extendedHandshake);
                 Tr.debug(trace, "   roleKind                        : " + roleKind);
                 Tr.debug(trace, "   sessionManagerCookieName        : " + sessionManagerCookieName);
                 Tr.debug(trace, "   sessionURLIdentifier            : " + sessionURLIdentifier);


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#24529

Tests failing in the PR are related to the changes in the PR.  extendedHandshake is used by WebSphere Liberty:  https://www.ibm.com/docs/en/was-liberty/nd?topic=configuration-pluginconfiguration

The failing tests use extendedHandshake in their server.xml configuration.

FYI @pmd1nh 