### PR TITLE
Make PKCE tests use a longer read timeout

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.SSO.clientTests/fat/src/com/ibm/ws/security/SSO/clientTests/PKCE/PKCEClientTests.java
+++ b/dev/com.ibm.ws.security.fat.common.SSO.clientTests/fat/src/com/ibm/ws/security/SSO/clientTests/PKCE/PKCEClientTests.java
@@ -49,6 +49,14 @@ public class PKCEClientTests extends CommonTest {
     public static RSCommonTestTools rsTools = new RSCommonTestTools();
     protected static boolean firstFFDCInstance = true;
 
+    public WebClient getAndSaveWebClientWithLongerTimeout(boolean override) throws Exception {
+
+        WebClient webClient = getAndSaveWebClient(override);
+        webClient.getOptions().setTimeout(5 * 60 * 1000);
+
+        return webClient;
+    }
+
     /**
      * Process a positive test case flow when a challenge should be included
      *
@@ -60,7 +68,7 @@ public class PKCEClientTests extends CommonTest {
      */
     public void positiveTestWithChallenge(String app, String challenge) throws Exception {
 
-        WebClient webClient = getAndSaveWebClient(true);
+        WebClient webClient = getAndSaveWebClientWithLongerTimeout(true);
 
         TestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setTestURL(clientServer.getHttpsString() + "/formlogin/simple/" + app);
@@ -82,7 +90,7 @@ public class PKCEClientTests extends CommonTest {
      */
     public void positiveTestWithoutChallenge(String app) throws Exception {
 
-        WebClient webClient = getAndSaveWebClient(true);
+        WebClient webClient = getAndSaveWebClientWithLongerTimeout(true);
 
         TestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setTestURL(clientServer.getHttpsString() + "/formlogin/simple/" + app);
@@ -105,7 +113,7 @@ public class PKCEClientTests extends CommonTest {
      */
     public void negativeTestWithoutChallenge(String app) throws Exception {
 
-        WebClient webClient = getAndSaveWebClient(true);
+        WebClient webClient = getAndSaveWebClientWithLongerTimeout(true);
 
         TestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setTestURL(clientServer.getHttpsString() + "/formlogin/simple/" + app);
@@ -127,125 +135,6 @@ public class PKCEClientTests extends CommonTest {
         genericRP(_testName, webClient, updatedTestSettings, Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT, expectations);
 
     }
-    //    //    @BeforeClass
-    //    //    public static void setUp() throws Exception {
-    //    //
-    //    //        firstFFDCInstance = true;
-    //    //
-    //    //        useLdap = false;
-    //    //        Log.info(thisClass, "beforeClass", "Set useLdap to: " + useLdap);
-    //    //
-    //    //        List<String> startMsgs = new ArrayList<String>();
-    //    //        startMsgs.add("CWWKT0016I.*" + SocialConstants.SOCIAL_DEFAULT_CONTEXT_ROOT);
-    //    //
-    //    //        List<String> opStartMsgs = new ArrayList<String>();
-    //    //        opStartMsgs.add("CWWKS1631I.*");
-    //    //
-    //    //        List<String> opExtraApps = new ArrayList<String>();
-    //    //        opExtraApps.add(SocialConstants.OP_SAMPLE_APP);
-    //    //
-    //    //        String[] propagationTokenTypes = rsTools.chooseTokenSettings(SocialConstants.OIDC_OP);
-    //    //        String tokenType = propagationTokenTypes[0];
-    //    //        String certType = propagationTokenTypes[1];
-    //    //        Log.info(thisClass, "setupBeforeTest", "inited tokenType to: " + tokenType);
-    //    //
-    //    //        socialSettings = new SocialTestSettings();
-    //    //        testSettings = socialSettings;
-    //    //
-    //    //        // Start the OIDC OP server
-    //    //        testOPServer = commonSetUp(SocialConstants.SERVER_NAME + ".LibertyOP.op.pkce", "op_server_PKCE.xml", SocialConstants.OIDC_OP, null, SocialConstants.DO_NOT_USE_DERBY, opStartMsgs, null, SocialConstants.OIDC_OP, true, true, tokenType, certType);
-    //    //        //Start the OIDC Social server and setup default values
-    //    //        genericTestServer = commonSetUp(SocialConstants.SERVER_NAME + ".LibertyOP.social.pkce", "server_LibertyOP_PKCE.xml", SocialConstants.GENERIC_SERVER, null, SocialConstants.DO_NOT_USE_DERBY, startMsgs);
-    //    //
-    //    //        setActionsForProvider(SocialConstants.LIBERTYOP_PROVIDER, SocialConstants.OIDC_OP);
-    //    //
-    //    //        setGenericVSSpeicificProviderFlags(GenericConfig, "server_LibertyOP_basicTests_oidc_usingSocialConfig");
-    //    //
-    //    //        socialSettings = updateLibertyOPSettings(socialSettings);
-    //    //        socialSettings.setUserName("testuser");
-    //    //
-    //    //    }
-    //    //
-    //    /**
-    //     * Process a positive test case flow when a challenge should be included
-    //     *
-    //     * @param app
-    //     *            - the app to invoke
-    //     * @param challenge
-    //     *            - the type of challenge (S256 or plain)
-    //     * @throws Exception
-    //     */
-    //    public abstract void positiveTestWithChallenge(String app, String challenge) throws Exception;
-    //
-    //    //        throw new Exception("positiveTestWithChallenge has not been overriden");
-    //    //        WebClient webClient = getAndSaveWebClient(true);
-    //    //
-    //    //        SocialTestSettings updatedSocialTestSettings = socialSettings.copyTestSettings();
-    //    //        updatedSocialTestSettings.setProtectedResource(genericTestServer.getHttpsString() + "/formlogin/simple/" + app);
-    //    //
-    //    //        List<validationData> expectations = vData.addSuccessStatusCodes();
-    //    //        expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.RESPONSE_URL, SocialConstants.STRING_CONTAINS, "Did not land on the test app.", null, updatedSocialTestSettings.getProtectedResource());
-    //    //        expectations = vData.addExpectation(expectations, SocialConstants.INVOKE_SOCIAL_RESOURCE, SocialConstants.RESPONSE_COOKIE, SocialConstants.STRING_MATCHES, "Should have found code_challenge in the WASReqURL cookie but didn't.", null, "WASReqURL" + ".*" + "code_challenge.*");
-    //    //        expectations = vData.addExpectation(expectations, SocialConstants.INVOKE_SOCIAL_RESOURCE, SocialConstants.RESPONSE_COOKIE, SocialConstants.STRING_MATCHES, "Should have found code_challenge_method=S256 in the WASReqURL cookie but didn't.", null, "WASReqURL" + ".*" + "code_challenge_method=" + challenge + ".*");
-    //    //
-    //    //        genericSocial(_testName, webClient, SocialConstants.LIBERTYOP_INVOKE_SOCIAL_LOGIN_ACTIONS, updatedSocialTestSettings, expectations);
-    //
-    //    //    }
-    //
-    //    /**
-    //     * Process a positive test case flow when a challenge should not be included
-    //     *
-    //     * @param app
-    //     *            - the app to invoke
-    //     * @throws Exception
-    //     */
-    //    public abstract void positiveTestWithoutChallenge(String app) throws Exception;
-    //
-    //    //        throw new Exception("positiveTestWithoutChallenge has not been overriden");
-    //
-    //    //        WebClient webClient = getAndSaveWebClient(true);
-    //    //
-    //    //        SocialTestSettings updatedSocialTestSettings = socialSettings.copyTestSettings();
-    //    //        updatedSocialTestSettings.setProtectedResource(genericTestServer.getHttpsString() + "/formlogin/simple/" + app);
-    //    //
-    //    //        List<validationData> expectations = vData.addSuccessStatusCodes();
-    //    //        expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.RESPONSE_URL, SocialConstants.STRING_CONTAINS, "Did not land on the test app.", null, updatedSocialTestSettings.getProtectedResource());
-    //    //        expectations = vData.addExpectation(expectations, SocialConstants.INVOKE_SOCIAL_RESOURCE, SocialConstants.RESPONSE_COOKIE, SocialConstants.STRING_DOES_NOT_CONTAIN, "Should NOT have found \"code_challenge\' in the WASReqURL cookie but did.", null, "code_challenge");
-    //    //        expectations = vData.addExpectation(expectations, SocialConstants.INVOKE_SOCIAL_RESOURCE, SocialConstants.RESPONSE_COOKIE, SocialConstants.STRING_DOES_NOT_CONTAIN, "Should NOT have found \"code_challenge_method\' in the WASReqURL cookie but did.", null, "code_challenge_method");
-    //    //
-    //    //        genericSocial(_testName, webClient, SocialConstants.LIBERTYOP_INVOKE_SOCIAL_LOGIN_ACTIONS, updatedSocialTestSettings, expectations);
-    //
-    //    //    }
-    //
-    //    /**
-    //     * Process a negative test case flow when a challenge should not be included - this tests when the server requires the
-    //     * challenge and the client is configured to not include it.
-    //     *
-    //     * @param app
-    //     *            - the app to invoke
-    //     * @throws Exception
-    //     */
-    //    public abstract void negativeTestWithoutChallenge(String app) throws Exception;
-    //
-    //    //        throw new Exception("negativeTestWithoutChallenge has not been overriden");
-    //
-    //    //        WebClient webClient = getAndSaveWebClient(true);
-    //    //
-    //    //        SocialTestSettings updatedSocialTestSettings = socialSettings.copyTestSettings();
-    //    //        updatedSocialTestSettings.setProtectedResource(genericTestServer.getHttpsString() + "/formlogin/simple/" + app);
-    //    //
-    //    //        List<validationData> expectations = vData.addSuccessStatusCodes(null, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN);
-    //    //        expectations = vData.addResponseStatusExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.UNAUTHORIZED_STATUS);
-    //    //        expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.RESPONSE_MESSAGE, SocialConstants.STRING_CONTAINS, "Response message should have contained the " + SocialConstants.UNAUTHORIZED_MESSAGE + " message.", null, SocialConstants.UNAUTHORIZED_MESSAGE);
-    //    //        if (firstFFDCInstance) {
-    //    //            expectations = validationTools.addMessageExpectation(testOPServer, expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.MESSAGES_LOG, SocialConstants.STRING_MATCHES, "Message log did not contain a message stating that the code_challenge was missing.", MessageConstants.CWOAU0033E_REQ_RUNTIME_PARAM_MISSING + ".*code_challenge.*");
-    //    //        }
-    //    //        firstFFDCInstance = false;
-    //    //        expectations = validationTools.addMessageExpectation(genericTestServer, expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.MESSAGES_LOG, SocialConstants.STRING_MATCHES, "Message log did not contain a message stating that the code_challenge was missing.", MessageConstants.CWWKS5495E_INVALID_SOCIAL_REQUEST + ".*" + MessageConstants.CWOAU0033E_REQ_RUNTIME_PARAM_MISSING + ".*code_challenge.*");
-    //    //
-    //    //        genericSocial(_testName, webClient, SocialConstants.LIBERTYOP_INVOKE_SOCIAL_LOGIN_ACTIONS, updatedSocialTestSettings, expectations);
-    //
-    //    //    }
 
     /**
      * Test with proofKeyForCodeExchange not set in the OP, so it uses the default value of false. The client sets
@@ -315,13 +204,13 @@ public class PKCEClientTests extends CommonTest {
     /**
      * Test with proofKeyForCodeExchange not set in the OP, so it uses the default value of false. The client does not set
      * pkceCodeChallengeMethod.
-     * Both client and server are using RS256 as the signature algorithm.
+     * Both client and server are using HS256 as the signature algorithm.
      * We should successfully access the protected application.
      */
     @Test
     public void PKCEClientTests_proofKeyFalse_HS256_na() throws Exception {
 
-        positiveTestWithChallenge("proofKeyFalse_RS256_Plain", "plain");
+        positiveTestWithoutChallenge("proofKeyFalse_HS256_na");
 
     }
 


### PR DESCRIPTION
SecureRandom is taking time and is causing some tests to time out.  While we investigate the issue, I'm updating the htmlunit timeout - hopefully this will only be needed for a short period of time.  This is just the time that htmlunit will wait before timing out - it won't always wait this long (only allow it to wait IF needed)