### PR TITLE
update acme to use the com.ibm.ws.org.jose4j bundle

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2044,11 +2044,6 @@
     <dependency>
       <groupId>org.bitbucket.b_c</groupId>
       <artifactId>jose4j</artifactId>
-      <version>0.6.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bitbucket.b_c</groupId>
-      <artifactId>jose4j</artifactId>
       <version>0.9.3</version>
     </dependency>
     <dependency>

--- a/dev/cnf/oss_source_dependencies.maven
+++ b/dev/cnf/oss_source_dependencies.maven
@@ -88,7 +88,6 @@ org.apache.kafka:kafka-clients:2.3.0
 org.apache.mina:mina-core:2.1.3
 org.apache.myfaces.buildtools:myfaces-builder-annotations:1.0.9
 org.apache.neethi:neethi:3.0.2
-org.bitbucket.b_c:jose4j:0.6.5
 org.eclipse.platform:org.eclipse.equinox.console:1.4.300
 org.eclipse.platform:org.eclipse.equinox.coordinator:1.4.0
 org.eclipse.platform:org.eclipse.equinox.metatype:1.6.0

--- a/dev/com.ibm.ws.security.acme/bnd.bnd
+++ b/dev/com.ibm.ws.security.acme/bnd.bnd
@@ -34,6 +34,7 @@ IBM-Web-Extension-Processing-Disabled: false
 
 Import-Package: !*.internal.*, *
 
+
 Export-Package: \
     com.ibm.ws.security.acme;version="1.0.0"
  
@@ -51,7 +52,6 @@ Include-Resource: \
     @${repo;org.bouncycastle:bcprov-jdk15on;1.69;EXACT}!/!META-INF/versions/9/module-info.class,\
     @${repo;org.bouncycastle:bcpkix-jdk15on;1.69;EXACT}!/!META-INF/versions/9/module-info.class,\
     @${repo;org.bouncycastle:bcutil-jdk15on;1.69;EXACT}!/!META-INF/versions/9/module-info.class,\
-    @${repo;org.bitbucket.b_c:jose4j;0.9.3;EXACT},\
     org=${bin}/org
 
 instrument.classesExcludes: com/ibm/ws/security/acme/resources/*.class
@@ -96,7 +96,7 @@ instrument.classesExcludes: com/ibm/ws/security/acme/resources/*.class
 	org.bouncycastle:bcprov-jdk15on;version=1.69,\
 	org.bouncycastle:bcpkix-jdk15on;version=1.69,\
 	org.bouncycastle:bcutil-jdk15on;version=1.69,\
- 	org.bitbucket.b_c:jose4j;version=0.9.3,\
+ 	com.ibm.ws.org.jose4j;version=latest,\
 	com.ibm.ws.app.manager;version=latest,\
 	com.ibm.ws.ssl;version=latest,\
 	com.ibm.ws.crypto.certificateutil;version=latest,\

--- a/dev/com.ibm.ws.security.acme_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.acme_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -39,7 +39,7 @@ fat.test.container.images: mariadb:10.3, \
     org.shredzone.acme4j:acme4j-utils;version=2.7,\
     com.ibm.ws.logging;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\
-    org.bitbucket.b_c:jose4j;version=0.9.3,\
+    com.ibm.ws.org.jose4j;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
     com.ibm.websphere.appserver.spi.kernel.service;version=latest,\


### PR DESCRIPTION
1. Update acme to use the `com.ibm.ws.org.jose4j` bundle instead of `org.bitbucket.b_c:jose4j`. So that in the future any version updates to jose4j will be picked up automatically for the acme project.
2. Remove last references to the old version: `org.bitbucket.b_c:jose4j:0.6.5`

resolves #15138 