### PR TITLE
Fix for Oracle provider enable for Jakarta Data #25296

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1721,9 +1721,12 @@ public class DataJPATestServlet extends FATServlet {
                                              .sorted()
                                              .collect(Collectors.toList()));
 
-        // Derby does not support comparisons of BLOB values
+        // Derby & Oracle  does not support comparisons of BLOB values
+        // Derby JDBC Jar Nake : derby.jar 
+        // Oracle JDBC Jar Name : ojdbc8_g.jar
+        // This value is passed as HTTP request Parameter(eg: http://{host}/DataJPATestApp?testMethod=testUnannotatedCollection&jdbcJarName=ojdbc8_g.jar)
         String jdbcJarName = request.getParameter("jdbcJarName").toLowerCase();
-        if (!jdbcJarName.startsWith("derby")) {
+        if (!(jdbcJarName.startsWith("derby") || jdbcJarName.startsWith("ojdbc8_g"))) {
             // find one entity by zipcodes as Optional
             c = counties.findByZipCodes(wabashaZipCodes).orElseThrow();
             assertEquals("Wabasha", c.name);


### PR DESCRIPTION
**Issues 2 in #25296** 
Package : test.jakarta.data.jpa.web;
Java File : DataJPATestServlet.java
Method : testUnannotatedCollection
Error : org.eclipse.persistence.exceptions.DatabaseException Internal Exception: **java.sql.SQLSyntaxErrorException: ORA-00932: inconsistent datatypes: expected - got BLOB Error Code: 932** Call: SELECT NAME, CITIES, POPULATION, ZIPCODES FROM WLPCounty WHERE (ZIPCODES = ?) bind => [1 parameter bound] Query: ReadAllQuery(referenceClass=County sql="SELECT NAME, CITIES, POPULATION, ZIPCODES FROM WLPCounty WHERE (**_ZIPCODES = ?_**)") at io.openliberty.data.internal.persistence.RepositoryImpl.failure(RepositoryImpl.java:543)