### PR TITLE
Avoid Concurrent Modification Exception

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/AccessTokenCacheHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/AccessTokenCacheHelper.java
@@ -142,12 +142,8 @@ public class AccessTokenCacheHelper {
             return newSubject;
         }
         Set<Object> newPRCreds = newSubject.getPrivateCredentials();
-        Set<Object> cachedPRCreds = cachedSubject.getPrivateCredentials();
-        for (Object cachedPRCred : cachedPRCreds) {
-            if (cachedPRCred instanceof OidcTokenImpl || cachedPRCred instanceof Hashtable) {
-                newPRCreds.add(cachedPRCred);
-            }
-        }
+        newPRCreds.addAll(cachedSubject.getPrivateCredentials(OidcTokenImpl.class));
+        newPRCreds.addAll(cachedSubject.getPrivateCredentials(Hashtable.class));
         return newSubject;
     }
 


### PR DESCRIPTION
This fixes #19861 by removing the iteration over the PrivateCredentials and instead fetching only the private credentials requested and using the addAll method to add them to the new subject.

