### PR TITLE
Update EclipseLink 4.0.1 to not get constants every time they are needed

### DIFF
--- a/dev/io.openliberty.persistence.3.1.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -131,7 +131,10 @@ Include-Resource: \
   @${repo;org.eclipse.persistence:org.eclipse.persistence.jpa;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
   @${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.jpql;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
   @${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
-  @${repo;org.eclipse.persistence:org.eclipse.persistence.json;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class)
+  @${repo;org.eclipse.persistence:org.eclipse.persistence.json;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
+  org/eclipse/persistence/asm=${bin}/org/eclipse/persistence/asm,\
+  org/eclipse/persistence/dynamic=${bin}/org/eclipse/persistence/dynamic,\
+  org/eclipse/persistence/internal/jpa=${bin}/org/eclipse/persistence/internal/jpa
 
 publish.wlp.jar.suffix: dev/api/third-party
 
@@ -149,5 +152,7 @@ Service-Component: \
 -buildpath: \
     org.eclipse.persistence:org.eclipse.persistence.core;version=${eclFullVersion};strategy=exact,\
     org.eclipse.persistence:org.eclipse.persistence.jpa;version=${eclFullVersion};strategy=exact,\
+    org.eclipse.persistence:org.eclipse.persistence.asm;version=${asmFullVersion};strategy=exact,\
     io.openliberty.jakarta.persistence.3.1;version=latest,\
-    com.ibm.websphere.org.osgi.core
+    com.ibm.websphere.org.osgi.core,\
+    com.ibm.ws.org.objectweb.asm

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/ASMFactory.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/ASMFactory.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.asm;
+
+import org.eclipse.persistence.config.SystemProperties;
+import org.eclipse.persistence.exceptions.ValidationException;
+import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class ASMFactory {
+
+    private final static SessionLog LOG = AbstractSessionLog.getLog();
+
+    public final static String ASM_SERVICE_ECLIPSELINK = "eclipselink";
+    public final static String ASM_SERVICE_OW2 = "ow2";
+    private final static String ASM_OW2_CLASS_VISITOR = "org.objectweb.asm.ClassVisitor";
+    private final static String ASM_ECLIPSELINK_CLASS_VISITOR = "org.eclipse.persistence.internal.libraries.asm.ClassVisitor";
+
+    //Should be changed in case of ASM upgrade
+    public final static int ASM_API_SELECTED = Opcodes.valueInt("ASM9");
+    public final static int JAVA_CLASS_VERSION = Opcodes.valueInt("V1_8");
+    public final static int JAVA_CLASS_LATEST_VERSION = ASMFactory.getLatestOPCodeVersion();
+
+    public static AnnotationVisitor createAnnotationVisitor(final int api) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.AnnotationVisitorImpl(api);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.AnnotationVisitorImpl(api);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static AnnotationVisitor createAnnotationVisitor(final int api, final AnnotationVisitor annotationVisitor) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.AnnotationVisitorImpl(api, annotationVisitor);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.AnnotationVisitorImpl(api, annotationVisitor);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static FieldVisitor createFieldVisitor(final int api) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.FieldVisitorImpl(api);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.FieldVisitorImpl(api);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static FieldVisitor createFieldVisitor(final int api, final FieldVisitor fieldVisitor) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.FieldVisitorImpl(api, fieldVisitor);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.FieldVisitorImpl(api, fieldVisitor);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static MethodVisitor createMethodVisitor(final int api) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.MethodVisitorImpl(api);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.MethodVisitorImpl(api);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static MethodVisitor createMethodVisitor(final int api, final MethodVisitor methodVisitor) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.MethodVisitorImpl(api, methodVisitor);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.MethodVisitorImpl(api, methodVisitor);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static ClassReader createClassReader(final InputStream inputStream) throws IOException {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.ClassReaderImpl(inputStream);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.ClassReaderImpl(inputStream);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static ClassReader createClassReader(final byte[] classFileBuffer) throws IOException {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.ClassReaderImpl(classFileBuffer);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.ClassReaderImpl(classFileBuffer);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static ClassReader createClassReader(final byte[] classFileBuffer, final int classFileOffset, final int classFileLength) throws IOException {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.ClassReaderImpl(classFileBuffer, classFileOffset, classFileLength);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.ClassReaderImpl(classFileBuffer, classFileOffset, classFileLength);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static ClassReader createClassReader(final InputStream inputStream, final boolean checkClassVersion) throws IOException {
+        String asmService = ASMFactory.getAsmService();
+        if (!checkClassVersion || ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.ClassReaderImpl(inputStream, checkClassVersion);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.ClassReaderImpl(inputStream);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static ClassWriter createClassWriter() {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.ClassWriterImpl();
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.ClassWriterImpl();
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static ClassWriter createClassWriter(final int flags) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.ClassWriterImpl(flags);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.ClassWriterImpl(flags);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static ClassWriter createClassWriter(final ClassReader classReader, final int flags) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.ClassWriterImpl(classReader, flags);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.ClassWriterImpl(classReader, flags);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static ClassVisitor createClassVisitor(final int api) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.ClassVisitorImpl(api);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.ClassVisitorImpl(api);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static ClassVisitor createClassVisitor(final int api, final ClassVisitor classVisitor) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.ClassVisitorImpl(api, classVisitor);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.ClassVisitorImpl(api, classVisitor);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static Type createType(final Class<?> clazz) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.TypeImpl(clazz);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.TypeImpl(clazz);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static Type createType(final String typeDescriptor) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.TypeImpl(typeDescriptor);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.TypeImpl(typeDescriptor);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static Type createVoidType() {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.TypeImpl((Class<?>)null);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.TypeImpl((Class<?>)null);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static Label createLabel() {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.LabelImpl();
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.LabelImpl();
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static SerialVersionUIDAdder createSerialVersionUIDAdder(final ClassVisitor classVisitor) {
+        String asmService = ASMFactory.getAsmService();
+        if (ASM_SERVICE_ECLIPSELINK.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.eclipselink.SerialVersionUIDAdderImpl(classVisitor);
+        } else if (ASM_SERVICE_OW2.equals(asmService)) {
+            return new org.eclipse.persistence.asm.internal.platform.ow2.SerialVersionUIDAdderImpl(classVisitor);
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    public static String getAsmService() {
+        String asmService = PrivilegedAccessHelper.getSystemProperty(SystemProperties.ASM_SERVICE);
+        if (asmService != null) {
+            if (ASM_SERVICE_ECLIPSELINK.equals(asmService) && isASMImplementationAvailable(ASM_ECLIPSELINK_CLASS_VISITOR)) {
+                LOG.finest("EclipseLink ASM implementation is used.");
+                return asmService;
+            } else if (ASM_SERVICE_OW2.equals(asmService) && isASMImplementationAvailable(ASM_OW2_CLASS_VISITOR)) {
+                LOG.finest("OW2 ASM implementation is used.");
+                return asmService;
+            } else {
+                throw ValidationException.incorrectASMServiceProvided();
+            }
+        }
+        //Fallback to default if ASM service is not specified
+        if (isASMImplementationAvailable(ASM_ECLIPSELINK_CLASS_VISITOR)) {
+            LOG.finest("EclipseLink ASM implementation is used.");
+            return ASM_SERVICE_ECLIPSELINK;
+        } else if (isASMImplementationAvailable(ASM_OW2_CLASS_VISITOR)) {
+            LOG.finest("OW2 ASM implementation is used.");
+            return ASM_SERVICE_OW2;
+        } else {
+            throw ValidationException.notAvailableASMService();
+        }
+    }
+
+    private static boolean isASMImplementationAvailable(String className) {
+        try {
+            PrivilegedAccessHelper.getClassForName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    static int getLatestOPCodeVersion() {
+        final Map<String, Integer> versionMap = new LinkedHashMap<>();
+        Pattern searchPattern = Pattern.compile("^V\\d((_\\d)?|\\d*)");
+        try {
+            Class opcodesClazz = Opcodes.getOpcodesClass();
+            for (Field f : opcodesClazz.getDeclaredFields()) {
+                if (searchPattern.matcher(f.getName()).matches()) {
+                    versionMap.put(f.getName().replace("V","").replace('_', '.'), f.getInt(opcodesClazz));
+                }
+            }
+        } catch (IllegalAccessException ex) {
+            LOG.log(SessionLog.SEVERE, "Error Java versions map from Opcodes.class fields.", ex);
+            throw new RuntimeException(ex);
+        }
+        final List<String> versions = new ArrayList<String>(versionMap.keySet());
+        final String oldest = versions.get(0);
+        final String latest = versions.get(versions.size() - 1);
+
+        // let's default to oldest supported Java SE version
+        String v = oldest;
+        if (System.getSecurityManager() == null) {
+            v = System.getProperty("java.specification.version");
+        } else {
+            try {
+                v = AccessController.doPrivileged(new PrivilegedAction<String>() {
+                    @Override
+                    public String run() {
+                        return System.getProperty("java.specification.version");
+                    }
+                });
+            } catch (Throwable t) {
+                // ie SecurityException
+                LOG.log(SessionLog.WARNING, "Cannot read 'java.specification.version' property.", t);
+                if (LOG.shouldLog(SessionLog.FINE)) {
+                    LOG.log(SessionLog.FINE, "Generating bytecode for Java SE ''{0}''.", v);
+                }
+            }
+        }
+        Integer version = versionMap.get(v);
+        if (version == null) {
+            // current JDK is either too new
+            if (latest.compareTo(v) < 0) {
+                LOG.log(SessionLog.WARNING, "Java SE ''{0}'' is not fully supported yet. Report this error to the EclipseLink open source project.", v);
+                if (LOG.shouldLog(SessionLog.FINE)) {
+                    LOG.log(SessionLog.FINE, "Generating bytecode for Java SE ''{0}''.", latest);
+                }
+                version = versionMap.get(latest);
+            } else {
+                // or too old
+                String key = oldest;
+                LOG.log(SessionLog.WARNING, "Java SE ''{0}'' is too old.", v);
+                if (LOG.shouldLog(SessionLog.FINE)) {
+                    LOG.log(SessionLog.FINE, "Generating bytecode for Java SE ''{0}''.", key);
+                }
+                version = versionMap.get(key);
+            }
+        }
+        return version;
+    }
+}

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/ASMFactory.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/ASMFactory.java
@@ -41,8 +41,8 @@ public class ASMFactory {
     private final static String ASM_ECLIPSELINK_CLASS_VISITOR = "org.eclipse.persistence.internal.libraries.asm.ClassVisitor";
 
     //Should be changed in case of ASM upgrade
-    public final static int ASM_API_SELECTED = Opcodes.valueInt("ASM9");
-    public final static int JAVA_CLASS_VERSION = Opcodes.valueInt("V1_8");
+    public final static int ASM_API_SELECTED = Opcodes.ASM9;
+    public final static int JAVA_CLASS_VERSION = Opcodes.V1_8;
     public final static int JAVA_CLASS_LATEST_VERSION = ASMFactory.getLatestOPCodeVersion();
 
     public static AnnotationVisitor createAnnotationVisitor(final int api) {

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/ClassReader.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/ClassReader.java
@@ -21,6 +21,7 @@ import org.eclipse.persistence.asm.internal.Util;
 
 public abstract class ClassReader {
 
+    //This block must be first - begin
     private final static String ASM_CLASSREADER_ECLIPSELINK = "org.eclipse.persistence.internal.libraries.asm.ClassReader";
     private final static String ASM_CLASSREADER_OW2 = "org.objectweb.asm.ClassReader";
 
@@ -30,8 +31,13 @@ public abstract class ClassReader {
         ASM_CLASSREADER_MAP.put(ASMFactory.ASM_SERVICE_OW2, ASM_CLASSREADER_OW2);
         ASM_CLASSREADER_MAP.put(ASMFactory.ASM_SERVICE_ECLIPSELINK, ASM_CLASSREADER_ECLIPSELINK);
     }
+    //This block must be first - end
 
-    public static int valueInt(String fieldName) {
+    public static final int SKIP_CODE = valueInt("SKIP_CODE");
+    public static final int SKIP_DEBUG = valueInt("SKIP_DEBUG");
+    public static final int SKIP_FRAMES = valueInt("SKIP_FRAMES");
+    
+    private static int valueInt(String fieldName) {
         return ((int) Util.getFieldValue(ASM_CLASSREADER_MAP, fieldName, Integer.TYPE));
     }
 

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/ClassReader.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/ClassReader.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.asm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.persistence.asm.internal.Util;
+
+public abstract class ClassReader {
+
+    private final static String ASM_CLASSREADER_ECLIPSELINK = "org.eclipse.persistence.internal.libraries.asm.ClassReader";
+    private final static String ASM_CLASSREADER_OW2 = "org.objectweb.asm.ClassReader";
+
+    private final static Map<String, String> ASM_CLASSREADER_MAP = new HashMap<>();
+
+    static {
+        ASM_CLASSREADER_MAP.put(ASMFactory.ASM_SERVICE_OW2, ASM_CLASSREADER_OW2);
+        ASM_CLASSREADER_MAP.put(ASMFactory.ASM_SERVICE_ECLIPSELINK, ASM_CLASSREADER_ECLIPSELINK);
+    }
+
+    public static int valueInt(String fieldName) {
+        return ((int) Util.getFieldValue(ASM_CLASSREADER_MAP, fieldName, Integer.TYPE));
+    }
+
+    public abstract void accept(final ClassVisitor classVisitor, final int parsingOptions);
+
+    public abstract void accept(final ClassVisitor classVisitor, final Attribute[] attributePrototypes, final int parsingOptions);
+
+    public abstract int getAccess();
+
+    public abstract String getSuperName();
+
+    public  abstract String[] getInterfaces();
+
+    public abstract <T> T unwrap();
+}

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/ClassWriter.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/ClassWriter.java
@@ -21,6 +21,7 @@ import org.eclipse.persistence.asm.internal.Util;
 
 public abstract class ClassWriter extends ClassVisitor {
 
+    //This block must be first - begin
     private final static String ASM_CLASSWRITER_ECLIPSELINK = "org.eclipse.persistence.internal.libraries.asm.ClassWriter";
     private final static String ASM_CLASSWRITER_OW2 = "org.objectweb.asm.ClassWriter";
 
@@ -30,6 +31,9 @@ public abstract class ClassWriter extends ClassVisitor {
         ASM_CLASSWRITER_MAP.put(ASMFactory.ASM_SERVICE_OW2, ASM_CLASSWRITER_OW2);
         ASM_CLASSWRITER_MAP.put(ASMFactory.ASM_SERVICE_ECLIPSELINK, ASM_CLASSWRITER_ECLIPSELINK);
     }
+    //This block must be first - end
+
+    public static final int COMPUTE_FRAMES = valueInt("COMPUTE_FRAMES");
 
     private ClassWriter cw;
     protected ClassWriter customClassWriter;
@@ -58,7 +62,7 @@ public abstract class ClassWriter extends ClassVisitor {
         return cw;
     }
 
-    public static int valueInt(String fieldName) {
+    private static int valueInt(String fieldName) {
         return ((int) Util.getFieldValue(ASM_CLASSWRITER_MAP, fieldName, Integer.TYPE));
     }
 

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/ClassWriter.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/ClassWriter.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.asm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.persistence.asm.internal.Util;
+
+public abstract class ClassWriter extends ClassVisitor {
+
+    private final static String ASM_CLASSWRITER_ECLIPSELINK = "org.eclipse.persistence.internal.libraries.asm.ClassWriter";
+    private final static String ASM_CLASSWRITER_OW2 = "org.objectweb.asm.ClassWriter";
+
+    private final static Map<String, String> ASM_CLASSWRITER_MAP = new HashMap<>();
+
+    static {
+        ASM_CLASSWRITER_MAP.put(ASMFactory.ASM_SERVICE_OW2, ASM_CLASSWRITER_OW2);
+        ASM_CLASSWRITER_MAP.put(ASMFactory.ASM_SERVICE_ECLIPSELINK, ASM_CLASSWRITER_ECLIPSELINK);
+    }
+
+    private ClassWriter cw;
+    protected ClassWriter customClassWriter;
+
+    public ClassWriter() {
+    }
+
+    public ClassWriter(final int flags) {
+        this(null, flags);
+    }
+
+    public ClassWriter(final ClassReader classReader, final int flags) {
+        super(ASMFactory.ASM_API_SELECTED);
+        cw = ASMFactory.createClassWriter(flags);
+    }
+
+    public void setCustomClassWriter(ClassWriter classWriter) {
+        this.customClassWriter = classWriter;
+    }
+
+    public void setCustomClassWriterInImpl(ClassWriter classWriter) {
+        this.cw.setCustomClassWriter(classWriter);
+    }
+
+    public ClassWriter getInternal() {
+        return cw;
+    }
+
+    public static int valueInt(String fieldName) {
+        return ((int) Util.getFieldValue(ASM_CLASSWRITER_MAP, fieldName, Integer.TYPE));
+    }
+
+    public abstract String getCommonSuperClass(final String type1, final String type2);
+
+    public void visit(final int access, final String name, final String signature, final String superName, final String[] interfaces) {
+        this.cw.visit(access, name, signature, superName, interfaces);
+    }
+
+    @Override
+    public void visit(final int version, final int access, final String name, final String signature, final String superName, final String[] interfaces) {
+        this.cw.visit(version, access, name, signature, superName, interfaces);
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
+        return this.cw.visitAnnotation(descriptor, visible);
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotationSuper(final String descriptor, final boolean visible) {
+        return this.cw.visitAnnotationSuper(descriptor, visible);
+    }
+
+    @Override
+    public FieldVisitor visitField(final int access, final String name, final String descriptor, final String signature, final Object value) {
+        return this.cw.visitField(access, name, descriptor, signature, value);
+    }
+
+    @Override
+    public FieldVisitor visitFieldSuper(final int access, final String name, final String descriptor, final String signature, final Object value) {
+        return this.cw.visitFieldSuper(access, name, descriptor, signature, value);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+        return this.cw.visitMethod(access, name, descriptor, signature, exceptions);
+    }
+
+    @Override
+    public MethodVisitor visitMethodSuper(int access, String name, String descriptor, String signature, String[] exceptions) {
+        return this.cw.visitMethodSuper(access, name, descriptor, signature, exceptions);
+    }
+
+    @Override
+    public void visitEnd() {
+        this.cw.visitEnd();
+    }
+
+    public byte[] toByteArray() {
+        return this.cw.toByteArray();
+    }
+
+    public byte[] toByteArraySuper() {
+        return this.cw.toByteArraySuper();
+    }
+
+    @Override
+    public abstract <T> T unwrap();
+}

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/EclipseLinkASMClassWriter.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/EclipseLinkASMClassWriter.java
@@ -23,7 +23,7 @@ public class EclipseLinkASMClassWriter extends ClassWriter {
     private ClassWriter classWriter;
 
     public EclipseLinkASMClassWriter() {
-        this(ClassWriter.valueInt("COMPUTE_FRAMES"));
+        this(ClassWriter.COMPUTE_FRAMES);
     }
 
     public EclipseLinkASMClassWriter(final int flags) {

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/EclipseLinkASMClassWriter.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/EclipseLinkASMClassWriter.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.asm;
+
+/**
+ * EclipseLink specific {@link ClassVisitor} that generates a corresponding ClassFile structure
+ * for currently running Java VM.
+ */
+public class EclipseLinkASMClassWriter extends ClassWriter {
+
+    private ClassWriter classWriter;
+
+    public EclipseLinkASMClassWriter() {
+        this(ClassWriter.valueInt("COMPUTE_FRAMES"));
+    }
+
+    public EclipseLinkASMClassWriter(final int flags) {
+        super();
+        this.classWriter = ASMFactory.createClassWriter(flags);
+    }
+
+    /**
+   * Visits the header of the class with {@code version} set
+   * equal to currently running Java SE version.
+   *
+   * @param access the class's access flags (see {@link org.eclipse.persistence.internal.libraries.asm.Opcodes}). This parameter also indicates if
+   *     the class is deprecated {@link org.eclipse.persistence.internal.libraries.asm.Opcodes#ACC_DEPRECATED} or a record {@link
+   *     org.eclipse.persistence.internal.libraries.asm.Opcodes#ACC_RECORD}.
+   * @param name the internal name of the class (see {@link org.eclipse.persistence.internal.libraries.asm.Type#getInternalName()}).
+   * @param signature the signature of this class. May be {@literal null} if the class is not a
+   *     generic one, and does not extend or implement generic classes or interfaces.
+   * @param superName the internal of name of the super class (see {@link org.eclipse.persistence.internal.libraries.asm.Type#getInternalName()}).
+   *     For interfaces, the super class is {@link Object}. May be {@literal null}, but only for the
+   *     {@link Object} class.
+   * @param interfaces the internal names of the class's interfaces (see {@link
+   *     Type#getInternalName()}). May be {@literal null}.
+   * @see #visit(int, int, String, String, String, String[])
+   */
+    @Override
+    public final void visit(final int access, final String name, final String signature, final String superName, final String[] interfaces) {
+        this.classWriter.visit(ASMFactory.JAVA_CLASS_LATEST_VERSION, access, name, signature, superName, interfaces);
+    }
+
+    @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        this.classWriter.visit(version, access, name, signature, superName, interfaces);
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+        return this.classWriter.visitAnnotation(descriptor, visible);
+    }
+
+    @Override
+    public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+        return this.classWriter.visitField(access, name, descriptor, signature, value);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+        return this.classWriter.visitMethod(access, name, descriptor, signature, exceptions);
+    }
+
+    @Override
+    public void visitEnd() {
+        this.classWriter.visitEnd();
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        return this.classWriter.toByteArray();
+    }
+
+    @Override
+    public String getCommonSuperClass(final String type1, final String type2) {
+        return this.classWriter.getCommonSuperClass(type1, type2);
+    }
+
+    @Override
+    public <T> T unwrap() {
+        if (this.classWriter instanceof org.eclipse.persistence.asm.internal.platform.ow2.ClassWriterImpl) {
+            return (T)((org.eclipse.persistence.asm.internal.platform.ow2.ClassWriterImpl)this.classWriter).getInternal(this.customClassWriter);
+        } else if (this.classWriter instanceof org.eclipse.persistence.asm.internal.platform.eclipselink.ClassWriterImpl) {
+            return (T)((org.eclipse.persistence.asm.internal.platform.eclipselink.ClassWriterImpl)this.classWriter).getInternal(this.customClassWriter);
+        } else {
+            return null;
+        }
+    }
+}

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/Opcodes.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/Opcodes.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 public class Opcodes {
 
+    //This block must be first - begin
     private final static String ASM_OPCCODES_ECLIPSELINK = "org.eclipse.persistence.internal.libraries.asm.Opcodes";
     private final static String ASM_OPCCODES_OW2 = "org.objectweb.asm.Opcodes";
 
@@ -31,13 +32,60 @@ public class Opcodes {
         ASM_OPCCODES_MAP.put(ASMFactory.ASM_SERVICE_OW2, ASM_OPCCODES_OW2);
         ASM_OPCCODES_MAP.put(ASMFactory.ASM_SERVICE_ECLIPSELINK, ASM_OPCCODES_ECLIPSELINK);
     }
+    //This block must be first - end
 
-    public static int valueInt(String fieldName) {
+    public static final int AASTORE = valueInt("AASTORE");
+    public static final int ACC_ENUM = valueInt("ACC_ENUM");
+    public static final int ACC_FINAL = valueInt("ACC_FINAL");
+    public static final int ACC_INTERFACE = valueInt("ACC_INTERFACE");
+    public static final int ACC_PRIVATE = valueInt("ACC_PRIVATE");
+    public static final int ACC_PROTECTED = valueInt("ACC_PROTECTED");
+    public static final int ACC_PUBLIC = valueInt("ACC_PUBLIC");
+    public static final int ACC_STATIC = valueInt("ACC_STATIC");
+    public static final int ACC_SUPER = valueInt("ACC_SUPER");
+    public static final int ACC_SYNTHETIC = valueInt("ACC_SYNTHETIC");
+    public static final int ACC_TRANSIENT = valueInt("ACC_TRANSIENT");
+    public static final int ACONST_NULL = valueInt("ACONST_NULL");
+    public static final int ALOAD = valueInt("ALOAD");
+    public static final int ANEWARRAY = valueInt("ANEWARRAY");
+    public static final int ARETURN = valueInt("ARETURN");
+    public static final int ASM9 = Opcodes.valueInt("ASM9");
+    public static final int ASTORE = valueInt("ASTORE");
+    public static final int BIPUSH = valueInt("BIPUSH");
+    public static final int CHECKCAST = valueInt("CHECKCAST");
+    public static final int DUP = valueInt("DUP");
+    public static final int F_SAME = valueInt("F_SAME");
+    public static final int GETFIELD = valueInt("GETFIELD");
+    public static final int GETSTATIC = valueInt("GETSTATIC");
+    public static final int GOTO = valueInt("GOTO");
+    public static final int ICONST_0 = valueInt("ICONST_0");
+    public static final int ICONST_1 = valueInt("ICONST_1");
+    public static final int ICONST_2 = valueInt("ICONST_2");
+    public static final int ICONST_3 = valueInt("ICONST_3");
+    public static final int ICONST_4 = valueInt("ICONST_4");
+    public static final int ICONST_5 = valueInt("ICONST_5");
+    public static final int IF_ACMPEQ = valueInt("IF_ACMPEQ");
+    public static final int IF_ACMPNE = valueInt("IF_ACMPNE");
+    public static final int IFEQ = valueInt("IFEQ");
+    public static final int IFNE = valueInt("IFNE");
+    public static final int IFNONNULL = valueInt("IFNONNULL");
+    public static final int IFNULL = valueInt("IFNULL");
+    public static final int ILOAD = valueInt("ILOAD");
+    public static final int INVOKEINTERFACE = valueInt("INVOKEINTERFACE");
+    public static final int INVOKESPECIAL = valueInt("INVOKESPECIAL");
+    public static final int INVOKESTATIC = valueInt("INVOKESTATIC");
+    public static final int INVOKEVIRTUAL = valueInt("INVOKEVIRTUAL");
+    public static final int IRETURN = valueInt("IRETURN");
+    public static final int NEW = valueInt("NEW");
+    public static final int POP = valueInt("POP");
+    public static final int PUTFIELD = valueInt("PUTFIELD");
+    public static final int PUTSTATIC = valueInt("PUTSTATIC");
+    public static final int RETURN = valueInt("RETURN");
+    public static final int SIPUSH = valueInt("SIPUSH");
+    public static final int V1_8 = Opcodes.valueInt("V1_8");
+    
+    private static int valueInt(String fieldName) {
         return ((int) Util.getFieldValue(ASM_OPCCODES_MAP, fieldName, Integer.TYPE));
-    }
-
-    public static Integer valueInteger(String fieldName) {
-        return ((Integer) Util.getFieldValue(ASM_OPCCODES_MAP, fieldName, Integer.class));
     }
 
     public static Class getOpcodesClass() {

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/Opcodes.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/asm/Opcodes.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.asm;
+
+import org.eclipse.persistence.asm.internal.Util;
+import org.eclipse.persistence.exceptions.ValidationException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Opcodes {
+
+    private final static String ASM_OPCCODES_ECLIPSELINK = "org.eclipse.persistence.internal.libraries.asm.Opcodes";
+    private final static String ASM_OPCCODES_OW2 = "org.objectweb.asm.Opcodes";
+
+    private final static Map<String, String> ASM_OPCCODES_MAP = new HashMap<>();
+
+    static {
+        ASM_OPCCODES_MAP.put(ASMFactory.ASM_SERVICE_OW2, ASM_OPCCODES_OW2);
+        ASM_OPCCODES_MAP.put(ASMFactory.ASM_SERVICE_ECLIPSELINK, ASM_OPCCODES_ECLIPSELINK);
+    }
+
+    public static int valueInt(String fieldName) {
+        return ((int) Util.getFieldValue(ASM_OPCCODES_MAP, fieldName, Integer.TYPE));
+    }
+
+    public static Integer valueInteger(String fieldName) {
+        return ((Integer) Util.getFieldValue(ASM_OPCCODES_MAP, fieldName, Integer.class));
+    }
+
+    public static Class getOpcodesClass() {
+        String asmService = ASMFactory.getAsmService();
+        Class<?> clazz;
+        try {
+            String className = ASM_OPCCODES_MAP.get(asmService);
+            if (className == null) {
+                throw ValidationException.incorrectASMServiceProvided();
+            }
+            clazz = Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw ValidationException.notAvailableASMService();
+        }
+        return clazz;
+    }
+
+}

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/dynamic/DynamicClassWriter.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/dynamic/DynamicClassWriter.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     dclarke, mnorman - Dynamic Persistence
+//       http://wiki.eclipse.org/EclipseLink/Development/Dynamic
+//       (https://bugs.eclipse.org/bugs/show_bug.cgi?id=200045)
+//     dclarke - Bug 387240: added field and method calls to allow extensibility
+//
+package org.eclipse.persistence.dynamic;
+
+//static imports
+import static org.eclipse.persistence.internal.dynamic.DynamicPropertiesManager.PROPERTIES_MANAGER_FIELD;
+
+//javase imports
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+//EclipseLink imports
+import org.eclipse.persistence.dynamic.DynamicClassLoader.EnumInfo;
+import org.eclipse.persistence.exceptions.DynamicException;
+import org.eclipse.persistence.internal.dynamic.DynamicEntityImpl;
+import org.eclipse.persistence.internal.dynamic.DynamicPropertiesManager;
+import org.eclipse.persistence.internal.helper.Helper;
+import org.eclipse.persistence.asm.ClassWriter;
+import org.eclipse.persistence.asm.EclipseLinkASMClassWriter;
+import org.eclipse.persistence.asm.MethodVisitor;
+import org.eclipse.persistence.asm.Opcodes;
+import org.eclipse.persistence.asm.Type;
+
+/**
+ * Write the byte codes of a dynamic entity class. The class writer will create
+ * the byte codes for a dynamic class that subclasses any provided class
+ * replicating its constructors and writeReplace method (if one exists).
+ * <p>
+ * The intent is to provide a common writer for dynamic JPA entities but also
+ * allow for subclasses of this to be used in more complex writing situations
+ * such as SDO and DBWS.
+ * <p>
+ * Instances of this class and any subclasses are maintained within the
+ * {@link DynamicClassLoader#getClassWriters()} and
+ * {@link DynamicClassLoader#defaultWriter} for the life of the class loader so
+ * it is important that no unnecessary state be maintained that may effect
+ * memory usage.
+ *
+ * @author dclarke, mnorman
+ * @since EclipseLink 1.2
+ */
+public class DynamicClassWriter implements EclipseLinkClassWriter {
+
+    /*
+     * Pattern is as follows: <pre> public class Foo extends DynamicEntityImpl {
+     *
+     * public static DynamicPropertiesManager DPM = new
+     * DynamicPropertiesManager();
+     *
+     * public Foo() { super(); } public DynamicPropertiesManager
+     * fetchPropertiesManager() { return DPM; } }
+     *
+     * later on, the DPM field is populated: Field dpmField =
+     * myDynamicClass.getField
+     * (DynamicPropertiesManager.PROPERTIES_MANAGER_FIELD);
+     * DynamicPropertiesManager dpm =
+     * (DynamicPropertiesManager)dpmField.get(null); dpm.setType(...) </pre>
+     */
+
+    protected static final String DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES = DynamicPropertiesManager.class.getName().replace('.', '/');
+    protected static final String INIT = "<init>";
+    protected static final String CLINIT = "<clinit>";
+
+    protected Class<?> parentClass;
+
+    /**
+     * Name of parent class. This is used only when the parent class is not
+     * known at the time the dynamic class writer is registered. This is
+     * generally only required when loading from an XML mapping file where the
+     * order of class access is not known.
+     */
+    protected String parentClassName;
+
+    private List<String> interfaces;
+
+    public DynamicClassWriter() {
+        this(DynamicEntityImpl.class);
+    }
+
+    public DynamicClassWriter(Class<?> parentClass) {
+        this.parentClass = parentClass;
+    }
+
+    /**
+     * Create using a loader and class name so that the parent class can be
+     * lazily loaded when the writer is used to generate a dynamic class.
+     * <p>
+     * The loader must not be null and the parentClassName must not be null and
+     * not an empty String. The parentClassName will be converted to a class
+     * using the provided loader lazily.
+     *
+     * @see #getParentClass()
+     * @see DynamicException#illegalDynamicClassWriter(DynamicClassLoader,
+     *      String)
+     */
+    public DynamicClassWriter(String parentClassName) {
+        if (parentClassName == null || parentClassName.length() == 0) {
+            throw DynamicException.illegalParentClassName(parentClassName);
+        }
+        this.parentClassName = parentClassName;
+    }
+
+    @Override
+    public Class<?> getParentClass() {
+        return this.parentClass;
+    }
+
+    @Override
+    public String getParentClassName() {
+        return this.parentClassName;
+    }
+
+    /**
+     * Return the {@link #parentClass} converting the {@link #parentClassName}
+     * using the provided loader if required.
+     *
+     * @throws ClassNotFoundException
+     *             if the parentClass is not available.
+     */
+    private Class<?> getParentClass(ClassLoader loader) throws ClassNotFoundException {
+        if (parentClass == null && parentClassName != null) {
+            parentClass = loader.loadClass(parentClassName);
+        }
+        return parentClass;
+    }
+
+    @Override
+    public byte[] writeClass(DynamicClassLoader loader, String className) throws ClassNotFoundException {
+
+        EnumInfo enumInfo = loader.enumInfoRegistry.get(className);
+        if (enumInfo != null) {
+            return createEnum(enumInfo);
+        }
+
+        Class<?> parent = getParentClass(loader);
+        parentClassName = parent.getName();
+        if (parent.isPrimitive() || parent.isArray() || parent.isEnum() || parent.isInterface() || Modifier.isFinal(parent.getModifiers())) {
+            throw new IllegalArgumentException("Invalid parent class: " + parent);
+        }
+        String classNameAsSlashes = className.replace('.', '/');
+        String parentClassNameAsSlashes = parentClassName.replace('.', '/');
+
+        ClassWriter cw = new EclipseLinkASMClassWriter();
+
+        // public class Foo extends DynamicEntityImpl {
+        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), classNameAsSlashes, null, parentClassNameAsSlashes, interfaces != null ? interfaces.toArray(new String[interfaces.size()]) : null);
+
+        // public static DynamicPropertiesManager DPM = new
+        // DynamicPropertiesManager();
+        cw.visitField(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_STATIC"), PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_STATIC"), CLINIT, "()V", null, null);
+        mv.visitTypeInsn(Opcodes.valueInt("NEW"), DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES);
+        mv.visitInsn(Opcodes.valueInt("DUP"));
+        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES, INIT, "()V", false);
+        mv.visitFieldInsn(Opcodes.valueInt("PUTSTATIC"), classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
+        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitMaxs(0, 0);
+
+        // public Foo() {
+        // super();
+        // }
+        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), INIT, "()V", null, null);
+        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), parentClassNameAsSlashes, INIT, "()V", false);
+        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitMaxs(0, 0);
+
+        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "fetchPropertiesManager", "()L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
+        mv.visitFieldInsn(Opcodes.valueInt("GETSTATIC"), classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
+        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv.visitMaxs(0, 0);
+
+        addFields(cw, parentClassNameAsSlashes);
+        addMethods(cw, parentClassNameAsSlashes);
+
+        cw.visitEnd();
+        return cw.toByteArray();
+
+    }
+
+    /**
+     * Allow subclasses to add additional interfaces to the dynamic entity.
+     *
+     * @param intf additional interface
+     */
+    protected void addInterface(String intf) {
+        if (interfaces == null) {
+            interfaces = new ArrayList<>();
+        }
+        interfaces.add(intf);
+    }
+
+    /**
+     * Allow subclasses to add additional state to the dynamic entity.
+     *
+     */
+    protected void addFields(ClassWriter cw, String parentClassType) {
+    }
+
+    /**
+     * Allow subclasses to add additional methods to the dynamic entity.
+     *
+     */
+    protected void addMethods(ClassWriter cw, String parentClassType) {
+    }
+
+    public static int[] ICONST = new int[] { Opcodes.valueInt("ICONST_0"), Opcodes.valueInt("ICONST_1"), Opcodes.valueInt("ICONST_2"), Opcodes.valueInt("ICONST_3"), Opcodes.valueInt("ICONST_4"), Opcodes.valueInt("ICONST_5") };
+
+    protected byte[] createEnum(EnumInfo enumInfo) {
+
+        String[] enumValues = enumInfo.getLiteralLabels();
+        String className = enumInfo.getClassName();
+
+        String internalClassName = className.replace('.', '/');
+
+        ClassWriter cw = new EclipseLinkASMClassWriter();
+        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_FINAL") + Opcodes.valueInt("ACC_SUPER") + Opcodes.valueInt("ACC_ENUM"), internalClassName, null, "java/lang/Enum", null);
+
+        // Add the individual enum values
+        for (String enumValue : enumValues) {
+            cw.visitField(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_FINAL") + Opcodes.valueInt("ACC_STATIC") + Opcodes.valueInt("ACC_ENUM"), enumValue, "L" + internalClassName + ";", null, null);
+        }
+
+        // add the synthetic "$VALUES" field
+        cw.visitField(Opcodes.valueInt("ACC_PRIVATE") + Opcodes.valueInt("ACC_FINAL") + Opcodes.valueInt("ACC_STATIC") + Opcodes.valueInt("ACC_SYNTHETIC"), "$VALUES", "[L" + internalClassName + ";", null, null);
+
+        // Add the "values()" method
+        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_STATIC"), "values", "()[L" + internalClassName + ";", null, null);
+        mv.visitFieldInsn(Opcodes.valueInt("GETSTATIC"), internalClassName, "$VALUES", "[L" + internalClassName + ";");
+        mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), "[L" + internalClassName + ";", "clone", "()Ljava/lang/Object;", false);
+        mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), "[L" + internalClassName + ";");
+        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv.visitMaxs(1, 0);
+
+        // Add the "valueOf()" method
+        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_STATIC"), "valueOf", "(Ljava/lang/String;)L" + internalClassName + ";", null, null);
+        mv.visitLdcInsn(Type.getType("L" + internalClassName + ";").unwrap());
+        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        mv.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), "java/lang/Enum", "valueOf", "(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;", false);
+        mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), internalClassName);
+        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv.visitMaxs(2, 1);
+
+        // Add constructors
+        // SignatureAttribute methodAttrs1 = new SignatureAttribute("()V");
+        mv = cw.visitMethod(Opcodes.valueInt("ACC_PRIVATE"), "<init>", "(Ljava/lang/String;I)V", null, null);
+        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        mv.visitVarInsn(Opcodes.valueInt("ILOAD"), 2);
+        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "java/lang/Enum", "<init>", "(Ljava/lang/String;I)V", false);
+        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitMaxs(3, 3);
+
+        // Add enum constants
+        mv = cw.visitMethod(Opcodes.valueInt("ACC_STATIC"), "<clinit>", "()V", null, null);
+
+        int lastCount = 0;
+        for (int i = 0; i < enumValues.length; i++) {
+            String enumValue = enumValues[i];
+            mv.visitTypeInsn(Opcodes.valueInt("NEW"), internalClassName);
+            mv.visitInsn(Opcodes.valueInt("DUP"));
+            mv.visitLdcInsn(enumValue);
+            if (i <= 5) {
+                mv.visitInsn(ICONST[i]);
+            } else if (i <= 127) {
+                mv.visitIntInsn(Opcodes.valueInt("BIPUSH"), i);
+            } else {
+                mv.visitIntInsn(Opcodes.valueInt("SIPUSH"), i);
+            }
+            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), internalClassName, "<init>", "(Ljava/lang/String;I)V", false);
+            mv.visitFieldInsn(Opcodes.valueInt("PUTSTATIC"), internalClassName, enumValue, "L" + internalClassName + ";");
+            lastCount = i;
+        }
+
+        if (lastCount < 5) {
+            mv.visitInsn(ICONST[lastCount + 1]);
+        } else if (lastCount < 127) {
+            mv.visitIntInsn(Opcodes.valueInt("BIPUSH"), lastCount + 1);
+        } else {
+            mv.visitIntInsn(Opcodes.valueInt("SIPUSH"), lastCount + 1);
+        }
+        mv.visitTypeInsn(Opcodes.valueInt("ANEWARRAY"), internalClassName);
+
+        for (int i = 0; i < enumValues.length; i++) {
+            String enumValue = enumValues[i];
+            mv.visitInsn(Opcodes.valueInt("DUP"));
+            if (i <= 5) {
+                mv.visitInsn(ICONST[i]);
+            } else if (i <= 127) {
+                mv.visitIntInsn(Opcodes.valueInt("BIPUSH"), i);
+            } else {
+                mv.visitIntInsn(Opcodes.valueInt("SIPUSH"), i);
+            }
+            mv.visitFieldInsn(Opcodes.valueInt("GETSTATIC"), internalClassName, enumValue, "L" + internalClassName + ";");
+            mv.visitInsn(Opcodes.valueInt("AASTORE"));
+        }
+        mv.visitFieldInsn(Opcodes.valueInt("PUTSTATIC"), internalClassName, "$VALUES", "[L" + internalClassName + ";");
+        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitMaxs(4, 0);
+
+        cw.visitEnd();
+        return cw.toByteArray();
+    }
+
+    /**
+     * Verify that the provided class meets the requirements of the writer. In
+     * the case of {@link DynamicClassWriter} this will ensure that the class is
+     * a subclass of the {@link #parentClass}
+     *
+     */
+    protected boolean verify(Class<?> dynamicClass, ClassLoader loader) throws ClassNotFoundException {
+        Class<?> parent = getParentClass(loader);
+        return dynamicClass != null && parent.isAssignableFrom(dynamicClass);
+    }
+
+    /**
+     * Interfaces the dynamic entity class implements. By default this is none
+     * but in the case of SDO a concrete interface must be implemented.
+     * Subclasses should override this as required.
+     *
+     * @return Interfaces implemented by Dynamic class. May be null
+     */
+    protected String[] getInterfaces() {
+        return null;
+    }
+
+    /**
+     * Create a copy of this {@link DynamicClassWriter} but with a different
+     * parent class.
+     *
+     * @see DynamicClassLoader#addClass(String, Class)
+     */
+    protected DynamicClassWriter createCopy(Class<?> parentClass) {
+        return new DynamicClassWriter(parentClass);
+    }
+
+    /**
+     * Verify that the provided writer is compatible with the current writer.
+     * Returning true means that the bytes that would be created using this
+     * writer are identical with what would come from the provided writer.
+     * <p>
+     * Used in {@link DynamicClassLoader#addClass(String, EclipseLinkClassWriter)}
+     * to verify if a duplicate request of the same className can proceed and
+     * return the same class that may already exist.
+     */
+    @Override
+    public boolean isCompatible(EclipseLinkClassWriter writer) {
+        if (writer == null) {
+            return false;
+        }
+        // Ensure writers are the exact same class. If subclasses do not alter
+        // the bytes created then they must override this method and not return
+        // false on this check.
+        if (getClass() != writer.getClass()) {
+            return false;
+        }
+        if (getParentClass() == null) {
+            return getParentClassName() != null && getParentClassName().equals(writer.getParentClassName());
+        }
+        return getParentClass() == writer.getParentClass();
+    }
+
+    @Override
+    public String toString() {
+        String parentName = getParentClass() == null ? getParentClassName() : getParentClass().getName();
+        return Helper.getShortClassName(getClass()) + "(" + parentName + ")";
+    }
+}

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/dynamic/DynamicClassWriter.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/dynamic/DynamicClassWriter.java
@@ -160,31 +160,31 @@ public class DynamicClassWriter implements EclipseLinkClassWriter {
         ClassWriter cw = new EclipseLinkASMClassWriter();
 
         // public class Foo extends DynamicEntityImpl {
-        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), classNameAsSlashes, null, parentClassNameAsSlashes, interfaces != null ? interfaces.toArray(new String[interfaces.size()]) : null);
+        cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, classNameAsSlashes, null, parentClassNameAsSlashes, interfaces != null ? interfaces.toArray(new String[interfaces.size()]) : null);
 
         // public static DynamicPropertiesManager DPM = new
         // DynamicPropertiesManager();
-        cw.visitField(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_STATIC"), PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_STATIC"), CLINIT, "()V", null, null);
-        mv.visitTypeInsn(Opcodes.valueInt("NEW"), DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES);
-        mv.visitInsn(Opcodes.valueInt("DUP"));
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES, INIT, "()V", false);
-        mv.visitFieldInsn(Opcodes.valueInt("PUTSTATIC"), classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        cw.visitField(Opcodes.ACC_PUBLIC + Opcodes.ACC_STATIC, PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_STATIC, CLINIT, "()V", null, null);
+        mv.visitTypeInsn(Opcodes.NEW, DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES);
+        mv.visitInsn(Opcodes.DUP);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES, INIT, "()V", false);
+        mv.visitFieldInsn(Opcodes.PUTSTATIC, classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(0, 0);
 
         // public Foo() {
         // super();
         // }
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), INIT, "()V", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), parentClassNameAsSlashes, INIT, "()V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, INIT, "()V", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, parentClassNameAsSlashes, INIT, "()V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(0, 0);
 
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "fetchPropertiesManager", "()L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
-        mv.visitFieldInsn(Opcodes.valueInt("GETSTATIC"), classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "fetchPropertiesManager", "()L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
+        mv.visitFieldInsn(Opcodes.GETSTATIC, classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(0, 0);
 
         addFields(cw, parentClassNameAsSlashes);
@@ -221,7 +221,7 @@ public class DynamicClassWriter implements EclipseLinkClassWriter {
     protected void addMethods(ClassWriter cw, String parentClassType) {
     }
 
-    public static int[] ICONST = new int[] { Opcodes.valueInt("ICONST_0"), Opcodes.valueInt("ICONST_1"), Opcodes.valueInt("ICONST_2"), Opcodes.valueInt("ICONST_3"), Opcodes.valueInt("ICONST_4"), Opcodes.valueInt("ICONST_5") };
+    public static int[] ICONST = new int[] { Opcodes.ICONST_0, Opcodes.ICONST_1, Opcodes.ICONST_2, Opcodes.ICONST_3, Opcodes.ICONST_4, Opcodes.ICONST_5 };
 
     protected byte[] createEnum(EnumInfo enumInfo) {
 
@@ -231,88 +231,88 @@ public class DynamicClassWriter implements EclipseLinkClassWriter {
         String internalClassName = className.replace('.', '/');
 
         ClassWriter cw = new EclipseLinkASMClassWriter();
-        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_FINAL") + Opcodes.valueInt("ACC_SUPER") + Opcodes.valueInt("ACC_ENUM"), internalClassName, null, "java/lang/Enum", null);
+        cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL + Opcodes.ACC_SUPER + Opcodes.ACC_ENUM, internalClassName, null, "java/lang/Enum", null);
 
         // Add the individual enum values
         for (String enumValue : enumValues) {
-            cw.visitField(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_FINAL") + Opcodes.valueInt("ACC_STATIC") + Opcodes.valueInt("ACC_ENUM"), enumValue, "L" + internalClassName + ";", null, null);
+            cw.visitField(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL + Opcodes.ACC_STATIC + Opcodes.ACC_ENUM, enumValue, "L" + internalClassName + ";", null, null);
         }
 
         // add the synthetic "$VALUES" field
-        cw.visitField(Opcodes.valueInt("ACC_PRIVATE") + Opcodes.valueInt("ACC_FINAL") + Opcodes.valueInt("ACC_STATIC") + Opcodes.valueInt("ACC_SYNTHETIC"), "$VALUES", "[L" + internalClassName + ";", null, null);
+        cw.visitField(Opcodes.ACC_PRIVATE + Opcodes.ACC_FINAL + Opcodes.ACC_STATIC + Opcodes.ACC_SYNTHETIC, "$VALUES", "[L" + internalClassName + ";", null, null);
 
         // Add the "values()" method
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_STATIC"), "values", "()[L" + internalClassName + ";", null, null);
-        mv.visitFieldInsn(Opcodes.valueInt("GETSTATIC"), internalClassName, "$VALUES", "[L" + internalClassName + ";");
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), "[L" + internalClassName + ";", "clone", "()Ljava/lang/Object;", false);
-        mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), "[L" + internalClassName + ";");
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_STATIC, "values", "()[L" + internalClassName + ";", null, null);
+        mv.visitFieldInsn(Opcodes.GETSTATIC, internalClassName, "$VALUES", "[L" + internalClassName + ";");
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "[L" + internalClassName + ";", "clone", "()Ljava/lang/Object;", false);
+        mv.visitTypeInsn(Opcodes.CHECKCAST, "[L" + internalClassName + ";");
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 0);
 
         // Add the "valueOf()" method
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_STATIC"), "valueOf", "(Ljava/lang/String;)L" + internalClassName + ";", null, null);
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_STATIC, "valueOf", "(Ljava/lang/String;)L" + internalClassName + ";", null, null);
         mv.visitLdcInsn(Type.getType("L" + internalClassName + ";").unwrap());
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), "java/lang/Enum", "valueOf", "(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;", false);
-        mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), internalClassName);
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Enum", "valueOf", "(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;", false);
+        mv.visitTypeInsn(Opcodes.CHECKCAST, internalClassName);
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(2, 1);
 
         // Add constructors
         // SignatureAttribute methodAttrs1 = new SignatureAttribute("()V");
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PRIVATE"), "<init>", "(Ljava/lang/String;I)V", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitVarInsn(Opcodes.valueInt("ILOAD"), 2);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "java/lang/Enum", "<init>", "(Ljava/lang/String;I)V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PRIVATE, "<init>", "(Ljava/lang/String;I)V", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitVarInsn(Opcodes.ILOAD, 2);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Enum", "<init>", "(Ljava/lang/String;I)V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(3, 3);
 
         // Add enum constants
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_STATIC"), "<clinit>", "()V", null, null);
+        mv = cw.visitMethod(Opcodes.ACC_STATIC, "<clinit>", "()V", null, null);
 
         int lastCount = 0;
         for (int i = 0; i < enumValues.length; i++) {
             String enumValue = enumValues[i];
-            mv.visitTypeInsn(Opcodes.valueInt("NEW"), internalClassName);
-            mv.visitInsn(Opcodes.valueInt("DUP"));
+            mv.visitTypeInsn(Opcodes.NEW, internalClassName);
+            mv.visitInsn(Opcodes.DUP);
             mv.visitLdcInsn(enumValue);
             if (i <= 5) {
                 mv.visitInsn(ICONST[i]);
             } else if (i <= 127) {
-                mv.visitIntInsn(Opcodes.valueInt("BIPUSH"), i);
+                mv.visitIntInsn(Opcodes.BIPUSH, i);
             } else {
-                mv.visitIntInsn(Opcodes.valueInt("SIPUSH"), i);
+                mv.visitIntInsn(Opcodes.SIPUSH, i);
             }
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), internalClassName, "<init>", "(Ljava/lang/String;I)V", false);
-            mv.visitFieldInsn(Opcodes.valueInt("PUTSTATIC"), internalClassName, enumValue, "L" + internalClassName + ";");
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, internalClassName, "<init>", "(Ljava/lang/String;I)V", false);
+            mv.visitFieldInsn(Opcodes.PUTSTATIC, internalClassName, enumValue, "L" + internalClassName + ";");
             lastCount = i;
         }
 
         if (lastCount < 5) {
             mv.visitInsn(ICONST[lastCount + 1]);
         } else if (lastCount < 127) {
-            mv.visitIntInsn(Opcodes.valueInt("BIPUSH"), lastCount + 1);
+            mv.visitIntInsn(Opcodes.BIPUSH, lastCount + 1);
         } else {
-            mv.visitIntInsn(Opcodes.valueInt("SIPUSH"), lastCount + 1);
+            mv.visitIntInsn(Opcodes.SIPUSH, lastCount + 1);
         }
