### PR TITLE
Add exception on start EJB test

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/.classpath
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/.classpath
@@ -10,6 +10,7 @@
 	<classpathentry kind="src" path="test-applications/Exception2xBean.jar/src"/>
 	<classpathentry kind="src" path="test-applications/Exception2xWeb.war/src"/>
 	<classpathentry kind="src" path="test-applications/ExceptionBean.jar/src"/>
+	<classpathentry kind="src" path="test-applications/ExceptionOnStartBean.jar/src"/>
 	<classpathentry kind="src" path="test-applications/ExceptionWeb.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/bnd.bnd
@@ -24,6 +24,7 @@ src: \
 	test-applications/Exception2xBean.jar/src, \
 	test-applications/Exception2xWeb.war/src, \
 	test-applications/ExceptionBean.jar/src, \
+	test-applications/ExceptionOnStartBean.jar/src, \
 	test-applications/ExceptionWeb.war/src
 
 fat.project: true

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/fat/src/com/ibm/ws/ejbcontainer/exception/fat/FATSuite.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/fat/src/com/ibm/ws/ejbcontainer/exception/fat/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,11 +16,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.ejbcontainer.exception.fat.tests.ExceptionOnStartTest;
 import com.ibm.ws.ejbcontainer.exception.fat.tests.ExceptionTest;
 import com.ibm.ws.ejbcontainer.exception.fat.tests.InheritedApplicationExceptionTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
