### PR TITLE
Fix clientSecret checks for OIDC in social login

### DIFF
--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
@@ -20,7 +20,7 @@
         <AD id="clientId" name="%clientId" description="%clientId.desc"
             required="true" type="String" />
         <AD id="clientSecret" name="%clientSecret" description="%clientSecret.desc"
-            type="String" ibm:type="password" />
+            required="false" type="String" ibm:type="password" />
         <!-- AD id="userApi" required="false" type="String" not defined -->
         <AD id="authorizationEndpoint" name="%authorizationEndpoint" description="%authorizationEndpoint.desc"
             required="false" type="String" default="https://accounts.google.com/o/oauth2/v2/auth"/>
@@ -370,7 +370,7 @@
         <AD id="clientId" name="%clientId" description="%clientId.desc"
             required="true" type="String" />
         <AD id="clientSecret" name="%clientSecret" description="%clientSecret.desc"
-            type="String" ibm:type="password" />
+            required="false" type="String" ibm:type="password" />
         <!-- AD id="userApi" required="false" type="String" not defined -->
         <AD id="authorizationEndpoint" name="%authorizationEndpoint" description="%authorizationEndpoint.desc"
             required="false" type="String" />

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
@@ -149,7 +149,6 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
     @Override
     protected void checkForRequiredConfigAttributes(Map<String, Object> props) {
         getRequiredConfigAttribute(props, KEY_clientId);
-        getRequiredSerializableProtectedStringConfigAttribute(props, KEY_clientSecret);
     }
 
     @Override

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/SocialLoginTAI.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/SocialLoginTAI.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.social.tai;
 
@@ -45,6 +42,7 @@ import com.ibm.ws.security.openidconnect.clients.common.OidcClientRequest;
 import com.ibm.ws.security.openidconnect.clients.common.OidcSessionCache;
 import com.ibm.ws.security.openidconnect.clients.common.OidcSessionInfo;
 import com.ibm.ws.security.openidconnect.clients.common.OidcSessionUtils;
+import com.ibm.ws.security.openidconnect.clients.common.token.auth.PrivateKeyJwtAuthMethod;
 import com.ibm.ws.security.social.Constants;
 import com.ibm.ws.security.social.SocialLoginConfig;
 import com.ibm.ws.security.social.SocialLoginWebappConfig;
@@ -576,13 +574,14 @@ public class SocialLoginTAI implements TrustAssociationInterceptor, UnprotectedR
         boolean valid = true;
         String clientId = config.getClientId();
         String clientSecret = config.getClientSecret();
+        String tokenEndpointAuthMethod = config.getTokenEndpointAuthMethod();
         String authorizationEndpoint = config.getAuthorizationEndpointUrl();
         String jwksUri = config.getJwkEndpointUrl();
         if (clientId == null || clientId.length() == 0) {
             Tr.error(tc, "INVALID_CONFIG_PARAM", new Object[] { OidcLoginConfigImpl.KEY_clientId, clientId });
             valid = false;
         }
-        if (clientSecret == null || clientSecret.length() == 0) {
+        if (!PrivateKeyJwtAuthMethod.AUTH_METHOD.equals(tokenEndpointAuthMethod) && (clientSecret == null || clientSecret.isEmpty())) {
             Tr.error(tc, "INVALID_CONFIG_PARAM", new Object[] { OidcLoginConfigImpl.KEY_clientSecret, "" });
             valid = false;
         }


### PR DESCRIPTION
Fixes to ensure the `clientSecret` attribute is only required for OIDC clients in social login that don't use the `private_key_jwt` token endpoint authentication method.

Fixes #25247