### PR TITLE
Performance improvements for REST monitor / metrics scenarios

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.restmetrics/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.restmetrics/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all:*=info
+com.ibm.ws.logging.trace.specification=com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all:*=info:io.openliberty.restfulws.mpmetrics.*=all
 com.ibm.ws.logging.max.file.size=0
 
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/JaxRsMonitorFilter.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/JaxRsMonitorFilter.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,6 +14,7 @@ package com.ibm.ws.jaxrs.monitor;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -35,6 +36,7 @@ import com.ibm.websphere.monitor.annotation.PublishedMetric;
 import com.ibm.websphere.monitor.meters.MeterCollection;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.jaxrs.monitor.RestMonitorKeyCache.MonitorKey;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.runtime.metadata.ModuleMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
@@ -45,7 +47,7 @@ import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 @Monitor(group = "REST")
 @Provider
 public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResponseFilter {
-	
+
     private static final TraceComponent tc = Tr.register(JaxRsMonitorFilter.class);
 
     @Context
@@ -59,18 +61,32 @@ public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResp
     // appMetricInfos is a hashmap used to store information for runtime and cleanup at 
     // application stop time.
     static final ConcurrentHashMap<String,RestMetricInfo> appMetricInfos = new ConcurrentHashMap<String,RestMetricInfo>();
-    static final Set<JaxRsMonitorFilter> instances = new HashSet<>();
-    private static final String START_TIME = "Start_Time";
-    private static final String CMD = "CMD";
+    static final Set<JaxRsMonitorFilter> instances = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private static final RestMonitorKeyCache monitorKeyCache = new RestMonitorKeyCache();
+    private static final String STATS_CONTEXT = "REST_Stats_Context";
+
+    private static class StatsContext {
+        final MonitorKey monitorKey;
+        final long startTime;
+        StatsContext(MonitorKey monitorKey, long startTime) {
+            this.monitorKey = monitorKey;
+            this.startTime = startTime;
+        }
+
+        @Override
+        public String toString() {
+            return "StatsContext [monitorKey=" + monitorKey + ", startTime=" + startTime + "]";
+        }
+    }
 
     @PostConstruct
     public void postConstruct() {
-    	instances.add(this);
+        instances.add(this);
     }
 
     @PreDestroy
     public void preDestroy() {
-    	instances.remove(this);
+        instances.remove(this);
     }
 
     /**
@@ -85,11 +101,46 @@ public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResp
      * 
      */
     @Override
-    public void filter(ContainerRequestContext reqCtx) throws IOException {	
-    	// Store the start time in the ContainerRequestContext that can be accessed
-    	// in the response filter method.  
-        reqCtx.setProperty(START_TIME, System.nanoTime());
-        reqCtx.setProperty(CMD, ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData());
+    public void filter(ContainerRequestContext reqCtx) throws IOException {
+        Class<?> resourceClass = resourceInfo.getResourceClass();
+
+        if (resourceClass != null) {
+            Method resourceMethod = resourceInfo.getResourceMethod();
+            MonitorKey monitorKey = monitorKeyCache.getMonitorKey(resourceClass, resourceMethod);
+
+            if (monitorKey == null) {
+                Class<?>[] parameterClasses = resourceMethod.getParameterTypes();
+                int i = 0;
+                String parameter;
+                String fullMethodName = resourceClass.getName() + "/" + resourceMethod.getName() + "(";
+                for (Class<?> p : parameterClasses) {
+                    parameter = p.getCanonicalName();
+                    if (i > 0) {
+                        fullMethodName = fullMethodName + "_" + parameter;
+                    } else {
+                        fullMethodName = fullMethodName + parameter;
+                    }
+                    i++;
+                }
+                fullMethodName = fullMethodName + ")";
+
+                ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+                String appName = getAppName(cmd);
+                String modName = getModName(cmd);
+                String keyPrefix = createKeyPrefix(appName, modName);
+                String key = keyPrefix + "/" + fullMethodName;
+                monitorKey = new MonitorKey(key, keyPrefix, fullMethodName);
+
+                // Save key in appMetricInfos for cleanup on application stop.
+                addKeyToMetricInfo(appName, key);
+
+                monitorKeyCache.putMonitorKey(resourceClass, resourceMethod, monitorKey);
+            }
+
+            // Store the start time and key information in the ContainerRequestContext that can be accessed
+            // in the response filter method.  
+            reqCtx.setProperty(STATS_CONTEXT, new StatsContext(monitorKey, System.nanoTime()));
+        }
     }
     
     /**
@@ -104,112 +155,82 @@ public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResp
      *            method and store the result in the REST_Stats MXBean.
      * 
      */
-	@Override
-	public void filter(ContainerRequestContext reqCtx, ContainerResponseContext respCtx) throws IOException {
-		
-		// Check that the ComponentMetaData has been set on the request context.  This will happen when 
-		// the ContainerRequestFilter.filter() method is invoked.  Situations, such as an improper jwt will cause the 
-		// request filter to not be called and we will therefore not record any statistics.
-		ComponentMetaData cmd = (ComponentMetaData) reqCtx.getProperty(CMD);
-		if (cmd == null) {
-	        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-	            Tr.debug(tc, "ContainerRequestContext.filter() has not been invoked for " + reqCtx.getUriInfo().getPath());
-	        }
-			return;
-		}
+    @Override
+    public void filter(ContainerRequestContext reqCtx, ContainerResponseContext respCtx) throws IOException {
 
-		long elapsedTime = 0;
-		// Calculate the response time for the resource method.
-		Long startTime = (Long) reqCtx.getProperty(START_TIME);
-		if (startTime != null) {
-			elapsedTime = System.nanoTime() - startTime.longValue();
-		}
+        // Check that the StatsContext has been set on the request context.  This will happen when 
+        // the ContainerRequestFilter.filter() method is invoked.  Situations, such as an improper jwt will cause the 
+        // request filter to not be called and we will therefore not record any statistics.
+        StatsContext statsContext = (StatsContext) reqCtx.getProperty(STATS_CONTEXT);
+        if (statsContext == null) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "ContainerRequestContext.filter() has not been invoked for " + reqCtx.getUriInfo().getPath());
+            }
+            return;
+        }
 
