### PR TITLE
Use Artifactory as an additional mvn repository

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/settings.xml
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/settings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<settings
-    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd"
-    xmlns="http://maven.apache.org/SETTINGS/1.1.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <!-- Note: this settings.xml is only used when connecting to artifactory -->
     <localRepository>${env.MAVEN_USER_HOME}/repository</localRepository>
     <servers>
@@ -17,18 +14,27 @@
             <id>artifactory</id>
         </server>
     </servers>
+    <profiles>
+        <profile>
+            <id>artifactory</id>
+            <repositories>
+                <repository>
+                    <id>central-mirror</id>
+                    <name>wasliberty-maven-remote</name>
+                    <url>https://${env.ARTIFACTORY_SERVER}:443/artifactory/wasliberty-maven-remote</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>artifactory</activeProfile>
+    </activeProfiles>
     <mirrors>
-        <mirror>
-            <id>central-mirror</id>
-            <name>wasliberty-maven-remote</name>
-            <url>https://${env.ARTIFACTORY_SERVER}:443/artifactory/wasliberty-maven-remote</url>
-            <mirrorOf>central</mirrorOf>
-        </mirror>
         <mirror>
             <id>artifactory</id>
             <name>wasliberty-open-liberty</name>
             <url>https://${env.ARTIFACTORY_SERVER}:443/artifactory/wasliberty-open-liberty</url>
-            <mirrorOf>!central, *</mirrorOf> <!-- Should only be the DHE olrepo -->
+            <mirrorOf>!central, !central-mirror, *</mirrorOf> <!-- Should only be the DHE olrepo -->
         </mirror>
     </mirrors>
 </settings>

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/settings.xml
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/settings.xml
@@ -11,6 +11,11 @@
         <server>
             <username>${env.MVNW_USERNAME}</username>
             <password>${env.MVNW_PASSWORD}</password>
+            <id>plugin-central-mirror</id>
+        </server>
+        <server>
+            <username>${env.MVNW_USERNAME}</username>
+            <password>${env.MVNW_PASSWORD}</password>
             <id>artifactory</id>
         </server>
     </servers>
@@ -24,6 +29,13 @@
                     <url>https://${env.ARTIFACTORY_SERVER}:443/artifactory/wasliberty-maven-remote</url>
                 </repository>
             </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>plugin-central-mirror</id>
+                    <name>wasliberty-maven-remote</name>
+                    <url>https://${env.ARTIFACTORY_SERVER}:443/artifactory/wasliberty-maven-remote</url>
+                </pluginRepository>
+            </pluginRepositories>
         </profile>
     </profiles>
     <activeProfiles>
@@ -34,7 +46,7 @@
             <id>artifactory</id>
             <name>wasliberty-open-liberty</name>
             <url>https://${env.ARTIFACTORY_SERVER}:443/artifactory/wasliberty-open-liberty</url>
-            <mirrorOf>!central, !central-mirror, *</mirrorOf> <!-- Should only be the DHE olrepo -->
+            <mirrorOf>!central,!central-mirror,!plugin-central-mirror,external:*</mirrorOf> <!-- Should only be the DHE olrepo -->
         </mirror>
     </mirrors>
 </settings>


### PR DESCRIPTION
Rather than as a mirror.

To work around occasional (but still far too common) connection errors when fetching from Artifactory.

For RTC295981