### PR TITLE
PH54373 - upgrade com.graphql-java:graphql-java to version 19.5

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java</artifactId>
-      <version>19.2</version>
+      <version>19.5</version>
     </dependency>
     <dependency>
       <groupId>com.graphql-java</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -28,7 +28,7 @@ com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java-util:3.19.6
 com.google.protobuf:protobuf-java:3.19.6
 com.googlecode.json-simple:json-simple:1.1.1
-com.graphql-java:graphql-java:19.2
+com.graphql-java:graphql-java:19.5
 com.graphql-java:java-dataloader:3.2.0
 com.hazelcast:hazelcast-client:3.12.12
 com.hazelcast:hazelcast:3.12.12

--- a/dev/com.ibm.ws.com.graphql.java/bnd.bnd
+++ b/dev/com.ibm.ws.com.graphql.java/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -19,7 +19,7 @@ bVersion=1.0
 
 
 -includeresource: \
-  @${repo;com.graphql-java:graphql-java;19.2},\
+  @${repo;com.graphql-java:graphql-java;19.5},\
   @${repo;com.graphql-java:java-dataloader;3.2.0},\
   @${repo;org.antlr:antlr4-runtime;4.8}
 


### PR DESCRIPTION
IBM WebSphere Application Server Liberty is vulnerable to a denial of service due to GraphQL Java (CVE-2023-28867 CVSS 7.5)