-		Class<?> resourceClass = resourceInfo.getResourceClass();
-		
-		if (resourceClass != null) {
-			Method resourceMethod = resourceInfo.getResourceMethod();
+        // Calculate the response time for the resource method.
+        long elapsedTime = System.nanoTime() - statsContext.startTime;
 
-			Class<?>[] parameterClasses = resourceMethod.getParameterTypes();
-			int i = 0;
-			String parameter;
-			String fullMethodName = resourceClass.getName() + "/" + resourceMethod.getName() + "(";
-			for (Class<?> p : parameterClasses) {
-				parameter = p.getCanonicalName();
-				if (i > 0) {
-					fullMethodName = fullMethodName + "_" + parameter;
-				} else {
-					fullMethodName = fullMethodName + parameter;
-				}
-				i++;
-			}
-			fullMethodName = fullMethodName + ")";
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Elapsed time for " + statsContext.monitorKey.statsKey + " is " + elapsedTime + " ns");
+        }
 
-			String appName = getAppName(cmd);
-			String modName = getModName(cmd);
-			String keyPrefix = createKeyPrefix(appName, modName);
-			String key = keyPrefix + "/" + fullMethodName;
+        REST_Stats stats = jaxRsCountByName.get(statsContext.monitorKey.statsKey);
+        if (stats == null) {
+            stats = initJaxRsStats(statsContext.monitorKey.statsKey, statsContext.monitorKey.statsKeyPrefix, statsContext.monitorKey.statsMethodName);
+        }
 
-			REST_Stats stats = jaxRsCountByName.get(key);
-			if (stats == null) {
-				stats = initJaxRsStats(key, keyPrefix, fullMethodName);
-			}
+        /*
+         * Explicitly checking for the Metrics Header via hard-coded header string.
+         * Don't want to add runtime/build dependency to this bundle/project because
+         * jaxrsMonitor-1.0.feature can run without metrics.
+         * 
+         */
+        String metricsHeader = respCtx
+                .getHeaderString("com.ibm.ws.microprofile.metrics.monitor.MetricsJaxRsEMCallbackImpl.Exception");
 
-			/*
-			 * Explicitly checking for the Metrics Header via hard-coded header string.
-			 * Don't want to add runtime/build dependency to this bundle/project because
-			 * jaxrsMonitor-1.0.feature can run without metrics.
-			 * 
-			 */
-			String metricsHeader = respCtx
-			        .getHeaderString("com.ibm.ws.microprofile.metrics.monitor.MetricsJaxRsEMCallbackImpl.Exception");
-			
-			//Check for MP Metrics 30 header;
-			if (metricsHeader == null)
-				metricsHeader = respCtx.getHeaderString("io.openliberty.microprofile.metrics.internal.monitor.MetricsJaxRsEMCallbackImpl.Exception");
+        //Check for MP Metrics 30 header;
+        if (metricsHeader == null)
+            metricsHeader = respCtx.getHeaderString("io.openliberty.microprofile.metrics.internal.monitor.MetricsJaxRsEMCallbackImpl.Exception");
 
