### PR TITLE
Defer tx recovery until restore config updates complete

### DIFF
--- a/dev/com.ibm.ws.transaction/bnd.bnd
+++ b/dev/com.ibm.ws.transaction/bnd.bnd
@@ -20,15 +20,19 @@ bVersion=1.0
 WS-TraceGroup: Transaction
 
 Service-Component: com.ibm.ws.transaction; \
-	  provide:='com.ibm.tx.config.ConfigurationProvider'; \
+      provide:='com.ibm.tx.config.ConfigurationProvider'; \
       implementation:=com.ibm.ws.transaction.services.JTMConfigurationProvider; \
       locationService=com.ibm.wsspi.kernel.service.location.WsLocationAdmin; \
       dataSourceFactory=com.ibm.wsspi.resource.ResourceFactory; \
       transactionSettingsProvider=com.ibm.tx.jta.embeddable.TransactionSettingsProvider ;\
-      optional:='dataSourceFactory,transactionSettingsProvider';\
-      dynamic:='dataSourceFactory,transactionSettingsProvider';\
+      runningCondition='org.osgi.service.condition.Condition';\
+      optional:='dataSourceFactory,transactionSettingsProvider,runningCondition';\
+      dynamic:='dataSourceFactory,transactionSettingsProvider,runningCondition';\
       configuration-policy:=require;\
-      properties:='service.vendor=IBM,dataSourceFactory.target=(id=unbound)', \
+      properties:='\
+         service.vendor=IBM,\
+         dataSourceFactory.target=(id=unbound),\
+         runningCondition.target=(osgi.condition.id=io.openliberty.process.running)',\
    TMRecoveryService; \
       implementation:=com.ibm.ws.transaction.services.TMRecoveryService; \
       provide:='com.ibm.ws.transaction.services.TMRecoveryService'; \

--- a/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/TransactionLogTest.java
+++ b/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/TransactionLogTest.java
@@ -63,6 +63,7 @@ public class TransactionLogTest extends FATServletClient {
     static final String SERVLET_NAME = APP_NAME + "/SimpleServlet";
 
     static final int DERBY_TXLOG_PORT = 1619; // Differs from server configuration
+    static final String DERBY_DS_JNDINAME = "jdbc/derby"; // Differs from server configuration
 
     static LibertyServer serverTranLog;
     static LibertyServer serverTranDbLog;
@@ -96,6 +97,7 @@ public class TransactionLogTest extends FATServletClient {
                     File serverEnvFile = new File(checkpointServer.getServerRoot() + "/server.env");
                     try (PrintWriter serverEnvWriter = new PrintWriter(new FileOutputStream(serverEnvFile))) {
                         serverEnvWriter.println("DERBY_TXLOG_PORT=" + DERBY_TXLOG_PORT);
+                        serverEnvWriter.println("DERBY_DS_JNDINAME=" + DERBY_DS_JNDINAME);
                     } catch (FileNotFoundException e) {
                         throw new UncheckedIOException(e);
                     }
@@ -155,16 +157,17 @@ public class TransactionLogTest extends FATServletClient {
     /**
      * Verify transactions log to a datasource within a restored server.
      * The test further ensures the datasource configuration has updated
-     * with config attribute(s) declared in server.env file.
+     * with config attribute(s) declared in the server.env file.
      */
     @Test
     public void testTransactionDbLogBasicConnection() throws Exception {
         serverTranDbLog.checkpointRestore();
 
         // Exercise a transaction to start tran logging to the datasource.
-        // The server will throw an exception and fail this test if it cannot
+        // The server will throw an exception and fail this test the TM cannot
         // establish a connection to the database.
-        runTest("testBasicConnection", serverTranDbLog);
+        runTest("testLTCAfterGlobalTran", serverTranDbLog);
+
     }
 
     private void runTest(String testName, LibertyServer ls) throws Exception {

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionDbLog/server.xml
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionDbLog/server.xml
@@ -29,7 +29,7 @@
 
     <variable name="DERBY_DS_UID" defaultValue="dbuser1"/>
     <variable name="DERBY_DS_PW" defaultValue="{xor}Oz0vKDtu"/>
-    <variable name="DERBY_DS_JNDINAME" defaultValue="jdbc/derby"/>
+    <variable name="DERBY_DS_JNDINAME" defaultValue="DUMMYjdbc/derby"/>
 
     <dataSource
         jndiName="${DERBY_DS_JNDINAME}"
@@ -63,7 +63,7 @@
 
     <transaction
         dataSourceRef="tranlogDataSource"
-        recoverOnStartup="false"
+        recoverOnStartup="true"
         waitForRecovery="false"
         heuristicRetryInterval="10"
     />


### PR DESCRIPTION
For issue [21198](https://github.com/OpenLiberty/open-liberty/issues/21198)

These changes defer recovery during checkpoint restore until the config update has completed.  The solution relies on checkpoint restore to register the checkpoint RunningCondition service+property immediately after updating the config at startup.

During checkpoint restore the checkpoint hook that starts the transaction manager will immediately start transaction recovery when `recoverOnStartup=true`.  And at the same time, checkpoint restore performs a config update, which may update the configuration of transactional datasources used by applications (i.e. update resource factories).  The datasource updates trigger further updates to the transaction recovery services, which must use the updated datasources in order to recover in-flight transactions.  Tx recovery at startup will suffer datasource connectivity failures if it executes before restore completes updating the datasources and their dependent transaction services. 