-        mv.visitTypeInsn(Opcodes.valueInt("ANEWARRAY"), internalClassName);
+        mv.visitTypeInsn(Opcodes.ANEWARRAY, internalClassName);
 
         for (int i = 0; i < enumValues.length; i++) {
             String enumValue = enumValues[i];
-            mv.visitInsn(Opcodes.valueInt("DUP"));
+            mv.visitInsn(Opcodes.DUP);
             if (i <= 5) {
                 mv.visitInsn(ICONST[i]);
             } else if (i <= 127) {
-                mv.visitIntInsn(Opcodes.valueInt("BIPUSH"), i);
+                mv.visitIntInsn(Opcodes.BIPUSH, i);
             } else {
-                mv.visitIntInsn(Opcodes.valueInt("SIPUSH"), i);
+                mv.visitIntInsn(Opcodes.SIPUSH, i);
             }
-            mv.visitFieldInsn(Opcodes.valueInt("GETSTATIC"), internalClassName, enumValue, "L" + internalClassName + ";");
-            mv.visitInsn(Opcodes.valueInt("AASTORE"));
+            mv.visitFieldInsn(Opcodes.GETSTATIC, internalClassName, enumValue, "L" + internalClassName + ";");
+            mv.visitInsn(Opcodes.AASTORE);
         }
