### PR TITLE
mpTelemetry performance changes

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryContainerFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryContainerFilter.java
@@ -123,10 +123,7 @@ public class TelemetryContainerFilter implements ContainerRequestFilter, Contain
         }
 
         try {
-            // instrumenter can be null if the filter isn't fully injected yet due to resource methods calls during constructor
-            if (instrumenter != null) {
-                instrumenter.end(spanContext, request, response, null);
-            }
+            instrumenter.end(spanContext, request, response, null);
         } finally {
             request.removeProperty(REST_RESOURCE_CLASS);
             request.removeProperty(REST_RESOURCE_METHOD);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryContainerFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry/internal/rest/TelemetryContainerFilter.java
@@ -91,8 +91,12 @@ public class TelemetryContainerFilter implements ContainerRequestFilter, Contain
 
     @Override
     public void filter(final ContainerRequestContext request) {
+        if (instrumenter == null) {
+            return;
+        }
+
         Context parentContext = Context.current();
-        if (instrumenter != null && instrumenter.shouldStart(parentContext, request)) {
+        if (instrumenter.shouldStart(parentContext, request)) {
             request.setProperty(REST_RESOURCE_CLASS, resourceInfo.getResourceClass());
             request.setProperty(REST_RESOURCE_METHOD, resourceInfo.getResourceMethod());
 
@@ -108,6 +112,10 @@ public class TelemetryContainerFilter implements ContainerRequestFilter, Contain
     public void filter(final ContainerRequestContext request, final ContainerResponseContext response) {
         // Note: for async resource methods, this may not run on the same thread as the other filter method
         // Scope is ended in TelemetryServletRequestListener to ensure it does run on the original request thread
+
+        if (instrumenter == null) {
+            return;
+        }
 
         Context spanContext = (Context) request.getProperty(SPAN_CONTEXT);
         if (spanContext == null) {
@@ -153,12 +161,12 @@ public class TelemetryContainerFilter implements ContainerRequestFilter, Contain
 
         @Override
         public String hostName(ContainerRequestContext request) {
-            return request.getUriInfo().getBaseUri().getHost();
+            return request.getUriInfo().getRequestUri().getHost();
         }
 
         @Override
         public Integer hostPort(ContainerRequestContext request) {
-            return request.getUriInfo().getBaseUri().getPort();
+            return request.getUriInfo().getRequestUri().getPort();
         }
 
     }


### PR DESCRIPTION
1. Return faster from filter methods when mpTelemetry is not enabled.

3. Use getRequestUri instead of getBaseUri since it has already been called and cached. This saves time because the baseURI does not need to be built.
