### PR TITLE
Redeliver fixes for repository resolver problems

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -891,5 +891,31 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    Log.exiting(c, METHOD_NAME);
 	}
 
+	/*
+	 * Test the updated resolve() api which returns all tolerated dependencies of
+	 * all features to be installed. Test with "RestfulWS-3.0".
+	 */
+	@Test
+	public void testComplexVersionTolerates() throws Exception {
+	    final String METHOD_NAME = "testComplexVersionTolerates";
+	    Log.entering(c, METHOD_NAME);
+
+	    // Begin Test
+	    String[] param1s = { "installFeature", "RestfulWS-3.0" };
+	    String[] filesList = { "/lib/features/com.ibm.websphere.appserver.eeCompatible-6.0.mf",
+		    "/lib/features/com.ibm.websphere.appserver.eeCompatible-7.0.mf",
+		    "/lib/features/com.ibm.websphere.appserver.eeCompatible-8.0.mf",
+		    "/lib/features/com.ibm.websphere.appserver.eeCompatible-9.0.mf",
+		    "/lib/features/io.openliberty.servlet.api-3.0.mf",
+		    "/lib/features/io.openliberty.servlet.api-3.1.mf",
+		    "/lib/features/io.openliberty.servlet.api-4.0.mf",
+		    "/lib/features/io.openliberty.servlet.api-5.0.mf" };
+
+	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
+
+	    checkCommandOutput(po, 0, null, filesList);
+
+	    Log.exiting(c, METHOD_NAME);
+	}
 
 }

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -282,6 +282,34 @@ public class InstallServerTest extends FeatureUtilityToolTest {
 	    checkCommandOutput(po, 0, null, filesList);
 
 	    Log.exiting(c, METHOD_NAME);
+	}
+
+	/*
+	 * Test resolveAsSet(EE8, adminCenter-1.0), then resolve(EE9). There should be
+	 * extra private features for adminCenter-1.0 which we need to install if we
+	 * want adminCenter to work with EE9.
+	 */
+	@Test
+	public void testResolveAsSetThenResolve() throws Exception {
+	    final String METHOD_NAME = "testResolveAsSetThenResolve";
+	    Log.entering(c, METHOD_NAME);
+
+	    copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/adminCenterServerXml/server.xml");
+
+	    String[] param1s = { "installServerFeatures", "serverX" };
+	    String[] filesList = { "/lib/features/io.openliberty.adminCenter1.0.internal.ee-9.0.mf" };
+
+	    // Run isf first
+	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
+	    checkCommandOutput(po, 0, null, null);
+
+	    // Install jakartaee-9.1 and check if private feature is installed.
+	    String[] param2s = { "installFeature", "jakartaee-9.1" };
+	    po = runFeatureUtility(METHOD_NAME, param2s);
+	    checkCommandOutput(po, 0, null, filesList);
+
+	    Log.exiting(c, METHOD_NAME);
+
 	}
 
 }

--- a/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/adminCenterServerXml/server.xml
+++ b/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/adminCenterServerXml/server.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>jakartaee-8.0</feature>
+        <feature>adminCenter-1.0</feature>
+    </featureManager>
+
+    <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
+    <httpEndpoint id="defaultHttpEndpoint"
+                  httpPort="9080"
+                  httpsPort="9443" />
+
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true"/>
+
+    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
+    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+</server>

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -955,7 +955,6 @@ public class InstallKernelMap implements Map {
             } else {
                 resolveResult = resolver.resolveAsSet((Collection<String>) data.get(InstallConstants.FEATURES_TO_RESOLVE));
             }