-        mv.visitFieldInsn(Opcodes.valueInt("PUTSTATIC"), internalClassName, "$VALUES", "[L" + internalClassName + ";");
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitFieldInsn(Opcodes.PUTSTATIC, internalClassName, "$VALUES", "[L" + internalClassName + ";");
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(4, 0);
 
         cw.visitEnd();

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/metadata/MetadataDynamicClassWriter.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/metadata/MetadataDynamicClassWriter.java
@@ -64,25 +64,25 @@ public class MetadataDynamicClassWriter extends DynamicClassWriter {
             Type returnType = getAsmType(accessor);
 
             // Add getter
-            MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), GET + propertyName, "()" + returnType.getDescriptor(), null, new String[] { DYNAMIC_EXCEPTION });
+            MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, GET + propertyName, "()" + returnType.getDescriptor(), null, new String[] { DYNAMIC_EXCEPTION });
             mv.visitCode();
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
             mv.visitLdcInsn(accessor.getAttributeName());
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), parentClassType, "get", "(" + LJAVA_LANG_STRING + ")" + LJAVA_LANG_OBJECT, false);
-            mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), returnType.getInternalName());
-            mv.visitInsn(Opcodes.valueInt("ARETURN"));
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, parentClassType, "get", "(" + LJAVA_LANG_STRING + ")" + LJAVA_LANG_OBJECT, false);
+            mv.visitTypeInsn(Opcodes.CHECKCAST, returnType.getInternalName());
+            mv.visitInsn(Opcodes.ARETURN);
             mv.visitMaxs(2, 1);
             mv.visitEnd();
 
             // Add setter
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), SET + propertyName, "(" + returnType.getDescriptor() + ")V", null, new String[] { DYNAMIC_EXCEPTION });
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC, SET + propertyName, "(" + returnType.getDescriptor() + ")V", null, new String[] { DYNAMIC_EXCEPTION });
             mv.visitCode();
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
             mv.visitLdcInsn("id");
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), parentClassType, SET, "(" + LJAVA_LANG_STRING + LJAVA_LANG_OBJECT + ")" + LDYNAMIC_ENTITY, false);
-            mv.visitInsn(Opcodes.valueInt("POP"));
-            mv.visitInsn(Opcodes.valueInt("RETURN"));
+            mv.visitVarInsn(Opcodes.ALOAD, 1);
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, parentClassType, SET, "(" + LJAVA_LANG_STRING + LJAVA_LANG_OBJECT + ")" + LDYNAMIC_ENTITY, false);
+            mv.visitInsn(Opcodes.POP);
+            mv.visitInsn(Opcodes.RETURN);
             mv.visitMaxs(3, 2);
             mv.visitEnd();
         }

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/metadata/MetadataDynamicClassWriter.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/metadata/MetadataDynamicClassWriter.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     dclarke - Metadata driven Dynamic Persistence
+//
+package org.eclipse.persistence.internal.jpa.metadata;
+
+import org.eclipse.persistence.asm.ASMFactory;
+import org.eclipse.persistence.asm.ClassWriter;
+import org.eclipse.persistence.asm.MethodVisitor;
+import org.eclipse.persistence.asm.Opcodes;
+import org.eclipse.persistence.asm.Type;
+import org.eclipse.persistence.dynamic.DynamicClassWriter;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.jpa.metadata.accessors.mappings.MappingAccessor;
+
+/**
+ * Custom {@link DynamicClassWriter} adding getter methods for virtual
+ * attributes so that 3rd party frameworks such as jakarta.validation can access
+ * the attribute values.
+ *
+ * @author dclarke
+ * @since EclipseLink 2.4.1
+ */
+public class MetadataDynamicClassWriter extends DynamicClassWriter {
+
+    private static final String LDYNAMIC_ENTITY = "Lorg/eclipse/persistence/dynamic/DynamicEntity;";
+    private static final String SET = "set";
+    private static final String LJAVA_LANG_OBJECT = "Ljava/lang/Object;";
+    private static final String LJAVA_LANG_STRING = "Ljava/lang/String;";
+    private static final String DYNAMIC_EXCEPTION = "org/eclipse/persistence/exceptions/DynamicException";
+    private static final String GET = "get";
+
+    /**
+     * The {@link MetadataDescriptor} for the dynamic entity
+     */
+    private MetadataDescriptor descriptor;
+
+    public MetadataDynamicClassWriter(MetadataDescriptor descriptor) {
+        this.descriptor = descriptor;
+    }
+
+    public MetadataDescriptor getDescriptor() {
+        return descriptor;
+    }
+
+    /**
+     * Add get methods for all virtual attributes
+     */
+    @Override
+    protected void addMethods(ClassWriter cw, String parentClassType) {
+        for (MappingAccessor accessor : getDescriptor().getMappingAccessors()) {
+            String propertyName = propertyName(accessor.getAttributeName());
+            Type returnType = getAsmType(accessor);
+
+            // Add getter
+            MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), GET + propertyName, "()" + returnType.getDescriptor(), null, new String[] { DYNAMIC_EXCEPTION });
+            mv.visitCode();
+            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            mv.visitLdcInsn(accessor.getAttributeName());
+            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), parentClassType, "get", "(" + LJAVA_LANG_STRING + ")" + LJAVA_LANG_OBJECT, false);
+            mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), returnType.getInternalName());
+            mv.visitInsn(Opcodes.valueInt("ARETURN"));
+            mv.visitMaxs(2, 1);
+            mv.visitEnd();
+
+            // Add setter
+            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), SET + propertyName, "(" + returnType.getDescriptor() + ")V", null, new String[] { DYNAMIC_EXCEPTION });
+            mv.visitCode();
+            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            mv.visitLdcInsn("id");
+            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), parentClassType, SET, "(" + LJAVA_LANG_STRING + LJAVA_LANG_OBJECT + ")" + LDYNAMIC_ENTITY, false);
+            mv.visitInsn(Opcodes.valueInt("POP"));
+            mv.visitInsn(Opcodes.valueInt("RETURN"));
+            mv.visitMaxs(3, 2);
+            mv.visitEnd();
+        }
+    }
+
+    /**
+     * Get the {@link Type} for the accessor. If the accessor's type is
+     * primitive return the the non-primitive type.
+     */
+    private Type getAsmType(MappingAccessor accessor) {
+        String attributeType = accessor.getFullyQualifiedClassName(accessor.getAttributeType());
+
+        Class<?> primClass = accessor.getPrimitiveClassForName(attributeType);
+
+        if (primClass != null) {
+            Type asmType = ASMFactory.createType(primClass);
+
+            int asmTypeSort = asmType.getSort();
+            if (asmTypeSort == Type.BOOLEAN) {
+                return Type.getType(ClassConstants.BOOLEAN);
+            } else if (asmTypeSort == Type.BYTE) {
+                return Type.getType(ClassConstants.BYTE);
+            } else if (asmTypeSort == Type.CHAR) {
+                return Type.getType(ClassConstants.CHAR);
+            } else if (asmTypeSort == Type.DOUBLE) {
+                return Type.getType(ClassConstants.DOUBLE);
+            } else if (asmTypeSort == Type.FLOAT) {
+                return Type.getType(ClassConstants.FLOAT);
+            } else if (asmTypeSort == Type.INT) {
+                return Type.getType(ClassConstants.INTEGER);
+            } else if (asmTypeSort == Type.LONG) {
+                return Type.getType(ClassConstants.LONG);
+            } else if (asmTypeSort == Type.SHORT) {
+                return Type.getType(ClassConstants.SHORT);
+            }
+        }
+
+        return Type.getType("L" + attributeType.replace(".", "/") + ";");
+    }
+
+    /**
+     * Convert attribute name into property name to be used in get/set method
+     * names by upper casing first letter.
+     */
+    private String propertyName(String attributeName) {
+        char string[] = attributeName.toCharArray();
+        string[0] = Character.toUpperCase(string[0]);
+        return new String(string);
+    }
+}

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
@@ -101,7 +101,7 @@ public class MetadataAsmFactory extends MetadataFactory {
 
             ClassReader reader = ASMFactory.createClassReader(stream);
             Attribute[] attributes = new Attribute[0];
-            reader.accept(visitor, attributes, ClassReader.valueInt("SKIP_CODE") | ClassReader.valueInt("SKIP_DEBUG") | ClassReader.valueInt("SKIP_FRAMES"));
+            reader.accept(visitor, attributes, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
         } catch (IllegalArgumentException iae) {
             // class was probably compiled with some newer than officially
             // supported and tested JDK
@@ -132,7 +132,7 @@ public class MetadataAsmFactory extends MetadataFactory {
                     //as checkClassVersion is not visible by public constructor
                     ClassReader reader = ASMFactory.createClassReader(stream, false);
                     Attribute[] attributes = new Attribute[0];
-                    reader.accept(visitor, attributes, ClassReader.valueInt("SKIP_CODE") | ClassReader.valueInt("SKIP_DEBUG") | ClassReader.valueInt("SKIP_FRAMES"));
+                    reader.accept(visitor, attributes, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
                 } catch (Exception e) {
                     SessionLog log = getLogger().getSession() != null
                             ? getLogger().getSession().getSessionLog() : AbstractSessionLog.getLog();

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
@@ -1,0 +1,738 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Hans Harz, Andrew Rustleund, IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     James Sutherland - initial impl
+//     05/14/2010-2.1 Guy Pelletier
+//       - 253083: Add support for dynamic persistence using ORM.xml/eclipselink-orm.xml
+//     Hans Harz, Andrew Rustleund - Bug 324862 - IndexOutOfBoundsException in
+//           DatabaseSessionImpl.initializeDescriptors because @MapKey Annotation is not found.
+//     04/21/2011-2.3 dclarke: Upgraded to support ASM 3.3.1
+//     08/10/2011-2.3 Lloyd Fernandes : Bug 336133 - Validation error during processing on parameterized generic OneToMany Entity relationship from MappedSuperclass
+//     10/05/2012-2.4.1 Guy Pelletier
+//       - 373092: Exceptions using generics, embedded key and entity inheritance
+//     19/04/2014-2.6 Lukas Jungmann
+//       - 429992: JavaSE 8/ASM 5.0.1 support (EclipseLink silently ignores Entity classes with lambda expressions)
+//     11/05/2015-2.6 Dalia Abo Sheasha
+//       - 480787 : Wrap several privileged method calls with a doPrivileged block
+package org.eclipse.persistence.internal.jpa.metadata.accessors.objects;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.persistence.asm.ASMFactory;
+import org.eclipse.persistence.asm.AnnotationVisitor;
+import org.eclipse.persistence.asm.EclipseLinkAnnotationVisitor;
+import org.eclipse.persistence.asm.Attribute;
+import org.eclipse.persistence.asm.ClassReader;
+import org.eclipse.persistence.asm.EclipseLinkClassVisitor;
+import org.eclipse.persistence.asm.EclipseLinkFieldVisitor;
+import org.eclipse.persistence.asm.EclipseLinkClassReader;
+import org.eclipse.persistence.asm.FieldVisitor;
+import org.eclipse.persistence.asm.EclipseLinkMethodVisitor;
+import org.eclipse.persistence.asm.MethodVisitor;
+import org.eclipse.persistence.asm.Type;
+import org.eclipse.persistence.internal.helper.Helper;
+import org.eclipse.persistence.internal.jpa.metadata.MetadataDescriptor;
+import org.eclipse.persistence.internal.jpa.metadata.MetadataLogger;
+import org.eclipse.persistence.internal.localization.ExceptionLocalization;
+import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.logging.SessionLogEntry;
+
+/**
+ * INTERNAL: A metadata factory that uses ASM technology and no reflection
+ * whatsoever to process the metadata model.
+ *
+ * @author James Sutherland
+ * @since EclipseLink 1.2
+ */
+public class MetadataAsmFactory extends MetadataFactory {
+    /** Set of primitive type codes. */
+    public static final String PRIMITIVES = "VJIBZCSFD";
+    /** Set of desc token characters. */
+    public static final String TOKENS = "()<>;";
+
+    /**
+     * INTERNAL:
+     */
+    public MetadataAsmFactory(MetadataLogger logger, ClassLoader loader) {
+        super(logger, loader);
+
+        addMetadataClass("I", new MetadataClass(this, int.class));
+        addMetadataClass("J", new MetadataClass(this, long.class));
+        addMetadataClass("S", new MetadataClass(this, short.class));
+        addMetadataClass("Z", new MetadataClass(this, boolean.class));
+        addMetadataClass("F", new MetadataClass(this, float.class));
+        addMetadataClass("D", new MetadataClass(this, double.class));
+        addMetadataClass("C", new MetadataClass(this, char.class));
+        addMetadataClass("B", new MetadataClass(this, byte.class));
+    }
+
+    /**
+     * Build the class metadata for the class name using ASM to read the class
+     * byte codes.
+     */
+    protected void buildClassMetadata(MetadataClass metadataClass, String className, boolean isLazy) {
+        ClassMetadataVisitor visitor = new ClassMetadataVisitor(metadataClass, isLazy);
+        InputStream stream = null;
+        String resourceString = className.replace('.', '/') + ".class";
+        boolean markSupported = false;
+        try {
+            stream = readResource(resourceString);
+            if (markSupported = stream.markSupported()) {
+                stream.mark(Integer.MAX_VALUE);
+            }
+
+            ClassReader reader = ASMFactory.createClassReader(stream);
+            Attribute[] attributes = new Attribute[0];
+            reader.accept(visitor, attributes, ClassReader.valueInt("SKIP_CODE") | ClassReader.valueInt("SKIP_DEBUG") | ClassReader.valueInt("SKIP_FRAMES"));
+        } catch (IllegalArgumentException iae) {
+            // class was probably compiled with some newer than officially
+            // supported and tested JDK
+            // in such case log a warning and try to re-read the class
+            // without class version check
+            if (stream != null) {
+                if (markSupported) {
+                    try {
+                        stream.reset();
+                    } catch (IOException e) {
+                        try {
+                            stream.close();
+                        } catch (IOException ex) {
+                            //ignore
+                        }
+                        stream = readResource(resourceString);
+                    }
+                } else {
+                    try {
+                        stream.close();
+                    } catch (IOException ex) {
+                        //ignore
+                    }
+                    stream = readResource(resourceString);
+                }
+                try {
+                    //Second argument checkClassVersion=false means, that EclipseLink ASM implementation is used
+                    //as checkClassVersion is not visible by public constructor
+                    ClassReader reader = ASMFactory.createClassReader(stream, false);
+                    Attribute[] attributes = new Attribute[0];
+                    reader.accept(visitor, attributes, ClassReader.valueInt("SKIP_CODE") | ClassReader.valueInt("SKIP_DEBUG") | ClassReader.valueInt("SKIP_FRAMES"));
+                } catch (Exception e) {
+                    SessionLog log = getLogger().getSession() != null
+                            ? getLogger().getSession().getSessionLog() : AbstractSessionLog.getLog();
+                    // our fall-back failed, this is severe
+                    if (log.shouldLog(SessionLog.SEVERE, SessionLog.METADATA)) {
+                        SessionLogEntry entry = new SessionLogEntry(getLogger().getSession(), SessionLog.SEVERE, SessionLog.METADATA, e);
+                        entry.setMessage(ExceptionLocalization.buildMessage("unsupported_classfile_version", new Object[] { className }));
+                        log.log(entry);
+                    }
+                    addMetadataClass(getVirtualMetadataClass(className));
+                }
+            } else {
+                addMetadataClass(getVirtualMetadataClass(className));
+            }
+        } catch (Exception exception) {
+            addMetadataClass(getVirtualMetadataClass(className));
+        } finally {
+            try {
+                if (stream != null) {
+                    stream.close();
+                }
+            } catch (IOException ignore) {
+                // Ignore.
+            }
+        }
+    }
+
+    /**
+     * Return the class metadata for the class name.
+     */
+    @Override
+    public MetadataClass getMetadataClass(String className) {
+        return getMetadataClass(className, false);
+    }
+
+    /**
+     * Return the class metadata for the class name.
+     */
+    @Override
+    public MetadataClass getMetadataClass(String className, boolean isLazy) {
+        if (className == null) {
+            return null;
+        }
+
+        MetadataClass metaClass = m_metadataClasses.get(className);
+        if ((metaClass == null) || (!isLazy && metaClass.isLazy())) {
+            if (metaClass != null) {
+                metaClass.setIsLazy(false);
+            }
+            buildClassMetadata(metaClass, className, isLazy);
+            metaClass = m_metadataClasses.get(className);
+        }
+
+        return metaClass;
+    }
+
+    /**
+     * INTERNAL: This method resolves generic types based on the ASM class
+     * metadata. Unless every other factory (e.g. APT mirror factory) respects
+     * the generic format as built from ASM this method will not work since it
+     * is very tied to it.
+     */
+    @Override
+    public void resolveGenericTypes(MetadataClass child, List<String> genericTypes, MetadataClass parent, MetadataDescriptor descriptor) {
+        // If we have a generic parent we need to grab our generic types
+        // that may be used (and therefore need to be resolved) to map
+        // accessors correctly.
+        if (genericTypes != null) {
+            // The generic types provided map to its parents generic types. The
+            // generics also include the superclass, and interfaces. The parent
+            // generics include the type and ":" and class.
+
+            List<String> parentGenericTypes = parent.getGenericType();
+            if (parentGenericTypes != null) {
+                List<String> genericParentTemp = new ArrayList<>(genericTypes);
+                genericParentTemp.removeAll(child.getInterfaces());
+
+                int size = genericParentTemp.size();
+                int parentIndex = 0;
+
+                for (int index = genericTypes.indexOf(parent.getName()) + 1; index < size; index++) {
+                    String actualTypeArgument = genericTypes.get(index);
+                    // Ignore extra types on the end of the child, such as
+                    // interface generics.
+                    if (parentIndex >= parentGenericTypes.size()) {
+                        break;
+                    }
+                    String variable = parentGenericTypes.get(parentIndex);
+
+                    // if we get as far as the superclass name in the parent generic type list,
+                    // there is nothing more to process.  We have processed all the generics in the type definition
+                    if (variable.equals(parent.getSuperclassName())){
+                        break;
+                    }
+                    parentIndex = parentIndex + 3;
+
+                    // We are building bottom up and need to link up any
+                    // TypeVariables with the actual class from the originating
+                    // entity.
+                    if (actualTypeArgument.length() == 1) {
+                        index++;
+                        actualTypeArgument = genericTypes.get(index);
+                        descriptor.addGenericType(variable, descriptor.getGenericType(actualTypeArgument));
+                    } else {
+                        descriptor.addGenericType(variable, actualTypeArgument);
+                    }
+                }
+            }
+        }
+    }
+
+    private InputStream readResource(String name) {
+        if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()) {
+            return AccessController.doPrivileged(new PrivilegedAction<InputStream>() {
+                @Override
+                public InputStream run() {
+                    return m_loader.getResourceAsStream(name);
+                }
+            });
+        } else {
+            return m_loader.getResourceAsStream(name);
+        }
+    }
+
+    /**
+     * Walk the class byte codes and collect the class info.
+     */
+    public class ClassMetadataVisitor extends EclipseLinkClassVisitor {
+
+        private boolean isLazy;
+        private boolean processedMemeber;
+        private MetadataClass classMetadata;
+
+        ClassMetadataVisitor(MetadataClass metadataClass, boolean isLazy) {
+            super();
+            super.setCustomClassVisitor(this);
+            this.isLazy = isLazy;
+            this.classMetadata = metadataClass;
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            String className = toClassName(name);
+            if ((this.classMetadata == null) || !this.classMetadata.getName().equals(className)) {
+                this.classMetadata = new MetadataClass(MetadataAsmFactory.this, className, isLazy);
+                addMetadataClass(this.classMetadata);
+            }
+            this.classMetadata.setName(className);
+            this.classMetadata.setSuperclassName(toClassName(superName));
+            this.classMetadata.setModifiers(access);
+            this.classMetadata.setGenericType(processDescription(signature, true));
+
+            for (String interfaceName : interfaces) {
+                this.classMetadata.addInterface(toClassName(interfaceName));
+            }
+        }
+
+        @Override
+        public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
+            this.processedMemeber = true;
+            if (this.classMetadata.isLazy()) {
+                return null;
+            }
+            return new MetadataFieldVisitor(this.classMetadata, access, name, desc, signature, value);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+            this.processedMemeber = true;
+            if (this.classMetadata.isLazy() || name.indexOf("init>") != -1) {
+                return null;
+            }
+            return new MetadataMethodVisitor(this.classMetadata, access, name, signature, desc, exceptions);
+        }
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+            boolean isJPA = false;
+            if (desc.startsWith("Lkotlin")) {
+                //ignore kotlin annotations
+                return null;
+            }
+            if (desc.startsWith("Ljava")) {
+                char c = desc.charAt(5);
+                //ignore annotations from 'java' namespace
+                if (c == '/') {
+                    return null;
+                }
+                //ignore annotations from other then 'javax/persistence' namespace
+                if (desc.regionMatches(5, "x/", 0, 2)) {
+                    if (desc.regionMatches(7, "persistence", 0, "persistence".length())) {
+                        isJPA = true;
+                    } else {
+                        return null;
+                    }
+                }
+            }
+            if (desc.startsWith("Ljakarta")) {
+                //ignore annotations from other then 'jakarta/persistence' namespace
+                    if (desc.regionMatches(9, "persistence", 0, "persistence".length())) {
+                        isJPA = true;
+                    } else {
+                        return null;
+                    }
+            }
+            if (!this.processedMemeber && this.classMetadata.isLazy()) {
+                this.classMetadata.setIsLazy(false);
+            }
+            //this currently forbids us to use meta-annotations defined in EclipseLink packages
+            return new MetadataAnnotationVisitor(this.classMetadata, desc, isJPA || desc.startsWith("Lorg/eclipse/persistence"));
+        }
+
+        @Override
+        public void visitEnd() {
+            //TODO should lead into infinite loop if visitEnd() is not implemented here
+        }
+    }
+
+    /**
+     * {@link AnnotationVisitor} used to process class, field , and method
+     * annotations populating a {@link MetadataAnnotation} and its nested state.
+     *
+     * @see MetadataAnnotationArrayVisitor for population of array attributes
+     */
+    class MetadataAnnotationVisitor extends EclipseLinkAnnotationVisitor {
+
+        /**
+         * Element the annotation is being applied to. If this is null the
+         * {@link MetadataAnnotation} being constructed is a nested annotation
+         * and is already referenced from its parent.
+         */
+        private MetadataAnnotatedElement element;
+
+        /**
+         * {@link MetadataAnnotation} being populated
+         */
+        private MetadataAnnotation annotation;
+
+        MetadataAnnotationVisitor(MetadataAnnotatedElement element, String name) {
+            this(element, name, true);
+        }
+
+        MetadataAnnotationVisitor(MetadataAnnotatedElement element, String name, boolean isRegular) {
+            super();
+            super.setCustomAnnotationVisitor(this);
+            this.element = element;
+            this.annotation = new MetadataAnnotation();
+            this.annotation.setName(processDescription(name, false).get(0));
+            this.annotation.setIsMeta(!isRegular);
+        }
+
+        public MetadataAnnotationVisitor(MetadataAnnotation annotation) {
+            super();
+            super.setCustomAnnotationVisitor(this);
+            this.annotation = annotation;
+        }
+
+        @Override
+        public void visit(String name, Object value) {
+            this.annotation.addAttribute(name, annotationValue(null, value));
+        }
+
+        @Override
+        public void visitEnum(String name, String desc, String value) {
+            this.annotation.addAttribute(name, annotationValue(desc, value));
+        }
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String name, String desc) {
+            MetadataAnnotation mda = new MetadataAnnotation();
+            mda.setName(processDescription(desc, false).get(0));
+            this.annotation.addAttribute(name, mda);
+            return new MetadataAnnotationVisitor(mda);
+        }
+
+        @Override
+        public AnnotationVisitor visitArray(String name) {
+            return new MetadataAnnotationArrayVisitor(this.annotation, name);
+        }
+
+        @Override
+        public void visitEnd() {
+            if (this.element != null) {
+                if (this.annotation.isMeta()) {
+                    this.element.addMetaAnnotation(this.annotation);
+                } else {
+                    this.element.addAnnotation(this.annotation);
+                }
+            }
+        }
+    }
+
+    /**
+     * Specialized visitor to handle the population of arrays of annotation
+     * values.
+     */
+    class MetadataAnnotationArrayVisitor extends EclipseLinkAnnotationVisitor {
+
+        private MetadataAnnotation annotation;
+
+        private String attributeName;
+
+        private List<Object> values;
+
+        public MetadataAnnotationArrayVisitor(MetadataAnnotation annotation, String name) {
+            super();
+            super.setCustomAnnotationVisitor(this);
+            this.annotation = annotation;
+            this.attributeName = name;
+            this.values = new ArrayList<Object>();
+        }
+
+        @Override
+        public void visit(String name, Object value) {
+            this.values.add(annotationValue(null, value));
+        }
+
+        @Override
+        public void visitEnum(String name, String desc, String value) {
+            this.values.add(annotationValue(desc, value));
+        }
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String name, String desc) {
+            MetadataAnnotation mda = new MetadataAnnotation();
+            mda.setName(processDescription(desc, false).get(0));
+            this.values.add(mda);
+            return new MetadataAnnotationVisitor(mda);
+        }
+
+        @Override
+        public void visitEnd() {
+            this.annotation.addAttribute(this.attributeName, this.values.toArray());
+        }
+    }
+
+    /**
+     * Factory for the creation of {@link MetadataField} handling basic type,
+     * generics, and annotations.
+     */
+    class MetadataFieldVisitor extends EclipseLinkFieldVisitor {
+
+        private MetadataField field;
+
+        public MetadataFieldVisitor(MetadataClass classMetadata, int access, String name, String desc, String signature, Object value) {
+            super();
+            super.setCustomFieldVisitor(this);
+            this.field = new MetadataField(classMetadata);
+            this.field.setModifiers(access);
+            this.field.setName(name);
+            this.field.setAttributeName(name);
+            this.field.setGenericType(processDescription(signature, true));
+            this.field.setType(processDescription(desc, false).get(0));
+        }
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+            if (desc.startsWith("Ljavax/persistence") || desc.startsWith("Ljakarta/persistence")
+                    || desc.startsWith("Lorg/eclipse/persistence")) {
+                return new MetadataAnnotationVisitor(this.field, desc);
+            }
+            return null;
+        }
+
+        @Override
+        public void visitEnd() {
+            this.field.getDeclaringClass().addField(this.field);
+        }
+    }
+
+    /**
+     * Factory for the creation of {@link MetadataMethod} handling basic type,
+     * generics, and annotations.
+     */
+    // Note: Subclassed EmptyListener to minimize signature requirements for
+    // ignored MethodVisitor API
+    class MetadataMethodVisitor extends EclipseLinkMethodVisitor {
+
+        private MetadataMethod method;
+
+        public MetadataMethodVisitor(MetadataClass classMetadata, int access, String name, String desc, String signature, String[] exceptions) {
+            super();
+            super.setCustomMethodVisitor(this);
+            this.method = new MetadataMethod(MetadataAsmFactory.this, classMetadata);
+
+            this.method.setName(name);
+            this.method.setAttributeName(Helper.getAttributeNameFromMethodName(name));
+            this.method.setModifiers(access);
+
+            this.method.setGenericType(processDescription(desc, true));
+
+            List<String> argumentNames = processDescription(signature, false);
+            if (argumentNames != null && !argumentNames.isEmpty()) {
+                this.method.setReturnType(argumentNames.get(argumentNames.size() - 1));
+                argumentNames.remove(argumentNames.size() - 1);
+                this.method.setParameters(argumentNames);
+            }
+        }
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+            if (desc.startsWith("Ljavax/persistence") || desc.startsWith("Ljakarta/persistence")
+                    || desc.startsWith("Lorg/eclipse/persistence")) {
+                return new MetadataAnnotationVisitor(this.method, desc);
+            }
+            return null;
+        }
+
+        /**
+         * At the end of visiting this method add it to the
+         * {@link MetadataClass} and handle duplicate method names by chaining
+         * them.
+         */
+        @Override
+        public void visitEnd() {
+            MetadataClass classMetadata = this.method.getMetadataClass();
+
+            MetadataMethod existing = classMetadata.getMethods().get(this.method.getName());
+            if (existing == null) {
+                classMetadata.getMethods().put(this.method.getName(), this.method);
+            } else {
+                // Handle methods with the same name.
+                while (existing.getNext() != null) {
+                    existing = existing.getNext();
+                }
+                existing.setNext(this.method);
+            }
+        }
+
+    }
+
+    /**
+     * Get MetadataClass for a class which can not be found
+     * @param className class which has not been found
+     * @return MetadataClass
+     */
+    private MetadataClass getVirtualMetadataClass(String className) {
+        // Some basic types can't be found, so can just be registered
+        // (i.e. arrays). Also, VIRTUAL classes may also not exist,
+        // therefore, tag the MetadataClass as loadable false. This will be
+        // used to determine if a class will be dynamically created or not.
+        MetadataClass metadataClass = new MetadataClass(this, className, false);
+        // If the class is a JDK class, then maybe there is a class loader
+        // issues,
+        // since it is a JDK class, just use reflection.
+        if ((className.length() > 5) && className.substring(0, 5).equals("java.")) {
+            try {
+                Class<?> reflectClass = Class.forName(className);
+                if (reflectClass.getSuperclass() != null) {
+                    metadataClass.setSuperclassName(reflectClass.getSuperclass().getName());
+                }
+                for (Class<?> reflectInterface : reflectClass.getInterfaces()) {
+                    metadataClass.addInterface(reflectInterface.getName());
+                }
+            } catch (Exception failed) {
+                //ignore
+                metadataClass.setIsAccessible(false);
+            }
+        } else {
+            metadataClass.setIsAccessible(false);
+        }
+        return metadataClass;
+    }
+
+    /**
+     * Process the byte-code argument description and return the array of Java
+     * class names. i.e.
+     * "(Lorg/foo/Bar;Z)Ljava/lang/Boolean;"={@literal >}[org.foo.Bar,boolean
+     * ,java.lang.Boolean]
+     */
+    private static List<String> processDescription(String desc, boolean isGeneric) {
+        if (desc == null) {
+            return null;
+        }
+        List<String> arguments = new ArrayList<String>();
+        int index = 0;
+        int length = desc.length();
+        boolean isGenericTyped=false;
+        // PERF: Use char array to make char index faster (note this is a heavily optimized method, be very careful on changes)
+        char[] chars = desc.toCharArray();
+        while (index < length) {
+            char next = chars[index];
+            if (('(' != next) && (')' != next) && ('<' != next) && ('>' != next) && (';' != next)) {
+                if (next == 'L') {
+                    index++;
+                    int start = index;
+                    next = chars[index];
+                    while (('(' != next) && (')' != next) && ('<' != next) && ('>' != next) && (';' != next)) {
+                        index++;
+                        next = chars[index];
+                    }
+                    arguments.add(toClassName(desc.substring(start, index)));
+                    if(isGenericTyped) {
+                        isGenericTyped=false;
+                        if(next == '<') {
+                            int cnt = 1;
+                            while((cnt > 0) && (++index<desc.length())) {
+                               switch (desc.charAt(index)) {
+                                    case '<': cnt ++; break;
+                                    case '>': cnt --; break;
+                               }
+                            }
+                         }
+                     }
+                } else if (!isGeneric && (PRIMITIVES.indexOf(next) != -1)) {
+                    // Primitives.
+                    arguments.add(getPrimitiveName(next));
+                } else if (next == '[') {
+                    // Arrays.
+                    int start = index;
+                    index++;
+                    next = chars[index];
+                    // Nested arrays.
+                    while (next == '[') {
+                        index++;
+                        next = chars[index];
+                    }
+                    if (PRIMITIVES.indexOf(next) == -1) {
+                        while (next != ';') {
+                            index++;
+                            next = chars[index];
+                        }
+                        arguments.add(toClassName(desc.substring(start, index + 1)));
+                    } else {
+                        arguments.add(desc.substring(start, index + 1));
+                    }
+                } else {
+                    // Is a generic type variable.
+                    int start = index;
+                    int end = start;
+
+                    char myNext = next;
+
+                    while (':' != myNext && '(' != myNext && ')' != myNext && '<' != myNext && '>' != myNext && ';' != myNext && end < length - 1) {
+                        end++;
+                        myNext = chars[end];
+                    }
+
+                    if (myNext == ':') {
+                        arguments.add(desc.substring(start, end));
+                        isGenericTyped=true;
+                        index = end;
+                        arguments.add(":");
+                        if(desc.charAt(index+1)==':') {
+                            index ++;
+                        }
+                    } else if (myNext == ';' && next == 'T') {
+                        arguments.add(String.valueOf(next));
+                        arguments.add(desc.substring(start + 1, end));
+                        index = end - 1;
+                    } else {
+                        arguments.add(String.valueOf(next));
+                    }
+                }
+            }
+            index++;
+        }
+        return arguments;
+
+    }
+
+    /**
+     * Return the Java type name for the primitive code.
+     */
+    private static String getPrimitiveName(char primitive) {
+        if (primitive == 'V') {
+            return "void";
+        } else if (primitive == 'I') {
+            return "int";
+        } else if (primitive == 'Z') {
+            return "boolean";
+        } else if (primitive == 'J') {
+            return "long";
+        } else if (primitive == 'F') {
+            return "float";
+        } else if (primitive == 'D') {
+            return "double";
+        } else if (primitive == 'B') {
+            return "byte";
+        } else if (primitive == 'C') {
+            return "char";
+        } else if (primitive == 'S') {
+            return "short";
+        } else {
+            return String.valueOf(primitive);
+        }
+    }
+
+    private static String toClassName(String classDescription) {
+        if (classDescription == null) {
+            return "void";
+        }
+        return classDescription.replace('/', '.');
+    }
+
+    /**
+     * Convert the annotation value into the value used in the meta model
+     */
+    private static Object annotationValue(String description, Object value) {
+        Object className = Type.getTypeClassName(value);
+        return (className != null) ? className: value;
+    }
+}

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataClass.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataClass.java
@@ -1,0 +1,623 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+//     05/16/2008-1.0M8 Guy Pelletier
+//       - 218084: Implement metadata merging functionality between mapping files
+//     03/08/2010-2.1 Guy Pelletier
+//       - 303632: Add attribute-type for mapping attributes to EclipseLink-ORM
+//     05/04/2010-2.1 Guy Pelletier
+//       - 309373: Add parent class attribute to EclipseLink-ORM
+//     05/14/2010-2.1 Guy Pelletier
+//       - 253083: Add support for dynamic persistence using ORM.xml/eclipselink-orm.xml
+//     01/25/2011-2.3 Guy Pelletier
+//       - 333488: Serializable attribute being defaulted to a variable one to one mapping and causing exception
+//     07/16/2013-2.5.1 Guy Pelletier
+//       - 412384: Applying Converter for parameterized basic-type for joda-time's DateTime does not work
+//     09/02/2019-3.0 Alexandre Jacob
+//        - 527415: Fix code when locale is tr, az or lt
+package org.eclipse.persistence.internal.jpa.metadata.accessors.objects;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.persistence.asm.Opcodes;
+import org.eclipse.persistence.internal.helper.Helper;
+
+/**
+ * INTERNAL:
+ * An object to hold onto a valid JPA decorated class.
+ *
+ * @author Guy Pelletier
+ * @since TopLink 10.1.3/EJB 3.0 Preview
+ */
+public class MetadataClass extends MetadataAnnotatedElement {
+    protected boolean m_isLazy;
+    protected boolean m_isAccessible;
+    protected boolean m_isPrimitive;
+    protected boolean m_isJDK;
+    protected int m_modifiers;
+
+    // Stores the implements interfaces of this class.
+    protected List<String> m_interfaces;
+
+    // Stores a list of enclosed classes found inside this metadata class.
+    // E.g. inner classes, enums etc.
+    protected List<MetadataClass> m_enclosedClasses;
+
+    // Store the classes field metadata, keyed by the field's name.
+    protected Map<String, MetadataField> m_fields;
+
+    // Store the classes method metadata, keyed by the method's name.
+    // Method's next is used if multiple method with the same name.
+    protected Map<String, MetadataMethod> m_methods;
+
+    protected MetadataClass m_superclass;
+    protected String m_superclassName;
+
+    /**
+     * Create the metadata class with the class name.
+     */
+    public MetadataClass(MetadataFactory factory, String name, boolean isLazy) {
+        super(factory);
+        setName(name);
+
+        // By default, set the type to be the same as the name. The canonical
+        // model generator relies on types which in most cases is the name, but
+        // the generator resolves generic types a little differently to
+        // correctly generate model classes.
+        setType(name);
+
+        m_isAccessible = true;
+        m_isLazy = isLazy;
+    }
+
+    /**
+     * Create the metadata class with the class name.
+     */
+    public MetadataClass(MetadataFactory factory, String name) {
+        this(factory, name, false);
+    }
+
+    /**
+     * Create the metadata class based on the class.
+     * Mainly used for primitive defaults.
+     */
+    public MetadataClass(MetadataFactory factory, Class<?> cls) {
+        this(factory, cls.getName(), false);
+        m_isPrimitive = cls.isPrimitive();
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public void addEnclosedClass(MetadataClass enclosedClass) {
+        if (m_enclosedClasses == null) {
+            m_enclosedClasses = new ArrayList<>();
+        }
+
+        m_enclosedClasses.add(enclosedClass);
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public void addField(MetadataField field) {
+        if (m_fields == null) {
+            m_fields = new HashMap<>();
+        }
+
+        m_fields.put(field.getName(), field);
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public void addInterface(String interfaceName) {
+        if (m_interfaces == null) {
+            m_interfaces = new ArrayList<>();
+        }
+
+        m_interfaces.add(interfaceName);
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public void addMethod(MetadataMethod method) {
+        if (m_methods == null) {
+            m_methods = new HashMap<>();
+        }
+
+        m_methods.put(method.getName(), method);
+    }
+
+    /**
+     * Allow comparison to Java classes and Metadata classes.
+     */
+    public boolean isClass(Class<?> clazz) {
+        if (getName() == null) {
+            return false;
+        }
+        return getName().equals(clazz.getName());
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this class is or extends, or super class extends the class.
+     */
+    public boolean extendsClass(Class<?> javaClass) {
+        return extendsClass(javaClass.getName());
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this class is or extends, or super class extends the class.
+     */
+    public boolean extendsClass(String className) {
+        if (getName() == null) {
+            return className == null;
+        }
+
+        if (getName().equals(className)) {
+            return true;
+        }
+
+        if (getSuperclassName() == null) {
+            return false;
+        }
+
+        if (getSuperclassName().equals(className)) {
+            return true;
+        }
+
+        return getSuperclass().extendsClass(className);
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this class is or extends, or super class extends the interface.
+     */
+    public boolean extendsInterface(Class<?> javaClass) {
+        return extendsInterface(javaClass.getName());
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this class is or extends, or super class extends the interface.
+     */
+    public boolean extendsInterface(String className) {
+        if (getName() == null) {
+            return false;
+        }
+
+        if (getName().equals(className)) {
+            return true;
+        }
+
+        if (getInterfaces().contains(className)) {
+            return true;
+        }
+
+        for (String interfaceName : getInterfaces()) {
+            if (getMetadataClass(interfaceName).extendsInterface(className)) {
+                return true;
+            }
+        }
+
+        if (getSuperclassName() == null) {
+            return false;
+        }
+
+        return getSuperclass().extendsInterface(className);
+    }
+
+    /**
+     * INTERNAL:
+     * Return the list of classes defined within this metadata class. E.g.
+     * enums and inner classes.
+     */
+    public List<MetadataClass> getEnclosedClasses() {
+        if (m_enclosedClasses == null) {
+            m_enclosedClasses = new ArrayList<>();
+        }
+
+        return m_enclosedClasses;
+    }
+
+    /**
+     * INTERNAL:
+     * Return the field with the name.
+     * Search for any declared or inherited field.
+     */
+    public MetadataField getField(String name) {
+        return getField(name, true);
+    }
+
+    /**
+     * INTERNAL:
+     * Return the field with the name.
+     * Search for any declared or inherited field.
+     */
+    public MetadataField getField(String name, boolean checkSuperClass) {
+        MetadataField field = getFields().get(name);
+
+        if (checkSuperClass && (field == null) && (getSuperclassName() != null)) {
+            return getSuperclass().getField(name);
+        }
+
+        return field;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public Map<String, MetadataField> getFields() {
+        if (m_fields == null) {
+            m_fields = new HashMap<>();
+
+            if (m_isLazy) {
+                m_factory.getMetadataClass(getName(), false);
+            }
+        }
+
+        return m_fields;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public List<String> getInterfaces() {
+        if (m_interfaces == null) {
+            m_interfaces = new ArrayList<>();
+        }
+
+        return m_interfaces;
+    }
+
+    /**
+     * INTERNAL:
+     * Return the method with the name and no arguments.
+     */
+    protected MetadataMethod getMethod(String name) {
+        return getMethods().get(name);
+    }
+
+    /**
+     * INTERNAL:
+     * Return the method with the name and argument types.
+     */
+    public MetadataMethod getMethod(String name, Class<?>[] arguments) {
+        List<String> argumentNames = new ArrayList<>(arguments.length);
+
+        for (int index = 0; index < arguments.length; index++) {
+            argumentNames.add(arguments[index].getName());
+        }
+
+        return getMethod(name, argumentNames);
+    }
+
+    /**
+     * INTERNAL:
+     * Return the method with the name and argument types (class names).
+     */
+    public MetadataMethod getMethod(String name, List<String> arguments) {
+        return getMethod(name, arguments, true);
+    }
+
+    /**
+     * INTERNAL:
+     * Return the method with the name and argument types (class names).
+     */
+    public MetadataMethod getMethod(String name, List<String> arguments, boolean checkSuperClass) {
+        MetadataMethod method = getMethods().get(name);
+
+        while ((method != null) && !method.getParameters().equals(arguments)) {
+            method = method.getNext();
+        }
+
+        if (checkSuperClass && (method == null) && (getSuperclassName() != null)) {
+            return getSuperclass().getMethod(name, arguments);
+        }
+
+        return method;
+    }
+
+    /**
+     * INTERNAL:
+     * Return the method with the name and argument types (class names).
+     */
+    public MetadataMethod getMethod(String name, String[] arguments) {
+        return getMethod(name, Arrays.asList(arguments));
+    }
+
+    /**
+     * INTERNAL:
+     * Return the method for the given property name.
+     */
+    public MetadataMethod getMethodForPropertyName(String propertyName) {
+        MetadataMethod method;
+
+        String leadingChar = String.valueOf(propertyName.charAt(0)).toUpperCase(Locale.ROOT);
+        String restOfName = propertyName.substring(1);
+
+        // Look for a getPropertyName() method
+        method = getMethod(Helper.GET_PROPERTY_METHOD_PREFIX.concat(leadingChar).concat(restOfName), new String[]{});
+
+        if (method == null) {
+            // Look for an isPropertyName() method
+            method = getMethod(Helper.IS_PROPERTY_METHOD_PREFIX.concat(leadingChar).concat(restOfName), new String[]{});
+        }
+
+        if (method != null) {
+            method.setSetMethod(method.getSetMethod(this));
+        }
+
+        return method;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public Map<String, MetadataMethod> getMethods() {
+        if (m_methods == null) {
+            m_methods = new HashMap<>();
+
+            if (m_isLazy) {
+                m_factory.getMetadataClass(getName(), false);
+            }
+        }
+        return m_methods;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    @Override
+    public int getModifiers() {
+        return m_modifiers;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public MetadataClass getSuperclass() {
+        if (m_superclass == null) {
+            m_superclass = getMetadataClass(m_superclassName);
+        }
+
+        return m_superclass;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public String getSuperclassName() {
+        return m_superclassName;
+    }
+
+    /**
+     * Return the ASM type name.
+     */
+    public String getTypeName() {
+        if (isArray()) {
+            return getName().replace('.', '/');
+        } else if (isPrimitive()) {
+            if (getName().equals("int")) {
+                return "I";
+            } else if (getName().equals("long")) {
+                return "J";
+            } else if (getName().equals("short")) {
+                return "S";
+            } else if (getName().equals("boolean")) {
+                return "Z";
+            } else if (getName().equals("float")) {
+                return "F";
+            } else if (getName().equals("double")) {
+                return "D";
+            } else if (getName().equals("char")) {
+                return "C";
+            } else if (getName().equals("byte")) {
+                return "B";
+            }
+        }
+        return "L" + getName().replace('.', '/') + ";";
+    }
+
+    /**
+     * INTERNAL:
+     * Return true is this class accessible to be found.
+     */
+    public boolean isAccessible() {
+        return m_isAccessible;
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this class is an array type.
+     */
+    public boolean isArray() {
+        return (getName() != null) && (getName().charAt(0) == '[');
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this is extends Collection.
+     */
+    public boolean isCollection() {
+        return extendsInterface(Collection.class);
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this is extends Enum.
+     */
+    public boolean isEnum() {
+        return extendsClass(Enum.class);
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this is an interface (super is null).
+     */
+    public boolean isInterface() {
+        return (Opcodes.valueInt("ACC_INTERFACE") & m_modifiers) != 0;
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this is a JDK (java/javax) class.
+     */
+    public boolean isJDK() {
+        return m_isJDK;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public boolean isLazy() {
+        return m_isLazy;
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this is extends List.
+     */
+    public boolean isList() {
+        return extendsInterface(List.class);
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this is extends Map.
+     */
+    public boolean isMap() {
+        return extendsInterface(Map.class);
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this is Object class.
+     */
+    public boolean isObject() {
+        return getName().equals(Object.class.getName());
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this is a primitive.
+     */
+    public boolean isPrimitive() {
+        return m_isPrimitive;
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this class extends Serializable or is an array type.
+     */
+    public boolean isSerializable() {
+        if (isArray()) {
+            return true;
+        }
+
+        return extendsInterface(Serializable.class);
+    }
+
+    /**
+     * INTENAL:
+     * Return true is this class is the Serializable.class interface.
+     */
+    public boolean isSerializableInterface() {
+        return getName().equals(Serializable.class.getName());
+    }
+
+    /**
+     * INTERNAL:
+     * Return true if this extends Set.
+     */
+    public boolean isSet() {
+        return extendsInterface(Set.class);
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this is the void class.
+     */
+    public boolean isVoid() {
+        return getName().equals(void.class.getName()) || getName().equals(Void.class.getName());
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public void setIsAccessible(boolean isAccessible) {
+        m_isAccessible = isAccessible;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public void setIsJDK(boolean isJDK) {
+        m_isJDK = isJDK;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public void setIsLazy(boolean isLazy) {
+        m_isLazy = isLazy;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    @Override
+    public void setModifiers(int modifiers) {
+        m_modifiers = modifiers;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    @Override
+    public void setName(String name) {
+        super.setName(name);
+
+        if ((!MetadataFactory.ALLOW_JDK) && (name.startsWith("java.")
+                || name.startsWith("javax.") || name.startsWith("jakarta.")
+                || name.startsWith("org.eclipse.persistence.internal."))) {
+            setIsJDK(true);
+        }
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public void setSuperclass(MetadataClass superclass) {
+        m_superclass = superclass;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public void setSuperclassName(String superclass) {
+        m_superclassName = superclass;
+    }
+}

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataClass.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataClass.java
@@ -478,7 +478,7 @@ public class MetadataClass extends MetadataAnnotatedElement {
      * Return if this is an interface (super is null).
      */
     public boolean isInterface() {
-        return (Opcodes.valueInt("ACC_INTERFACE") & m_modifiers) != 0;
+        return (Opcodes.ACC_INTERFACE & m_modifiers) != 0;
     }
 
     /**

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
@@ -161,28 +161,28 @@ public class ClassWeaver extends ClassVisitor {
         String wrapper = wrapperFor(attribute.getReferenceClassType().getSort());
         int sort = attribute.getReferenceClassType().getSort();
         if (sort == Type.BOOLEAN) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "booleanValue", "()Z", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "booleanValue", "()Z", false);
             return;
         } else if (sort == Type.BYTE) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "byteValue", "()B", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "byteValue", "()B", false);
             return;
         } else if (sort == Type.CHAR) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "charValue", "()C", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "charValue", "()C", false);
             return;
         } else if (sort == Type.SHORT) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "shortValue", "()S", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "shortValue", "()S", false);
             return;
         } else if (sort == Type.INT) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "intValue", "()I", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "intValue", "()I", false);
             return;
         } else if (sort == Type.FLOAT) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "floatValue", "()F", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "floatValue", "()F", false);
             return;
         } else if (sort == Type.LONG) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "longValue", "()J", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "longValue", "()J", false);
             return;
         } else if (sort == Type.DOUBLE) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "doubleValue", "()D", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "doubleValue", "()D", false);
             return;
         }
     }
@@ -233,7 +233,7 @@ public class ClassWeaver extends ClassVisitor {
      */
     public void addValueHolder(AttributeDetails attributeDetails) {
         String attribute = attributeDetails.getAttributeName();
-        FieldVisitor fv = cv.visitField(Opcodes.valueInt("ACC_PROTECTED"), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE, null, null);
+        FieldVisitor fv = cv.visitField(Opcodes.ACC_PROTECTED, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE, null, null);
 
         // only mark @Transient if this is property access. Otherwise, the
         // @Transient annotation could mistakenly
@@ -255,7 +255,7 @@ public class ClassWeaver extends ClassVisitor {
      * private transient _persistence_listener;
      */
     public void addPropertyChangeListener(boolean attributeAccess) {
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_listener", PCL_SIGNATURE, null, null);
+        cv.visitField(Opcodes.ACC_PROTECTED + Opcodes.ACC_TRANSIENT, "_persistence_listener", PCL_SIGNATURE, null, null);
     }
 
     /**
@@ -266,10 +266,10 @@ public class ClassWeaver extends ClassVisitor {
      * return _persistence_listener; }
      */
     public void addGetPropertyChangeListener(ClassDetails classDetails) {
-        MethodVisitor cv_getPCL = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getPropertyChangeListener", "()" + PCL_SIGNATURE, null, null);
-        cv_getPCL.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getPCL.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
-        cv_getPCL.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getPCL = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_getPropertyChangeListener", "()" + PCL_SIGNATURE, null, null);
+        cv_getPCL.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getPCL.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        cv_getPCL.visitInsn(Opcodes.ARETURN);
         cv_getPCL.visitMaxs(0, 0);
     }
 
@@ -282,11 +282,11 @@ public class ClassWeaver extends ClassVisitor {
      * }
      */
     public void addSetPropertyChangeListener(ClassDetails classDetails) {
-        MethodVisitor cv_setPCL = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setPropertyChangeListener", "(" + PCL_SIGNATURE + ")V", null, null);
-        cv_setPCL.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setPCL.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setPCL.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
-        cv_setPCL.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setPCL = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_setPropertyChangeListener", "(" + PCL_SIGNATURE + ")V", null, null);
+        cv_setPCL.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setPCL.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setPCL.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        cv_setPCL.visitInsn(Opcodes.RETURN);
         cv_setPCL.visitMaxs(0, 0);
     }
 
@@ -300,37 +300,37 @@ public class ClassWeaver extends ClassVisitor {
      */
     public void addPropertyChange(ClassDetails classDetails) {
         // create the _toplink_propertyChange() method
-        MethodVisitor cv_addPC = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", null, null);
+        MethodVisitor cv_addPC = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", null, null);
 
         // if (_toplink_Listener != null)
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_addPC.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_addPC.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
         Label l0 = ASMFactory.createLabel();
-        cv_addPC.visitJumpInsn(Opcodes.valueInt("IFNULL"), l0);
+        cv_addPC.visitJumpInsn(Opcodes.IFNULL, l0);
 
         // if (obj != obj1)
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
-        cv_addPC.visitJumpInsn(Opcodes.valueInt("IF_ACMPEQ"), l0);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 2);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 3);
+        cv_addPC.visitJumpInsn(Opcodes.IF_ACMPEQ, l0);
 
         // _toplink_listener.propertyChange(...);
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_addPC.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
-        cv_addPC.visitTypeInsn(Opcodes.valueInt("NEW"), PCE_SHORT_SIGNATURE);
-        cv_addPC.visitInsn(Opcodes.valueInt("DUP"));
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_addPC.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        cv_addPC.visitTypeInsn(Opcodes.NEW, PCE_SHORT_SIGNATURE);
+        cv_addPC.visitInsn(Opcodes.DUP);
 
         // new PropertyChangeEvent(this, s, obj, obj1)
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
-        cv_addPC.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), PCE_SHORT_SIGNATURE, "<init>", "(Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
-        cv_addPC.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), PCL_SHORT_SIGNATURE, "propertyChange", "(" + PCE_SIGNATURE + ")V", true);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 2);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 3);
+        cv_addPC.visitMethodInsn(Opcodes.INVOKESPECIAL, PCE_SHORT_SIGNATURE, "<init>", "(Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
+        cv_addPC.visitMethodInsn(Opcodes.INVOKEINTERFACE, PCL_SHORT_SIGNATURE, "propertyChange", "(" + PCE_SIGNATURE + ")V", true);
 
         // }
         cv_addPC.visitLabel(l0);
 
-        cv_addPC.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_addPC.visitInsn(Opcodes.RETURN);
         cv_addPC.visitMaxs(0, 0);
     }
 
@@ -350,37 +350,37 @@ public class ClassWeaver extends ClassVisitor {
 
         // Create a getter method for the new valueholder
         // protected void _persistence_initialize_attribute_vh(){
-        MethodVisitor cv_init_VH = cv.visitMethod(Opcodes.valueInt("ACC_PROTECTED"), "_persistence_initialize_" + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "()V", null, null);
+        MethodVisitor cv_init_VH = cv.visitMethod(Opcodes.ACC_PROTECTED, "_persistence_initialize_" + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "()V", null, null);
 
         // if(_persistence_attribute_vh == null){
-        cv_init_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_init_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_init_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_init_VH.visitFieldInsn(Opcodes.GETFIELD, className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
         Label l0 = ASMFactory.createLabel();
-        cv_init_VH.visitJumpInsn(Opcodes.valueInt("IFNONNULL"), l0);
+        cv_init_VH.visitJumpInsn(Opcodes.IFNONNULL, l0);
 
         // _persistence_attribute_vh = new ValueHolder(this.attribute);
-        cv_init_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_init_VH.visitTypeInsn(Opcodes.valueInt("NEW"), VH_SHORT_SIGNATURE);
-        cv_init_VH.visitInsn(Opcodes.valueInt("DUP"));
+        cv_init_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_init_VH.visitTypeInsn(Opcodes.NEW, VH_SHORT_SIGNATURE);
+        cv_init_VH.visitInsn(Opcodes.DUP);
         if (attributeDetails.hasField()) {
-            cv_init_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_init_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), className, attribute, attributeDetails.getReferenceClassType().getDescriptor());
-            cv_init_VH.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), VH_SHORT_SIGNATURE, "<init>", "(Ljava/lang/Object;)V", false);
+            cv_init_VH.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_init_VH.visitFieldInsn(Opcodes.GETFIELD, className, attribute, attributeDetails.getReferenceClassType().getDescriptor());
+            cv_init_VH.visitMethodInsn(Opcodes.INVOKESPECIAL, VH_SHORT_SIGNATURE, "<init>", "(Ljava/lang/Object;)V", false);
         } else {
-            cv_init_VH.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), VH_SHORT_SIGNATURE, "<init>", "()V", false);
+            cv_init_VH.visitMethodInsn(Opcodes.INVOKESPECIAL, VH_SHORT_SIGNATURE, "<init>", "()V", false);
         }
-        cv_init_VH.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_init_VH.visitFieldInsn(Opcodes.PUTFIELD, className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
 
         // _persistence_attribute_vh.setIsNewlyWeavedValueHolder(true);
-        cv_init_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_init_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
-        cv_init_VH.visitInsn(Opcodes.valueInt("ICONST_1"));
-        cv_init_VH.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "setIsNewlyWeavedValueHolder", "(Z)V", true);
+        cv_init_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_init_VH.visitFieldInsn(Opcodes.GETFIELD, className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_init_VH.visitInsn(Opcodes.ICONST_1);
+        cv_init_VH.visitMethodInsn(Opcodes.INVOKEINTERFACE, VHI_SHORT_SIGNATURE, "setIsNewlyWeavedValueHolder", "(Z)V", true);
 
         // }
         cv_init_VH.visitLabel(l0);
 
-        cv_init_VH.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_init_VH.visitInsn(Opcodes.RETURN);
         cv_init_VH.visitMaxs(0, 0);
     }
 
@@ -399,59 +399,59 @@ public class ClassWeaver extends ClassVisitor {
         String attribute = attributeDetails.getAttributeName();
         String className = classDetails.getClassName();
         // Create a getter method for the new valueholder
-        MethodVisitor cv_get_VH = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_GET + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "()" + VHI_SIGNATURE, null, null);
+        MethodVisitor cv_get_VH = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_GET + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "()" + VHI_SIGNATURE, null, null);
 
         // _persistence_initialize_attributeName_vh();
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get_VH.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
 
         // if (_toplink_foo_vh.isCoordinatedWithProperty() ||
         // _toplink_foo_vh.isNewlyWeavedValueHolder()){
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
-        cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "isCoordinatedWithProperty", "()Z", true);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get_VH.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_get_VH.visitMethodInsn(Opcodes.INVOKEINTERFACE, VHI_SHORT_SIGNATURE, "isCoordinatedWithProperty", "()Z", true);
         Label l0 = ASMFactory.createLabel();
-        cv_get_VH.visitJumpInsn(Opcodes.valueInt("IFNE"), l0);
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
-        cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "isNewlyWeavedValueHolder", "()Z", true);
+        cv_get_VH.visitJumpInsn(Opcodes.IFNE, l0);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get_VH.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_get_VH.visitMethodInsn(Opcodes.INVOKEINTERFACE, VHI_SHORT_SIGNATURE, "isNewlyWeavedValueHolder", "()Z", true);
         Label l1 = ASMFactory.createLabel();
-        cv_get_VH.visitJumpInsn(Opcodes.valueInt("IFEQ"), l1);
+        cv_get_VH.visitJumpInsn(Opcodes.IFEQ, l1);
         cv_get_VH.visitLabel(l0);
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
 
         // EntityC object = (EntityC)getFoo();
         if (attributeDetails.getGetterMethodName() != null) {
-            cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), attributeDetails.getGetterMethodName(), "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
-            cv_get_VH.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+            cv_get_VH.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), attributeDetails.getGetterMethodName(), "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
+            cv_get_VH.visitTypeInsn(Opcodes.CHECKCAST, attributeDetails.getReferenceClassName().replace('.', '/'));
         } else {
-            cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), PERSISTENCE_GET + attributeDetails.attributeName, "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
+            cv_get_VH.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), PERSISTENCE_GET + attributeDetails.attributeName, "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
         }
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ASTORE"), 1);
+        cv_get_VH.visitVarInsn(Opcodes.ASTORE, 1);
 
         // if (object != _toplink_foo_vh.getValue()){
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
-        cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
-        cv_get_VH.visitJumpInsn(Opcodes.valueInt("IF_ACMPEQ"), l1);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get_VH.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_get_VH.visitMethodInsn(Opcodes.INVOKEINTERFACE, VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+        cv_get_VH.visitJumpInsn(Opcodes.IF_ACMPEQ, l1);
 
         // setFoo(object);
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 1);
         if (attributeDetails.getSetterMethodName() != null) {
-            cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), attributeDetails.getSetterMethodName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
+            cv_get_VH.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), attributeDetails.getSetterMethodName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
         } else {
-            cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), PERSISTENCE_SET + attributeDetails.getAttributeName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
+            cv_get_VH.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), PERSISTENCE_SET + attributeDetails.getAttributeName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
         }
 
         // }
         cv_get_VH.visitLabel(l1);
 
         // return _toplink_foo_vh;
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
-        cv_get_VH.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get_VH.visitFieldInsn(Opcodes.GETFIELD, className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_get_VH.visitInsn(Opcodes.ARETURN);
 
         cv_get_VH.visitMaxs(0, 0);
     }
@@ -470,72 +470,72 @@ public class ClassWeaver extends ClassVisitor {
         String attribute = attributeDetails.getAttributeName();
         String className = classDetails.getClassName();
         // create a setter method for the new valueholder
-        MethodVisitor cv_set_value = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_SET + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "(" + VHI_SIGNATURE + ")V", null, null);
+        MethodVisitor cv_set_value = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_SET + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "(" + VHI_SIGNATURE + ")V", null, null);
 
         // _toplink_foo_vh = valueholderinterface;
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_set_value.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_set_value.visitFieldInsn(Opcodes.PUTFIELD, className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
 
         // if (valueholderinterface.isInstantiated()){
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "isInstantiated", "()Z", true);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_set_value.visitMethodInsn(Opcodes.INVOKEINTERFACE, VHI_SHORT_SIGNATURE, "isInstantiated", "()Z", true);
         Label l0 = ASMFactory.createLabel();
-        cv_set_value.visitJumpInsn(Opcodes.valueInt("IFEQ"), l0);
+        cv_set_value.visitJumpInsn(Opcodes.IFEQ, l0);
 
         // Object object = getFoo();
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 0);
         if (attributeDetails.getGetterMethodName() != null) {
-            cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), className, attributeDetails.getGetterMethodName(), "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
+            cv_set_value.visitMethodInsn(Opcodes.INVOKEVIRTUAL, className, attributeDetails.getGetterMethodName(), "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
         } else {
-            cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), className, PERSISTENCE_GET + attributeDetails.attributeName, "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
+            cv_set_value.visitMethodInsn(Opcodes.INVOKEVIRTUAL, className, PERSISTENCE_GET + attributeDetails.attributeName, "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
         }
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ASTORE"), 2);
+        cv_set_value.visitVarInsn(Opcodes.ASTORE, 2);
 
         // Object value = valueholderinterface.getValue();
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ASTORE"), 3);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_set_value.visitMethodInsn(Opcodes.INVOKEINTERFACE, VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+        cv_set_value.visitVarInsn(Opcodes.ASTORE, 3);
 
         // if (object != value){
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 2);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 3);
         if (attributeDetails.getSetterMethodName() != null) {
-            cv_set_value.visitJumpInsn(Opcodes.valueInt("IF_ACMPEQ"), l0);
+            cv_set_value.visitJumpInsn(Opcodes.IF_ACMPEQ, l0);
             // setFoo((EntityC)value);
-            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
-            cv_set_value.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
-            cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), className, attributeDetails.getSetterMethodName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
+            cv_set_value.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_set_value.visitVarInsn(Opcodes.ALOAD, 3);
+            cv_set_value.visitTypeInsn(Opcodes.CHECKCAST, attributeDetails.getReferenceClassName().replace('.', '/'));
+            cv_set_value.visitMethodInsn(Opcodes.INVOKEVIRTUAL, className, attributeDetails.getSetterMethodName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
             //}
             cv_set_value.visitLabel(l0);
         } else {
             Label l1 = ASMFactory.createLabel();
-            cv_set_value.visitJumpInsn(Opcodes.valueInt("IF_ACMPEQ"), l1);
+            cv_set_value.visitJumpInsn(Opcodes.IF_ACMPEQ, l1);
             // _persistence_setFoo((EntityC)value);
-            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
-            cv_set_value.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
-            cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), className, PERSISTENCE_SET + attributeDetails.getAttributeName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
+            cv_set_value.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_set_value.visitVarInsn(Opcodes.ALOAD, 3);
+            cv_set_value.visitTypeInsn(Opcodes.CHECKCAST, attributeDetails.getReferenceClassName().replace('.', '/'));
+            cv_set_value.visitMethodInsn(Opcodes.INVOKEVIRTUAL, className, PERSISTENCE_SET + attributeDetails.getAttributeName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
             // }
             cv_set_value.visitLabel(l1);
-            cv_set_value.visitFrame(Opcodes.valueInt("F_SAME"), 0, null, 0, null);
+            cv_set_value.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
             Label l2 = ASMFactory.createLabel();
-            cv_set_value.visitJumpInsn(Opcodes.valueInt("GOTO"), l2);
+            cv_set_value.visitJumpInsn(Opcodes.GOTO, l2);
             // }
             cv_set_value.visitLabel(l0);
             // else {
-            cv_set_value.visitFrame(Opcodes.valueInt("F_SAME"), 0, null, 0, null);
+            cv_set_value.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
             // foo = null;
-            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_set_value.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-            cv_set_value.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), className, attributeDetails.attributeName, attributeDetails.getReferenceClassType().getDescriptor());
+            cv_set_value.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_set_value.visitInsn(Opcodes.ACONST_NULL);
+            cv_set_value.visitFieldInsn(Opcodes.PUTFIELD, className, attributeDetails.attributeName, attributeDetails.getReferenceClassType().getDescriptor());
             //}
             cv_set_value.visitLabel(l2);
-            cv_set_value.visitFrame(Opcodes.valueInt("F_SAME"), 0, null, 0, null);
+            cv_set_value.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
         }
 
-        cv_set_value.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_set_value.visitInsn(Opcodes.RETURN);
         cv_set_value.visitMaxs(0, 0);
     }
 
@@ -555,43 +555,43 @@ public class ClassWeaver extends ClassVisitor {
         String attribute = attributeDetails.getAttributeName();
 
         // create _persistence_set_variableName
-        MethodVisitor cv_set = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_SET + attribute, "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", null, null);
+        MethodVisitor cv_set = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_SET + attribute, "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", null, null);
 
         // Get the opcode for the load instruction. This may be different
         // depending on the type
-        int opcode = attributeDetails.getReferenceClassType().getOpcode(Opcodes.valueInt("ILOAD"));
+        int opcode = attributeDetails.getReferenceClassType().getOpcode(Opcodes.ILOAD);
 
         if (classDetails.shouldWeaveFetchGroups()) {
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 0);
             cv_set.visitLdcInsn(attribute);
             // _persistence_checkFetchedForSet("variableName");
-            cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
+            cv_set.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
         }
 
         if (classDetails.shouldWeaveChangeTracking()) {
             if (attributeDetails.weaveValueHolders()) {
                 // _persistence_initialize_variableName_vh();
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
 
                 // _persistenc_variableName_vh.getValue();
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                cv_set.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
 
                 // Add the cast:
                 // (<VariableClass>)_persistenc_variableName_vh.getValue()
-                cv_set.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+                cv_set.visitTypeInsn(Opcodes.CHECKCAST, attributeDetails.getReferenceClassName().replace('.', '/'));
 
                 // add the assignment: this.variableName =
                 // (<VariableClass>)_persistenc_variableName_vh.getValue();
-                cv_set.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+                cv_set.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
             }
 
             // load the string attribute name as the first argument of the
             // property change call
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 0);
             cv_set.visitLdcInsn(attribute);
 
             // if the attribute is a primitive, wrap it
@@ -599,70 +599,70 @@ public class ClassWeaver extends ClassVisitor {
             // This is the first part of the wrapping
             String wrapper = ClassWeaver.wrapperFor(attributeDetails.getReferenceClassType().getSort());
             if (wrapper != null) {
-                cv_set.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
-                cv_set.visitInsn(Opcodes.valueInt("DUP"));
+                cv_set.visitTypeInsn(Opcodes.NEW, wrapper);
+                cv_set.visitInsn(Opcodes.DUP);
             }
 
             // load the method argument
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+            cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_set.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
 
             if (wrapper != null) {
                 // invoke the constructor for wrapping
                 // e.g. Integer.valueOf(variableName)
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
+                cv_set.visitMethodInsn(Opcodes.INVOKESPECIAL, wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
 
                 // wrap the method argument
                 // e.g. Integer.valueOf(argument)
-                cv_set.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
-                cv_set.visitInsn(Opcodes.valueInt("DUP"));
+                cv_set.visitTypeInsn(Opcodes.NEW, wrapper);
+                cv_set.visitInsn(Opcodes.DUP);
                 cv_set.visitVarInsn(opcode, 1);
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
+                cv_set.visitMethodInsn(Opcodes.INVOKESPECIAL, wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
             } else {
                 // if we are not wrapping the argument, just load it
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 1);
             }
             // _persistence_propertyChange("variableName", variableName,
             // argument);
-            cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
+            cv_set.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
         } else {
             if (attributeDetails.weaveValueHolders()) {
                 // _persistence_initialize_variableName_vh();
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
 
                 // _persistenc_variableName_vh.getValue();
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                cv_set.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
 
                 // Add the cast:
                 // (<VariableClass>)_persistenc_variableName_vh.getValue()
-                cv_set.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+                cv_set.visitTypeInsn(Opcodes.CHECKCAST, attributeDetails.getReferenceClassName().replace('.', '/'));
 
                 // add the assignment: this.variableName =
                 // (<VariableClass>)_persistenc_variableName_vh.getValue();
-                cv_set.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+                cv_set.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
             }
         }
 
         // Must set variable after raising change event, so event has old and
         // new value.
         // variableName = argument
-        cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_set.visitVarInsn(Opcodes.ALOAD, 0);
         cv_set.visitVarInsn(opcode, 1);
-        cv_set.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+        cv_set.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
 
         if (attributeDetails.weaveValueHolders()) {
             // _persistence_variableName_vh.setValue(argument);
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "setValue", "(Ljava/lang/Object;)V", true);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_set.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_set.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "setValue", "(Ljava/lang/Object;)V", true);
         }
 
-        cv_set.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_set.visitInsn(Opcodes.RETURN);
         cv_set.visitMaxs(0, 0);
     }
 
@@ -680,41 +680,41 @@ public class ClassWeaver extends ClassVisitor {
         String attribute = attributeDetails.getAttributeName();
 
         // create the _persistenc_getvariableName method
-        MethodVisitor cv_get = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_GET + attribute, "()" + attributeDetails.getReferenceClassType().getDescriptor(), null, null);
+        MethodVisitor cv_get = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_GET + attribute, "()" + attributeDetails.getReferenceClassType().getDescriptor(), null, null);
 
         if (classDetails.shouldWeaveFetchGroups()) {
-            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_get.visitVarInsn(Opcodes.ALOAD, 0);
             cv_get.visitLdcInsn(attribute);
             // _persistence_checkFetched("variableName");
-            cv_get.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_checkFetched", "(Ljava/lang/String;)V", false);
+            cv_get.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_checkFetched", "(Ljava/lang/String;)V", false);
         }
 
         if (attributeDetails.weaveValueHolders()) {
             // _persistence_initialize_variableName_vh();
-            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_get.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+            cv_get.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_get.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
 
             // _persistenc_variableName_vh.getValue();
-            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_get.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-            cv_get.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+            cv_get.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_get.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_get.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+            cv_get.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
 
             // Add the cast:
             // (<VariableClass>)_persistenc_variableName_vh.getValue()
-            cv_get.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+            cv_get.visitTypeInsn(Opcodes.CHECKCAST, attributeDetails.getReferenceClassName().replace('.', '/'));
 
             // add the assignment: this.variableName =
             // (<VariableClass>)_persistenc_variableName_vh.getValue();
-            cv_get.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+            cv_get.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
         }
 
         // return this.variableName;
-        cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+        cv_get.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
         // Get the opcode for the return insturction. This may be different
         // depending on the type.
-        int opcode = attributeDetails.getReferenceClassType().getOpcode(Opcodes.valueInt("IRETURN"));
+        int opcode = attributeDetails.getReferenceClassType().getOpcode(Opcodes.IRETURN);
         cv_get.visitInsn(opcode);
         cv_get.visitMaxs(0, 0);
     }
@@ -727,8 +727,8 @@ public class ClassWeaver extends ClassVisitor {
      * private Object _persistence_primaryKey;
      */
     public void addPersistenceEntityVariables() {
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_primaryKey", OBJECT_SIGNATURE, null, null);
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_cacheKey", CACHEKEY_SIGNATURE, null, null);
+        cv.visitField(Opcodes.ACC_PROTECTED + Opcodes.ACC_TRANSIENT, "_persistence_primaryKey", OBJECT_SIGNATURE, null, null);
+        cv.visitField(Opcodes.ACC_PROTECTED + Opcodes.ACC_TRANSIENT, "_persistence_cacheKey", CACHEKEY_SIGNATURE, null, null);
     }
 
     /**
@@ -741,14 +741,14 @@ public class ClassWeaver extends ClassVisitor {
      */
     public void addPersistencePostClone(ClassDetails classDetails) {
         // create the _persistence_post_clone() method
-        MethodVisitor cv_clone = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_post_clone", "()Ljava/lang/Object;", null, null);
+        MethodVisitor cv_clone = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_post_clone", "()Ljava/lang/Object;", null, null);
 
         // if there is a weaved superclass, it will implement
         // _persistence_post_clone. Call that method
         // super._persistence_post_clone()
         if (classDetails.getSuperClassDetails() != null && classDetails.getSuperClassDetails().shouldWeaveInternal()) {
-            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "_persistence_post_clone", "()Ljava/lang/Object;", false);
+            cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_clone.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getSuperClassName(), "_persistence_post_clone", "()Ljava/lang/Object;", false);
         }
 
         if (classDetails.shouldWeaveValueHolders()) {
@@ -758,47 +758,47 @@ public class ClassWeaver extends ClassVisitor {
                                                             // !attributeDetails.isAttributeOnSuperClass())
                                                             // {
                     // clone._attribute_vh = this._attribute_vh.clone();
-                    cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                    cv_clone.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                    cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+                    cv_clone.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
                     Label label = ASMFactory.createLabel();
-                    cv_clone.visitJumpInsn(Opcodes.valueInt("IFNULL"), label);
-                    cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                    cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                    cv_clone.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                    cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "clone", "()Ljava/lang/Object;", true);
-                    cv_clone.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), ClassWeaver.VHI_SHORT_SIGNATURE);
-                    cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                    cv_clone.visitJumpInsn(Opcodes.IFNULL, label);
+                    cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+                    cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+                    cv_clone.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                    cv_clone.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "clone", "()Ljava/lang/Object;", true);
+                    cv_clone.visitTypeInsn(Opcodes.CHECKCAST, ClassWeaver.VHI_SHORT_SIGNATURE);
+                    cv_clone.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
                     cv_clone.visitLabel(label);
                 }
             }
         }
         if (classDetails.shouldWeaveChangeTracking()) {
             // clone._persistence_listener = null;
-            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_clone.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-            cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+            cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_clone.visitInsn(Opcodes.ACONST_NULL);
+            cv_clone.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
         }
         if (classDetails.shouldWeaveFetchGroups()) {
             // clone._persistence_fetchGroup = null;
             // clone._persistence_session = null;
-            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_clone.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-            cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
-            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_clone.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-            cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
+            cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_clone.visitInsn(Opcodes.ACONST_NULL);
+            cv_clone.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+            cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_clone.visitInsn(Opcodes.ACONST_NULL);
+            cv_clone.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
         }
 
         if (!classDetails.isEmbedable()) {
             // clone._persistence_primaryKey = null;
-            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_clone.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-            cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
+            cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_clone.visitInsn(Opcodes.ACONST_NULL);
+            cv_clone.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
         }
 
         // return clone;
