### PR TITLE
PR for Issue 25137: Log error and description returned in OIDC redirect

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.SSO.clientTests/fat/src/com/ibm/ws/security/SSO/clientTests/PKCE/PKCEClientTests.java
+++ b/dev/com.ibm.ws.security.fat.common.SSO.clientTests/fat/src/com/ibm/ws/security/SSO/clientTests/PKCE/PKCEClientTests.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.SSO.clientTests.PKCE;
 
@@ -114,6 +111,7 @@ public class PKCEClientTests extends CommonTest {
         if (updatedTestSettings.getFlowType().equals(Constants.RP_FLOW)) {
             expectations = vData.addResponseStatusExpectation(expectations, Constants.LOGIN_USER, Constants.FORBIDDEN_STATUS);
             expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_MESSAGE, Constants.STRING_CONTAINS, "Response message should have contained the " + Constants.FORBIDDEN + " message.", null, Constants.FORBIDDEN);
+            expectations = validationTools.addMessageExpectation(clientServer, expectations, Constants.LOGIN_USER, Constants.MESSAGES_LOG, Constants.STRING_MATCHES, "Message log did not contain a message stating that the code_challenge was missing.", MessageConstants.CWWKS1557E_REDIRECT_URI_CONTAINED_ERROR + ".*" + MessageConstants.CWOAU0033E_REQ_RUNTIME_PARAM_MISSING + ".*code_challenge.*");
         } else {
             expectations = vData.addResponseStatusExpectation(expectations, Constants.LOGIN_USER, Constants.UNAUTHORIZED_STATUS);
             expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_MESSAGE, Constants.STRING_CONTAINS, "Response message should have contained the " + Constants.UNAUTHORIZED_MESSAGE + " message.", null, Constants.UNAUTHORIZED_MESSAGE);

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/MessageConstants.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/MessageConstants.java
@@ -168,6 +168,7 @@ public class MessageConstants extends com.ibm.ws.security.fat.common.MessageCons
 
     public static final String CWWKS1551E_LOGOUT_TOKEN_DUP_JTI = "CWWKS1551E";
     public static final String CWWKS1552E_NO_RECENT_SESSIONS_WITH_CLAIMS = "CWWKS1552E";
+    public static final String CWWKS1557E_REDIRECT_URI_CONTAINED_ERROR = "CWWKS1557E";
 
     public static final String CWWKS2300E_HTTP_WITH_PUBLIC_CLIENT = "CWWKS2300E";
 

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages.nlsprops
@@ -290,7 +290,7 @@ OIDC_CLIENT_BAD_REQUEST_MALFORMED_URL_IN_COOKIE.useraction=Verify the OpenID Con
 # 1533-1556 used in clients.common bundle, do not use here.
 
 REDIRECT_URI_CONTAINED_ERROR=CWWKS1557E: An authentication request failed because the OpenID Connect provider returned the following {0} error: {1}
-REDIRECT_URI_CONTAINED_ERROR.explanation=The specified response status indicated that the authentication was not successful. The error and error description provided in the message contain additional information.
-REDIRECT_URI_CONTAINED_ERROR.useraction=See the error in the message for more information.
+REDIRECT_URI_CONTAINED_ERROR.explanation=The specified response status indicated that the authentication was not successful. The error and error description that are provided in the message contain additional information.
+REDIRECT_URI_CONTAINED_ERROR.useraction=For more information, see the error in the message.
 
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages.nlsprops
@@ -1,14 +1,11 @@
 ###############################################################################
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 #CMVCPATHNAME com.ibm.ws.security/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
 #COMPONENTPREFIX CWWKS
@@ -290,6 +287,10 @@ OIDC_CLIENT_BAD_REQUEST_MALFORMED_URL_IN_COOKIE=CWWKS1532E: A request to [{0}] i
 OIDC_CLIENT_BAD_REQUEST_MALFORMED_URL_IN_COOKIE.explanation=A request was received that includes a malformed cookie.
 OIDC_CLIENT_BAD_REQUEST_MALFORMED_URL_IN_COOKIE.useraction=Verify the OpenID Connect provider and client configurations. The malformed cookie can be caused by cookie modification at the user agent with a host name that differs from the host name of the redirect that is registered with the provider. If the host name is expected, then add it to the wasReqURLRedirectDomainNames attribute of the webAppSecurity element in server.xml.
 