-            ResolveDirector.resolveAutoFeatures(resolveResult, new RepositoryResolver(productDefinitions, installedFeatures, Collections.<IFixInfo> emptySet(), repoList));
 
             if (!resolveResult.isEmpty()) {
                 for (List<RepositoryResource> item : resolveResult) {

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ResolveDirector.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ResolveDirector.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -673,6 +673,9 @@ class ResolveDirector extends AbstractDirector {
         return installResourcesCollection;
     }
 
+    /*
+     * No need to call anymore. OLGH21992 - Calling resolve() or resolveAsSet() api should return required autoFeatures.
+     */
     static void resolveAutoFeatures(Collection<List<RepositoryResource>> installResources,
                                     RepositoryResolver resolver) throws RepositoryResolutionException {
         if (installResources.isEmpty()) {

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/FeatureTreeWalker.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/FeatureTreeWalker.java
@@ -1,0 +1,221 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.repository.resolver;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.ibm.ws.kernel.feature.provisioning.FeatureResource;
+import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
+import com.ibm.ws.kernel.feature.provisioning.SubsystemContentType;
+import com.ibm.ws.repository.resolver.internal.kernel.CapabilityMatching;
+import com.ibm.ws.repository.resolver.internal.kernel.KernelResolverRepository;
+
+/**
+ * Performs a walk over a tree of features by following their dependencies
+ * <p>
+ * Features are retrieved from a source (either a {@link KernelResolverRepository} or a map of resolved features)
+ * <p>
+ * If a dependency tolerates multiple versions of a feature, all tolerated versions available in the source are walked.
+ */
+public class FeatureTreeWalker {
+
+    private Consumer<? super ProvisioningFeatureDefinition> forEach;
+    private BiConsumer<? super ProvisioningFeatureDefinition, ? super FeatureResource> onMissingDependency;
+    private boolean useAutofeatureProvisionAsDependency = true;
+    private final Supplier<Collection<? extends ProvisioningFeatureDefinition>> allFeaturesSupplier;
+    private final Function<String, ProvisioningFeatureDefinition> getFeatureByNameFunction;
+
+    /**
+     * Create a FeatureTreeWalker for walking feature dependencies for features in the repository
+     *
+     * @param repository the repository
+     */
+    public static FeatureTreeWalker walkOver(KernelResolverRepository repositry) {
+        return new FeatureTreeWalker(repositry::getAllFeatures,
+                                     repositry::getFeature);
+    }
+
+    /**
+     * Create a FeatureTreeWalker for walking feature dependencies for features from a Map of features
+     * <p>
+     * The map must map from feature symbolic name to the feature
+     *
+     * @param resolvedFeatureMap the map of features
+     */
+    public static FeatureTreeWalker walkOver(Map<String, ProvisioningFeatureDefinition> resolvedFeatureMap) {
+        return new FeatureTreeWalker(resolvedFeatureMap::values,
+                                     resolvedFeatureMap::get);
+    }
+
+    private FeatureTreeWalker(Supplier<Collection<? extends ProvisioningFeatureDefinition>> allFeaturesSupplier,
+                              Function<String, ProvisioningFeatureDefinition> getFeatureByNameFunction) {
+        this.allFeaturesSupplier = allFeaturesSupplier;
+        this.getFeatureByNameFunction = getFeatureByNameFunction;
+    }
+
+    /**
+     * Perform a breadth first walk
+     *
+     * @param roots the starting points of the walk
+     */
+    public void walkBreadthFirst(Collection<ProvisioningFeatureDefinition> roots) {
+        Walker.walkCollectionBreadthFirst(roots, this::processForEach, this::getChildren);
+    }
+
+    /**
+     * Perform a breadth first walk
+     *
+     * @param root the starting point of the walk
+     */
+    public void walkBreadthFirst(ProvisioningFeatureDefinition root) {
+        Walker.walkBreadthFirst(root, this::processForEach, this::getChildren);
+    }
+
+    /**
+     * Perform a depth first walk
+     * <p>
+     * Features are visited before their children
+     *
+     * @param root the start point of the walk
+     */
+    public void walkDepthFirst(ProvisioningFeatureDefinition root) {
+        Walker.walkDepthFirst(root, this::processForEach, this::getChildren);
+    }
+
+    /**
+     * Supply a function to be called when visiting a feature
+     *
+     * @param forEach the function to call
+     * @return {@code this} to allow chaining
+     */
+    public FeatureTreeWalker forEach(Consumer<? super ProvisioningFeatureDefinition> forEach) {
+        this.forEach = forEach;
+        return this;
+    }
+
+    /**
+     * Supply a function to be called when an unsatisfied dependency is found
+     * <p>
+     * For a tolerated dependency, this method is only called if none of the tolerated versions can be found
+     * <p>
+     * The function is passed two arguments: the feature with the unsatisfied dependency and the unsatisfied dependency itself
+     *
+     * @param onMissingDependency the function to call
+     * @return {@code this} to allow chaining
+     */
+    public FeatureTreeWalker onMissingDependency(BiConsumer<? super ProvisioningFeatureDefinition, ? super FeatureResource> onMissingDependency) {
+        this.onMissingDependency = onMissingDependency;
+        return this;
+    }
+
+    /**
+     * Whether or not to treat features which satisfy one of the capabilities of an autofeature as children of that autofeature when walking the tree
+     * <p>
+     * Regular dependencies of an autofeature are always walked.
+     * <p>
+     * The default is {@code true}.
+     *
+     * @param useAutofeatureProvisionAsDependency whether to walk features which enable an autofeature
+     * @return {@code this} for chaining
+     */
+    public FeatureTreeWalker useAutofeatureProvisionAsDependency(boolean useAutofeatureProvisionAsDependency) {
+        this.useAutofeatureProvisionAsDependency = useAutofeatureProvisionAsDependency;
+        return this;
+    }
+
+    /**
+     * This method is called by the walker to get the children of a given feature
+     * <p>
+     * We look up and return the features dependencies as it's children
+     *
+     * @param feature the feature
+     * @return the feature's children
+     */
+    private List<ProvisioningFeatureDefinition> getChildren(ProvisioningFeatureDefinition feature) {
+        List<ProvisioningFeatureDefinition> result = new ArrayList<>();
+        for (FeatureResource dependency : feature.getConstituents(SubsystemContentType.FEATURE_TYPE)) {
+            List<ProvisioningFeatureDefinition> children = findDependencies(dependency);
+
+            if (children.isEmpty()) {
+                processMissingDependency(feature, dependency);
+            }
+
+            result.addAll(children);
+        }
+
+        if (useAutofeatureProvisionAsDependency) {
+            result.addAll(CapabilityMatching.findFeaturesSatisfyingCapability(feature, allFeaturesSupplier.get()));
+        }
+
+        return result;
+    }
+
+    private List<ProvisioningFeatureDefinition> findDependencies(FeatureResource featureResource) {
+        List<ProvisioningFeatureDefinition> result = new ArrayList<>();
+        ProvisioningFeatureDefinition feature = getFeatureByNameFunction.apply(featureResource.getSymbolicName());
+        if (feature != null) {
+            result.add(feature);
+        }
+
+        String baseName = getFeatureBaseName(featureResource.getSymbolicName());
+        List<String> tolerates = featureResource.getTolerates();
+        if (tolerates != null) {
+            for (String toleratedVersion : tolerates) {
+                String featureName = baseName + toleratedVersion;
+
+                feature = getFeatureByNameFunction.apply(featureName);
+                if (feature != null) {
+                    result.add(feature);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private void processMissingDependency(ProvisioningFeatureDefinition feature, FeatureResource dependency) {
+        if (onMissingDependency != null) {
+            onMissingDependency.accept(feature, dependency);
+        }
+    }
+
+    private void processForEach(ProvisioningFeatureDefinition feature) {
+        if (forEach != null) {
+            forEach.accept(feature);
+        }
+    }
+
+    /**
+     * Removes the version from the end of a feature symbolic name
+     * <p>
+     * The version is presumed to start after the last dash character in the name.
+     * <p>
+     * E.g. {@code getFeatureBaseName("com.example.featureA-1.0")} returns {@code "com.example.featureA-"}
+     *
+     * @param nameAndVersion the feature symbolic name
+     * @return the feature symbolic name with any version stripped
+     */
+    private String getFeatureBaseName(String nameAndVersion) {
+        int dashPosition = nameAndVersion.lastIndexOf('-');
+        if (dashPosition != -1) {
+            return nameAndVersion.substring(0, dashPosition + 1);
+        } else {
+            return nameAndVersion;
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,23 +15,22 @@ package com.ibm.ws.repository.resolver;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.ibm.ws.kernel.feature.internal.FeatureResolverImpl;
-import com.ibm.ws.kernel.feature.provisioning.FeatureResource;
 import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
-import com.ibm.ws.kernel.feature.provisioning.SubsystemContentType;
 import com.ibm.ws.kernel.feature.resolver.FeatureResolver;
 import com.ibm.ws.kernel.feature.resolver.FeatureResolver.Chain;
 import com.ibm.ws.kernel.feature.resolver.FeatureResolver.Result;
 import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.product.utility.extension.IFixUtils;
 import com.ibm.ws.product.utility.extension.ifix.xml.IFixInfo;
+import com.ibm.ws.repository.common.enums.InstallPolicy;
 import com.ibm.ws.repository.common.enums.ResourceType;
 import com.ibm.ws.repository.connections.ProductDefinition;
 import com.ibm.ws.repository.connections.RepositoryConnectionList;
@@ -88,6 +87,11 @@ public class RepositoryResolver {
      * Keyset is mutually exclusive with {@link #featuresMissing} and {@link #requirementsFoundForOtherProducts}
      */
     Map<String, ProvisioningFeatureDefinition> resolvedFeatures;
+
+    /**
+     * The list of extra features for which we need to generate install lists
+     */
+    List<ProvisioningFeatureDefinition> additionalInstallListRoots;
 
     /**
      * List of requested features that were reported missing by the kernel resolver and weren't found in the repository applicable to another product.
@@ -152,8 +156,8 @@ public class RepositoryResolver {
      *
      * @param installDefinition Information about the product(s) installed such as ID and edition. Must not be <code>null</code>.
      * @param installedFeatures The features that are installed. Must not be <code>null</code>.
-     * @param installedIFixes No longer used, parameter retained for backwards compatibility
-     * @param repoConnections The connection to the repository
+     * @param installedIFixes   No longer used, parameter retained for backwards compatibility
+     * @param repoConnections   The connection to the repository
      * @throws RepositoryException If there is a connection error with the Massive repository
      * @see ProductInfo#getAllProductInfo()
      * @see IFixUtils#getInstalledIFixes(java.io.File, com.ibm.ws.product.utility.CommandConsole)
@@ -177,8 +181,8 @@ public class RepositoryResolver {
      * Allows resolution to be tested without connecting to a repository
      *
      * @param installedFeatures the features which are installed
-     * @param repoFeatures the features available in the repository
-     * @param repoSamples the samples available in the repository
+     * @param repoFeatures      the features available in the repository
+     * @param repoSamples       the samples available in the repository
      */
     RepositoryResolver(Collection<ProvisioningFeatureDefinition> installedFeatures,
                        Collection<? extends EsaResource> repoFeatures,
@@ -226,8 +230,8 @@ public class RepositoryResolver {
         }
     }
 
-    void initializeResolverRepository(Collection<ProductDefinition> installDefintion, ResolutionMode mode) {
-        resolverRepository = new KernelResolverRepository(installDefintion, repoConnections, mode);
+    void initializeResolverRepository(Collection<ProductDefinition> installDefintion) {
+        resolverRepository = new KernelResolverRepository(installDefintion, repoConnections);
         resolverRepository.addInstalledFeatures(installedFeatures);
         resolverRepository.addFeatures(repoFeatures);
     }
@@ -255,31 +259,39 @@ public class RepositoryResolver {
     }
 
     /**
-     * <p>Will resolve a collection of resources from Massive. This method will find the resources specified by the <code>toResolve</code> parameter and any dependencies that they
-     * require and return a list of the resources in massive that need to be installed. If any of the dependencies are already installed they will not be returned in the list.</p>
-     * <p>Note that this will use the information about what is installed and in the Massive repository as was the case when this object was created so care should be taken that
-     * this is still up to date (i.e. no features or fixes have been installed since this object was created).</p>
-     * <p>This will also return a list of resources for any auto features that have their required provision capabilities satisfied either by what is already installed, the new
-     * features being installed or a combination of the two. Note that this means auto features that are in no way related to what you have asked to resolve could be returned by
-     * this method if they are satisfied by the current installation.</p>
-     * <p>This method may return conflicting versions of singleton features (it's valid to have conflicting versions installed but they can't be started together). If you don't
-     * want that, you may want to use {@link #resolveAsSet(Collection)} instead.</p>
+     * Takes a list of feature and sample names that the user wants to install and returns the {@link RepositoryResource}s that should be installed.
+     * <p>
+     * This method attempts to install everything that could be needed once the requested features are installed. This means:
+     * <ul>
+     * <li>If a requested feature has a dependency which tolerates multiple versions of another feature, <b>all</b> tolerated versions of that other feature which are not installed
+     * will be returned
+     * <li>If an installed feature has a dependency which tolerates multiple versions of another feature, <b>all</b> tolerated versions of that other feature which are not
+     * installed will be returned
+     * <li>All autofeatures which can have their capabilities met by the combination of features already installed and those to be installed will be returned
+     * </ul>
+     * <p>
+     * Note that the last two points mean that this method can return features which are in no-way related to the names in {@code toResolve}.
+     * <p>
+     * Note that this method will return as many features as necessary to ensure that after installing the resources returned from this method, any of the features installed which
+     * are compatible will work if listed together in the server.xml and any relevant auto-features will be present. This will likely be more features than are required for
+     * specific scenarios.
+     * <p>
+     * If you want to install just the <i>minimal</i> set of features required to start a server with a given set of features, you should use {@link #resolveAsSet(Collection)}
+     * instead.
      *
      * @param toResolve A collection of the identifiers of the resources to resolve. It should be in the form:</br>
-     *            <code>{name}/{version}</code></br>
-     *            <p>Where the <code>{name}</code> can be either the symbolic name, short name or lower case short name of the resource and <code>/{version}</code> is
-     *            optional. The
-     *            collection may contain a mixture of symbolic names and short names. Must not be <code>null</code> or empty.</p>
+     *                      <code>{name}/{version}</code></br>
+     *                      <p>Where the <code>{name}</code> can be either the symbolic name, short name or lower case short name of the resource and <code>/{version}</code> is
+     *                      optional. The collection may contain a mixture of symbolic names and short names. Must not be <code>null</code> or empty.</p>
      * @return <p>A collection of ordered lists of {@link RepositoryResource}s to install. Each list represents a collection of resources that must be installed together or not
-     *         at
-     *         all. They should be installed in the iteration order of the list(s). Note that if a resource is required by multiple different resources then it will appear in
+     *         at all. They should be installed in the iteration order of the list(s). Note that if a resource is required by multiple different resources then it will appear in
      *         multiple lists. For instance if you have requested to install A and B and A requires N which requires M and O whereas B requires Z that requires O then the returned
      *         collection will be (represented in JSON):</p>
      *         <code>
      *         [[M, O, N, A],[O, Z, B]]
      *         </code>
-     *         <p>This will not return <code>null</code> although it may return an empty collection if there isn't anything to install (i.e. it resolves to resources that are
-     *         already installed)</p>
+     *         <p>This method will not return <code>null</code> although it may return an empty collection if there isn't anything to install (i.e. it resolves to resources that
+     *         are already installed)</p>
      *         <p>Every auto-feature will have it's own list in the collection, this is to stop the failure to install either an auto feature or one of it's dependencies from
      *         stopping everything from installing. Therefore if you have features A and B that are required to provision auto feature C and you ask to resolve A and B then this
      *         method will return:</p>
@@ -309,28 +321,32 @@ public class RepositoryResolver {
     }
 
     /**
-     * As {@link #resolve(Collection)} except this method assumes that all the resources should start together on one server.
+     * Takes a list of feature names that the user wants to install and returns a minimal set of the {@link RepositoryResource}s that should be installed to allow those features to
+     * start together in one server.
      * <p>
-     * The resolution result will not include more than one version of a singleton feature.
+     * This method uses the same resolution logic that is used by the kernel at server startup to decide which features to start. Therefore calling this method with a list of
+     * feature names and installing the resources returned will guarantee that a server which has the same list of feature names in its server.xml will start.
      * <p>
-     * This method of resolution can be used when you want to install all the features necessary to start a server.
+     * The caller must provide the full set of features from the server.xml, including those that are already installed, so that tolerated dependencies and auto-features can be
+     * resolved correctly.
      * <p>
-     * Note that to use this method, you must provide the full set of features from the server.xml, including those that are already installed. Failure to do this may result in
-     * an incorrect set of features being installed.
-     * <p>
-     * Also note that this method will fail if there's no valid set of dependencies for the required features that doesn't include conflicting versions of singleton features.
+     * This method will fail if there's no valid set of dependencies for the required features that doesn't include conflicting versions of singleton features.
      * <p>
      * For example, {@code resolve(Arrays.asList("javaee-7.0", "javaee-8.0"))} would work but {@code resolveAsSet(Arrays.asList("javaee-7.0", "javaee-8.0"))} would fail because
      * javaee-7.0 and javaee-8.0 contain features which conflict with each other (and other versions are not tolerated).
+     * <p>
+     * This method guarantees that it will return all the features required to start the requested features but will not ensure that the requested features will work with features
+     * which were already installed but were not requested in the call to this method.
+     * <p>
+     * For example, if {@code ejbLite-3.2} is already installed and {@code resolve(Arrays.asList("cdi-2.0"))} is called, it will not return the autofeature which would be required
+     * for {@code cdi-2.0} and {@code ejbLite-3.2} to work together.
      *
      * @param toResolve A collection of the identifiers of the resources to resolve. It should be in the form:</br>
-     *            <code>{name}/{version}</code></br>
-     *            <p>Where the <code>{name}</code> can be either the symbolic name, short name or lower case short name of the resource and <code>/{version}</code> is
-     *            optional. The
-     *            collection may contain a mixture of symbolic names and short names. Must not be <code>null</code> or empty.</p>
+     *                      <code>{name}/{version}</code></br>
+     *                      <p>Where the <code>{name}</code> can be either the symbolic name, short name or lower case short name of the resource and <code>/{version}</code> is
+     *                      optional. The collection may contain a mixture of symbolic names and short names. Must not be <code>null</code> or empty.</p>
      * @return <p>A collection of ordered lists of {@link RepositoryResource}s to install. Each list represents a collection of resources that must be installed together or not
-     *         at
-     *         all. They should be installed in the iteration order of the list(s). Note that if a resource is required by multiple different resources then it will appear in
+     *         at all. They should be installed in the iteration order of the list(s). Note that if a resource is required by multiple different resources then it will appear in
      *         multiple lists. For instance if you have requested to install A and B and A requires N which requires M and O whereas B requires Z that requires O then the returned
      *         collection will be (represented in JSON):</p>
      *         <code>
@@ -353,15 +369,27 @@ public class RepositoryResolver {
 
     Collection<List<RepositoryResource>> resolve(Collection<String> toResolve, ResolutionMode resolutionMode) throws RepositoryResolutionException {
         initResolve();
-        initializeResolverRepository(installDefinition, resolutionMode);
+        initializeResolverRepository(installDefinition);
 
         processNames(toResolve);
         findAutofeatureDependencies();
-        if (resolutionMode == ResolutionMode.IGNORE_CONFLICTS) {
-            requireInstalledFeaturesWhenResolving();
+
+        if (resolutionMode == ResolutionMode.DETECT_CONFLICTS) {
+            // Call the kernel resolver to determine the features needed
+            resolveFeaturesAsSet();
+        } else {
+            // Resolve all dependencies of installed features
+            resolveFeaturesBasic();
         }
 
-        resolveFeatures(resolutionMode);
+        // Basic resolve auto-features satisfied by installed + resolved features
+        resolveAutoFeatures();
+
+        // Find any any features which aren't direct dependencies of a requested feature
+        // Can happen if resolveAsSet is used to install some features
+        // and then resolve is used to install more features in the same server
+        computeAdditionalInstallListRoots();
+
         Collection<List<RepositoryResource>> installLists = createInstallLists();
 
         reportErrors();
@@ -460,12 +488,15 @@ public class RepositoryResolver {
     /**
      * Uses the kernel resolver to resolve {@link #featureNamesToResolve} and populates {@link #resolvedFeatures} with the result.
      *
-     * @param mode the resolution mode
+     * Populates:
+     * - {@link #resolvedFeatures}
+     * - {@link #featuresMissing}
+     * - {@link #requirementsFoundForOtherProducts}
+     * - {@link #resourcesWrongProduct}
      */
-    void resolveFeatures(ResolutionMode mode) {
-        boolean allowMultipleVersions = mode == ResolutionMode.IGNORE_CONFLICTS ? true : false;
+    void resolveFeaturesAsSet() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        Result result = resolver.resolveFeatures(resolverRepository, kernelFeatures, featureNamesToResolve, Collections.<String> emptySet(), allowMultipleVersions);
+        Result result = resolver.resolveFeatures(resolverRepository, kernelFeatures, featureNamesToResolve, Collections.<String> emptySet(), false);
 
         featureConflicts.putAll(result.getConflicts());
 
@@ -475,30 +506,154 @@ public class RepositoryResolver {
         }
 
         for (String missingFeature : result.getMissing()) {
-            Collection<ApplicableToProduct> featureOtherProducts = resolverRepository.getNonApplicableResourcesForName(missingFeature);
-            if (featureOtherProducts.isEmpty()) {
-                featuresMissing.add(missingFeature);
-            } else {
-                requirementsFoundForOtherProducts.add(missingFeature);
-                for (ApplicableToProduct feature : featureOtherProducts) {
-                    resourcesWrongProduct.add(feature);
+            recordMissingFeature(missingFeature);
+        }
+    }
+
+    /**
+     * Resolves {@link #featureNamesToResolve} using a simple traversal of the dependency tree
+     *
+     * Populates:
+     * - {@link #resolvedFeatures}
+     * - {@link #featuresMissing}
+     * - {@link #requirementsFoundForOtherProducts}
+     * - {@link #resourcesWrongProduct}
+     */
+    void resolveFeaturesBasic() {
+        // For each feature to resolve
+        //   Look up the PFD
+        //   walk the dependency tree, adding each PFD to the resolvedFeatures set
+        //   If all features from a tolerated dependency are missing, log as missing
+        for (String name : featureNamesToResolve) {
+            ProvisioningFeatureDefinition feature = resolverRepository.getFeature(name);
+            if (feature == null) {
+                recordMissingFeature(name);
+                continue;
+            }
+            FeatureTreeWalker.walkOver(resolverRepository)
+                             .forEach(f -> resolvedFeatures.put(f.getSymbolicName(), f))
+                             .onMissingDependency((f, dep) -> recordMissingFeature(dep.getSymbolicName()))
+                             .walkDepthFirst(feature);
+        }
+
+        // Walk dependencies of all installed features as well to ensure we install all their tolerated dependencies
+        for (ProvisioningFeatureDefinition feature : installedFeatures) {
+            FeatureTreeWalker.walkOver(resolverRepository)
+                             .forEach(f -> resolvedFeatures.put(f.getSymbolicName(), f))
+                             .onMissingDependency((f, dep) -> recordMissingFeature(dep.getSymbolicName()))
+                             .useAutofeatureProvisionAsDependency(false)
+                             .walkDepthFirst(feature);
+        }
+    }
+
+    /**
+     * Finds any autofeatures which are satisfied by the installed and resolved features and adds them to the resolvedFeatures set
+     * <p>
+     * This is necessary for both basic resolve and resolveAsSet:
+     * <ul>
+     * <li>basic resolve won't have found any autofeatures yet
+     * <li>resolveAsSet will have found autofeatures needed for the resolution set, but won't have added any additional which could be enabled by already installed features.
+     */
+    void resolveAutoFeatures() {
+
+        HashSet<ProvisioningFeatureDefinition> resolvedAndInstalled = new HashSet<>();
+        resolvedAndInstalled.addAll(installedFeatures);
+        resolvedAndInstalled.addAll(resolvedFeatures.values());
+
+        FeatureTreeWalker autofeatureWalker = FeatureTreeWalker.walkOver(resolverRepository)
+                                                               .forEach(f -> {
+                                                                   resolvedFeatures.put(f.getSymbolicName(), f);
+                                                                   resolvedAndInstalled.add(f);
+                                                               })
+                                                               .onMissingDependency((f, dep) -> recordMissingFeature(dep.getSymbolicName()))
+                                                               .useAutofeatureProvisionAsDependency(false);
+
+        // Autofeatures can satisfy other autofeatures, so we loop,
+        // looking for more satisfied autofeatures until we stop finding any
+        int oldSize = 0;
+        while (resolvedAndInstalled.size() > oldSize) {
+            oldSize = resolvedAndInstalled.size();
+            for (ProvisioningFeatureDefinition feature : resolverRepository.getAutoFeatures()) {
+                EsaResource esa = getResource(feature);
+                if (esa == null) {
+                    continue; // Ignore already installed features
+                }
+
+                if (resolvedAndInstalled.contains(feature)) {
+                    continue; // Ignore features we've already resolved
+                }
+
+                if (esa.getInstallPolicy() != InstallPolicy.WHEN_SATISFIED) {
+                    continue; // Ignore autofeatures which need manual installation
+                }
+
+                if (feature.isCapabilitySatisfied(resolvedAndInstalled)) {
+                    // Found a satisfied autofeature, add it and all its dependencies
+                    // (only its real dependencies, not features which satisfy its provision capability requirement)
+                    autofeatureWalker.walkDepthFirst(feature);
                 }
             }
         }
     }
 
     /**
-     * Require that all installed features are included in the resolution result
+     * Situations can arise where a resolved feature is not a dependency of a requested feature or an autofeature.
      * <p>
-     * This allows autofeatures which depend on an already installed feature to be resolved.
+     * This can happen when doing a basic resolve and an already installed feature has a tolerated dependency which is not installed and not required by the requested feature. This
+     * tolerated dependency still needs to be installed.
      * <p>
-     * This method can't be used when detecting conflicts between singleton features, as we might already have conflicting features installed (which is fine, as long as they're not
-     * started together in a running server).
+     * This method finds such features and works out a minimal set to use as roots for install lists to ensure that every resolved feature gets installed
      */
-    void requireInstalledFeaturesWhenResolving() {
-        // We need to include installed features in the resolution to allow all autofeatures to resolve
-        for (ProvisioningFeatureDefinition installedFeature : installedFeatures) {
-            featureNamesToResolve.add(installedFeature.getSymbolicName());
+    private void computeAdditionalInstallListRoots() {
+        HashSet<ProvisioningFeatureDefinition> additionalRootCandidates = new HashSet<>(resolvedFeatures.values());
+        FeatureTreeWalker removeCandidateWalker = FeatureTreeWalker.walkOver(resolvedFeatures)
+                                                                   .forEach(additionalRootCandidates::remove);
+
+        // Remove already installed features
+        additionalRootCandidates.removeAll(installedFeatures);
+
+        // Remove dependencies of requested features and samples
+        for (String name : featureNamesToResolve) {
+            ProvisioningFeatureDefinition feature = resolverRepository.getFeature(name);
+            if (feature == null) {
+                continue;
+            }
+            removeCandidateWalker.walkDepthFirst(feature);
+        }
+
+        // Remove dependencies of autofeatures
+        for (ProvisioningFeatureDefinition feature : resolvedFeatures.values()) {
+            if (feature.isAutoFeature()) {
+                removeCandidateWalker.walkDepthFirst(feature);
+            }
+        }
+
+        // For each remaining candidate, remove all of its dependencies, but not itself
+        // Candidates will still be removed if they are dependencies of another candidate
+        // Note: Copy additionalRootCandidates to avoid ConcurrentModificationException
+        for (ProvisioningFeatureDefinition feature : new ArrayList<>(additionalRootCandidates)) {
+            // Ignore this feature if it's already been removed as a dependency of another feature
+            // This avoids having two candidates remove each other if the graph contains a loop
+            if (additionalRootCandidates.contains(feature)) {
+                // Remove ourself and our dependencies
+                removeCandidateWalker.walkDepthFirst(feature);
+                // Add ourself back in
+                additionalRootCandidates.add(feature);
+            }
+        }
+
+        additionalInstallListRoots = new ArrayList<>(additionalRootCandidates);
+    }
+
+    private void recordMissingFeature(String missingFeature) {
+        Collection<ApplicableToProduct> featureOtherProducts = resolverRepository.getNonApplicableResourcesForName(missingFeature);
+        if (featureOtherProducts.isEmpty()) {
+            featuresMissing.add(missingFeature);
+        } else {
+            requirementsFoundForOtherProducts.add(missingFeature);
+            for (ApplicableToProduct feature : featureOtherProducts) {
+                resourcesWrongProduct.add(feature);
+            }
         }
     }
 
@@ -531,6 +686,10 @@ public class RepositoryResolver {
             }
         }
 
+        for (ProvisioningFeatureDefinition feature : additionalInstallListRoots) {
+            installLists.add(createInstallList(feature.getSymbolicName()));
+        }
+
         return installLists;
     }
 
@@ -543,42 +702,69 @@ public class RepositoryResolver {
      * @return the ordered list of resources to install
      */
     List<RepositoryResource> createInstallList(SampleResource resource) {
-        Map<String, Integer> maxDistanceMap = new HashMap<>();
         List<MissingRequirement> missingRequirements = new ArrayList<>();
 
-        boolean allDependenciesResolved = true;
+        AtomicBoolean allDependenciesResolved = new AtomicBoolean(true);
+        ArrayList<ProvisioningFeatureDefinition> installList = new ArrayList<>();
         if (resource.getRequireFeature() != null) {
-            for (String featureName : resource.getRequireFeature()) {
 
+            List<ProvisioningFeatureDefinition> rootFeatures = new ArrayList<>();
+
+            for (String featureName : resource.getRequireFeature()) {
                 // Check that the sample actually exists
                 ProvisioningFeatureDefinition feature = resolverRepository.getFeature(featureName);
                 if (feature == null) {
-                    allDependenciesResolved = false;
+                    allDependenciesResolved.set(false);
                     // Unless we know it exists but applies to another product, note the missing requirement as well
                     if (featuresMissing.contains(featureName)) {
                         missingRequirements.add(new MissingRequirement(featureName, resource));
                     }
                 } else {
-                    // Build distance map and check dependencies
-                    allDependenciesResolved &= populateMaxDistanceMap(maxDistanceMap, featureName, 1, new HashSet<ProvisioningFeatureDefinition>(), missingRequirements);
+                    rootFeatures.add(feature);
                 }
-
             }
+
+            // We do a breadth first walk, adding features to the list. If we find a feature a second time, we move it to the end of the list.
+            // This creates a list ordered by their deepest occurrence in the tree which ensures that all the dependencies of a feature
+            // come after it in the list.
+            FeatureTreeWalker.walkOver(resolvedFeatures)
+                             .forEach(f -> {
+                                 // Move the feature to the end if it's already in the list
+                                 // to ensure it comes after everything that depends on it
+                                 installList.remove(f);
+                                 installList.add(f);
+                             })
+                             .onMissingDependency((f, dependency) -> {
+                                 if (featuresMissing.contains(dependency.getSymbolicName())) {
+                                     // The dependency was totally missing, add it to the list of missing requirements
+                                     missingRequirements.add(new MissingRequirement(dependency.getSymbolicName(), getResource(f)));
+                                 }
+                                 allDependenciesResolved.set(false);
+                             })
+                             .walkBreadthFirst(rootFeatures);
         }
 
-        if (!allDependenciesResolved) {
+        if (!allDependenciesResolved.get()) {
             missingTopLevelRequirements.add(resource.getShortName());
             this.missingRequirements.addAll(missingRequirements);
         }
 
-        ArrayList<RepositoryResource> installList = new ArrayList<>();
+        // Remove installed features from the list and convert to EsaResources
+        ArrayList<RepositoryResource> resourceInstallList = new ArrayList<>();
+        for (ProvisioningFeatureDefinition installFeature : installList) {
+            EsaResource featureResource = getResource(installFeature);
+            if (featureResource != null) {
+                resourceInstallList.add(featureResource);
+            }
+        }
 
-        installList.addAll(convertFeatureNamesToResources(maxDistanceMap.keySet()));
-        Collections.sort(installList, byMaxDistance(maxDistanceMap));
+        // Our walk ensures that every feature comes before its dependencies, but we actually need it to be the other way around
+        Collections.reverse(resourceInstallList);
 
-        installList.add(resource);
+        // Add the sample itself to the end of the install list
+        resourceInstallList.add(resource);
 
-        return installList;
+        return resourceInstallList;
     }
 
     /**
@@ -607,195 +793,47 @@ public class RepositoryResolver {
             return Collections.emptyList();
         }
 
-        Map<String, Integer> maxDistanceMap = new HashMap<>();
         List<MissingRequirement> missingRequirements = new ArrayList<>();
-        boolean foundAllDependencies = populateMaxDistanceMap(maxDistanceMap, feature.getSymbolicName(), 0, new HashSet<ProvisioningFeatureDefinition>(), missingRequirements);
+        List<ProvisioningFeatureDefinition> installList = new ArrayList<>();
+        AtomicBoolean foundAll = new AtomicBoolean(true);
 
-        if (!foundAllDependencies) {
+        // We do a breadth first walk, adding features to the list. If we find a feature a second time, we move it to the end of the list.
+        // This creates a list ordered by their deepest occurrence in the tree which ensures that all the dependencies of a feature
+        // come after it in the list.
+        FeatureTreeWalker.walkOver(resolvedFeatures)
+                         .forEach(f -> {
+                             // Move the feature to the end if it's already in the list
+                             // to ensure it comes after everything that depends on it
+                             installList.remove(f);
+                             installList.add(f);
+                         })
+                         .onMissingDependency((f, dependency) -> {
+                             if (featuresMissing.contains(dependency.getSymbolicName())) {
+                                 // The dependency was totally missing, add it to the list of missing requirements
+                                 missingRequirements.add(new MissingRequirement(dependency.getSymbolicName(), getResource(f)));
+                             }
+                             foundAll.set(false);
+                         })
+                         .walkBreadthFirst(feature);
+
+        if (!foundAll.get()) {
             missingTopLevelRequirements.add(featureName);
             this.missingRequirements.addAll(missingRequirements);
         }
 
-        ArrayList<RepositoryResource> installList = new ArrayList<>();
-
-        installList.addAll(convertFeatureNamesToResources(maxDistanceMap.keySet()));
-        Collections.sort(installList, byMaxDistance(maxDistanceMap));
-
-        return installList;
-    }
-
-    /**
-     * Returns a comparator which sorts EsaResources by their values from {@code maxDistanceMap} from greatest to smallest
-     * <p>
-     * Resources whose symbolic names do not appear in the map or which are not EsaResources are assigned a value of zero meaning that they will appear last in a sorted list.
-     *
-     * @param maxDistanceMap map from symbolic name to the length of the longest dependency chain from a specific point
-     * @return compariator which sorts based on the maxDistance of resources
-     */
-    static Comparator<RepositoryResource> byMaxDistance(final Map<String, Integer> maxDistanceMap) {
-        return new Comparator<RepositoryResource>() {
-
-            @Override
-            public int compare(RepositoryResource o1, RepositoryResource o2) {
-                return Integer.compare(getDistance(o2), getDistance(o1));
-            }
-
-            private int getDistance(RepositoryResource res) {
-                if (res.getType() == ResourceType.FEATURE) {
-                    Integer distance = maxDistanceMap.get(((EsaResource) res).getProvideFeature());
-                    return distance == null ? 0 : distance;
-                } else {
-                    return 0;
-                }
-            }
-
-        };
-    }
-
-    /**
-     * Build a map which maps feature symbolic names to the length of the longest dependency chain from the starting point to that feature
-     * <p>
-     * This method adds {@code featureName} to the map with {@code currentDistance} and then recurses through its dependencies, repeating this operation. It will stop if it
-     * encounters a dependency loop.
-     * <p>
-     * This method also adds any dependencies which can't be satisfied to {@code missingRequirements}.
-     * <p>
-     * The result of this operation is useful for building install lists as the features to be installed can be sorted by the longest dependency chain in descending order to ensure
-     * that the dependencies of a feature are installed before the feature itself.
-     * <p>
-     * Example. To find the longest dependency chain for all dependent features of com.example.featureA, the following code can be used:
-     * <p>
-     * <code>
-     *
-     * <pre>
-     * Map<String, Integer> distanceMap = new HashMap<>();
-     * populateMaxDistanceMap(distanceMap, "com.example.featureA", 0, new HashSet&lt;ProvisioningFeatureDefinition&gt;());
-     * </pre>
-     *
-     * </code>
-     * <p>
-     * Having done this, {@code distanceMap.keySet()} gives the set of all the dependencies of com.example.featureA. {@code distanceMap.get("com.example.featureB")} gives
-     * the length of the longest dependency chain from featureA to featureB.
-     *
-     * @param maxDistanceMap the map to be populated
-     * @param featureName the current feature
-     * @param currentDistance the distance to use for the current feature
-     * @param currentStack the set of feature names already in the current dependency chain (used to detect loops)
-     * @param missingRequirements the list which missing requirements are to be added
-     * @return true if all requirements were found, false otherwise
-     */
-    boolean populateMaxDistanceMap(Map<String, Integer> maxDistanceMap, String featureName, int currentDistance, Set<ProvisioningFeatureDefinition> currentStack,
-                                   List<MissingRequirement> missingRequirements) {
-        ProvisioningFeatureDefinition feature = resolvedFeatures.get(featureName);
-
-        if (currentStack.contains(feature)) {
-            // We've hit a dependency loop
-            return true;
-        }
-
-        boolean result = true;
-
-        currentStack.add(feature);
-
-        Integer oldDistance = maxDistanceMap.get(feature.getSymbolicName());
-        if (oldDistance == null || oldDistance < currentDistance) {
-            maxDistanceMap.put(feature.getSymbolicName(), currentDistance);
-        }
-
-        for (FeatureResource dependency : feature.getConstituents(SubsystemContentType.FEATURE_TYPE)) {
-            String resolvedFeatureName = findResolvedDependency(dependency);
-
-            if (resolvedFeatureName != null) {
-                // We found the dependency, continue populating the distance map
-                result &= populateMaxDistanceMap(maxDistanceMap, resolvedFeatureName, currentDistance + 1, currentStack, missingRequirements);
-            } else {
-                if (featuresMissing.contains(dependency.getSymbolicName())) {
-                    // The dependency was totally missing, add it to the list of missing requirements
-                    missingRequirements.add(new MissingRequirement(dependency.getSymbolicName(), getResource(feature)));
-                }
-                result = false;
+        // Remove installed features from the list and convert to EsaResources
+        ArrayList<RepositoryResource> resourceInstallList = new ArrayList<>();
+        for (ProvisioningFeatureDefinition installFeature : installList) {
+            EsaResource resource = getResource(installFeature);
+            if (resource != null) {
+                resourceInstallList.add(resource);
             }
         }
 
-        // Find autofeature dependencies
-        for (ProvisioningFeatureDefinition dependency : CapabilityMatching.findFeaturesSatisfyingCapability(feature, resolvedFeatures.values())) {
-            result &= populateMaxDistanceMap(maxDistanceMap, dependency.getSymbolicName(), currentDistance + 1, currentStack, missingRequirements);
-        }
+        // Our walk ensures that every feature comes before its dependencies, but we actually need it to be the other way around
+        Collections.reverse(resourceInstallList);
 
-        currentStack.remove(feature);
-
-        return result;
-    }
-
-    /**
-     * Find the actual resolved feature from a dependency with tolerates
-     * <p>
-     * Tries each of the tolerated versions in order until it finds one that exists in the set of resolved features.
-     *
-     * @param featureResource the dependency definition to resolve
-     * @return the symbolic name of the resolved dependency, or {@code null} if it was not found
-     */
-    String findResolvedDependency(FeatureResource featureResource) {
-        ProvisioningFeatureDefinition feature = resolvedFeatures.get(featureResource.getSymbolicName());
-        if (feature != null) {
-            return feature.getSymbolicName();
-        }
-
-        String baseName = getFeatureBaseName(featureResource.getSymbolicName());
-        List<String> tolerates = featureResource.getTolerates();
-        if (tolerates != null) {
-            for (String toleratedVersion : tolerates) {
-                String featureName = baseName + toleratedVersion;
-
-                feature = resolvedFeatures.get(featureName);
-                if (feature != null) {
-                    return feature.getSymbolicName();
-                }
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Removes the version from the end of a feature symbolic name
-     * <p>
-     * The version is presumed to start after the last dash character in the name.
-     * <p>
-     * E.g. {@code getFeatureBaseName("com.example.featureA-1.0")} returns {@code "com.example.featureA-"}
-     *
-     * @param nameAndVersion the feature symbolic name
-     * @return the feature symbolic name with any version stripped
-     */
-    String getFeatureBaseName(String nameAndVersion) {
-        int dashPosition = nameAndVersion.lastIndexOf('-');
-        if (dashPosition != -1) {
-            return nameAndVersion.substring(0, dashPosition + 1);
-        } else {
-            return nameAndVersion;
-        }
-    }
-
-    /**
-     * Convert a collection of feature names into a list of EsaResources
-     * <p>
-     * If a feature with the given name is not found, or if it corresponds to a feature which is already installed, it is ignored. Therefore, this method can be used to convert a
-     * list of names from the kernel resolver into a list of esas which need to be installed.
-     *
-     * @param names the feature names to find
-     * @return a list comprised of the corresponding EsaResource for each name in {@code names}, if one exists
-     */
-    List<EsaResource> convertFeatureNamesToResources(Collection<String> names) {
-        List<EsaResource> results = new ArrayList<>();
-
-        for (String name : names) {
-            ProvisioningFeatureDefinition feature = resolverRepository.getFeature(name);
-            if (feature instanceof KernelResolverEsa) {
-                results.add(((KernelResolverEsa) feature).getResource());
-            }
-        }
-
-        return results;
+        return resourceInstallList;
     }
 
     /**

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -37,7 +37,6 @@ import com.ibm.ws.repository.connections.RepositoryConnectionList;
 import com.ibm.ws.repository.exceptions.RepositoryException;
 import com.ibm.ws.repository.resolver.RepositoryResolutionException.MissingRequirement;
 import com.ibm.ws.repository.resolver.internal.ResolutionMode;
-import com.ibm.ws.repository.resolver.internal.kernel.CapabilityMatching;
 import com.ibm.ws.repository.resolver.internal.kernel.KernelResolverEsa;
 import com.ibm.ws.repository.resolver.internal.kernel.KernelResolverRepository;
 import com.ibm.ws.repository.resources.ApplicableToProduct;
@@ -372,7 +371,6 @@ public class RepositoryResolver {
         initializeResolverRepository(installDefinition);
 
         processNames(toResolve);
-        findAutofeatureDependencies();
 
         if (resolutionMode == ResolutionMode.DETECT_CONFLICTS) {
             // Call the kernel resolver to determine the features needed
@@ -459,29 +457,6 @@ public class RepositoryResolver {
         } else {
             return new NameAndVersion(nameAndVersion, null);
         }
-    }
-
-    /**
-     * If any of the requested features are auto-features, find the set of features that satisfy their provisionCapability header and add those to the list of feature names to
-     * resolve.
-     * <p>
-     * This is necessary because the kernel resolver will ignore the provision capability header if the feature has been specifically requested, but that's not usually helpful at
-     * install time.
-     */
-    void findAutofeatureDependencies() {
-        // If the user has requested an autofeature to be resolved, we want to treat the features mentioned in its provisionCapability header as dependencies
-        ArrayList<String> autofeatureDependencies = new ArrayList<>();
-        for (String featureName : featureNamesToResolve) {
-            ProvisioningFeatureDefinition feature = resolverRepository.getFeature(featureName);
-            if (feature != null && feature.isAutoFeature()) {
-                Collection<ProvisioningFeatureDefinition> dependencies = CapabilityMatching.findFeaturesSatisfyingCapability(feature, resolverRepository.getAllFeatures());
-                for (ProvisioningFeatureDefinition dependency : dependencies) {
-                    autofeatureDependencies.add(dependency.getSymbolicName());
-                }
-            }
-        }
-
-        featureNamesToResolve.addAll(autofeatureDependencies);
     }
 
     /**

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -380,10 +380,9 @@ public class RepositoryResolver {
         } else {
             // Resolve all dependencies of installed features
             resolveFeaturesBasic();
+            // Basic resolve auto-features satisfied by installed + resolved features
+            resolveAutoFeatures();
         }
-
-        // Basic resolve auto-features satisfied by installed + resolved features
-        resolveAutoFeatures();
 
         // Find any any features which aren't direct dependencies of a requested feature
         // Can happen if resolveAsSet is used to install some features
@@ -549,10 +548,7 @@ public class RepositoryResolver {
     /**
      * Finds any autofeatures which are satisfied by the installed and resolved features and adds them to the resolvedFeatures set
      * <p>
-     * This is necessary for both basic resolve and resolveAsSet:
-     * <ul>
-     * <li>basic resolve won't have found any autofeatures yet
-     * <li>resolveAsSet will have found autofeatures needed for the resolution set, but won't have added any additional which could be enabled by already installed features.
+     * This is only used for basic resolve because the kernel resolver will find autofeatures for us when using resolveAsSet
      */
     void resolveAutoFeatures() {
 

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -594,7 +594,7 @@ public class RepositoryResolver {
 
         // Remove dependencies of autofeatures
         for (ProvisioningFeatureDefinition feature : resolvedFeatures.values()) {
-            if (feature.isAutoFeature()) {
+            if (feature.isAutoFeature() && feature instanceof KernelResolverEsa) {
                 removeCandidateWalker.walkDepthFirst(feature);
             }
         }
@@ -652,7 +652,7 @@ public class RepositoryResolver {
 
         // Create install list for each autofeature which wasn't explicitly requested (otherwise we'd have covered it above) and isn't already installed
         for (ProvisioningFeatureDefinition feature : resolvedFeatures.values()) {
-            if (feature.isAutoFeature() && !requestedFeatureNames.contains(feature.getSymbolicName())) {
+            if (feature.isAutoFeature() && !requestedFeatureNames.contains(feature.getSymbolicName()) && feature instanceof KernelResolverEsa) {
                 installLists.add(createInstallList(feature.getSymbolicName()));
             }
         }

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/Walker.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/Walker.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.repository.resolver;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Generic walk implementations
+ * <p>
+ * These are used by {@link FeatureTreeWalker} but are implemented separately to separate the walking logic from the feature details
+ */
+public class Walker {
+
+    /**
+     * Walk a tree of elements breadth first
+     * <p>
+     * Any cycles in the tree are detected and the element and its children are ignored when it is encountered as a descendant of itself
+     *
+     * @param <T>         the element type
+     * @param root        the starting element
+     * @param forEach     a consumer called when each element is visited
+     * @param getChildren a function to get the children of an element
+     */
+    public static <T> void walkBreadthFirst(T root, Consumer<? super T> forEach, Function<T, Collection<? extends T>> getChildren) {
+        walkCollectionBreadthFirst(Collections.singleton(root), forEach, getChildren);
+    }
+
+    /**
+     * Walk a tree of elements breadth first
+     * <p>
+     * Any cycles in the tree are detected and the element and its children are ignored when it is encountered as a descendant of itself
+     *
+     * @param <T>         the element type
+     * @param roots       the starting elements
+     * @param forEach     a consumer called when each element is visited
+     * @param getChildren a function to get the children of an element
+     */
+    public static <T> void walkCollectionBreadthFirst(Collection<? extends T> roots, Consumer<? super T> forEach, Function<T, Collection<? extends T>> getChildren) {
+        Deque<WalkElement<T>> queue = new ArrayDeque<>(); // Queue of the next things to walk
+        for (T root : roots) {
+            queue.add(new WalkElement<>(root, null));
+        }
+
+        while (!queue.isEmpty()) {
+            WalkElement<T> current = queue.pollFirst();
+            forEach.accept(current.item());
+
+            for (T child : getChildren.apply(current.item())) {
+                if (!current.hasAncestor(child)) { // check for loops
+                    queue.addLast(new WalkElement<T>(child, current));
+                }
+            }
+        }
+    }
+
+    /**
+     * Walk a tree of elements depth first, parents are visited before their children
+     * <p>
+     * Any cycles in the tree are detected and the element and its children are ignored when it is encountered as a descendant of itself
+     *
+     * @param <T>         the element type
+     * @param roots       the starting elements
+     * @param forEach     a consumer called when each element is visited
+     * @param getChildren a function to get the children of an element
+     */
+    public static <T> void walkDepthFirst(T root, Consumer<? super T> forEach, Function<T, Collection<? extends T>> getChildren) {
+        walkDepthFirst(root, forEach, getChildren, new HashSet<T>());
+    }
+
+    private static <T> void walkDepthFirst(T item, Consumer<? super T> forEach, Function<T, Collection<? extends T>> getChildren, HashSet<T> stack) {
+        stack.add(item);
+
+        forEach.accept(item);
+
+        for (T child : getChildren.apply(item)) {
+            if (!stack.contains(child)) {
+                walkDepthFirst(child, forEach, getChildren, stack);
+            }
+        }
+
+        stack.remove(item);
+    }
+
+    /**
+     * Helper class to keep track of the ancestors of an element when doing a breadth first search
+     * <p>
+     * These effectively form a linked stack
+     *
+     * @param <T> the element type
+     */
+    private static class WalkElement<T> {
+        private final T item;
+        private final WalkElement<T> parent;
+
+        public WalkElement(T item, WalkElement<T> parent) {
+            super();
+            this.item = item;
+            this.parent = parent;
+        }
+
+        public T item() {
+            return item;
+        }
+
+        public boolean hasAncestor(T search) {
+            WalkElement<T> current = this;
+            while (current != null) {
+                if (current.item.equals(search)) {
+                    return true;
+                }
+                current = current.parent;
+            }
+            return false;
+        }
+
+    }
+
+}

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsa.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsa.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -31,7 +31,6 @@ import com.ibm.ws.kernel.feature.provisioning.HeaderElementDefinition;
 import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
 import com.ibm.ws.kernel.feature.provisioning.SubsystemContentType;
 import com.ibm.ws.repository.common.enums.InstallPolicy;
-import com.ibm.ws.repository.resolver.internal.ResolutionMode;
 import com.ibm.ws.repository.resources.EsaResource;
 
 /**
@@ -42,14 +41,12 @@ import com.ibm.ws.repository.resources.EsaResource;
 public class KernelResolverEsa implements ProvisioningFeatureDefinition {
 
     private final EsaResource esaResource;
-    private final ResolutionMode resolutionMode;
 
-    public KernelResolverEsa(EsaResource esaResource, ResolutionMode resolutionMode) {
+    public KernelResolverEsa(EsaResource esaResource) {
         if (esaResource == null) {
             throw new NullPointerException();
         }
         this.esaResource = esaResource;
-        this.resolutionMode = resolutionMode;
     }
 
     /**
@@ -82,26 +79,20 @@ public class KernelResolverEsa implements ProvisioningFeatureDefinition {
 
     @Override
     public Visibility getVisibility() {
-        if (resolutionMode == ResolutionMode.DETECT_CONFLICTS) {
-            // When we're installing a set, all features must be public and we must report visibility correctly
-            // as it affects the rules around tolerated features
-            switch (esaResource.getVisibility()) {
-                case PUBLIC:
-                    return Visibility.PUBLIC;
-                case PROTECTED:
-                    return Visibility.PROTECTED;
-                case INSTALL:
-                    return Visibility.INSTALL;
-                case PRIVATE:
-                    return Visibility.PRIVATE;
-                default:
-                    throw new IllegalArgumentException("Invalid visibility: " + esaResource.getVisibility());
-            }
-        } else {
-            // When installing from the command line, we don't care about visibility
-            // However, the kernel resolver requires that the features requested by the user are public
-            // To subvert this check, make all features report as public
-            return Visibility.PUBLIC;
+        if (esaResource.getVisibility() == null) {
+            return Visibility.PRIVATE;
+        }
+        switch (esaResource.getVisibility()) {
+            case PUBLIC:
+                return Visibility.PUBLIC;
+            case PROTECTED:
+                return Visibility.PROTECTED;
+            case INSTALL:
+                return Visibility.INSTALL;
+            case PRIVATE:
+                return Visibility.PRIVATE;
+            default:
+                throw new IllegalArgumentException("Invalid visibility: " + esaResource.getVisibility());
         }
     }
 

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -31,7 +31,6 @@ import com.ibm.ws.repository.common.enums.ResourceType;
 import com.ibm.ws.repository.connections.ProductDefinition;
 import com.ibm.ws.repository.connections.RepositoryConnectionList;
 import com.ibm.ws.repository.exceptions.RepositoryBackendException;
-import com.ibm.ws.repository.resolver.internal.ResolutionMode;
 import com.ibm.ws.repository.resources.ApplicableToProduct;
 import com.ibm.ws.repository.resources.EsaResource;
 import com.ibm.ws.repository.resources.RepositoryResource;
@@ -40,6 +39,7 @@ import com.ibm.ws.repository.resources.internal.RepositoryResourceImpl;
 /**
  * Implementation of {@link FeatureResolver.Repository} which is backed by a collection of {@link EsaResource}s.
  */
+@SuppressWarnings("restriction") // Ignore restricted use of RepositoryResourceImpl, it's ok here because the resolver doesn't run inside OSGi
 public class KernelResolverRepository implements FeatureResolver.Repository {
 
     /**
@@ -58,9 +58,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
     private final Collection<ProductDefinition> productDefinitions;
     private final RepositoryConnectionList repositoryConnection;
 
-    private final ResolutionMode resolutionMode;
-
-    public KernelResolverRepository(Collection<ProductDefinition> productDefinitions, RepositoryConnectionList repositoryConnection, ResolutionMode resolutionMode) {
+    public KernelResolverRepository(Collection<ProductDefinition> productDefinitions, RepositoryConnectionList repositoryConnection) {
         this.repositoryConnection = repositoryConnection;
 
         if (productDefinitions == null) {
@@ -68,8 +66,6 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
         } else {
             this.productDefinitions = productDefinitions;
         }
-
-        this.resolutionMode = resolutionMode;
     }
 
     public void addFeatures(Collection<? extends EsaResource> esas) {
@@ -79,7 +75,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
     }
 
     public void addFeature(EsaResource esa) {
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, resolutionMode);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
         addFeature(resolverEsa);
     }
 
@@ -134,7 +130,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
      * Checks whether {@code featureList} contains a feature with the same name and version as {@code feature}.
      *
      * @param featureList the list of features
-     * @param feature the feature
+     * @param feature     the feature
      * @return {@code true} if {@code featureList} contains a feature with the same symbolic name and version as {@code feature}, otherwise {@code false}
      */
     private boolean listContainsDuplicate(List<ProvisioningFeatureDefinition> featureList, ProvisioningFeatureDefinition feature) {
@@ -323,7 +319,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
      * When a preferred version is set, {@link #getFeature(String)} will return the preferred version if available, unless another version is already installed.
      *
      * @param featureName the short or symbolic feature name
-     * @param version the version
+     * @param version     the version
      */
     public void setPreferredVersion(String featureName, String version) {
         if (!symbolicNameToFeature.containsKey(featureName)) {
@@ -355,7 +351,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
      * If no preferred version has been configured for this symbolic name, or if the preferred version cannot be found in the list, return the latest version.
      *
      * @param symbolicName the symbolic name of the feature
-     * @param featureList the list of features, which should all have the same symbolic name
+     * @param featureList  the list of features, which should all have the same symbolic name
      * @return the best feature from the list
      */
     private ProvisioningFeatureDefinition getPreferredVersion(String symbolicName, List<ProvisioningFeatureDefinition> featureList) {

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
@@ -98,14 +98,14 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
             return;
         }
 
-        // If we already have a feature with this symbolic name and version, ignore the duplicate
-        if (listContainsDuplicate(featureList, feature)) {
-            return;
-        }
-
         // If this is an installed feature, wipe out any repository features added earlier
         if (!(feature instanceof KernelResolverEsa)) {
             featureList.clear();
+        }
+
+        // If we already have a feature with this symbolic name and version, ignore the duplicate
+        if (listContainsDuplicate(featureList, feature)) {
+            return;
         }
 
         featureList.add(feature);

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/RepositoryResolverTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/RepositoryResolverTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,20 +14,13 @@ package com.ibm.ws.repository.resolver;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -37,8 +30,6 @@ import org.junit.Test;
 import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
 import com.ibm.ws.repository.common.enums.ResourceType;
 import com.ibm.ws.repository.connections.ProductDefinition;
-import com.ibm.ws.repository.resolver.RepositoryResolutionException.MissingRequirement;
-import com.ibm.ws.repository.resolver.internal.ResolutionMode;
 import com.ibm.ws.repository.resolver.internal.kernel.KernelResolverEsa;
 import com.ibm.ws.repository.resources.EsaResource;
 import com.ibm.ws.repository.resources.RepositoryResource;
@@ -90,79 +81,7 @@ public class RepositoryResolverTest {
     }
 
     @Test
-    public void testMaxDistanceComparator() {
-        EsaResourceWritable featureA = WritableResourceFactory.createEsa(null);
-        featureA.setProvideFeature("com.example.featureA");
-
-        EsaResourceWritable featureB = WritableResourceFactory.createEsa(null);
-        featureB.setProvideFeature("com.example.featureB");
-
-        EsaResourceWritable featureC = WritableResourceFactory.createEsa(null);
-        featureC.setProvideFeature("com.example.featureC");
-
-        SampleResourceWritable sampleA = WritableResourceFactory.createSample(null, ResourceType.PRODUCTSAMPLE);
-        sampleA.setShortName("sampleA");
-
-        Map<String, Integer> distanceMap = new HashMap<>();
-        distanceMap.put("com.example.featureA", 1);
-        distanceMap.put("com.example.featureB", 2);
-
-        Comparator<RepositoryResource> comparator = RepositoryResolver.byMaxDistance(distanceMap);
-
-        // B has a greater distance than A, so it should come first when sorting, so A should be considered greater. A > B
-        assertThat(comparator.compare(featureA, featureB), greaterThan(0));
-
-        // sampleA is not a feature, it should come last in sorting so it should be greater. featureA < sampleA
-        assertThat(comparator.compare(featureA, sampleA), lessThan(0));
-
-        // featureC is not listed in the distanceMap, it should come last in sorting so it should be greater. A < C
-        assertThat(comparator.compare(featureA, featureC), lessThan(0));
-
-        // sampleA and featureC should be considered equal, as neither is is in the distance map. featureC == sampleA
-        assertThat(comparator.compare(featureC, sampleA), equalTo(0));
-    }
-
-    @Test
-    public void testPopulateMaxDistanceMap() {
-        EsaResourceWritable featureA = WritableResourceFactory.createEsa(null);
-        featureA.setProvideFeature("com.example.featureA");
-        featureA.addRequireFeatureWithTolerates("com.example.featureB", Collections.<String> emptyList());
-        featureA.addRequireFeatureWithTolerates("com.example.featureD", Collections.<String> emptyList());
-
-        EsaResourceWritable featureB = WritableResourceFactory.createEsa(null);
-        featureB.setProvideFeature("com.example.featureB");
-        featureB.addRequireFeatureWithTolerates("com.example.featureC", Collections.<String> emptyList());
-
-        EsaResourceWritable featureC = WritableResourceFactory.createEsa(null);
-        featureC.setProvideFeature("com.example.featureC");
-        featureC.addRequireFeatureWithTolerates("com.example.featureD", Collections.<String> emptyList());
-
-        EsaResourceWritable featureD = WritableResourceFactory.createEsa(null);
-        featureD.setProvideFeature("com.example.featureD");
-
-        EsaResourceWritable featureE = WritableResourceFactory.createEsa(null);
-        featureE.setProvideFeature("com.example.featureE");
-
-        RepositoryResolver resolver = testResolver().withResolvedFeature(featureA, featureB, featureC, featureD, featureE).build();
-
-        Map<String, Integer> distanceMap = new HashMap<>();
-        resolver.populateMaxDistanceMap(distanceMap, "com.example.featureA", 0, new HashSet<ProvisioningFeatureDefinition>(), new ArrayList<MissingRequirement>());
-
-        assertThat(distanceMap, hasEntry("com.example.featureA", 0));
-        assertThat(distanceMap, hasEntry("com.example.featureB", 1));
-        assertThat(distanceMap, hasEntry("com.example.featureC", 2));
-        assertThat(distanceMap, hasEntry("com.example.featureD", 3)); // Note that featureD has distance of 3, even though featureA depends directly on featureD
-        assertThat(distanceMap.entrySet(), hasSize(4));
-
-        distanceMap = new HashMap<>();
-        resolver.populateMaxDistanceMap(distanceMap, "com.example.featureC", 0, new HashSet<ProvisioningFeatureDefinition>(), new ArrayList<MissingRequirement>());
-        assertThat(distanceMap, hasEntry("com.example.featureC", 0));
-        assertThat(distanceMap, hasEntry("com.example.featureD", 1));
-        assertThat(distanceMap.entrySet(), hasSize(2));
-    }
-
-    @Test
-    public void testPopulateMaxDistanceMapTolerates() {
+    public void testCreateInstallListWithTolerates() {
         EsaResourceWritable featureA = WritableResourceFactory.createEsa(null);
         featureA.setProvideFeature("com.example.featureA-1.0");
         featureA.addRequireFeatureWithTolerates("com.example.featureB-1.0", Arrays.asList("1.5", "2.0"));
@@ -188,21 +107,12 @@ public class RepositoryResolverTest {
 
         RepositoryResolver resolver = testResolver().withResolvedFeature(featureA, featureB, featureC12, featureC15, featureD, featureE).build();
 
-        Map<String, Integer> distanceMap = new HashMap<>();
-        resolver.populateMaxDistanceMap(distanceMap, "com.example.featureA-1.0", 0, new HashSet<ProvisioningFeatureDefinition>(), new ArrayList<MissingRequirement>());
-
-        assertThat(distanceMap, hasEntry("com.example.featureA-1.0", 0));
-        assertThat(distanceMap, hasEntry("com.example.featureB-2.0", 1)); // Note that we've picked featureB-2.0 from the tolerated versions
-        assertThat(distanceMap, hasEntry("com.example.featureC-1.2", 2)); // Note that we've picked featureC-1.2 rather than featureC-1.5 because 1.2 is earlier in the tolerates list
-        assertThat(distanceMap, hasEntry("com.example.featureD", 3)); // Note that featureD has distance of 3, even though featureA depends directly on featureD
-        assertThat(distanceMap.entrySet(), hasSize(4));
-
-        distanceMap = new HashMap<>();
-        resolver.populateMaxDistanceMap(distanceMap, "com.example.featureC-1.5", 0, new HashSet<ProvisioningFeatureDefinition>(), new ArrayList<MissingRequirement>());
-
-        assertThat(distanceMap, hasEntry("com.example.featureC-1.5", 0));
-        assertThat(distanceMap, hasEntry("com.example.featureD", 1));
-        assertThat(distanceMap.entrySet(), hasSize(2));
+        List<RepositoryResource> installList = resolver.createInstallList("com.example.featureA-1.0");
+        assertThat(installList, contains(featureD, // Note that featureD is first because featureC depends on it, even though featureA also depends directly on it
+                                         featureC15, // Note we get both featureC-1.2 and 1.5 as both are tolerated and both are resolved features
+                                         featureC12,
+                                         featureB, // Note we've picked featureB-2.0 and not worried that featureB-1.0 and 1.5 aren't present
+                                         featureA));
     }
 
     @SuppressWarnings("unchecked")
@@ -291,19 +201,14 @@ public class RepositoryResolverTest {
     }
 
     private static ResolverBuilder testResolver() {
-        return new ResolverBuilder(ResolutionMode.IGNORE_CONFLICTS);
+        return new ResolverBuilder();
     }
 
     private static class ResolverBuilder {
-        final ResolutionMode resolutionMode;
         List<ProvisioningFeatureDefinition> installedFeatures = new ArrayList<>();
         List<EsaResource> repoFeatures = new ArrayList<>();
         List<SampleResource> repoSamples = new ArrayList<>();
         Map<String, ProvisioningFeatureDefinition> resolvedFeatures = new HashMap<>();
-
-        public ResolverBuilder(ResolutionMode resolutionMode) {
-            this.resolutionMode = resolutionMode;
-        }
 
         public ResolverBuilder withFeature(EsaResource... esa) {
             repoFeatures.addAll(Arrays.asList(esa));
@@ -318,7 +223,7 @@ public class RepositoryResolverTest {
         public ResolverBuilder withResolvedFeature(EsaResource... esas) {
             repoFeatures.addAll(Arrays.asList(esas));
             for (EsaResource esa : esas) {
-                resolvedFeatures.put(esa.getProvideFeature(), new KernelResolverEsa(esa, resolutionMode));
+                resolvedFeatures.put(esa.getProvideFeature(), new KernelResolverEsa(esa));
             }
             return this;
         }
@@ -339,7 +244,7 @@ public class RepositoryResolverTest {
         public RepositoryResolver build() {
             RepositoryResolver resolver = new RepositoryResolver(installedFeatures, repoFeatures, repoSamples);
             resolver.initResolve();
-            resolver.initializeResolverRepository(Collections.<ProductDefinition> emptySet(), resolutionMode);
+            resolver.initializeResolverRepository(Collections.<ProductDefinition> emptySet());
             resolver.resolvedFeatures = resolvedFeatures;
             return resolver;
         }

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolutionTests.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolutionTests.java
@@ -990,11 +990,15 @@ public class ResolutionTests {
         // Now see if we can resolve it!
         RepositoryResolver resolver = createResolver();
         Collection<List<RepositoryResource>> resolvedResources = resolve(resolver, autoSymbolicName);
-        assertEquals("There should only be a single list of resources, set is:" + resolvedResources, 1, resolvedResources.size());
-        List<RepositoryResource> resolvedList = resolvedResources.iterator().next();
-        assertEquals("There should be 2 resolved resources in the auto list", 2, resolvedList.size());
-        assertEquals("Auto should be installed last", autoFeature, resolvedList.get(1));
-        assertEquals("Main feature should be installed first", testResource, resolvedList.get(0));
+
+        if (testType == TestType.RESOLVE) {
+            // For a basic resolve, we should install the features which enable the auto-feature
+            assertThat(resolvedResources, contains(contains(testResource, autoFeature)));
+        } else {
+            // For resovle as set, we resolve exactly as the kernel resolver would, returning just the auto-feature
+            // Note that this scenario is unusual as it's only possible if the autofeature is public
+            assertThat(resolvedResources, contains(contains(autoFeature)));
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolutionTests.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolutionTests.java
@@ -2516,7 +2516,7 @@ public class ResolutionTests {
         resolved = resolve(resolver, Arrays.asList(c10.getSymbolicName()));
         if (testType == TestType.RESOLVE_AS_SET) {
             // Resolves nothing because C-1.0 and A-1.0 are already installed
-            assertThat(resolved, contains(empty()));
+            assertThat(resolved, is(empty()));
         } else {
             // Resolves Base-2.0 and A.internal-2.0 because all tolerated dependencies of autofeatures are installed
             assertThat(resolved, contains(contains(base20, aInternal20)));

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/LibertyVersionRangeTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/LibertyVersionRangeTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,9 +16,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
-
-import com.ibm.ws.repository.resolver.internal.LibertyVersion;
-import com.ibm.ws.repository.resolver.internal.LibertyVersionRange;
 
 /**
  * Tests for {@link LibertyVersionRange}.

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/LibertyVersionTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/LibertyVersionTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,8 +19,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
-
-import com.ibm.ws.repository.resolver.internal.LibertyVersion;
 
 /**
  * Test for {@link LibertyVersion}
@@ -86,7 +84,7 @@ public class LibertyVersionTest {
 
     /**
      * Tests to versions against each other. Will test the string matches the toString on the higher value and that equals and compare to work and are symetrical.
-     * 
+     *
      * @param versionString
      * @param lower
      * @param higher

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/FeatureResolverTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/FeatureResolverTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package com.ibm.ws.repository.resolver.internal.kernel;
 
-import static com.ibm.ws.repository.resolver.internal.ResolutionMode.DETECT_CONFLICTS;
-import static com.ibm.ws.repository.resolver.internal.ResolutionMode.IGNORE_CONFLICTS;
 import static com.ibm.ws.repository.resolver.internal.kernel.KernelResolverResultMatcher.result;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -40,7 +38,7 @@ public class FeatureResolverTest {
     @Test
     public void testSingleFeatureResolution() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
 
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
         esa.setProvideFeature("com.example.featureA");
@@ -55,7 +53,7 @@ public class FeatureResolverTest {
     @Test
     public void testDependencyResolution() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
 
         EsaResourceWritable featureA = WritableResourceFactory.createEsa(null);
         featureA.setProvideFeature("com.example.featureA");
@@ -76,7 +74,7 @@ public class FeatureResolverTest {
     @Test
     public void testToleratesChoosesPreferred() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
 
         EsaResourceWritable featureA10 = WritableResourceFactory.createEsa(null);
         featureA10.setProvideFeature("com.example.featureA-1.0");
@@ -102,7 +100,7 @@ public class FeatureResolverTest {
     @Test
     public void testToleratesUsedWhenPreferredMissing() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
 
         EsaResourceWritable featureA11 = WritableResourceFactory.createEsa(null);
         featureA11.setProvideFeature("com.example.featureA-1.1");
@@ -123,7 +121,7 @@ public class FeatureResolverTest {
     @Test
     public void testToleratesUsedWhenConflictingVersionsRequired() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
 
         EsaResourceWritable featureA10 = WritableResourceFactory.createEsa(null);
         featureA10.setProvideFeature("com.example.featureA-1.0");
@@ -157,7 +155,7 @@ public class FeatureResolverTest {
     @Test
     public void testToleratesNotUsedWhenNotSingleton() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
 
         // Note featureA-1.0 and 1.1 are not singletons so can resolve together
         EsaResourceWritable featureA10 = WritableResourceFactory.createEsa(null);
@@ -190,7 +188,7 @@ public class FeatureResolverTest {
     @Test
     public void testAutofeatureResolved() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
 
         EsaResourceWritable featureA = WritableResourceFactory.createEsa(null);
         featureA.setProvideFeature("com.example.featureA");
@@ -221,7 +219,7 @@ public class FeatureResolverTest {
     @Test
     public void testFeatureMissing() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, DETECT_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
 
         EsaResourceWritable featureB = WritableResourceFactory.createEsa(null);
         featureB.setProvideFeature("com.example.featureB-1.0");
@@ -237,7 +235,7 @@ public class FeatureResolverTest {
     @Test
     public void testConflict() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, DETECT_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
 
         EsaResourceWritable featureA1 = WritableResourceFactory.createEsa(null);
         featureA1.setProvideFeature("com.example.featureA-1.0");

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsaTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsaTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package com.ibm.ws.repository.resolver.internal.kernel;
 
-import static com.ibm.ws.repository.resolver.internal.ResolutionMode.DETECT_CONFLICTS;
-import static com.ibm.ws.repository.resolver.internal.ResolutionMode.IGNORE_CONFLICTS;
 import static com.ibm.ws.repository.resolver.internal.kernel.FeatureResourceMatcher.featureResource;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -44,7 +42,7 @@ public class KernelResolverEsaTest {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
         esa.setProvideFeature("com.example.featureA");
 
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
         assertThat(resolverEsa.getSymbolicName(), is("com.example.featureA"));
     }
 
@@ -53,7 +51,7 @@ public class KernelResolverEsaTest {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
         esa.setProvideFeature("com.example.featureA");
 
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
 
         assertThat(resolverEsa.getSymbolicName(), is("com.example.featureA"));
         assertThat(resolverEsa.getFeatureName(), is("com.example.featureA"));
@@ -63,7 +61,7 @@ public class KernelResolverEsaTest {
         assertThat(resolverEsa.isCapabilitySatisfied(Collections.<ProvisioningFeatureDefinition> emptyList()), is(true));
         assertThat(resolverEsa.isAutoFeature(), is(false));
         assertThat(resolverEsa.isSingleton(), is(false));
-        assertThat(resolverEsa.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PUBLIC)); // Esas always public
+        assertThat(resolverEsa.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PRIVATE));
         assertThat(resolverEsa.getProcessTypes(), is(EnumSet.of(ProcessType.SERVER)));
     }
 
@@ -71,7 +69,7 @@ public class KernelResolverEsaTest {
     public void testBundleRepositoryType() {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
 
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
         assertThat(resolverEsa.getBundleRepositoryType(), is(""));
     }
 
@@ -81,7 +79,7 @@ public class KernelResolverEsaTest {
         esa.setProvideFeature("com.example.featureA");
         esa.addRequireFeatureWithTolerates("com.example.featureB-1.0", Arrays.asList("1.1", "1.5"));
 
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
         assertThat(resolverEsa.getConstituents(SubsystemContentType.FEATURE_TYPE), contains(featureResource("com.example.featureB-1.0", "1.1", "1.5")));
     }
 
@@ -91,7 +89,7 @@ public class KernelResolverEsaTest {
         esa.setProvideFeature("com.example.featureA");
         esa.setShortName("featureA");
 
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
         assertThat(resolverEsa.getIbmShortName(), is("featureA"));
     }
 
@@ -109,9 +107,9 @@ public class KernelResolverEsaTest {
         autoFeature.setProvisionCapability("osgi.identity; filter:=\"(&(type=osgi.subsystem.feature)(osgi.identity=com.example.featureA))\","
                                            + "osgi.identity; filter:=\"(&(type=osgi.subsystem.feature)(osgi.identity=com.example.featureB))\"");
 
-        KernelResolverEsa resolverFeatureA = new KernelResolverEsa(featureA, IGNORE_CONFLICTS);
-        KernelResolverEsa resolverFeatureB = new KernelResolverEsa(featureB, IGNORE_CONFLICTS);
-        KernelResolverEsa resolverAutoFeature = new KernelResolverEsa(autoFeature, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverFeatureA = new KernelResolverEsa(featureA);
+        KernelResolverEsa resolverFeatureB = new KernelResolverEsa(featureB);
+        KernelResolverEsa resolverAutoFeature = new KernelResolverEsa(autoFeature);
 
         assertThat(resolverFeatureA.isCapabilitySatisfied(Collections.<ProvisioningFeatureDefinition> emptySet()), is(true));
         assertThat(resolverFeatureB.isCapabilitySatisfied(Collections.<ProvisioningFeatureDefinition> emptySet()), is(true));
@@ -125,7 +123,7 @@ public class KernelResolverEsaTest {
     @Test
     public void testIsAutoFeature() {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
 
         assertThat(resolverEsa.isAutoFeature(), is(false));
 
@@ -140,7 +138,7 @@ public class KernelResolverEsaTest {
     public void testIsSingleton() {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
 
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
         assertThat(resolverEsa.isSingleton(), is(false));
 
         esa.setSingleton("true");
@@ -159,8 +157,8 @@ public class KernelResolverEsaTest {
         featureB.setProvideFeature("com.example.featureB");
         featureB.setShortName("featureB");
 
-        KernelResolverEsa resolverFeatureA = new KernelResolverEsa(featureA, IGNORE_CONFLICTS);
-        KernelResolverEsa resolverFeatureB = new KernelResolverEsa(featureB, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverFeatureA = new KernelResolverEsa(featureA);
+        KernelResolverEsa resolverFeatureB = new KernelResolverEsa(featureB);
 
         assertThat(resolverFeatureA.getFeatureName(), is("com.example.featureA"));
         assertThat(resolverFeatureB.getFeatureName(), is("featureB"));
@@ -184,54 +182,37 @@ public class KernelResolverEsaTest {
         installFeature.setProvideFeature("com.example.installFeature");
         installFeature.setVisibility(Visibility.INSTALL);
 
-        // Test visibility for normal resolution
-        KernelResolverEsa resolverPublicFeature = new KernelResolverEsa(publicFeature, IGNORE_CONFLICTS);
-        KernelResolverEsa resolverPrivateFeature = new KernelResolverEsa(privateFeature, IGNORE_CONFLICTS);
-        KernelResolverEsa resolverProtectedFeature = new KernelResolverEsa(protectedFeature, IGNORE_CONFLICTS);
-        KernelResolverEsa resolverInstallFeature = new KernelResolverEsa(installFeature, IGNORE_CONFLICTS);
+        // Test visibility
+        KernelResolverEsa resolverPublicFeature = new KernelResolverEsa(publicFeature);
+        KernelResolverEsa resolverPrivateFeature = new KernelResolverEsa(privateFeature);
+        KernelResolverEsa resolverProtectedFeature = new KernelResolverEsa(protectedFeature);
+        KernelResolverEsa resolverInstallFeature = new KernelResolverEsa(installFeature);
 
-        // Note: no matter the visibility of the EsaResource, the ResolverEsa should always report as PUBLIC
-        // this is because we allow installation of private and protected resources by name, even though they're
-        // not permitted in the server.xml.
         assertThat(resolverPublicFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PUBLIC));
-        assertThat(resolverPrivateFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PUBLIC));
-        assertThat(resolverProtectedFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PUBLIC));
-        assertThat(resolverInstallFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PUBLIC));
-
-        // Test visibility for resolving as a set
-        KernelResolverEsa resolverSetPublicFeature = new KernelResolverEsa(publicFeature, DETECT_CONFLICTS);
-        KernelResolverEsa resolverSetPrivateFeature = new KernelResolverEsa(privateFeature, DETECT_CONFLICTS);
-        KernelResolverEsa resolverSetProtectedFeature = new KernelResolverEsa(protectedFeature, DETECT_CONFLICTS);
-        KernelResolverEsa resolverSetInstallFeature = new KernelResolverEsa(installFeature, DETECT_CONFLICTS);
-
-        // Note: when resolving as a set, the visibility of the ResolverEsa must match the EsaResource because
-        // it affects the rules for feature toleration, which is only used for set resolution.
-        assertThat(resolverSetPublicFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PUBLIC));
-        assertThat(resolverSetPrivateFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PRIVATE));
-        assertThat(resolverSetProtectedFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PROTECTED));
-        assertThat(resolverSetInstallFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.INSTALL));
-
+        assertThat(resolverPrivateFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PRIVATE));
+        assertThat(resolverProtectedFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PROTECTED));
+        assertThat(resolverInstallFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.INSTALL));
     }
 
     @Test
     public void testVersion() {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
         assertThat(resolverEsa.getVersion(), is(Version.emptyVersion));
 
         EsaResourceWritable esa2 = WritableResourceFactory.createEsa(null);
         esa2.setVersion("1.0");
-        KernelResolverEsa resolverEsa2 = new KernelResolverEsa(esa2, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverEsa2 = new KernelResolverEsa(esa2);
         assertThat(resolverEsa2.getVersion(), is(Version.valueOf("1.0.0")));
 
         EsaResourceWritable esa3 = WritableResourceFactory.createEsa(null);
         esa3.setVersion("4.8.2");
-        KernelResolverEsa resolverEsa3 = new KernelResolverEsa(esa3, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverEsa3 = new KernelResolverEsa(esa3);
         assertThat(resolverEsa3.getVersion(), is(Version.valueOf("4.8.2")));
 
         EsaResourceWritable esa4 = WritableResourceFactory.createEsa(null);
         esa2.setVersion("wibble");
-        KernelResolverEsa resolverEsa4 = new KernelResolverEsa(esa4, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverEsa4 = new KernelResolverEsa(esa4);
         assertThat(resolverEsa4.getVersion(), is(Version.emptyVersion));
     }
 

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepositoryTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepositoryTest.java
@@ -275,6 +275,10 @@ public class KernelResolverRepositoryTest {
         esa.setProvideFeature("com.example.featureA");
         esa.setVersion("1.0.1");
 
+        EsaResourceWritable esa2 = WritableResourceFactory.createEsa(null);
+        esa2.setProvideFeature("com.example.featureA");
+        esa2.setVersion("1.0.0");
+
         Mockery mockery = new Mockery();
         ProvisioningFeatureDefinition installedFeature = ResolverTestUtils.mockSimpleFeatureDefinition(mockery, "com.example.featureA", Version.valueOf("1.0.0"), null);
 
@@ -282,6 +286,10 @@ public class KernelResolverRepositoryTest {
 
         // With just the esa added, it should be returned
         repo.addFeature(esa);
+        assertThat(repo.getFeature("com.example.featureA"), is(resolverEsaWrapping(esa)));
+
+        // With the second esa added, the first one should still be returned (later version)
+        repo.addFeature(esa2);
         assertThat(repo.getFeature("com.example.featureA"), is(resolverEsaWrapping(esa)));
 
         // After adding the installed feature, it should be returned instead

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepositoryTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepositoryTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package com.ibm.ws.repository.resolver.internal.kernel;
 
-import static com.ibm.ws.repository.resolver.internal.ResolutionMode.IGNORE_CONFLICTS;
 import static com.ibm.ws.repository.resolver.internal.kernel.KernelResolverEsaMatcher.resolverEsaWrapping;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -43,7 +42,7 @@ public class KernelResolverRepositoryTest {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
         esa.setProvideFeature("com.example.featureA");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
         repo.addFeature(esa);
 
         assertThat(repo.getFeature("com.example.featureA"), is(resolverEsaWrapping(esa)));
@@ -57,7 +56,7 @@ public class KernelResolverRepositoryTest {
         publicEsa.setShortName("publicFeature");
         publicEsa.setVisibility(Visibility.PUBLIC);
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
         repo.addFeature(publicEsa);
 
         // Lookup by symbolic name works case insensitively
@@ -76,12 +75,12 @@ public class KernelResolverRepositoryTest {
         privateEsa.setShortName("privateFeature");
         privateEsa.setVisibility(Visibility.PRIVATE);
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
         repo.addFeature(privateEsa);
 
-        // Lookup by symbolic name works case insensitively
+        // Lookup by symbolic name does not work case insensitively
         assertThat(repo.getFeature("com.example.privateFeature"), is(resolverEsaWrapping(privateEsa)));
-        assertThat(repo.getFeature("com.EXAMPLE.privatefeature"), is(resolverEsaWrapping(privateEsa)));
+        assertThat(repo.getFeature("com.EXAMPLE.privatefeature"), is(nullValue()));
 
         // Looking up by short name works case insensitively
         assertThat(repo.getFeature("privateFeature"), is(resolverEsaWrapping(privateEsa)));
@@ -95,12 +94,12 @@ public class KernelResolverRepositoryTest {
         protectedEsa.setShortName("protectedFeature");
         protectedEsa.setVisibility(Visibility.PROTECTED);
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
         repo.addFeature(protectedEsa);
 
-        // Lookup by symbolic name works case insensitively
+        // Lookup by symbolic name does not work case insensitively
         assertThat(repo.getFeature("com.example.protectedFeature"), is(resolverEsaWrapping(protectedEsa)));
-        assertThat(repo.getFeature("com.EXAMPLE.protectedfeature"), is(resolverEsaWrapping(protectedEsa)));
+        assertThat(repo.getFeature("com.EXAMPLE.protectedfeature"), is(nullValue()));
 
         // Looking up by short name works case insensitively
         assertThat(repo.getFeature("protectedFeature"), is(resolverEsaWrapping(protectedEsa)));
@@ -114,7 +113,7 @@ public class KernelResolverRepositoryTest {
         installEsa.setShortName("installFeature");
         installEsa.setVisibility(Visibility.INSTALL);
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
         repo.addFeature(installEsa);
 
         // Lookup by symbolic name works case insensitively
@@ -131,7 +130,7 @@ public class KernelResolverRepositoryTest {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
         esa.setProvideFeature("com.example.featureA");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
         repo.addFeature(esa);
 
         // GetConfiguredTolerates should always return an empty list
@@ -142,7 +141,7 @@ public class KernelResolverRepositoryTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testGetAutoFeatures() {
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
 
         EsaResourceWritable featureA = WritableResourceFactory.createEsa(null);
         featureA.setProvideFeature("com.example.featureA");
@@ -177,7 +176,7 @@ public class KernelResolverRepositoryTest {
         featureAduplicate.setProvideFeature("com.example.featureA");
         featureAduplicate.setShortName("featureA");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
         repo.addFeatures(Arrays.asList(featureA, featureB, featureAduplicate));
 
         assertThat(repo.getFeature("com.example.featureA"), is(resolverEsaWrapping(featureA)));
@@ -198,7 +197,7 @@ public class KernelResolverRepositoryTest {
         featureA_11.setProvideFeature("com.example.featureA-1.0");
         featureA_11.setVersion("1.1");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
         repo.addFeatures(Arrays.asList(featureA_10, featureA_11));
 
         // The latest version should be returned
@@ -215,7 +214,7 @@ public class KernelResolverRepositoryTest {
         featureA_11.setProvideFeature("com.example.featureA-1.0");
         featureA_11.setVersion("1.1");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
         repo.addFeatures(Arrays.asList(featureA_10, featureA_11));
         repo.setPreferredVersion("com.example.featureA-1.0", "1.0");
 
@@ -238,7 +237,7 @@ public class KernelResolverRepositoryTest {
         featureA_110.setProvideFeature("com.example.featureA-1.0");
         featureA_110.setVersion("1.10");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
         repo.addFeatures(Arrays.asList(featureA_19, featureA_110));
         repo.setPreferredVersion("com.example.featureA-1.0", "1.9");
 
@@ -262,7 +261,7 @@ public class KernelResolverRepositoryTest {
         featureA_wibble.setProvideFeature("com.example.featureA-1.0");
         featureA_wibble.setVersion("wibble");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
         repo.addFeatures(Arrays.asList(featureA_wibble, featureA_1));
 
         // The feature with the valid version should be returned
@@ -279,7 +278,7 @@ public class KernelResolverRepositoryTest {
         Mockery mockery = new Mockery();
         ProvisioningFeatureDefinition installedFeature = ResolverTestUtils.mockSimpleFeatureDefinition(mockery, "com.example.featureA", Version.valueOf("1.0.0"), null);
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
 
         // With just the esa added, it should be returned
         repo.addFeature(esa);
@@ -309,7 +308,7 @@ public class KernelResolverRepositoryTest {
         ProvisioningFeatureDefinition installedFeature = ResolverTestUtils.mockSimpleFeatureDefinition(mockery, "com.example.featureA", Version.valueOf("1.0.0"), "featureA",
                                                                                                        "foo:featureA", com.ibm.ws.kernel.feature.Visibility.PUBLIC, false);
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null);
         repo.addFeature(installedFeature);
         assertThat(repo.getFeature("foo:featureA"), is(installedFeature));
     }


### PR DESCRIPTION
Basic resolve (i.e. not resolveAsSet) is now expected to return all tolerated dependencies of all features to be installed.

Removed install `resolveAutoFeature()` method which calls `resolve()` api again after the first `resolve()` or `resolveAsSet()` call. It's not needed anymore.

Added test case for #24315 and updated archive-1.0.zip in artifactory/dhe

This redelivers the reverted change #25106 with an additional fix for a performance issue.

Fixes #25379 
For #21992