### PR TITLE
Telemetry WithSpan fix

### DIFF
--- a/dev/io.openliberty.io.opentelemetry/bnd.bnd
+++ b/dev/io.openliberty.io.opentelemetry/bnd.bnd
@@ -32,6 +32,7 @@ Import-Package: \
   zipkin2.reporter,\
   zipkin2.reporter.okhttp3,\
   jakarta.interceptor,\
+  jakarta.enterprise.util,\
   com.ibm.wsspi.classloading,\
   org.osgi.framework,\
   com.ibm.websphere.ras,\
@@ -63,6 +64,7 @@ Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 	io.openliberty.com.squareup.okio-jvm;version=latest,\
 	io.openliberty.io.zipkin.zipkin2;version=latest,\
 	io.openliberty.jakarta.interceptor.2.1;version=latest,\
+	io.openliberty.jakarta.cdi.4.0;version=latest,\
 	io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations-support;version='1.19.0.alpha';strategy=exact,\
 	io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations;version='1.19.0.alpha';strategy=exact,\
 	io.opentelemetry.instrumentation:opentelemetry-instrumentation-api;version='1.19.0';strategy=exact,\

--- a/dev/io.openliberty.io.opentelemetry/src/io/opentelemetry/instrumentation/annotations/WithSpan.java
+++ b/dev/io.openliberty.io.opentelemetry/src/io/opentelemetry/instrumentation/annotations/WithSpan.java
@@ -11,6 +11,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.opentelemetry.api.trace.SpanKind;
+import jakarta.enterprise.util.Nonbinding;
 import jakarta.interceptor.InterceptorBinding;
 
 /**
@@ -28,7 +29,7 @@ import jakarta.interceptor.InterceptorBinding;
  *      OpenTelemetry Instrumentation for Java</a>
  */
 
-//Adds ElementType.TYPE to target and interceptor binding
+//Adds ElementType.TYPE to target, @InterceptorBinding annotation and @Nonbinding annotations
 @InterceptorBinding
 @Target({ ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
@@ -39,8 +40,10 @@ public @interface WithSpan {
      * <p>If not specified, an appropriate default name should be created by auto-instrumentation.
      * E.g. {@code "className"."method"}
      */
+    @Nonbinding
     String value() default "";
 
     /** Specify the {@link SpanKind} of span to be created. Defaults to {@link SpanKind#INTERNAL}. */
+    @Nonbinding
     SpanKind kind() default SpanKind.INTERNAL;
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
@@ -20,6 +20,7 @@ import componenttest.annotation.MinimumJavaLevel;
 @SuiteClasses({
                 JaxRsIntegration.class,
                 JaxRsIntegrationWithConcurrency.class,
+                Telemetry10.class,
                 TelemetryBeanTest.class,
                 TelemetryMultiAppTest.class,
                 TelemetrySpiTest.class,


### PR DESCRIPTION
- Add nonbinding annotations to WithSpan
  - The WithSpan annotation should bind the same interceptor, regardless of the name or kind configured, so these fields need the Nonbinding annotation added.
- Add FAT tests for having `name` and `kind` set

Fixes #25429 