-        cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_clone.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_clone.visitInsn(Opcodes.ARETURN);
         cv_clone.visitMaxs(0, 0);
     }
 
@@ -806,69 +806,69 @@ public class ClassWeaver extends ClassVisitor {
         // public List<RelationshipInfo> _persistence_getRelationships() {
         //   return this._persistence_relationshipInfo;
         // }
-        MethodVisitor cv_getPKVector = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "getRelationships", "()" + LIST_RELATIONSHIP_INFO_SIGNATURE, "()" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
-        cv_getPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getPKVector.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
-        cv_getPKVector.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getPKVector = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "getRelationships", "()" + LIST_RELATIONSHIP_INFO_SIGNATURE, "()" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
+        cv_getPKVector.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getPKVector.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
+        cv_getPKVector.visitInsn(Opcodes.ARETURN);
         cv_getPKVector.visitMaxs(0, 0);
 
         // public void _persistence_setRelationships(List<RelationshipInfo> paramList) {
         //   this._persistence_relationshipInfo = paramList;
         // }
-        MethodVisitor cv_setPKVector = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "setRelationships", "(" + LIST_RELATIONSHIP_INFO_SIGNATURE + ")V", "(" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE + ")V", null);
-        cv_setPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setPKVector.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
-        cv_setPKVector.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setPKVector = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "setRelationships", "(" + LIST_RELATIONSHIP_INFO_SIGNATURE + ")V", "(" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE + ")V", null);
+        cv_setPKVector.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setPKVector.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setPKVector.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
+        cv_setPKVector.visitInsn(Opcodes.RETURN);
         cv_setPKVector.visitMaxs(0, 0);
 
         // public Link _persistence_getHref() {
         //   return this._persistence_href;
         // }
-        MethodVisitor cv_getHref = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "getHref", "()" + LINK_SIGNATURE, null, null);
-        cv_getHref.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getHref.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
-        cv_getHref.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getHref = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "getHref", "()" + LINK_SIGNATURE, null, null);
+        cv_getHref.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getHref.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
+        cv_getHref.visitInsn(Opcodes.ARETURN);
         cv_getHref.visitMaxs(0, 0);
 
         // public void _persistence_setHref(Link paramLink)
         //   this._persistence_href = paramLink;
         // }
-        MethodVisitor cv_setHref = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "setHref", "(" + LINK_SIGNATURE + ")V", null, null);
-        cv_setHref.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setHref.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setHref.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
-        cv_setHref.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setHref = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "setHref", "(" + LINK_SIGNATURE + ")V", null, null);
+        cv_setHref.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setHref.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setHref.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
+        cv_setHref.visitInsn(Opcodes.RETURN);
         cv_setHref.visitMaxs(0, 0);
 
         // public ItemLinks _persistence_getLinks() {
         //   return this._persistence_links;
         // }
-        MethodVisitor cv_getLinks = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "getLinks", "()" + ITEM_LINKS_SIGNATURE, null, null);
-        cv_getLinks.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getLinks.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
-        cv_getLinks.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getLinks = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "getLinks", "()" + ITEM_LINKS_SIGNATURE, null, null);
+        cv_getLinks.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getLinks.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
+        cv_getLinks.visitInsn(Opcodes.ARETURN);
         cv_getLinks.visitMaxs(0, 0);
 
         // public void _persistence_setLinks(ItemLinks paramItemLinks) {
         //   this._persistence_links = paramItemLinks;
         // }
-        MethodVisitor cv_setLinks = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "setLinks", "(" + ITEM_LINKS_SIGNATURE + ")V", null, null);
-        cv_setLinks.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setLinks.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setLinks.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
-        cv_setLinks.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setLinks = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "setLinks", "(" + ITEM_LINKS_SIGNATURE + ")V", null, null);
+        cv_setLinks.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setLinks.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setLinks.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
+        cv_setLinks.visitInsn(Opcodes.RETURN);
         cv_setLinks.visitMaxs(0, 0);
 
     }
 
     public void addPersistenceRestVariables() {
         // protected transient List<RelationshipInfo> _persistence_relationshipInfo;
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") | Opcodes.valueInt("ACC_TRANSIENT"), PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE, LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
+        cv.visitField(Opcodes.ACC_PROTECTED | Opcodes.ACC_TRANSIENT, PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE, LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
         // protected transient Link _persistence_href;
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") | Opcodes.valueInt("ACC_TRANSIENT"), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE, null, null);
+        cv.visitField(Opcodes.ACC_PROTECTED | Opcodes.ACC_TRANSIENT, PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE, null, null);
         // protected transient ItemLinks _persistence_links;
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") | Opcodes.valueInt("ACC_TRANSIENT"), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE, null, null);
+        cv.visitField(Opcodes.ACC_PROTECTED | Opcodes.ACC_TRANSIENT, PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE, null, null);
     }
 
     /**
@@ -879,13 +879,13 @@ public class ClassWeaver extends ClassVisitor {
      */
     public void addShallowClone(ClassDetails classDetails) {
         // create the _persistence_shallow_clone() method
-        MethodVisitor cv_clone = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_shallow_clone", "()Ljava/lang/Object;", null, null);
+        MethodVisitor cv_clone = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_shallow_clone", "()Ljava/lang/Object;", null, null);
 
         // return super.clone();
-        cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "java/lang/Object", "clone", "()Ljava/lang/Object;", false);
+        cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_clone.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "clone", "()Ljava/lang/Object;", false);
 
