### PR TITLE
Ensure apps are validated before testing

### DIFF
--- a/dev/com.ibm.ws.beanvalidation.v11_fat/fat/src/com/ibm/ws/beanvalidation/fat/basic/BasicValidation_Common.java
+++ b/dev/com.ibm.ws.beanvalidation.v11_fat/fat/src/com/ibm/ws/beanvalidation/fat/basic/BasicValidation_Common.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,9 +12,6 @@
  *******************************************************************************/
 package com.ibm.ws.beanvalidation.fat.basic;
 
-import static com.ibm.websphere.simplicity.ShrinkHelper.buildDefaultApp;
-import static com.ibm.websphere.simplicity.ShrinkHelper.defaultDropinApp;
-import static com.ibm.websphere.simplicity.ShrinkHelper.exportToServer;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -22,6 +19,8 @@ import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
@@ -38,28 +37,28 @@ public abstract class BasicValidation_Common extends FATServletClient {
     protected static int bvalVersion;
 
     public static void createAndExportCommonWARs(LibertyServer server) throws Exception {
-        defaultDropinApp(server, "defaultbeanvalidation_10.war", "defaultbeanvalidation10.web.*");
-        defaultDropinApp(server, "defaultbeanvalidation_11.war", "defaultbeanvalidation11.web.*");
-        WebArchive beanvalidation_10War = buildDefaultApp("beanvalidation_10.war", "beanvalidation10.*");
-        WebArchive beanvalidation_11War = buildDefaultApp("beanvalidation_11.war", "beanvalidation11.*");
+        ShrinkHelper.defaultDropinApp(server, "defaultbeanvalidation_10.war", "defaultbeanvalidation10.web.*");
+        ShrinkHelper.defaultDropinApp(server, "defaultbeanvalidation_11.war", "defaultbeanvalidation11.web.*");
+        WebArchive beanvalidation_10War = ShrinkHelper.buildDefaultApp("beanvalidation_10.war", "beanvalidation10.*");
+        WebArchive beanvalidation_11War = ShrinkHelper.buildDefaultApp("beanvalidation_11.war", "beanvalidation11.*");
 
         if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             beanvalidation_10War.move("/WEB-INF/constraints-house_EE9.xml", "/WEB-INF/constraints-house.xml");
             beanvalidation_11War.move("/WEB-INF/constraints-house_EE9.xml", "/WEB-INF/constraints-house.xml");
         }
 
-        exportToServer(server, "dropins", beanvalidation_10War);
-        exportToServer(server, "dropins", beanvalidation_11War);
+        ShrinkHelper.exportDropinAppToServer(server, beanvalidation_10War);
+        ShrinkHelper.exportDropinAppToServer(server, beanvalidation_11War);
     }
 
     public static void createAndExportApacheWARs(LibertyServer server) throws Exception {
-        defaultDropinApp(server, "ApacheBvalConfig_10.war", "beanvalidation.apachebvalconfig10.web");
-        defaultDropinApp(server, "ApacheBvalConfig_11.war", "beanvalidation.apachebvalconfig11.web");
+        ShrinkHelper.defaultDropinApp(server, "ApacheBvalConfig_10.war", "beanvalidation.apachebvalconfig10.web");
+        ShrinkHelper.defaultDropinApp(server, "ApacheBvalConfig_11.war", "beanvalidation.apachebvalconfig11.web");
     }
 
     public static void createAndExportCDIWARs(LibertyServer server) throws Exception {
-        defaultDropinApp(server, "BeanValidationCDI_11" + ".war", "beanvalidation.cdi.*");
-        defaultDropinApp(server, "DefaultBeanValidationCDI_11" + ".war", "defaultbeanvalidation.cdi.*");
+        ShrinkHelper.defaultDropinApp(server, "BeanValidationCDI_11" + ".war", "beanvalidation.cdi.*");
+        ShrinkHelper.defaultDropinApp(server, "DefaultBeanValidationCDI_11" + ".war", "defaultbeanvalidation.cdi.*");
     }
 
     public abstract LibertyServer getServer();

--- a/dev/com.ibm.ws.beanvalidation.v11_fat/fat/src/com/ibm/ws/beanvalidation/fat/ejb/EJBModule_Common.java
+++ b/dev/com.ibm.ws.beanvalidation.v11_fat/fat/src/com/ibm/ws/beanvalidation/fat/ejb/EJBModule_Common.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -52,14 +52,14 @@ public abstract class EJBModule_Common extends FATServletClient {
                         .addAsModule(war)
                         .addAsModule(jar);
         ShrinkHelper.addDirectory(ear, "test-applications/OneEJBModuleApp.ear/resources/");
-        ShrinkHelper.exportToServer(server, "dropins", ear);
+        ShrinkHelper.exportDropinAppToServer(server, ear);
 
         EnterpriseArchive ear2 = ShrinkWrap.create(EnterpriseArchive.class, "TwoEJBModulesApp.ear")
                         .addAsModule(war)
                         .addAsModule(jar)
                         .addAsModule(jar2);
         ShrinkHelper.addDirectory(ear2, "test-applications/TwoEJBModulesApp.ear/resources/");
-        ShrinkHelper.exportToServer(server, "dropins", ear2);
+        ShrinkHelper.exportDropinAppToServer(server, ear2);
     }
 
     protected abstract LibertyServer getServer();

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/fat/src/com/ibm/ws/bval/v20/fat/BeanVal20Test.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/fat/src/com/ibm/ws/bval/v20/fat/BeanVal20Test.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,7 +16,7 @@ import static com.ibm.websphere.simplicity.ShrinkHelper.addDirectory;
 import static com.ibm.websphere.simplicity.ShrinkHelper.buildDefaultApp;
 import static com.ibm.websphere.simplicity.ShrinkHelper.buildJavaArchive;
 import static com.ibm.websphere.simplicity.ShrinkHelper.defaultDropinApp;
