### PR TITLE
Increase trace for artifact FATs.

### DIFF
--- a/dev/com.ibm.ws.artifact_fat/publish/servers/com.ibm.ws.artifact.dynamism/server.xml
+++ b/dev/com.ibm.ws.artifact_fat/publish/servers/com.ibm.ws.artifact.dynamism/server.xml
@@ -4,6 +4,8 @@
     <feature>servlet-3.1</feature>
   </featureManager>
 
+  <logging traceSpecification="com.ibm.ws.artifact*=all" maxFileSize="20" maxFiles="10"/>
+
   <include location="../fatTestPorts.xml"/>
 
   <application location="jarneeder.war"/>

--- a/dev/com.ibm.ws.artifact_fat/publish/servers/com.ibm.ws.artifact.zipDumps/server.xml
+++ b/dev/com.ibm.ws.artifact_fat/publish/servers/com.ibm.ws.artifact.zipDumps/server.xml
@@ -1,17 +1,17 @@
-<server description="Test server to verify dumping server works and contains introspections for com.ibm.ws.artifact.zip">
+<server description="Test server: Verify server dump and zip file instrospection">
 
   <featureManager>
     <feature>servlet-3.1</feature>
   </featureManager>
 
-<logging traceSpecification="com.ibm.ws.artifact.zip*=all" />
+  <logging traceSpecification="com.ibm.ws.artifact*=all" maxFileSize="20" maxFiles="10"/>
 
-<include location="../fatTestPorts.xml"/>
+  <include location="../fatTestPorts.xml"/>
 
-<application location="jarneeder.war"/>
-<application location="testServlet1.war" />
-<application location="testServlet2.war" />
+  <application location="jarneeder.war"/>
+  <application location="testServlet1.war" />
+  <application location="testServlet2.war" />
 
-<javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read" />
+  <javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read" />
 
 </server>

--- a/dev/com.ibm.ws.artifact_fat/publish/servers/com.ibm.ws.artifact.zipIntrospections/server.xml
+++ b/dev/com.ibm.ws.artifact_fat/publish/servers/com.ibm.ws.artifact.zipIntrospections/server.xml
@@ -1,13 +1,13 @@
-<server description="Test server to verify zip reaper functionality and history">
+<server description="Test server: Verify zip file introspection">
 
   <featureManager>
     <feature>servlet-3.1</feature>
   </featureManager>
 
-<logging traceSpecification="com.ibm.ws.artifact.zip*=all" />
+  <logging traceSpecification="com.ibm.ws.artifact*=all" maxFileSize="20" maxFiles="10"/>
 
-<include location="../fatTestPorts.xml"/>
+  <include location="../fatTestPorts.xml"/>
 
-<javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read" />
+  <javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read" />
 
 </server>


### PR DESCRIPTION
Trace update for RTC 296004.

The trace which is currently generated is not sufficient to diagnose the problem.

This update is an attempt to gather sufficient trace.  This may be a temporary update.