-        cv_clone.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_clone.visitInsn(Opcodes.ARETURN);
         cv_clone.visitMaxs(0, 0);
     }
 
@@ -900,36 +900,36 @@ public class ClassWeaver extends ClassVisitor {
      */
     public void addPersistenceNew(ClassDetails classDetails) {
         // create the _persistence_new() method
-        MethodVisitor cv_new = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_new", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")Ljava/lang/Object;", null, null);
+        MethodVisitor cv_new = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_new", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")Ljava/lang/Object;", null, null);
 
         // return new ClassType(factory);
-        cv_new.visitTypeInsn(Opcodes.valueInt("NEW"), classDetails.getClassName());
-        cv_new.visitInsn(Opcodes.valueInt("DUP"));
+        cv_new.visitTypeInsn(Opcodes.NEW, classDetails.getClassName());
+        cv_new.visitInsn(Opcodes.DUP);
         if (!classDetails.canWeaveConstructorOptimization()) {
-            cv_new.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getClassName(), "<init>", "()V", false);
-            cv_new.visitInsn(Opcodes.valueInt("ARETURN"));
+            cv_new.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getClassName(), "<init>", "()V", false);
+            cv_new.visitInsn(Opcodes.ARETURN);
             cv_new.visitMaxs(0, 0);
             return;
         } else {
-            cv_new.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_new.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getClassName(), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", false);
+            cv_new.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_new.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getClassName(), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", false);
         }
-        cv_new.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_new.visitInsn(Opcodes.ARETURN);
         cv_new.visitMaxs(0, 0);
 
         // create the ClassType() method
-        MethodVisitor cv_constructor = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", null, null);
+        MethodVisitor cv_constructor = cv.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", null, null);
 
-        cv_constructor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_constructor.visitVarInsn(Opcodes.ALOAD, 0);
         if (classDetails.getSuperClassDetails() == null) {
             // super();
-            cv_constructor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "<init>", "()V", false);
+            cv_constructor.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getSuperClassName(), "<init>", "()V", false);
         } else {
             // super(factory);
-            cv_constructor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_constructor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", false);
+            cv_constructor.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_constructor.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getSuperClassName(), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", false);
         }
-        cv_constructor.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_constructor.visitInsn(Opcodes.RETURN);
         cv_constructor.visitMaxs(0, 0);
     }
 
@@ -947,7 +947,7 @@ public class ClassWeaver extends ClassVisitor {
      */
     public void addPersistenceGetSet(ClassDetails classDetails) {
         // create the _persistence_get() method
-        MethodVisitor cv_get = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_get", "(Ljava/lang/String;)Ljava/lang/Object;", null, null);
+        MethodVisitor cv_get = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_get", "(Ljava/lang/String;)Ljava/lang/Object;", null, null);
 
         Label label = null;
         for (AttributeDetails attributeDetails : classDetails.getAttributesMap().values()) {
@@ -956,22 +956,22 @@ public class ClassWeaver extends ClassVisitor {
                     cv_get.visitLabel(label);
                 }
                 // else if (attribute == "address")
-                cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                cv_get.visitVarInsn(Opcodes.ALOAD, 1);
                 cv_get.visitLdcInsn(attributeDetails.getAttributeName().intern());
                 label = ASMFactory.createLabel();
-                cv_get.visitJumpInsn(Opcodes.valueInt("IF_ACMPNE"), label);
+                cv_get.visitJumpInsn(Opcodes.IF_ACMPNE, label);
                 // return this.address
-                cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_get.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), attributeDetails.getAttributeName(), attributeDetails.getReferenceClassType().getDescriptor());
+                cv_get.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_get.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), attributeDetails.getAttributeName(), attributeDetails.getReferenceClassType().getDescriptor());
                 // if this is a primitive, get the wrapper class
                 String wrapper = ClassWeaver.wrapperFor(attributeDetails.getReferenceClassType().getSort());
                 if (wrapper != null) {
                     // Call valueOf on the wrapper (more optimal than
                     // constructor).
-                    cv_get.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), wrapper, "valueOf", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")L" + wrapper + ";", false);
+                    cv_get.visitMethodInsn(Opcodes.INVOKESTATIC, wrapper, "valueOf", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")L" + wrapper + ";", false);
                 }
 
-                cv_get.visitInsn(Opcodes.valueInt("ARETURN"));
+                cv_get.visitInsn(Opcodes.ARETURN);
             }
         }
         if (label != null) {
@@ -980,18 +980,18 @@ public class ClassWeaver extends ClassVisitor {
         // call super, or return null
         if (classDetails.getSuperClassDetails() == null) {
             // return null;
-            cv_get.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+            cv_get.visitInsn(Opcodes.ACONST_NULL);
         } else {
-            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_get.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "_persistence_get", "(Ljava/lang/String;)Ljava/lang/Object;", false);
+            cv_get.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_get.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_get.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getSuperClassName(), "_persistence_get", "(Ljava/lang/String;)Ljava/lang/Object;", false);
         }
 
-        cv_get.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_get.visitInsn(Opcodes.ARETURN);
         cv_get.visitMaxs(0, 0);
 
         // create the _persistence_set() method
-        MethodVisitor cv_set = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_set", "(Ljava/lang/String;Ljava/lang/Object;)V", null, null);
+        MethodVisitor cv_set = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_set", "(Ljava/lang/String;Ljava/lang/Object;)V", null, null);
 
         label = null;
         for (AttributeDetails attribute : classDetails.getAttributesMap().values()) {
@@ -1000,23 +1000,23 @@ public class ClassWeaver extends ClassVisitor {
                     cv_set.visitLabel(label);
                 }
                 // else if (attribute == "address")
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 1);
                 cv_set.visitLdcInsn(attribute.getAttributeName().intern());
                 label = ASMFactory.createLabel();
-                cv_set.visitJumpInsn(Opcodes.valueInt("IF_ACMPNE"), label);
+                cv_set.visitJumpInsn(Opcodes.IF_ACMPNE, label);
                 // this.address = (String)value;
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 2);
                 String wrapper = wrapperFor(attribute.getReferenceClassType().getSort());
                 if (wrapper == null) {
                     wrapper = attribute.getReferenceClassName().replace('.', '/');
                 }
-                cv_set.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), wrapper);
+                cv_set.visitTypeInsn(Opcodes.CHECKCAST, wrapper);
                 // Unwrap any primitive wrapper to its value.
                 unwrapPrimitive(attribute, cv_set);
-                cv_set.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute.getAttributeName(), attribute.getReferenceClassType().getDescriptor());
+                cv_set.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), attribute.getAttributeName(), attribute.getReferenceClassType().getDescriptor());
                 // return;
-                cv_set.visitInsn(Opcodes.valueInt("RETURN"));
+                cv_set.visitInsn(Opcodes.RETURN);
             }
         }
         if (label != null) {
@@ -1024,13 +1024,13 @@ public class ClassWeaver extends ClassVisitor {
         }
         // call super, or return null
         if (classDetails.getSuperClassDetails() != null) {
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-            cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "_persistence_set", "(Ljava/lang/String;Ljava/lang/Object;)V", false);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 2);
+            cv_set.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getSuperClassName(), "_persistence_set", "(Ljava/lang/String;Ljava/lang/Object;)V", false);
         }
 
-        cv_set.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_set.visitInsn(Opcodes.RETURN);
         cv_set.visitMaxs(0, 0);
     }
 
@@ -1043,30 +1043,30 @@ public class ClassWeaver extends ClassVisitor {
      * this._persistence_primaryKey = primaryKey; }
      */
     public void addPersistenceEntityMethods(ClassDetails classDetails) {
-        MethodVisitor cv_getPKVector = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getId", "()" + OBJECT_SIGNATURE, null, null);
-        cv_getPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getPKVector.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
-        cv_getPKVector.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getPKVector = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_getId", "()" + OBJECT_SIGNATURE, null, null);
+        cv_getPKVector.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getPKVector.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
+        cv_getPKVector.visitInsn(Opcodes.ARETURN);
         cv_getPKVector.visitMaxs(0, 0);
 
-        MethodVisitor cv_setPKVector = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setId", "(" + OBJECT_SIGNATURE + ")V", null, null);
-        cv_setPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setPKVector.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
-        cv_setPKVector.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setPKVector = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_setId", "(" + OBJECT_SIGNATURE + ")V", null, null);
+        cv_setPKVector.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setPKVector.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setPKVector.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
+        cv_setPKVector.visitInsn(Opcodes.RETURN);
         cv_setPKVector.visitMaxs(0, 0);
 
-        MethodVisitor cv_getCacheKey = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getCacheKey", "()" + CACHEKEY_SIGNATURE, null, null);
-        cv_getCacheKey.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getCacheKey.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_cacheKey", CACHEKEY_SIGNATURE);
-        cv_getCacheKey.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getCacheKey = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_getCacheKey", "()" + CACHEKEY_SIGNATURE, null, null);
+        cv_getCacheKey.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getCacheKey.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_cacheKey", CACHEKEY_SIGNATURE);
+        cv_getCacheKey.visitInsn(Opcodes.ARETURN);
         cv_getCacheKey.visitMaxs(0, 0);
 
-        MethodVisitor cv_setCacheKey = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setCacheKey", "(" + CACHEKEY_SIGNATURE + ")V", null, null);
-        cv_setCacheKey.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setCacheKey.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setCacheKey.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_cacheKey", CACHEKEY_SIGNATURE);
-        cv_setCacheKey.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setCacheKey = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_setCacheKey", "(" + CACHEKEY_SIGNATURE + ")V", null, null);
+        cv_setCacheKey.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setCacheKey.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setCacheKey.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_cacheKey", CACHEKEY_SIGNATURE);
+        cv_setCacheKey.visitInsn(Opcodes.RETURN);
         cv_setCacheKey.visitMaxs(0, 0);
     }
 
@@ -1080,7 +1080,7 @@ public class ClassWeaver extends ClassVisitor {
      * _persistence_session;
      */
     public void addFetchGroupVariables() {
-        FieldVisitor fv = cv.visitField(Opcodes.valueInt("ACC_PROTECTED"), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE, null, null);
+        FieldVisitor fv = cv.visitField(Opcodes.ACC_PROTECTED, "_persistence_fetchGroup", FETCHGROUP_SIGNATURE, null, null);
         // Only add jakarta.persistence.Transient annotation if attribute access
         // is being used
         if (classDetails.usesAttributeAccess()) {
@@ -1091,8 +1091,8 @@ public class ClassWeaver extends ClassVisitor {
         }
         fv.visitEnd();
 
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE, null, null).visitEnd();
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_session", SESSION_SIGNATURE, null, null).visitEnd();
+        cv.visitField(Opcodes.ACC_PROTECTED + Opcodes.ACC_TRANSIENT, "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE, null, null).visitEnd();
+        cv.visitField(Opcodes.ACC_PROTECTED + Opcodes.ACC_TRANSIENT, "_persistence_session", SESSION_SIGNATURE, null, null).visitEnd();
     }
 
     /**
@@ -1129,96 +1129,96 @@ public class ClassWeaver extends ClassVisitor {
      * EntityManagerImpl.processUnfetchedAttributeForSet(this, attribute); } }
      */
     public void addFetchGroupMethods(ClassDetails classDetails) {
-        MethodVisitor cv_getSession = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getSession", "()" + SESSION_SIGNATURE, null, null);
-        cv_getSession.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getSession.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
-        cv_getSession.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getSession = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_getSession", "()" + SESSION_SIGNATURE, null, null);
+        cv_getSession.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getSession.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
+        cv_getSession.visitInsn(Opcodes.ARETURN);
         cv_getSession.visitMaxs(0, 0);
 
-        MethodVisitor cv_setSession = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setSession", "(" + SESSION_SIGNATURE + ")V", null, null);
-        cv_setSession.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setSession.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setSession.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
-        cv_setSession.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setSession = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_setSession", "(" + SESSION_SIGNATURE + ")V", null, null);
+        cv_setSession.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setSession.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setSession.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
+        cv_setSession.visitInsn(Opcodes.RETURN);
         cv_setSession.visitMaxs(0, 0);
 
-        MethodVisitor cv_getFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getFetchGroup", "()" + FETCHGROUP_SIGNATURE, null, null);
-        cv_getFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getFetchGroup.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
-        cv_getFetchGroup.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getFetchGroup = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_getFetchGroup", "()" + FETCHGROUP_SIGNATURE, null, null);
+        cv_getFetchGroup.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getFetchGroup.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+        cv_getFetchGroup.visitInsn(Opcodes.ARETURN);
         cv_getFetchGroup.visitMaxs(0, 0);
 
-        MethodVisitor cv_setFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setFetchGroup", "(" + FETCHGROUP_SIGNATURE + ")V", null, null);
-        cv_setFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setFetchGroup.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
-        cv_setFetchGroup.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setFetchGroup = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_setFetchGroup", "(" + FETCHGROUP_SIGNATURE + ")V", null, null);
+        cv_setFetchGroup.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setFetchGroup.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setFetchGroup.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+        cv_setFetchGroup.visitInsn(Opcodes.RETURN);
         cv_setFetchGroup.visitMaxs(0, 0);
 
-        MethodVisitor cv_shouldRefreshFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_shouldRefreshFetchGroup", "()" + PBOOLEAN_SIGNATURE, null, null);
-        cv_shouldRefreshFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_shouldRefreshFetchGroup.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE);
-        cv_shouldRefreshFetchGroup.visitInsn(Opcodes.valueInt("IRETURN"));
+        MethodVisitor cv_shouldRefreshFetchGroup = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_shouldRefreshFetchGroup", "()" + PBOOLEAN_SIGNATURE, null, null);
+        cv_shouldRefreshFetchGroup.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_shouldRefreshFetchGroup.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE);
+        cv_shouldRefreshFetchGroup.visitInsn(Opcodes.IRETURN);
         cv_shouldRefreshFetchGroup.visitMaxs(0, 0);
 
-        MethodVisitor cv_setShouldRefreshFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setShouldRefreshFetchGroup", "(" + PBOOLEAN_SIGNATURE + ")V", null, null);
-        cv_setShouldRefreshFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setShouldRefreshFetchGroup.visitVarInsn(Opcodes.valueInt("ILOAD"), 1);
-        cv_setShouldRefreshFetchGroup.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE);
-        cv_setShouldRefreshFetchGroup.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setShouldRefreshFetchGroup = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_setShouldRefreshFetchGroup", "(" + PBOOLEAN_SIGNATURE + ")V", null, null);
+        cv_setShouldRefreshFetchGroup.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setShouldRefreshFetchGroup.visitVarInsn(Opcodes.ILOAD, 1);
+        cv_setShouldRefreshFetchGroup.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE);
+        cv_setShouldRefreshFetchGroup.visitInsn(Opcodes.RETURN);
         cv_setShouldRefreshFetchGroup.visitMaxs(0, 0);
 
-        MethodVisitor cv_resetFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_resetFetchGroup", "()V", null, null);
-        cv_resetFetchGroup.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_resetFetchGroup = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_resetFetchGroup", "()V", null, null);
+        cv_resetFetchGroup.visitInsn(Opcodes.RETURN);
         cv_resetFetchGroup.visitMaxs(0, 0);
 
-        MethodVisitor cv_isAttributeFetched = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", null, null);
-        cv_isAttributeFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_isAttributeFetched.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+        MethodVisitor cv_isAttributeFetched = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", null, null);
+        cv_isAttributeFetched.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_isAttributeFetched.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
         Label gotoTrue = ASMFactory.createLabel();
-        cv_isAttributeFetched.visitJumpInsn(Opcodes.valueInt("IFNULL"), gotoTrue);
-        cv_isAttributeFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_isAttributeFetched.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
-        cv_isAttributeFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_isAttributeFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), FETCHGROUP_SHORT_SIGNATURE, "containsAttributeInternal", "(Ljava/lang/String;)Z", false);
+        cv_isAttributeFetched.visitJumpInsn(Opcodes.IFNULL, gotoTrue);
+        cv_isAttributeFetched.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_isAttributeFetched.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+        cv_isAttributeFetched.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_isAttributeFetched.visitMethodInsn(Opcodes.INVOKEVIRTUAL, FETCHGROUP_SHORT_SIGNATURE, "containsAttributeInternal", "(Ljava/lang/String;)Z", false);
         Label gotoFalse = ASMFactory.createLabel();
-        cv_isAttributeFetched.visitJumpInsn(Opcodes.valueInt("IFEQ"), gotoFalse);
+        cv_isAttributeFetched.visitJumpInsn(Opcodes.IFEQ, gotoFalse);
         cv_isAttributeFetched.visitLabel(gotoTrue);
-        cv_isAttributeFetched.visitInsn(Opcodes.valueInt("ICONST_1"));
+        cv_isAttributeFetched.visitInsn(Opcodes.ICONST_1);
         Label gotoReturn = ASMFactory.createLabel();
-        cv_isAttributeFetched.visitJumpInsn(Opcodes.valueInt("GOTO"), gotoReturn);
+        cv_isAttributeFetched.visitJumpInsn(Opcodes.GOTO, gotoReturn);
         cv_isAttributeFetched.visitLabel(gotoFalse);
-        cv_isAttributeFetched.visitInsn(Opcodes.valueInt("ICONST_0"));
+        cv_isAttributeFetched.visitInsn(Opcodes.ICONST_0);
         cv_isAttributeFetched.visitLabel(gotoReturn);
-        cv_isAttributeFetched.visitInsn(Opcodes.valueInt("IRETURN"));
+        cv_isAttributeFetched.visitInsn(Opcodes.IRETURN);
         cv_isAttributeFetched.visitMaxs(0, 0);
 
-        MethodVisitor cv_checkFetched = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetched", "(Ljava/lang/String;)V", null, null);
-        cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", false);
+        MethodVisitor cv_checkFetched = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_checkFetched", "(Ljava/lang/String;)V", null, null);
+        cv_checkFetched.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_checkFetched.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_checkFetched.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", false);
         gotoReturn = ASMFactory.createLabel();
-        cv_checkFetched.visitJumpInsn(Opcodes.valueInt("IFNE"), gotoReturn);
-        cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_checkFetched.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), FETCHGROUP_TRACKER_SHORT_SIGNATURE);
-        cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), ENTITY_MANAGER_IMPL_SHORT_SIGNATURE, "processUnfetchedAttribute", "(" + FETCHGROUP_TRACKER_SIGNATURE + "Ljava/lang/String;)V", false);
+        cv_checkFetched.visitJumpInsn(Opcodes.IFNE, gotoReturn);
+        cv_checkFetched.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_checkFetched.visitTypeInsn(Opcodes.CHECKCAST, FETCHGROUP_TRACKER_SHORT_SIGNATURE);
+        cv_checkFetched.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_checkFetched.visitMethodInsn(Opcodes.INVOKESTATIC, ENTITY_MANAGER_IMPL_SHORT_SIGNATURE, "processUnfetchedAttribute", "(" + FETCHGROUP_TRACKER_SIGNATURE + "Ljava/lang/String;)V", false);
         cv_checkFetched.visitLabel(gotoReturn);
-        cv_checkFetched.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_checkFetched.visitInsn(Opcodes.RETURN);
         cv_checkFetched.visitMaxs(0, 0);
 
-        MethodVisitor cv_checkFetchedForSet = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", null, null);
-        cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", false);
+        MethodVisitor cv_checkFetchedForSet = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", null, null);
+        cv_checkFetchedForSet.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_checkFetchedForSet.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_checkFetchedForSet.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", false);
         gotoReturn = ASMFactory.createLabel();
-        cv_checkFetchedForSet.visitJumpInsn(Opcodes.valueInt("IFNE"), gotoReturn);
-        cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_checkFetchedForSet.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), FETCHGROUP_TRACKER_SHORT_SIGNATURE);
-        cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), ENTITY_MANAGER_IMPL_SHORT_SIGNATURE, "processUnfetchedAttributeForSet", "(" + FETCHGROUP_TRACKER_SIGNATURE + "Ljava/lang/String;)V", false);
+        cv_checkFetchedForSet.visitJumpInsn(Opcodes.IFNE, gotoReturn);
+        cv_checkFetchedForSet.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_checkFetchedForSet.visitTypeInsn(Opcodes.CHECKCAST, FETCHGROUP_TRACKER_SHORT_SIGNATURE);
+        cv_checkFetchedForSet.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_checkFetchedForSet.visitMethodInsn(Opcodes.INVOKESTATIC, ENTITY_MANAGER_IMPL_SHORT_SIGNATURE, "processUnfetchedAttributeForSet", "(" + FETCHGROUP_TRACKER_SIGNATURE + "Ljava/lang/String;)V", false);
         cv_checkFetchedForSet.visitLabel(gotoReturn);