-import static com.ibm.websphere.simplicity.ShrinkHelper.exportToServer;
+import static com.ibm.websphere.simplicity.ShrinkHelper.exportDropinAppToServer;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -84,7 +84,7 @@ public class BeanVal20Test extends FATServletClient {
                         .addAsModule(multipleValidationXmlEjb2_jar)
                         .addAsModule(multipleValidationXmlWeb_war);
         addDirectory(multiValXmlEar, "test-applications/MultipleValidationXmlEjb.ear/resources");
-        exportToServer(server, "dropins", multiValXmlEar);
+        exportDropinAppToServer(server, multiValXmlEar);
 
         defaultDropinApp(server, REG_APP, "bval.v20.web");
         defaultDropinApp(server, CDI_APP, "bval.v20.cdi.web");

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/fat/src/com/ibm/ws/concurrent/persistent/fat/compatibility/FatTestConcurrentCompatible.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/fat/src/com/ibm/ws/concurrent/persistent/fat/compatibility/FatTestConcurrentCompatible.java
@@ -17,12 +17,9 @@ import static org.junit.Assert.assertEquals;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -45,8 +42,6 @@ import componenttest.topology.utils.HttpUtils.HTTPRequestMethod;
 
 @RunWith(FATRunner.class)
 public class FatTestConcurrentCompatible extends CommonUtils {
-	
-    private static final Set<String> appNames = new TreeSet<String>(Arrays.asList("PersistExecComp"));
     
 	private static final String APP_NAME = "PersistentExecutor";
 
@@ -57,11 +52,10 @@ public class FatTestConcurrentCompatible extends CommonUtils {
 
     @BeforeClass
     public static void beforeSuite() throws Exception {
-    	//TODO using ShrinkHelper.defaultApp(server, APP_NAME, "com.ibm.test.servlet")
-    	//causes time out error waiting for app to start.
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                 .addPackage("com.ibm.test.servlet");
         ShrinkHelper.exportAppToServer(server, app);
+        
         //No need to start the server.  Each test will start the server when necessary.
     }
 
@@ -89,7 +83,6 @@ public class FatTestConcurrentCompatible extends CommonUtils {
         } else {
             server.setMarkToEndOfLog();
             server.setServerConfigurationFile("/config/disableTaskExecuteServer.xml");
-            server.waitForConfigUpdateInLogUsingMark(appNames);
         }
 
         // set default props

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/fat/src/com/ibm/ws/concurrent/persistent/fat/compatibility/FatTestConcurrentCompatible.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/fat/src/com/ibm/ws/concurrent/persistent/fat/compatibility/FatTestConcurrentCompatible.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -61,7 +61,7 @@ public class FatTestConcurrentCompatible extends CommonUtils {
     	//causes time out error waiting for app to start.
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                 .addPackage("com.ibm.test.servlet");
-        ShrinkHelper.exportToServer(server, "apps", app);
+        ShrinkHelper.exportAppToServer(server, app);
         //No need to start the server.  Each test will start the server when necessary.
     }
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/publish/files/config/disableTaskExecuteServer.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/publish/files/config/disableTaskExecuteServer.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -44,7 +44,7 @@
       <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
     </library>
     
-   <application id="PersistentExecutorCompatibility" name="PersistExecComp" context-root="persist" type="war" location="PersistentExecutor.war"/>
+   <application id="PersistentExecutorCompatibility" context-root="persist" type="war" location="PersistentExecutor.war"/>
    
    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>  
 </server>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/publish/files/config/enableTaskExecuteServer.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/publish/files/config/enableTaskExecuteServer.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -44,7 +44,7 @@
       <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
     </library>
     
-   <application id="PersistentExecutorCompatibility" name="PersistExecComp" context-root="persist" type="war" location="PersistentExecutor.war"/>
+   <application id="PersistentExecutorCompatibility" context-root="persist" type="war" location="PersistentExecutor.war"/>
    
    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>  
 </server>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/publish/servers/com.ibm.ws.concurrent.persistent.fat.compatibility/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/publish/servers/com.ibm.ws.concurrent.persistent.fat.compatibility/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2012, 2019 IBM Corporation and others.
+    Copyright (c) 2012, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@
       <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
     </library>
     
-   <application id="PersistentExecutorCompatibility" name="PersistExecComp" context-root="persist" type="war" location="PersistentExecutor.war"/>
+   <application id="PersistentExecutorCompatibility" context-root="persist" type="war" location="PersistentExecutor.war"/>
    
    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>  
 </server>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo/fat/src/com/ibm/ws/concurrent/persistent/fat/demo/PersistentExecutorDemoTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo/fat/src/com/ibm/ws/concurrent/persistent/fat/demo/PersistentExecutorDemoTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -102,8 +102,7 @@ public class PersistentExecutorDemoTest extends FATServletClient {
     public static void setUp() throws Exception {
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackage("web");
-        ShrinkHelper.exportToServer(server, "dropins", app);
-        server.addInstalledAppForValidation(APP_NAME);
+        ShrinkHelper.exportDropinAppToServer(server, app);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiserver/fat/src/com/ibm/ws/concurrent/persistent/fat/multiserver/FATValidateConcurrentMultiserver.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiserver/fat/src/com/ibm/ws/concurrent/persistent/fat/multiserver/FATValidateConcurrentMultiserver.java
@@ -59,7 +59,7 @@ public class FATValidateConcurrentMultiserver {
     private static final LibertyServer server2 = FATSuite.server2;
     
     private static AtomicInteger taskNumber = new AtomicInteger(1);
-    private static final String APP_NAME = "webApps.war";
+    private static final String APP_NAME = "webApps";
 
     /**
      * Start Servers.
@@ -68,9 +68,9 @@ public class FATValidateConcurrentMultiserver {
      */
     @BeforeClass
     public static void beforeClass() throws Exception {
-        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME)
+        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                 .addPackage("com.ibm.test.servlet")
-                .addAsWebInfResource(new File("test-applications/" + APP_NAME + "/resources/WEB-INF/web.xml"));
+                .addAsWebInfResource(new File("test-applications/" + APP_NAME + ".war/resources/WEB-INF/web.xml"));
         ShrinkHelper.exportAppToServer(server1, app);
         ShrinkHelper.exportAppToServer(server2, app);
     	
@@ -185,7 +185,7 @@ public class FATValidateConcurrentMultiserver {
      * @throws IOException if an error occurs
      */
     protected StringBuilder runInServlet(LibertyServer server, String queryString) throws Exception {
-        URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/multiServer?" + queryString);
+        URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + APP_NAME + "?" + queryString);
         Log.info(getClass(), "runInServlet", "URL is " + url);
         HttpURLConnection con = (HttpURLConnection) url.openConnection();
         try {

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiserver/fat/src/com/ibm/ws/concurrent/persistent/fat/multiserver/FATValidateConcurrentMultiserver.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiserver/fat/src/com/ibm/ws/concurrent/persistent/fat/multiserver/FATValidateConcurrentMultiserver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -71,8 +71,8 @@ public class FATValidateConcurrentMultiserver {
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME)
                 .addPackage("com.ibm.test.servlet")
                 .addAsWebInfResource(new File("test-applications/" + APP_NAME + "/resources/WEB-INF/web.xml"));
-        ShrinkHelper.exportToServer(server1, "apps", app);
-        ShrinkHelper.exportToServer(server2, "apps", app);
+        ShrinkHelper.exportAppToServer(server1, app);
+        ShrinkHelper.exportAppToServer(server2, app);
     	
     	server1.startServer(true);
         server2.startServer(true);

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiserver/publish/servers/com.ibm.ws.concurrent.persistent.fat.multiserver.server1/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiserver/publish/servers/com.ibm.ws.concurrent.persistent.fat.multiserver.server1/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2014, 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@
 <jndiEntry jndiName="ActualDefaultPort" value="${bvt.prop.httpFAT_1}"/>
 
 
-  <application id="multiServer_ID" context-root="multiServer" name="multiServer" type="war" location="webApps.war"/>                    
+  <application id="multiServer_ID" type="war" location="webApps.war"/>                    
 
   <persistentExecutor jndiName="concurrent/myScheduler" taskStoreRef="DBTaskStore"/>
   <!--  Create database to be used by both servers for persistent executor -->

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiserver/publish/servers/com.ibm.ws.concurrent.persistent.fat.multiserver.server2/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiserver/publish/servers/com.ibm.ws.concurrent.persistent.fat.multiserver.server2/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2014, 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@
                 httpPort="${bvt.prop.HTTP_secondary}"
                 httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
 
-  <application id="multiServer_ID" context-root="multiServer" name="multiServer" type="war" location="webApps.war"/>                  
+  <application id="multiServer_ID" type="war" location="webApps.war"/>                  
   
   <persistentExecutor jndiName="concurrent/myScheduler" taskStoreRef="DBTaskStore"/>
   <!-- Create Derby Net Client datasource. Note no create statement. DB should be created by Server 1 -->

--- a/dev/com.ibm.ws.concurrent_fat_demo/fat/src/test/concurrent/ShippingEstimateDemoTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_demo/fat/src/test/concurrent/ShippingEstimateDemoTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -39,8 +39,7 @@ public class ShippingEstimateDemoTest extends FATServletClient {
     public static void setUp() throws Exception {
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackage("com.ibm.example");
-        ShrinkHelper.exportToServer(server, "dropins", app);
-        server.addInstalledAppForValidation(APP_NAME);
+        ShrinkHelper.exportDropinAppToServer(server, app);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.concurrent_fat_ejb/fat/src/com/ibm/ws/concurrent/ejb/fat/ConcurrentEJBTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_ejb/fat/src/com/ibm/ws/concurrent/ejb/fat/ConcurrentEJBTest.java
@@ -60,8 +60,7 @@ public class ConcurrentEJBTest extends FATServletClient {
                         .addPackage("web")
                         .addPackage("ejb")
                         .addAsWebInfResource(new File("test-applications/" + APP_NAME + "/resources/WEB-INF/web.xml"));
-        ShrinkHelper.exportToServer(server, "dropins", app);
-        server.addInstalledAppForValidation(APP_NAME);
+        ShrinkHelper.exportDropinAppToServer(server, app);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.concurrent_fat_policy/fat/src/com/ibm/ws/concurrent/policy/fat/ConcurrentPolicyExecutorTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_policy/fat/src/com/ibm/ws/concurrent/policy/fat/ConcurrentPolicyExecutorTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -43,8 +43,7 @@ public class ConcurrentPolicyExecutorTest extends FATServletClient {
     public static void setUp() throws Exception {
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackage("web");
-        ShrinkHelper.exportToServer(server, "dropins", app);
-        server.addInstalledAppForValidation(APP_NAME);
+        ShrinkHelper.exportDropinAppToServer(server, app);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.jca.1.7_fat/fat/src/com/ibm/ws/jca/fat/JCA17Test.java
+++ b/dev/com.ibm.ws.jca.1.7_fat/fat/src/com/ibm/ws/jca/fat/JCA17Test.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -95,9 +95,7 @@ public class JCA17Test extends FATServletClient {
         ShrinkHelper.exportToServer(server, "connectors", fvtra);
         ShrinkHelper.exportToServer(server, "connectors", helloworldra);
         ShrinkHelper.exportToServer(server, "connectors", helloworldbeanra);
-        ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
-
-        server.addInstalledAppForValidation("fvtapp");
+        ShrinkHelper.exportAppToServer(server, fvtapp_ear);
 
         server.startServer();
 

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/ConnectionManagerMBeanTest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/ConnectionManagerMBeanTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -95,7 +95,7 @@ public class ConnectionManagerMBeanTest extends FATServletClient {
         EnterpriseArchive fvtapp_ear = ShrinkWrap.create(EnterpriseArchive.class, fvtapp + ".ear");
         fvtapp_ear.addAsModule(fvtweb_war);
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/fvtapp");
-        ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
+        ShrinkHelper.exportAppToServer(server, fvtapp_ear);
 
         if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             /*
@@ -117,7 +117,6 @@ public class ConnectionManagerMBeanTest extends FATServletClient {
         }
 
         originalServerConfig = server.getServerConfiguration().clone();
-        server.addInstalledAppForValidation(fvtapp);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/DependantApplicationTest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/DependantApplicationTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -122,7 +122,7 @@ public class DependantApplicationTest extends FATServletClient {
         EnterpriseArchive fvtapp_ear = ShrinkWrap.create(EnterpriseArchive.class, fvtapp + ".ear");
         fvtapp_ear.addAsModule(fvtweb_war);
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/fvtapp");
-        ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
+        ShrinkHelper.exportAppToServer(server, fvtapp_ear);
 
         if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             /*
@@ -144,7 +144,6 @@ public class DependantApplicationTest extends FATServletClient {
         }
 
         originalServerConfig = server.getServerConfiguration().clone();
-        server.addInstalledAppForValidation(fvtapp);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/JCATest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/JCATest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -87,7 +87,7 @@ public class JCATest extends FATServletClient {
         EnterpriseArchive fvtapp_ear = ShrinkWrap.create(EnterpriseArchive.class, fvtapp + ".ear");
         fvtapp_ear.addAsModule(fvtweb_war);
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/fvtapp");
-        ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
+        ShrinkHelper.exportAppToServer(server, fvtapp_ear);
 
         if (JakartaEE9Action.isActive() || JakartaEE10Action.isActive()) {
             /*
@@ -108,7 +108,6 @@ public class JCATest extends FATServletClient {
             server.updateServerConfiguration(clone);
         }
 
-        server.addInstalledAppForValidation(fvtapp);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/regr/JCAFATTest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/regr/JCAFATTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011,2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -92,7 +92,7 @@ public abstract class JCAFATTest {
      * Utility method to search for a clear text passwords
      *
      * @throws Exception
-     *             if occurrences found
+     *                       if occurrences found
      */
     protected void checkForTextPasswordsInLogs() throws Exception {
         List<String> uncheckedMatches = new ArrayList<String>();
@@ -134,13 +134,13 @@ public abstract class JCAFATTest {
      * checkForTextPasswordsInLogs()
      *
      * @param server
-     *            the server
+     *                              the server
      * @param excludeTraceNames
-     *            a list of Strings that the password check will use to ignore
-     *            instances of a password found if the line also contains a
-     *            string in the exclude list
+     *                              a list of Strings that the password check will use to ignore
+     *                              instances of a password found if the line also contains a
+     *                              string in the exclude list
      * @throws Exception
-     *             if occurrences found
+     *                       if occurrences found
      */
     protected static void activatePasswordCheck(List<String> excludeTraceNames) throws Exception {
         String method = "activatePasswordCheck";
@@ -185,12 +185,12 @@ public abstract class JCAFATTest {
      * Utility method to run a test on a JCA FAT servlet.
      *
      * @param servlet
-     *            Name of servlet to run test on
+     *                    Name of servlet to run test on
      * @param test
-     *            Test name to supply as an argument to the servlet
+     *                    Test name to supply as an argument to the servlet
      * @return output of the servlet
      * @throws IOException
-     *             if an error occurs
+     *                         if an error occurs
      */
     protected StringBuilder runInJCAFATServlet(String warFile, String servlet,
                                                String test) throws Exception {
@@ -279,6 +279,6 @@ public abstract class JCAFATTest {
         EnterpriseArchive fvtapp_ear = ShrinkWrap.create(EnterpriseArchive.class, fvtapp + ".ear");
         fvtapp_ear.addAsModules(fvtweb_war, JCAFAT1_rar);
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/fvtapp_regr");
-        ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
+        ShrinkHelper.exportAppToServer(server, fvtapp_ear);
     }
 }

--- a/dev/com.ibm.ws.jca_fat_bvt.jms/fat/src/test/jca/jms/example/tests/JCAStoreSampleAppTest.java
+++ b/dev/com.ibm.ws.jca_fat_bvt.jms/fat/src/test/jca/jms/example/tests/JCAStoreSampleAppTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -43,7 +43,7 @@ public class JCAStoreSampleAppTest extends FATServletClient {
         fvtweb_war.addPackage("test.jca.jms.example.mdb");
         fvtweb_war.addPackage("test.jca.jms.example.web");
         fvtweb_war.addAsWebInfResource(new File("test-applications/" + WAR_NAME + "/resources/WEB-INF/web.xml"));
-        ShrinkHelper.exportToServer(server, "apps", fvtweb_war);
+        ShrinkHelper.exportAppToServer(server, fvtweb_war);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.jca_fat_bvt/fat/src/test/client/jca/JCABVTTest.java
+++ b/dev/com.ibm.ws.jca_fat_bvt/fat/src/test/client/jca/JCABVTTest.java
@@ -56,8 +56,7 @@ public class JCABVTTest extends FATServletClient {
                         .addAsWebInfResource(new File("test-applications/bvtapp/resources/WEB-INF/web.xml"))
                         .addAsWebInfResource(new File("test-applications/bvtapp/resources/WEB-INF/ibm-web-bnd.xml"))
                         .addAsWebInfResource(new File("test-applications/bvtapp/resources/WEB-INF/ibm-ejb-jar-bnd.xml"));
-        ShrinkHelper.exportToServer(server, "dropins", war);
-        server.addInstalledAppForValidation("bvtapp");
+        ShrinkHelper.exportDropinAppToServer(server, war);
 
         ResourceAdapterArchive rar1 = ShrinkWrap.create(ResourceAdapterArchive.class, "JCARAR1.rar")
                         .addAsLibraries(ShrinkWrap.create(JavaArchive.class)

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterSecurityTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterSecurityTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -56,7 +57,7 @@ public class DerbyResourceAdapterSecurityTest extends FATServletClient {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP + ".ear");
         ear.addAsModule(war);
         ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/derbyRAApp");
-        ShrinkHelper.exportAppToServer(server, ear);
+        ShrinkHelper.exportAppToServer(server, ear, DeployOptions.SERVER_ONLY);
 
         ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, RAR_NAME + ".rar");
         rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterSecurityTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterSecurityTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -56,7 +56,7 @@ public class DerbyResourceAdapterSecurityTest extends FATServletClient {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP + ".ear");
         ear.addAsModule(war);
         ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/derbyRAApp");
-        ShrinkHelper.exportToServer(server, "apps", ear);
+        ShrinkHelper.exportAppToServer(server, ear);
 
         ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "DerbyRA.rar");
         rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterSecurityTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterSecurityTest.java
@@ -38,7 +38,7 @@ public class DerbyResourceAdapterSecurityTest extends FATServletClient {
 
     private static final String APP = "derbyRAApp";
     private static final String WAR_NAME = "fvtweb";
-    private static final String derbyRAAppName = "derbyRAAppName";
+    private static final String RAR_NAME = "DerbyRA";
     private static final String DerbyRAServlet = "fvtweb/DerbyRAServlet";
     private static final String DerbyRAAnnoServlet = "fvtweb/DerbyRAAnnoServlet";
 
@@ -58,7 +58,7 @@ public class DerbyResourceAdapterSecurityTest extends FATServletClient {
         ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/derbyRAApp");
         ShrinkHelper.exportAppToServer(server, ear);
 
-        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "DerbyRA.rar");
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, RAR_NAME + ".rar");
         rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");
         rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml"));
         rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/wlp-ra.xml"));
@@ -74,7 +74,6 @@ public class DerbyResourceAdapterSecurityTest extends FATServletClient {
 
         server.addEnvVar("PERMISSION", (JakartaEE9Action.isActive()
                                         || JakartaEE10Action.isActive()) ? "jakarta.resource.spi.security.PasswordCredential" : "javax.resource.spi.security.PasswordCredential");
-        server.addInstalledAppForValidation(derbyRAAppName);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -63,7 +63,7 @@ public class DerbyResourceAdapterTest extends FATServletClient {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP + ".ear");
         ear.addAsModule(war);
         ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/derbyRAApp");
-        ShrinkHelper.exportToServer(server, "apps", ear);
+        ShrinkHelper.exportAppToServer(server, ear);
 
         ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "DerbyRA.rar");
         rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -41,8 +41,8 @@ public class DerbyResourceAdapterTest extends FATServletClient {
 
     private static final String APP = "derbyRAApp";
     private static final String WAR_NAME = "fvtweb";
+    private static final String RAR_NAME = "DerbyRA";
 
-    private static final String derbyRAAppName = "derbyRAAppName";
     private static final String DerbyRAAnnoServlet = "fvtweb/DerbyRAAnnoServlet";
     private static final String DerbyRACFDServlet = "fvtweb/DerbyRACFDServlet";
     private static final String DerbyRAServlet = "fvtweb/DerbyRAServlet";
@@ -65,7 +65,7 @@ public class DerbyResourceAdapterTest extends FATServletClient {
         ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/derbyRAApp");
         ShrinkHelper.exportAppToServer(server, ear);
 
-        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "DerbyRA.rar");
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, RAR_NAME + ".rar");
         rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");
         rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml"));
         rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/wlp-ra.xml"));
@@ -76,7 +76,6 @@ public class DerbyResourceAdapterTest extends FATServletClient {
 
         server.addEnvVar("PERMISSION", (JakartaEE9Action.isActive()
                                         || JakartaEE10Action.isActive()) ? "jakarta.resource.spi.security.PasswordCredential" : "javax.resource.spi.security.PasswordCredential");
-        server.addInstalledAppForValidation(derbyRAAppName);
         server.startServer();
 
         FATServletClient.runTest(server, DerbyRAServlet, "initDatabaseTables");

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
@@ -63,7 +64,7 @@ public class DerbyResourceAdapterTest extends FATServletClient {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP + ".ear");
         ear.addAsModule(war);
         ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/derbyRAApp");
-        ShrinkHelper.exportAppToServer(server, ear);
+        ShrinkHelper.exportAppToServer(server, ear, DeployOptions.SERVER_ONLY);
 
         ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, RAR_NAME + ".rar");
         rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/LoginModuleInStandaloneResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/LoginModuleInStandaloneResourceAdapterTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -56,7 +57,7 @@ public class LoginModuleInStandaloneResourceAdapterTest extends FATServletClient
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP + ".ear");
         ear.addAsModule(war);
         ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/derbyRAApp");
-        ShrinkHelper.exportAppToServer(server, ear);
+        ShrinkHelper.exportAppToServer(server, ear, DeployOptions.SERVER_ONLY);
 
         ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, RAR_NAME + ".rar");
         rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/LoginModuleInStandaloneResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/LoginModuleInStandaloneResourceAdapterTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -55,7 +55,7 @@ public class LoginModuleInStandaloneResourceAdapterTest extends FATServletClient
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP + ".ear");
         ear.addAsModule(war);
         ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/derbyRAApp");
-        ShrinkHelper.exportToServer(server, "apps", ear);
+        ShrinkHelper.exportAppToServer(server, ear);
 
         ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "DerbyLMRA.rar");
         rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/LoginModuleInStandaloneResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/LoginModuleInStandaloneResourceAdapterTest.java
@@ -38,6 +38,7 @@ public class LoginModuleInStandaloneResourceAdapterTest extends FATServletClient
 
     private static final String APP = "derbyRAApp";
     private static final String WAR_NAME = "fvtweb";
+    private static final String RAR_NAME = "DerbyLMRA";
     private static final String DerbyRAServlet = "fvtweb/DerbyRAServlet";
     private static final String DerbyRAAnnoServlet = "fvtweb/DerbyRAAnnoServlet";
 
@@ -57,7 +58,7 @@ public class LoginModuleInStandaloneResourceAdapterTest extends FATServletClient
         ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/derbyRAApp");
         ShrinkHelper.exportAppToServer(server, ear);
 
-        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "DerbyLMRA.rar");
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, RAR_NAME + ".rar");
         rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");
         rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml"));
         rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/permissions.xml"));
@@ -72,7 +73,6 @@ public class LoginModuleInStandaloneResourceAdapterTest extends FATServletClient
 
         server.addEnvVar("PERMISSION", (JakartaEE9Action.isActive()
                                         || JakartaEE10Action.isActive()) ? "jakarta.resource.spi.security.PasswordCredential" : "javax.resource.spi.security.PasswordCredential");
-        server.addInstalledAppForValidation(APP);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/server.xml
@@ -24,7 +24,7 @@
 
     <variable name="onError" value="FAIL"/>
 
-    <application location="derbyRAApp.ear"/>
+    <application id="derbyRAApp" location="derbyRAApp.ear"/>
 
     <resourceAdapter id="DerbyLMRA" location="${server.config.dir}/connectors/DerbyLMRA.rar"/>
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.security/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.security/server.xml
@@ -52,7 +52,7 @@
     <!-- "APP" is the default schema for Derby -->
     <authData id="APP" user="APP" password="{aes}APb9ZaYzUL+JsfFD/OOBGaPM0evjmx5AnvmzbaKgffyX"/>
 
-    <application type="ear" id="derbyRAApp" name="${id}Name" location="derbyRAApp.ear"/>
+    <application type="ear" id="derbyRAApp" location="derbyRAApp.ear"/>
     
     <!-- 
     NOTE: for this bucket to run cleanly with j2sec enabled with IBM JDK, the following permission must 

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
@@ -72,7 +72,7 @@
     <!-- "APP" is the default schema for Derby -->
     <authData id="APP" user="APP" password="{aes}APb9ZaYzUL+JsfFD/OOBGaPM0evjmx5AnvmzbaKgffyX"/>
 
-    <application type="ear" id="derbyRAApp" name="${id}Name" location="derbyRAApp.ear"/>
+    <application type="ear" id="derbyRAApp" location="derbyRAApp.ear"/>
 
     <transaction heuristicRetryInterval="2"/>
 

--- a/dev/com.ibm.ws.jca_fat_dynamicConfig/fat/src/com/ibm/ws/jca/fat/dynamicConfig/DynaCfgTest.java
+++ b/dev/com.ibm.ws.jca_fat_dynamicConfig/fat/src/com/ibm/ws/jca/fat/dynamicConfig/DynaCfgTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -98,7 +98,7 @@ public class DynaCfgTest extends FATServletClient {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, dynamicConfigTestAppName + ".ear")
                         .addAsModule(war);
         ShrinkHelper.addDirectory(ear, "test-applications/dynaCfgTestApp/resources");
-        ShrinkHelper.exportToServer(server, "apps", ear);
+        ShrinkHelper.exportAppToServer(server, ear);
 
         //Create rar
         ShrinkHelper.defaultRar(server, dynamicConfigTestRarName, "com.ibm.test.dynamicconfigadapter");

--- a/dev/com.ibm.ws.jca_fat_enterpriseApp/fat/src/com/ibm/ws/jca/fat/enterpriseApp/EnterpriseAppTest.java
+++ b/dev/com.ibm.ws.jca_fat_enterpriseApp/fat/src/com/ibm/ws/jca/fat/enterpriseApp/EnterpriseAppTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -64,11 +64,10 @@ public class EnterpriseAppTest extends FATServletClient {
         ear.addAsModule(rar);
         ear.addAsModule(lmrar);
         ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/enterpriseApp");
-        ShrinkHelper.exportToServer(server, "apps", ear);
+        ShrinkHelper.exportAppToServer(server, ear);
 
         server.addEnvVar("PERMISSION", (JakartaEE9Action.isActive()
                                         || JakartaEE10Action.isActive()) ? "jakarta.resource.spi.security.PasswordCredential" : "javax.resource.spi.security.PasswordCredential");
-        server.addInstalledAppForValidation(appName);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.jca_fat_example/fat/src/test/examplera/ResourceAdapterExampleTest.java
+++ b/dev/com.ibm.ws.jca_fat_example/fat/src/test/examplera/ResourceAdapterExampleTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012,2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
@@ -52,14 +53,13 @@ public class ResourceAdapterExampleTest extends FATServletClient {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "ExampleApp.ear")
                         .addAsModule(war)
                         .addAsManifestResource(new File("test-applications/ExampleApp/resources/META-INF/application.xml"));
-        ShrinkHelper.exportToServer(server, "dropins", ear);
-        server.addInstalledAppForValidation("ExampleApp");
+        ShrinkHelper.exportDropinAppToServer(server, ear);
 
         ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "ExampleRA.rar")
                         .addAsLibraries(ShrinkWrap.create(JavaArchive.class)
                                         .addPackage("com.ibm.example.jca.adapter"))
                         .addAsManifestResource(new File("test-resourceadapters/ExampleRA/resources/META-INF/ra.xml"));
-        ShrinkHelper.exportToServer(server, "dropins", rar);
+        ShrinkHelper.exportDropinAppToServer(server, rar, DeployOptions.DISABLE_VALIDATION);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.jca_fat_example_anno/fat/src/test/examplera/anno/ResourceAdapterExampleTest.java
+++ b/dev/com.ibm.ws.jca_fat_example_anno/fat/src/test/examplera/anno/ResourceAdapterExampleTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
@@ -43,13 +44,12 @@ public class ResourceAdapterExampleTest extends FATServletClient {
     public static void setup() throws Exception {
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackages(true, "web");
-        ShrinkHelper.exportToServer(server, "dropins", app);
-        server.addInstalledAppForValidation(APP_NAME);
+        ShrinkHelper.exportDropinAppToServer(server, app);
 
         ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "ExampleRA.rar")
                         .addAsLibraries(ShrinkWrap.create(JavaArchive.class)
                                         .addPackage("com.ibm.example.jca.anno"));
-        ShrinkHelper.exportToServer(server, "dropins", rar);
+        ShrinkHelper.exportDropinAppToServer(server, rar, DeployOptions.DISABLE_VALIDATION);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.jca_fat_mbean/fat/src/com/ibm/ws/jca/mbean/fat/app/ConnectionPoolStatsTest.java
+++ b/dev/com.ibm.ws.jca_fat_mbean/fat/src/com/ibm/ws/jca/mbean/fat/app/ConnectionPoolStatsTest.java
@@ -128,9 +128,8 @@ public class ConnectionPoolStatsTest {
         EnterpriseArchive fvtapp_ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
         fvtapp_ear.addAsModule(fvtweb_war);
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/" + APP_NAME);
-        ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
+        ShrinkHelper.exportAppToServer(server, fvtapp_ear);
 
-        server.addInstalledAppForValidation(APP_NAME);
         server.startServer();
     }
 
@@ -160,7 +159,7 @@ public class ConnectionPoolStatsTest {
     @Test
     public void testGetMaxConnectionsLimit() throws Exception {
         final String fvtweb = "fvtweb/ConnectionPoolStatsServlet";
-		// run test, check for 50 
+        // run test, check for 50
         runInServlet(testName.getMethodName(), fvtweb);
 
         // Dynamically change the maximum connections while server is running.

--- a/dev/com.ibm.ws.jca_fat_mbean/fat/src/com/ibm/ws/jca/mbean/fat/app/JCA_JDBC_JSR77_MBeanTest.java
+++ b/dev/com.ibm.ws.jca_fat_mbean/fat/src/com/ibm/ws/jca/mbean/fat/app/JCA_JDBC_JSR77_MBeanTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -124,9 +124,8 @@ public class JCA_JDBC_JSR77_MBeanTest {
         EnterpriseArchive fvtapp_ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
         fvtapp_ear.addAsModule(fvtweb_war);
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/" + APP_NAME);
-        ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
+        ShrinkHelper.exportAppToServer(server, fvtapp_ear);
 
-        server.addInstalledAppForValidation(APP_NAME);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.jca_fat_mbean/fat/src/com/ibm/ws/jca/mbean/fat/app/JCA_JDBC_JSR77_MBean_ExtendedTest.java
+++ b/dev/com.ibm.ws.jca_fat_mbean/fat/src/com/ibm/ws/jca/mbean/fat/app/JCA_JDBC_JSR77_MBean_ExtendedTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -102,9 +102,8 @@ public class JCA_JDBC_JSR77_MBean_ExtendedTest {
         EnterpriseArchive fvtapp_ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
         fvtapp_ear.addAsModule(fvtweb_war);
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/" + APP_NAME);
-        ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
+        ShrinkHelper.exportAppToServer(server, fvtapp_ear);
 
-        server.addInstalledAppForValidation(APP_NAME);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.jca_fat_mbean/fat/src/com/ibm/ws/jca/mbean/fat/app/JCA_JDBC_JSR77_MBean_MultipleTest.java
+++ b/dev/com.ibm.ws.jca_fat_mbean/fat/src/com/ibm/ws/jca/mbean/fat/app/JCA_JDBC_JSR77_MBean_MultipleTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -129,9 +129,8 @@ public class JCA_JDBC_JSR77_MBean_MultipleTest {
         EnterpriseArchive fvtapp_ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
         fvtapp_ear.addAsModule(fvtweb_war);
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/" + APP_NAME);
-        ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
+        ShrinkHelper.exportAppToServer(server, fvtapp_ear);
 
-        server.addInstalledAppForValidation(APP_NAME);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.jca_fat_regr.rar.beanVal/fat/src/suite/r80/base/jca16/TestSetupUtils.java
+++ b/dev/com.ibm.ws.jca_fat_regr.rar.beanVal/fat/src/suite/r80/base/jca16/TestSetupUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -66,7 +66,7 @@ public class TestSetupUtils {
             ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/" + app_name);
         }
 
-        ShrinkHelper.exportAppToServer(server, fvtapp_ear);
+        ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
     }
 
     public static JavaArchive getResourceAdapter_jar() {

--- a/dev/com.ibm.ws.jca_fat_regr.rar.beanVal/fat/src/suite/r80/base/jca16/TestSetupUtils.java
+++ b/dev/com.ibm.ws.jca_fat_regr.rar.beanVal/fat/src/suite/r80/base/jca16/TestSetupUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -66,7 +66,7 @@ public class TestSetupUtils {
             ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/" + app_name);
         }
 
-        ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
+        ShrinkHelper.exportAppToServer(server, fvtapp_ear);
     }
 
     public static JavaArchive getResourceAdapter_jar() {

--- a/dev/com.ibm.ws.jca_fat_regr.rar.beanVal/fat/src/suite/r80/base/jca16/jbv/RarBeanValidationTestCommon.java
+++ b/dev/com.ibm.ws.jca_fat_regr.rar.beanVal/fat/src/suite/r80/base/jca16/jbv/RarBeanValidationTestCommon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jca_fat_regr.rar.beanVal/fat/src/suite/r80/base/jca16/jbv/RarBeanValidationTestCommon.java
+++ b/dev/com.ibm.ws.jca_fat_regr.rar.beanVal/fat/src/suite/r80/base/jca16/jbv/RarBeanValidationTestCommon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -155,7 +155,7 @@ public abstract class RarBeanValidationTestCommon extends FATServletClient {
         EnterpriseArchive sampleapp_jca16_jbv_embeddedra_ear = ShrinkWrap.create(EnterpriseArchive.class, RarTests.sampleapp_jca16_jbv_embeddedraApp + ".ear");
         sampleapp_jca16_jbv_embeddedra_ear.addAsModules(jbvweb1_war, adapter_jca16_jbv_ResourceAdapterValidation_Embedded, jbv_no_xmls_ejb1_jar);
 
-        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_embeddedra_ear);
+        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_embeddedra_ear);
 
         //Package adapter_jca16_jbv_AdministeredObjectValidation_Success adapter_jca16_jbv_AdministeredObjectValidation_Success.rar
         JavaArchive resourceAdapterAdminObject_jar = ShrinkWrap.create(JavaArchive.class, "rarBeanResourceAdapterAdminObject.jar");
@@ -227,12 +227,12 @@ public abstract class RarBeanValidationTestCommon extends FATServletClient {
         EnterpriseArchive jvbapp_ear = ShrinkWrap.create(EnterpriseArchive.class, RarTests.Jbvapp + ".ear");
         jvbapp_ear.addAsModules(jvbweb_war);
         ShrinkHelper.addDirectory(jvbapp_ear, "lib/LibertyFATTestFiles/" + RarTests.Jbvapp);
-        ShrinkHelper.exportToServer(server, "apps", jvbapp_ear);
+        ShrinkHelper.exportAppToServer(server, jvbapp_ear);
 
         EnterpriseArchive sampleapp_jca16_jbv_embeddedao_ear = ShrinkWrap.create(EnterpriseArchive.class, RarTests.sampleapp_jca16_jbv_embeddedaoApp + ".ear");
         sampleapp_jca16_jbv_embeddedao_ear.addAsModules(jbvweb1_war, adapter_jca16_jbv_AdministeredObjectValidation_Embedded, jbv_no_xmls_ejb1_jar, jvbweb_war);
 
-        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_embeddedao_ear);
+        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_embeddedao_ear);
 
         //Package adapter_jca16_jbv_ActivationSpecValidation_Success adapter_jca16_jbv_ActivationSpecValidation_Success.rar
         JavaArchive resourceAdapterActivSpecResourceAdapter_jar = ShrinkWrap.create(JavaArchive.class, "ResourceAdapterActivSpecResourceAdapter.jar");
@@ -314,13 +314,13 @@ public abstract class RarBeanValidationTestCommon extends FATServletClient {
         EnterpriseArchive sampleapp_jca16_jbv_embeddedas_ear = ShrinkWrap.create(EnterpriseArchive.class, RarTests.sampleapp_jca16_jbv_embeddedasApp + ".ear");
         sampleapp_jca16_jbv_embeddedas_ear.addAsModules(rar10, jbv_no_override_ejb2_jar, jvbweb_war);
 
-        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_embeddedas_ear);
+        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_embeddedas_ear);
 
         EnterpriseArchive sampleapp_jca16_jbv_standaloneassuccess_ear = ShrinkWrap.create(EnterpriseArchive.class,
                                                                                           RarTests.sampleapp_jca16_jbv_standaloneassuccessApp + ".ear");
         sampleapp_jca16_jbv_standaloneassuccess_ear.addAsModules(jbv_no_override_ejb2_jar);
 
-        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_standaloneassuccess_ear);
+        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_standaloneassuccess_ear);
 
         //Package adapter_jca16_jbv_ManagedConnectionFactoryValidation_Success adapter_jca16_jbv_ManagedConnectionFactoryValidation_Success.rar
         JavaArchive managedConnectionFactoryValidation_Success_jar = ShrinkWrap.create(JavaArchive.class, "ManagedConnectionFactoryValidation_Success.jar");
@@ -357,7 +357,7 @@ public abstract class RarBeanValidationTestCommon extends FATServletClient {
                                                                                                        RarTests.sampleapp_jca16_jbv_embeddedraApp + ".ear");
         adapter_jca16_jbv_ResourceAdapterValidation_Embedded_ear.addAsModules(jbvweb1_war, adapter_jca16_jbv_ResourceAdapterValidation_Embedded, jbv_no_xmls_ejb1_jar);
 
-        ShrinkHelper.exportToServer(server, "apps", adapter_jca16_jbv_ResourceAdapterValidation_Embedded_ear);
+        ShrinkHelper.exportAppToServer(server, adapter_jca16_jbv_ResourceAdapterValidation_Embedded_ear);
 
         JavaArchive jbv_ejb1_jar = ShrinkWrap.create(JavaArchive.class, JBV_EJB1_JAR_NAME + ".jar");
         jbv_ejb1_jar.addPackage("ejb");
@@ -368,18 +368,18 @@ public abstract class RarBeanValidationTestCommon extends FATServletClient {
         EnterpriseArchive sampleapp_jca16_jbv_embeddedra_ejbvalconfig_ear = ShrinkWrap.create(EnterpriseArchive.class,
                                                                                               RarTests.sampleapp_jca16_jbv_embeddedra_ejbvalconfigApp + ".ear");
         sampleapp_jca16_jbv_embeddedra_ejbvalconfig_ear.addAsModules(jbvweb1_war, adapter_jca16_jbv_ResourceAdapterValidation_Embedded, jbv_ejb1_jar);
-        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_embeddedra_ejbvalconfig_ear);
+        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_embeddedra_ejbvalconfig_ear);
 
         EnterpriseArchive sampleapp_jca16_jbv_embeddedravalconfig_ejb = ShrinkWrap.create(EnterpriseArchive.class,
                                                                                           RarTests.sampleapp_jca16_jbv_embeddedravalconfig_ejbApp + ".ear");
         sampleapp_jca16_jbv_embeddedravalconfig_ejb.addAsModules(jbvweb1_war, adapter_jca16_jbv_ResourceAdapterValidation_Success, jbv_no_xmls_ejb1_jar);
-        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_embeddedravalconfig_ejb);
+        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_embeddedravalconfig_ejb);
 
         EnterpriseArchive sampleapp_jca16_jbv_embeddedravalconfig_ejbvalconfig_ear = ShrinkWrap.create(EnterpriseArchive.class,
                                                                                                        RarTests.sampleapp_jca16_jbv_embeddedravalconfig_ejbvalconfigApp
                                                                                                                                 + ".ear");
         sampleapp_jca16_jbv_embeddedravalconfig_ejbvalconfig_ear.addAsModules(jbvweb1_war, adapter_jca16_jbv_ResourceAdapterValidation_Success, jbv_ejb1_jar);
-        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_embeddedravalconfig_ejbvalconfig_ear);
+        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_embeddedravalconfig_ejbvalconfig_ear);
 
         JavaArchive jbv_ejb2_jar = ShrinkWrap.create(JavaArchive.class, "jbv_ejb2.jar");
         jbv_ejb2_jar.addPackages(true, "ejb1");
@@ -387,17 +387,17 @@ public abstract class RarBeanValidationTestCommon extends FATServletClient {
         EnterpriseArchive sampleapp_jca16_jbv_standaloneasfailure_ear = ShrinkWrap.create(EnterpriseArchive.class,
                                                                                           RarTests.sampleapp_jca16_jbv_standaloneasfailureApp + ".ear");
         sampleapp_jca16_jbv_standaloneasfailure_ear.addAsModules(jbv_ejb2_jar);
-        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_standaloneasfailure_ear);
+        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_standaloneasfailure_ear);
 
         EnterpriseArchive sampleapp_jca16_jbv_ejb_ear = ShrinkWrap.create(EnterpriseArchive.class,
                                                                           RarTests.sampleapp_jca16_jbv_ejbApp + ".ear");
         sampleapp_jca16_jbv_ejb_ear.addAsModules(jbvweb1_war, jbv_no_xmls_ejb1_jar);
-        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_ejb_ear);
+        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_ejb_ear);
 
         EnterpriseArchive sampleapp_jca16_jbv_ejbvalconfig_ear = ShrinkWrap.create(EnterpriseArchive.class,
                                                                                    RarTests.sampleapp_jca16_jbv_ejbvalconfigApp + ".ear");
         sampleapp_jca16_jbv_ejbvalconfig_ear.addAsModules(jbvweb1_war, jbv_ejb1_jar);
-        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_ejbvalconfig_ear);
+        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_ejbvalconfig_ear);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jca_fat_regr.rar.beanVal/fat/src/suite/r80/base/jca16/jbv/RarBeanValidationTestCommon.java
+++ b/dev/com.ibm.ws.jca_fat_regr.rar.beanVal/fat/src/suite/r80/base/jca16/jbv/RarBeanValidationTestCommon.java
@@ -155,7 +155,7 @@ public abstract class RarBeanValidationTestCommon extends FATServletClient {
         EnterpriseArchive sampleapp_jca16_jbv_embeddedra_ear = ShrinkWrap.create(EnterpriseArchive.class, RarTests.sampleapp_jca16_jbv_embeddedraApp + ".ear");
         sampleapp_jca16_jbv_embeddedra_ear.addAsModules(jbvweb1_war, adapter_jca16_jbv_ResourceAdapterValidation_Embedded, jbv_no_xmls_ejb1_jar);
 
-        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_embeddedra_ear);
+        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_embeddedra_ear);
 
         //Package adapter_jca16_jbv_AdministeredObjectValidation_Success adapter_jca16_jbv_AdministeredObjectValidation_Success.rar
         JavaArchive resourceAdapterAdminObject_jar = ShrinkWrap.create(JavaArchive.class, "rarBeanResourceAdapterAdminObject.jar");
@@ -227,12 +227,12 @@ public abstract class RarBeanValidationTestCommon extends FATServletClient {
         EnterpriseArchive jvbapp_ear = ShrinkWrap.create(EnterpriseArchive.class, RarTests.Jbvapp + ".ear");
         jvbapp_ear.addAsModules(jvbweb_war);
         ShrinkHelper.addDirectory(jvbapp_ear, "lib/LibertyFATTestFiles/" + RarTests.Jbvapp);
-        ShrinkHelper.exportAppToServer(server, jvbapp_ear);
+        ShrinkHelper.exportToServer(server, "apps", jvbapp_ear);
 
         EnterpriseArchive sampleapp_jca16_jbv_embeddedao_ear = ShrinkWrap.create(EnterpriseArchive.class, RarTests.sampleapp_jca16_jbv_embeddedaoApp + ".ear");
         sampleapp_jca16_jbv_embeddedao_ear.addAsModules(jbvweb1_war, adapter_jca16_jbv_AdministeredObjectValidation_Embedded, jbv_no_xmls_ejb1_jar, jvbweb_war);
 
-        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_embeddedao_ear);
+        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_embeddedao_ear);
 
         //Package adapter_jca16_jbv_ActivationSpecValidation_Success adapter_jca16_jbv_ActivationSpecValidation_Success.rar
         JavaArchive resourceAdapterActivSpecResourceAdapter_jar = ShrinkWrap.create(JavaArchive.class, "ResourceAdapterActivSpecResourceAdapter.jar");
@@ -314,13 +314,13 @@ public abstract class RarBeanValidationTestCommon extends FATServletClient {
         EnterpriseArchive sampleapp_jca16_jbv_embeddedas_ear = ShrinkWrap.create(EnterpriseArchive.class, RarTests.sampleapp_jca16_jbv_embeddedasApp + ".ear");
         sampleapp_jca16_jbv_embeddedas_ear.addAsModules(rar10, jbv_no_override_ejb2_jar, jvbweb_war);
 
-        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_embeddedas_ear);
+        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_embeddedas_ear);
 
         EnterpriseArchive sampleapp_jca16_jbv_standaloneassuccess_ear = ShrinkWrap.create(EnterpriseArchive.class,
                                                                                           RarTests.sampleapp_jca16_jbv_standaloneassuccessApp + ".ear");
         sampleapp_jca16_jbv_standaloneassuccess_ear.addAsModules(jbv_no_override_ejb2_jar);
 
-        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_standaloneassuccess_ear);
+        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_standaloneassuccess_ear);
 
         //Package adapter_jca16_jbv_ManagedConnectionFactoryValidation_Success adapter_jca16_jbv_ManagedConnectionFactoryValidation_Success.rar
         JavaArchive managedConnectionFactoryValidation_Success_jar = ShrinkWrap.create(JavaArchive.class, "ManagedConnectionFactoryValidation_Success.jar");
