### PR TITLE
CrudRepository methods with record

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityDefiner.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityDefiner.java
@@ -374,6 +374,8 @@ public class EntityDefiner implements Runnable {
             // Classes explicitly annotated with JPA @Entity:
             Set<String> entityClassNames = new HashSet<>(entities.size() * 2);
 
+            Map<Class<?>, Class<?>> generatedToRecordClass = new HashMap<>();
+
             ArrayList<InMemoryMappingFile> generatedEntities = new ArrayList<InMemoryMappingFile>();
 
             // List of classes to inspect for the above
@@ -393,6 +395,7 @@ public class EntityDefiner implements Runnable {
                         byte[] generatedEntityBytes = generateEntityClassBytes(c, entityClassName);
                         generatedEntities.add(new InMemoryMappingFile(generatedEntityBytes, entityClassName.replace('.', '/') + ".class"));
                         Class<?> generatedEntity = classDefiner.findLoadedOrDefineClass(loader, entityClassName, generatedEntityBytes);
+                        generatedToRecordClass.put(generatedEntity, c);
                         c = generatedEntity;
                     }
 
@@ -577,8 +580,10 @@ public class EntityDefiner implements Runnable {
 
                 Class<?> entityClass = entityType.getJavaType();
 
-                EntityInfo entityInfo = new EntityInfo(entityType.getName(), //
+                EntityInfo entityInfo = new EntityInfo( //
+                                entityType.getName(), //
                                 entityClass, //
+                                generatedToRecordClass.get(entityClass), //
                                 attributeAccessors, //
                                 attributeNames, //
                                 attributeTypes, //

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityDefiner.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityDefiner.java
@@ -461,6 +461,7 @@ public class EntityDefiner implements Runnable {
                 Queue<Attribute<?, ?>> relationships = new LinkedList<>();
                 Queue<String> relationPrefixes = new LinkedList<>();
                 Queue<List<Member>> relationAccessors = new LinkedList<>();
+                Class<?> recordClass = generatedToRecordClass.get(entityType.getJavaType());
                 Class<?> idClass = null;
                 SortedMap<String, Member> idClassAttributeAccessors = null;
 
@@ -475,8 +476,11 @@ public class EntityDefiner implements Runnable {
                         relationPrefixes.add(attributeName);
                         relationAccessors.add(Collections.singletonList(attr.getJavaMember()));
                     }
+
+                    Member accessor = recordClass == null ? attr.getJavaMember() : recordClass.getMethod(attributeName);
+
                     attributeNames.put(attributeName.toLowerCase(), attributeName);
-                    attributeAccessors.put(attributeName, Collections.singletonList(attr.getJavaMember()));
+                    attributeAccessors.put(attributeName, Collections.singletonList(accessor));
                     attributeTypes.put(attributeName, attr.getJavaType());
                     if (attr.isCollection()) {
                         if (attr instanceof PluralAttribute)

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/KeysetAwarePageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/KeysetAwarePageImpl.java
@@ -70,7 +70,7 @@ public class KeysetAwarePageImpl<T> implements KeysetAwarePage<T> {
                                             queryInfo.jpqlBeforeKeyset;
 
             @SuppressWarnings("unchecked")
-            TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql, queryInfo.entityInfo.type);
+            TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql, queryInfo.entityInfo.entityClass);
             queryInfo.setParameters(query, args);
 
             if (keysetCursor != null)

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -55,7 +55,7 @@ public class PageImpl<T> implements Page<T> {
         EntityManager em = queryInfo.entityInfo.persister.createEntityManager();
         try {
             @SuppressWarnings("unchecked")
-            TypedQuery<T> query = (TypedQuery<T>) em.createQuery(queryInfo.jpql, queryInfo.entityInfo.type);
+            TypedQuery<T> query = (TypedQuery<T>) em.createQuery(queryInfo.jpql, queryInfo.entityInfo.entityClass);
             queryInfo.setParameters(query, args);
 
             int maxPageSize = pagination.size();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PaginatedIterator.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PaginatedIterator.java
@@ -62,7 +62,7 @@ public class PaginatedIterator<T> implements Iterator<T> {
         EntityManager em = queryInfo.entityInfo.persister.createEntityManager();
         try {
             @SuppressWarnings("unchecked")
-            TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql, queryInfo.entityInfo.type);
+            TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql, queryInfo.entityInfo.entityClass);
             queryInfo.setParameters(query, args);
 
             if (keysetCursor != null)

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -264,11 +264,11 @@ class QueryInfo {
      */
     @Trivial
     Object[] getKeysetValues(Object entity) {
-        if (!entityInfo.type.isInstance(entity))
+        if (!entityInfo.getType().isInstance(entity))
             throw new MappingException("Unable to obtain keyset values from the " +
                                        (entity == null ? null : entity.getClass().getName()) +
                                        " type query result. Queries that use keyset pagination must return results of the same type as the entity type, which is " +
-                                       entityInfo.type.getName() + "."); // TODO NLS
+                                       entityInfo.getType().getName() + "."); // TODO NLS
         ArrayList<Object> keyValues = new ArrayList<>();
         for (Sort keyInfo : sorts)
             try {
@@ -485,9 +485,9 @@ class QueryInfo {
             }
         } else { // Special case: CrudRepository.delete(entity) where entity has IdClass
             Object arg = args == null || args.length == 0 ? null : args[0];
-            if (arg == null || !entityInfo.type.isAssignableFrom(arg.getClass()))
+            if (arg == null || !entityInfo.entityClass.isAssignableFrom(arg.getClass()))
                 throw new DataException("The " + (arg == null ? null : arg.getClass().getName()) +
-                                        " parameter does not match the " + entityInfo.type.getClass().getName() +
+                                        " parameter does not match the " + entityInfo.getType().getName() +
                                         " entity type that is expected for this repository.");
             int p = 0;
             for (String idClassAttr : entityInfo.idClassAttributeAccessors.keySet()) {

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -2542,20 +2542,46 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * TODO use a real record
+     * Tests all CrudRepository methods with a record as the entity.
+     * TODO use a real record once compiling against Java 17
      */
     @Test
-    public void testRecordAsEntity() {
+    public void testRecordCrudRepositoryMethods() {
         receipts.deleteAll();
 
         receipts.save(new Receipt(100L, "C0013-00-031", 101.90f));
         receipts.saveAll(List.of(new Receipt(200L, "C0022-00-022", 202.40f),
-                                 new Receipt(300L, "C0013-00-031", 33.99f)));
+                                 new Receipt(300L, "C0013-00-031", 33.99f),
+                                 new Receipt(400L, "C0045-00-054", 44.49f),
+                                 new Receipt(500L, "C0045-00-054", 155.00f)));
 
         assertEquals(true, receipts.existsById(300L));
-        assertEquals(3L, receipts.count());
+        assertEquals(5L, receipts.count());
+
+        Receipt receipt = receipts.findById(200L).orElseThrow();
+        assertEquals(202.40f, receipt.total(), 0.001f);
+
+        assertIterableEquals(List.of("C0013-00-031:300", "C0022-00-022:200", "C0045-00-054:500"),
+                             receipts.findAllById(List.of(200L, 300L, 500L))
+                                             .map(r -> r.customer() + ":" + r.purchaseId())
+                                             .sorted()
+                                             .collect(Collectors.toList()));
+
+        receipts.deleteAllById(List.of(200L, 500L));
+
+        assertIterableEquals(List.of("C0013-00-031:100", "C0013-00-031:300", "C0045-00-054:400"),
+                             receipts.findAll()
+                                             .map(r -> r.customer() + ":" + r.purchaseId())
+                                             .sorted()
+                                             .collect(Collectors.toList()));
+
+        receipts.deleteById(100L);
+
+        assertEquals(2L, receipts.count());
 
         receipts.deleteAll();
+
+        assertEquals(0L, receipts.count());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -2579,6 +2579,19 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(2L, receipts.count());
 
+        receipts.delete(new Receipt(400L, "C0045-00-054", 44.49f));
+
+        assertEquals(false, receipts.existsById(400L));
+
+        receipts.saveAll(List.of(new Receipt(600L, "C0067-00-076", 266.80f),
+                                 new Receipt(700L, "C0067-00-076", 17.99f),
+                                 new Receipt(800L, "C0088-00-088", 88.98f)));
+
+        receipts.deleteAll(List.of(new Receipt(300L, "C0013-00-031", 33.99f),
+                                   new Receipt(700L, "C0067-00-076", 17.99f)));
+
+        assertEquals(2L, receipts.count());
+
         receipts.deleteAll();
 
         assertEquals(0L, receipts.count());


### PR DESCRIPTION
Get the remaining CrudRepository methods working when the entity is a record.
This requires getting JPA to return query results as record instances rather than the generated entity and identifying the correct accessor from the record instead of the metamodel of the generated entity when attempting deletes based on specific entity instances rather than by their primary keys.