### PR TITLE
Convert logging to use DateTimeFormatter

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonHelpers.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonHelpers.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,7 +14,6 @@ package com.ibm.ws.logging.collector;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 
 import com.ibm.ws.logging.data.AccessLogData;
@@ -97,12 +96,11 @@ public class CollectorJsonHelpers {
             return "";
     }
 
-    public static ThreadLocal<BurstDateFormat> dateFormatTL = new ThreadLocal<BurstDateFormat>() {
-        @Override
-        protected BurstDateFormat initialValue() {
-            return new BurstDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
-        }
-    };
+    private static BurstDateFormat dateFormat = new BurstDateFormat("uuuu-MM-dd'T'HH:mm:ss.SSSZ", '.');
+
+    public static String formatTime(long dateTime) {
+        return dateFormat.format(dateTime);
+    }
 
     protected static boolean addToJSON(StringBuilder sb, String name, String value, boolean jsonEscapeName,
                                        boolean jsonEscapeValue, boolean trim, boolean isFirstField) {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -107,7 +107,7 @@ public class CollectorJsonUtils {
         jsonBuilder.addField(gcData.getGcTypeKey(), gcData.getGcType(), false, true);
         jsonBuilder.addField(gcData.getReasonKey(), gcData.getReason(), false, true);
 
-        String datetime = CollectorJsonHelpers.dateFormatTL.get().format(gcData.getDatetime());
+        String datetime = CollectorJsonHelpers.formatTime(gcData.getDatetime());
         jsonBuilder.addField(gcData.getDatetimeKey(), datetime, false, true);
 
         jsonBuilder.addField(gcData.getSequenceKey(), gcData.getSequence(), false, true);
@@ -143,7 +143,7 @@ public class CollectorJsonUtils {
 
         StringBuilder formattedValue = new StringBuilder(CollectorJsonHelpers.formatMessage(message, maxFieldLength));
 
-        String datetime = CollectorJsonHelpers.dateFormatTL.get().format(logData.getDatetime());
+        String datetime = CollectorJsonHelpers.formatTime(logData.getDatetime());
 
         //@formatter:off
         jsonBuilder.addField(LogTraceData.getMessageKey(LOGSTASH_KEY, isMessageEvent), formattedValue.toString(), false, true)
@@ -204,7 +204,7 @@ public class CollectorJsonUtils {
 
         JSONObjectBuilder jsonBuilder = CollectorJsonHelpers.startFFDC(LOGSTASH_KEY);
 
-        String datetime = CollectorJsonHelpers.dateFormatTL.get().format(ffdcData.getDatetime());
+        String datetime = CollectorJsonHelpers.formatTime(ffdcData.getDatetime());
         String formattedValue = CollectorJsonHelpers.formatMessage(ffdcData.getStacktrace(), maxFieldLength);
         //@formatter:off
         jsonBuilder.addField(FFDCData.getDatetimeKey(LOGSTASH_KEY), datetime, false, true)
@@ -280,7 +280,7 @@ public class CollectorJsonUtils {
                      * This method is to parse and format into logstash_1.0 expected formatting.
                      */
                     if (key.equals(LogFieldConstants.IBM_DATETIME) || key.equals("loggingEventTime")) {
-                        String datetime = CollectorJsonHelpers.dateFormatTL.get().format(kvp.getLongValue());
+                        String datetime = CollectorJsonHelpers.formatTime(kvp.getLongValue());
                         jsonBuilder.addField(AuditData.getDatetimeKey(LOGSTASH_KEY), datetime, false, true);
                     } else if (key.equals(LogFieldConstants.IBM_SEQUENCE) || key.equals("loggingSequenceNumber")) {
                         jsonBuilder.addField(AuditData.getSequenceKey(LOGSTASH_KEY), kvp.getStringValue(), false, false);

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils_JSON.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils_JSON.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -84,7 +84,7 @@ public class CollectorJsonUtils_JSON {
 
         JSONObjectBuilder jsonBuilder = CollectorJsonHelpers.startFFDC(JSON_KEY);
 
-        String datetime = CollectorJsonHelpers.dateFormatTL.get().format(ffdcData.getDatetime());
+        String datetime = CollectorJsonHelpers.formatTime(ffdcData.getDatetime());
         String formattedValue = CollectorJsonHelpers.formatMessage(ffdcData.getStacktrace(), maxFieldLength);
 
         //@formatter:off
@@ -152,7 +152,7 @@ public class CollectorJsonUtils_JSON {
 
         StringBuilder formattedValue = new StringBuilder(CollectorJsonHelpers.formatMessage(message, maxFieldLength));
 
-        String datetime = CollectorJsonHelpers.dateFormatTL.get().format(logData.getDatetime());
+        String datetime = CollectorJsonHelpers.formatTime(logData.getDatetime());
 
         //@formatter:off
         jsonBuilder.addField(LogTraceData.getMessageKey(JSON_KEY, isMessageEvent), formattedValue.toString(), false, true)
@@ -234,7 +234,7 @@ public class CollectorJsonUtils_JSON {
                      * Parse the rest of audit GDO KVP - They are strings.
                      */
                     if (key.equals(LogFieldConstants.IBM_DATETIME) || key.equals("loggingEventTime") || AuditData.getDatetimeKey(JSON_KEY).equals(key)) {
-                        String datetime = CollectorJsonHelpers.dateFormatTL.get().format(kvp.getLongValue());
+                        String datetime = CollectorJsonHelpers.formatTime(kvp.getLongValue());
                         jsonBuilder.addField(AuditData.getDatetimeKey(JSON_KEY), datetime, false, true);
                     } else if (key.equals(LogFieldConstants.IBM_SEQUENCE) || key.equals("loggingSequenceNumber") || AuditData.getSequenceKey(JSON_KEY).equals(key)) {
                         jsonBuilder.addField(AuditData.getSequenceKey(JSON_KEY), kvp.getStringValue(), false, false);

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/DateFormatHelper.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/DateFormatHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,57 +12,48 @@
  *******************************************************************************/
 package com.ibm.ws.logging.collector;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.chrono.Chronology;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.FormatStyle;
+import java.util.Locale;
+import java.util.Locale.Category;
 
 /**
  *
  */
 public class DateFormatHelper {
 
-    /** Thread specific date format objects */
-    private static ThreadLocal<BurstDateFormat[]> dateformats = new ThreadLocal<BurstDateFormat[]>();
-
     /**
-     * A format string that will produce a reasonable standard way for
+     * A format that will produce a reasonable standard way for
      * formatting time (but still using the current locale)
      */
-    private static final String localeDatePattern;
+    private static final BurstDateFormat localeDateFormat;
 
-    private static final boolean localeDateFormatInvald;
-
-    private static final boolean isoDateFormatInvalid;
+    private static final BurstDateFormat isoDateFormat;
 
     static {
         // Retrieve a standard Java DateFormat object with desired format.
-        DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM);
-        if (formatter instanceof SimpleDateFormat) {
-            // Retrieve the pattern from the formatter, since we will need to
-            // modify it.
-            SimpleDateFormat sdFormatter = (SimpleDateFormat) formatter;
-            String pattern = sdFormatter.toPattern();
-            // Append milliseconds and timezone after seconds
-            int patternLength = pattern.length();
-            int endOfSecsIndex = pattern.lastIndexOf('s') + 1;
-            StringBuilder newPattern = new StringBuilder(pattern.substring(0, endOfSecsIndex) + ":SSS z");
-            if (endOfSecsIndex < patternLength)
-                newPattern.append(pattern.substring(endOfSecsIndex, patternLength));
-            // 0-23 hour clock (get rid of any other clock formats and am/pm)
-            localeDatePattern = removeClockFormat(newPattern);
-        } else {
-            localeDatePattern = "dd/MMM/yyyy HH:mm:ss:SSS z";
-        }
+        Locale locale = Locale.getDefault(Category.FORMAT);
+        String pattern = DateTimeFormatterBuilder.getLocalizedDateTimePattern(FormatStyle.SHORT, FormatStyle.MEDIUM, Chronology.ofLocale(locale), locale);
+        // Append milliseconds and timezone after seconds
+        int patternLength = pattern.length();
+        int endOfSecsIndex = pattern.lastIndexOf('s') + 1;
+        StringBuilder newPattern = new StringBuilder(pattern.substring(0, endOfSecsIndex) + ":SSS z");
+        if (endOfSecsIndex < patternLength)
+            newPattern.append(pattern.substring(endOfSecsIndex, patternLength));
+        // 0-23 hour clock (get rid of any other clock formats and am/pm)
+        String localeDatePattern = removeClockFormat(newPattern);
 
-        localeDateFormatInvald = BurstDateFormat.isFormatInvalid(new SimpleDateFormat(localeDatePattern));
+        localeDateFormat = new BurstDateFormat(localeDatePattern, ':', locale);
 
-        isoDateFormatInvalid = BurstDateFormat.isFormatInvalid(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
+        isoDateFormat = new BurstDateFormat("uuuu-MM-dd'T'HH:mm:ss.SSSZ", '.');
     }
 
     /**
      * Return the localeDatePattern without clock formats and am/pm as a trimmed String
      *
      * @param sb
-     *            A StringBuilder holding the pre-formatted localeDatePattern
+     *               A StringBuilder holding the pre-formatted localeDatePattern
      * @return
      *         The formatted localeDatePattern
      */
@@ -91,33 +82,17 @@ public class DateFormatHelper {
      * Return the given time formatted, based on the provided format structure
      *
      * @param timestamp
-     *            A timestamp as a long, e.g. what would be returned from
-     *            <code>System.currentTimeMillis()</code>
+     *                             A timestamp as a long, e.g. what would be returned from
+     *                             <code>System.currentTimeMillis()</code>
      *
      * @param useIsoDateFormat
-     *            A boolean, if true, the given date and time will be formatted in ISO-8601,
-     *            e.g. yyyy-MM-dd'T'HH:mm:ss.SSSZ
-     *            if false, the date and time will be formatted as the current locale,
+     *                             A boolean, if true, the given date and time will be formatted in ISO-8601,
+     *                             e.g. yyyy-MM-dd'T'HH:mm:ss.SSSZ
+     *                             if false, the date and time will be formatted as the current locale,
      *
      * @return formated date string
      */
     public static final String formatTime(long timestamp, boolean useIsoDateFormat) {
-        BurstDateFormat[] dfs = dateformats.get();
-        int index = useIsoDateFormat ? 1 : 0;
-        if (dfs == null) {
-            dfs = new BurstDateFormat[index + 1];
-            dateformats.set(dfs);
-        } else if (useIsoDateFormat && dfs.length == 1) {
-            BurstDateFormat[] newDfs = new BurstDateFormat[2];
-            newDfs[0] = dfs[0];
-            dfs = newDfs;
-            dateformats.set(dfs);
-        }
-
-        if (dfs[index] == null) {
-            dfs[index] = useIsoDateFormat ? new BurstDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"), isoDateFormatInvalid) : new BurstDateFormat(new SimpleDateFormat(localeDatePattern), localeDateFormatInvald);
-        }
-
-        return dfs[index].format(timestamp);
+        return (useIsoDateFormat ? isoDateFormat : localeDateFormat).format(timestamp);
     }
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/source/AccessLogSource.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/source/AccessLogSource.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -659,14 +659,14 @@ public class AccessLogSource implements Source {
 
     private static JsonFieldAdder addRequestStartTimeField(int format) {
         return (jsonBuilder, ald) -> {
-            String startTime = CollectorJsonHelpers.dateFormatTL.get().format(ald.getRequestStartTime());
+            String startTime = CollectorJsonHelpers.formatTime(ald.getRequestStartTime());
             return jsonBuilder.addField(AccessLogData.getRequestStartTimeKey(format), startTime, false, true);
         };
     }
 
     private static JsonFieldAdder addAccessLogDatetimeField(int format) {
         return (jsonBuilder, ald) -> {
-            String accessLogDatetime = CollectorJsonHelpers.dateFormatTL.get().format(ald.getAccessLogDatetime());
+            String accessLogDatetime = CollectorJsonHelpers.formatTime(ald.getAccessLogDatetime());
             return jsonBuilder.addField(AccessLogData.getAccessLogDatetimeKey(format), accessLogDatetime, false, true);
         };
     }
@@ -687,7 +687,7 @@ public class AccessLogSource implements Source {
 
     private static JsonFieldAdder addDatetimeField(int format) {
         return (jsonBuilder, ald) -> {
-            String datetime = CollectorJsonHelpers.dateFormatTL.get().format(ald.getDatetime());
+            String datetime = CollectorJsonHelpers.formatTime(ald.getDatetime());
             return jsonBuilder.addField(AccessLogData.getDatetimeKey(format), datetime, false, true);
         };
     }


### PR DESCRIPTION
- Update BurstDateFormat to use DateTimeFormatter instead of SimpleDateFormat
- Add and use a new formatTime method in CollectorJsonHelpers class
- Update DataFormatHelper to use the DateTimeForamtter pattern logic instead of SimpleDateFormat pattern
- This is the continuation of #25167