### PR TITLE
ordering for find and delete

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1154,8 +1154,12 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                 .toString();
             }
 
-            if (methodName.length() > c)
-                generateWhereClause(queryInfo, methodName, c, methodName.length(), q);
+            int orderBy = isDeleteOnly ? -1 : methodName.lastIndexOf("OrderBy");
+            if (orderBy > c || orderBy == -1 && methodName.length() > c)
+                generateWhereClause(queryInfo, methodName, c, orderBy > 0 ? orderBy : methodName.length(), q);
+            if (orderBy >= c)
+                parseOrderBy(queryInfo, orderBy, q);
+
             queryInfo.type = queryInfo.type == null ? QueryInfo.Type.DELETE : queryInfo.type;
         } else if (methodName.startsWith("update")) {
             int by = methodName.indexOf("By", 6);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1927,6 +1927,10 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
                                 List<?> results = query.getResultList();
 
+                                if (queryInfo.type == QueryInfo.Type.FIND_AND_DELETE)
+                                    for (Object result : results)
+                                        em.remove(result); // TODO not all results are entity instances
+
                                 if (results.isEmpty() && queryInfo.getOptionalResultType() != null) {
                                     returnValue = null;
                                 } else if (multiType == null && (queryInfo.entityInfo.entityClass).equals(singleType)) {
@@ -2014,10 +2018,6 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                             returnValue = ((Number) returnValue).byteValue();
                                     }
                                 }
-
-                                if (queryInfo.type == QueryInfo.Type.FIND_AND_DELETE)
-                                    for (Object result : results)
-                                        em.remove(result); // TODO not all results are entity instances
                             }
                         }
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1136,7 +1136,24 @@ public class RepositoryImpl<R> implements InvocationHandler {
                         throw new MappingException("The deleteAll operation cannot be used on entities with composite IDs."); // TODO NLS
                     }
             }
