### PR TITLE
Better network handling for testcontainers

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryRegistry.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryRegistry.java
@@ -162,7 +162,7 @@ public class ArtifactoryRegistry {
                 int splitAt = contents.indexOf('{');
                 String firstHalf = contents.substring(0, splitAt + 1);
                 String secondHalf = contents.substring(splitAt + 1);
-                String delimiter = secondHalf.contains("{") ? "," : "";
+                String delimiter = secondHalf.contains(":") ? "," : "";
                 contents = firstHalf + "\n\t\"auths\": {\n" + privateAuth + "\n\t}" + delimiter + secondHalf;
             }
         } else {

--- a/dev/io.openliberty.org.testcontainers/cache/projects
+++ b/dev/io.openliberty.org.testcontainers/cache/projects
@@ -145,7 +145,6 @@ com.ibm.ws.transaction.hadb_fat.sqlserver.2
 com.ibm.ws.transaction.hadb_fat.sqlserver.lease
 com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes
 fattest.simplicity
-io.openliberty.checkpoint_fat_container
 io.openliberty.checkpoint_fat_persistence
 io.openliberty.data.internal_fat
 io.openliberty.data.internal_fat_jpa


### PR DESCRIPTION
Introduces a repeat when testing transport configurations in test containers. 

<details>
<summary>Output showing retries when testcontainer test() fails</summary>

```txt
[05/09/2023 10:46:23:013 CDT] 001 ExternalDockerClientStrategy   useRemoteDocker                I Remote docker host will be the highest priority. Reason: fat.test.use.remote.docker set to true
[05/09/2023 10:46:23:034 CDT] 001 ExternalDockerClientStrategy   test                           I Verifying strategy, retry countdown: 3
[05/09/2023 10:46:23:037 CDT] 001 HttpRequest                    run                            I GET https://fyre.ibm.com/consul/v1/health/service/docker-engine?passing=true
[05/09/2023 10:46:23:715 CDT] 001 HttpRequest                    finishedRequest                I GET https://fyre.ibm.com/consul/v1/health/service/docker-engine?passing=true
[05/09/2023 10:46:24:534 CDT] 001 HttpRequest                    run                            I GET https://fyre.ibm.com/consul/v1/kv/service/docker-engine/?recurse=true
[05/09/2023 10:46:24:947 CDT] 001 HttpRequest                    finishedRequest                I GET https://fyre.ibm.com/consul/v1/kv/service/docker-engine/?recurse=true
[05/09/2023 10:46:26:103 CDT] 001 HttpRequest                    run                            I GET https://fyre.ibm.com/consul/v1/health/service/liberty-properties-decrypter?passing=true
[05/09/2023 10:46:26:488 CDT] 001 HttpRequest                    finishedRequest                I GET https://fyre.ibm.com/consul/v1/health/service/liberty-properties-decrypter?passing=true
[05/09/2023 10:46:26:900 CDT] 001 HttpRequest                    run                            I GET https://fyre.ibm.com/consul/v1/kv/service/liberty-properties-decrypter/?recurse=true
[05/09/2023 10:46:27:269 CDT] 001 HttpRequest                    finishedRequest                I GET https://fyre.ibm.com/consul/v1/kv/service/liberty-properties-decrypter/?recurse=true
[05/09/2023 10:46:28:561 CDT] 001 ExternalDockerClientFilter     isMatched                      I Checking if Docker host tcp://0.0.0.3:2376 is available and healthy...
[05/09/2023 10:46:28:562 CDT] 001 ExternalDockerClientFilter     writeFile                      I Wrote property to: /path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates/ca.pem
[05/09/2023 10:46:28:563 CDT] 001 ExternalDockerClientFilter     writeFile                      I Wrote property to: /path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates/cert.pem
[05/09/2023 10:46:28:564 CDT] 001 ExternalDockerClientFilter     writeFile                      I Wrote property to: /path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates/key.pem
[05/09/2023 10:46:28:567 CDT] 001 ExternalDockerClientFilter     test                           I Pinging URL: https://0.0.0.3:2376
[05/09/2023 10:46:28:674 CDT] 001 HttpRequest                    run                            I GET https://0.0.0.3:2376/_ping
[05/09/2023 10:46:29:441 CDT] 001 HttpRequest                    finishedRequest                I GET https://0.0.0.3:2376/_ping
[05/09/2023 10:46:29:441 CDT] 001 ExternalDockerClientFilter     test                           I Ping successful. Response: OK
[05/09/2023 10:46:29:441 CDT] 001 ExternalDockerClientFilter     isMatched                      I Docker host tcp://0.0.0.3:2376 is healthy.
[05/09/2023 10:46:29:442 CDT] 001 ExternalDockerClientFilter     isMatched                      I If you need to connect to any currently running docker containers manually, export the following environment variables in your terminal:
export DOCKER_HOST=tcp://0.0.0.3:2376
export DOCKER_TLS_VERIFY=1
export DOCKER_CERT_PATH=/path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates
[05/09/2023 10:46:29:631 CDT] 001 ExternalDockerClientStrategy   test                           I Unverified strategy, throwing away transport config for host tcp://0.0.0.3:2376
[05/09/2023 10:46:29:631 CDT] 001 ExternalDockerClientStrategy   test                           I Verifying strategy, retry countdown: 2
[05/09/2023 10:46:29:631 CDT] 001 HttpRequest                    run                            I GET https://fyre.ibm.com/consul/v1/health/service/docker-engine?passing=true
[05/09/2023 10:46:30:035 CDT] 001 HttpRequest                    finishedRequest                I GET https://fyre.ibm.com/consul/v1/health/service/docker-engine?passing=true
[05/09/2023 10:46:30:811 CDT] 001 HttpRequest                    run                            I GET https://fyre.ibm.com/consul/v1/kv/service/docker-engine/?recurse=true
[05/09/2023 10:46:32:069 CDT] 001 HttpRequest                    finishedRequest                I GET https://fyre.ibm.com/consul/v1/kv/service/docker-engine/?recurse=true
[05/09/2023 10:46:34:190 CDT] 001 ExternalDockerClientFilter     isMatched                      I Checking if Docker host tcp://0.0.0.2:2376 is available and healthy...
[05/09/2023 10:46:34:192 CDT] 001 ExternalDockerClientFilter     writeFile                      I Wrote property to: /path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates/ca.pem
[05/09/2023 10:46:34:192 CDT] 001 ExternalDockerClientFilter     writeFile                      I Wrote property to: /path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates/cert.pem
[05/09/2023 10:46:34:193 CDT] 001 ExternalDockerClientFilter     writeFile                      I Wrote property to: /path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates/key.pem
[05/09/2023 10:46:34:195 CDT] 001 ExternalDockerClientFilter     test                           I Pinging URL: https://0.0.0.2:2376
[05/09/2023 10:46:34:204 CDT] 001 HttpRequest                    run                            I GET https://0.0.0.2:2376/_ping
[05/09/2023 10:46:34:975 CDT] 001 HttpRequest                    finishedRequest                I GET https://0.0.0.2:2376/_ping
[05/09/2023 10:46:34:976 CDT] 001 ExternalDockerClientFilter     test                           I Ping successful. Response: OK
[05/09/2023 10:46:34:976 CDT] 001 ExternalDockerClientFilter     isMatched                      I Docker host tcp://0.0.0.2:2376 is healthy.
[05/09/2023 10:46:34:976 CDT] 001 ExternalDockerClientFilter     isMatched                      I If you need to connect to any currently running docker containers manually, export the following environment variables in your terminal:
export DOCKER_HOST=tcp://0.0.0.2:2376
export DOCKER_TLS_VERIFY=1
export DOCKER_CERT_PATH=/path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates
[05/09/2023 10:46:35:156 CDT] 001 ExternalDockerClientStrategy   test                           I Unverified strategy, throwing away transport config for host tcp://0.0.0.2:2376
[05/09/2023 10:46:35:156 CDT] 001 ExternalDockerClientStrategy   test                           I Verifying strategy, retry countdown: 1
[05/09/2023 10:46:35:156 CDT] 001 HttpRequest                    run                            I GET https://fyre.ibm.com/consul/v1/health/service/docker-engine?passing=true
[05/09/2023 10:46:35:546 CDT] 001 HttpRequest                    finishedRequest                I GET https://fyre.ibm.com/consul/v1/health/service/docker-engine?passing=true
[05/09/2023 10:46:36:259 CDT] 001 HttpRequest                    run                            I GET https://fyre.ibm.com/consul/v1/kv/service/docker-engine/?recurse=true
[05/09/2023 10:46:36:663 CDT] 001 HttpRequest                    finishedRequest                I GET https://fyre.ibm.com/consul/v1/kv/service/docker-engine/?recurse=true
[05/09/2023 10:46:39:168 CDT] 001 ExternalDockerClientFilter     isMatched                      I Checking if Docker host tcp://0.0.0.1:2376 is available and healthy...
[05/09/2023 10:46:39:170 CDT] 001 ExternalDockerClientFilter     writeFile                      I Wrote property to: /path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates/ca.pem
[05/09/2023 10:46:39:171 CDT] 001 ExternalDockerClientFilter     writeFile                      I Wrote property to: /path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates/cert.pem
[05/09/2023 10:46:39:172 CDT] 001 ExternalDockerClientFilter     writeFile                      I Wrote property to: /path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates/key.pem
[05/09/2023 10:46:39:173 CDT] 001 ExternalDockerClientFilter     test                           I Pinging URL: https://0.0.0.1:2376
[05/09/2023 10:46:39:178 CDT] 001 HttpRequest                    run                            I GET https://0.0.0.1:2376/_ping
[05/09/2023 10:46:39:886 CDT] 001 HttpRequest                    finishedRequest                I GET https://0.0.0.1:2376/_ping
[05/09/2023 10:46:39:886 CDT] 001 ExternalDockerClientFilter     test                           I Ping successful. Response: OK
[05/09/2023 10:46:39:887 CDT] 001 ExternalDockerClientFilter     isMatched                      I Docker host tcp://0.0.0.1:2376 is healthy.
[05/09/2023 10:46:39:887 CDT] 001 ExternalDockerClientFilter     isMatched                      I If you need to connect to any currently running docker containers manually, export the following environment variables in your terminal:
export DOCKER_HOST=tcp://0.0.0.1:2376
export DOCKER_TLS_VERIFY=1
export DOCKER_CERT_PATH=/path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates
[05/09/2023 10:46:40:058 CDT] 001 ExternalDockerClientStrategy   test                           I Unverified strategy, throwing away transport config for host tcp://0.0.0.1:2376
[05/09/2023 10:46:40:059 CDT] 001 Log                            warning                        W Verification failed for any transport config obtained from consul
```

</details>

<details>
<summary>Output showing when testcontainer test() passes</summary>

```txt
[05/09/2023 11:03:36:111 CDT] 001 ExternalDockerClientStrategy   useRemoteDocker                I Remote docker host will be the highest priority. Reason: fat.test.use.remote.docker set to true
[05/09/2023 11:03:36:139 CDT] 001 ExternalDockerClientStrategy   test                           I Verifying strategy, retry countdown: 3
[05/09/2023 11:03:36:142 CDT] 001 HttpRequest                    run                            I GET https://fyre.ibm.com/consul/v1/health/service/docker-engine?passing=true
[05/09/2023 11:03:42:637 CDT] 001 HttpRequest                    finishedRequest                I GET https://fyre.ibm.com/consul/v1/health/service/docker-engine?passing=true
[05/09/2023 11:03:43:667 CDT] 001 HttpRequest                    run                            I GET https://fyre.ibm.com/consul/v1/kv/service/docker-engine/?recurse=true
[05/09/2023 11:03:44:227 CDT] 001 HttpRequest                    finishedRequest                I GET https://fyre.ibm.com/consul/v1/kv/service/docker-engine/?recurse=true
[05/09/2023 11:03:45:419 CDT] 001 HttpRequest                    run                            I GET https://fyre.ibm.com/consul/v1/health/service/liberty-properties-decrypter?passing=true
[05/09/2023 11:03:45:956 CDT] 001 HttpRequest                    finishedRequest                I GET https://fyre.ibm.com/consul/v1/health/service/liberty-properties-decrypter?passing=true
[05/09/2023 11:03:46:458 CDT] 001 HttpRequest                    run                            I GET https://fyre.ibm.com/consul/v1/kv/service/liberty-properties-decrypter/?recurse=true
[05/09/2023 11:03:46:987 CDT] 001 HttpRequest                    finishedRequest                I GET https://fyre.ibm.com/consul/v1/kv/service/liberty-properties-decrypter/?recurse=true
[05/09/2023 11:03:49:482 CDT] 001 ExternalDockerClientFilter     isMatched                      I Checking if Docker host tcp://0.0.0.3:2376 is available and healthy...
[05/09/2023 11:03:49:483 CDT] 001 ExternalDockerClientFilter     writeFile                      I Wrote property to: /path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates/ca.pem
[05/09/2023 11:03:49:484 CDT] 001 ExternalDockerClientFilter     writeFile                      I Wrote property to: /path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates/cert.pem
[05/09/2023 11:03:49:484 CDT] 001 ExternalDockerClientFilter     writeFile                      I Wrote property to: /path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates/key.pem
[05/09/2023 11:03:49:487 CDT] 001 ExternalDockerClientFilter     test                           I Pinging URL: https://0.0.0.3:2376
[05/09/2023 11:03:49:598 CDT] 001 HttpRequest                    run                            I GET https://0.0.0.3:2376/_ping
[05/09/2023 11:03:50:357 CDT] 001 HttpRequest                    finishedRequest                I GET https://0.0.0.3:2376/_ping
[05/09/2023 11:03:50:358 CDT] 001 ExternalDockerClientFilter     test                           I Ping successful. Response: OK
[05/09/2023 11:03:50:358 CDT] 001 ExternalDockerClientFilter     isMatched                      I Docker host tcp://0.0.0.3:2376 is healthy.
[05/09/2023 11:03:50:358 CDT] 001 ExternalDockerClientFilter     isMatched                      I If you need to connect to any currently running docker containers manually, export the following environment variables in your terminal:
export DOCKER_HOST=tcp://0.0.0.3:2376
export DOCKER_TLS_VERIFY=1
export DOCKER_CERT_PATH=/path/to/dev/build.example.testcontainers_fat/build/libs/autoFVT/docker-certificates
[05/09/2023 11:03:50:564 CDT] 001 ExternalDockerClientStrategy   test                           I Verified strategy, using transport config for host tcp://0.0.0.3:2376
```

</details>