-# 1533-1555 used in clients.common bundle, do not use here.
+# 1533-1556 used in clients.common bundle, do not use here.
+
+REDIRECT_URI_CONTAINED_ERROR=CWWKS1557E: An authentication request failed because the OpenID Connect provider returned the following {0} error: {1}
+REDIRECT_URI_CONTAINED_ERROR.explanation=The specified response status indicated that the authentication was not successful. The error and error description provided in the message contain additional information.
+REDIRECT_URI_CONTAINED_ERROR.useraction=See the error in the message for more information.
 
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServlet.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServlet.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- * IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.client.web;
 
@@ -207,6 +204,7 @@ public class OidcRedirectServlet extends HttpServlet {
             return;
         }
 
+        Tr.error(tc, "REDIRECT_URI_CONTAINED_ERROR", error, request.getParameter(Constants.ERROR_DESCRIPTION));
         StringBuilder query = new StringBuilder();
         if (error != null && OAuth20Exception.INVALID_SCOPE.equals(error)) {
             query.append(Constants.ERROR + "=" + OAuth20Exception.INVALID_SCOPE);

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServlet.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServlet.java
@@ -203,8 +203,9 @@ public class OidcRedirectServlet extends HttpServlet {
             response.sendError(HttpServletResponse.SC_FORBIDDEN, errorMsg);
             return;
         }
-
-        Tr.error(tc, "REDIRECT_URI_CONTAINED_ERROR", error, request.getParameter(Constants.ERROR_DESCRIPTION));
+        if (error != null) {
+            Tr.error(tc, "REDIRECT_URI_CONTAINED_ERROR", error, request.getParameter(Constants.ERROR_DESCRIPTION));
+        }
         StringBuilder query = new StringBuilder();
         if (error != null && OAuth20Exception.INVALID_SCOPE.equals(error)) {
             query.append(Constants.ERROR + "=" + OAuth20Exception.INVALID_SCOPE);

--- a/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServletTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServletTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.client.web;
 
@@ -237,6 +234,7 @@ public class OidcRedirectServletTest {
     public void testDoPost_nullCode_invalidScopeError() {
         OidcRedirectServlet redirectServlet = new OidcRedirectServlet();
         String error = OAuth20Exception.INVALID_SCOPE;
+        String errorDescription = "Some description of the error.";
         final String query = Constants.ERROR + "=" + error;
         final List<String> wasReqURLRedirectDomainNames = new ArrayList<String>();
         wasReqURLRedirectDomainNames.add("localhost");
@@ -246,6 +244,7 @@ public class OidcRedirectServletTest {
             mockParamValue(Constants.ID_TOKEN, null);
             mockParamValue(Constants.STATE, OIDC_STATE);
             mockParamValue(Constants.ERROR, error);
+            mockParamValue(Constants.ERROR_DESCRIPTION, errorDescription);
             mockGoodCookie();
             mock.checking(new Expectations() {
                 {
@@ -268,6 +267,7 @@ public class OidcRedirectServletTest {
     public void testDoPost_nullCode_otherError() {
         OidcRedirectServlet redirectServlet = new OidcRedirectServlet();
         String error = OAuth20Exception.INVALID_GRANT;
+        String errorDescription = "Some description of the error.";
         final String query = Constants.ERROR + "=" + OAuth20Exception.ACCESS_DENIED;
         final List<String> wasReqURLRedirectDomainNames = new ArrayList<String>();
         wasReqURLRedirectDomainNames.add("localhost");
@@ -278,6 +278,7 @@ public class OidcRedirectServletTest {
             mockParamValue(Constants.STATE, OIDC_STATE);
             mockParamValue(Constants.SESSION_STATE, OIDC_SESSION_STATE);
             mockParamValue(Constants.ERROR, error);
+            mockParamValue(Constants.ERROR_DESCRIPTION, errorDescription);
             mockGoodCookie();
             mock.checking(new Expectations() {
                 {

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
@@ -322,5 +322,7 @@ PRIVATE_KEY_JWT_MISSING_KEYSTORE_REF=CWWKS1556E: The [{0}] OpenID Connect client
 PRIVATE_KEY_JWT_MISSING_KEYSTORE_REF.explanation=The OpenID Connect client must configure a keystore reference to define where to find the key to use to sign the JWT.
 PRIVATE_KEY_JWT_MISSING_KEYSTORE_REF.useraction=Verify that the OpenID Connect client has a keystore reference configured.
 
+#CWWKS1557 used in client bundle, do not use here.
+
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649
 


### PR DESCRIPTION
Adds a new NLS message that's logged when an `error` parameter is included in the redirect URI back from the OpenID Connect provider.

Resolves #25137