### PR TITLE
featureUtility handle no_proxy

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
@@ -283,27 +283,31 @@ public class FeatureUtility {
         String password = FeatureUtilityProperties.getProxyPassword();
 
         String protocol = null;
-		if (host != null && !host.isEmpty()) {
-			if (host.toLowerCase().startsWith("https://")) {
-				protocol = "https";
-			} else {
-				protocol = "http";
-			}
-		}
+	if (host != null && !host.isEmpty()) {
+	    if (host.toLowerCase().startsWith("https://")) {
+		protocol = "https";
+	    } else {
+		protocol = "http";
+	    }
+	}
 
-		if (protocol != null && !protocol.isEmpty()) {
-			if (port != null && !port.isEmpty()) {
-				overrideMap.put(protocol + ".proxyHost", host);
-				overrideMap.put(protocol + ".proxyPort", port);
-			} else {
-				throw new InstallException(
-						Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_TOOL_PROXY_PORT_MISSING"),
-						InstallException.MISSING_CONTENT);
-			}
-			overrideMap.put(protocol + ".proxyUser", username);
-			overrideMap.put(protocol + ".proxyPassword", password);
+	if (protocol != null && !protocol.isEmpty()) {
+	    if (port != null && !port.isEmpty()) {
+		overrideMap.put(protocol + ".proxyHost", host);
+		overrideMap.put(protocol + ".proxyPort", port);
+	    } else {
+		throw new InstallException(
+			Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_TOOL_PROXY_PORT_MISSING"),
+			InstallException.MISSING_CONTENT);
+	    }
+	    overrideMap.put(protocol + ".proxyUser", username);
+	    overrideMap.put(protocol + ".proxyPassword", password);
+	}
 
-		}
+	// override no_proxy settings
+	if (FeatureUtilityProperties.getNoProxySetting() != null) {
+	    overrideMap.put("NO_PROXY", FeatureUtilityProperties.getNoProxySetting());
+	}
 
         // override the local feature repo
         if(FeatureUtilityProperties.getFeatureLocalRepo() != null){

--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/props/FeatureUtilityProperties.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/props/FeatureUtilityProperties.java
@@ -39,7 +39,7 @@ public class FeatureUtilityProperties {
     private final static String FILEPATH_EXT = "/etc/featureUtility.properties";
     private final static String FeatureVerifyQualifier = "feature.verify";
     private final static Set<String> DEFINED_OPTIONS = new HashSet<>(Arrays.asList("proxyHost", "proxyPort",
-	    "proxyUser", "proxyPassword", "featureLocalRepo", FeatureVerifyQualifier));
+	    "proxyUser", "proxyPassword", "featureLocalRepo", "noProxy", FeatureVerifyQualifier));
     private static Map<String, String> definedVariables = new HashMap<>();
     private static List<MavenRepository> repositoryList = new ArrayList<>();
     private static List<String> bomIdList = new ArrayList<>();
@@ -97,6 +97,10 @@ public class FeatureUtilityProperties {
 
     public static String getProxyPassword(){
         return definedVariables.get("proxyPassword"); // char array instead?
+    }
+
+    public static String getNoProxySetting() {
+	return definedVariables.get("noProxy");
     }
 
     public static String getFeatureLocalRepo(){

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.Authenticator;
-import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.URI;
@@ -394,15 +393,9 @@ public class ArtifactDownloader implements AutoCloseable {
     }
 
     private void downloadInternal(URI address, File destination, MavenRepository repository) throws IOException, InstallException {
-        Proxy proxy;
-        if (envMap.get("https.proxyHost") != null) {
-            proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress((String) envMap.get("https.proxyHost"), Integer.parseInt((String) envMap.get("https.proxyPort"))));
-        } else if (envMap.get("http.proxyHost") != null) {
-            proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress((String) envMap.get("http.proxyHost"), Integer.parseInt((String) envMap.get("http.proxyPort"))));
-        } else {
-            proxy = Proxy.NO_PROXY;
-        }
         URL url = address.toURL();
+        Proxy proxy = ArtifactDownloaderUtils.getProxy(url, envMap);
+
         URLConnection conn = url.openConnection(proxy);
         addBasicAuthentication(address, conn, repository);
         final String userAgentValue = calculateUserAgent();
@@ -465,9 +458,6 @@ public class ArtifactDownloader implements AutoCloseable {
         if (repository.getUserId() != null && repository.getPassword() != null) {
             return repository.getUserId() + ":" + repository.getPassword();
         }
-//        if (envMap.get("FEATURE_REPO_USER") != null && envMap.get("FEATURE_REPO_PASSWORD") != null) {
-//            return (String)envMap.get("FEATURE_REPO_USER") + ':' + (String)envMap.get("FEATURE_REPO_PASSWORD");
-//        }
         return uri.getUserInfo();
     }
 

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -1904,6 +1904,7 @@ public class InstallKernelMap implements Map {
             }
         }
 
+        envMapRet.put("NO_PROXY", System.getenv("NO_PROXY"));
         envMapRet.put("FEATURE_REPO_URL", System.getenv("FEATURE_REPO_URL"));
         envMapRet.put("FEATURE_REPO_USER", System.getenv("FEATURE_REPO_USER"));
         envMapRet.put("FEATURE_REPO_PASSWORD", System.getenv("FEATURE_REPO_PASSWORD"));

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/VerifySignatureUtility.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/VerifySignatureUtility.java
@@ -19,7 +19,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
@@ -147,14 +146,7 @@ public class VerifySignatureUtility {
             try {
                 logger.fine("Downloading key... " + key.getValue());
                 URL keyUrl = new URL(key.getValue());
-                Proxy proxy;
-                if (envMap.get("https.proxyHost") != null) {
-                    proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress((String) envMap.get("https.proxyHost"), Integer.parseInt((String) envMap.get("https.proxyPort"))));
-                } else if (envMap.get("http.proxyHost") != null) {
-                    proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress((String) envMap.get("http.proxyHost"), Integer.parseInt((String) envMap.get("http.proxyPort"))));
-                } else {
-                    proxy = Proxy.NO_PROXY;
-                }
+                Proxy proxy = ArtifactDownloaderUtils.getProxy(keyUrl, envMap);
                 conn = keyUrl.openConnection(proxy);
                 conn.setConnectTimeout(10000);
 

--- a/dev/com.ibm.ws.install/test/com/ibm/ws/install/internal/ArtifactDownloaderUtilsTest.java
+++ b/dev/com.ibm.ws.install/test/com/ibm/ws/install/internal/ArtifactDownloaderUtilsTest.java
@@ -1,0 +1,145 @@
+/*******************************************************************************n * Copyright (c) 2023 IBM Corporation and others.n * All rights reserved. This program and the accompanying materialsn * are made available under the terms of the Eclipse Public License 2.0n * which accompanies this distribution, and is available atn * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0n *n * Contributors:n *     IBM Corporation - initial API and implementationn *******************************************************************************/
+package com.ibm.ws.install.internal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ *
+ */
+public class ArtifactDownloaderUtilsTest {
+
+    @Test
+    public void testNoProxyURL_localhost() {
+        URL address;
+        try {
+            address = new URL("http://localhost:8081");
+
+            Map<String, Object> envMap = new HashMap<>();
+            envMap.put("NO_PROXY", "localhost");
+            assertTrue(ArtifactDownloaderUtils.isNoProxyURL(address, envMap));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testNoProxyURL_suffixWithLeadingDot() {
+        URL address;
+        try {
+            address = new URL("https://www.ibm.com");
+
+            Map<String, Object> envMap = new HashMap<>();
+            envMap.put("NO_PROXY", ".ibm.com");
+            assertTrue(ArtifactDownloaderUtils.isNoProxyURL(address, envMap));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testNoProxyURL_subString() {
+        URL address;
+        try {
+            address = new URL("https://www.ibm.com");
+
+            Map<String, Object> envMap = new HashMap<>();
+            envMap.put("NO_PROXY", ".ibm");
+            assertFalse(ArtifactDownloaderUtils.isNoProxyURL(address, envMap));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testNoProxyURL_fullURL() {
+        URL address;
+        try {
+            address = new URL("https://www.ibm.com/test/test");
+
+            Map<String, Object> envMap = new HashMap<>();
+            envMap.put("NO_PROXY", ".ibm.com");
+            assertTrue(ArtifactDownloaderUtils.isNoProxyURL(address, envMap));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testNoProxyURL_yesProxy() {
+        URL address;
+        try {
+            address = new URL("https://www.ibm.com");
+
+            Map<String, Object> envMap = new HashMap<>();
+            envMap.put("NO_PROXY", "test");
+            assertFalse(ArtifactDownloaderUtils.isNoProxyURL(address, envMap));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testNoProxyURL_suffix() {
+        URL address;
+        try {
+            address = new URL("https://www.ibm.com");
+
+            Map<String, Object> envMap = new HashMap<>();
+            envMap.put("NO_PROXY", "ibm.com");
+            assertTrue(ArtifactDownloaderUtils.isNoProxyURL(address, envMap));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testNoProxyURL_IP() {
+        URL address;
+        try {
+            address = new URL("http://9.160.4.63:8081");
+
+            Map<String, Object> envMap = new HashMap<>();
+            envMap.put("NO_PROXY", "9.160.4.63");
+            assertTrue(ArtifactDownloaderUtils.isNoProxyURL(address, envMap));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testNoProxyURL_IPwithPort() {
+        URL address;
+        try {
+            address = new URL("http://9.160.4.63:8081");
+
+            Map<String, Object> envMap = new HashMap<>();
+            envMap.put("NO_PROXY", "9.160.4.63:8081");
+            assertTrue(ArtifactDownloaderUtils.isNoProxyURL(address, envMap));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testNoProxyURL_empty() {
+        URL address;
+        try {
+            address = new URL("https://www.ibm.com");
+            Map<String, Object> envMap = new HashMap<>();
+            envMap.put("NO_PROXY", "");
+            assertTrue(ArtifactDownloaderUtils.isNoProxyURL(address, envMap));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
no proxy list
- A comma-separated list of host names that are not allowed to make inbound connections on this endpoint. Host names are not case-sensitive and can start with an asterisk, which is used as a wildcard character. 