@@ -357,7 +357,7 @@ public abstract class RarBeanValidationTestCommon extends FATServletClient {
                                                                                                        RarTests.sampleapp_jca16_jbv_embeddedraApp + ".ear");
         adapter_jca16_jbv_ResourceAdapterValidation_Embedded_ear.addAsModules(jbvweb1_war, adapter_jca16_jbv_ResourceAdapterValidation_Embedded, jbv_no_xmls_ejb1_jar);
 
-        ShrinkHelper.exportAppToServer(server, adapter_jca16_jbv_ResourceAdapterValidation_Embedded_ear);
+        ShrinkHelper.exportToServer(server, "apps", adapter_jca16_jbv_ResourceAdapterValidation_Embedded_ear);
 
         JavaArchive jbv_ejb1_jar = ShrinkWrap.create(JavaArchive.class, JBV_EJB1_JAR_NAME + ".jar");
         jbv_ejb1_jar.addPackage("ejb");
@@ -368,18 +368,18 @@ public abstract class RarBeanValidationTestCommon extends FATServletClient {
         EnterpriseArchive sampleapp_jca16_jbv_embeddedra_ejbvalconfig_ear = ShrinkWrap.create(EnterpriseArchive.class,
                                                                                               RarTests.sampleapp_jca16_jbv_embeddedra_ejbvalconfigApp + ".ear");
         sampleapp_jca16_jbv_embeddedra_ejbvalconfig_ear.addAsModules(jbvweb1_war, adapter_jca16_jbv_ResourceAdapterValidation_Embedded, jbv_ejb1_jar);
-        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_embeddedra_ejbvalconfig_ear);
+        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_embeddedra_ejbvalconfig_ear);
 
         EnterpriseArchive sampleapp_jca16_jbv_embeddedravalconfig_ejb = ShrinkWrap.create(EnterpriseArchive.class,
                                                                                           RarTests.sampleapp_jca16_jbv_embeddedravalconfig_ejbApp + ".ear");
         sampleapp_jca16_jbv_embeddedravalconfig_ejb.addAsModules(jbvweb1_war, adapter_jca16_jbv_ResourceAdapterValidation_Success, jbv_no_xmls_ejb1_jar);
