### PR TITLE
Enable User customization of OpenAPI UI Endpoint

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi.ui/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.openapi.ui/bnd.bnd
@@ -5,18 +5,41 @@ Bundle-Name: OpenAPI UI
 Bundle-SymbolicName: com.ibm.ws.microprofile.openapi.ui
 Bundle-Description: OpenAPI User Interface, version ${bVersion}
 
-Web-ContextPath: /openapi/ui
+Web-ContextPath: @openAPIUIPATH
 
 IBM-Authorization-Roles: com.ibm.ws.management
 
 Import-Package: \
-  com.ibm.ws.microprofile.openapi.servlet.filter
+  com.ibm.ws.microprofile.openapi.servlet.filter, \
+  org.eclipse.microprofile.config.*;version="[1.0,4)",\
+  *
+
+Private-Package: \
+  com.ibm.ws.microprofile.openapi.ui,\
+  com.ibm.ws.microprofile.openapi.ui.resources
+
+-dsannotations-inherit: true
+-dsannotations: \
+  com.ibm.ws.microprofile.openapi.ui.OpenAPIUIEndpointManager
 
 Include-Resource: \
   WEB-INF=resources/WEB-INF, \
-  ../com.ibm.ws.openapi.ui/swagger-ui/dist;filter:=!(*.html|*.map), \
-  ../com.ibm.ws.openapi.ui/swagger-ui/dist/oauth2-redirect.html, \
+  ../com.ibm.ws.openapi.ui/swagger-ui/dist;filter:=!(*.html|*.map),\
+  ../com.ibm.ws.openapi.ui/swagger-ui/dist/oauth2-redirect.html,\
   index.html=../com.ibm.ws.openapi.ui/swagger-ui/dist/mpOpenApi.html
 
 -buildpath: \
-  com.ibm.ws.openapi.ui
+  com.ibm.ws.openapi.ui;version=latest,\
+  com.ibm.ws.app.manager.wab;version=latest,\
+  com.ibm.ws.logging;version=latest,\
+  com.ibm.ws.kernel.boot.core;version=latest,\
+  com.ibm.ws.kernel.service;version=latest,\
+  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+  com.ibm.websphere.org.eclipse.microprofile.config.1.2.1;version=latest,\
+  com.ibm.websphere.org.osgi.core;version=latest,\
+  com.ibm.websphere.org.osgi.service.component;version=latest,\
+  com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+  com.ibm.wsspi.org.osgi.service.event;version=latest
+
+-testpath: \
+    ../build.sharedResources/lib/junit/old/junit.jar;version=file

--- a/dev/com.ibm.ws.microprofile.openapi.ui/resources/com/ibm/ws/microprofile/openapi/ui/resources/OpenAPIUIMessages.nlsprops
+++ b/dev/com.ibm.ws.microprofile.openapi.ui/resources/com/ibm/ws/microprofile/openapi/ui/resources/OpenAPIUIMessages.nlsprops
@@ -37,8 +37,8 @@ CWWKO1753W_OPEN_API_UI_PATH_POTENTIAL_CONFLICT.explanation=The OpenAPI UI path w
 CWWKO1753W_OPEN_API_UI_PATH_POTENTIAL_CONFLICT.useraction=Specify a different path for the OpenAPI UI path.
 
 CWWKO1754W_OPEN_API_UI_PATH_INVALID=CWWKO1754W: The OpenAPI UI path is invalid or contains invalid characters. The URL must be constructed using Unicode alphanumeric characters A-Za-z0-9, the underscore (_), dash (-), forward slash (/) and period (.).
-CWWKO1754W_OPEN_API_UI_PATH_INVALID.explanation=The value assigned to the OpenAPI UI path must not include any characters that are considered invalid.
-CWWKO1754W_OPEN_API_UI_PATH_INVALID.useraction=The OpenAPI UI path cannot be set to a value that contains invalid characters.
+CWWKO1754W_OPEN_API_UI_PATH_INVALID.explanation=The OpenAPI UI Path cannot be set to a value that contains invalid characters.
+CWWKO1754W_OPEN_API_UI_PATH_INVALID.useraction=Ensure the OpenAPI Path contains only A-Za-z0-9, _, -, ., /.
 
 CWWKO1755W_OPEN_API_UI_PATH_SEGMENT_INVALID=CWWKO1755W: OpenAPI UI path segments "/." or "/.." are invalid.
 CWWKO1755W_OPEN_API_UI_PATH_SEGMENT_INVALID.explanation=OpenAPI UI path segments "/." or "/.." are invalid.