-            q = new StringBuilder(150).append("DELETE FROM ").append(entityInfo.name).append(' ').append(o);
+            boolean isDeleteOnly = queryInfo.hasVoidOrBooleanOrUpdateCountReturnType();
+            if (isDeleteOnly) {
+                queryInfo.type = queryInfo.type == null ? QueryInfo.Type.DELETE : queryInfo.type;
+                q = new StringBuilder(150).append("DELETE FROM ").append(entityInfo.name).append(' ').append(o);
+            } else { // FIND_AND_DELETE
+                if (queryInfo.type != null)
+                    throw new UnsupportedOperationException("The " + queryInfo.method.getGenericReturnType() +
+                                                            " return type is not supported for the " + methodName +
+                                                            " repository method."); // TODO NLS
+                queryInfo.type = QueryInfo.Type.FIND_AND_DELETE;
+                Select select = null; // queryInfo.method.getAnnotation(Select.class); // TODO This would be limited by collision with update count/boolean
+                q = generateSelectClause(queryInfo, select);
+                queryInfo.jpqlDelete = new StringBuilder(22 + o.length() * 2 + entityInfo.name.length()) // TODO add length of id attribute
+                                .append("DELETE FROM ").append(entityInfo.name).append(' ').append(o) //
+                                .append(" WHERE ").append(o).append('.').append("id").append("=?") // TODO need name of id attribute
+                                .toString();
+            }
+
             if (methodName.length() > c)
                 generateWhereClause(queryInfo, methodName, c, methodName.length(), q);
             queryInfo.type = queryInfo.type == null ? QueryInfo.Type.DELETE : queryInfo.type;

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -20,6 +20,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
@@ -41,6 +42,7 @@ import test.jakarta.data.web.DataTestServlet;
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 11) // TODO 17
 public class DataTest extends FATServletClient {
+    private static String jdbcJarName;
 
     @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
@@ -54,7 +56,7 @@ public class DataTest extends FATServletClient {
     public static void setUp() throws Exception {
         // Get driver type
         DatabaseContainerType type = DatabaseContainerType.valueOf(testContainer);
-        server.addEnvVar("DB_DRIVER", type.getDriverName());
+        server.addEnvVar("DB_DRIVER", jdbcJarName = type.getDriverName());
         server.addEnvVar("DB_USER", testContainer.getUsername());
         server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
 
@@ -79,5 +81,21 @@ public class DataTest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer();
+    }
+
+    /**
+     * This test has conditional logic based on the JDBC driver/database.
+     */
+    @Test
+    public void testFindAndDelete() throws Exception {
+        runTest(server, "DataTestApp", "testFindAndDelete&jdbcJarName=" + jdbcJarName);
+    }
+
+    /**
+     * This test has conditional logic based on the JDBC driver/database.
+     */
+    @Test
+    public void testFindAndDeleteMultipleAnnotated() throws Exception {
+        runTest(server, "DataTestApp", "testFindAndDeleteMultipleAnnotated&jdbcJarName=" + jdbcJarName);
     }
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1051,6 +1051,66 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Query-by-method name repository operation to remove and return one or more entities.
+     */
+    @Test
+    public void testFindAndDelete() {
+        packages.save(new Package(40001, 41.0f, 14.0f, 4.0f, "testFindAndDelete#40001"));
+        packages.save(new Package(40004, 44.0f, 40.4f, 4.4f, "testFindAndDelete#40004"));
+        packages.save(new Package(40012, 42.0f, 12.0f, 2.0f, "testFindAndDelete#4001x"));
+        packages.save(new Package(40013, 43.0f, 13.0f, 3.0f, "testFindAndDelete#4001x"));
+
+        Optional<Package> none = packages.deleteByDescription("testFindAndDelete#40000");
+        assertEquals(true, none.isEmpty());
+
+        Package p1 = packages.deleteByDescription("testFindAndDelete#40001").orElseThrow();
+        assertEquals(40001, p1.id);
+        assertEquals(41.0f, p1.length, 0.01f);
+        assertEquals(14.0f, p1.width, 0.01f);
+        assertEquals(4.0f, p1.height, 0.01f);
+        assertEquals("testFindAndDelete#40001", p1.description);
+
+        try {
+            Optional<Package> p = packages.deleteByDescription("testFindAndDelete#4001x");
+            fail("Should get NonUniqueResultException when there are multiple results but a singular return type. Instead, result is: " + p);
+        } catch (NonUniqueResultException x) {
+            // expected
+        }
+
+        Package[] p = packages.deleteByDescriptionEndsWith("#4001x");
+        assertEquals(Arrays.toString(p), 2, p.length);
+
+        p = Stream.of(p) // sort by id
+                        .sorted(Comparator.comparing(pkg -> pkg.id))
+                        .collect(Collectors.toList())
+                        .toArray(new Package[2]);
+
+        assertEquals(40012, p[0].id);
+        assertEquals(42.0f, p[0].length, 0.01f);
+        assertEquals(12.0f, p[0].width, 0.01f);
+        assertEquals(2.0f, p[0].height, 0.01f);
+        assertEquals("testFindAndDelete#4001x", p[0].description);
+
+        assertEquals(40013, p[1].id);
+        assertEquals(43.0f, p[1].length, 0.01f);
+        assertEquals(13.0f, p[1].width, 0.01f);
+        assertEquals(3.0f, p[1].height, 0.01f);
+        assertEquals("testFindAndDelete#4001x", p[1].description);
+
+        p = packages.deleteByDescriptionEndsWith("#40000");
+        assertEquals(Arrays.toString(p), 0, p.length);
+
+        p = packages.deleteByDescriptionEndsWith("#40004");
+        assertEquals(Arrays.toString(p), 1, p.length);
+
+        assertEquals(40004, p[0].id);
+        assertEquals(44.0f, p[0].length, 0.01f);
+        assertEquals(40.4f, p[0].width, 0.01f);
+        assertEquals(4.4f, p[0].height, 0.01f);
+        assertEquals("testFindAndDelete#40004", p[0].description);
+    }
+
+    /**
      * Annotated repository operation to remove and return a single entity.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -13,6 +13,7 @@
 package test.jakarta.data.web;
 
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.data.repository.KeysetAwarePage;
 import jakarta.data.repository.KeysetAwareSlice;
@@ -35,6 +36,10 @@ import io.openliberty.data.repository.Update;
  */
 @Repository
 public interface Packages extends PageableRepository<Package, Integer> {
+    Optional<Package> deleteByDescription(String description);
+
+    Package[] deleteByDescriptionEndsWith(String ending);
+
     List<Package> findByHeightBetween(float minHeight, float maxHeight);
 
     @OrderBy(value = "width", descending = true)

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -23,6 +23,7 @@ import jakarta.data.repository.PageableRepository;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Sort;
 
 import io.openliberty.data.repository.Compare;
 import io.openliberty.data.repository.Delete;
@@ -38,7 +39,7 @@ import io.openliberty.data.repository.Update;
 public interface Packages extends PageableRepository<Package, Integer> {
     Optional<Package> deleteByDescription(String description);
 
-    Package[] deleteByDescriptionEndsWith(String ending);
+    Package[] deleteByDescriptionEndsWith(String ending, Sort... sorts);
 
     List<Package> findByHeightBetween(float minHeight, float maxHeight);
 
@@ -80,6 +81,11 @@ public interface Packages extends PageableRepository<Package, Integer> {
     @Delete
     @Filter(by = "length", op = Compare.Between)
     List<Package> takeWithin(float minLength, float maxLength);
+
+    @Delete
+    @Filter(by = "length", op = Compare.Between)
+    @OrderBy("id")
+    List<Package> takeWithinOrdered(float minLength, float maxLength);
 
     boolean updateByIdAddHeightMultiplyLengthDivideWidth(int id, float heightToAdd, float lengthMultiplier, float widthDivisor);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
@@ -75,6 +75,14 @@ public class DataJPATest extends FATServletClient {
      * This test has conditional logic based on the JDBC driver/database.
      */
     @Test
+    public void testFindAndDeleteEntityThatHasAnIdClass() throws Exception {
+        runTest(server, "DataJPATestApp", "testFindAndDeleteEntityThatHasAnIdClass&jdbcJarName=" + jdbcJarName);
+    }
+
+    /**
+     * This test has conditional logic based on the JDBC driver/database.
+     */
+    @Test
     public void testUnannotatedCollection() throws Exception {
         runTest(server, "DataJPATestApp", "testUnannotatedCollection&jdbcJarName=" + jdbcJarName);
     }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -21,6 +21,7 @@ import jakarta.data.repository.Pageable;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Sort;
+import jakarta.data.repository.Streamable;
 
 import io.openliberty.data.repository.Compare;
 import io.openliberty.data.repository.Exists;
@@ -100,6 +101,10 @@ public interface Cities {
     Stream<City> largerThan(int minPopulation, CityId exceptFor, String statePattern);
 
     boolean remove(City city);
+
+    Streamable<City> removeByStateName(String state);
+
+    Streamable<City> removeByStateNameOrderByName(String state);
 
     @Filter(by = "id")
     @Update(attr = "id")


### PR DESCRIPTION
Various ways of specifying ordering when using find and delete:
- with Sort parameters
- with OrderBy in query-by-method name
- with OrderBy annotation