### PR TITLE
TCK Runner improvements

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/servers/FATServer/jvm.options
@@ -5,7 +5,7 @@
 #-Dcom.ibm.tools.attach.enable=yes
 #-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777
 
--Xmx1536m
+-Xmx1024m
 
 # required for TCK:
 -Dmp.graphql.tck.endpoint.port=8010

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
@@ -918,6 +918,8 @@ public class TCKRunner {
                                  " -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS");
 
         if (mavenUserHome != null) {
+            // If we have created a custom user home dir, we need to set some environment variables
+            // to correspond with the placeholders in the settings.xml
             String artifactoryServer = TCKUtilities.getArtifactoryServer();
             if (artifactoryServer == null) {
                 Log.info(c, "getMvnEnv", "Artifactory Download Server not found");

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKUtilities.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKUtilities.java
@@ -665,15 +665,19 @@ public class TCKUtilities {
      * @return {@code true} if we are configured to use artifactory, {@code false} if not
      */
     public static boolean useArtifactory() {
-        Log.info(c, "useArtifactory", "Force external: " + System.getProperty(FAT_TEST_PREFIX + ARTIFACTORY_FORCE_EXTERNAL_KEY));
-        boolean forceExternal = Boolean.getBoolean(FAT_TEST_PREFIX + ARTIFACTORY_FORCE_EXTERNAL_KEY);
+        String forceExternalString = System.getProperty(FAT_TEST_PREFIX + ARTIFACTORY_FORCE_EXTERNAL_KEY);
+        boolean forceExternal = Boolean.parseBoolean(forceExternalString);
 
         String artifactoryServer = getArtifactoryServer();
-        Log.info(c, "useArtifactory", "Artifactory Server: " + artifactoryServer);
-
         boolean haveArtifactoryServer = (artifactoryServer != null && !artifactoryServer.isEmpty());
 
-        return haveArtifactoryServer && !forceExternal;
+        boolean useArtifactory = haveArtifactoryServer && !forceExternal;
+
+        Log.info(c, "useArtifactory", "Use artifactory = " + useArtifactory + " ("
+                                      + ARTIFACTORY_SERVER_KEY + "=" + artifactoryServer + ", "
+                                      + ARTIFACTORY_FORCE_EXTERNAL_KEY + "=" + forceExternalString
+                                      + ")");
+        return useArtifactory;
     }
 
     /**

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKUtilities.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKUtilities.java
@@ -229,7 +229,7 @@ public class TCKUtilities {
     public static void zosTagASCII(File file) {
         try {
             String command = "chtag";
-            String[] params = new String[] { "-tcISO8859-1", file.getCanonicalPath() };
+            List<String> params = Arrays.asList("-tcISO8859-1", file.getCanonicalPath());
             ProcessResult output = startProcess(command, params, file.getParentFile(), Collections.emptyMap(), null, 20_000);
             int exitValue = output.getExitCode();
             Log.info(c, "zosTagASCII", "chtag RC = " + exitValue);
@@ -268,7 +268,7 @@ public class TCKUtilities {
      * @return                  the result of running the process, caller should check {@link ProcessResult#isTimedOut()} and {@link ProcessResult#getExitCode()}
      * @throws Exception        if an unexpected exception occurs while starting or waiting for the process. Note that a non-zero exit code will <b>not</b> result in an exception.
      */
-    public static ProcessResult startProcess(String command, String[] params, File workingDirectory, Map<String, String> envProperties, File logFile,
+    public static ProcessResult startProcess(String command, List<String> params, File workingDirectory, Map<String, String> envProperties, File logFile,
                                              long timeout) throws Exception {
         assertThat("Process timeout", timeout, greaterThan(0L));
         if (TCKUtilities.isZos()) {
@@ -285,9 +285,9 @@ public class TCKUtilities {
             commandLine.add("/c");
         }
         commandLine.add(command);
-        commandLine.addAll(Arrays.asList(params));
+        commandLine.addAll(params);
 
-        Log.info(c, "startProcess", "Running command: " + command + " " + String.join(" ", params));
+        Log.info(c, "startProcess", "Running command with timeout of " + timeout + "ms: " + command + " " + String.join(" ", params));
 
         ProcessBuilder pb = new ProcessBuilder(commandLine);
         pb.environment().putAll(envProperties);

--- a/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/publish/servers/FATServer/jvm.options
@@ -5,4 +5,4 @@
 #-Dcom.ibm.tools.attach.enable=yes
 #-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777
 
--Xmx1536m
+-Xmx1024m

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -386,7 +386,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx1536m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -380,7 +380,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx1536m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>


### PR DESCRIPTION
Follow on improvements for #25191

- Reduce heap size of GraphQL and RestClient TCK processes to address OOM errors runing on z/OS where the test environment has a hard limit on the memory consumed by each process
- Add some additional logging output
- Add a comments suggested in code review
- Improve the calculation of the TCK process timeout to ensure we stop the TCK process and collect the results so far before the entire test bucket is aborted