### PR TITLE
Issue 19029: Add disabled option for PKCE in OIDC client

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
@@ -289,5 +289,9 @@ accessTokenCacheEnabled.desc=Specifies whether authenticated subjects that are c
 accessTokenCacheTimeout=Access token cache timeout
 accessTokenCacheTimeout.desc=Specifies how long an authenticated subject that is created by using a propagated access token is cached.
 
+pkceCodeChallengeMethod=Proof key for code exchange challenge method
+pkceCodeChallengeMethod.desc=Specifies the challenge method to use for Proof Key for Code Exchange (PKCE).
+
+pkceCodeChallengeMethod.disabled=Disabled
 pkceCodeChallengeMethod.plain=Plain
 pkceCodeChallengeMethod.S256=S256

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
@@ -157,7 +157,8 @@
          <AD id="keyManagementKeyAlias" name="%keyManagementKeyAlias" description="%keyManagementKeyAlias.desc" required="false" type="String" />
          <AD id="accessTokenCacheEnabled" name="%accessTokenCacheEnabled" description="%accessTokenCacheEnabled.desc" required="false" type="Boolean" default="true" />
          <AD id="accessTokenCacheTimeout" name="%accessTokenCacheTimeout" description="%accessTokenCacheTimeout.desc" required="false" type="String" default="5m" ibm:type="duration" />
-         <AD id="pkceCodeChallengeMethod" name="internal" description="internal use only" required="false" type="String" ibm:beta="true" >
+         <AD id="pkceCodeChallengeMethod" name="%pkceCodeChallengeMethod" description="%pkceCodeChallengeMethod.desc" required="false" type="String" default="disabled" ibm:beta="true" >
+                <Option label="%pkceCodeChallengeMethod.disabled" value="disabled" />
                 <Option label="%pkceCodeChallengeMethod.plain" value="plain" />
                 <Option label="%pkceCodeChallengeMethod.S256" value="S256" />
          </AD>

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandler.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandler.java
@@ -183,7 +183,7 @@ public class AuthorizationCodeHandler {
     HashMap<String, String> getTokenRequestCustomParameters(String state) {
         HashMap<String, String> customParams = clientConfig.getTokenRequestParams();
         String codeChallengeMethod = clientConfig.getPkceCodeChallengeMethod();
-        if (codeChallengeMethod != null) {
+        if (codeChallengeMethod != null && !ClientConstants.PKCE_CODE_CHALLENGE_DISABLED.equals(codeChallengeMethod)) {
             customParams = addPkceParameters(state, customParams);
         }
         return customParams;

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ClientConstants.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ClientConstants.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- * IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
@@ -98,5 +95,7 @@ public class ClientConstants {
     public static final String CREDENTIAL_STORING_TIME_MILLISECONDS = Constants.CREDENTIAL_STORING_TIME_MILLISECONDS;
     public static final String RSA = "RSA";
     public static final String EC = "EC";
+
+    public static final String PKCE_CODE_CHALLENGE_DISABLED = "disabled";
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequest.java
@@ -222,7 +222,7 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
         }
 
         String pkceCodeChallengeMethod = clientConfig.getPkceCodeChallengeMethod();
-        if (pkceCodeChallengeMethod != null) {
+        if (pkceCodeChallengeMethod != null && !ClientConstants.PKCE_CODE_CHALLENGE_DISABLED.equals(pkceCodeChallengeMethod)) {
             addPkceParameters(pkceCodeChallengeMethod, state, authzParameters);
         }
 

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
@@ -289,5 +289,9 @@ createSession.desc=Specifies whether to create an HttpSession if the current Htt
 keyManagementKeyAlias=Key management key alias
 keyManagementKeyAlias.desc=Private key alias of the key management key that is used to decrypt the Content Encryption Key of a JSON Web Encryption (JWE) token.
 
+pkceCodeChallengeMethod=Proof key for code exchange challenge method
+pkceCodeChallengeMethod.desc=Specifies the code challenge method to use for Proof Key for Code Exchange (PKCE).
+
+pkceCodeChallengeMethod.disabled=Disabled
 pkceCodeChallengeMethod.plain=Plain
 pkceCodeChallengeMethod.S256=S256

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
@@ -458,7 +458,8 @@
         <AD id="forwardLoginParameter" name="internal" description="internal use only" required="false" type="String" cardinality="2147483647" />
         <AD id="createSession" name="%createSession" description="%createSession.desc" required="false" type="Boolean" default="false" />
         <AD id="keyManagementKeyAlias" name="%keyManagementKeyAlias" description="%keyManagementKeyAlias.desc" required="false" type="String" />
-        <AD id="pkceCodeChallengeMethod" name="internal" description="internal use only" required="false" type="String" ibm:beta="true" >
+        <AD id="pkceCodeChallengeMethod" name="%pkceCodeChallengeMethod" description="%pkceCodeChallengeMethod.desc" required="false" type="String" default="disabled" ibm:beta="true" >
+            <Option label="%pkceCodeChallengeMethod.disabled" value="disabled" />
             <Option label="%pkceCodeChallengeMethod.plain" value="plain" />
             <Option label="%pkceCodeChallengeMethod.S256" value="S256" />
         </AD>


### PR DESCRIPTION
Adds a `disabled` option as the default value to the `pkceCodeChallengeMethod` element in the OIDC clients for `openidConnectClient-1.0` and `socialLogin-1.0`.

For #19029