### PR TITLE
hash details in oidc session cookie

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/BackchannelLogoutHelper.java
@@ -21,6 +21,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.productinfo.ProductInfo;
+import com.ibm.ws.security.oauth20.util.HashUtils;
 import com.ibm.ws.security.openidconnect.backchannellogout.internal.LogoutTokenValidator;
 import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
 import com.ibm.ws.security.openidconnect.clients.common.OidcSessionCache;
@@ -89,8 +90,8 @@ public class BackchannelLogoutHelper {
 
     void performLogout(JwtClaims logoutTokenClaims) throws BackchannelLogoutException {
         try {
-            String sub = logoutTokenClaims.getSubject();
-            String sid = logoutTokenClaims.getClaimValue("sid", String.class);
+            String sub = HashUtils.digest(logoutTokenClaims.getSubject());
+            String sid = HashUtils.digest(logoutTokenClaims.getClaimValue("sid", String.class));
 
             OidcSessionCache oidcSessionCache = clientConfig.getOidcSessionCache();
             if (sid != null && !sid.isEmpty()) {

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/internal/LogoutTokenValidator.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/backchannellogout/internal/LogoutTokenValidator.java
@@ -28,6 +28,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.security.jwt.Claims;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.common.crypto.HashUtils;
 import com.ibm.ws.security.openidconnect.backchannellogout.BackchannelLogoutException;
 import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
 import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
@@ -223,19 +224,19 @@ public class LogoutTokenValidator {
      * session of this RP with the OP. Also verifies that the iss Logout Token Claim matches the iss Claim in the same session.
      */
     void verifySubAndSidClaimsMatchRecentSession(JwtClaims claims, OidcSessionCache oidcSessionCache) throws MalformedClaimException, BackchannelLogoutException {
-        String sub = claims.getSubject();
+        String sub = HashUtils.digest(claims.getSubject());
         Map<String, OidcSessionsStore> subToSessionsMap = oidcSessionCache.getSubMap();
         if (!subToSessionsMap.containsKey(sub)) {
-            String errorMsg = Tr.formatMessage(tc, "NO_RECENT_SESSIONS_WITH_CLAIMS", config.getId(), claims.getIssuer(), sub, claims.getStringClaimValue("sid"));
+            String errorMsg = Tr.formatMessage(tc, "NO_RECENT_SESSIONS_WITH_CLAIMS", config.getId(), claims.getIssuer(), claims.getSubject(), claims.getStringClaimValue("sid"));
             throw new BackchannelLogoutException(errorMsg);
         }
         OidcSessionsStore sessionDataForSub = subToSessionsMap.get(sub);
 
-        String iss = claims.getIssuer();
-        String sid = claims.getStringClaimValue("sid");
+        String iss = HashUtils.digest(claims.getIssuer());
+        String sid = HashUtils.digest(claims.getStringClaimValue("sid"));
         OidcSessionInfo matchingSession = findSessionMatchingIssAndSid(sessionDataForSub, iss, sid);
         if (matchingSession == null) {
-            String errorMsg = Tr.formatMessage(tc, "NO_RECENT_SESSIONS_WITH_CLAIMS", config.getId(), claims.getIssuer(), sub, claims.getStringClaimValue("sid"));
+            String errorMsg = Tr.formatMessage(tc, "NO_RECENT_SESSIONS_WITH_CLAIMS", config.getId(), claims.getIssuer(), claims.getSubject(), claims.getStringClaimValue("sid"));
             throw new BackchannelLogoutException(errorMsg);
         }
     }
@@ -278,13 +279,13 @@ public class LogoutTokenValidator {
      * session of this RP with the OP. Also verifies that the iss Logout Token Claim matches the iss Claim in the same session.
      */
     void verifySidClaimMatchesRecentSession(JwtClaims claims, OidcSessionCache oidcSessionCache) throws MalformedClaimException, BackchannelLogoutException {
-        String sid = claims.getStringClaimValue("sid");
+        String sid = HashUtils.digest(claims.getStringClaimValue("sid"));
         if (sid == null) {
             // Token is not required to contain a sid claim
             return;
         }
         OidcSessionInfo matchingSession = null;
-        String iss = claims.getIssuer();
+        String iss = HashUtils.digest(claims.getIssuer());
         Map<String, OidcSessionsStore> subToSessionsMap = oidcSessionCache.getSubMap();
         for (Entry<String, OidcSessionsStore> entry : subToSessionsMap.entrySet()) {
             OidcSessionsStore sessionsStore = entry.getValue();
@@ -294,7 +295,7 @@ public class LogoutTokenValidator {
             }
         }
         if (matchingSession == null) {
-            String errorMsg = Tr.formatMessage(tc, "NO_RECENT_SESSIONS_WITH_CLAIMS", config.getId(), claims.getIssuer(), claims.getSubject(), sid);
+            String errorMsg = Tr.formatMessage(tc, "NO_RECENT_SESSIONS_WITH_CLAIMS", config.getId(), claims.getIssuer(), claims.getSubject(), claims.getStringClaimValue("sid"));
             throw new BackchannelLogoutException(errorMsg);
         }
     }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
@@ -37,6 +37,7 @@ import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.security.authentication.AuthenticationConstants;
+import com.ibm.ws.security.common.crypto.HashUtils;
 import com.ibm.ws.security.common.jwk.impl.JwKRetriever;
 import com.ibm.ws.security.common.web.WebSSOUtils;
 import com.ibm.ws.security.jwt.utils.JweHelper;
@@ -205,10 +206,10 @@ public class Jose4jUtil {
     }
 
     private void createWASOidcSession(OidcClientRequest oidcClientRequest, @Sensitive JwtClaims jwtClaims, ConvergedClientConfig clientConfig) throws MalformedClaimException {
-        String configId = clientConfig.getId();
-        String iss = jwtClaims.getIssuer();
-        String sub = jwtClaims.getSubject();
-        String sid = jwtClaims.getClaimValue("sid", String.class);
+        String configId = HashUtils.digest(clientConfig.getId());
+        String iss = HashUtils.digest(jwtClaims.getIssuer());
+        String sub = HashUtils.digest(jwtClaims.getSubject());
+        String sid = HashUtils.digest(jwtClaims.getClaimValue("sid", String.class));
         String exp = String.valueOf(jwtClaims.getExpirationTime().getValueInMillis());
 
         OidcSessionInfo sessionInfo = new OidcSessionInfo(configId, iss, sub, sid, exp, clientConfig);

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionUtils.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcSessionUtils.java
@@ -18,6 +18,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.security.common.crypto.HashUtils;
 import com.ibm.ws.webcontainer.security.CookieHelper;
 
 import io.openliberty.security.oidcclientcore.storage.OidcClientStorageConstants;
@@ -64,7 +65,7 @@ public class OidcSessionUtils {
         }
 
         String configId = sessionInfo.getConfigId();
-        if (!clientConfig.getId().equals(configId)) {
+        if (!HashUtils.digest(clientConfig.getId()).equals(configId)) {
             return;
         }
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/internal/LogoutTokenValidatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/backchannellogout/internal/LogoutTokenValidatorTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.security.jwt.Claims;
+import com.ibm.ws.security.common.crypto.HashUtils;
 import com.ibm.ws.security.jwt.config.ConsumerUtils;
 import com.ibm.ws.security.openidconnect.backchannellogout.BackchannelLogoutException;
 import com.ibm.ws.security.openidconnect.clients.common.ConvergedClientConfig;
@@ -955,9 +956,9 @@ public class LogoutTokenValidatorTest extends CommonTestClass {
         Map<String, OidcSessionsStore> subToSessionsMap = new HashMap<>();
         if (sub != null || sid != null) {
             OidcSessionsStore sessionStore = new OidcSessionsStore();
-            OidcSessionInfo oidcSessionInfo = new OidcSessionInfo(CONFIG_ID, ISSUER, sub, sid, "1234", clientConfig);
-            sessionStore.insertSession(sid, oidcSessionInfo);
-            subToSessionsMap.put(sub, sessionStore);
+            OidcSessionInfo oidcSessionInfo = new OidcSessionInfo(HashUtils.digest(CONFIG_ID), HashUtils.digest(ISSUER), HashUtils.digest(sub), HashUtils.digest(sid), "1234", clientConfig);
+            sessionStore.insertSession(HashUtils.digest(sid), oidcSessionInfo);
+            subToSessionsMap.put(HashUtils.digest(sub), sessionStore);
         }
         return subToSessionsMap;
     }


### PR DESCRIPTION
for #20360

hash the clientId, iss, sub, and sid obscure the details in the oidc session cookie.