### PR TITLE
Check for errors in log after a server checkpoint

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/BellsTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/BellsTest.java
@@ -87,7 +87,6 @@ public class BellsTest extends FATServletClient {
             default:
                 break;
         }
-        server.addCheckpointRegexIgnoreMessage("CWWKL0062W");
         server.startServer(getTestMethod(TestMethod.class, testName) + ".log");
     }
 

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/BellsTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/BellsTest.java
@@ -87,6 +87,7 @@ public class BellsTest extends FATServletClient {
             default:
                 break;
         }
+        server.addCheckpointRegexIgnoreMessage("CWWKL0062W");
         server.startServer(getTestMethod(TestMethod.class, testName) + ".log");
     }
 

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPFaultToleranceTimeoutTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPFaultToleranceTimeoutTest.java
@@ -67,7 +67,6 @@ public class MPFaultToleranceTimeoutTest {
             assertNotNull("Timeout call not found at checkpoint", result);
         });
 
-        server.addCheckpointRegexIgnoreMessage("CWWKZ0014W");
         server.startServer();
         Thread.sleep(22000);
         server.checkpointRestore();
@@ -85,7 +84,6 @@ public class MPFaultToleranceTimeoutTest {
             String result = server.waitForStringInLogUsingMark("TIMEOUT CALLED", 20000);
             assertNotNull("Timeout call not found at checkpoint", result);
         });
-        server.addCheckpointRegexIgnoreMessage("CWWKZ0014W");
         server.startServer();
         Thread.sleep(22000);
         server.checkpointRestore();

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPFaultToleranceTimeoutTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPFaultToleranceTimeoutTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -66,6 +66,8 @@ public class MPFaultToleranceTimeoutTest {
             String result = server.waitForStringInLogUsingMark("TIMEOUT CALLED", 20000);
             assertNotNull("Timeout call not found at checkpoint", result);
         });
+
+        server.addCheckpointRegexIgnoreMessage("CWWKZ0014W");
         server.startServer();
         Thread.sleep(22000);
         server.checkpointRestore();
@@ -83,6 +85,7 @@ public class MPFaultToleranceTimeoutTest {
             String result = server.waitForStringInLogUsingMark("TIMEOUT CALLED", 20000);
             assertNotNull("Timeout call not found at checkpoint", result);
         });
+        server.addCheckpointRegexIgnoreMessage("CWWKZ0014W");
         server.startServer();
         Thread.sleep(22000);
         server.checkpointRestore();

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/URAPIs_Federation_2LDAPsTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/URAPIs_Federation_2LDAPsTest.java
@@ -133,6 +133,7 @@ public class URAPIs_Federation_2LDAPsTest {
                 throw failed;
             }
         }));
+        server.addCheckpointRegexIgnoreMessage("CWWKG0075E");
         server.startServer(c.getName() + ".log");
         server.checkpointRestore();
 

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/timeoutServer/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/timeoutServer/server.xml
@@ -18,5 +18,4 @@
       <feature>checkpoint-1.0</feature>
     </featureManager>
     <variable id="timeout" name="timeout" defaultValue="true"/>
-    <webApplication id="testingApp" location="testingApp.war" name="testingApp"/>
 </server>

--- a/dev/io.openliberty.checkpoint_fat/test-applications/bells/src/bells/AppInitializer.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/bells/src/bells/AppInitializer.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package bells;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.ServletContainerInitializer;
@@ -23,5 +24,10 @@ public class AppInitializer implements ServletContainerInitializer {
     @Override
     public void onStartup(Set<Class<?>> c, ServletContext ctx) throws ServletException {
         System.out.println("Inside Servlet Container Initializer...");
+    }
+
+    // Only here to suppress warnings messages that we have no method supporting BELL prop injection.
+    public void updateBell(Map<String, String> ubProps) {
+        System.out.println("Updated bell properties: " + ubProps);
     }
 }

--- a/dev/io.openliberty.checkpoint_fat_persistence/fat/src/io/openliberty/checkpoint/fat/JPATest.java
+++ b/dev/io.openliberty.checkpoint_fat_persistence/fat/src/io/openliberty/checkpoint/fat/JPATest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -138,7 +138,7 @@ public class JPATest {
         };
 
         server.setCheckpoint(CheckpointPhase.APPLICATIONS, true, preRestoreLogic);
-
+        server.addCheckpointRegexIgnoreMessage("CWWKG0083W");
         server.startServer();
     }
 


### PR DESCRIPTION
Check for errors in log after a server checkpoint. Fail test if errors found. Allow exceptions set of string.


