### PR TITLE
Update Jakarta Data TCK to use database rotation

### DIFF
--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/bnd.bnd
@@ -21,7 +21,23 @@ src: \
 
 fat.project: true
 
+# Uncomment to use remote docker host to simulate continuous build behavior.
+# This will only work if you are on the IBM Network.
+# External contributors will need to have docker installed on their local machine.
+#fat.test.use.remote.docker: true
+
+# This property is used to tell the SOE build system that this FAT suite
+# should be run in the database rotation build.
+fat.test.databases: true
+
+# Uncomment to test against alternative databases
+# This allows you to locally tell gradle what database you want to test against.
+# This is the same way the database rotation build sets the database. 
+# Options: Derby, Postgre, DB2, Oracle, SQLServer
+#fat.bucket.db.type: Postgre
+
 tested.features:\
 	data-1.0
 
 -buildpath: \
+	io.openliberty.org.testcontainers;version=latest

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/build.gradle
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/build.gradle
@@ -35,6 +35,7 @@ task copySigTest(type: Copy) {
   rename 'sigtest-maven-plugin-.*.jar', 'sigtest.jar'
 }
 
-addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries.dependsOn copyTestContainers
+addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn copyJunit5
 addRequiredLibraries.dependsOn copySigTest

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
@@ -26,6 +26,8 @@ import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.database.container.DatabaseContainerType;
+import componenttest.topology.database.container.DatabaseContainerUtil;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
@@ -39,6 +41,8 @@ public class DataCoreTckLauncher {
 
     @BeforeClass
     public static void setup() throws Exception {
+        DatabaseContainerUtil.setupDataSourceDatabaseProperties(server, FATSuite.jdbcContainer);
+        server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(FATSuite.jdbcContainer).getDriverName());
         server.startServer();
     }
 

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
@@ -26,6 +26,8 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.database.container.DatabaseContainerType;
+import componenttest.topology.database.container.DatabaseContainerUtil;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
@@ -40,6 +42,8 @@ public class DataWebTckLauncher {
 
     @BeforeClass
     public static void setup() throws Exception {
+        DatabaseContainerUtil.setupDataSourceDatabaseProperties(server, FATSuite.jdbcContainer);
+        server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(FATSuite.jdbcContainer).getDriverName());
         server.startServer();
     }
 

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
@@ -12,11 +12,14 @@
  *******************************************************************************/
 package io.openliberty.jakarta.data.tck;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -25,4 +28,6 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
                 DataWebTckLauncher.class //full mode
 })
 public class FATSuite {
+    @ClassRule
+    public static JdbcDatabaseContainer<?> jdbcContainer = DatabaseContainerFactory.create();
 }

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/servers/io.openliberty.org.jakarta.data.1.0.core/server.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/servers/io.openliberty.org.jakarta.data.1.0.core/server.xml
@@ -21,9 +21,9 @@
         <!-- Features needed for arquillan support -->
         <feature>localConnector-1.0</feature>
         <!-- Required by test infrastructure -->
-	    <feature>timedexit-1.0</feature>
+        <feature>timedexit-1.0</feature>
         <!-- Convenience feature -->
-	    <feature>arquillian-support-jakarta-2.1</feature>
+        <feature>arquillian-support-jakarta-2.1</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml" />
@@ -36,13 +36,13 @@
         <writeDir>${server.config.dir}/dropins</writeDir>
     </remoteFileAccess>
     
+    <library id="dbRotationLib">
+      <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
+    </library>
+    
     <!-- The datasource used by JPA -->
-    <dataSource id="DefaultDataSource">
-      <jdbcDriver>
-        <library id="DerbyLib">
-          <file name="${shared.resource.dir}/derby/derby.jar"/>
-        </library>
-      </jdbcDriver>
+    <dataSource id="DefaultDataSource"  fat.modify="true">
+      <jdbcDriver libraryRef="dbRotationLib"/>
       <properties.derby.embedded createDatabase="create" databaseName="memory:testdb" user="dbuser1" password="dbpwd1"/>
     </dataSource>
     
@@ -58,11 +58,21 @@
     <!-- Signature test application permissions -->
     <javaPermission codeBase="${shared.resource.dir}/sigtest/sigtest-maven-plugin.jar" className="java.security.AllPermission"/>
     <javaPermission codeBase="${server.config.dir}/dropins/signatureTest.war" className="java.security.AllPermission"/>