-			//Check for MP Metrics 31 header;
-			if (metricsHeader == null)
-				metricsHeader = respCtx.getHeaderString("io.openliberty.restfulws.mpmetrics.MetricsRestfulWsEMCallbackImpl.Exception");
+        //Check for MP Metrics 31 header;
+        if (metricsHeader == null)
+            metricsHeader = respCtx.getHeaderString("io.openliberty.restfulws.mpmetrics.MetricsRestfulWsEMCallbackImpl.Exception");
 
-			// Save key in appMetricInfos for cleanup on application stop.
-			addKeyToMetricInfo(appName, key);
-			
-			if (metricsHeader == null) {
-				// Need to start new minute here.. we need to pass in the stat object so we can
-				// actually update Mbean
-				maybeStartNewMinute(stats);
+        if (metricsHeader == null) {
+            // Need to start new minute here.. we need to pass in the stat object so we can
+            // actually update Mbean
+            maybeStartNewMinute(stats);
 
+            // Increment the request count for the resource method.
+            stats.incrementCountBy(1);
 
-				// Increment the request count for the resource method.
-				stats.incrementCountBy(1);
+            // Store the response time for the resource method.
+            stats.updateRT(elapsedTime < 0 ? 0 : elapsedTime);
 
-				// Store the response time for the resource method.
-				stats.updateRT(elapsedTime < 0 ? 0 : elapsedTime);
+            // Figure out min/max
+            if (elapsedTime >= 0) {
+                long minuteLatestMaximumDuration = stats.getMinuteLatestMaximumDuration();
+                while (elapsedTime > minuteLatestMaximumDuration) {
+                    if (stats.compareAndUpdateMinuteLatestMaximumDuration(minuteLatestMaximumDuration, elapsedTime)) {
+                            break;
+                    }
+                    minuteLatestMaximumDuration = stats.getMinuteLatestMaximumDuration();
+                }
 
-				// Figure out min/max
-				if (elapsedTime >= 0) {
-					long minuteLatestMaximumDuration = stats.getMinuteLatestMaximumDuration();
-					while (elapsedTime > minuteLatestMaximumDuration) {
-						if (stats.compareAndUpdateMinuteLatestMaximumDuration(minuteLatestMaximumDuration, elapsedTime)) {
-								break;
-						}
-						minuteLatestMaximumDuration = stats.getMinuteLatestMaximumDuration();
-					}
-
-					long minuteLatestMinimumDuration = stats.getMinuteLatestMinimumDuration();
-					if (!(elapsedTime == 0L && minuteLatestMinimumDuration == 0L)) {
-						while (elapsedTime < minuteLatestMinimumDuration || minuteLatestMinimumDuration == 0L) {
-							if (stats.compareAndUpdateMinuteLatestMinimumDuration(minuteLatestMinimumDuration, elapsedTime)) {
-								break;
-							}
-							minuteLatestMinimumDuration = stats.getMinuteLatestMinimumDuration();
-						}
-					}
-				}
-			}
-		}
-	}
+                long minuteLatestMinimumDuration = stats.getMinuteLatestMinimumDuration();
+                if (!(elapsedTime == 0L && minuteLatestMinimumDuration == 0L)) {
+                    while (elapsedTime < minuteLatestMinimumDuration || minuteLatestMinimumDuration == 0L) {
+                        if (stats.compareAndUpdateMinuteLatestMinimumDuration(minuteLatestMinimumDuration, elapsedTime)) {
+                            break;
+                        }
+                        minuteLatestMinimumDuration = stats.getMinuteLatestMinimumDuration();
+                    }
+                }
+            }
+        }
+    }
     
     private void maybeStartNewMinute(REST_Stats stats) {
         long newMinute = getCurrentMinuteFromSystem();
@@ -253,18 +274,18 @@ public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResp
     private synchronized REST_Stats initJaxRsStats(String key, String keyPrefix, String method) {
        REST_Stats nStats = this.jaxRsCountByName.get(key);
         if (nStats == null) {
-             nStats = new REST_Stats(keyPrefix, method);
-            this.jaxRsCountByName.put(key, nStats);            
+            nStats = new REST_Stats(keyPrefix, method);
+            this.jaxRsCountByName.put(key, nStats);
         }
         return nStats;
     }
     
     private String getModName(ComponentMetaData cmd) {
-    	String modName = null;
+        String modName = null;
         if (cmd != null) {
             ModuleMetaData mmd = cmd.getModuleMetaData();
             if (mmd != null) {
-            	modName  = mmd.getName();          	
+                modName  = mmd.getName();
             }
         }
         return modName;
@@ -272,80 +293,79 @@ public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResp
 
 
     private String getAppName(ComponentMetaData cmd) {
-    	String appName = null;
+        String appName = null;
         if (cmd != null) {
-        	J2EEName j2name= cmd.getJ2EEName();
+            J2EEName j2name= cmd.getJ2EEName();
             if (j2name != null) {
-            	appName = j2name.getApplication();
+                appName = j2name.getApplication();
             }
         }
         return appName;
     }
    
     private String createKeyPrefix(String appName, String modName) {
-    	// If the application is packaged in an ear file then the key prefix will be
-    	// appname/modname.  Otherwise it will just be modName.
-    	if (getMetricInfo(appName).isEar) {
-    		return appName + "/" + modName;
-    	} else {
-    		return modName;
-    	}
+        // If the application is packaged in an ear file then the key prefix will be
+        // appname/modname.  Otherwise it will just be modName.
+        if (getMetricInfo(appName).isEar) {
+            return appName + "/" + modName;
+        } else {
+            return modName;
+        }
     }
     
     static RestMetricInfo getMetricInfo(String appName) {
-    	RestMetricInfo rMetricInfo = appMetricInfos.get(appName);
-    	if (rMetricInfo == null) {
-    		rMetricInfo = new RestMetricInfo();
-    		appMetricInfos.put(appName, rMetricInfo);
-    	}
-    	return rMetricInfo;
+        RestMetricInfo rMetricInfo = appMetricInfos.get(appName);
+        if (rMetricInfo == null) {
+            rMetricInfo = new RestMetricInfo();
+            appMetricInfos.put(appName, rMetricInfo);
+        }
+        return rMetricInfo;
     }
     
     // At application stop time we will need to clean up the jaxRsCountByName 
     // MeteredCollection.  To do this we will need to store the keys for every 
     // entry in this collection.
     private void addKeyToMetricInfo(String appName, String key) {
-    	RestMetricInfo rMetricInfo = appMetricInfos.get(appName);
-    	if (rMetricInfo != null) {
-    		rMetricInfo.setKey(key);
-     	}
+        RestMetricInfo rMetricInfo = appMetricInfos.get(appName);
+        if (rMetricInfo != null) {
+            rMetricInfo.setKey(key);
+        }
     }
     
     // Clean up the resources that were created for each resource method within
     // an application
-    static void cleanApplication(String appName) {   	
-    	RestMetricInfo rMetricInfo = appMetricInfos.get(appName);
-    	if (rMetricInfo != null) {
-    		HashSet<String> keys = rMetricInfo.getKeys();
-    		if (!keys.isEmpty()) {
-        		Iterator<String> keyIterator = keys.iterator();
-        		String key = null;
-        		while (keyIterator.hasNext()) {
-        			key = keyIterator.next();
-        			for (JaxRsMonitorFilter filter : instances)
-        				filter.jaxRsCountByName.remove(key);      			
-        		}
-    			
-    		}
-    		appMetricInfos.remove(appName);
-    	}
+    static void cleanApplication(String appName) {
+        RestMetricInfo rMetricInfo = appMetricInfos.get(appName);
+        if (rMetricInfo != null) {
+            HashSet<String> keys = rMetricInfo.getKeys();
+            if (!keys.isEmpty()) {
+                Iterator<String> keyIterator = keys.iterator();
+                String key = null;
+                while (keyIterator.hasNext()) {
+                    key = keyIterator.next();
+                    for (JaxRsMonitorFilter filter : instances)
+                        filter.jaxRsCountByName.remove(key);
+                }
+            }
+            appMetricInfos.remove(appName);
+        }
     }
     
     static class RestMetricInfo {
-    	boolean isEar = false;
-    	HashSet<String> keys = new HashSet<String>();
-    	
-    	void setIsEar() {
-    		isEar = true;   	
-    	}
-    	
-    	void setKey(String key) {
-    		keys.add(key);
-    	}
-    	
-    	HashSet<String> getKeys() {
-    		return keys;
-    	}
+        boolean isEar = false;
+        HashSet<String> keys = new HashSet<String>();
+
+        void setIsEar() {
+            isEar = true;
+        }
+
+        void setKey(String key) {
+            keys.add(key);
+        }
+
+        HashSet<String> getKeys() {
+            return keys;
+        }
     }
 }
 

--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/RestMonitorKeyCache.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/RestMonitorKeyCache.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.monitor;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * Stores a cache of {@code (class, method) -> monitor key data}
+ * <p>
+ * Conceptually this is just a thread-safe {@code WeakHashMap<Pair<Class<?>, Method>, MonitorKey>} but it's more complicated because we need a weak reference to the class and the
+ * method, not to the pair object.
+ */
+@Trivial
+public class RestMonitorKeyCache {
+
+    private final ConcurrentHashMap<RestResourceMethodKey, MonitorKey> routes = new ConcurrentHashMap<>();
+    private final ReferenceQueue<Class<?>> referenceQueue = new ReferenceQueue<>();
+
+    @Trivial
+    static class MonitorKey {
+        final String statsKey;
+        final String statsKeyPrefix;
+        final String statsMethodName;
+        MonitorKey(String statsKey, String statsKeyPrefix, String statsMethodName) {
+            this.statsKey = statsKey;
+            this.statsKeyPrefix = statsKeyPrefix;
+            this.statsMethodName = statsMethodName;
+        }
+
+        @Override
+        public String toString() {
+            return "MonitorKey [statsKey=" + statsKey + ", statsKeyPrefix=" + statsKeyPrefix + ", statsMethodName="
+                    + statsMethodName + "]";
+        }
+    }
+
+    /**
+     * Retrieve the cached monitor key for the specified REST Class and Method
+     *
+     * @param restClass  the class
+     * @param restMethod the method
+     * @return the monitor key, or {@code null} if no route is in the cache
+     */
+    public MonitorKey getMonitorKey(Class<?> restClass, Method restMethod) {
+        evictGarbageCollectedEntries();
+        return routes.get(new RestResourceMethodKey(restClass, restMethod));
+    }
+
+    /**
+     * Add a new monitor key for the specified REST Class and Method
+     *
+     * @param restClass
+     * @param restMethod
+     * @param monitorKey
+     */
+    public void putMonitorKey(Class<?> restClass, Method restMethod, MonitorKey monitorKey) {
+        evictGarbageCollectedEntries();
+        routes.put(new RestResourceMethodKey(referenceQueue, restClass, restMethod), monitorKey);
+    }
+
+    private void evictGarbageCollectedEntries() {
+        RestMonitorKeyWeakReference<?> key;
+        while ((key = (RestMonitorKeyWeakReference<?>) referenceQueue.poll()) != null) {
+            routes.remove(key.getOwningKey());
+        }
+    }
+
+    @Trivial
+    private static class RestResourceMethodKey {
+        private final RestMonitorKeyWeakReference<Class<?>> restClassRef;
+        private final RestMonitorKeyWeakReference<Method> restMethodRef;
+        private final int hash;
+
+        RestResourceMethodKey(Class<?> restClass, Method restMethod) {
+            this.restClassRef = new RestMonitorKeyWeakReference<>(restClass, this);
+            this.restMethodRef = new RestMonitorKeyWeakReference<>(restMethod, this);
+            hash = Objects.hash(restClass, restMethod);
+        }
+
+        RestResourceMethodKey(ReferenceQueue<Class<?>> referenceQueue, Class<?> restClass, Method restMethod) {
+            this.restClassRef = new RestMonitorKeyWeakReference<>(restClass, this, referenceQueue);
+            this.restMethodRef = new RestMonitorKeyWeakReference<>(restMethod, this);
+            hash = Objects.hash(restClass, restMethod);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            RestResourceMethodKey other = (RestResourceMethodKey) obj;
+            if (!restClassRef.equals(other.restClassRef)) {
+                return false;
+            }
+            if (!restMethodRef.equals(other.restMethodRef)) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    @Trivial
+    private static class RestMonitorKeyWeakReference<T> extends WeakReference<T> {
+        private final RestResourceMethodKey owningKey;
+
+        RestMonitorKeyWeakReference(T referent, RestResourceMethodKey owningKey) {
+            super(referent);
+            this.owningKey = owningKey;
+        }
+
+        RestMonitorKeyWeakReference(T referent, RestResourceMethodKey owningKey,
+                                  ReferenceQueue<T> referenceQueue) {
+            super(referent, referenceQueue);
+            this.owningKey = owningKey;
+        }
+
+        RestResourceMethodKey getOwningKey() {
+            return owningKey;
+        }
+
+        @SuppressWarnings("rawtypes")
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj instanceof RestMonitorKeyWeakReference) {
+                return get() == ((RestMonitorKeyWeakReference) obj).get();
+            }
+
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            T referent = get();
+            return new StringBuilder("RestMonitorKeyWeakReference: ").append(referent).toString();
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/filter/WebAppFilterManager.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/filter/WebAppFilterManager.java
@@ -340,7 +340,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
      * 
      */
     public FilterInstanceWrapper getFilterInstanceWrapper(String filterName) throws ServletException {
-        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE))
+        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINER))
             logger.entering(CLASS_NAME,"getFilterInstanceWrapper", "entry for " + filterName);
 
         try {
@@ -359,7 +359,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
                     }
                 }//PM01682 End
             }
