### PR TITLE
Adding servlet-3.1 to tested features

### DIFF
--- a/dev/com.ibm.ws.logging_2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.logging_2_fat/bnd.bnd
@@ -22,6 +22,9 @@ src: \
 
 fat.project: true
 
+tested.features:\
+	servlet-3.1
+
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	org.hamcrest:hamcrest-all;version=1.3, \


### PR DESCRIPTION
Resolving a build break
` Installed feature(s) [servlet-3.1] were not defined in the autoFVT/fat-metadata.json file! To correct this, add [servlet-3.1] to the 'tested.features' property in the bnd.bnd or build-test.xml file for this FAT so that an accurate test depdendency graph can be generated in the future.`