-        cv_checkFetchedForSet.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_checkFetchedForSet.visitInsn(Opcodes.RETURN);
         cv_checkFetchedForSet.visitMaxs(0, 0);
     }
 

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
@@ -1,0 +1,1499 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+//     dclarke Bug 244124: Enhanced weaving to support extended FetchGroup functionality
+//     08/23/2010-2.2 Michael O'Brien
+//        - 323043: application.xml module ordering may cause weaving not to occur causing an NPE.
+//                       warn if expected "_persistence_//_vh" method not found
+//                       instead of throwing NPE during deploy validation.
+//     19/04/2014-2.6 Lukas Jungmann
+//       - 429992: JavaSE 8/ASM 5.0.1 support (EclipseLink silently ignores Entity classes with lambda expressions)
+package org.eclipse.persistence.internal.jpa.weaving;
+
+import java.util.Iterator;
+
+import org.eclipse.persistence.asm.ASMFactory;
+import org.eclipse.persistence.asm.AnnotationVisitor;
+import org.eclipse.persistence.asm.ClassVisitor;
+import org.eclipse.persistence.asm.FieldVisitor;
+import org.eclipse.persistence.asm.Label;
+import org.eclipse.persistence.asm.MethodVisitor;
+import org.eclipse.persistence.asm.Opcodes;
+import org.eclipse.persistence.asm.Type;
+import org.eclipse.persistence.internal.helper.Helper;
+
+/**
+ * INTERNAL: Weaves classes to allow them to support EclipseLink indirection.
+ * Classes are weaved to add a variable of type ValueHolderInterface for each
+ * attribute that uses indirection. In addition, access methods are added for
+ * the new variable. Also, triggers the process of weaving the methods of the
+ * class.
+ *
+ * @see org.eclipse.persistence.internal.jpa.weaving.MethodWeaver
+ */
+
+public class ClassWeaver extends ClassVisitor {
+
+    // PersistenceWeaved
+    public static final String PERSISTENCE_WEAVED_SHORT_SIGNATURE = "org/eclipse/persistence/internal/weaving/PersistenceWeaved";
+
+    // ValueHolders
+    public static final String TW_LAZY_SHORT_SIGNATURE = "org/eclipse/persistence/internal/weaving/PersistenceWeavedLazy";
+    public static final String VHI_CLASSNAME = "org.eclipse.persistence.indirection.WeavedAttributeValueHolderInterface";
+    public static final String VH_SHORT_SIGNATURE = "org/eclipse/persistence/indirection/ValueHolder";
+    public static final String VHI_SHORT_SIGNATURE = "org/eclipse/persistence/indirection/WeavedAttributeValueHolderInterface";
+    public static final String VHI_SIGNATURE = "L" + VHI_SHORT_SIGNATURE + ";";
+
+    // Change tracking
+    public static final String TW_CT_SHORT_SIGNATURE = "org/eclipse/persistence/internal/weaving/PersistenceWeavedChangeTracking";
+    public static final String PCL_SHORT_SIGNATURE = "java/beans/PropertyChangeListener";
+    public static final String PCL_SIGNATURE = "L" + PCL_SHORT_SIGNATURE + ";";
+    public static final String CT_SHORT_SIGNATURE = "org/eclipse/persistence/descriptors/changetracking/ChangeTracker";
+    public static final String PCE_SHORT_SIGNATURE = "java/beans/PropertyChangeEvent";
+    public static final String PCE_SIGNATURE = "L" + PCE_SHORT_SIGNATURE + ";";
+
+    // PersistenceEntity
+    public static final String PERSISTENCE_ENTITY_SHORT_SIGNATURE = "org/eclipse/persistence/internal/descriptors/PersistenceEntity";
+    public static final String PERSISTENCE_OBJECT_SHORT_SIGNATURE = "org/eclipse/persistence/internal/descriptors/PersistenceObject";
+    public static final String PERSISTENCE_OBJECT_SIGNATURE = "L" + PERSISTENCE_OBJECT_SHORT_SIGNATURE + ";";
+    public static final String VECTOR_SIGNATURE = "Ljava/util/Vector;";
+    public static final String OBJECT_SIGNATURE = "Ljava/lang/Object;";
+    public static final String STRING_SIGNATURE = "Ljava/lang/String;";
+    public static final String CACHEKEY_SIGNATURE = "Lorg/eclipse/persistence/internal/identitymaps/CacheKey;";
+
+    // Fetch groups
+    public static final String WEAVED_FETCHGROUPS_SHORT_SIGNATURE = "org/eclipse/persistence/internal/weaving/PersistenceWeavedFetchGroups";
+    public static final String FETCHGROUP_TRACKER_SIGNATURE = "Lorg/eclipse/persistence/queries/FetchGroupTracker;";
+    public static final String FETCHGROUP_TRACKER_SHORT_SIGNATURE = "org/eclipse/persistence/queries/FetchGroupTracker";
+    public static final String FETCHGROUP_SHORT_SIGNATURE = "org/eclipse/persistence/queries/FetchGroup";
+    public static final String FETCHGROUP_SIGNATURE = "Lorg/eclipse/persistence/queries/FetchGroup;";
+    public static final String SESSION_SIGNATURE = "Lorg/eclipse/persistence/sessions/Session;";
+    public static final String ENTITY_MANAGER_IMPL_SHORT_SIGNATURE = "org/eclipse/persistence/internal/jpa/EntityManagerImpl";
+    public static final String PBOOLEAN_SIGNATURE = "Z";
+    public static final String LONG_SIGNATURE = "J";
+
+    // REST
+    public static final String WEAVED_REST_LAZY_SHORT_SIGNATURE = "org/eclipse/persistence/internal/jpa/rs/weaving/PersistenceWeavedRest";
+    public static final String LIST_RELATIONSHIP_INFO_SIGNATURE = "Ljava/util/List;";
+    public static final String LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE = "Ljava/util/List<Lorg/eclipse/persistence/internal/jpa/rs/weaving/RelationshipInfo;>;";
+    public static final String LINK_SIGNATURE = "Lorg/eclipse/persistence/internal/jpa/rs/metadata/model/Link;";
+    public static final String ITEM_LINKS_SIGNATURE = "Lorg/eclipse/persistence/internal/jpa/rs/metadata/model/ItemLinks;";
+
+    // Cloneable
+    public static final String CLONEABLE_SHORT_SIGNATURE = "java/lang/Cloneable";
+
+    // Transient
+    public static final String JPA_TRANSIENT_DESCRIPTION = "Ljakarta/persistence/Transient;";
+    public static final String XML_TRANSIENT_DESCRIPTION = "Ljakarta/xml/bind/annotation/XmlTransient;";
+
+    public static final String PERSISTENCE_SET = Helper.PERSISTENCE_SET;
+    public static final String PERSISTENCE_GET = Helper.PERSISTENCE_GET;
+
+    // 323403: These constants are used to search for missing weaved functions -
+    // a copy is in the foundation project under internal.Helper
+    public static final String PERSISTENCE_FIELDNAME_PREFIX = "_persistence_";
+    public static final String PERSISTENCE_FIELDNAME_POSTFIX = "_vh";
+
+    public static final String VIRTUAL_GETTER_SIGNATURE = "(" + ClassWeaver.STRING_SIGNATURE + ")" + ClassWeaver.OBJECT_SIGNATURE;
+    public static final String VIRTUAL_SETTER_SIGNATURE = "(" + ClassWeaver.STRING_SIGNATURE + ClassWeaver.OBJECT_SIGNATURE + ")" + ClassWeaver.OBJECT_SIGNATURE;
+
+    /** Store if JAXB is on the classpath, true in Java SE 6 - 8, maybe true from 9 */
+    private static Boolean isJAXBOnPath = null;
+
+    /**
+     * Stores information on the class gathered from the temp class loader and
+     * descriptor.
+     */
+    protected ClassDetails classDetails;
+
+    // Keep track of what was weaved.
+    protected boolean alreadyWeaved = false;
+    public boolean weaved = false;
+    public boolean weavedLazy = false;
+    public boolean weavedPersistenceEntity = false;
+    public boolean weavedChangeTracker = false;
+    public boolean weavedFetchGroups = false;
+    public boolean weavedRest = false;
+
+    private ClassVisitor cw;
+
+    /**
+     * Used for primitive conversion. Returns the name of the class that wraps a
+     * given type.
+     */
+    public static String wrapperFor(int sort) {
+        if (sort == Type.BOOLEAN) {
+            return "java/lang/Boolean";
+        } else if (sort == Type.BYTE) {
+            return "java/lang/Byte";
+        } else if (sort == Type.CHAR) {
+            return "java/lang/Character";
+        } else if (sort == Type.SHORT) {
+            return "java/lang/Short";
+        } else if (sort == Type.INT) {
+            return "java/lang/Integer";
+        } else if (sort == Type.FLOAT) {
+            return "java/lang/Float";
+        } else if (sort == Type.LONG) {
+            return "java/lang/Long";
+        } else if (sort == Type.DOUBLE) {
+            return "java/lang/Double";
+        }
+        return null;
+    }
+
+    /**
+     * Used for primitive conversion. Returns the name conversion method for the
+     * given type.
+     */
+    public static void unwrapPrimitive(AttributeDetails attribute, MethodVisitor visitor) {
+        String wrapper = wrapperFor(attribute.getReferenceClassType().getSort());
+        int sort = attribute.getReferenceClassType().getSort();
+        if (sort == Type.BOOLEAN) {
+            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "booleanValue", "()Z", false);
+            return;
+        } else if (sort == Type.BYTE) {
+            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "byteValue", "()B", false);
+            return;
+        } else if (sort == Type.CHAR) {
+            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "charValue", "()C", false);
+            return;
+        } else if (sort == Type.SHORT) {
+            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "shortValue", "()S", false);
+            return;
+        } else if (sort == Type.INT) {
+            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "intValue", "()I", false);
+            return;
+        } else if (sort == Type.FLOAT) {
+            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "floatValue", "()F", false);
+            return;
+        } else if (sort == Type.LONG) {
+            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "longValue", "()J", false);
+            return;
+        } else if (sort == Type.DOUBLE) {
+            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "doubleValue", "()D", false);
+            return;
+        }
+    }
+
+    /**
+     * Return the get method name weaved for a value-holder attribute.
+     */
+    public static String getWeavedValueHolderGetMethodName(String attributeName) {
+        return Helper.getWeavedValueHolderGetMethodName(attributeName);
+    }
+
+    /**
+     * Return the set method name weaved for a value-holder attribute.
+     */
+    public static String getWeavedValueHolderSetMethodName(String attributeName) {
+        return Helper.getWeavedValueHolderSetMethodName(attributeName);
+    }
+
+    /**
+     * Return if the JAXB classes are on the classpath (if they are the
+     * XmlTransient annotation is added).
+     */
+    public static boolean isJAXBOnPath() {
+        if (isJAXBOnPath == null) {
+            try {
+                Class.forName("jakarta.xml.bind.annotation.XmlTransient");
+                isJAXBOnPath = true;
+            } catch (Exception notThere) {
+                isJAXBOnPath = false;
+            }
+        }
+        return isJAXBOnPath;
+    }
+
+    public ClassWeaver(ClassVisitor classWriter, ClassDetails classDetails) {
+        super(ASMFactory.ASM_API_SELECTED, classWriter);
+        super.setCustomClassVisitor(this);
+        this.cw = classWriter;
+        this.classDetails = classDetails;
+    }
+
+    /**
+     * Add a variable of type ValueHolderInterface to the class. When this
+     * method has been run, the class will contain a variable declaration
+     * similar to the following:
+     *
+     * private ValueHolderInterface _persistence_variableName_vh;
+     */
+    public void addValueHolder(AttributeDetails attributeDetails) {
+        String attribute = attributeDetails.getAttributeName();
+        FieldVisitor fv = cv.visitField(Opcodes.valueInt("ACC_PROTECTED"), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE, null, null);
+
+        // only mark @Transient if this is property access. Otherwise, the
+        // @Transient annotation could mistakenly
+        // cause the class to use attribute access.
+        if (attributeDetails.getGetterMethodName() == null || attributeDetails.getGetterMethodName().equals("") || attributeDetails.weaveTransientFieldValueHolders()) {
+            fv.visitAnnotation(JPA_TRANSIENT_DESCRIPTION, true).visitEnd();
+            if (isJAXBOnPath()) {
+                fv.visitAnnotation(XML_TRANSIENT_DESCRIPTION, true).visitEnd();
+            }
+        }
+        fv.visitEnd();
+    }
+
+    /**
+     * Add a variable of type PropertyChangeListener to the class. When this
+     * method has been run, the class will contain a variable declaration
+     * similar to the following
+     *
+     * private transient _persistence_listener;
+     */
+    public void addPropertyChangeListener(boolean attributeAccess) {
+        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_listener", PCL_SIGNATURE, null, null);
+    }
+
+    /**
+     * Add the implementation of the changeTracker_getPropertyChangeListener
+     * method to the class. The result is a method that looks as follows:
+     *
+     * public PropertyChangeListener _persistence_getPropertyChangeListener() {
+     * return _persistence_listener; }
+     */
+    public void addGetPropertyChangeListener(ClassDetails classDetails) {
+        MethodVisitor cv_getPCL = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getPropertyChangeListener", "()" + PCL_SIGNATURE, null, null);
+        cv_getPCL.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_getPCL.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        cv_getPCL.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_getPCL.visitMaxs(0, 0);
+    }
+
+    /**
+     * Add the implementation of the changeTracker_setPropertyChangeListener
+     * method to the class. The result is a method that looks as follows:
+     *
+     * public void _persistence_setPropertyChangeListener(PropertyChangeListener
+     * propertychangelistener){ _persistence_listener = propertychangelistener;
+     * }
+     */
+    public void addSetPropertyChangeListener(ClassDetails classDetails) {
+        MethodVisitor cv_setPCL = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setPropertyChangeListener", "(" + PCL_SIGNATURE + ")V", null, null);
+        cv_setPCL.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_setPCL.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_setPCL.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        cv_setPCL.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_setPCL.visitMaxs(0, 0);
+    }
+
+    /**
+     * Add a method to track property changes. The method will look as follows:
+     *
+     * public void _toplink_propertyChange(String s, Object obj, Object obj1){
+     * if(_persistence_listener != null {@literal &&} obj != obj1){
+     * _persistence_listener.propertyChange(new PropertyChangeEvent(this, s,
+     * obj, obj1)); } }
+     */
+    public void addPropertyChange(ClassDetails classDetails) {
+        // create the _toplink_propertyChange() method
+        MethodVisitor cv_addPC = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", null, null);
+
+        // if (_toplink_Listener != null)
+        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_addPC.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        Label l0 = ASMFactory.createLabel();
+        cv_addPC.visitJumpInsn(Opcodes.valueInt("IFNULL"), l0);
+
+        // if (obj != obj1)
+        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
+        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
+        cv_addPC.visitJumpInsn(Opcodes.valueInt("IF_ACMPEQ"), l0);
+
+        // _toplink_listener.propertyChange(...);
+        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_addPC.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        cv_addPC.visitTypeInsn(Opcodes.valueInt("NEW"), PCE_SHORT_SIGNATURE);
+        cv_addPC.visitInsn(Opcodes.valueInt("DUP"));
+
+        // new PropertyChangeEvent(this, s, obj, obj1)
+        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
+        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
+        cv_addPC.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), PCE_SHORT_SIGNATURE, "<init>", "(Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
+        cv_addPC.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), PCL_SHORT_SIGNATURE, "propertyChange", "(" + PCE_SIGNATURE + ")V", true);
+
+        // }
+        cv_addPC.visitLabel(l0);
+
+        cv_addPC.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_addPC.visitMaxs(0, 0);
+    }
+
+    /**
+     * Add a method that allows us to lazily initialize a valueholder we have
+     * woven in This allows us to avoid initializing valueholders in the
+     * constructor.
+     *
+     * protected void _persistence_initialize_attribute_vh(){
+     * if(_persistence_attribute_vh == null){ _persistence_attribute_vh = new
+     * ValueHolder(this.attribute); // or new ValueHolder() if property access.
+     * _persistence_attribute_vh.setIsNewlyWeavedValueHolder(true); } }
+     */
+    public void addInitializerForValueHolder(ClassDetails classDetails, AttributeDetails attributeDetails) {
+        String attribute = attributeDetails.getAttributeName();
+        String className = classDetails.getClassName();
+
+        // Create a getter method for the new valueholder
+        // protected void _persistence_initialize_attribute_vh(){
+        MethodVisitor cv_init_VH = cv.visitMethod(Opcodes.valueInt("ACC_PROTECTED"), "_persistence_initialize_" + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "()V", null, null);
+
+        // if(_persistence_attribute_vh == null){
+        cv_init_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_init_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        Label l0 = ASMFactory.createLabel();
+        cv_init_VH.visitJumpInsn(Opcodes.valueInt("IFNONNULL"), l0);
+
+        // _persistence_attribute_vh = new ValueHolder(this.attribute);
+        cv_init_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_init_VH.visitTypeInsn(Opcodes.valueInt("NEW"), VH_SHORT_SIGNATURE);
+        cv_init_VH.visitInsn(Opcodes.valueInt("DUP"));
+        if (attributeDetails.hasField()) {
+            cv_init_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_init_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), className, attribute, attributeDetails.getReferenceClassType().getDescriptor());
+            cv_init_VH.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), VH_SHORT_SIGNATURE, "<init>", "(Ljava/lang/Object;)V", false);
+        } else {
+            cv_init_VH.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), VH_SHORT_SIGNATURE, "<init>", "()V", false);
+        }
+        cv_init_VH.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+
+        // _persistence_attribute_vh.setIsNewlyWeavedValueHolder(true);
+        cv_init_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_init_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_init_VH.visitInsn(Opcodes.valueInt("ICONST_1"));
+        cv_init_VH.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "setIsNewlyWeavedValueHolder", "(Z)V", true);
+
+        // }
+        cv_init_VH.visitLabel(l0);
+
+        cv_init_VH.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_init_VH.visitMaxs(0, 0);
+    }
+
+    /**
+     * Add a get method for the newly added valueholder. Adds a method of the
+     * following form:
+     *
+     * public WeavedAttributeValueHolderInterface _persistence_getfoo_vh(){
+     * _persistence_initialize_attributeName_vh(); if
+     * (_persistence_vh.isCoordinatedWithProperty() ||
+     * _persistence_foo_vh.isNewlyWeavedValueHolder()){ EntityC object =
+     * (EntityC)getFoo(); if (object != _persistence_foo_vh.getValue()){
+     * setFoo(object); } } return _persistence_foo_vh; }
+     */
+    public void addGetterMethodForValueHolder(ClassDetails classDetails, AttributeDetails attributeDetails) {
+        String attribute = attributeDetails.getAttributeName();
+        String className = classDetails.getClassName();
+        // Create a getter method for the new valueholder
+        MethodVisitor cv_get_VH = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_GET + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "()" + VHI_SIGNATURE, null, null);
+
+        // _persistence_initialize_attributeName_vh();
+        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+
+        // if (_toplink_foo_vh.isCoordinatedWithProperty() ||
+        // _toplink_foo_vh.isNewlyWeavedValueHolder()){
+        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_get_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "isCoordinatedWithProperty", "()Z", true);
+        Label l0 = ASMFactory.createLabel();
+        cv_get_VH.visitJumpInsn(Opcodes.valueInt("IFNE"), l0);
+        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_get_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "isNewlyWeavedValueHolder", "()Z", true);
+        Label l1 = ASMFactory.createLabel();
+        cv_get_VH.visitJumpInsn(Opcodes.valueInt("IFEQ"), l1);
+        cv_get_VH.visitLabel(l0);
+        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+
+        // EntityC object = (EntityC)getFoo();
+        if (attributeDetails.getGetterMethodName() != null) {
+            cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), attributeDetails.getGetterMethodName(), "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
+            cv_get_VH.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+        } else {
+            cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), PERSISTENCE_GET + attributeDetails.attributeName, "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
+        }
+        cv_get_VH.visitVarInsn(Opcodes.valueInt("ASTORE"), 1);
+
+        // if (object != _toplink_foo_vh.getValue()){
+        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_get_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+        cv_get_VH.visitJumpInsn(Opcodes.valueInt("IF_ACMPEQ"), l1);
+
+        // setFoo(object);
+        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        if (attributeDetails.getSetterMethodName() != null) {
+            cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), attributeDetails.getSetterMethodName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
+        } else {
+            cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), PERSISTENCE_SET + attributeDetails.getAttributeName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
+        }
+
+        // }
+        cv_get_VH.visitLabel(l1);
+
+        // return _toplink_foo_vh;
+        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_get_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_get_VH.visitInsn(Opcodes.valueInt("ARETURN"));
+
+        cv_get_VH.visitMaxs(0, 0);
+    }
+
+    /**
+     * Add a set method for the newly added ValueHolder. Adds a method of this
+     * form:
+     *
+     * public void _persistence_setfoo_vh(WeavedAttributeValueHolderInterface
+     * valueholderinterface){ _persistence_foo_vh = valueholderinterface; if
+     * (valueholderinterface.isInstantiated()){ Object object = getFoo(); Object
+     * value = valueholderinterface.getValue(); if (object != value){
+     * setFoo((EntityC)value); } } else { foo = null; } }
+     */
+    public void addSetterMethodForValueHolder(ClassDetails classDetails, AttributeDetails attributeDetails) {
+        String attribute = attributeDetails.getAttributeName();
+        String className = classDetails.getClassName();
+        // create a setter method for the new valueholder
+        MethodVisitor cv_set_value = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_SET + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "(" + VHI_SIGNATURE + ")V", null, null);
+
+        // _toplink_foo_vh = valueholderinterface;
+        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_set_value.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+
+        // if (valueholderinterface.isInstantiated()){
+        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "isInstantiated", "()Z", true);
+        Label l0 = ASMFactory.createLabel();
+        cv_set_value.visitJumpInsn(Opcodes.valueInt("IFEQ"), l0);
+
+        // Object object = getFoo();
+        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        if (attributeDetails.getGetterMethodName() != null) {
+            cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), className, attributeDetails.getGetterMethodName(), "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
+        } else {
+            cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), className, PERSISTENCE_GET + attributeDetails.attributeName, "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
+        }
+        cv_set_value.visitVarInsn(Opcodes.valueInt("ASTORE"), 2);
+
+        // Object value = valueholderinterface.getValue();
+        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+        cv_set_value.visitVarInsn(Opcodes.valueInt("ASTORE"), 3);
+
+        // if (object != value){
+        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
+        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
+        if (attributeDetails.getSetterMethodName() != null) {
+            cv_set_value.visitJumpInsn(Opcodes.valueInt("IF_ACMPEQ"), l0);
+            // setFoo((EntityC)value);
+            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
+            cv_set_value.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+            cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), className, attributeDetails.getSetterMethodName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
+            //}
+            cv_set_value.visitLabel(l0);
+        } else {
+            Label l1 = ASMFactory.createLabel();
+            cv_set_value.visitJumpInsn(Opcodes.valueInt("IF_ACMPEQ"), l1);
+            // _persistence_setFoo((EntityC)value);
+            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
+            cv_set_value.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+            cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), className, PERSISTENCE_SET + attributeDetails.getAttributeName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
+            // }
+            cv_set_value.visitLabel(l1);
+            cv_set_value.visitFrame(Opcodes.valueInt("F_SAME"), 0, null, 0, null);
+            Label l2 = ASMFactory.createLabel();
+            cv_set_value.visitJumpInsn(Opcodes.valueInt("GOTO"), l2);
+            // }
+            cv_set_value.visitLabel(l0);
+            // else {
+            cv_set_value.visitFrame(Opcodes.valueInt("F_SAME"), 0, null, 0, null);
+            // foo = null;
+            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_set_value.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+            cv_set_value.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), className, attributeDetails.attributeName, attributeDetails.getReferenceClassType().getDescriptor());
+            //}
+            cv_set_value.visitLabel(l2);
+            cv_set_value.visitFrame(Opcodes.valueInt("F_SAME"), 0, null, 0, null);
+        }
+
+        cv_set_value.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_set_value.visitMaxs(0, 0);
+    }
+
+    /**
+     * Adds a convenience method used to replace a PUTFIELD when field access is
+     * used. The method follows the following form:
+     *
+     * public void _persistence_set_variableName((VariableClas) argument) {
+     * _persistence_checkFetchedForSet("variableName");
+     * _persistence_initialize_variableName_vh();
+     * _persistence_propertyChange("variableName", this.variableName, argument);
+     * // if change tracking enabled, wrapping primitives, i.e. Long.valueOf(item)
+     * this.variableName = argument;
+     * _persistence_variableName_vh.setValue(variableName); // if lazy enabled }
+     */
+    public void addSetterMethodForFieldAccess(ClassDetails classDetails, AttributeDetails attributeDetails) {
+        String attribute = attributeDetails.getAttributeName();
+
+        // create _persistence_set_variableName
+        MethodVisitor cv_set = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_SET + attribute, "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", null, null);
+
+        // Get the opcode for the load instruction. This may be different
+        // depending on the type
+        int opcode = attributeDetails.getReferenceClassType().getOpcode(Opcodes.valueInt("ILOAD"));
+
+        if (classDetails.shouldWeaveFetchGroups()) {
+            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_set.visitLdcInsn(attribute);
+            // _persistence_checkFetchedForSet("variableName");
+            cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
+        }
+
+        if (classDetails.shouldWeaveChangeTracking()) {
+            if (attributeDetails.weaveValueHolders()) {
+                // _persistence_initialize_variableName_vh();
+                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+
+                // _persistenc_variableName_vh.getValue();
+                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+
+                // Add the cast:
+                // (<VariableClass>)_persistenc_variableName_vh.getValue()
+                cv_set.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+
+                // add the assignment: this.variableName =
+                // (<VariableClass>)_persistenc_variableName_vh.getValue();
+                cv_set.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+            }
+
+            // load the string attribute name as the first argument of the
+            // property change call
+            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_set.visitLdcInsn(attribute);
+
+            // if the attribute is a primitive, wrap it
+            // e.g. if it is an integer: Integer.valueOf(attribute)
+            // This is the first part of the wrapping
+            String wrapper = ClassWeaver.wrapperFor(attributeDetails.getReferenceClassType().getSort());
+            if (wrapper != null) {
+                cv_set.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
+                cv_set.visitInsn(Opcodes.valueInt("DUP"));
+            }
+
+            // load the method argument
+            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+
+            if (wrapper != null) {
+                // invoke the constructor for wrapping
+                // e.g. Integer.valueOf(variableName)
+                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
+
+                // wrap the method argument
+                // e.g. Integer.valueOf(argument)
+                cv_set.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
+                cv_set.visitInsn(Opcodes.valueInt("DUP"));
+                cv_set.visitVarInsn(opcode, 1);
+                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
+            } else {
+                // if we are not wrapping the argument, just load it
+                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+            }
+            // _persistence_propertyChange("variableName", variableName,
+            // argument);
+            cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
+        } else {
+            if (attributeDetails.weaveValueHolders()) {
+                // _persistence_initialize_variableName_vh();
+                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+
+                // _persistenc_variableName_vh.getValue();
+                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+
+                // Add the cast:
+                // (<VariableClass>)_persistenc_variableName_vh.getValue()
+                cv_set.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+
+                // add the assignment: this.variableName =
+                // (<VariableClass>)_persistenc_variableName_vh.getValue();
+                cv_set.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+            }
+        }
+
+        // Must set variable after raising change event, so event has old and
+        // new value.
+        // variableName = argument
+        cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_set.visitVarInsn(opcode, 1);
+        cv_set.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+
+        if (attributeDetails.weaveValueHolders()) {
+            // _persistence_variableName_vh.setValue(argument);
+            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+            cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "setValue", "(Ljava/lang/Object;)V", true);
+        }
+
+        cv_set.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_set.visitMaxs(0, 0);
+    }
+
+    /**
+     * Adds a convenience method used to replace a GETFIELD when field access is
+     * used. The method follows the following form:
+     *
+     * public (VariableClass) _persistence_get_variableName() {
+     * _persistence_checkFetched("variableName");
+     * _persistence_initialize_variableName_vh(); this.variableName =
+     * ((VariableClass))_persistence_variableName_vh.getValue(); return
+     * this.variableName; }
+     */
+    public void addGetterMethodForFieldAccess(ClassDetails classDetails, AttributeDetails attributeDetails) {
+        String attribute = attributeDetails.getAttributeName();
+
+        // create the _persistenc_getvariableName method
+        MethodVisitor cv_get = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_GET + attribute, "()" + attributeDetails.getReferenceClassType().getDescriptor(), null, null);
+
+        if (classDetails.shouldWeaveFetchGroups()) {
+            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_get.visitLdcInsn(attribute);
+            // _persistence_checkFetched("variableName");
+            cv_get.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_checkFetched", "(Ljava/lang/String;)V", false);
+        }
+
+        if (attributeDetails.weaveValueHolders()) {
+            // _persistence_initialize_variableName_vh();
+            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_get.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+
+            // _persistenc_variableName_vh.getValue();
+            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_get.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+            cv_get.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+
+            // Add the cast:
+            // (<VariableClass>)_persistenc_variableName_vh.getValue()
+            cv_get.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+
+            // add the assignment: this.variableName =
+            // (<VariableClass>)_persistenc_variableName_vh.getValue();
+            cv_get.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+        }
+
+        // return this.variableName;
+        cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_get.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+        // Get the opcode for the return insturction. This may be different
+        // depending on the type.
+        int opcode = attributeDetails.getReferenceClassType().getOpcode(Opcodes.valueInt("IRETURN"));
+        cv_get.visitInsn(opcode);
+        cv_get.visitMaxs(0, 0);
+    }
+
+    /**
+     * Add a variable of type Object to the class. When this method has been
+     * run, the class will contain a variable declarations similar to the
+     * following:
+     *
+     * private Object _persistence_primaryKey;
+     */
+    public void addPersistenceEntityVariables() {
+        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_primaryKey", OBJECT_SIGNATURE, null, null);
+        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_cacheKey", CACHEKEY_SIGNATURE, null, null);
+    }
+
+    /**
+     * Add an internal post clone method. This will clone value holders to avoid
+     * change original/clone to effect the other.
+     *
+     * public Object _persistence_post_clone() { this._attribute_vh =
+     * this._attribute_vh.clone(); ... this._persistence_listener = null; return
+     * this; }
+     */
+    public void addPersistencePostClone(ClassDetails classDetails) {
+        // create the _persistence_post_clone() method
+        MethodVisitor cv_clone = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_post_clone", "()Ljava/lang/Object;", null, null);
+
+        // if there is a weaved superclass, it will implement
+        // _persistence_post_clone. Call that method
+        // super._persistence_post_clone()
+        if (classDetails.getSuperClassDetails() != null && classDetails.getSuperClassDetails().shouldWeaveInternal()) {
+            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "_persistence_post_clone", "()Ljava/lang/Object;", false);
+        }
+
+        if (classDetails.shouldWeaveValueHolders()) {
+            for (Iterator<AttributeDetails> iterator = classDetails.getAttributesMap().values().iterator(); iterator.hasNext();) {
+                AttributeDetails attributeDetails = iterator.next();
+                if (attributeDetails.weaveValueHolders()) { // &&
+                                                            // !attributeDetails.isAttributeOnSuperClass())
+                                                            // {
+                    // clone._attribute_vh = this._attribute_vh.clone();
+                    cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                    cv_clone.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                    Label label = ASMFactory.createLabel();
+                    cv_clone.visitJumpInsn(Opcodes.valueInt("IFNULL"), label);
+                    cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                    cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                    cv_clone.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                    cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "clone", "()Ljava/lang/Object;", true);
+                    cv_clone.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), ClassWeaver.VHI_SHORT_SIGNATURE);
+                    cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                    cv_clone.visitLabel(label);
+                }
+            }
+        }
+        if (classDetails.shouldWeaveChangeTracking()) {
+            // clone._persistence_listener = null;
+            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_clone.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+            cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        }
+        if (classDetails.shouldWeaveFetchGroups()) {
+            // clone._persistence_fetchGroup = null;
+            // clone._persistence_session = null;
+            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_clone.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+            cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_clone.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+            cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
+        }
+
+        if (!classDetails.isEmbedable()) {
+            // clone._persistence_primaryKey = null;
+            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_clone.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+            cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
+        }
+
+        // return clone;
+        cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_clone.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_clone.visitMaxs(0, 0);
+    }
+
+    public void addPersistenceRestMethods(ClassDetails classDetails) {
+        // public List<RelationshipInfo> _persistence_getRelationships() {
+        //   return this._persistence_relationshipInfo;
+        // }
+        MethodVisitor cv_getPKVector = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "getRelationships", "()" + LIST_RELATIONSHIP_INFO_SIGNATURE, "()" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
+        cv_getPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_getPKVector.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
+        cv_getPKVector.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_getPKVector.visitMaxs(0, 0);
+
+        // public void _persistence_setRelationships(List<RelationshipInfo> paramList) {
+        //   this._persistence_relationshipInfo = paramList;
+        // }
+        MethodVisitor cv_setPKVector = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "setRelationships", "(" + LIST_RELATIONSHIP_INFO_SIGNATURE + ")V", "(" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE + ")V", null);
+        cv_setPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_setPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_setPKVector.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
+        cv_setPKVector.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_setPKVector.visitMaxs(0, 0);
+
+        // public Link _persistence_getHref() {
+        //   return this._persistence_href;
+        // }
+        MethodVisitor cv_getHref = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "getHref", "()" + LINK_SIGNATURE, null, null);
+        cv_getHref.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_getHref.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
+        cv_getHref.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_getHref.visitMaxs(0, 0);
+
+        // public void _persistence_setHref(Link paramLink)
+        //   this._persistence_href = paramLink;
+        // }
+        MethodVisitor cv_setHref = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "setHref", "(" + LINK_SIGNATURE + ")V", null, null);
+        cv_setHref.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_setHref.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_setHref.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
+        cv_setHref.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_setHref.visitMaxs(0, 0);
+
+        // public ItemLinks _persistence_getLinks() {
+        //   return this._persistence_links;
+        // }
+        MethodVisitor cv_getLinks = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "getLinks", "()" + ITEM_LINKS_SIGNATURE, null, null);
+        cv_getLinks.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_getLinks.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
+        cv_getLinks.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_getLinks.visitMaxs(0, 0);
+
+        // public void _persistence_setLinks(ItemLinks paramItemLinks) {
+        //   this._persistence_links = paramItemLinks;
+        // }
+        MethodVisitor cv_setLinks = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "setLinks", "(" + ITEM_LINKS_SIGNATURE + ")V", null, null);
+        cv_setLinks.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_setLinks.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_setLinks.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
+        cv_setLinks.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_setLinks.visitMaxs(0, 0);
+
+    }
+
+    public void addPersistenceRestVariables() {
+        // protected transient List<RelationshipInfo> _persistence_relationshipInfo;
+        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") | Opcodes.valueInt("ACC_TRANSIENT"), PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE, LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
+        // protected transient Link _persistence_href;
+        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") | Opcodes.valueInt("ACC_TRANSIENT"), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE, null, null);
+        // protected transient ItemLinks _persistence_links;
+        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") | Opcodes.valueInt("ACC_TRANSIENT"), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE, null, null);
+    }
+
+    /**
+     * Add an internal shallow clone method. This can be used to optimize uow
+     * cloning.
+     *
+     * public Object _persistence_shallow_clone() { return super.clone(); }
+     */
+    public void addShallowClone(ClassDetails classDetails) {
+        // create the _persistence_shallow_clone() method
+        MethodVisitor cv_clone = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_shallow_clone", "()Ljava/lang/Object;", null, null);
+
+        // return super.clone();
+        cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "java/lang/Object", "clone", "()Ljava/lang/Object;", false);
+
+        cv_clone.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_clone.visitMaxs(0, 0);
+    }
+
+    /**
+     * Add an internal empty constructor, and new method. This is used to avoid
+     * unnecessary initialization and avoid reflection.
+     *
+     * public void _persistence_new(PersistenceObject factory) { return new
+     * ClassType(factory); }
+     *
+     * public ClassType(PersistenceObject factory) { super(); }
+     */
+    public void addPersistenceNew(ClassDetails classDetails) {
+        // create the _persistence_new() method
+        MethodVisitor cv_new = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_new", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")Ljava/lang/Object;", null, null);
+
+        // return new ClassType(factory);
+        cv_new.visitTypeInsn(Opcodes.valueInt("NEW"), classDetails.getClassName());
+        cv_new.visitInsn(Opcodes.valueInt("DUP"));
+        if (!classDetails.canWeaveConstructorOptimization()) {
+            cv_new.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getClassName(), "<init>", "()V", false);
+            cv_new.visitInsn(Opcodes.valueInt("ARETURN"));
+            cv_new.visitMaxs(0, 0);
+            return;
+        } else {
+            cv_new.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+            cv_new.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getClassName(), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", false);
+        }
+        cv_new.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_new.visitMaxs(0, 0);
+
+        // create the ClassType() method
+        MethodVisitor cv_constructor = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", null, null);
+
+        cv_constructor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        if (classDetails.getSuperClassDetails() == null) {
+            // super();
+            cv_constructor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "<init>", "()V", false);
+        } else {
+            // super(factory);
+            cv_constructor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+            cv_constructor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", false);
+        }
+        cv_constructor.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_constructor.visitMaxs(0, 0);
+    }
+
+    /**
+     * Add an internal generic get and set method. This is used to avoid
+     * reflection.
+     *
+     * public Object _persistence_get(String attribute) { if (attribute ==
+     * "address") { return this.address; } if (attribute == "city") { return
+     * this.city; } return null; }
+     *
+     * public void _persistence_set(int index, Object value) { if (attribute ==
+     * "address") { this.address = (String)value; } else if (attribute ==
+     * "city") { this.city = (String)city; } }
+     */
+    public void addPersistenceGetSet(ClassDetails classDetails) {
+        // create the _persistence_get() method
+        MethodVisitor cv_get = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_get", "(Ljava/lang/String;)Ljava/lang/Object;", null, null);
+
+        Label label = null;
+        for (AttributeDetails attributeDetails : classDetails.getAttributesMap().values()) {
+            if (!attributeDetails.isAttributeOnSuperClass() && !attributeDetails.isVirtualProperty()) {
+                if (label != null) {
+                    cv_get.visitLabel(label);
+                }
+                // else if (attribute == "address")
+                cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                cv_get.visitLdcInsn(attributeDetails.getAttributeName().intern());
+                label = ASMFactory.createLabel();
+                cv_get.visitJumpInsn(Opcodes.valueInt("IF_ACMPNE"), label);
+                // return this.address
+                cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                cv_get.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), attributeDetails.getAttributeName(), attributeDetails.getReferenceClassType().getDescriptor());
+                // if this is a primitive, get the wrapper class
+                String wrapper = ClassWeaver.wrapperFor(attributeDetails.getReferenceClassType().getSort());
+                if (wrapper != null) {
+                    // Call valueOf on the wrapper (more optimal than
+                    // constructor).
+                    cv_get.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), wrapper, "valueOf", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")L" + wrapper + ";", false);
+                }
+
+                cv_get.visitInsn(Opcodes.valueInt("ARETURN"));
+            }
+        }
+        if (label != null) {
+            cv_get.visitLabel(label);
+        }
+        // call super, or return null
+        if (classDetails.getSuperClassDetails() == null) {
+            // return null;
+            cv_get.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+        } else {
+            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+            cv_get.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "_persistence_get", "(Ljava/lang/String;)Ljava/lang/Object;", false);
+        }
+
+        cv_get.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_get.visitMaxs(0, 0);
+
+        // create the _persistence_set() method
+        MethodVisitor cv_set = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_set", "(Ljava/lang/String;Ljava/lang/Object;)V", null, null);
+
+        label = null;
+        for (AttributeDetails attribute : classDetails.getAttributesMap().values()) {
+            if (!attribute.isAttributeOnSuperClass() && !attribute.isVirtualProperty()) {
+                if (label != null) {
+                    cv_set.visitLabel(label);
+                }
+                // else if (attribute == "address")
+                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                cv_set.visitLdcInsn(attribute.getAttributeName().intern());
+                label = ASMFactory.createLabel();
+                cv_set.visitJumpInsn(Opcodes.valueInt("IF_ACMPNE"), label);
+                // this.address = (String)value;
+                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
+                String wrapper = wrapperFor(attribute.getReferenceClassType().getSort());
+                if (wrapper == null) {
+                    wrapper = attribute.getReferenceClassName().replace('.', '/');
+                }
+                cv_set.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), wrapper);
+                // Unwrap any primitive wrapper to its value.
+                unwrapPrimitive(attribute, cv_set);
+                cv_set.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute.getAttributeName(), attribute.getReferenceClassType().getDescriptor());
+                // return;
+                cv_set.visitInsn(Opcodes.valueInt("RETURN"));
+            }
+        }
+        if (label != null) {
+            cv_set.visitLabel(label);
+        }
+        // call super, or return null
+        if (classDetails.getSuperClassDetails() != null) {
+            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
+            cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "_persistence_set", "(Ljava/lang/String;Ljava/lang/Object;)V", false);
+        }
+
+        cv_set.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_set.visitMaxs(0, 0);
+    }
+
+    /**
+     * Adds get/set method for PersistenceEntity interface. This adds the
+     * following methods:
+     *
+     * public Object _persistence_getId() { return _persistence_primaryKey; }
+     * public void _persistence_setId(Object primaryKey) {
+     * this._persistence_primaryKey = primaryKey; }
+     */
+    public void addPersistenceEntityMethods(ClassDetails classDetails) {
+        MethodVisitor cv_getPKVector = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getId", "()" + OBJECT_SIGNATURE, null, null);
+        cv_getPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_getPKVector.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
+        cv_getPKVector.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_getPKVector.visitMaxs(0, 0);
+
+        MethodVisitor cv_setPKVector = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setId", "(" + OBJECT_SIGNATURE + ")V", null, null);
+        cv_setPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_setPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_setPKVector.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
+        cv_setPKVector.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_setPKVector.visitMaxs(0, 0);
+
+        MethodVisitor cv_getCacheKey = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getCacheKey", "()" + CACHEKEY_SIGNATURE, null, null);
+        cv_getCacheKey.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_getCacheKey.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_cacheKey", CACHEKEY_SIGNATURE);
+        cv_getCacheKey.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_getCacheKey.visitMaxs(0, 0);
+
+        MethodVisitor cv_setCacheKey = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setCacheKey", "(" + CACHEKEY_SIGNATURE + ")V", null, null);
+        cv_setCacheKey.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_setCacheKey.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_setCacheKey.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_cacheKey", CACHEKEY_SIGNATURE);
+        cv_setCacheKey.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_setCacheKey.visitMaxs(0, 0);
+    }
+
+    /**
+     * Add a variable of type FetchGroup, Session to the class. When this method
+     * has been run, the class will contain a variable declarations similar to
+     * the following:
+     *
+     * private FetchGroup _persistence_fetchGroup; private boolean
+     * _persistence_shouldRefreshFetchGroup; private Session
+     * _persistence_session;
+     */
+    public void addFetchGroupVariables() {
+        FieldVisitor fv = cv.visitField(Opcodes.valueInt("ACC_PROTECTED"), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE, null, null);
+        // Only add jakarta.persistence.Transient annotation if attribute access
+        // is being used
+        if (classDetails.usesAttributeAccess()) {
+            fv.visitAnnotation(JPA_TRANSIENT_DESCRIPTION, true).visitEnd();
+        }
+        if (isJAXBOnPath()) {
+            fv.visitAnnotation(XML_TRANSIENT_DESCRIPTION, true).visitEnd();
+        }
+        fv.visitEnd();
+
+        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE, null, null).visitEnd();
+        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_session", SESSION_SIGNATURE, null, null).visitEnd();
+    }
+
+    /**
+     * Adds get/set method for FetchGroupTracker interface. This adds the
+     * following methods:
+     *
+     * public Session _persistence_getSession() { return _persistence_session; }
+     * public void _persistence_setSession(Session session) {
+     * this._persistence_session = session; }
+     *
+     * public FetchGroup _persistence_getFetchGroup() { return
+     * _persistence_fetchGroup; } public void
+     * _persistence_setFetchGroup(FetchGroup fetchGroup) {
+     * this._persistence_fetchGroup = fetchGroup; }
+     *
+     * public boolean _persistence_shouldRefreshFetchGroup() { return
+     * _persistence_shouldRefreshFetchGroup; } public void
+     * _persistence_setShouldRefreshFetchGroup(boolean shouldRefreshFetchGroup)
+     * { this._persistence_shouldRefreshFetchGroup = shouldRefreshFetchGroup; }
+     *
+     * public void _persistence_resetFetchGroup() { }
+     *
+     * public void _persistence_isAttributeFetched(String attribute) { return
+     * this._persistence_fetchGroup == null ||
+     * _persistence_fetchGroup.containsAttribute(attribute); }
+     *
+     * public void _persistence_checkFetched(String attribute) { if
+     * (this._persistence_fetchGroup != null) {
+     * EntityManagerImpl.processUnfetchedAttribute(this, attribute); } }
+     *
+     *
+     * public void _persistence_checkSetFetched(String attribute) { if
+     * (this._persistence_fetchGroup != null) {
+     * EntityManagerImpl.processUnfetchedAttributeForSet(this, attribute); } }
+     */
+    public void addFetchGroupMethods(ClassDetails classDetails) {
+        MethodVisitor cv_getSession = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getSession", "()" + SESSION_SIGNATURE, null, null);
+        cv_getSession.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_getSession.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
+        cv_getSession.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_getSession.visitMaxs(0, 0);
+
+        MethodVisitor cv_setSession = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setSession", "(" + SESSION_SIGNATURE + ")V", null, null);
+        cv_setSession.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_setSession.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_setSession.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
+        cv_setSession.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_setSession.visitMaxs(0, 0);
+
+        MethodVisitor cv_getFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getFetchGroup", "()" + FETCHGROUP_SIGNATURE, null, null);
+        cv_getFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_getFetchGroup.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+        cv_getFetchGroup.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_getFetchGroup.visitMaxs(0, 0);
+
+        MethodVisitor cv_setFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setFetchGroup", "(" + FETCHGROUP_SIGNATURE + ")V", null, null);
+        cv_setFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_setFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_setFetchGroup.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+        cv_setFetchGroup.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_setFetchGroup.visitMaxs(0, 0);
+
+        MethodVisitor cv_shouldRefreshFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_shouldRefreshFetchGroup", "()" + PBOOLEAN_SIGNATURE, null, null);
+        cv_shouldRefreshFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_shouldRefreshFetchGroup.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE);
+        cv_shouldRefreshFetchGroup.visitInsn(Opcodes.valueInt("IRETURN"));
+        cv_shouldRefreshFetchGroup.visitMaxs(0, 0);
+
+        MethodVisitor cv_setShouldRefreshFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setShouldRefreshFetchGroup", "(" + PBOOLEAN_SIGNATURE + ")V", null, null);
+        cv_setShouldRefreshFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_setShouldRefreshFetchGroup.visitVarInsn(Opcodes.valueInt("ILOAD"), 1);
+        cv_setShouldRefreshFetchGroup.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE);
+        cv_setShouldRefreshFetchGroup.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_setShouldRefreshFetchGroup.visitMaxs(0, 0);
+
+        MethodVisitor cv_resetFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_resetFetchGroup", "()V", null, null);
+        cv_resetFetchGroup.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_resetFetchGroup.visitMaxs(0, 0);
+
+        MethodVisitor cv_isAttributeFetched = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", null, null);
+        cv_isAttributeFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_isAttributeFetched.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+        Label gotoTrue = ASMFactory.createLabel();
+        cv_isAttributeFetched.visitJumpInsn(Opcodes.valueInt("IFNULL"), gotoTrue);
+        cv_isAttributeFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_isAttributeFetched.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+        cv_isAttributeFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_isAttributeFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), FETCHGROUP_SHORT_SIGNATURE, "containsAttributeInternal", "(Ljava/lang/String;)Z", false);
+        Label gotoFalse = ASMFactory.createLabel();
+        cv_isAttributeFetched.visitJumpInsn(Opcodes.valueInt("IFEQ"), gotoFalse);
+        cv_isAttributeFetched.visitLabel(gotoTrue);
+        cv_isAttributeFetched.visitInsn(Opcodes.valueInt("ICONST_1"));
+        Label gotoReturn = ASMFactory.createLabel();
+        cv_isAttributeFetched.visitJumpInsn(Opcodes.valueInt("GOTO"), gotoReturn);
+        cv_isAttributeFetched.visitLabel(gotoFalse);
+        cv_isAttributeFetched.visitInsn(Opcodes.valueInt("ICONST_0"));
+        cv_isAttributeFetched.visitLabel(gotoReturn);
+        cv_isAttributeFetched.visitInsn(Opcodes.valueInt("IRETURN"));
+        cv_isAttributeFetched.visitMaxs(0, 0);
+
+        MethodVisitor cv_checkFetched = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetched", "(Ljava/lang/String;)V", null, null);
+        cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", false);
+        gotoReturn = ASMFactory.createLabel();
+        cv_checkFetched.visitJumpInsn(Opcodes.valueInt("IFNE"), gotoReturn);
+        cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_checkFetched.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), FETCHGROUP_TRACKER_SHORT_SIGNATURE);
+        cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), ENTITY_MANAGER_IMPL_SHORT_SIGNATURE, "processUnfetchedAttribute", "(" + FETCHGROUP_TRACKER_SIGNATURE + "Ljava/lang/String;)V", false);
+        cv_checkFetched.visitLabel(gotoReturn);
+        cv_checkFetched.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_checkFetched.visitMaxs(0, 0);
+
+        MethodVisitor cv_checkFetchedForSet = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", null, null);
+        cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", false);
+        gotoReturn = ASMFactory.createLabel();
+        cv_checkFetchedForSet.visitJumpInsn(Opcodes.valueInt("IFNE"), gotoReturn);
+        cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_checkFetchedForSet.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), FETCHGROUP_TRACKER_SHORT_SIGNATURE);
+        cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), ENTITY_MANAGER_IMPL_SHORT_SIGNATURE, "processUnfetchedAttributeForSet", "(" + FETCHGROUP_TRACKER_SIGNATURE + "Ljava/lang/String;)V", false);
+        cv_checkFetchedForSet.visitLabel(gotoReturn);
+        cv_checkFetchedForSet.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_checkFetchedForSet.visitMaxs(0, 0);
+    }
+
+    /**
+     * Visit the class byte-codes and modify to weave Persistence interfaces.
+     * This add PersistenceWeaved, PersistenceWeavedLazy,
+     * PersistenceWeavedChangeTracking, PersistenceEntity, ChangeTracker. The
+     * new interfaces are pass to the super weaver.
+     */
+    @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        boolean weaveCloneable = true;
+        // To prevent 'double' weaving: scan for PersistenceWeaved interface.
+        for (int index = 0; index < interfaces.length; index++) {
+            String existingInterface = interfaces[index];
+            if (PERSISTENCE_WEAVED_SHORT_SIGNATURE.equals(existingInterface)) {
+                this.alreadyWeaved = true;
+                super.visitSuper(version, access, name, signature, superName, interfaces);
+                return;
+            } else if (CT_SHORT_SIGNATURE.equals(existingInterface)) {
+                // Disable weaving of change tracking if already implemented
+                // (such as by user).
+                classDetails.setShouldWeaveChangeTracking(false);
+            } else if (CLONEABLE_SHORT_SIGNATURE.equals(existingInterface)) {
+                weaveCloneable = false;
+            }
+        }
+        int newInterfacesLength = interfaces.length;
+        // Cloneable
+        int cloneableIndex = 0;
+        weaveCloneable = classDetails.shouldWeaveInternal() && weaveCloneable && (classDetails.getSuperClassDetails() == null);
+        if (weaveCloneable) {
+            cloneableIndex = newInterfacesLength;
+            newInterfacesLength++;
+        }
+        // PersistenceWeaved
+        int persistenceWeavedIndex = newInterfacesLength;
+        newInterfacesLength++;
+        // PersistenceEntity
+        int persistenceEntityIndex = 0;
+        boolean persistenceEntity = classDetails.shouldWeaveInternal() && (classDetails.getSuperClassDetails() == null) && (!classDetails.isEmbedable());
+        if (persistenceEntity) {
+            persistenceEntityIndex = newInterfacesLength;
+            newInterfacesLength++;
+        }
+        // PersistenceObject
+        int persistenceObjectIndex = 0;
+        boolean persistenceObject = classDetails.shouldWeaveInternal();
+        if (persistenceObject) {
+            persistenceObjectIndex = newInterfacesLength;
+            newInterfacesLength++;
+        }
+        // FetchGroupTracker
+        int fetchGroupTrackerIndex = 0;
+        boolean fetchGroupTracker = classDetails.shouldWeaveFetchGroups() && (classDetails.getSuperClassDetails() == null);
+        if (fetchGroupTracker) {
+            fetchGroupTrackerIndex = newInterfacesLength;
+            newInterfacesLength++;
+        }
+        int persistenceWeavedFetchGroupsIndex = 0;
+        if (classDetails.shouldWeaveFetchGroups()) {
+            persistenceWeavedFetchGroupsIndex = newInterfacesLength;
+            newInterfacesLength++;
+        }
+        // PersistenceWeavedLazy
+        int persistenceWeavedLazyIndex = 0;
+        if (classDetails.shouldWeaveValueHolders()) {
+            persistenceWeavedLazyIndex = newInterfacesLength;
+            newInterfacesLength++;
+        }
+
+        // ChangeTracker
+        boolean changeTracker = !classDetails.doesSuperclassWeaveChangeTracking() && classDetails.shouldWeaveChangeTracking();
+        int persistenceWeavedChangeTrackingIndex = 0;
+        int changeTrackerIndex = 0;
+        if (changeTracker) {
+            changeTrackerIndex = newInterfacesLength;
+            newInterfacesLength++;
+        }
+        if (classDetails.shouldWeaveChangeTracking()) {
+            persistenceWeavedChangeTrackingIndex = newInterfacesLength;
+            newInterfacesLength++;
+        }
+
+        int persistenceWeavedRestIndex = 0;
+        boolean weaveRest = classDetails.shouldWeaveREST() && classDetails.getSuperClassDetails() == null;
+        if (weaveRest) {
+            persistenceWeavedRestIndex = newInterfacesLength;
+            newInterfacesLength++;
+        }
+
+        String[] newInterfaces = new String[newInterfacesLength];
+        System.arraycopy(interfaces, 0, newInterfaces, 0, interfaces.length);
+        // Add 'marker'
+        // org.eclipse.persistence.internal.weaving.PersistenceWeaved interface.
+        newInterfaces[persistenceWeavedIndex] = PERSISTENCE_WEAVED_SHORT_SIGNATURE;
+        weaved = true;
+        // Add Cloneable interface.
+        if (weaveCloneable) {
+            newInterfaces[cloneableIndex] = CLONEABLE_SHORT_SIGNATURE;
+        }
+        // Add org.eclipse.persistence.internal.descriptors.PersistenceEntity
+        // interface.
+        if (persistenceEntity) {
+            newInterfaces[persistenceEntityIndex] = PERSISTENCE_ENTITY_SHORT_SIGNATURE;
+        }
+        // Add org.eclipse.persistence.internal.descriptors.PersistenceObject
+        // interface.
+        if (persistenceObject) {
+            newInterfaces[persistenceObjectIndex] = PERSISTENCE_OBJECT_SHORT_SIGNATURE;
+        }
+        // Add org.eclipse.persistence.queries.FetchGroupTracker interface.
+        if (fetchGroupTracker) {
+            newInterfaces[fetchGroupTrackerIndex] = FETCHGROUP_TRACKER_SHORT_SIGNATURE;
+        }
+        if (classDetails.shouldWeaveFetchGroups()) {
+            newInterfaces[persistenceWeavedFetchGroupsIndex] = WEAVED_FETCHGROUPS_SHORT_SIGNATURE;
+        }
+        // Add marker interface for LAZY.
+        if (classDetails.shouldWeaveValueHolders()) {
+            newInterfaces[persistenceWeavedLazyIndex] = TW_LAZY_SHORT_SIGNATURE;
+        }
+        // Add marker interface and change tracker interface for change
+        // tracking.
+        if (changeTracker) {
+            newInterfaces[changeTrackerIndex] = CT_SHORT_SIGNATURE;
+        }
+        if (classDetails.shouldWeaveChangeTracking()) {
+            newInterfaces[persistenceWeavedChangeTrackingIndex] = TW_CT_SHORT_SIGNATURE;
+        }
+
+        if (weaveRest) {
+            newInterfaces[persistenceWeavedRestIndex] = WEAVED_REST_LAZY_SHORT_SIGNATURE;
+        }
+
+        String newSignature = null;
+        // fix the signature to include any new methods we weave
+        if (signature != null) {
+            StringBuffer newSignatureBuf = new StringBuffer();
+            newSignatureBuf.append(signature);
+
+            for (int i = interfaces.length; i < newInterfaces.length; i++) {
+                newSignatureBuf.append("L" + newInterfaces[i] + ";");
+            }
+            newSignature = newSignatureBuf.toString();
+        }
+
+        if (cw != null) {
+            cv = cw;
+        }
+        cv.visit(version, access, name, newSignature, superName, newInterfaces);
+    }
+
+    /**
+     * Construct a MethodWeaver and allow it to process the method.
+     */
+    @Override
+    public MethodVisitor visitMethod(int access, String methodName, String desc, String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethodSuper(access, methodName, desc, signature, exceptions);
+        if (!alreadyWeaved) {
+            // skip constructors, they will not changed
+            if (!"<init>".equals(methodName) && !"<cinit>".equals(methodName)) {
+                // remaining modifications to the 'body' of the class are
+                // delegated to MethodWeaver
+                mv = new MethodWeaver(this, methodName, desc, mv);
+            }
+        }
+        return mv;
+    }
+
+    /**
+     * Visit the end of the class byte codes. Add any new methods or variables to the end.
+     */
+    @Override
+    public void visitEnd() {
+        if (!alreadyWeaved) {
+            if (this.classDetails.shouldWeaveInternal()) {
+
+                // Add a persistence and shallow clone method.
+                addPersistencePostClone(this.classDetails);
+                if (this.classDetails.getSuperClassDetails() == null) {
+                    addShallowClone(this.classDetails);
+                    if (!this.classDetails.isEmbedable()) {
+                        // Add PersistenceEntity variables and methods.
+                        addPersistenceEntityVariables();
+                        addPersistenceEntityMethods(this.classDetails);
+                        this.weavedPersistenceEntity = true;
+                    }
+                }
+                // Add empty new method and generic get/set methods.
+                addPersistenceNew(this.classDetails);
+                addPersistenceGetSet(this.classDetails);
+            }
+
+            boolean attributeAccess = false;
+            // For each attribute we need to check what methods and variables to
+            // add.
+            for (Iterator<AttributeDetails> iterator = this.classDetails.getAttributesMap().values().iterator(); iterator.hasNext();) {
+                AttributeDetails attributeDetails = iterator.next();
+                // Only add to classes that actually contain the attribute we
+                // are
+                // processing
+                // an attribute could be in the classDetails but not actually in
+                // the
+                // class
+                // if it is owned by a MappedSuperClass.
+                if (!attributeDetails.isAttributeOnSuperClass()) {
+                    if (attributeDetails.weaveValueHolders()) {
+                        // We will add valueholders and methods to classes that
+                        // have
+                        // not already been weaved
+                        // and classes that actually contain the attribute we
+                        // are
+                        // processing
+                        // an attribute could be in the classDetails but not
+                        // actually in the class
+                        // if it is owned by a MappedSuperClass.
+                        if (!attributeDetails.isAttributeOnSuperClass()) {
+                            weaved = true;
+                            weavedLazy = true;
+                            addValueHolder(attributeDetails);
+                            addInitializerForValueHolder(classDetails, attributeDetails);
+                            addGetterMethodForValueHolder(classDetails, attributeDetails);
+                            addSetterMethodForValueHolder(classDetails, attributeDetails);
+                        }
+                    }
+                    if (classDetails.shouldWeaveChangeTracking() || classDetails.shouldWeaveFetchGroups() || attributeDetails.weaveValueHolders()) {
+                        if (attributeDetails.hasField()) {
+                            weaved = true;
+                            addGetterMethodForFieldAccess(classDetails, attributeDetails);
+                            addSetterMethodForFieldAccess(classDetails, attributeDetails);
+                            attributeAccess = true;
+                        }
+                    }
+                }
+            }
+            if (classDetails.shouldWeaveChangeTracking()) {
+                weaved = true;
+                weavedChangeTracker = true;
+                if ((classDetails.getSuperClassDetails() == null) || (!classDetails.doesSuperclassWeaveChangeTracking())) {
+                    addPropertyChangeListener(attributeAccess);
+                    addGetPropertyChangeListener(classDetails);
+                    addSetPropertyChangeListener(classDetails);
+                    addPropertyChange(classDetails);
+                }
+            }
+            if (classDetails.shouldWeaveFetchGroups()) {
+                weaved = true;
+                weavedFetchGroups = true;
+                if (classDetails.getSuperClassDetails() == null) {
+                    addFetchGroupVariables();
+                    addFetchGroupMethods(this.classDetails);
+                }
+            }
+        }
+        if (classDetails.shouldWeaveREST() && classDetails.getSuperClassDetails() == null) {
+            weavedRest = true;
+            addPersistenceRestVariables();
+            addPersistenceRestMethods(classDetails);
+        }
+        if (cw != null) {
+            cw.visitEnd();
+        } else {
+            cv.visitEnd();
+        }
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+        return super.visitAnnotationSuper(desc, visible);
+    }
+
+    @Override
+    public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
+        return super.visitFieldSuper(access, name, desc, signature, value);
+    }
+
+}

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/ComputeClassWriter.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/ComputeClassWriter.java
@@ -64,14 +64,14 @@ class ComputeClassWriter extends ClassWriter {
         try {
             ClassReader info1 = typeInfo(type1);
             ClassReader info2 = typeInfo(type2);
-            if ((info1.getAccess() & Opcodes.valueInt("ACC_INTERFACE")) != 0) {
+            if ((info1.getAccess() & Opcodes.ACC_INTERFACE) != 0) {
                 if (typeImplements(type2, info2, type1)) {
                     return type1;
                 } else {
                     return "java/lang/Object";
                 }
             }
-            if ((info2.getAccess() & Opcodes.valueInt("ACC_INTERFACE")) != 0) {
+            if ((info2.getAccess() & Opcodes.ACC_INTERFACE) != 0) {
                 if (typeImplements(type1, info1, type2)) {
                     return type2;
                 } else {

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/ComputeClassWriter.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/ComputeClassWriter.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2000, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2015 -2011 INRIA, France Telecom
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Oracle nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+package org.eclipse.persistence.internal.jpa.weaving;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.persistence.asm.ASMFactory;
+import org.eclipse.persistence.asm.AnnotationVisitor;
+import org.eclipse.persistence.asm.ClassReader;
+import org.eclipse.persistence.asm.ClassWriter;
+import org.eclipse.persistence.asm.Opcodes;
+
+/**
+ * A ClassWriter that computes the common super class of two classes without
+ * actually loading them with a ClassLoader.
+ *
+ * @author Eric Bruneton
+ */
+class ComputeClassWriter extends ClassWriter {
+
+    private ClassLoader l = null;//getClass().getClassLoader();
+
+    public ComputeClassWriter(ClassLoader loader, final int flags) {
+        super(flags);
+        setCustomClassWriter(this);
+        l = loader;
+    }
+
+    @Override
+    public String getCommonSuperClass(final String type1, final String type2)
+    {
+        try {
+            ClassReader info1 = typeInfo(type1);
+            ClassReader info2 = typeInfo(type2);
+            if ((info1.getAccess() & Opcodes.valueInt("ACC_INTERFACE")) != 0) {
+                if (typeImplements(type2, info2, type1)) {
+                    return type1;
+                } else {
+                    return "java/lang/Object";
+                }
+            }
+            if ((info2.getAccess() & Opcodes.valueInt("ACC_INTERFACE")) != 0) {
+                if (typeImplements(type1, info1, type2)) {
+                    return type2;
+                } else {
+                    return "java/lang/Object";
+                }
+            }
+            StringBuilder b1 = typeAncestors(type1, info1);
+            StringBuilder b2 = typeAncestors(type2, info2);
+            String result = "java/lang/Object";
+            int end1 = b1.length();
+            int end2 = b2.length();
+            while (true) {
+                int start1 = b1.lastIndexOf(";", end1 - 1);
+                int start2 = b2.lastIndexOf(";", end2 - 1);
+                if (start1 != -1 && start2 != -1
+                        && end1 - start1 == end2 - start2)
+                {
+                    String p1 = b1.substring(start1 + 1, end1);
+                    String p2 = b2.substring(start2 + 1, end2);
+                    if (p1.equals(p2)) {
+                        result = p1;
+                        end1 = start1;
+                        end2 = start2;
+                    } else {
+                        return result;
+                    }
+                } else {
+                    return result;
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e.toString());
+        }
+    }
+
+    @Override
+    public void visit(int access, String name, String signature, String superName, String[] interfaces) {
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+        return super.visitAnnotationSuper(descriptor, visible);
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        return super.toByteArraySuper();
+    }
+
+        @Override
+    public <T> T unwrap() {
+        return super.getInternal().unwrap();
+    }
+
+    /**
+     * Returns the internal names of the ancestor classes of the given type.
+     *
+     * @param type the internal name of a class or interface.
+     * @param info the ClassReader corresponding to 'type'.
+     * @return a StringBuilder containing the ancestor classes of 'type',
+     *         separated by ';'. The returned string has the following format:
+     *         ";type1;type2 ... ;typeN", where type1 is 'type', and typeN is a
+     *         direct subclass of Object. If 'type' is Object, the returned
+     *         string is empty.
+     * @throws IOException if the bytecode of 'type' or of some of its ancestor
+     *         class cannot be loaded.
+     */
+    private StringBuilder typeAncestors(String type, ClassReader info)
+            throws IOException
+    {
+        StringBuilder b = new StringBuilder();
+        while (!"java/lang/Object".equals(type)) {
+            b.append(';').append(type);
+            type = info.getSuperName();
+            info = typeInfo(type);
+        }
+        return b;
+    }
+
+    /**
+     * Returns true if the given type implements the given interface.
+     *
+     * @param type the internal name of a class or interface.
+     * @param info the ClassReader corresponding to 'type'.
+     * @param itf the internal name of a interface.
+     * @return true if 'type' implements directly or indirectly 'itf'
+     * @throws IOException if the bytecode of 'type' or of some of its ancestor
+     *         class cannot be loaded.
+     */
+    private boolean typeImplements(String type, ClassReader info, String itf)
+            throws IOException
+    {
+        while (!"java/lang/Object".equals(type)) {
+            String[] itfs = info.getInterfaces();
+            for (int i = 0; i < itfs.length; ++i) {
+                if (itfs[i].equals(itf)) {
+                    return true;
+                }
+            }
+            for (int i = 0; i < itfs.length; ++i) {
+                if (typeImplements(itfs[i], typeInfo(itfs[i]), itf)) {
+                    return true;
+                }
+            }
+            type = info.getSuperName();
+            info = typeInfo(type);
+        }
+        return false;
+    }
+
+    /**
+     * Returns a ClassReader corresponding to the given class or interface.
+     *
+     * @param type the internal name of a class or interface.
+     * @return the ClassReader corresponding to 'type'.
+     * @throws IOException if the bytecode of 'type' cannot be loaded.
+     */
+    private ClassReader typeInfo(final String type) throws IOException {
+        InputStream is = l.getResourceAsStream(type + ".class");
+        try {
+            return ASMFactory.createClassReader(is);
+        } finally {
+            is.close();
+        }
+    }
+}

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
@@ -58,7 +58,7 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
     @Override
     public void visitInsn (final int opcode) {
         weaveBeginningOfMethodIfRequired();
-        if (opcode == Opcodes.valueInt("RETURN")) {
+        if (opcode == Opcodes.RETURN) {
             weaveEndOfMethodIfRequired();
         }
         super.visitInsnSuper(opcode);
@@ -104,8 +104,8 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
                 this.tcw.classDetails.isInSuperclassHierarchy(owner) && this.tcw.classDetails.isInMetadataHierarchy(descClassName) &&
                 (this.tcw.classDetails.getNameOfSuperclassImplementingCloneMethod() == null)) {
             super.visitMethodInsnSuper(opcode, owner, name, desc, intf);
-            super.visitTypeInsnSuper(Opcodes.valueInt("CHECKCAST"), this.tcw.classDetails.getClassName());
-            super.visitMethodInsnSuper(Opcodes.valueInt("INVOKEVIRTUAL"), this.tcw.classDetails.getClassName(), "_persistence_post_clone", "()Ljava/lang/Object;", false);
+            super.visitTypeInsnSuper(Opcodes.CHECKCAST, this.tcw.classDetails.getClassName());
+            super.visitMethodInsnSuper(Opcodes.INVOKEVIRTUAL, this.tcw.classDetails.getClassName(), "_persistence_post_clone", "()Ljava/lang/Object;", false);
         } else {
             super.visitMethodInsnSuper(opcode, owner, name, desc, intf);
         }
@@ -210,15 +210,15 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
             super.visitFieldInsnSuper(opcode, owner, name, desc);
             return;
         }
-        if (opcode == Opcodes.valueInt("GETFIELD")) {
+        if (opcode == Opcodes.GETFIELD) {
             if (attributeDetails.weaveValueHolders() || tcw.classDetails.shouldWeaveFetchGroups()) {
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_GET + name, "()" + attributeDetails.getReferenceClassType().getDescriptor(), false);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_GET + name, "()" + attributeDetails.getReferenceClassType().getDescriptor(), false);
             } else {
                 super.visitFieldInsnSuper(opcode, owner, name, desc);
             }
-        } else if (opcode == Opcodes.valueInt("PUTFIELD")) {
+        } else if (opcode == Opcodes.PUTFIELD) {
             if ((attributeDetails.weaveValueHolders()) || (tcw.classDetails.shouldWeaveChangeTracking()) || (tcw.classDetails.shouldWeaveFetchGroups())) {
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_SET + name, "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_SET + name, "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
             } else {
                 super.visitFieldInsnSuper(opcode, owner, name, desc);
             }
@@ -332,51 +332,51 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
         }
         if (isVirtual || (isGetMethod && !attributeDetails.hasField())) {
             if (tcw.classDetails.shouldWeaveFetchGroups()) {
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                 if (isVirtual){
-                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                    methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                 } else {
                     methodVisitor.visitLdcInsn(attributeName);
                 }
                 // _persistence_checkFetched("attributeName");
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_checkFetched", "(Ljava/lang/String;)V", false);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_checkFetched", "(Ljava/lang/String;)V", false);
             }
             if (!isVirtual && attributeDetails.weaveValueHolders()) {
                 // _persistence_initialize_attributeName_vh();
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_initialize_" + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_initialize_" + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
 
                 // if (!_persistence_attributeName_vh.isInstantiated()) {
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "isInstantiated", "()Z", true);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitFieldInsn(Opcodes.GETFIELD, tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "isInstantiated", "()Z", true);
                 Label l0 = ASMFactory.createLabel();
-                methodVisitor.visitJumpInsn(Opcodes.valueInt("IFNE"), l0);
+                methodVisitor.visitJumpInsn(Opcodes.IFNE, l0);
 
                 // Need to disable change tracking when the set method is called to avoid thinking the attribute changed.
                 if (tcw.classDetails.shouldWeaveChangeTracking()) {
                     // PropertyChangeListener temp_persistence_listener = _persistence_listener;
-                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                    methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
-                    methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), 4);
+                    methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                    methodVisitor.visitFieldInsn(Opcodes.GETFIELD, tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
+                    methodVisitor.visitVarInsn(Opcodes.ASTORE, 4);
                     // _persistence_listener = null;
-                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                    methodVisitor.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-                    methodVisitor.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
+                    methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                    methodVisitor.visitInsn(Opcodes.ACONST_NULL);
+                    methodVisitor.visitFieldInsn(Opcodes.PUTFIELD, tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
                 }
                 // setAttributeName((AttributeType)_persistence_attributeName_vh.getValue());
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
-                methodVisitor.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), referenceClassName.replace('.','/'));
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), setterMethodName, "(" + referenceClassType.getDescriptor() + ")V", false);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitFieldInsn(Opcodes.GETFIELD, tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, referenceClassName.replace('.','/'));
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), setterMethodName, "(" + referenceClassType.getDescriptor() + ")V", false);
 
                 if (tcw.classDetails.shouldWeaveChangeTracking()) {
                     // _persistence_listener = temp_persistence_listener;
-                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 4);
-                    methodVisitor.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
+                    methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                    methodVisitor.visitVarInsn(Opcodes.ALOAD, 4);
+                    methodVisitor.visitFieldInsn(Opcodes.PUTFIELD, tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
                 }
                 // }
                 methodVisitor.visitLabel(l0);