--- a/dev/com.ibm.ws.microprofile.openapi.ui/resources/com/ibm/ws/microprofile/openapi/ui/resources/OpenAPIUIMessages.nlsprops
+++ b/dev/com.ibm.ws.microprofile.openapi.ui/resources/com/ibm/ws/microprofile/openapi/ui/resources/OpenAPIUIMessages.nlsprops
@@ -1,0 +1,45 @@
+###############################################################################
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+# -------------------------------------------------------------------------------------------------
+#CMVCPATHNAME N/A
+#COMPONENTPREFIX CWWKO
+#COMPONENTNAMEFOR Open API UI
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_NONE
+#NLS_ENCODING=UNICODE
+# -------------------------------------------------------------------------------------------------
+
+# Message prefix block: CWWKO1750 - CWWKO1799
+CWWKO1750I_OPEN_API_PATH_UPDATE=CWWKO1750I: The OpenAPI UI path has been set to {0}.
+CWWKO1750I_OPEN_API_PATH_UPDATE.explanation=The OpenAPI UI path has been set to a value that is not the default.
+CWWKO1750I_OPEN_API_PATH_UPDATE.useraction=No action is required.
+
+CWWKO1751W_OPEN_API_PATH_UPDATE_FAILED=CWWKO1751W: The OpenAPI UI path is invalid, the default value will be used instead. Check previous warnings for cause of validation failure.
+CWWKO1751W_OPEN_API_PATH_UPDATE_FAILED.explanation= The OpenAPI UI path is invalid and will use the default value instead.
+CWWKO1751W_OPEN_API_PATH_UPDATE_FAILED.useraction=Check earlier warning messages for causes of validation failures.
+
+CWWKO1752W_OPEN_API_PATH_CONFLICT=CWWKO1752W: The OpenAPI UI path cannot be set to {0}. This path is used to retrieve the OpenAPI documents.
+CWWKO1752W_OPEN_API_PATH_CONFLICT.explanation=The OpenAPI document and OpenAPI UI paths cannot be the same.
+CWWKO1752W_OPEN_API_PATH_CONFLICT.useraction=Specify a unique path for the OpenAPI UI.
+
+CWWKO1753W_OPEN_API_UI_PATH_POTENTIAL_CONFLICT=CWWKO1753W: The OpenAPI UI path was set to the same path as the {0} feature, which might prevent startup of itself or the other feature.
+CWWKO1753W_OPEN_API_UI_PATH_POTENTIAL_CONFLICT.explanation=The OpenAPI UI path was set to the same path as another feature, which can prevent startup or access.
+CWWKO1753W_OPEN_API_UI_PATH_POTENTIAL_CONFLICT.useraction=Specify a different path for the OpenAPI UI path.
+
+CWWKO1754W_OPEN_API_UI_PATH_INVALID=CWWKO1754W: The OpenAPI UI path is invalid or contains invalid characters. The URL must be constructed using Unicode alphanumeric characters A-Za-z0-9, the underscore (_), dash (-), forward slash (/) and period (.).
+CWWKO1754W_OPEN_API_UI_PATH_INVALID.explanation=The value assigned to the OpenAPI UI path must not include any characters that are considered invalid.
+CWWKO1754W_OPEN_API_UI_PATH_INVALID.useraction=The OpenAPI UI path cannot be set to a value that contains invalid characters.
+
+CWWKO1755W_OPEN_API_UI_PATH_SEGMENT_INVALID=CWWKO1755W: OpenAPI UI path segments "/." or "/.." are invalid.
+CWWKO1755W_OPEN_API_UI_PATH_SEGMENT_INVALID.explanation=OpenAPI UI path segments "/." or "/.." are invalid.
+CWWKO1755W_OPEN_API_UI_PATH_SEGMENT_INVALID.useraction=Remove any path "/." or "/.." segments from the path.