+                ExceptionOnStartTest.class,
                 ExceptionTest.class,
                 InheritedApplicationExceptionTest.class
 })

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/fat/src/com/ibm/ws/ejbcontainer/exception/fat/tests/ExceptionOnStartTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/fat/src/com/ibm/ws/ejbcontainer/exception/fat/tests/ExceptionOnStartTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.exception.fat.tests;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+
+@RunWith(FATRunner.class)
+public class ExceptionOnStartTest {
+    @Server("com.ibm.ws.ejbcontainer.exception.fat.ExceptionOnStartServer")
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.exception.fat.ExceptionOnStartServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.exception.fat.ExceptionOnStartServer")).andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11).forServers("com.ibm.ws.ejbcontainer.exception.fat.ExceptionOnStartServer")).andWith(FeatureReplacementAction.EE10_FEATURES().forServers("com.ibm.ws.ejbcontainer.exception.fat.ExceptionOnStartServer"));
+
+    public static String[] ignoredFailuresRegExps;
+
+    @Before
+    public void before() throws Exception {
+        ignoredFailuresRegExps = null;
+    }
+
+    @After
+    public void after() throws Exception {
+        if (server.isStarted()) {
+            server.stopServer(ignoredFailuresRegExps);
+        }
+    }
+
+    /**
+     * Test that an application fails to start when a bean configured to start on application start
+     * is missing a referenced class file. Verifies the appropriate messages and FFDC are logged.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    @ExpectedFFDC({ "com.ibm.ejs.container.EJBConfigurationException", "com.ibm.ws.container.service.state.StateChangeException" })
+    public void testExceptionOnBeanInitialization() throws Exception {
+        String BEAN_START_FAILED = "CNTR5007E:.*ExceptionOnStartSingletonBean";
+        String MODULE_START_FAILED = "CNTR4002E:.*ExceptionOnStartBean.jar";
+        String APP_START_FAILED = "CWWKZ0106E:.*ExceptionOnStartApp";
+        String EXCEPTION_STARTING_APP = "CWWKZ0002E:.*ExceptionOnStartApp";
+
+        ignoredFailuresRegExps = new String[] { BEAN_START_FAILED, MODULE_START_FAILED, APP_START_FAILED, EXCEPTION_STARTING_APP };
+
+        // Use ShrinkHelper to build the application ear; excluding the exception class to cause a failure
+        JavaArchive ExceptionOnStartBean = ShrinkHelper.buildJavaArchive("ExceptionOnStartBean.jar", "com.ibm.ws.ejbcontainer.exception.start.ejb.");
+        EnterpriseArchive ExceptionOnStartApp = ShrinkWrap.create(EnterpriseArchive.class, "ExceptionOnStartApp.ear");
+        ExceptionOnStartApp.addAsModule(ExceptionOnStartBean);
+
+        ShrinkHelper.exportDropinAppToServer(server, ExceptionOnStartApp, DeployOptions.DISABLE_VALIDATION, DeployOptions.SERVER_ONLY);
+
+        server.startServer();
+
+        assertNotNull("Bean ExceptionOnStartSingletonBean started", server.waitForStringInLog(BEAN_START_FAILED));
+        assertNotNull("EJB module ExceptionOnStartBean.jar started", server.waitForStringInLog(MODULE_START_FAILED));
+        assertNotNull("Application ExceptionOnStartApp started", server.waitForStringInLog(APP_START_FAILED));
+        assertNotNull("Application ExceptionOnStartApp started", server.waitForStringInLog(EXCEPTION_STARTING_APP));
+    }
+
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.AppExceptionServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.AppExceptionServer/server.xml
@@ -10,9 +10,10 @@
 
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" iiopsPort="${bvt.prop.IIOP.secure}"/>
 
-    <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv around getClassLoader -->	
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="line.separator" actions="read"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="testLauncher" actions="read"/>
     <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
     <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="line.separator" actions="read"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="testLauncher" actions="read"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.ExceptionOnStartServer/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.ExceptionOnStartServer/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:EJBContainer=all

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.ExceptionOnStartServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.ExceptionOnStartServer/server.xml
@@ -1,0 +1,10 @@
+<server>
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>ejbLite-3.2</feature>
+        <feature>componenttest-1.0</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/EJB31AppExAnnApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/EJB31AppExAnnApp.ear/resources/META-INF/permissions.xml
@@ -10,4 +10,10 @@
         <class-name>java.lang.RuntimePermission</class-name>
         <name>getClassLoader</name>
     </permission> 
+    <permission>
+        <!-- Yoko ORB bug; org.apache.yoko.orb.OBCORBA.ORB_impl.initialize needs doPriv -->
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+        <actions>read,write</actions>
+    </permission>
 </permissions>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionApp.ear/resources/META-INF/permissions.xml
@@ -10,4 +10,10 @@
         <class-name>java.lang.RuntimePermission</class-name>
         <name>getClassLoader</name>
     </permission> 
+    <permission>
+        <!-- Yoko ORB bug; org.apache.yoko.orb.OBCORBA.ORB_impl.initialize needs doPriv -->
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+        <actions>read,write</actions>
+    </permission>
 </permissions>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionOnStartBean.jar/resources/META-INF/ibm-ejb-jar-ext.xml
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionOnStartBean.jar/resources/META-INF/ibm-ejb-jar-ext.xml
@@ -1,0 +1,11 @@
+<ejb-jar-ext
+  xmlns="http://websphere.ibm.com/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ejb-jar-ext_1_1.xsd"
+  version="1.1"
+>
+  <session name="ExceptionOnStartSingletonBean">
+    <start-at-app-start value="true"/>
+  </session>
+
+</ejb-jar-ext>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionOnStartBean.jar/src/com/ibm/ws/ejbcontainer/exception/start/ejb/ExceptionOnStartSingletonBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionOnStartBean.jar/src/com/ibm/ws/ejbcontainer/exception/start/ejb/ExceptionOnStartSingletonBean.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.ejbcontainer.exception.start.ejb;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.EJBException;
+import javax.ejb.Singleton;
+
+import com.ibm.ws.ejbcontainer.exception.start.util.ExceptionOnStartException;
+
+/**
+ * Enterprise Bean: ExceptionOnStartSingletonBean
+ *
+ * Class will fail to load because the exception on the throws clause is missing.
+ */
+@Singleton
+public class ExceptionOnStartSingletonBean {
+
+    public ExceptionOnStartSingletonBean() throws ExceptionOnStartException {
+        System.out.println("StartupSingletonBean.<init>() called");
+    }
+
+    @PostConstruct
+    private void postConstruct() throws EJBException {
+        System.out.println("StartupSingletonBean.postConstruct() called");
+    }
+
+    public String sayHello(String name) {
+        return ("Hello " + name + "!");
+    }
+
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionOnStartBean.jar/src/com/ibm/ws/ejbcontainer/exception/start/util/ExceptionOnStartException.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionOnStartBean.jar/src/com/ibm/ws/ejbcontainer/exception/start/util/ExceptionOnStartException.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.ejbcontainer.exception.start.util;
+
+/**
+ * Exception intentionally not packaged with application.
+ */
+public class ExceptionOnStartException extends Exception {
+
+    private static final long serialVersionUID = 4528063737084563623L;
+
+}


### PR DESCRIPTION
- verify appropriate errors/ffdc when excption occurs during EJB initialization on app start
- add some permissions for Java 2 security when running locally or in a different order
