### PR TITLE
Return correct object in JSFContainerApplicationFactory#getWrapped

### DIFF
--- a/dev/com.ibm.ws.jsfContainer/src/com/ibm/ws/jsf/container/application/JSFContainerApplicationFactory.java
+++ b/dev/com.ibm.ws.jsfContainer/src/com/ibm/ws/jsf/container/application/JSFContainerApplicationFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -105,7 +105,7 @@ public class JSFContainerApplicationFactory extends ApplicationFactory {
 
     @Override
     public ApplicationFactory getWrapped() {
-        return delegate.getWrapped();
+        return delegate;
     }
 
     /**


### PR DESCRIPTION
fixes  #25283

While testing MyFaces-4469 —We should just return delegate here, not the delegate.getWrapped:
[https://github.com/OpenLiberty/open-liberty/blob/696a0a0210f72b0d3f18bb9657a22434d[…]s/jsf/container/application/JSFContainerApplicationFactory.java](https://github.com/OpenLiberty/open-liberty/blob/696a0a0210f72b0d3f18bb9657a22434d958e8ab/dev/com.ibm.ws.jsfContainer/src/com/ibm/ws/jsf/container/application/JSFContainerApplicationFactory.java#LL106C1-L109C6)

Null would be returned which is not what we want. 


We do it correctly for our main JSF features here:
[https://github.com/OpenLiberty/open-liberty/blob/696a0a0210f72b0d3f18bb9657a22434d[…]ternal/src/com/ibm/ws/jsf/config/WASApplicationFactoryImpl.java](https://github.com/OpenLiberty/open-liberty/blob/696a0a0210f72b0d3f18bb9657a22434d958e8ab/dev/io.openliberty.faces.internal/src/com/ibm/ws/jsf/config/WASApplicationFactoryImpl.java#LL74C1-L78C6)