-            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {
+            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINER)) {
                 logger.exiting(CLASS_NAME,"getFilterInstanceWrapper", "exit for " + filterName);
             }
             return filterInstW;
@@ -560,7 +560,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
     private FilterInstanceWrapper _loadFilter(String filterName) throws ServletException {
         final boolean isTraceOn = com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled();
 
-        if (isTraceOn && logger.isLoggable(Level.FINE))
+        if (isTraceOn && logger.isLoggable(Level.FINER))
             logger.entering(CLASS_NAME, "_loadFilter", "filter--->" + filterName);
 
         FilterInstanceWrapper fiw = null;
@@ -716,7 +716,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
             }
         }
 
-        if (isTraceOn && logger.isLoggable(Level.FINE))
+        if (isTraceOn && logger.isLoggable(Level.FINER))
             logger.exiting(CLASS_NAME, "_loadFilter");
 
         return fiw;
@@ -740,7 +740,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
      */
     private FilterChainContents getFilterChainContents(String reqURI, String reqServletName, DispatcherType dispatcherType, boolean servletIsInternal) {
         final boolean isTraceOn = com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled();
-        if (isTraceOn && logger.isLoggable(Level.FINE)) {
+        if (isTraceOn && logger.isLoggable(Level.FINER)) {
             logger.entering(CLASS_NAME, "getFilterChainContents", "reqUri->" + reqURI + ", reqServletName->" + reqServletName + ", mode->" + dispatcherType
                             + ", servletIsInternal->" + servletIsInternal);
         }
@@ -945,7 +945,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
 
             // 144464 part 4
         }
-        if (isTraceOn && logger.isLoggable(Level.FINE)) {
+        if (isTraceOn && logger.isLoggable(Level.FINER)) {
             logger.exiting(CLASS_NAME, "getFilterChainContents");
         }
 
@@ -1019,7 +1019,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
     public void doFilter(ServletRequest request, ServletResponse response, RequestProcessor requestProcessor,
                          WebAppDispatcherContext dispatchContext) throws ServletException, IOException {
         final boolean isTraceOn = com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled();
-        if (isTraceOn && logger.isLoggable(Level.FINE)) { // 306998.15
+        if (isTraceOn && logger.isLoggable(Level.FINER)) { // 306998.15
             logger.entering(CLASS_NAME, "doFilter");
         }
 
@@ -1066,7 +1066,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
 
         // invoke the first filter
         fc.doFilter(request, response);
-        if (isTraceOn && logger.isLoggable(Level.FINE)) { // 306998.15
+        if (isTraceOn && logger.isLoggable(Level.FINER)) { // 306998.15
             logger.exiting(CLASS_NAME, "doFilter");
         }
 
@@ -1082,7 +1082,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
                              RequestProcessor requestProcessor, EnumSet<CollaboratorInvocationEnum> colEnum,
                              HttpInboundConnection httpInboundConnection) throws ServletException, IOException {
         final boolean isTraceOn = com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled();
-        if (isTraceOn && logger.isLoggable(Level.FINE)) {
+        if (isTraceOn && logger.isLoggable(Level.FINER)) {
             logger.entering(CLASS_NAME, "invokeFilters", "request->" + request + ", response->" + response + ", requestProcessor->"
                             + requestProcessor + ", context->" + context);
         }
@@ -1158,7 +1158,8 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
                                 alreadyVerifiedEncodedChar = true;        //either way, skip subsequent check in filterDefined
                             }
                             catch (IOException ioe) {
-                                logger.logp(Level.FINE, CLASS_NAME, "invokeFilters", "servletWrapper. Bad request - sending 400 [" + ioe.getMessage() + "]");
+                                if (isTraceOn && logger.isLoggable(Level.FINE)) 
+                                    logger.logp(Level.FINE, CLASS_NAME, "invokeFilters", "servletWrapper. Bad request - sending 400 [" + ioe.getMessage() + "]");
                                 throw ioe;
                             }
                         }
@@ -1177,7 +1178,8 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
                                 alreadyVerifiedEncodedChar = true;        //to skip check in filterDefined later on
                             }
                             catch (IOException ioe) {
-                                logger.logp(Level.FINE, CLASS_NAME, "invokeFilters", "genericServletWrapper. Bad request - sending 400 [" + ioe.getMessage() + "]");
+                                if (isTraceOn && logger.isLoggable(Level.FINE)) 
+                                    logger.logp(Level.FINE, CLASS_NAME, "invokeFilters", "genericServletWrapper. Bad request - sending 400 [" + ioe.getMessage() + "]");
                                 throw ioe;
                             }
                         }
@@ -1249,7 +1251,8 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
                         alreadyVerifiedEncodedChar = true;      // skip checking in the DefaultExtension
                     }
                     catch (IOException ioe) {
-                        logger.logp(Level.FINE, CLASS_NAME, "invokeFilters", "filtersDefined. Bad request - sending 400 [" + ioe.getMessage() + "]");
+                        if (isTraceOn && logger.isLoggable(Level.FINE)) 
+                            logger.logp(Level.FINE, CLASS_NAME, "invokeFilters", "filtersDefined. Bad request - sending 400 [" + ioe.getMessage() + "]");
                         throw ioe;
                     }
                 }