-        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_embeddedravalconfig_ejb);
+        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_embeddedravalconfig_ejb);
 
         EnterpriseArchive sampleapp_jca16_jbv_embeddedravalconfig_ejbvalconfig_ear = ShrinkWrap.create(EnterpriseArchive.class,
                                                                                                        RarTests.sampleapp_jca16_jbv_embeddedravalconfig_ejbvalconfigApp
                                                                                                                                 + ".ear");
         sampleapp_jca16_jbv_embeddedravalconfig_ejbvalconfig_ear.addAsModules(jbvweb1_war, adapter_jca16_jbv_ResourceAdapterValidation_Success, jbv_ejb1_jar);
-        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_embeddedravalconfig_ejbvalconfig_ear);
+        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_embeddedravalconfig_ejbvalconfig_ear);
 
         JavaArchive jbv_ejb2_jar = ShrinkWrap.create(JavaArchive.class, "jbv_ejb2.jar");
         jbv_ejb2_jar.addPackages(true, "ejb1");
@@ -387,17 +387,17 @@ public abstract class RarBeanValidationTestCommon extends FATServletClient {
         EnterpriseArchive sampleapp_jca16_jbv_standaloneasfailure_ear = ShrinkWrap.create(EnterpriseArchive.class,
                                                                                           RarTests.sampleapp_jca16_jbv_standaloneasfailureApp + ".ear");
         sampleapp_jca16_jbv_standaloneasfailure_ear.addAsModules(jbv_ejb2_jar);
-        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_standaloneasfailure_ear);
+        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_standaloneasfailure_ear);
 
         EnterpriseArchive sampleapp_jca16_jbv_ejb_ear = ShrinkWrap.create(EnterpriseArchive.class,
                                                                           RarTests.sampleapp_jca16_jbv_ejbApp + ".ear");
         sampleapp_jca16_jbv_ejb_ear.addAsModules(jbvweb1_war, jbv_no_xmls_ejb1_jar);