@@ -412,16 +412,16 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
                         // if this is a primitive, get the wrapper class
                         String wrapper = ClassWeaver.wrapperFor(referenceClassType.getSort());
 
-                        methodVisitor.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+                        methodVisitor.visitInsn(Opcodes.ACONST_NULL);
                         if (wrapper != null){
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation + 1);
+                            methodVisitor.visitVarInsn(Opcodes.ASTORE, valueStorageLocation + 1);
                         } else {
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation);
+                            methodVisitor.visitVarInsn(Opcodes.ASTORE, valueStorageLocation);
                         }
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                        methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), "_persistence_listener", "Ljava/beans/PropertyChangeListener;");
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                        methodVisitor.visitFieldInsn(Opcodes.GETFIELD, tcw.classDetails.getClassName(), "_persistence_listener", "Ljava/beans/PropertyChangeListener;");
                         Label l0 = ASMFactory.createLabel();
-                        methodVisitor.visitJumpInsn(Opcodes.valueInt("IFNULL"), l0);
+                        methodVisitor.visitJumpInsn(Opcodes.IFNULL, l0);
 
                         /**
                          * The code below constructs the following code
@@ -432,65 +432,65 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
                          */
                         // 1st part of invoking constructor for primitives to wrap them
                         if (wrapper != null) {
-                            methodVisitor.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
-                            methodVisitor.visitInsn(Opcodes.valueInt("DUP"));
+                            methodVisitor.visitTypeInsn(Opcodes.NEW, wrapper);
+                            methodVisitor.visitInsn(Opcodes.DUP);
                         }
 
                         // Call the getter
                         // getAttribute()
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                         String getterArgument = "";
                         String getterReturn = referenceClassType.getDescriptor();
                         if (isVirtual){
                             getterArgument = ClassWeaver.STRING_SIGNATURE;
                             getterReturn = ClassWeaver.OBJECT_SIGNATURE;
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                         }
-                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), getterMethodName, "(" + getterArgument + ")" + getterReturn, false);
+                        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), getterMethodName, "(" + getterArgument + ")" + getterReturn, false);
                         if (wrapper != null){
                             // 2nd part of using constructor.
-                            methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"),  valueStorageLocation + 1);
+                            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
+                            methodVisitor.visitVarInsn(Opcodes.ASTORE,  valueStorageLocation + 1);
                         } else {
                             // store the result
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation);
+                            methodVisitor.visitVarInsn(Opcodes.ASTORE, valueStorageLocation);
                         }
 
                         Label l1 = ASMFactory.createLabel();
-                        methodVisitor.visitJumpInsn(Opcodes.valueInt("GOTO"), l1);
+                        methodVisitor.visitJumpInsn(Opcodes.GOTO, l1);
                         methodVisitor.visitLabel(l0);
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
 
                         if (isVirtual){
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                         } else {
                             methodVisitor.visitLdcInsn(attributeName);
                         }
-                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
+                        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
                         methodVisitor.visitLabel(l1);
 
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
 
                         if (isVirtual){
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                         } else {
                             methodVisitor.visitLdcInsn(attributeName);
                         }
 
                         if (wrapper != null) {
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), valueStorageLocation + 1);
-                            methodVisitor.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
-                            methodVisitor.visitInsn(Opcodes.valueInt("DUP"));
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, valueStorageLocation + 1);
+                            methodVisitor.visitTypeInsn(Opcodes.NEW, wrapper);
+                            methodVisitor.visitInsn(Opcodes.DUP);
                         } else {
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), valueStorageLocation);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, valueStorageLocation);
                         }
                         // get an appropriate load opcode for the type
-                        int opcode = referenceClassType.getOpcode(Opcodes.valueInt("ILOAD"));
+                        int opcode = referenceClassType.getOpcode(Opcodes.ILOAD);
                         methodVisitor.visitVarInsn(opcode, valueHoldingLocation);
                         if (wrapper != null){
-                            methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
+                            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
                         }
