### PR TITLE
featureUtility modify help messages for verify

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility/resources/com/ibm/ws/install/featureUtility/internal/resources/FeatureUtilityToolOptions.nlsprops
+++ b/dev/com.ibm.ws.install.featureUtility/resources/com/ibm/ws/install/featureUtility/internal/resources/FeatureUtilityToolOptions.nlsprops
@@ -73,15 +73,14 @@ installFeature.option-desc.--from=\
 \trepository as a source for featureUtility to install assets.
 #------------------------------\n at 72 chars -- leading tab-----------\n\#
 installFeature.option-key.--verify=\
-\ \ \ \ --verify=[enforce|warn|skip|all]
+\ \ \ \ --verify=[enforce|skip|all|warn]
 installFeature.option-desc.--verify=\
 \tUse this option to specify how features are verified. The      \n\
-\tdefault option is "enforce", which verifies the signatures of all Liberty     \n\
-\tfeatures except for user features. The "warn" option is the same as  \n\
-\t"enforce", but it does not terminate installation if  \n\
-\tverification fails. The "skip" option skips verification \n\
+\tdefault option is "enforce", which verifies the signatures of all Liberty \n\
+\tfeatures except for user features. The "skip" option skips verification \n\
 \tand does not download any feature signatures. The "all" option verifies \n\
-\tboth Liberty features and user features.                                  
+\tboth Liberty features and user features. The "warn" option is the same as \n\
+\t"all", but it does not terminate installation if verification fails.                                  
 #------------------------------\n at 72 chars -- leading tab-----------\n\#
 installFeature.option-key.--verbose=\
 \ \ \ \ --verbose
@@ -122,15 +121,14 @@ installServerFeatures.option-desc.--from=\
 \trepository as a source for featureUtility to install assets.
 #------------------------------\n at 72 chars -- leading tab-----------\n\#
 installServerFeatures.option-key.--verify=\
-\ \ \ \ --verify=[enforce|warn|skip|all]
+\ \ \ \ --verify=[enforce|skip|all|warn]
 installServerFeatures.option-desc.--verify=\
 \tUse this option to specify how features are verified. The      \n\
-\tdefault option is "enforce," which verifies the signatures of all Liberty    \n\
-\tfeatures except for user features. The "warn" option is the same as  \n\
-\t"enforce," but it does not terminate installation if verification fails.\n\
-\tThe "skip" option skips verification and does not download\n\
-\tany feature signatures. The "all" option verifies both Liberty       \n\
-\tfeatures and user features.                                  
+\tdefault option is "enforce," which verifies the signatures of all Liberty \n\
+\tfeatures except for user features. The "skip" option skips verification \n\ 
+\tand does not download any feature signatures. The "all" option verifies \n\
+\t both Liberty features and user features. The "warn" option is the same as \n\
+\t"all," but it does not terminate installation if verification fails.                                
 #------------------------------\n at 72 chars -- leading tab-----------\n\#
 installServerFeatures.option-key.--verbose=\
 \ \ \ \ --verbose

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -2326,8 +2326,9 @@ public class InstallKernelMap implements Map {
                         data.put(InstallConstants.ACTION_ERROR_MESSAGE, Messages.INSTALL_KERNEL_MESSAGES.getMessage("ERROR_FAILED_TO_VERIFY_FEATURE_SIGNATURE", failedFeatures));
                         return ERROR;
                     }
+                } else {
+                    logger.warning(Messages.INSTALL_KERNEL_MESSAGES.getMessage("ERROR_FAILED_TO_VERIFY_FEATURE_SIGNATURE", failedFeatures));
                 }
-                logger.warning(Messages.INSTALL_KERNEL_MESSAGES.getMessage("ERROR_FAILED_TO_VERIFY_FEATURE_SIGNATURE", failedFeatures));
                 actionType = ActionType.install;
                 return OK;
 

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/VerifySignatureUtility.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/VerifySignatureUtility.java
@@ -187,7 +187,7 @@ public class VerifySignatureUtility {
         return downloadedKeys;
     }
 
-    private Map<String, String> getPublicKeyURL(Collection<Map<String, String>> keys, VerifyOption verify) throws InstallException {
+    protected Map<String, String> getPublicKeyURL(Collection<Map<String, String>> keys, VerifyOption verify) throws InstallException {
         Map<String, String> pubKeyUrls = new HashMap();
         try {
             if (isKeyValid(LIBERTY_KEY, getLibertyKeyID())) {
@@ -201,6 +201,15 @@ public class VerifySignatureUtility {
         }
 
         //get users public keys
+        getUserPubKey(keys, pubKeyUrls);
+        return pubKeyUrls;
+    }
+
+    /**
+     * @param keys
+     * @param pubKeyUrls
+     */
+    protected void getUserPubKey(Collection<Map<String, String>> keys, Map<String, String> pubKeyUrls) {
         for (Map<String, String> keyMap : keys) {
             String keyURL = keyMap.get(InstallConstants.KEYURL_QUALIFIER);
             String keyID = keyMap.get(InstallConstants.KEYID_QUALIFIER);
@@ -218,7 +227,6 @@ public class VerifySignatureUtility {
                 }
             }
         }
-        return pubKeyUrls;
     }
 
     /**


### PR DESCRIPTION
https://github.com/OpenLiberty/open-liberty/issues/17220 verifies features downloaded from Maven Central
- modify help messages for verify. 
- small bug fix : don't show warning message for --verify=encode when user feature fails. 
- add unit tests for keyURL  #22734