-        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_ejb_ear);
+        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_ejb_ear);
 
         EnterpriseArchive sampleapp_jca16_jbv_ejbvalconfig_ear = ShrinkWrap.create(EnterpriseArchive.class,
                                                                                    RarTests.sampleapp_jca16_jbv_ejbvalconfigApp + ".ear");
         sampleapp_jca16_jbv_ejbvalconfig_ear.addAsModules(jbvweb1_war, jbv_ejb1_jar);
-        ShrinkHelper.exportAppToServer(server, sampleapp_jca16_jbv_ejbvalconfig_ear);
+        ShrinkHelper.exportToServer(server, "apps", sampleapp_jca16_jbv_ejbvalconfig_ear);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jca_fat_regr/fat/src/suite/r80/base/jca16/TestSetupUtils.java
+++ b/dev/com.ibm.ws.jca_fat_regr/fat/src/suite/r80/base/jca16/TestSetupUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,8 +65,7 @@ public class TestSetupUtils {
             gwcapp_ear.addAsModules(fvtweb_war, rar1);
             ShrinkHelper.addDirectory(gwcapp_ear, "lib/LibertyFATTestFiles/" + app_name);
         }
-        ShrinkHelper.exportToServer(server, "apps", gwcapp_ear);
-        server.addInstalledAppForValidation(app_name);
+        ShrinkHelper.exportAppToServer(server, gwcapp_ear);
     }
 
     public static void setUpFvtApp(LibertyServer server) throws Exception {
@@ -98,7 +97,7 @@ public class TestSetupUtils {
             ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/" + app_name);
         }
 
-        ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
+        ShrinkHelper.exportAppToServer(server, fvtapp_ear);
     }
 
     public static JavaArchive getResourceAdapter_jar() {
@@ -180,8 +179,7 @@ public class TestSetupUtils {
             annApp_ear.addAsModules(fvtweb_war);
             ShrinkHelper.addDirectory(annApp_ear, "lib/LibertyFATTestFiles/" + app_name);
         }
-        ShrinkHelper.exportToServer(server, "apps", annApp_ear);
-        server.addInstalledAppForValidation(app_name);
+        ShrinkHelper.exportAppToServer(server, annApp_ear);
     }
 
 }

