### PR TITLE
OIDC PKCE: Make code verifier longest allowed length (128 characters)

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/ProofKeyForCodeExchange.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/ProofKeyForCodeExchange.java
@@ -35,7 +35,7 @@ public class ProofKeyForCodeExchange {
      */
     public static String generateCodeVerifier() {
         SecureRandom random = new SecureRandom();
-        byte verifierBytes[] = new byte[32];
+        byte verifierBytes[] = new byte[96];
         random.nextBytes(verifierBytes);
         String codeVerifier = new String(Base64.getUrlEncoder().encode(verifierBytes));
         codeVerifier = codeVerifier.replaceAll("[=]+$", "");


### PR DESCRIPTION
Update the code verifier generated by Liberty to be 128 characters long - the maximum allowed by the PKCE specification.