### PR TITLE
removed synchronized from invalideTU method in TransactionUserWrapper

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/tu/TransactionUserWrapper.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/tu/TransactionUserWrapper.java
@@ -1700,7 +1700,8 @@ ClientTransactionListener, Serializable, SipServletInvokerListener,SipDialogCont
     *
     */
    public void invalidateTU(boolean removeFromAppSession, boolean removeFromSessionsTbl){
-	   	synchronized (getSynchronizer()) {
+	   	//remove synchronized as it can cause a deadlock if called in a synchronized block in application code
+	   	//synchronized (getSynchronizer()) {
 	   		if (c_logger.isTraceEntryExitEnabled()) {
 	   			c_logger.traceEntry(this, "invalidateTU", new Object[] {removeFromAppSession});
 	   		}
@@ -1770,7 +1771,7 @@ ClientTransactionListener, Serializable, SipServletInvokerListener,SipDialogCont
 
 	   			ThreadLocalStorage.setTUKey(null);
 	   		}
-	   	}
+	   	//}
    }
    
    


### PR DESCRIPTION
fixes https://github.com/OpenLiberty/open-liberty/issues/23838

Trying to invalidate a transaction user can lead to a deadlock when application code is calling getApplicationSession() in a synchronized block.