--- a/dev/com.ibm.ws.jsonp_fat/fat/src/com/ibm/ws/jsonp/fat/BasicJSONPTest.java
+++ b/dev/com.ibm.ws.jsonp_fat/fat/src/com/ibm/ws/jsonp/fat/BasicJSONPTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014,2017 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -52,8 +52,7 @@ public class BasicJSONPTest extends FATServletClient {
         WebArchive customAppJSONPWAR = ShrinkWrap.create(WebArchive.class, "customAppJSONPWAR.war")
                         .addAsServiceProvider(javax.json.spi.JsonProvider.class, jsonp.app.custom.provider.JsonProviderImpl.class)
                         .addPackages(true, "jsonp.app.custom");
-        ShrinkHelper.exportToServer(server, "dropins", customAppJSONPWAR);
-        server.addInstalledAppForValidation("customAppJSONPWAR");
+        ShrinkHelper.exportDropinAppToServer(server, customAppJSONPWAR);
 
         JavaArchive customLibJSONPProvider = ShrinkWrap.create(JavaArchive.class, "customLibJSONPProvider.jar")
                         .addAsServiceProvider(javax.json.spi.JsonProvider.class, jsonp.lib.provider.JsonProviderImpl.class)
@@ -63,13 +62,11 @@ public class BasicJSONPTest extends FATServletClient {
         WebArchive customLibJSONPWAR = ShrinkWrap.create(WebArchive.class, "customLibJSONPWAR.war")
                         .addPackage("jsonp.lib.web");
         ShrinkHelper.exportAppToServer(server, customLibJSONPWAR);
-        server.addInstalledAppForValidation("customLibJSONPWAR");
 
         WebArchive jsonpWar = ShrinkWrap.create(WebArchive.class, APP_JSONP + ".war")
                         .addAsWebInfResource(new File("test-applications/JSONPWAR.war/resources/WEB-INF/json_read_test_data.js"))
                         .addPackage("jsonp.app.web");
-        ShrinkHelper.exportToServer(server, "dropins", jsonpWar);
-        server.addInstalledAppForValidation(APP_JSONP);
+        ShrinkHelper.exportDropinAppToServer(server, jsonpWar);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.jsonp_fat/fat/src/com/ibm/ws/jsonp/fat/CustomFeatureJSONPTest.java
+++ b/dev/com.ibm.ws.jsonp_fat/fat/src/com/ibm/ws/jsonp/fat/CustomFeatureJSONPTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014,2017 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -45,8 +45,7 @@ public class CustomFeatureJSONPTest extends FATServletClient {
 
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackages(true, "jsonp.app.feature.web");
-        ShrinkHelper.exportToServer(server, "dropins", app);
-        server.addInstalledAppForValidation(APP_NAME);
+        ShrinkHelper.exportDropinAppToServer(server, app);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.org.apache.servicemix.bundles.bcel/.project
+++ b/dev/com.ibm.ws.org.apache.servicemix.bundles.bcel/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.ws.org.apache.servicemix.bundles.bcel</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.ws.org.cyberneko.html/.project
+++ b/dev/com.ibm.ws.org.cyberneko.html/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.ws.org.cyberneko.html</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ShrinkHelper.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ShrinkHelper.java
@@ -82,10 +82,6 @@ public class ShrinkHelper {
      * autoFVT/publish/... and wlp/usr/...
      */
     public static void exportToServer(LibertyServer server, String path, Archive<?> a, DeployOptions... options) throws Exception {
-        if (path == "dropins" || path == "apps") {
-            Log.warning(c, "Consider using 'exportAppToServer' or 'exportDropinAppToServer' when copying an Application "
-                           + "these methods will automatically add the application for validation on server startup.");
-        }
         String localLocation;
         if (serverOnly(options)) {
             localLocation = getTmpLocation(a);

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ShrinkHelper.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ShrinkHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -82,6 +82,10 @@ public class ShrinkHelper {
      * autoFVT/publish/... and wlp/usr/...
      */
     public static void exportToServer(LibertyServer server, String path, Archive<?> a, DeployOptions... options) throws Exception {
+        if (path == "dropins" || path == "apps") {
+            Log.warning(c, "Consider using 'exportAppToServer' or 'exportDropinAppToServer' when copying an Application "
+                           + "these methods will automatically add the application for validation on server startup.");
+        }
         String localLocation;
         if (serverOnly(options)) {
             localLocation = getTmpLocation(a);

--- a/dev/io.openliberty.security.3.0.internal/.project
+++ b/dev/io.openliberty.security.3.0.internal/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.security.3.0.internal</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
Not all applications being deployed during the Bean Validation test suite are validated prior to testing. 
That means that in cases of slow test infrastructure, the application could still be in the process of being installed, while tests are trying to perform HTTP requests to the server. 

Switch from using `exportToServer` to `exportDropinAppToServer` which performs validation