### PR TITLE
Test oracle ojdbc8 on Java 17

### DIFF
--- a/dev/build.example.testcontainers_fat/test-applications/app/src/web/dbrotation/DbRotationServlet.java
+++ b/dev/build.example.testcontainers_fat/test-applications/app/src/web/dbrotation/DbRotationServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -228,6 +228,11 @@
     </dependency>
     <dependency>
       <groupId>com.oracle.database.jdbc.debug</groupId>
+      <artifactId>ojdbc11_g</artifactId>
+      <version>21.8.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.database.jdbc.debug</groupId>
       <artifactId>ojdbc8_g</artifactId>
       <version>21.8.0.0</version>
     </dependency>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -41,6 +41,7 @@ com.icegreen:greenmail:1.5.10
 com.jcraft:jsch:0.1.54
 com.microsoft.sqlserver:mssql-jdbc:9.2.1.jre8
 com.nimbusds:nimbus-jose-jwt:4.23
+com.oracle.database.jdbc.debug:ojdbc11_g:21.8.0.0
 com.oracle.database.jdbc.debug:ojdbc8_g:21.8.0.0
 com.oracle.database.jdbc:ucp:21.8.0.0
 com.oracle.database.security:oraclepki:21.8.0.0

--- a/dev/com.ibm.ws.jdbc_fat_krb5/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,8 +11,25 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+configurations {
+	oracle11 { transitive = false; }
+}
+
+dependencies {
+	oracle11 'com.oracle.database.jdbc.debug:ojdbc11_g:21.8.0.0'
+}
+
+task addOracle11(type: Copy) {
+  mustRunAfter jar
+  from configurations.oracle11
+  into new File(autoFvtDir, 'publish/shared/resources/jdbc')
+  rename 'ojdbc11_g.*.jar', 'ojdbc11_g.jar'
+}
+
+
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
+  dependsOn addOracle11
   dependsOn addJakartaTransformer
   dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
@@ -34,7 +34,6 @@ import com.ibm.ws.jdbc.fat.krb5.containers.KerberosPlatformRule;
 import com.ibm.ws.jdbc.fat.krb5.containers.OracleKerberosContainer;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -48,7 +47,6 @@ import jdbc.krb5.oracle.web.OracleKerberosTestServlet;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
-@MaximumJavaLevel(javaLevel = 15) // TODO The current Oracle JDBC driver (ojdbc8_g.jar v21.8.0.0) only supports Java 8-15, modify/remove this line once it supports 16+
 public class OracleKerberosTest extends FATServletClient {
 
     private static final Class<?> c = OracleKerberosTest.class;
@@ -75,6 +73,19 @@ public class OracleKerberosTest extends FATServletClient {
         oracle.start();
 
         ShrinkHelper.defaultDropinApp(server, APP_NAME, "jdbc.krb5.oracle.web");
+
+        if (JavaInfo.JAVA_VERSION >= 1.8 && JavaInfo.JAVA_VERSION < 11) {
+            server.addEnvVar("ORACLE_DRIVER", "ojdbc8_g.jar");
+        }
+
+        if (JavaInfo.JAVA_VERSION >= 11 && JavaInfo.JAVA_VERSION < 21) {
+            server.addEnvVar("ORACLE_DRIVER", "ojdbc11_g.jar");
+        }
+
+        // Precaution in case there are breaking changes to the driver in Java 21
+        if (JavaInfo.JAVA_VERSION >= 21) {
+            server.addEnvVar("ORACLE_DRIVER", "ojdbc11_g.jar");
+        }
 
         server.addEnvVar("ORACLE_DBNAME", oracle.getDatabaseName());
         server.addEnvVar("ORACLE_HOSTNAME", oracle.getHost());

--- a/dev/com.ibm.ws.jdbc_fat_krb5/publish/servers/com.ibm.ws.jdbc.fat.krb5.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/publish/servers/com.ibm.ws.jdbc.fat.krb5.oracle/server.xml
@@ -8,7 +8,7 @@
   <include location="../fatTestPorts.xml"/>
 
   <library id="OracleLib">
-    <file name="${shared.resource.dir}/jdbc/ojdbc8_g.jar"/>
+    <fileset dir="${shared.resource.dir}/jdbc" includes="${env.ORACLE_DRIVER}"/>
   </library>
   
   <kerberos keytab="${server.config.dir}security/oracle_client.keytab" configFile="${KRB5_CONF}"/>


### PR DESCRIPTION
Figure out what failures might happen when using ojdbc8 driver on Java 17.
Oracle says the ojdbc8 driver is only supported on JDK 8-15

Fixes #18341 