-	
+    
     <!-- Signature test plugin permissions -->
     <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.security.AllPermission" />
     <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal" />
     <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal.reflect" />
     <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal.vm.annotation" />
+    
+    <!-- Permission needed for Oracle driver -->
+    <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers" />
+    
+    <!-- Permission needed for Postgres driver -->
+    <javaPermission codeBase="${server.config.dir}/apps/app.war" className="java.util.PropertyPermission" name="org.postgresql.forceBinary" actions="read"/>
+
+    <!-- Permission needed for SQLServer driver -->
+    <javaPermission className="java.util.PropertyPermission" name="java.specification.version" actions="read"/>
+    <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
 
 </server>

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/servers/io.openliberty.org.jakarta.data.1.0.web/server.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/servers/io.openliberty.org.jakarta.data.1.0.web/server.xml
@@ -21,14 +21,13 @@
         <feature>localConnector-1.0</feature>
         
         <!-- Required by test infrastructure -->
-	    <feature>timedexit-1.0</feature>
-	    
+        <feature>timedexit-1.0</feature>
+        
         <!-- Convenience feature -->
-	    <feature>arquillian-support-jakarta-2.1</feature>
+        <feature>arquillian-support-jakarta-2.1</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml" />
-
 
     <!-- Allow Arquillian to monitor application -->
     <applicationMonitor updateTrigger="mbean"/>
@@ -38,13 +37,13 @@
         <writeDir>${server.config.dir}/dropins</writeDir>
     </remoteFileAccess>
     
+    <library id="dbRotationLib">
+      <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
+    </library>
+    
     <!-- The datasource used by JPA -->
-    <dataSource id="DefaultDataSource">
-      <jdbcDriver>
-        <library id="DerbyLib">
-          <file name="${shared.resource.dir}/derby/derby.jar"/>
-        </library>
-      </jdbcDriver>
+    <dataSource id="DefaultDataSource"  fat.modify="true">
+      <jdbcDriver libraryRef="dbRotationLib"/>
       <properties.derby.embedded createDatabase="create" databaseName="memory:testdb" user="dbuser1" password="dbpwd1"/>
     </dataSource>
     
@@ -56,15 +55,24 @@
 
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
-    <javaPermission className="java.util.PropertyPermission"  name="sun.jvmstat.monitor.local" actions="read" />
 
     <!-- Signature test application permissions -->
     <javaPermission codeBase="${shared.resource.dir}/sigtest/sigtest-maven-plugin.jar" className="java.security.AllPermission"/>
     <javaPermission codeBase="${server.config.dir}/dropins/signatureTest.war" className="java.security.AllPermission"/>
-	
+    
     <!-- Signature test plugin permissions -->
     <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.security.AllPermission" />
     <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal" />
     <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal.reflect" />
     <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal.vm.annotation" />
+    
+    <!-- Permission needed for Oracle driver -->
+    <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers" />
+    
+    <!-- Permission needed for Postgres driver -->
+    <javaPermission codeBase="${server.config.dir}/apps/app.war" className="java.util.PropertyPermission" name="org.postgresql.forceBinary" actions="read"/>
+
+    <!-- Permission needed for SQLServer driver -->
+    <javaPermission className="java.util.PropertyPermission" name="java.specification.version" actions="read"/>
+    <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
 </server>

--- a/dev/io.openliberty.org.testcontainers/cache/projects
+++ b/dev/io.openliberty.org.testcontainers/cache/projects
@@ -148,6 +148,7 @@ fattest.simplicity
 io.openliberty.checkpoint_fat_persistence
 io.openliberty.data.internal_fat
 io.openliberty.data.internal_fat_jpa
+io.openliberty.jakarta.data.1.0_fat_tck
 io.openliberty.jcache.internal_fat.hazelcast
 io.openliberty.jcache.internal_fat.infinispan
 io.openliberty.microprofile.openapi.ui.internal_fat


### PR DESCRIPTION
Allow the Jakarta Data TCK to run against the derby, db2, oracle, postgresql, and sqlserver.

NOTE:  Our current database rotation builds use Java 8 and will need to be updated to use Java 17 otherwise these tests will never run. 
