### PR TITLE
Remove defunct library references in OIDC features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/openidConnectClient-1.0/com.ibm.websphere.appserver.openidConnectClient-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/openidConnectClient-1.0/com.ibm.websphere.appserver.openidConnectClient-1.0.feature
@@ -12,9 +12,7 @@ Subsystem-Name: OpenID Connect Client 1.0
   com.ibm.websphere.appserver.oauth-2.0, \
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"
 -bundles=\
-  com.ibm.ws.net.oauth.jsontoken.1.1-r42, \
   com.ibm.ws.org.joda.time.1.6.2, \
-  com.ibm.ws.com.google.guava, \
   com.ibm.json4j, \
   io.openliberty.org.apache.commons.codec, \
   io.openliberty.org.apache.commons.logging, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/openidConnectServer-1.0/com.ibm.websphere.appserver.openidConnectServer-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/openidConnectServer-1.0/com.ibm.websphere.appserver.openidConnectServer-1.0.feature
@@ -16,9 +16,7 @@ Subsystem-Endpoint-Icons: clientManagement=OSGI-INF/clientManagement_142.png,OSG
   com.ibm.websphere.appserver.httpcommons-1.0, \
   io.openliberty.openidConnectServer1.0.internal.ee-6.0; ibm.tolerates:="9.0, 10.0, 11.0"
 -bundles=\
-  com.ibm.ws.net.oauth.jsontoken.1.1-r42, \
   com.ibm.ws.org.joda.time.1.6.2, \
-  com.ibm.ws.com.google.guava, \
   io.openliberty.org.apache.commons.codec, \
   io.openliberty.org.apache.commons.logging, \
   com.ibm.ws.security.common.jsonwebkey, \

--- a/dev/com.ibm.ws.security.openidconnect.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.common/bnd.bnd
@@ -1,14 +1,11 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -54,7 +51,6 @@ Service-Component:
 	com.ibm.ws.kernel.service;version=latest, \
 	io.openliberty.com.google.gson;version=latest,\
 	com.ibm.ws.webcontainer.security;version=latest,\
-	com.ibm.ws.net.oauth.jsontoken.1.1-r42;version=latest,\
 	com.ibm.ws.org.joda.time.1.6.2;version=latest,\
 	com.ibm.ws.org.jose4j;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\


### PR DESCRIPTION
Removes references to the Google Guava and net.oauth.jsontoken libraries that aren't used in OIDC.

Resolves #25561