### PR TITLE
persistence service updates and record-like class on Java 11

### DIFF
--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/InMemoryMappingFile.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/InMemoryMappingFile.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -27,9 +27,7 @@ public final class InMemoryMappingFile {
 
      /**
       * An in memory mapping file.
-      * 
-      * @param resourceName
-      *             - A non-null unique file name.
+      *
       * @param mappingFile
       *             - A non-null byte[] that represents an orm.xml mapping file.
       */
@@ -37,6 +35,19 @@ public final class InMemoryMappingFile {
           _mappingFile = mappingFile;
           _resourceName =
                "mappingfile-" + _counter.incrementAndGet() + "-" + String.valueOf(Arrays.hashCode(_mappingFile));
+     }
+
+     /**
+      * An in memory mapping file for records as entities in Jakarta Data.
+      *
+      * @param mappingFile
+      *             - A non-null byte[] that represents an orm.xml mapping file.
+      * @param resourceName
+      *             - A non-null unique file name that does not begin with "mappingfile-", which is reserved for the other constructor.
+      */
+     public InMemoryMappingFile(byte[] file, String resourceName) {
+         _mappingFile = file;
+         _resourceName = resourceName;
      }
 
      @Trivial

--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
@@ -14,10 +14,12 @@ package com.ibm.wsspi.persistence.internal;
 
 import java.io.UnsupportedEncodingException;
 import java.sql.Connection;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -281,26 +283,34 @@ public class DatabaseStoreImpl implements DatabaseStore {
         // TODO: replace temporary code specific to persistentExecutor with general solution that applies the
         // table prefix, schema, and keyGenerationStrategy to all entities
 
-        InMemoryMappingFile ormFile = null;
+        List<InMemoryMappingFile> inMemoryFiles;
         SpecialEntitySet entitySet = entityClassNames.length == 0 ? SpecialEntitySet.NONE : recognizeSpecialEntityPackage(entityClassNames[0]);
         if (entitySet.equals(SpecialEntitySet.PERSISTENT_EXECUTOR)) {
             String ormFileContents = createOrmFileContentsForPersistentExecutor();
-            ormFile = new InMemoryMappingFile(ormFileContents.getBytes("UTF-8"));
+            inMemoryFiles = Collections.singletonList(new InMemoryMappingFile(ormFileContents.getBytes("UTF-8")));
         } else if (entitySet.equals(SpecialEntitySet.BATCH)) {
             String ormFileContents = createOrmFileContentsForBatch(entityClassNames);
-            ormFile = new InMemoryMappingFile(ormFileContents.getBytes("UTF-8"));
+            inMemoryFiles = Collections.singletonList(new InMemoryMappingFile(ormFileContents.getBytes("UTF-8")));
         } else {
             // hidden internal non-ship property for experimenting with Jakarta Data
             String[] entityClassEntries = (String[]) properties.get("io.openliberty.persistence.internal.entityClassInfo");
-            ormFile = createOrmFile(schema, tablePrefix, entityClassNames, entityClassEntries);
+            InMemoryMappingFile ormFile = createOrmFile(schema, tablePrefix, entityClassNames, entityClassEntries);
+            inMemoryFiles = (List<InMemoryMappingFile>) properties.get("io.openliberty.persistence.internal.generatedEntities");
+            if (ormFile != null)
+                if (inMemoryFiles == null) {
+                    inMemoryFiles = Collections.singletonList(ormFile);
+                } else {
+                    inMemoryFiles = new ArrayList<>(inMemoryFiles);
+                    inMemoryFiles.add(ormFile);
+                }
         }
 
         PersistenceServiceUnitConfig config = new PersistenceServiceUnitConfig();
         config.setClasses(Arrays.asList(entityClassNames));
         config.setConsumerLoader(loader);
         config.setProperties(puProps);
-        if (ormFile != null)
-            config.setInMemoryMappingFiles(Collections.singletonList(ormFile));
+        if (inMemoryFiles != null)
+            config.setInMemoryMappingFiles(inMemoryFiles);
         config.setJtaDataSource(dataSource);
         if (nonJTADataSource != null)
             config.setNonJtaDataSource(nonJTADataSource);

--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/PUInfoImpl.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/PUInfoImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -120,7 +120,12 @@ public final class PUInfoImpl implements PersistenceUnitInfo {
     private List<InMemoryMappingFile> copyInMemoryMappingFiles(List<InMemoryMappingFile> copyIMMF) {
         List<InMemoryMappingFile> immf = new ArrayList<InMemoryMappingFile>();
         for (InMemoryMappingFile file : copyIMMF) {
-            immf.add(new InMemoryMappingFile(file.getMappingFile()));
+            String name = file.getName();
+            if (name.startsWith("mappingfile-")) {
+                immf.add(new InMemoryMappingFile(file.getMappingFile()));
+            } else {
+                immf.add(new InMemoryMappingFile(file.getMappingFile(), name));
+            }
         }
         return immf;
     }
@@ -280,7 +285,11 @@ public final class PUInfoImpl implements PersistenceUnitInfo {
             _inMemHandler.register(url, immf);
             // Save a reference to the URL so we can cleanup later.
             _inMemoryMappingFileURLs.add(url);
-            res.add(immf.getName());
+            // Only include resources that start with "mappingfile-" to exclude in memory classes.
+            String resourceName = immf.getName();
+            if (resourceName.startsWith("mappingfile-")) {
+                res.add(immf.getName());
+            }
         }
 
         return res;

--- a/dev/io.openliberty.data.internal.persistence/bnd.bnd
+++ b/dev/io.openliberty.data.internal.persistence/bnd.bnd
@@ -46,6 +46,7 @@ instrument.classesExcludes: io/openliberty/data/internal/persistence/resources/*
   com.ibm.wsspi.org.osgi.service.component.annotations,\
   com.ibm.ws.cdi.interfaces.jakarta;version=latest, \
   com.ibm.ws.container.service;version=latest,\
+  com.ibm.ws.org.objectweb.asm;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.persistence.jakarta;version=latest,\
   com.ibm.ws.resource;version=latest,\

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/ClassDefiner.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/ClassDefiner.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.data.internal.persistence;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.AllPermission;
+import java.security.Permissions;
+import java.security.ProtectionDomain;
+
+/**
+ * Initially copied from @nmittles pull #25248
+ */
+public class ClassDefiner {
+    /**
+     * Accessible {@link ClassLoader#findLoadedClass}. This field is lazily
+     * initialized by {@link #findLoadedClass}.
+     */
+    private static volatile Method svFindLoadedClassMethod;
+
+    /**
+     * Accessible {@link ClassLoader#defineClass}. This field is lazily
+     * initialized by {@link #defineClass}.
+     */
+    private static volatile Method svDefineClassMethod;
+
+    /**
+     * A protection domain containing {@link AllPermission}. This field is
+     * lazily initialized by {@link #defineClass}, with the synchronization
+     * managed by the volatile read/write of {@link #svDefineClassMethod}.
+     */
+    private static ProtectionDomain svAllPermissionProtectionDomain;
+
+    /**
+     * Return {@link ClassLoader#findLoadedClass}.
+     *
+     * @param classLoader the class loader
+     * @param className   the class name
+     * @return the class, or null if not loaded
+     */
+    public Class<?> findLoadedClass(ClassLoader classLoader, String className) {
+        try {
+            Method findLoadedClassMethod = svFindLoadedClassMethod;
+            if (findLoadedClassMethod == null) {
+                try {
+                    findLoadedClassMethod = ClassLoader.class.getDeclaredMethod("findLoadedClass", String.class);
+                } catch (NoSuchMethodException ex) {
+                    throw new IllegalStateException(ex);
+                }
+
+                findLoadedClassMethod.setAccessible(true);
+                svFindLoadedClassMethod = findLoadedClassMethod;
+            }
+
+            return (Class<?>) findLoadedClassMethod.invoke(classLoader, className);
+        } catch (IllegalAccessException ex) {
+            throw new IllegalStateException(ex);
+        } catch (InvocationTargetException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    /**
+     * Return {@link ClassLoader#defineClass} with a PermissionCollection containing AllPermission.
+     *
+     * @param classLoader the class loader
+     * @param className   the class name
+     * @param classbytes  the class bytes
+     * @return the class
+     * @throws LinkageError     if a class is defined twice within the given class loader
+     * @throws ClassFormatError if the bytes passed in are invalid
+     */
+    public Class<?> defineClass(ClassLoader classLoader, String className, byte[] classbytes) {
+        Method defineClassMethod = svDefineClassMethod;
+        if (defineClassMethod == null) {
+            Permissions perms = new Permissions();
+            perms.add(new AllPermission());
+            svAllPermissionProtectionDomain = new ProtectionDomain(null, perms);
+
+            try {
+                defineClassMethod = ClassLoader.class.getDeclaredMethod("defineClass",
+                                                                        String.class,
+                                                                        byte[].class,
+                                                                        int.class,
+                                                                        int.class,
+                                                                        ProtectionDomain.class);
+            } catch (NoSuchMethodException ex) {
+                throw new IllegalStateException(ex);
+            }
+
+            defineClassMethod.setAccessible(true);
+            svDefineClassMethod = defineClassMethod;
+        }
+
+        try {
+            // We declare the class using a non-dynamic AllPermission
+            // ProtectionDomain so that it will be ignored by Java 2 security.
+            return (Class<?>) defineClassMethod.invoke(classLoader,
+                                                       className,
+                                                       classbytes,
+                                                       0,
+                                                       classbytes.length,
+                                                       svAllPermissionProtectionDomain);
+        } catch (IllegalAccessException ex) {
+            throw new IllegalStateException(ex);
+        } catch (InvocationTargetException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+
+            throw new IllegalStateException(cause);
+        }
+    }
+
+    /**
+     * Return {@link ClassLoader#defineClass} with a PermissionCollection containing AllPermission.
+     * This method searches for a class and returns it. If it's not found, it's defined.
+     *
+     * @param classLoader the class loader
+     * @param className   the class name
+     * @param classbytes  the class bytes
+     * @return the class
+     * @throws LinkageError     if a class is defined twice within the given class loader
+     * @throws ClassFormatError if the bytes passed in are invalid
+     */
+    public Class<?> findLoadedOrDefineClass(ClassLoader classLoader, String className, byte[] classbytes) {
+        Class<?> klass = findLoadedClass(classLoader, className);
+        if (klass == null) {
+            try {
+                klass = defineClass(classLoader, className, classbytes);
+            } catch (LinkageError ex) {
+                klass = findLoadedClass(classLoader, className);
+                if (klass == null) {
+                    throw ex;
+                }
+            }
+        }
+
+        return klass;
+    }
+
+}

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -81,7 +81,7 @@ public class RepositoryProducer<R, P> implements Producer<R> {
         if (r != null)
             repository = r;
 
-        RepositoryImpl<?, ?> handler = (RepositoryImpl<?, ?>) Proxy.getInvocationHandler(repository);
+        RepositoryImpl<?> handler = (RepositoryImpl<?>) Proxy.getInvocationHandler(repository);
         handler.beanDisposed();
     }
 
@@ -121,7 +121,7 @@ public class RepositoryProducer<R, P> implements Producer<R> {
                         Tr.debug(this, tc, "add " + anno + " for " + method.getAnnotated().getJavaMember());
                 }
 
-        RepositoryImpl<R, ?> handler = new RepositoryImpl<>(factory.provider, factory.entityDefiner, repositoryInterface, factory.entityClass);
+        RepositoryImpl<R> handler = new RepositoryImpl<>(factory.provider, factory.entityDefiner, repositoryInterface, factory.entityClass);
 
         R instance = repositoryInterface.cast(Proxy.newProxyInstance(repositoryInterface.getClassLoader(),
                                                                      new Class<?>[] { repositoryInterface },

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -118,6 +118,9 @@ public class DataTestServlet extends FATServlet {
     Products products;
 
     @Inject
+    Receipts receipts;
+
+    @Inject
     Reservations reservations;
 
     @Inject
@@ -2536,6 +2539,23 @@ public class DataTestServlet extends FATServlet {
                              primes.lessThanWithSuffixOrBetweenWithSuffix(40L, "even", 30L, 50L, "one")
                                              .map(p -> p.numberId)
                                              .collect(Collectors.toList()));
+    }
+
+    /**
+     * TODO use a real record
+     */
+    @Test
+    public void testRecordAsEntity() {
+        receipts.deleteAll();
+
+        receipts.save(new Receipt(100L, "C0013-00-031", 101.90f));
+        receipts.saveAll(List.of(new Receipt(200L, "C0022-00-022", 202.40f),
+                                 new Receipt(300L, "C0013-00-031", 33.99f)));
+
+        assertEquals(true, receipts.existsById(300L));
+        assertEquals(3L, receipts.count());
+
+        receipts.deleteAll();
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipt.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipt.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+/**
+ * Entity that simulates a Java record, but usable on Java 11. // TODO switch to Java 17+
+ */
+public class Receipt {
+    public Receipt(long purchaseId,
+                   String customer,
+                   float total) { // TODO more fields
+
+        // TODO The remainder of the class would be unnecessary if it were actually a record
+        this.purchaseId = purchaseId;
+        this.customer = customer;
+        this.total = total;
+    }
+
+    private final String customer;
+    private final long purchaseId;
+    private final float total;
+
+    public long purchaseId() {
+        return purchaseId;
+    }
+
+    public String customer() {
+        return customer;
+    }
+
+    public float total() {
+        return total;
+    }
+
+    @Override
+    public String toString() {
+        return "Receipt[productId=" + purchaseId + ", customer=" + customer + ", total=" + total + "]";
+    }
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository interface for the Receipt entity,
+ * which simulates an entity being a record and will later be switched to an actual record // TODO
+ */
+@Repository
+public interface Receipts extends CrudRepository<Receipt, Long> {
+}


### PR DESCRIPTION
Persistence service updates from #25248
Also, I was able to copy addition parts of 25248, temporarily hard-coding them to use a simulated record-like class on Java 11.  This allows us to get more of the code in to ensure it won't be broken by other changes.