@@ -1299,7 +1302,8 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
                                         IRequestExtended iReq = (IRequestExtended)srtReq.getIRequest();
                                         if (iReq != null) {
                                             httpInboundConnection = iReq.getHttpInboundConnection();
-                                            logger.logp(Level.FINE, CLASS_NAME, "invokeTarget", "HttpInboundConnection: " + httpInboundConnection);
+                                            if (isTraceOn && logger.isLoggable(Level.FINE)) 
+                                                logger.logp(Level.FINE, CLASS_NAME, "invokeTarget", "HttpInboundConnection: " + httpInboundConnection);
                                         }
                                     }
 
@@ -1356,7 +1360,8 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
                                             alreadyVerifiedEncodedChar = true;  //nothing after this, but just incase
                                         }
                                         catch (IOException ioe) {
-                                            logger.logp(Level.FINE, CLASS_NAME, "invokeFilters", "DefaultExtensionProcessor. Bad request - sending 400 [" + ioe.getMessage() + "]");
+                                            if (isTraceOn && logger.isLoggable(Level.FINE)) 
+                                                logger.logp(Level.FINE, CLASS_NAME, "invokeFilters", "DefaultExtensionProcessor. Bad request - sending 400 [" + ioe.getMessage() + "]");
                                             throw ioe;
                                         }
                                     }
