### PR TITLE
version conflict on save

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import java.sql.Timestamp;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +28,8 @@ import jakarta.data.repository.Repository;
 @Repository
 public interface Counties {
 
+    boolean deleteByNameAndLastUpdated(String name, Timestamp version);
+
     int deleteByNameIn(List<String> names);
 
     Optional<County> findByName(String name);
@@ -38,6 +41,8 @@ public interface Counties {
 
     @OrderBy("name")
     List<Set<CityId>> findCitiesByNameStartsWith(String beginning);
+
+    Timestamp findLastUpdatedByName(String name);
 
     int[] findZipCodesById(String name);
 
@@ -54,7 +59,9 @@ public interface Counties {
     Page<int[]> findZipCodesByNameStartsWith(String beginning, Pageable pagination);
 
     @OrderBy("population")
-    Optional<Iterator<int[]>> findZipCodesByPopulationLessThanEqual(int maxPopuluation);
+    Optional<Iterator<int[]>> findZipCodesByPopulationLessThanEqual(int maxPopulation);
+
+    boolean remove(County c);
 
     void save(County... c);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/County.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/County.java
@@ -10,11 +10,13 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import java.sql.Timestamp;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 
 /**
  * An entity with a collection attribute that is not annotated as ElementCollection.
@@ -22,6 +24,9 @@ import jakarta.persistence.Id;
 @Entity
 public class County {
     public Set<CityId> cities;
+
+    @Version
+    public Timestamp lastUpdated;
 
     @Id
     public String name;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import java.util.List;
+
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
@@ -27,4 +29,6 @@ public interface Orders extends CrudRepository<Order, Long> {
     boolean addTaxAndShipping(@Param("id") long orderId,
                               @Param("rate") float taxRate,
                               @Param("shipping") float shippingCost);
+
+    List<Float> findTotalByPurchasedByIn(Iterable<String> purchasers);
 }


### PR DESCRIPTION
Add test coverage for version conflicts that occur during save.
Also, add coverage for a version that is a Timestamp rather than a numeric type.