### PR TITLE
PR for Issue 21811: Fix OIDC back-channel logout with SAML IDP-initiated logout

### DIFF
--- a/dev/com.ibm.ws.security.oauth/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth/bnd.bnd
@@ -144,7 +144,8 @@ Include-Resource: \
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.org.eclipse.equinox.metatype;version=latest,\
 	com.ibm.ws.security.jwt;version=latest,\
-	com.ibm.ws.kernel.boot.core;version=latest
+	com.ibm.ws.kernel.boot.core;version=latest,\
+	com.ibm.ws.security.sso.common;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.security.openidconnect.server/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.server/bnd.bnd
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 
@@ -165,7 +162,8 @@ Include-Resource: \
 	com.ibm.ws.security.jwt;version=latest,\
 	com.ibm.ws.org.apache.httpcomponents;version=latest,\
 	io.openliberty.security.oidcclientcore.internal;version=latest,\
-	io.openliberty.security.common.jwt;version=latest
+	io.openliberty.security.common.jwt;version=latest,\
+	com.ibm.ws.security.sso.common;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutService.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutService.java
@@ -1,21 +1,21 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package io.openliberty.security.openidconnect.backchannellogout;
 
+import java.util.Hashtable;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.security.auth.Subject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -28,8 +28,11 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.security.WSSecurityException;
+import com.ibm.websphere.security.auth.WSSubject;
 import com.ibm.ws.security.oauth20.util.OIDCConstants;
 import com.ibm.ws.security.oauth20.web.OAuth20Request.EndpointType;
+import com.ibm.ws.security.sso.common.Constants;
 import com.ibm.ws.webcontainer.security.UnprotectedResourceService;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
 import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceSet;
@@ -108,7 +111,7 @@ public class BackchannelLogoutService implements UnprotectedResourceService {
             ServiceAndServiceReferencePair<OidcServerConfig> configServiceAndRef = servicesWithRefs.next();
             OidcServerConfig config = configServiceAndRef.getService();
             String configId = config.getProviderId();
-            if (isEndpointThatMatchesConfig(requestUri, configId)) {
+            if (isEndpointThatMatchesConfig(requestUri, configId) || isDelegatedLogoutRequestForConfig(requestUri, configId)) {
                 return config;
             }
         }
@@ -118,6 +121,46 @@ public class BackchannelLogoutService implements UnprotectedResourceService {
     boolean isEndpointThatMatchesConfig(String requestUri, String providerId) {
         return (requestUri.endsWith("/" + providerId + "/" + EndpointType.end_session.name())
                 || requestUri.endsWith("/" + providerId + "/" + EndpointType.logout.name()));
+    }
+
+    /**
+     * Checks if the logout request originated from a SAML IDP-initiated single logout request.
+     */
+    boolean isDelegatedLogoutRequestForConfig(String requestUri, String providerId) {
+        String getOpFromSubject = getPropertyFromRunAsSubjectPrivateCredentials(Constants.WSCREDENTIAL_OIDC_OP_USED);
+        if (!providerId.equals(getOpFromSubject)) {
+            return false;
+        }
+        String samlIdpFromSubject = getPropertyFromRunAsSubjectPrivateCredentials(Constants.WSCREDENTIAL_SAML_IDP_USED);
+        return (samlIdpFromSubject != null && requestUri.endsWith("/" + samlIdpFromSubject + "/" + "slo"));
+    }
+
+    @SuppressWarnings("rawtypes")
+    String getPropertyFromRunAsSubjectPrivateCredentials(String key) {
+        Subject runAsSubject = getRunAsSubject();
+        if (runAsSubject != null) {
+            Set<Hashtable> hashtableCreds = runAsSubject.getPrivateCredentials(Hashtable.class);
+            if (hashtableCreds != null) {
+                for (Hashtable hashtable : hashtableCreds) {
+                    String propertyValue = (String) hashtable.get(key);
+                    if (propertyValue != null) {
+                        return propertyValue;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    Subject getRunAsSubject() {
+        try {
+            return WSSubject.getRunAsSubject();
+        } catch (WSSecurityException e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Exception while getting runAsSubject:", e.getCause());
+            }
+        }
+        return null;
     }
 
     void sendBackchannelLogoutRequests(OidcServerConfig oidcServerConfig, String userName, String idTokenString) {

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/Authenticator.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/Authenticator.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.saml.sso20.internal;
 
@@ -202,6 +199,7 @@ public class Authenticator {
         String realm = null;
         String uniqueID = null;
         List<String> groups = null;
+        String samlProviderId = mapAssertToSubject.ssoConfig.getProviderId();
 
         switch (ssoConfig.getMapToUserRegistry()) {
             case No:
@@ -232,6 +230,7 @@ public class Authenticator {
                 break;
         }
 
+        putValue(hashtable, com.ibm.ws.security.sso.common.Constants.WSCREDENTIAL_SAML_IDP_USED, samlProviderId);
         putValue(hashtable, AuthenticationConstants.INTERNAL_ASSERTION_KEY, Boolean.TRUE);
 
         // In the case disableLtpaToken is true, this needs to be true all the time

--- a/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/AuthenticatorTest.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/AuthenticatorTest.java
@@ -213,6 +213,8 @@ public class AuthenticatorTest {
 
                 allowing(ssoConfig).isAllowCustomCacheKey();
                 will(returnValue(false));
+                allowing(ssoConfig).getProviderId();
+                will(returnValue(PROVIDER_ID));
 
                 //Expectations for ssoServiceRefMap mock object.
                 one(ssoServiceRefMap).getService(PROVIDER_ID);
@@ -229,11 +231,6 @@ public class AuthenticatorTest {
     public static void tearDown() {
         WebAppSecurityCollaboratorImpl.setGlobalWebAppSecurityConfig(null);
         outputMgr.trace("*=all=disabled");
-    }
-
-    @Test
-    public void testDeleteMe() {
-        // TODO - Delete me
     }
 
     @Test

--- a/dev/com.ibm.ws.security.sso.common/src/com/ibm/ws/security/sso/common/Constants.java
+++ b/dev/com.ibm.ws.security.sso.common/src/com/ibm/ws/security/sso/common/Constants.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.sso.common;
+
+public class Constants {
+
+    public static final String WSCREDENTIAL_OIDC_OP_USED = "io.openliberty.security.sso.oidc.op";
+    public static final String WSCREDENTIAL_SAML_IDP_USED = "io.openliberty.security.sso.saml.idp";
+
+}


### PR DESCRIPTION
Creates two new attributes to include in an authenticated subject's private credentials hashtable:
- `io.openliberty.security.sso.oidc.op`
- `io.openliberty.security.sso.saml.idp`

These two properties track the OIDC OP and SAML IdP, respectively, that are being logged into. When the OIDC back-channel logout service receives a logout request, it can check these properties to validate/determine which OP/IdP originated the logout request. That, in turn, determines the clients that are notified for logout.

For #21811