-                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
+                        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
                     } else {
                         // tcw.classDetails.shouldWeaveFetchGroups()
                         /**
@@ -505,63 +505,63 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
 
                         // 1st part of invoking constructor for primitives to wrap them
                         if (wrapper != null) {
-                            methodVisitor.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
-                            methodVisitor.visitInsn(Opcodes.valueInt("DUP"));
+                            methodVisitor.visitTypeInsn(Opcodes.NEW, wrapper);
+                            methodVisitor.visitInsn(Opcodes.DUP);
                         }
 
                         // Call the getter
                         // getAttribute()
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                         String getterArgument = "";
                         String getterReturn = referenceClassType.getDescriptor();
                         if (isVirtual){
                             getterArgument = ClassWeaver.STRING_SIGNATURE;
                             getterReturn = ClassWeaver.OBJECT_SIGNATURE;
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                         }
-                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), getterMethodName, "(" + getterArgument + ")" + getterReturn, false);
+                        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), getterMethodName, "(" + getterArgument + ")" + getterReturn, false);
                         if (wrapper != null){
                             // 2nd part of using constructor.
-                            methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation + 1);
+                            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
+                            methodVisitor.visitVarInsn(Opcodes.ASTORE, valueStorageLocation + 1);
                         } else {
                             // store the result
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation);
+                            methodVisitor.visitVarInsn(Opcodes.ASTORE, valueStorageLocation);
                         }
 
                         // makes use of the value stored in weaveBeginningOfMethodIfRequired to call property change method
                         // _persistence_propertyChange("attributeName", oldAttribute, argument);
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                         if (isVirtual){
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                         } else {
                             methodVisitor.visitLdcInsn(attributeName);
                         }
                         if (wrapper != null) {
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), valueStorageLocation + 1);
-                            methodVisitor.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
-                            methodVisitor.visitInsn(Opcodes.valueInt("DUP"));
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, valueStorageLocation + 1);
+                            methodVisitor.visitTypeInsn(Opcodes.NEW, wrapper);
+                            methodVisitor.visitInsn(Opcodes.DUP);
                         } else {
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), valueStorageLocation);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, valueStorageLocation);
                         }
-                        int opcode = referenceClassType.getOpcode(Opcodes.valueInt("ILOAD"));
+                        int opcode = referenceClassType.getOpcode(Opcodes.ILOAD);
                         methodVisitor.visitVarInsn(opcode, valueHoldingLocation);
                         if (wrapper != null) {
-                            methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
+                            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
                         }
-                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
+                        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
                     }
                 } else {
                     // !tcw.classDetails.shouldWeaveChangeTracking()
                     if(tcw.classDetails.shouldWeaveFetchGroups()) {
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                         if (isVirtual){
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                         } else {
                             methodVisitor.visitLdcInsn(attributeName);
                         }
                         // _persistence_checkFetchedForSet("variableName");
-                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
+                        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
                     }
                 }
             }
@@ -588,20 +588,20 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
         boolean isSetMethod = (attributeDetails != null) && this.methodDescriptor.equals(attributeDetails.getSetterMethodSignature());
         if (isSetMethod  && !attributeDetails.hasField()) {
             if (attributeDetails.weaveValueHolders()) {
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
 
                 //_persistence_attributeName_vh.setValue(argument);
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "setValue", "(Ljava/lang/Object;)V", true);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitFieldInsn(Opcodes.GETFIELD, tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "setValue", "(Ljava/lang/Object;)V", true);
 
                 //  _persistence_attributeName_vh.setIsCoordinatedWithProperty(true);
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                methodVisitor.visitInsn(Opcodes.valueInt("ICONST_1"));
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "setIsCoordinatedWithProperty", "(Z)V", true);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitFieldInsn(Opcodes.GETFIELD, tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                methodVisitor.visitInsn(Opcodes.ICONST_1);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "setIsCoordinatedWithProperty", "(Z)V", true);
             }
         }
     }

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
@@ -1,0 +1,609 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+//     19/04/2014-2.6 Lukas Jungmann
+//       - 429992: JavaSE 8/ASM 5.0.1 support (EclipseLink silently ignores Entity classes with lambda expressions)
+ package org.eclipse.persistence.internal.jpa.weaving;
+
+//ASM imports
+import org.eclipse.persistence.asm.ASMFactory;
+import org.eclipse.persistence.asm.AnnotationVisitor;
+import org.eclipse.persistence.asm.Attribute;
+import org.eclipse.persistence.asm.Label;
+import org.eclipse.persistence.asm.EclipseLinkMethodVisitor;
+import org.eclipse.persistence.asm.MethodVisitor;
+import org.eclipse.persistence.asm.Opcodes;
+import org.eclipse.persistence.asm.Type;
+
+import org.eclipse.persistence.internal.descriptors.VirtualAttributeMethodInfo;
+
+/**
+ * Processes all the methods of a class to weave in persistence code such as,
+ * lazy value holder, change tracking and fetch groups.
+ *
+ * For FIELD access, changes references to GETFIELD and PUTFIELD to call weaved get/set methods.
+ *
+ * For Property access, modifies the getters and setters.
+ *
+ */
+
+public class MethodWeaver extends EclipseLinkMethodVisitor {
+
+    protected ClassWeaver tcw;
+    protected String methodName;
+    protected String methodDescriptor = null;
+
+    /** Determines if we are at the first line of a method. */
+    protected boolean methodStarted = false;
+
+    public MethodWeaver(ClassWeaver tcw, String methodName, String methodDescriptor, MethodVisitor mv) {
+        super(mv);
+        this.setCustomMethodVisitor(this);
+        this.tcw = tcw;
+        this.methodName = methodName;
+        this.methodDescriptor = methodDescriptor;
+    }
+
+    @Override
+    public void visitInsn (final int opcode) {
+        weaveBeginningOfMethodIfRequired();
+        if (opcode == Opcodes.valueInt("RETURN")) {
+            weaveEndOfMethodIfRequired();
+        }
+        super.visitInsnSuper(opcode);
+    }
+
+    @Override
+    public void visitIntInsn (final int opcode, final int operand) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitIntInsnSuper(opcode, operand);
+    }
+
+    @Override
+    public void visitVarInsn (final int opcode, final int var) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitVarInsnSuper(opcode, var);
+    }
+
+    @Override
+    public void visitTypeInsn (final int opcode, final String desc) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitTypeInsnSuper(opcode, desc);
+    }
+
+    @Override
+    public void visitFieldInsn (final int opcode, final String owner, final String name, final String desc) {
+        weaveBeginningOfMethodIfRequired();
+        weaveAttributesIfRequired(opcode, owner, name, desc);
+    }
+
+    @Override
+    public void visitMethodInsn (final int opcode, final String owner, final String name, final String desc, boolean intf) {
+        weaveBeginningOfMethodIfRequired();
+        String descClassName = "";
+        if (desc.length() > 3){
+            descClassName = desc.substring(3, desc.length()-1);
+        }
+        // Need to find super.clone and add _persistence_post_clone(clone).
+        if (this.tcw.classDetails.shouldWeaveInternal() && name.equals("clone") &&
+                /* the following will return true if we are calling a method stored on our direct superclass or one of its superclasses
+                 * that is involved in our metadata hierarchy and if there are no classes farther up the hierarchy that implement a clone method
+                 * The goal is to call _persistence_post_clone() at the highest level in the hierarchy possible
+                 * For completeness, we check to ensure the return type is in that same hierarchy */
+                this.tcw.classDetails.isInSuperclassHierarchy(owner) && this.tcw.classDetails.isInMetadataHierarchy(descClassName) &&
+                (this.tcw.classDetails.getNameOfSuperclassImplementingCloneMethod() == null)) {
+            super.visitMethodInsnSuper(opcode, owner, name, desc, intf);
+            super.visitTypeInsnSuper(Opcodes.valueInt("CHECKCAST"), this.tcw.classDetails.getClassName());
+            super.visitMethodInsnSuper(Opcodes.valueInt("INVOKEVIRTUAL"), this.tcw.classDetails.getClassName(), "_persistence_post_clone", "()Ljava/lang/Object;", false);
+        } else {
+            super.visitMethodInsnSuper(opcode, owner, name, desc, intf);
+        }
+    }
+
+    @Override
+    public void visitJumpInsn (final int opcode, final Label label) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitJumpInsnSuper(opcode, label);
+    }
+
+    @Override
+    public void visitLabel (final Label label) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitLabelSuper(label);
+    }
+
+    @Override
+    public void visitLdcInsn (final Object cst) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitLdcInsnSuper(cst);
+    }
+
+    @Override
+    public void visitIincInsn (final int var, final int increment) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitIincInsnSuper(var, increment);
+    }
+
+    @Override
+    public void visitTableSwitchInsn (final int min, final int max, final Label dflt, final Label... labels) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitTableSwitchInsnSuper(min, max, dflt, labels);
+    }
+
+    @Override
+    public void visitLookupSwitchInsn (final Label dflt, final int keys[], final Label labels[]) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitLookupSwitchInsnSuper(dflt, keys, labels);
+    }
+
+    @Override
+    public void visitMultiANewArrayInsn (final String desc, final int dims) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitMultiANewArrayInsnSuper(desc, dims);
+    }
+
+    @Override
+    public void visitTryCatchBlock (final Label start, final Label end,final Label handler, final String type) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitTryCatchBlockSuper(start, end, handler, type);
+    }
+
+    @Override
+    public void visitMaxs (final int maxStack, final int maxLocals) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitMaxsSuper(maxStack, maxLocals);
+    }
+
+    @Override
+    public void visitLocalVariable (final String name, final String desc, String signature, final Label start, final Label end, final int index) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitLocalVariableSuper(name, desc, signature, start, end, index);
+    }
+
+    @Override
+    public void visitLineNumber (final int line, final Label start) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitLineNumberSuper(line, start);
+    }
+
+    @Override
+    public void visitAttribute (final Attribute attr) {
+        weaveBeginningOfMethodIfRequired();
+        super.visitAttributeSuper(attr);
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+        return super.visitAnnotationSuper(desc, visible);
+    }
+
+    @Override
+    public void visitEnd() {
+        // Nothing to do.
+    }
+
+    /**
+     * Change GETFIELD and PUTFIELD for fields that use attribute access to make use of new convenience methods.
+     *
+     * A GETFIELD for an attribute named 'variableName' will be replaced by a call to:
+     *
+     * _persistence_get_variableName()
+     *
+     * A PUTFIELD for an attribute named 'variableName' will be replaced by a call to:
+     *
+     * _persistence_set_variableName(variableName)
+     */
+    public void weaveAttributesIfRequired(int opcode, String owner, String name, String desc) {
+        AttributeDetails attributeDetails = tcw.classDetails.getAttributeDetailsFromClassOrSuperClass(name);
+        if ((attributeDetails == null) || (!attributeDetails.hasField()) || (!this.tcw.classDetails.isInMetadataHierarchy(owner))) {
+            super.visitFieldInsnSuper(opcode, owner, name, desc);
+            return;
+        }
+        if (opcode == Opcodes.valueInt("GETFIELD")) {
+            if (attributeDetails.weaveValueHolders() || tcw.classDetails.shouldWeaveFetchGroups()) {
+                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_GET + name, "()" + attributeDetails.getReferenceClassType().getDescriptor(), false);
+            } else {
+                super.visitFieldInsnSuper(opcode, owner, name, desc);
+            }
+        } else if (opcode == Opcodes.valueInt("PUTFIELD")) {
+            if ((attributeDetails.weaveValueHolders()) || (tcw.classDetails.shouldWeaveChangeTracking()) || (tcw.classDetails.shouldWeaveFetchGroups())) {
+                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_SET + name, "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
+            } else {
+                super.visitFieldInsnSuper(opcode, owner, name, desc);
+            }
+        }  else {
+            super.visitFieldInsnSuper(opcode, owner, name, desc);
+        }
+    }
+
+    /**
+     * Makes modifications to the beginning of a method.
+     *
+     * 1. Modifies getter method for attributes using property access
+     *
+     * In a getter method for 'attributeName', the following lines are added at the beginning of the method
+     *
+     *  _persistence_checkFetched("attributeName");
+     *  _persistence_initialize_attributeName_vh();
+     *  if (!_persistence_attributeName_vh.isInstantiated()) {
+     *      PropertyChangeListener temp_persistence_listener = _persistence_listener;
+     *      _persistence_listener = null;
+     *      setAttributeName((AttributeType)_persistence_attributeName_vh.getValue());
+     *      _persistence_listener = temp_persistence_listener;
+     *  }
+     *
+     *  2. Modifies setter methods to store old value of attribute
+     *  If weaving for fetch groups:
+     *
+     *  // if weaving for change tracking:
+     *  if(_persistence_listener != null)
+     *      // for Objects
+     *      AttributeType oldAttribute = getAttribute()
+     *      // for primitives
+     *      AttributeWrapperType oldAttribute = new AttributeWrapperType(getAttribute());
+     *          e.g. Double oldAttribute = Double.valueOf(getAttribute());
+     *  else
+     *      _persistence_checkFetchedForSet("attributeName");
+     *  _persistence_propertyChange("attributeName", oldAttribute, argument);
+     *
+     *  otherwise (not weaving for fetch groups):
+     *
+     *      // for Objects
+     *      AttributeType oldAttribute = getAttribute()
+     *      // for primitives
+     *      AttributeWrapperType oldAttribute = new AttributeWrapperType(getAttribute());
+     *          e.g. Double oldAttribute = Double.valueOf(getAttribute());
+     *  _persistence_propertyChange("attributeName", oldAttribute, argument);
+     *
+     *  // if not weaving for change tracking, but for fetch groups only:
+     *  _persistence_checkFetchedForSet("attributeName");
+     *
+     *  3. Modifies getter Method for attributes using virtual access
+     *
+     *  add: _persistence_checkFetched(name);
+     *
+     *  4. Modifies setter Method for attributes using virtual access
+     *
+     *  add code of the following form:
+     *
+     *   Object obj = null;
+     *   if(_persistence_listener != null){
+     *      obj = get(name);
+     *   } else {
+     *       _persistence_checkFetchedForSet(name);
+     *   }
+     *   _persistence_propertyChange(name, obj, value);
+     *
+     *   _persistence_checkFetchedForSet(name) call will be excluded if weaving of fetch groups is not enabled
+     *
+     *   _persistence_propertyChange(name, obj, value); will be excluded if weaving of change tracking is not enabled
+     */
+    public void weaveBeginningOfMethodIfRequired() {
+        if (this.methodStarted){
+            return;
+        }
+        // Must set immediately, as weaving can trigger this method.
+        this.methodStarted = true;
+        boolean isVirtual = false;
+        AttributeDetails attributeDetails = tcw.classDetails.getGetterMethodToAttributeDetails().get(methodName);
+        boolean isGetMethod = (attributeDetails != null) && (this.methodDescriptor.startsWith("()") ||
+                (attributeDetails.isVirtualProperty() && this.methodDescriptor.startsWith("(" + ClassWeaver.STRING_SIGNATURE +")")));
+
+        String attributeName = null;
+        String referenceClassName = null;
+        String setterMethodName = null;
+        Type referenceClassType = null;
+        String getterMethodName = null;
+        int valueHoldingLocation = 1;
+        int valueStorageLocation = 2;
+
+        if (attributeDetails == null){
+            VirtualAttributeMethodInfo info = tcw.classDetails.getInfoForVirtualGetMethod(methodName);
+            if ((info != null) && this.methodDescriptor.equals(ClassWeaver.VIRTUAL_GETTER_SIGNATURE) ){
+                isGetMethod = true;
+                isVirtual = true;
+                referenceClassName = "java.lang.Object";
+                setterMethodName = info.getSetMethodName();
+                referenceClassType = Type.getType(ClassWeaver.OBJECT_SIGNATURE);
+                getterMethodName = methodName;
+            }
+        } else {
+            attributeName = attributeDetails.getAttributeName();
+            referenceClassName = attributeDetails.getReferenceClassName();
+            setterMethodName = attributeDetails.getSetterMethodName();
+            referenceClassType = attributeDetails.getReferenceClassType();
+            getterMethodName = attributeDetails.getGetterMethodName();
+            isVirtual = attributeDetails.isVirtualProperty();
+        }
+        if (isVirtual){
+            valueHoldingLocation = 2;
+            valueStorageLocation = 3;
+        }
+        if (isVirtual || (isGetMethod && !attributeDetails.hasField())) {
+            if (tcw.classDetails.shouldWeaveFetchGroups()) {
+                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                if (isVirtual){
+                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                } else {
+                    methodVisitor.visitLdcInsn(attributeName);
+                }
+                // _persistence_checkFetched("attributeName");
+                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_checkFetched", "(Ljava/lang/String;)V", false);
+            }
+            if (!isVirtual && attributeDetails.weaveValueHolders()) {
+                // _persistence_initialize_attributeName_vh();
+                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_initialize_" + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+
+                // if (!_persistence_attributeName_vh.isInstantiated()) {
+                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "isInstantiated", "()Z", true);
+                Label l0 = ASMFactory.createLabel();
+                methodVisitor.visitJumpInsn(Opcodes.valueInt("IFNE"), l0);
+
+                // Need to disable change tracking when the set method is called to avoid thinking the attribute changed.
+                if (tcw.classDetails.shouldWeaveChangeTracking()) {
+                    // PropertyChangeListener temp_persistence_listener = _persistence_listener;
+                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                    methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
+                    methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), 4);
+                    // _persistence_listener = null;
+                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                    methodVisitor.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+                    methodVisitor.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
+                }
+                // setAttributeName((AttributeType)_persistence_attributeName_vh.getValue());
+                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+                methodVisitor.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), referenceClassName.replace('.','/'));
+                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), setterMethodName, "(" + referenceClassType.getDescriptor() + ")V", false);
+
+                if (tcw.classDetails.shouldWeaveChangeTracking()) {
+                    // _persistence_listener = temp_persistence_listener;
+                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 4);
+                    methodVisitor.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
+                }
+                // }
+                methodVisitor.visitLabel(l0);
+            }
+        } else {
+            attributeDetails = tcw.classDetails.getSetterMethodToAttributeDetails().get(methodName);
+            boolean isSetMethod = (attributeDetails != null) && this.methodDescriptor.equals(attributeDetails.getSetterMethodSignature());
+            if (attributeDetails == null){
+                VirtualAttributeMethodInfo info = tcw.classDetails.getInfoForVirtualSetMethod(methodName);
+                if (info != null && this.methodDescriptor.equals(ClassWeaver.VIRTUAL_GETTER_SIGNATURE) ){
+                    isGetMethod = true;
+                    isVirtual = true;
+                    referenceClassName = "java.lang.Object";
+                    setterMethodName = methodName;
+                    referenceClassType = Type.getType(ClassWeaver.OBJECT_SIGNATURE);
+                    getterMethodName = info.getGetMethodName();
+                }
+            } else {
+                attributeName = attributeDetails.getAttributeName();
+                referenceClassName = attributeDetails.getReferenceClassName();
+                setterMethodName = attributeDetails.getSetterMethodName();
+                referenceClassType = attributeDetails.getReferenceClassType();
+                getterMethodName = attributeDetails.getGetterMethodName();
+                isVirtual = attributeDetails.isVirtualProperty();
+            }
+            if (isVirtual){
+                valueHoldingLocation = 2;
+                valueStorageLocation = 3;
+            }
+            if (isVirtual || (isSetMethod  && !attributeDetails.hasField())) {
+                if(tcw.classDetails.shouldWeaveChangeTracking()) {
+                    if(tcw.classDetails.shouldWeaveFetchGroups()) {
+                        // if this is a primitive, get the wrapper class
+                        String wrapper = ClassWeaver.wrapperFor(referenceClassType.getSort());
+
+                        methodVisitor.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+                        if (wrapper != null){
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation + 1);
+                        } else {
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation);
+                        }
+                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), "_persistence_listener", "Ljava/beans/PropertyChangeListener;");
+                        Label l0 = ASMFactory.createLabel();
+                        methodVisitor.visitJumpInsn(Opcodes.valueInt("IFNULL"), l0);
+
+                        /**
+                         * The code below constructs the following code
+                         *
+                         * AttributeType oldAttribute = getAttribute() // for Objects
+                         *
+                         * AttributeWrapperType oldAttribute = new AttributeWrapperType(getAttribute()); // for primitives
+                         */
+                        // 1st part of invoking constructor for primitives to wrap them
+                        if (wrapper != null) {
+                            methodVisitor.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
+                            methodVisitor.visitInsn(Opcodes.valueInt("DUP"));
+                        }
+
+                        // Call the getter
+                        // getAttribute()
+                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        String getterArgument = "";
+                        String getterReturn = referenceClassType.getDescriptor();
+                        if (isVirtual){
+                            getterArgument = ClassWeaver.STRING_SIGNATURE;
+                            getterReturn = ClassWeaver.OBJECT_SIGNATURE;
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                        }
+                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), getterMethodName, "(" + getterArgument + ")" + getterReturn, false);
+                        if (wrapper != null){
+                            // 2nd part of using constructor.
+                            methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"),  valueStorageLocation + 1);
+                        } else {
+                            // store the result
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation);
+                        }
+
+                        Label l1 = ASMFactory.createLabel();
+                        methodVisitor.visitJumpInsn(Opcodes.valueInt("GOTO"), l1);
+                        methodVisitor.visitLabel(l0);
+                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+
+                        if (isVirtual){
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                        } else {
+                            methodVisitor.visitLdcInsn(attributeName);
+                        }
+                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
+                        methodVisitor.visitLabel(l1);
+
+                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+
+                        if (isVirtual){
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                        } else {
+                            methodVisitor.visitLdcInsn(attributeName);
+                        }
+
+                        if (wrapper != null) {
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), valueStorageLocation + 1);
+                            methodVisitor.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
+                            methodVisitor.visitInsn(Opcodes.valueInt("DUP"));
+                        } else {
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), valueStorageLocation);
+                        }
+                        // get an appropriate load opcode for the type
+                        int opcode = referenceClassType.getOpcode(Opcodes.valueInt("ILOAD"));
+                        methodVisitor.visitVarInsn(opcode, valueHoldingLocation);
+                        if (wrapper != null){
+                            methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
+                        }
+                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
+                    } else {
+                        // tcw.classDetails.shouldWeaveFetchGroups()
+                        /**
+                         * The code below constructs the following code
+                         *
+                         * AttributeType oldAttribute = getAttribute() // for Objects
+                         *
+                         * AttributeWrapperType oldAttribute = new AttributeWrapperType(getAttribute()); // for primitives
+                         */
+                        // if this is a primitive, get the wrapper class
+                        String wrapper = ClassWeaver.wrapperFor(referenceClassType.getSort());
+
+                        // 1st part of invoking constructor for primitives to wrap them
+                        if (wrapper != null) {
+                            methodVisitor.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
+                            methodVisitor.visitInsn(Opcodes.valueInt("DUP"));
+                        }
+
+                        // Call the getter
+                        // getAttribute()
+                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        String getterArgument = "";
+                        String getterReturn = referenceClassType.getDescriptor();
+                        if (isVirtual){
+                            getterArgument = ClassWeaver.STRING_SIGNATURE;
+                            getterReturn = ClassWeaver.OBJECT_SIGNATURE;
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                        }
+                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), getterMethodName, "(" + getterArgument + ")" + getterReturn, false);
+                        if (wrapper != null){
+                            // 2nd part of using constructor.
+                            methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation + 1);
+                        } else {
+                            // store the result
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation);
+                        }
+
+                        // makes use of the value stored in weaveBeginningOfMethodIfRequired to call property change method
+                        // _persistence_propertyChange("attributeName", oldAttribute, argument);
+                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        if (isVirtual){
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                        } else {
+                            methodVisitor.visitLdcInsn(attributeName);
+                        }
+                        if (wrapper != null) {
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), valueStorageLocation + 1);
+                            methodVisitor.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
+                            methodVisitor.visitInsn(Opcodes.valueInt("DUP"));
+                        } else {
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), valueStorageLocation);
+                        }
+                        int opcode = referenceClassType.getOpcode(Opcodes.valueInt("ILOAD"));
+                        methodVisitor.visitVarInsn(opcode, valueHoldingLocation);
+                        if (wrapper != null) {
+                            methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
+                        }
+                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
+                    }
+                } else {
+                    // !tcw.classDetails.shouldWeaveChangeTracking()
+                    if(tcw.classDetails.shouldWeaveFetchGroups()) {
+                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        if (isVirtual){
+                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                        } else {
+                            methodVisitor.visitLdcInsn(attributeName);
+                        }
+                        // _persistence_checkFetchedForSet("variableName");
+                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Modifies methods just before the return.
+     *
+     * In a setter method for a LAZY mapping, for 'attributeName', the following lines are added at the end of the method.
+     *
+     *  _persistence_initialize_attributeName_vh();
+     *  _persistence_attributeName_vh.setValue(argument);
+     *  _persistence_attributeName_vh.setIsCoordinatedWithProperty(true);
+     *
+     * In a setter method for a non-LAZY mapping, the followings lines are added if change tracking is activated:
+     *
+     *  _persistence_propertyChange("attributeName", oldAttribute, argument);
+     *
+     *  Note: This code will wrap primitives by adding a call to the primitive constructor.
+     */
+    public void weaveEndOfMethodIfRequired() {
+        AttributeDetails attributeDetails = tcw.classDetails.getSetterMethodToAttributeDetails().get(methodName);
+        boolean isSetMethod = (attributeDetails != null) && this.methodDescriptor.equals(attributeDetails.getSetterMethodSignature());
+        if (isSetMethod  && !attributeDetails.hasField()) {
+            if (attributeDetails.weaveValueHolders()) {
+                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+
+                //_persistence_attributeName_vh.setValue(argument);
+                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "setValue", "(Ljava/lang/Object;)V", true);
+
+                //  _persistence_attributeName_vh.setIsCoordinatedWithProperty(true);
+                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                methodVisitor.visitInsn(Opcodes.valueInt("ICONST_1"));
+                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "setIsCoordinatedWithProperty", "(Z)V", true);
+            }
+        }
+    }
+
+}

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/PersistenceWeaver.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/PersistenceWeaver.java
@@ -131,9 +131,9 @@ public class PersistenceWeaver implements ClassTransformer {
                         PrivilegedAccessHelper.getSystemProperty(SystemProperties.WEAVING_REFLECTIVE_INTROSPECTION);
                 ClassWriter classWriter = null;
                 if (reflectiveIntrospectionProperty != null) {
-                    classWriter = ASMFactory.createClassWriter(ClassWriter.valueInt("COMPUTE_FRAMES"));
+                    classWriter = ASMFactory.createClassWriter(ClassWriter.COMPUTE_FRAMES);
                 } else {
-                    classWriter = new ComputeClassWriter(loader, ClassWriter.valueInt("COMPUTE_FRAMES"));
+                    classWriter = new ComputeClassWriter(loader, ClassWriter.COMPUTE_FRAMES);
                     classWriter.setCustomClassWriterInImpl(classWriter);
                 }
                 final ClassWeaver classWeaver = new ClassWeaver(classWriter, classDetails);

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/PersistenceWeaver.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/internal/jpa/weaving/PersistenceWeaver.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+//     19/04/2014-2.6 Lukas Jungmann
+//       - 429992: JavaSE 8/ASM 5.0.1 support (EclipseLink silently ignores Entity classes with lambda expressions)
+package org.eclipse.persistence.internal.jpa.weaving;
+
+// J2SE imports
+import java.security.ProtectionDomain;
+import java.util.Map;
+
+import jakarta.persistence.spi.ClassTransformer;
+import jakarta.persistence.spi.TransformerException;
+
+import org.eclipse.persistence.config.SystemProperties;
+import org.eclipse.persistence.internal.helper.Helper;
+import org.eclipse.persistence.asm.ASMFactory;
+import org.eclipse.persistence.asm.ClassReader;
+import org.eclipse.persistence.asm.ClassVisitor;
+import org.eclipse.persistence.asm.ClassWriter;
+import org.eclipse.persistence.asm.EclipseLinkClassReader;
+import org.eclipse.persistence.internal.localization.ExceptionLocalization;
+import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.logging.SessionLogEntry;
+
+/**
+ * INTERNAL:
+ * This class performs dynamic byte code weaving: for each attribute
+ * mapped with One To One mapping with Basic Indirection it substitutes the
+ * original attribute's type for ValueHolderInterface.
+ */
+public class PersistenceWeaver implements ClassTransformer {
+
+    /** Class name in JVM '/' format to {@link ClassDetails} map. */
+    protected Map<String, ClassDetails> classDetailsMap;
+
+    /**
+     * INTERNAL:
+     * Creates an instance of dynamic byte code weaver.
+     * @param classDetailsMap Class name to {@link ClassDetails} map.
+     * @since 2.7
+     */
+    public PersistenceWeaver(final Map<String, ClassDetails> classDetailsMap) {
+        this.classDetailsMap = classDetailsMap;
+    }
+
+    /**
+     * INTERNAL:
+     * Allow the weaver to be clear to release its referenced memory.
+     * This is required because the class loader reference to the transformer will never gc.
+     */
+    public void clear() {
+        this.classDetailsMap = null;
+    }
+
+    /**
+     * INTERNAL:
+     * Get Class name in JVM '/' format to {@link ClassDetails} map.
+     * @return Class name in JVM '/' format to {@link ClassDetails} map.
+     */
+    public Map<String, ClassDetails> getClassDetailsMap() {
+        return classDetailsMap;
+    }
+
+    /**
+     * INTERNAL:
+     * Perform dynamic byte code weaving of class.
+     * @param loader              The defining loader of the class to be transformed, may be {@code null}
+     *                            if the bootstrap loader.
+     * @param className           The name of the class in the internal form of fully qualified class and interface
+     *                            names.
+     * @param classBeingRedefined If this is a redefine, the class being redefined, otherwise {@code null}.
+     * @param protectionDomain    The protection domain of the class being defined or redefined.
+     * @param classfileBuffer     The input byte buffer in class file format (must not be modified).
+     * @return  A well-formed class file buffer (the result of the transform), or {@code null} if no transform
+     *          is performed.
+     */
+    @Override
+    public byte[] transform(final ClassLoader loader, final String className,
+            final Class<?> classBeingRedefined, final ProtectionDomain protectionDomain,
+            final byte[] classfileBuffer) throws TransformerException {
+        final SessionLog log = AbstractSessionLog.getLog();
+        // PERF: Is finest logging on weaving turned on?
+        final boolean shouldLogFinest = log.shouldLog(SessionLog.FINEST, SessionLog.WEAVER);
+        final Map<String, ClassDetails> classDetailsMap = this.classDetailsMap;
+        // Check if cleared already.
+        if (classDetailsMap == null) {
+            return null;
+        }
+        try {
+            /*
+             * The ClassFileTransformer callback - when called by the JVM's
+             * Instrumentation implementation - is invoked for every class loaded.
+             * Thus, we must check the classDetailsMap to see if we are 'interested'
+             * in the class.
+             */
+            final ClassDetails classDetails = classDetailsMap.get(Helper.toSlashedClassName(className));
+
+            if (classDetails != null) {
+                if (shouldLogFinest) {
+                    log.log(SessionLog.FINEST, SessionLog.WEAVER, "begin_weaving_class", className);
+                }
+                ClassReader classReader = null;
+                try {
+                    classReader = ASMFactory.createClassReader(classfileBuffer);
+
+                } catch (IllegalArgumentException iae) {
+                    // class was probably compiled with some newer than officially supported and tested JDK
+                    // in such case log a warning and try to re-read the class without class version check
+                    if (log.shouldLog(SessionLog.FINE, SessionLog.WEAVER)) {
+                        SessionLogEntry entry = new SessionLogEntry(null, SessionLog.FINE, SessionLog.WEAVER, iae);
+                        entry.setMessage(ExceptionLocalization.buildMessage("unsupported_classfile_version", new Object[] { className }));
+                        log.log(entry);
+                    }
+                    classReader = new EclipseLinkClassReader(classfileBuffer);
+                }
+                final String reflectiveIntrospectionProperty =
+                        PrivilegedAccessHelper.getSystemProperty(SystemProperties.WEAVING_REFLECTIVE_INTROSPECTION);
+                ClassWriter classWriter = null;
+                if (reflectiveIntrospectionProperty != null) {
+                    classWriter = ASMFactory.createClassWriter(ClassWriter.valueInt("COMPUTE_FRAMES"));
+                } else {
+                    classWriter = new ComputeClassWriter(loader, ClassWriter.valueInt("COMPUTE_FRAMES"));
+                    classWriter.setCustomClassWriterInImpl(classWriter);
+                }
+                final ClassWeaver classWeaver = new ClassWeaver(classWriter, classDetails);
+                final ClassVisitor sv = ASMFactory.createSerialVersionUIDAdder(classWeaver);
+                classReader.accept(sv, 0);
+                if (classWeaver.alreadyWeaved) {
+                    if (shouldLogFinest) {
+                        log.log(SessionLog.FINEST, SessionLog.WEAVER, "end_weaving_class", className);
+                    }
+                    return null;
+                }
+                if (classWeaver.weaved) {
+                    final byte[] bytes = classWriter.toByteArray();
+                    final String outputPath =
+                            PrivilegedAccessHelper.getSystemProperty(SystemProperties.WEAVING_OUTPUT_PATH, "");
+
+                    if (!outputPath.equals("")) {
+                        Helper.outputClassFile(className, bytes, outputPath);
+                    }
+                    // PERF: Don't execute this set of if statements with logging turned off.
+                    if (shouldLogFinest) {
+                        if (classWeaver.weavedPersistenceEntity) {
+                            log.log(SessionLog.FINEST, SessionLog.WEAVER, "weaved_persistenceentity", className);
+                        }
+                        if (classWeaver.weavedChangeTracker) {
+                            log.log(SessionLog.FINEST, SessionLog.WEAVER, "weaved_changetracker", className);
+                        }
+                        if (classWeaver.weavedLazy) {
+                            log.log(SessionLog.FINEST, SessionLog.WEAVER, "weaved_lazy", className);
+                        }
+                        if (classWeaver.weavedFetchGroups) {
+                            log.log(SessionLog.FINEST, SessionLog.WEAVER, "weaved_fetchgroups", className);
+                        }
+                        if (classWeaver.weavedRest) {
+                            log.log(SessionLog.FINEST, SessionLog.WEAVER, "weaved_rest", className);
+                        }
+                        log.log(SessionLog.FINEST, SessionLog.WEAVER, "end_weaving_class", className);
+                    }
+                    return bytes;
+                }
+                if (shouldLogFinest) {
+                    log.log(SessionLog.FINEST, SessionLog.WEAVER, "end_weaving_class", className);
+                }
+            } else {
+                if (shouldLogFinest) {
+                    log.log(SessionLog.FINEST, SessionLog.WEAVER, "transform_missing_class_details", className);
+                }
+            }
+        } catch (Throwable exception) {
+            if (log.shouldLog(SessionLog.WARNING, SessionLog.WEAVER)) {
+                log.log(SessionLog.WARNING, SessionLog.WEAVER,
+                        "exception_while_weaving", new Object[] {className, exception.getLocalizedMessage()});
+                if (shouldLogFinest) {
+                    log.logThrowable(SessionLog.FINEST, SessionLog.WEAVER, exception);
+                }
+            }
+        }
+        if (shouldLogFinest) {
+            log.log(SessionLog.FINEST, SessionLog.WEAVER, "transform_existing_class_bytes", className);
+        }
+        // Returning null means 'use existing class bytes'.
+        return null;
+    }
+
+    /**
+     * INTERNAL:
+     * Returns an unqualified class name from the specified class name.
+     * @param name Class name with {@code '/'} as delimiter.
+     * @return Unqualified class name.
+     */
+    protected static String getShortName(String name) {
+        int pos  = name.lastIndexOf('/');
+        if (pos >= 0) {
+            name = name.substring(pos+1);
+            if (name.endsWith(";")) {
+                name = name.substring(0, name.length()-1);
+            }
+            return name;
+        }
+        return "";
+    }
+
+}


### PR DESCRIPTION
- Update to have cached versions of the constants instead of getting them on every request via MethodHandles which is more expensive.
- This change resolves a 5 to 8% startup performance regression that happened when upgrading from EclipseLink 4.0.0 to 4.0.1.

Fixes #25414