### PR TITLE
OIDC Back-channel logout minor fixes

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OIDCConstants.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OIDCConstants.java
@@ -88,6 +88,7 @@ public interface OIDCConstants extends OAuth20Constants {
     public static final String OIDC_LOGOUT_ID_TOKEN_HINT = OIDC_AUTHZ_PARAM_ID_TOKEN_HINT;
     public static final String OIDC_LOGOUT_REDIRECT_URI = "post_logout_redirect_uri";
     public static final String OIDC_LOGOUT_CLIENT_ID = "client_id";
+    public static final String OIDC_LOGOUT_STATE = "state";
 
     /* parameters for oidc discovery response */
     public static final String OIDC_DISC_ISSUER = "issuer";

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
@@ -243,5 +243,5 @@ ERROR_BUILDING_LOGOUT_TOKEN_BASED_ON_ID_TOKEN_CLAIMS.useraction=For more informa
 
 # Do not translate aud
 ID_TOKEN_HINT_CLIENT_ID_DOES_NOT_MATCH_REQUEST_PARAMETER=CWWKS1954E: The [{0}] aud claim within the id_token_hint parameter does not match the [{1}] value for the client_id request parameter.
-ID_TOKEN_HINT_CLIENT_ID_DOES_NOT_MATCH_REQUEST_PARAMETER.explanation=When both a client_id and id_token_hint parameter are present, the client identifier within the ID token must match the value that is provided for the client_id parameter.
+ID_TOKEN_HINT_CLIENT_ID_DOES_NOT_MATCH_REQUEST_PARAMETER.explanation=When both the client_id and id_token_hint parameters are present, the client identifier within the ID token must match the value that is provided for the client_id parameter.
 ID_TOKEN_HINT_CLIENT_ID_DOES_NOT_MATCH_REQUEST_PARAMETER.useraction=Ensure that the client_id parameter value matches the aud claim in the ID token.

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/com/ibm/ws/security/openidconnect/server/internal/resources/OidcServerMessages.nlsprops
@@ -240,3 +240,8 @@ ERROR_BUILDING_LOGOUT_TOKEN_BASED_ON_ID_TOKEN.useraction=For more information, s
 ERROR_BUILDING_LOGOUT_TOKEN_BASED_ON_ID_TOKEN_CLAIMS=CWWKS1953E: A back-channel logout token that is based on a cached ID token with claims [{0}] for the {1} client cannot be created due to the following error: {2}
 ERROR_BUILDING_LOGOUT_TOKEN_BASED_ON_ID_TOKEN_CLAIMS.explanation=An error occurred in building the logout token string. Alternatively, the issuer of the cached ID token might not match this OpenID Connect provider, or the cached ID token might be missing some claims that are required.
 ERROR_BUILDING_LOGOUT_TOKEN_BASED_ON_ID_TOKEN_CLAIMS.useraction=For more information, see the error included in the message.
+
+# Do not translate aud
+ID_TOKEN_HINT_CLIENT_ID_DOES_NOT_MATCH_REQUEST_PARAMETER=CWWKS1954E: The [{0}] aud claim within the id_token_hint parameter does not match the [{1}] value for the client_id request parameter.
+ID_TOKEN_HINT_CLIENT_ID_DOES_NOT_MATCH_REQUEST_PARAMETER.explanation=When both a client_id and id_token_hint parameter are present, the client identifier within the ID token must match the value that is provided for the client_id parameter.
+ID_TOKEN_HINT_CLIENT_ID_DOES_NOT_MATCH_REQUEST_PARAMETER.useraction=Ensure that the client_id parameter value matches the aud claim in the ID token.

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcRpInitiatedLogoutTokenAndRequestData.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcRpInitiatedLogoutTokenAndRequestData.java
@@ -57,6 +57,8 @@ public class OidcRpInitiatedLogoutTokenAndRequestData {
     }
 
     public void populate() {
+        isDataValidForLogout = true;
+
         initializeUserPrincipalData();
         initializeValuesFromRequestParameters();
 
@@ -65,7 +67,7 @@ public class OidcRpInitiatedLogoutTokenAndRequestData {
         subjectFromIdToken = ((cachedIdToken == null) ? null : cachedIdToken.getUsername());
         clientId = ((cachedIdToken == null) ? clientId : cachedIdToken.getClientId());
 
-        if (idTokenHintParameter != null && cachedIdToken == null) {
+        if (idTokenHintParameter != null && cachedIdToken == null && isDataValidForLogout) {
             parseAndPopulateDataFromIdTokenHint();
         }
 
@@ -76,8 +78,7 @@ public class OidcRpInitiatedLogoutTokenAndRequestData {
         if (userPrincipalName != null && subjectFromIdToken != null && !userPrincipalName.equals(subjectFromIdToken)) {
             // user mismatch, abort
             Tr.error(tc, "OIDC_SERVER_USERNAME_MISMATCH_ERR", new Object[] { userPrincipalName, subjectFromIdToken });
-        } else {
-            isDataValidForLogout = true;
+            isDataValidForLogout = false;
         }
     }
 
@@ -123,6 +124,7 @@ public class OidcRpInitiatedLogoutTokenAndRequestData {
                     }
                 } else {
                     Tr.error(tc, "OIDC_SERVER_IDTOKEN_VERIFY_ERR", new Object[] { "IDTokenValidatonFailedException" });
+                    isDataValidForLogout = false;
                 }
             }
         }
@@ -146,12 +148,15 @@ public class OidcRpInitiatedLogoutTokenAndRequestData {
                     }
                 } catch (Exception e) {
                     Tr.error(tc, "OIDC_SERVER_IDTOKEN_VERIFY_ERR", new Object[] { e });
+                    isDataValidForLogout = false;
                 }
             } else {
                 Tr.error(tc, "OIDC_SERVER_IDTOKEN_VERIFY_ERR", new Object[] { ivfe });
+                isDataValidForLogout = false;
             }
         } catch (Exception e) {
             Tr.error(tc, "OIDC_SERVER_IDTOKEN_VERIFY_ERR", new Object[] { e });
+            isDataValidForLogout = false;
         }
     }
 