@@ -1557,7 +1562,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
             }
         }
 
-        if (isTraceOn && logger.isLoggable(Level.FINE)) {
+        if (isTraceOn && logger.isLoggable(Level.FINER)) {
             logger.exiting(CLASS_NAME, "invokeFilters", "result=" + result);
         }
 
@@ -1657,7 +1662,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
         final boolean isTraceOn = com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled();
         final String METHOD_NAME ="verifyEncodedCharacter";
 
-        if (isTraceOn && logger.isLoggable(Level.FINE))
+        if (isTraceOn && logger.isLoggable(Level.FINER))
             logger.entering(CLASS_NAME, METHOD_NAME + " [" + uri + "]");
 
         String path = uri.toLowerCase();
@@ -1686,7 +1691,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
             }
         }
         finally {
-            if (isTraceOn && logger.isLoggable(Level.FINE))
+            if (isTraceOn && logger.isLoggable(Level.FINER))
                 logger.exiting(CLASS_NAME, METHOD_NAME);
         }
     }

--- a/dev/io.openliberty.restfulWS.mpMetrics.filter/src/io/openliberty/restfulws/mpmetrics/RestMonitorKeyCache.java
+++ b/dev/io.openliberty.restfulWS.mpMetrics.filter/src/io/openliberty/restfulws/mpmetrics/RestMonitorKeyCache.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.restfulws.mpmetrics;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * Stores a cache of {@code (class, method) -> monitor key}
+ * <p>
+ * Conceptually this is just a thread-safe {@code WeakHashMap<Pair<Class<?>, Method>, String>} but it's more complicated because we need a weak reference to the class and the
+ * method, not to the pair object.
+ */
+@Trivial
+public class RestMonitorKeyCache {
+
+    private final ConcurrentHashMap<RestResourceMethodKey, String> routes = new ConcurrentHashMap<>();
+    private final ReferenceQueue<Class<?>> referenceQueue = new ReferenceQueue<>();
+
+    /**
+     * Retrieve the cached monitor key for the specified REST Class and Method
+     *
+     * @param restClass  the class
+     * @param restMethod the method
+     * @return the monitor key, or {@code null} if no route is in the cache
+     */
+    public String getMonitorKey(Class<?> restClass, Method restMethod) {
+        evictGarbageCollectedEntries();
+        return routes.get(new RestResourceMethodKey(restClass, restMethod));
+    }
+
+    /**
+     * Add a new monitor key for the specified REST Class and Method
+     *
+     * @param restClass
+     * @param restMethod
+     * @param monitorKey
+     */
+    public void putMonitorKey(Class<?> restClass, Method restMethod, String monitorKey) {
+        evictGarbageCollectedEntries();
+        routes.put(new RestResourceMethodKey(referenceQueue, restClass, restMethod), monitorKey);
+    }
+
+    private void evictGarbageCollectedEntries() {
+        RestMonitorKeyWeakReference<?> key;
+        while ((key = (RestMonitorKeyWeakReference<?>) referenceQueue.poll()) != null) {
+            routes.remove(key.getOwningKey());
+        }
+    }
+
+    @Trivial
+    private static class RestResourceMethodKey {
+        private final RestMonitorKeyWeakReference<Class<?>> restClassRef;
+        private final RestMonitorKeyWeakReference<Method> restMethodRef;
+        private final int hash;
+
+        RestResourceMethodKey(Class<?> restClass, Method restMethod) {
+            this.restClassRef = new RestMonitorKeyWeakReference<>(restClass, this);
+            this.restMethodRef = new RestMonitorKeyWeakReference<>(restMethod, this);
+            hash = Objects.hash(restClass, restMethod);
+        }
+
+        RestResourceMethodKey(ReferenceQueue<Class<?>> referenceQueue, Class<?> restClass, Method restMethod) {
+            this.restClassRef = new RestMonitorKeyWeakReference<>(restClass, this, referenceQueue);
+            this.restMethodRef = new RestMonitorKeyWeakReference<>(restMethod, this);
+            hash = Objects.hash(restClass, restMethod);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            RestResourceMethodKey other = (RestResourceMethodKey) obj;
+            if (!restClassRef.equals(other.restClassRef)) {
+                return false;
+            }
+            if (!restMethodRef.equals(other.restMethodRef)) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    @Trivial
+    private static class RestMonitorKeyWeakReference<T> extends WeakReference<T> {
+        private final RestResourceMethodKey owningKey;
+
+        RestMonitorKeyWeakReference(T referent, RestResourceMethodKey owningKey) {
+            super(referent);
+            this.owningKey = owningKey;
+        }
+
+        RestMonitorKeyWeakReference(T referent, RestResourceMethodKey owningKey,
+                                  ReferenceQueue<T> referenceQueue) {
+            super(referent, referenceQueue);
+            this.owningKey = owningKey;
+        }
+
+        RestResourceMethodKey getOwningKey() {
+            return owningKey;
+        }
+
+        @SuppressWarnings("rawtypes")
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj instanceof RestMonitorKeyWeakReference) {
+                return get() == ((RestMonitorKeyWeakReference) obj).get();
+            }
+
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            T referent = get();
+            return new StringBuilder("RestMonitorKeyWeakReference: ").append(referent).toString();
+        }
+    }
+
+}


### PR DESCRIPTION
- Update rest monitor / metrics logic to add some caching for calculating the keys used for looking up Stats and Timer objects
- Add / correct isLoggable calls in WebAppFilterManager to avoid calling logp which requires doing a String concatenation.
