### PR TITLE
get Data JPA tests working on Postgres

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -596,13 +596,10 @@ public class DataJPATestServlet extends FATServlet {
             // expected
         }
 
-        try {
-            System.out.println("findByIdInOrOwner: " + accounts.findByIdInOrOwner(List.of(AccountId.of(1004470, 30372),
-                                                                                          AccountId.of(1006380, 22158)),
-                                                                                  "Emma TestEmbeddedId"));
-        } catch (MappingException x) {
-            // expected
-        }
+        // Varies by database whether MappingException or DatabaseException is raised,
+        // System.out.println("findByIdInOrOwner: " + accounts.findByIdInOrOwner(List.of(AccountId.of(1004470, 30372),
+        //                                                                               AccountId.of(1006380, 22158)),
+        //                                                                       "Emma TestEmbeddedId"));
 
         try {
             System.out.println("findByIdTrue: " + accounts.findByIdTrue());


### PR DESCRIPTION
Get the io.openliberty.data.internal_fat_jpa test bucket full passing on PostgreSQL.
The only error appears to be on an exception path that we were trying out with Derby - it gets surfaced as a different DataException.  The tests really shouldn't be attempting that path at all because it isn't supported.