@@ -166,6 +171,7 @@ public class OidcRpInitiatedLogoutTokenAndRequestData {
             clientId = getVerifiedClientId(jwt.getPayload());
         } else {
             Tr.error(tc, "OIDC_SERVER_IDTOKEN_VERIFY_ERR", new Object[] { "IDTokenValidatonFailedException" });
+            isDataValidForLogout = false;
         }
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilder.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilder.java
@@ -157,7 +157,7 @@ public class LogoutTokenBuilder {
             clientIdsBeingLoggedOut.add(client.getClientId());
         }
         for (OAuth20Token token : allCachedUserTokens) {
-            if (OAuth20Constants.ACCESS_TOKEN.equals(token.getType())) {
+            if (isAccessTokenCreatedForUser(token)) {
                 String clientIdForAccessToken = token.getClientId();
                 if (clientIdsBeingLoggedOut.contains(clientIdForAccessToken)) {
                     // Only remove access tokens for this user for the clients that are being logged out
@@ -165,6 +165,20 @@ public class LogoutTokenBuilder {
                 }
             }
         }
+    }
+
+    /**
+     * Checks the grant type of the token to ensure it wasn't created via an app password or app token.
+     */
+    boolean isAccessTokenCreatedForUser(OAuth20Token token) {
+        if (!OAuth20Constants.ACCESS_TOKEN.equals(token.getType())) {
+            return false;
+        }
+        String grantType = token.getGrantType();
+        if (grantType != null && (grantType.equals(OAuth20Constants.GRANT_TYPE_APP_PASSWORD) || grantType.equals(OAuth20Constants.GRANT_TYPE_APP_TOKEN))) {
+            return false;
+        }
+        return true;
     }
 
     void removeAccessTokenAndAssociatedRefreshTokenFromCache(OAuth20Token accessToken) {


### PR DESCRIPTION
- Updates BCL code to check the grant type of access tokens it's querying to log out to ensure the tokens weren't created with the `app_password` or `app_token` grant type
- Verifies the `aud` claim in the ID token hint matches the value for the `client_id` parameter if one was passed in the RP-initiated logout request
- Passes the `state` parameter back in the RP-initiated logout redirect URL if one was included in the logout request
- Minor refactoring of RP-initiated logout code