--- a/dev/com.ibm.ws.microprofile.openapi.ui/src/com/ibm/ws/microprofile/openapi/ui/OpenAPIUIEndpointManager.java
+++ b/dev/com.ibm.ws.microprofile.openapi.ui/src/com/ibm/ws/microprofile/openapi/ui/OpenAPIUIEndpointManager.java
@@ -56,9 +56,9 @@ public class OpenAPIUIEndpointManager {
         uiPath = OPEN_API_ENDPOINT_PATH + OPEN_API_UI_PATH;
 
         if (ProductInfo.getBetaEdition()) {
-            Config config = ConfigProvider.getConfig(OpenAPIUIEndpointManager.class.getClassLoader());
             //check for system property `open_api_path_enabled` as additional guide - getBoolean returns `true` if the value exists and is set to `true`, if the value is `false`
             if (Boolean.getBoolean("open_api_path_enabled")) {
+                Config config = ConfigProvider.getConfig(OpenAPIUIEndpointManager.class.getClassLoader());
                 resolvePathFromConfig(config);
             }
         }

--- a/dev/com.ibm.ws.microprofile.openapi.ui/src/com/ibm/ws/microprofile/openapi/ui/OpenAPIUIEndpointManager.java
+++ b/dev/com.ibm.ws.microprofile.openapi.ui/src/com/ibm/ws/microprofile/openapi/ui/OpenAPIUIEndpointManager.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+package com.ibm.ws.microprofile.openapi.ui;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true, property = { "service.vendor=IBM" })
+public class OpenAPIUIEndpointManager {
+
+    private static final TraceComponent tc = Tr.register(OpenAPIUIEndpointManager.class);
+
+    private static final String OPEN_API_ENDPOINT_CONFIG_NAME = "mp.openapi.extensions.liberty.path";
+    private static final String OPEN_API_ENDPOINT_PATH = "/openapi";
+
+    private static final String OPEN_API_UI_VAR_NAME = "openAPIUIPATH";
+    private static final String OPEN_API_UI_CONFIG_NAME = "mp.openapi.extensions.liberty.ui.path";
+    private static final String OPEN_API_UI_PATH = "/ui";
+
+    private static final Pattern PATH_PATTERN = Pattern.compile("^(/[\\w./_-]*)?$");
+    private static final Map<String, String> CONFLICTING_PATHS_MAP = Stream.of(
+                                                                               new AbstractMap.SimpleEntry<>("/ibm/api", "OpenAPI"),
+                                                                               new AbstractMap.SimpleEntry<>("/health", "mpHealth"),
+                                                                               new AbstractMap.SimpleEntry<>("/metrics", "mpMetrics")).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    private String uiPath = null;
+    private String dataPath = null;
+
+    private OpenAPIWABConfigManager openAPIWABConfigManager;
+
+    @Activate
+    protected void activate(ComponentContext context, Map<String, Object> properties) {
+        //Default UI Path is /openapi/ui
+        uiPath = OPEN_API_ENDPOINT_PATH + OPEN_API_UI_PATH;
+
+        if (ProductInfo.getBetaEdition()) {
+            Config config = ConfigProvider.getConfig(OpenAPIUIEndpointManager.class.getClassLoader());
+            if (config.getOptionalValue("open_api_path_enabled", Boolean.class).orElse(false)) {
+                resolvePathFromConfig(config);
+                if (!validatePath(uiPath, dataPath)) {
+                    uiPath = dataPath + OPEN_API_UI_PATH;
+                    Tr.warning(tc,"CWWKO1751W_OPEN_API_PATH_UPDATE_FAILED");
+                } else if(!uiPath.equals(OPEN_API_ENDPOINT_PATH + OPEN_API_UI_PATH)){
+                    Tr.info(tc,"CWWKO1750I_OPEN_API_PATH_UPDATE",uiPath);
+                }
+            }
+        }
+        openAPIWABConfigManager = new OpenAPIWABConfigManager(context, OPEN_API_UI_VAR_NAME, uiPath, "OpenAPI UI");
+        openAPIWABConfigManager.activate();
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext context, int reason) {
+        openAPIWABConfigManager.deactivate();
+    }
+
+    /**
+     * Validate the OpenAPI path to ensure it is Valid, contains only valid characters and mets certain rules.
+     *
+     * Reserved Path is a related entitiy where the path and the reserved path cannot be the same*
+     *
+     * @param path
+     * @param reservedPath
+     * @return
+     */
+    public static boolean validatePath(String path, String reservedPath) {
+        boolean valid = true;
+        try {
+            //temporarily construct a URL using provided path to use the URL validation code.
+            new URL("https://localhost" + path);
+        } catch (MalformedURLException e) {
+            Tr.warning(tc, "CWWKO1754W_OPEN_API_UI_PATH_INVALID",e.getLocalizedMessage());
+            return false;
+        }
+        if (path.equals(reservedPath)) {
+            Tr.warning(tc, "CWWKO1752W_OPEN_API_PATH_CONFLICT", path);
+            valid = false;
+        }
+        //check that path is made up of valid characters
+        if (!PATH_PATTERN.matcher(path).matches()) {
+            Tr.warning(tc, "CWWKO1754W_OPEN_API_UI_PATH_INVALID", path);
+            valid = false;
+            //check against other feature paths to see if a potential conflict might occur
+        }
+
+        // check that no segment is just `/.` or `/..`, `/.....` should be left as is as it has no special meaning
+        ArrayList<String> segments = new ArrayList<>(Arrays.asList(path.split("/")));
+        if (segments.contains(".") || segments.contains("..")) {
+            Tr.warning(tc, "CWWKO1755W_OPEN_API_UI_PATH_SEGMENT_INVALID");
+            valid = false;
+        }
+
+        // Check if there are potential conflicts with other Liberty/MicroProfile features and warn if there is a match.
+        if (CONFLICTING_PATHS_MAP.containsKey(path)) {
+            //Just warn that might conflict with other features as they might not be active, so not a cause for failure.
+            //If there is a conflict WebContainer will error for the second feature that starts.
+            Tr.warning(tc, "CWWKO1753W_OPEN_API_UI_PATH_POTENTIAL_CONFLICT", CONFLICTING_PATHS_MAP.get(path));
+        }
+
+        return valid;
+    }
+
+    /**
+     * Resolve the provided path to check and modify the path to meet a basic path structure
+     *
+     * @param path
+     * @return
+     */
+    public static String resolvePath(String path) {
+        // Add a forward slash if the path does not already start with one.
+        if (!path.startsWith("/")) {
+            path = '/' + path;
+        }
+        //in case someone specifies for example`////foo//bar` which will get through, keep running until all potential double `//` are removed
+        while (path.contains("//")) {
+            path = path.replace("//", "/");
+        }
+        // Remove trailing slash if the path contains one.
+        if (path.endsWith("/") && !path.equals("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
+
+    private void resolvePathFromConfig(Config config) {
+        //Process dataPath first as the value is used by UI Path if value does not exist
+        dataPath = resolvePath(config.getOptionalValue(OPEN_API_ENDPOINT_CONFIG_NAME, String.class).orElse(OPEN_API_ENDPOINT_PATH));
+        uiPath = resolvePath(config.getOptionalValue(OPEN_API_UI_CONFIG_NAME, String.class).orElse(dataPath + OPEN_API_UI_PATH));
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.openapi.ui/src/com/ibm/ws/microprofile/openapi/ui/OpenAPIWABConfigManager.java
+++ b/dev/com.ibm.ws.microprofile.openapi.ui/src/com/ibm/ws/microprofile/openapi/ui/OpenAPIWABConfigManager.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+package com.ibm.ws.microprofile.openapi.ui;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.wsspi.wab.configure.WABConfiguration;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+public class OpenAPIWABConfigManager {
+
+    private static final TraceComponent tc = Tr.register(OpenAPIUIEndpointManager.class);
+
+    final ComponentContext context;
+    final String contextName;
+    final String contextPath;
+    final String name;
+
+    ServiceRegistration<WABConfiguration> wabConfigReg;
+
+    /**
+     * WAB Configuration Manager for OpenAPI Endpoints
+     *
+     * @param context Component Context for the Web bundle
+     * @param contextName Name of the property within the bnd that the Web-ContextPath is bound to
+     * @param contextPath Path for the bundle
+     * @param name Name associated with the OpenAPI bundle
+     */
+    public OpenAPIWABConfigManager(ComponentContext context, String contextName, String contextPath, String name) {
+        this.context = context;
+        this.contextName = contextName;
+        this.contextPath = contextPath;
+        this.name=name;
+    }
+
+    /**
+     * Active Web Bundle
+     */
+    public void activate() {
+        final BundleContext bundleContext = context.getBundleContext();
+        final Dictionary<String, String> props = new Hashtable<String, String>();
+        props.put(WABConfiguration.CONTEXT_NAME, contextName);
+        props.put(WABConfiguration.CONTEXT_PATH, contextPath);
+        if (wabConfigReg == null) {
+            wabConfigReg = bundleContext.registerService(WABConfiguration.class, new WABConfiguration() {}, props);
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                registerEvent(props);
+            }
+        } else {
+            wabConfigReg.setProperties(props);
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                modifiedEvent(props);
+            }
+        }
+    }
+
+    /**
+     * Deactivate Web bundle
+     */
+    public void deactivate() {
+        if (wabConfigReg != null) {
+            wabConfigReg.unregister();
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                deactivateEvent();
+            }
+            wabConfigReg = null;
+        }
+    }
+
+    public void registerEvent(Dictionary<String, String> props) {
+        Tr.event(tc, name + " web app bundle registered, WAB config=" + wabConfigReg + " using props=" + props);
+    }
+
+    public void modifiedEvent(Dictionary<String, String> props) {
+        Tr.event(tc, name + " web app bundle modified, WAB config=" + wabConfigReg + " using props=" + props);
+    }
+
+    public void deactivateEvent() {
+        Tr.event(tc, "Unregistered web app bundle "+ name +", WAB config=" + wabConfigReg + " for contextName=" + contextName + " and contextPath=" + contextPath);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.openapi.ui/src/com/ibm/ws/microprofile/openapi/ui/WABConfigManager.java
+++ b/dev/com.ibm.ws.microprofile.openapi.ui/src/com/ibm/ws/microprofile/openapi/ui/WABConfigManager.java
@@ -20,26 +20,33 @@ import org.osgi.service.component.ComponentContext;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
-public class OpenAPIWABConfigManager {
+/**
+ * Manage the service registration of Web Application Bundles that support configurable context paths
+ * 
+ * For more information about WAB Configuration, including how to enable configurable context paths for bundles, refer to:
+ * dev/com.ibm.websphere.appserver.spi.wab.configure/build/libs/javadoc/com/ibm/wsspi/wab/configure/WABConfiguration.html
+ * 
+ */
+public class WABConfigManager {
 
-    private static final TraceComponent tc = Tr.register(OpenAPIUIEndpointManager.class);
+    private static final TraceComponent tc = Tr.register(WABConfigManager.class);
 
-    final ComponentContext context;
-    final String contextName;
-    final String contextPath;
-    final String name;
+    private final ComponentContext context;
+    private final String contextName;
+    private final String contextPath;
+    private final String name;
 
-    ServiceRegistration<WABConfiguration> wabConfigReg;
+    private ServiceRegistration<WABConfiguration> wabConfigReg;
 
     /**
      * WAB Configuration Manager for OpenAPI Endpoints
      *
      * @param context Component Context for the Web bundle
-     * @param contextName Name of the property within the bnd that the Web-ContextPath is bound to
-     * @param contextPath Path for the bundle
-     * @param name Name associated with the OpenAPI bundle
+     * @param contextName Name of the property within the bnd that the Web-ContextPath is bound to e.g. "openAPIUIPATH"
+     * @param contextPath Context path for the bundle to be served from
+     * @param name Name associated with the bundle for tracing
      */
-    public OpenAPIWABConfigManager(ComponentContext context, String contextName, String contextPath, String name) {
+    public WABConfigManager(ComponentContext context, String contextName, String contextPath, String name) {
         this.context = context;
         this.contextName = contextName;
         this.contextPath = contextPath;
@@ -47,9 +54,9 @@ public class OpenAPIWABConfigManager {
     }
 
     /**
-     * Active Web Bundle
+     * Register Web Bundle
      */
-    public void activate() {
+    public void register() {
         final BundleContext bundleContext = context.getBundleContext();
         final Dictionary<String, String> props = new Hashtable<String, String>();
         props.put(WABConfiguration.CONTEXT_NAME, contextName);
@@ -68,9 +75,9 @@ public class OpenAPIWABConfigManager {
     }
 
     /**
-     * Deactivate Web bundle
+     * Unregister Web bundle
      */
-    public void deactivate() {
+    public void unregister() {
         if (wabConfigReg != null) {
             wabConfigReg.unregister();
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {

--- a/dev/com.ibm.ws.microprofile.openapi.ui/src/com/ibm/ws/microprofile/openapi/ui/package-info.java
+++ b/dev/com.ibm.ws.microprofile.openapi.ui/src/com/ibm/ws/microprofile/openapi/ui/package-info.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@com.ibm.websphere.ras.annotation.TraceOptions(traceGroup = "OpenAPIUI", messageBundle = "com.ibm.ws.microprofile.openapi.ui.resources.OpenAPIUIMessages")
+package com.ibm.ws.microprofile.openapi.ui;

--- a/dev/com.ibm.ws.microprofile.openapi.ui/test/com/ibm/ws/microprofile/openapi/ui/OpenAPIUIEndpointManagerTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi.ui/test/com/ibm/ws/microprofile/openapi/ui/OpenAPIUIEndpointManagerTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+package com.ibm.ws.microprofile.openapi.ui;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+public class OpenAPIUIEndpointManagerTest {
+
+    private static final String DEFAULT_OPENAPI_ENDPOINT="/openapi";
+    private static final String ALTERNATIVE_OPENAPI_ENDPOINT="/docs";
+
+    private static String METRICS_PATH="/metrics";
+    private static String API_PATH="/ibm/api";
+    private static String HEALTH_PATH="/health";
+
+    @Test
+    public void resolvePathValidPath(){
+        assertEquals(OpenAPIUIEndpointManager.resolvePath("/path"),"/path");
+    }
+
+    @Test
+    public void resolvePathAddStartingSlash(){
+        assertEquals(OpenAPIUIEndpointManager.resolvePath("path"),"/path");
+    }
+
+    @Test
+    public void resolvePathRemoveTraillingSlash(){
+        assertEquals(OpenAPIUIEndpointManager.resolvePath("/path/"),"/path");
+    }
+
+    @Test
+    public void resolvePathReplaceMultiSlash(){
+        assertEquals(OpenAPIUIEndpointManager.resolvePath("/path//path2////path3"),"/path/path2/path3");
+    }
+
+    @Test
+    public void resolvePathSingleSlash(){
+        assertEquals(OpenAPIUIEndpointManager.resolvePath("/"),"/");
+    }
+
+    @Test
+    public void resolvePathEmptyPath(){
+        assertEquals(OpenAPIUIEndpointManager.resolvePath(""),"/");
+    }
+
+    @Test
+    public void validatePathSlashPath(){
+         assertTrue(OpenAPIUIEndpointManager.validatePath("/",DEFAULT_OPENAPI_ENDPOINT));
+    }
+
+    @Test
+    public void validatePathSimpleValidPath(){
+        assertTrue(OpenAPIUIEndpointManager.validatePath("/foo/bar", DEFAULT_OPENAPI_ENDPOINT));
+    }
+
+    @Test
+    public void validatePathConflictOpenAPIPath(){
+        assertFalse(OpenAPIUIEndpointManager.validatePath(DEFAULT_OPENAPI_ENDPOINT, DEFAULT_OPENAPI_ENDPOINT));
+    }
+
+    @Test
+    public void validatePathOpenAPIPath(){
+        //UI Path becomes `/openapi`, while Document path is registered as `/docs`
+        assertTrue(OpenAPIUIEndpointManager.validatePath(DEFAULT_OPENAPI_ENDPOINT,ALTERNATIVE_OPENAPI_ENDPOINT));
+    }
+
+    @Test
+    public void validatePathDotPathStart(){
+        assertFalse(OpenAPIUIEndpointManager.validatePath("/.", DEFAULT_OPENAPI_ENDPOINT));
+    }
+
+    @Test
+    public void validatePathDoubleDotPathStart(){
+        assertFalse(OpenAPIUIEndpointManager.validatePath("/..", DEFAULT_OPENAPI_ENDPOINT));
+    }
+
+    @Test
+    public void validatePathInvalidDotSegments(){
+        assertFalse(OpenAPIUIEndpointManager.validatePath("/foo/./bar", DEFAULT_OPENAPI_ENDPOINT));
+        assertFalse(OpenAPIUIEndpointManager.validatePath("/foo/../bar", DEFAULT_OPENAPI_ENDPOINT));
+    }
+
+    @Test
+    public void validatePathMultiDotSegments(){
+        assertTrue(OpenAPIUIEndpointManager.validatePath("/foo/..../bar", DEFAULT_OPENAPI_ENDPOINT));
+    }
+
+    @Test
+    public void validatePathFeaturePaths(){
+        assertTrue(OpenAPIUIEndpointManager.validatePath(METRICS_PATH, DEFAULT_OPENAPI_ENDPOINT));
+        assertTrue(OpenAPIUIEndpointManager.validatePath(HEALTH_PATH, DEFAULT_OPENAPI_ENDPOINT));
+        assertTrue(OpenAPIUIEndpointManager.validatePath(API_PATH, DEFAULT_OPENAPI_ENDPOINT));
+    }
+
+    @Test
+    public void validatePathEncodedCharacter(){
+        assertFalse(OpenAPIUIEndpointManager.validatePath("/foo%3ebar", DEFAULT_OPENAPI_ENDPOINT));
+    }
+
+    @Test
+    public void validatePathValidNonAlphaCharacters(){
+        assertTrue(OpenAPIUIEndpointManager.validatePath("/foo.bar", DEFAULT_OPENAPI_ENDPOINT));
+        assertTrue(OpenAPIUIEndpointManager.validatePath("/foo..bar", DEFAULT_OPENAPI_ENDPOINT));
+        assertTrue(OpenAPIUIEndpointManager.validatePath("/foo-bar", DEFAULT_OPENAPI_ENDPOINT));
+        assertTrue(OpenAPIUIEndpointManager.validatePath("/foo_bar", DEFAULT_OPENAPI_ENDPOINT));
+        assertTrue(OpenAPIUIEndpointManager.validatePath("/f00/bar", DEFAULT_OPENAPI_ENDPOINT));
+    }
+
+    @Test
+    public void validatePathInvalidCharacters(){
+        assertFalse(OpenAPIUIEndpointManager.validatePath("/foo\\bar", DEFAULT_OPENAPI_ENDPOINT));
+        assertFalse(OpenAPIUIEndpointManager.validatePath("/foo/bar?query=param", DEFAULT_OPENAPI_ENDPOINT));
+        assertFalse(OpenAPIUIEndpointManager.validatePath("/foo#bar", DEFAULT_OPENAPI_ENDPOINT));
+        assertFalse(OpenAPIUIEndpointManager.validatePath("/foo;bar", DEFAULT_OPENAPI_ENDPOINT));
+        assertFalse(OpenAPIUIEndpointManager.validatePath("/foo%3ebar", DEFAULT_OPENAPI_ENDPOINT));
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/FATSuite.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/FATSuite.java
@@ -17,7 +17,8 @@ import componenttest.containers.TestContainerSuite;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                UIBasicTest.class
+                UIBasicTest.class,
+                UICustomPathTest.class
 })
 public class FATSuite extends TestContainerSuite {
 

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UICustomPathTest.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UICustomPathTest.java
@@ -79,9 +79,7 @@ public class UICustomPathTest {
         server.addEnvVar(PROPERTY_NAME,PATH_VALUE);
 
         //Set guards
-        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
-        server.setAdditionalSystemProperties(Collections.singletonMap("open_api_path_enabled", "true"));
-
+        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true", "-Dopen_api_path_enabled=true"));
         server.startServer();
 
         Testcontainers.exposeHostPorts(server.getHttpDefaultPort(), server.getHttpDefaultSecurePort());

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UICustomPathTest.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UICustomPathTest.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+package io.openliberty.microprofile.openapi.ui.internal.fat.tests;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.ws.fat.util.Props;
+import componenttest.annotation.Server;
+import componenttest.containers.SimpleLogConsumer;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.microprofile.openapi.ui.internal.fat.app.TestResource;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.BrowserWebDriverContainer;
+import org.testcontainers.containers.BrowserWebDriverContainer.VncRecordingMode;
+import org.testcontainers.containers.VncRecordingContainer.VncRecordingFormat;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static componenttest.selenium.SeleniumWaits.waitForElement;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * A Test of UI Path rewriting
+ */
+@RunWith(FATRunner.class)
+public class UICustomPathTest {
+
+    public static final String APP_NAME = "app";
+    public static final String PROPERTY_NAME = "customUIPath";
+    public static final String PATH_VALUE = "/foo/bar";
+    /**
+     * Wait for "long" tasks like initial page load or making a test request to the server
+     */
+    private static final Duration LONG_WAIT = Duration.ofSeconds(30);
+
+    @Server("openapi-ui-custom-test")
+    public static LibertyServer server;
+
+    @Rule
+    public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>().withCapabilities(new ChromeOptions()).withAccessToHost(true).withRecordingMode(VncRecordingMode.RECORD_FAILING,
+                                                                                                                                                                  Props.getInstance().getFileProperty(Props.DIR_LOG),
+                                                                                                                                                                  VncRecordingFormat.MP4).withLogConsumer(new SimpleLogConsumer(UICustomPathTest.class, "selenium-driver"));
+
+    private RemoteWebDriver driver;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war").addClass(TestResource.class);
+
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
+
+        //Set the new path value
+        server.addEnvVar(PROPERTY_NAME,PATH_VALUE);
+
+        //Set guards
+        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
+        server.setAdditionalSystemProperties(Collections.singletonMap("open_api_path_enabled", "true"));
+
+        server.startServer();
+
+        Testcontainers.exposeHostPorts(server.getHttpDefaultPort(), server.getHttpDefaultSecurePort());
+    }
+
+    @Before
+    public void setupTest() {
+        driver = new RemoteWebDriver(chrome.getSeleniumAddress(), new ChromeOptions());
+        driver.get("http://host.testcontainers.internal:" + server.getHttpDefaultPort() + PATH_VALUE);
+    }
+
+    @Test
+    public void testCustomUIPath() {
+
+        // Check the title loads
+        WebElement title = waitForElement(driver, By.cssSelector("h2.title"), LONG_WAIT);
+        assertThat("Page title", title.getText(), Matchers.containsString("Generated API"));
+
+        // Check the headerbar colour
+        WebElement headerbar = waitForElement(driver, By.cssSelector("div.headerbar"));
+        assertEquals("Headerbar colour", "rgba(25, 28, 44, 1)", headerbar.getCssValue("background-color"));
+
+        // Check the headerbar has a background image. It's a data URL, so it's hard to assert it's actually correct, we just assert that there is one
+        WebElement headerbarWrapper = waitForElement(headerbar, By.cssSelector("div.headerbar-wrapper"));
+        assertThat("Headerbar image", headerbarWrapper.getCssValue("background-image"), startsWith("url(\"data:image/png"));
+
+        // Check we can see and open the operation
+        WebElement testGetOpBlock = waitForElement(driver, By.id("operations-default-get_test"));
+        WebElement testGetButton = testGetOpBlock.findElement(By.tagName("button"));
+        testGetButton.click();
+        WebElement testGet200Response = waitForElement(testGetOpBlock, By.cssSelector("tr.response[data-code=\"200\"]"));
+        assertNotNull("200 response line", testGet200Response);
+    }
+}

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/publish/servers/openapi-ui-custom-test/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/publish/servers/openapi-ui-custom-test/bootstrap.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+#com.ibm.ws.logging.trace.specification=*=info:MPOPENAPI=debug:io.smallrye.openapi.*=all
+

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/publish/servers/openapi-ui-custom-test/server.xml
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/publish/servers/openapi-ui-custom-test/server.xml
@@ -1,0 +1,20 @@
+<!--Copyright (c) 2023 IBM Corporation and others. All rights reserved.
+    This program and the accompanying materials are made available under the 
+    terms of the Eclipse Public License 2.0 which accompanies this distribution, 
+    and is available at 
+        http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0 
+    Contributors: 
+        IBM Corporation - initial API and implementation
+-->
+<server>
+    <featureManager>
+        <feature>restfulWS-3.1</feature>
+        <feature>mpOpenAPI-3.1</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml" />
+
+    <variable name="mp.openapi.extensions.liberty.ui.path" value="${customUIPath}"/>
+</server>


### PR DESCRIPTION
Allow user to define a property for the MP OpenAPI UI Endpoint such that the UI is available on that path e.g. `/custom/location` 

Given package is used by all OpenAPI feature versions, it will always default to `/openapi/ui` and is currently beta guarded

includes validation to prevent conflict with the OpenAPI 

Expands UI testing to include test for updating of UI - runs the same tests against the UI as the basic test and basic test covers the reverting to default 

#25072 