### PR TITLE
Add ant task for pom cleanup in WL build

### DIFF
--- a/dev/wlp-updatePom/bnd.bnd
+++ b/dev/wlp-updatePom/bnd.bnd
@@ -38,11 +38,14 @@ publish.wlp.jar.disabled: true
 Export-Package: \
   io.openliberty.build.update;version=1.0, \
   io.openliberty.build.update.pom;version=1.0, \
-  io.openliberty.build.update.util;version=1.0
+   io.openliberty.build.update.pom.task;version=1.0, \
+  io.openliberty.build.update.util;version=1.0, \
+  org.apache.maven.model*;version=3.6.3, \
+  org.codehaus.plexus.util*;version=5.1
 
 -buildpath: \
-	org.apache.maven:maven-model;version='3.6.3',\
-	org.codehaus.plexus:plexus-utils;version='3.2.1',\
+  org.apache.maven:maven-model;version=3.6.3, \
+  org.codehaus.plexus:plexus-utils;version=3.2.1,\
 	com.ibm.ws.org.apache.ant;version=latest
 
 -testpath: \

--- a/dev/wlp-updatePom/bnd.bnd
+++ b/dev/wlp-updatePom/bnd.bnd
@@ -41,8 +41,9 @@ Export-Package: \
   io.openliberty.build.update.util;version=1.0
 
 -buildpath: \
-  org.apache.maven:maven-model;version=3.6.3, \
-  org.codehaus.plexus:plexus-utils;version=3.2.1
+	org.apache.maven:maven-model;version='3.6.3',\
+	org.codehaus.plexus:plexus-utils;version='3.2.1',\
+	com.ibm.ws.org.apache.ant;version=latest
 
 -testpath: \
   ../build.sharedResources/lib/junit/old/junit.jar;version=file

--- a/dev/wlp-updatePom/src/io/openliberty/build/update/pom/task/UpdatePomFilesTask.java
+++ b/dev/wlp-updatePom/src/io/openliberty/build/update/pom/task/UpdatePomFilesTask.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.build.update.pom.task;
+
+import java.io.File;
+
+import org.apache.tools.ant.Task;
+
+import io.openliberty.build.update.pom.UpdatePomFiles;
+
+/**
+ *
+ */
+public class UpdatePomFilesTask extends Task {
+
+    /**
+     * @return the inputDir
+     */
+    public File getInputDir() {
+        return inputDir;
+    }
+
+    /**
+     * @param inputDir the inputDir to set
+     */
+    public void setInputDir(File inputDir) {
+        this.inputDir = inputDir;
+    }
+
+    /**
+     * @return the tmpDir
+     */
+    public File getTmpDir() {
+        return tmpDir;
+    }
+
+    /**
+     * @param tmpDir the tmpDir to set
+     */
+    public void setTmpDir(File tmpDir) {
+        this.tmpDir = tmpDir;
+    }
+
+    /**
+     * @return the failOnError
+     */
+    public boolean isFailOnError() {
+        return failOnError;
+    }
+
+    /**
+     * @param failOnError the failOnError to set
+     */
+    public void setFailOnError(boolean failOnError) {
+        this.failOnError = failOnError;
+    }
+
+    protected File inputDir;
+    protected File tmpDir;
+    protected boolean failOnError;
+
+    /**
+     * Execute the build task.
+     */
+    @Override
+    public void execute() {
+
+        String[] args = { inputDir.getPath(), tmpDir.getPath(), Boolean.toString(failOnError) };
+
+        UpdatePomFiles.main(args);
+    }
+
+}

--- a/dev/wlp-updatePom/src/io/openliberty/build/update/pom/task/UpdatePomJarsTask.java
+++ b/dev/wlp-updatePom/src/io/openliberty/build/update/pom/task/UpdatePomJarsTask.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.build.update.pom.task;
+
+import java.io.File;
+
+import org.apache.tools.ant.Task;
+
+import io.openliberty.build.update.pom.UpdatePomJars;
+
+/**
+ *
+ */
+public class UpdatePomJarsTask extends Task {
+
+    /**
+     * @return the inputDir
+     */
+    public File getInputDir() {
+        return inputDir;
+    }
+
+    /**
+     * @param inputDir the inputDir to set
+     */
+    public void setInputDir(File inputDir) {
+        this.inputDir = inputDir;
+    }
+
+    /**
+     * @return the tmpDir
+     */
+    public File getTmpDir() {
+        return tmpDir;
+    }
+
+    /**
+     * @param tmpDir the tmpDir to set
+     */
+    public void setTmpDir(File tmpDir) {
+        this.tmpDir = tmpDir;
+    }
+
+    /**
+     * @return the failOnError
+     */
+    public boolean isFailOnError() {
+        return failOnError;
+    }
+
+    /**
+     * @param failOnError the failOnError to set
+     */
+    public void setFailOnError(boolean failOnError) {
+        this.failOnError = failOnError;
+    }
+
+    protected File inputDir;
+    protected File tmpDir;
+    protected boolean failOnError;
+
+    /**
+     * Execute the build task.
+     */
+    @Override
+    public void execute() {
+
+        String[] args = { inputDir.getPath(), tmpDir.getPath(), Boolean.toString(failOnError) };
+
+        UpdatePomJars.main(args);
+    }
+
+}


### PR DESCRIPTION
Need to add ant tasks to call from the WL side build (Calling from ant much easier to call this way)

Ant tasks just wrap the main() calls .