### PR TITLE
PR for Issue 25247: Do not require client secret for OIDC clients using private_key_jwt token auth method

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/internal/OidcClientAuthenticatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/internal/OidcClientAuthenticatorTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- * IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.client.internal;
 
@@ -311,6 +308,8 @@ public class OidcClientAuthenticatorTest {
                 {
                     allowing(convClientConfig).getClientId();
                     will(returnValue(CLIENT01));
+                    one(convClientConfig).getId();
+                    will(returnValue(testName.getMethodName()));
                     one(convClientConfig).getClientSecret();
                     will(returnValue("clientsecret"));
                     allowing(convClientConfig).getClockSkewInSeconds();
@@ -379,6 +378,8 @@ public class OidcClientAuthenticatorTest {
             {
                 exactly(3).of(convClientConfig).getClientId();
                 will(returnValue(CLIENTID));
+                one(convClientConfig).getId();
+                will(returnValue(testName.getMethodName()));
                 one(convClientConfig).getClientSecret();
                 will(returnValue("clientsecret"));
                 allowing(convClientConfig).getClockSkewInSeconds();

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandlerTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandlerTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- * IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
@@ -91,6 +88,8 @@ public class AuthorizationCodeHandlerTest {
             {
                 one(convClientConfig).getClientId();
                 will(returnValue(CLIENTID));
+                one(convClientConfig).getId();
+                will(returnValue(testName.getMethodName()));
                 allowing(webAppSecConfig).getSSORequiresSSL();
                 will(returnValue(true));
                 allowing(webAppSecConfig).getHttpOnlyCookies();
@@ -165,6 +164,8 @@ public class AuthorizationCodeHandlerTest {
                 {
                     allowing(convClientConfig).getClientId();
                     will(returnValue(CLIENT01));
+                    one(convClientConfig).getId();
+                    will(returnValue(testName.getMethodName()));
                     one(oidcClientAuthUtil).verifyResponseState(req, res, originalState, convClientConfig);
                     will(returnValue(new ProviderAuthenticationResult(AuthResult.SEND_401, HttpServletResponse.SC_UNAUTHORIZED)));
                 }
@@ -187,6 +188,8 @@ public class AuthorizationCodeHandlerTest {
                 {
                     allowing(convClientConfig).getClientId();
                     will(returnValue(CLIENT01));
+                    one(convClientConfig).getId();
+                    will(returnValue(testName.getMethodName()));
                     one(oidcClientAuthUtil).verifyResponseState(req, res, originalState, convClientConfig);
                     will(returnValue(null));
                     allowing(convClientConfig).getTokenEndpointUrl();
@@ -212,6 +215,8 @@ public class AuthorizationCodeHandlerTest {
             {
                 one(convClientConfig).getClientId();
                 will(returnValue(CLIENTID));
+                one(convClientConfig).getId();
+                will(returnValue(testName.getMethodName()));
                 one(oidcClientAuthUtil).verifyResponseState(req, res, originalState, convClientConfig);
                 will(returnValue(null));
                 one(convClientConfig).getTokenEndpointUrl();
@@ -242,6 +247,8 @@ public class AuthorizationCodeHandlerTest {
             {
                 allowing(convClientConfig).getClientId();
                 will(returnValue(CLIENTID));
+                one(convClientConfig).getId();
+                will(returnValue(testName.getMethodName()));
                 one(oidcClientAuthUtil).verifyResponseState(req, res, originalState, convClientConfig);
                 will(returnValue(null));
                 allowing(convClientConfig).getTokenEndpointUrl();

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
@@ -20,7 +20,7 @@
         <AD id="clientId" name="%clientId" description="%clientId.desc"
             required="true" type="String" />
         <AD id="clientSecret" name="%clientSecret" description="%clientSecret.desc"
-            required="true" type="String" ibm:type="password" />
+            type="String" ibm:type="password" />
         <!-- AD id="userApi" required="false" type="String" not defined -->
         <AD id="authorizationEndpoint" name="%authorizationEndpoint" description="%authorizationEndpoint.desc"
             required="false" type="String" default="https://accounts.google.com/o/oauth2/v2/auth"/>
@@ -370,7 +370,7 @@
         <AD id="clientId" name="%clientId" description="%clientId.desc"
             required="true" type="String" />
         <AD id="clientSecret" name="%clientSecret" description="%clientSecret.desc"
-            required="true" type="String" ibm:type="password" />
+            type="String" ibm:type="password" />
         <!-- AD id="userApi" required="false" type="String" not defined -->
         <AD id="authorizationEndpoint" name="%authorizationEndpoint" description="%authorizationEndpoint.desc"
             required="false" type="String" />

--- a/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
+++ b/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
@@ -652,6 +652,6 @@ BACKCHANNEL_REQUEST_NOT_SUPPORTED_CONFIG=CWWKS2350E: The back-channel logout req
 BACKCHANNEL_REQUEST_NOT_SUPPORTED_CONFIG.explanation=The social media login configuration is not an OpenID Connect client, so it does not support back-channel logout.
 BACKCHANNEL_REQUEST_NOT_SUPPORTED_CONFIG.useraction=Use the logout endpoint that is appropriate for the social media login configuration.
 
-CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD=CWWKS2351E: The {0} OpenID Connect client uses the {1} token endpoint authentication method which requires a client secret, but a client secret is not configured.
+CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD=CWWKS2351E: The {0} OpenID Connect client uses the {1} token endpoint authentication method. This authentication method requires a client secret, but a client secret is not configured.
 CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD.explanation=The token endpoint authentication method that is specified in the message requires a client secret to authenticate with the token endpoint of the OpenID Connect provider.
-CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD.useraction=Either configure a client secret for the OpenID Connect client, or change the token endpoint authentication method used by the client to one that does not require a client secret.
+CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD.useraction=Configure a client secret for the OpenID Connect client, or switch the token endpoint authentication method of the client to one that does not require a client secret.

--- a/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
+++ b/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
@@ -1,14 +1,11 @@
 ###############################################################################
-# Copyright (c) 2016, 2020 IBM Corporation and others.
+# Copyright (c) 2016, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 # -------------------------------------------------------------------------------------------------
 #CMVCPATHNAME com.ibm.ws.security/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
@@ -655,3 +652,6 @@ BACKCHANNEL_REQUEST_NOT_SUPPORTED_CONFIG=CWWKS2350E: The back-channel logout req
 BACKCHANNEL_REQUEST_NOT_SUPPORTED_CONFIG.explanation=The social media login configuration is not an OpenID Connect client, so it does not support back-channel logout.
 BACKCHANNEL_REQUEST_NOT_SUPPORTED_CONFIG.useraction=Use the logout endpoint that is appropriate for the social media login configuration.
 
+CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD=CWWKS2351E: The {0} OpenID Connect client uses the {1} token endpoint authentication method which requires a client secret, but a client secret is not configured.
+CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD.explanation=The token endpoint authentication method that is specified in the message requires a client secret to authenticate with the token endpoint of the OpenID Connect provider.
+CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD.useraction=Either configure a client secret for the OpenID Connect client, or change the token endpoint authentication method used by the client to one that does not require a client secret.

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
@@ -231,9 +231,9 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
         performMiscellaneousConfigurationChecks();
     }
 
-    void performMiscellaneousConfigurationChecks() throws SocialLoginException {
+    void performMiscellaneousConfigurationChecks() {
         if (!PrivateKeyJwtAuthMethod.AUTH_METHOD.equals(tokenEndpointAuthMethod) && (clientSecret == null || clientSecret.isEmpty())) {
-            throw new SocialLoginException("CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD", null, new Object[] { clientId, tokenEndpointAuthMethod });
+            Tr.error(tc, "CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD", uniqueId, tokenEndpointAuthMethod);
         }
     }
 

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
@@ -166,9 +166,6 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
         userInfoEndpointEnabled = configUtils.getBooleanConfigAttribute(props, KEY_USERINFO_ENDPOINT_ENABLED, userInfoEndpointEnabled);
         signatureAlgorithm = configUtils.getConfigAttribute(props, KEY_SIGNATURE_ALGORITHM);
         tokenEndpointAuthMethod = configUtils.getConfigAttribute(props, KEY_tokenEndpointAuthMethod);
-        if (!"private_key_jwt".equals(tokenEndpointAuthMethod) && (clientSecret == null || clientSecret.isEmpty())) {
-            // TODO - log new warning message letting them know a client secret is required unless they're using the private_key_jwt auth method
-        }
         tokenEndpointAuthSigningAlgorithm = configUtils.getConfigAttribute(props, CFG_KEY_TOKEN_ENDPOINT_AUTH_SIGNING_ALGORITHM);
         keyAliasName = configUtils.getConfigAttribute(props, KEY_keyAliasName);
         scope = configUtils.getConfigAttribute(props, KEY_scope);
@@ -231,6 +228,13 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
             discoveryUtil.logDiscoveryMessage("OIDC_CLIENT_DISCOVERY_COMPLETE", null, OIDC_CLIENT_DISCOVERY_COMPLETE);
         }
 
+        performMiscellaneousConfigurationChecks();
+    }
+
+    void performMiscellaneousConfigurationChecks() throws SocialLoginException {
+        if (!PrivateKeyJwtAuthMethod.AUTH_METHOD.equals(tokenEndpointAuthMethod) && (clientSecret == null || clientSecret.isEmpty())) {
+            throw new SocialLoginException("CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD", null, new Object[] { clientId, tokenEndpointAuthMethod });
+        }
     }
 
     private HashMap<String, String> populateCustomRequestParameterMap(Map<String, Object> configProps, String configAttributeName) {

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/internal/OidcLoginConfigImplTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/internal/OidcLoginConfigImplTest.java
@@ -102,9 +102,9 @@ public class OidcLoginConfigImplTest extends CommonConfigTestClass {
 
         try {
             configImpl.initProps(cc, minimumProps);
-            fail("Should have thrown an exception but didn't.");
-        } catch (SocialLoginException e) {
-            verifyException(e, CWWKS2351E_CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD);
+            verifyLogMessage(outputMgr, CWWKS2351E_CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
         }
     }
 

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/internal/OidcLoginConfigImplTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/internal/OidcLoginConfigImplTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.social.internal;
 
@@ -17,6 +14,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.security.Key;
 import java.security.KeyStoreException;
@@ -46,6 +44,8 @@ import test.common.SharedOutputManager;
 public class OidcLoginConfigImplTest extends CommonConfigTestClass {
 
     private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.social.*=all");
+
+    private static final String CWWKS2351E_CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD = "CWWKS2351E";
 
     protected OidcLoginConfigImpl configImpl = null;
 
@@ -84,16 +84,6 @@ public class OidcLoginConfigImplTest extends CommonConfigTestClass {
     /************************************** initProps **************************************/
 
     @Test
-    public void initProps_emptyProps() {
-        try {
-            configImpl.initProps(cc, new HashMap<String, Object>());
-            verifyAllMissingRequiredAttributes(outputMgr);
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    @Test
     public void initProps_minimumProps() {
         try {
             Map<String, Object> minimumProps = getRequiredConfigProps();
@@ -101,6 +91,20 @@ public class OidcLoginConfigImplTest extends CommonConfigTestClass {
             verifyNoLogMessage(outputMgr, MSG_BASE);
         } catch (Throwable t) {
             outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void initProps_clientSecretMissing_requiredByTokenEndpointAuthMethod() {
+        Map<String, Object> minimumProps = getRequiredConfigProps();
+        minimumProps.remove(OidcLoginConfigImpl.KEY_clientSecret);
+        minimumProps.put(OidcLoginConfigImpl.KEY_tokenEndpointAuthMethod, "client_secret_post");
+
+        try {
+            configImpl.initProps(cc, minimumProps);
+            fail("Should have thrown an exception but didn't.");
+        } catch (SocialLoginException e) {
+            verifyException(e, CWWKS2351E_CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD);
         }
     }
 

--- a/dev/com.ibm.ws.security.social_fat/fat/src/com/ibm/ws/security/social/fat/commonTests/Social_BasicConfigTests.java
+++ b/dev/com.ibm.ws.security.social_fat/fat/src/com/ibm/ws/security/social/fat/commonTests/Social_BasicConfigTests.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 package com.ibm.ws.security.social.fat.commonTests;
@@ -93,6 +90,7 @@ public class Social_BasicConfigTests extends SocialCommonTest {
                 genericTestServer.addIgnoredServerException(SocialMessageConstants.CWWKG0032W_CONFIG_INVALID_VALUE + ".+" + "tokenEndpointAuthMethod");
                 genericTestServer.addIgnoredServerException(SocialMessageConstants.CWWKG0033W_ATTRIBUTE_VALUE_NOT_FOUND);
                 genericTestServer.addIgnoredServerException(SocialMessageConstants.CWWKS5479E_CONFIG_REQUIRED_ATTRIBUTE_NULL);
+                genericTestServer.addIgnoredServerException(SocialMessageConstants.CWWKS2351E_CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD);
                 // 248970 this next one is seen occasionally on windows when a bad ssl config is being deliberately used.
                 genericTestServer.addIgnoredServerException(SocialMessageConstants.CWWKO0801E_CANNOT_INIT_SSL);
                 genericTestServer.addIgnoredServerException(SocialMessageConstants.CWWKS6104W_MISSING_REQUIRED_ATTRIBUTE);

--- a/dev/com.ibm.ws.security.social_fat/fat/src/com/ibm/ws/security/social/fat/utils/SocialMessageConstants.java
+++ b/dev/com.ibm.ws.security.social_fat/fat/src/com/ibm/ws/security/social/fat/utils/SocialMessageConstants.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- * IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
 package com.ibm.ws.security.social.fat.utils;
@@ -27,6 +24,8 @@ public class SocialMessageConstants extends MessageConstants {
 
     public static final String CWPKI0022E_HANDSHAKE_EXCEPTION = "CWPKI0022E";
     public static final String CWPKI0823E_HANDSHAKE_EXCEPTION = "CWPKI0823E";
+
+    public static final String CWWKS2351E_CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD = "CWWKS2351E";
 
     public static final String CWWKS3005E_NO_USER_REGISTRY = "CWWKS3005E";
 


### PR DESCRIPTION
Resolves #25247