### PR TITLE
Update Jakarta EE 9 and 10 FAT to also test WebSphere Liberty features

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE6FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE6FeatureReplacementAction.java
@@ -21,8 +21,7 @@ public class EE6FeatureReplacementAction extends FeatureReplacementAction {
 
     public static final String ID = "EE6_FEATURES";
 
-    static final String[] EE6_FEATURES_ARRAY = { "javaee-6.0",
-                                                 "webProfile-6.0",
+    static final String[] EE6_FEATURES_ARRAY = { "webProfile-6.0",
                                                  "javaeeClient-6.0",
                                                  "cdi-1.0",
                                                  "appSecurity-2.0",
@@ -38,6 +37,8 @@ public class EE6FeatureReplacementAction extends FeatureReplacementAction {
                                                  "mdb-3.1",
                                                  "jaxrs-1.1",
                                                  "jca-1.6",
+                                                 "jms-1.1",
+                                                 "wasJmsClient-1.1",
                                                  "componenttest-1.0" };
 
     public static final Set<String> EE6_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE6_FEATURES_ARRAY)));

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
@@ -92,25 +92,25 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
     @Server("jakartaee10.fat")
     public static LibertyServer server;
 
-    static Set<String> getAllCompatibleFeatures() {
+    static Set<String> getAllCompatibleFeatures(boolean openLibertyOnly) {
         Set<String> allFeatures = new HashSet<>();
         try {
             File installRoot = new File(Bootstrap.getInstance().getValue("libertyInstallPath"));
-            allFeatures.addAll(FeatureUtilities.getFeaturesFromServer(installRoot));
+            allFeatures.addAll(FeatureUtilities.getFeaturesFromServer(installRoot, openLibertyOnly));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        return getCompatibleFeatures(allFeatures);
+        return getCompatibleFeatures(allFeatures, openLibertyOnly);
     }
 
-    private static Set<String> getCompatibleFeatures(Set<String> allFeatures) {
+    private static Set<String> getCompatibleFeatures(Set<String> allFeatures, boolean openLibertyOnly) {
         Set<String> compatibleFeatures = new HashSet<>();
 
         // By default, features are assumed to be compatible
         compatibleFeatures.addAll(allFeatures);
 
         // Non-ee10 features are not compatible
-        compatibleFeatures.removeAll(FeatureUtilities.allEeFeatures());
+        compatibleFeatures.removeAll(FeatureUtilities.allEeFeatures(openLibertyOnly));
         compatibleFeatures.addAll(JakartaEE10Action.EE10_FEATURE_SET);
 
         // MP features are only compatible if they're in MP versions which work with EE10
@@ -130,6 +130,34 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         compatibleFeatures.remove("springBoot-2.0");
 
         compatibleFeatures.remove("mpReactiveMessaging-3.0"); //still in development
+
+        if (!openLibertyOnly) {
+            // stabilized features
+            compatibleFeatures.remove("apiDiscovery-1.0");
+            compatibleFeatures.remove("blueprint-1.0");
+            compatibleFeatures.remove("httpWhiteboard-1.0");
+            compatibleFeatures.remove("mqtt-3.1");
+            compatibleFeatures.remove("openapi-3.0");
+            compatibleFeatures.remove("osgiAppConsole-1.0");
+            compatibleFeatures.remove("osgiAppIntegration-1.0");
+            compatibleFeatures.remove("osgiBundle-1.0");
+            compatibleFeatures.remove("osgi.jpa-1.0");
+            compatibleFeatures.remove("restConnector-1.0");
+            compatibleFeatures.remove("rtcomm-1.0");
+            compatibleFeatures.remove("rtcommGateway-1.0");
+            compatibleFeatures.remove("scim-1.0");
+            compatibleFeatures.remove("wab-1.0");
+            compatibleFeatures.remove("zosConnect-1.0");
+            compatibleFeatures.remove("zosConnect-1.2");
+
+            // depend on previous EE versions and now uses wmqMessagingClient-3.0 for EE9
+            compatibleFeatures.remove("wmqJmsClient-1.1");
+            compatibleFeatures.remove("wmqJmsClient-2.0");
+
+            // heritage API features
+            compatibleFeatures.remove("heritageAPIs-1.0");
+            compatibleFeatures.remove("heritageAPIs-1.1");
+        }
 
         // Test features may or may not be compatible, we don't want to assert either way
         compatibleFeatures.removeAll(FeatureUtilities.allTestFeatures());
@@ -154,8 +182,8 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        allFeatures = FeatureUtilities.getFeaturesFromServer(new File(server.getInstallRoot()));
-        compatibleFeatures = getCompatibleFeatures(allFeatures);
+        allFeatures = FeatureUtilities.getFeaturesFromServer(new File(server.getInstallRoot()), false);
+        compatibleFeatures = getCompatibleFeatures(allFeatures, false);
         incompatibleFeatures = getIncompatibleFeatures(allFeatures, compatibleFeatures);
 
         // Check for typos, every feature we've declared as being compatible or non-compatible should exist
@@ -288,6 +316,7 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         specialEE10Conflicts.put("servlet-5.0", "com.ibm.websphere.appserver.servlet");
         specialEE10Conflicts.put("servlet-4.0", "com.ibm.websphere.appserver.servlet");
         specialEE10Conflicts.put("servlet-3.1", "com.ibm.websphere.appserver.servlet");
+        specialEE10Conflicts.put("servlet-3.0", "com.ibm.websphere.appserver.servlet");
 
         testCompatibility("servlet-6.0", allFeatures, specialEE10Conflicts);
     }

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
@@ -92,25 +92,25 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
     @Server("jakartaee9.fat")
     public static LibertyServer server;
 
-    static Set<String> getAllCompatibleFeatures() {
+    static Set<String> getAllCompatibleFeatures(boolean openLibertyOnly) {
         Set<String> allFeatures = new HashSet<>();
         try {
             File installRoot = new File(Bootstrap.getInstance().getValue("libertyInstallPath"));
-            allFeatures.addAll(FeatureUtilities.getFeaturesFromServer(installRoot));
+            allFeatures.addAll(FeatureUtilities.getFeaturesFromServer(installRoot, openLibertyOnly));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        return getCompatibleFeatures(allFeatures);
+        return getCompatibleFeatures(allFeatures, openLibertyOnly);
     }
 
-    private static Set<String> getCompatibleFeatures(Set<String> allFeatures) {
+    private static Set<String> getCompatibleFeatures(Set<String> allFeatures, boolean openLibertyOnly) {
         Set<String> compatibleFeatures = new HashSet<>();
 
         // By default, features are assumed to be compatible
         compatibleFeatures.addAll(allFeatures);
 
         // Non-ee9 features are not compatible
-        compatibleFeatures.removeAll(FeatureUtilities.allEeFeatures());
+        compatibleFeatures.removeAll(FeatureUtilities.allEeFeatures(openLibertyOnly));
         compatibleFeatures.addAll(JakartaEE9Action.EE9_FEATURE_SET);
 
         // MP features are only compatible if they're in MP versions which work with EE9
@@ -129,6 +129,34 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         compatibleFeatures.remove("springBoot-1.5");
         compatibleFeatures.remove("springBoot-2.0");
         compatibleFeatures.remove("springBoot-3.0"); // springBoot 3.0 only supports EE 10
+
+        if (!openLibertyOnly) {
+            // stabilized features
+            compatibleFeatures.remove("apiDiscovery-1.0");
+            compatibleFeatures.remove("blueprint-1.0");
+            compatibleFeatures.remove("httpWhiteboard-1.0");
+            compatibleFeatures.remove("mqtt-3.1");
+            compatibleFeatures.remove("openapi-3.0");
+            compatibleFeatures.remove("osgiAppConsole-1.0");
+            compatibleFeatures.remove("osgiAppIntegration-1.0");
+            compatibleFeatures.remove("osgiBundle-1.0");
+            compatibleFeatures.remove("osgi.jpa-1.0");
+            compatibleFeatures.remove("restConnector-1.0");
+            compatibleFeatures.remove("rtcomm-1.0");
+            compatibleFeatures.remove("rtcommGateway-1.0");
+            compatibleFeatures.remove("scim-1.0");
+            compatibleFeatures.remove("wab-1.0");
+            compatibleFeatures.remove("zosConnect-1.0");
+            compatibleFeatures.remove("zosConnect-1.2");
+
+            // depend on previous EE versions and now uses wmqMessagingClient-3.0 for EE9
+            compatibleFeatures.remove("wmqJmsClient-1.1");
+            compatibleFeatures.remove("wmqJmsClient-2.0");
+
+            // heritage API features
+            compatibleFeatures.remove("heritageAPIs-1.0");
+            compatibleFeatures.remove("heritageAPIs-1.1");
+        }
 
         // Test features may or may not be compatible, we don't want to assert either way
         compatibleFeatures.removeAll(FeatureUtilities.allTestFeatures());
@@ -151,8 +179,8 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        allFeatures = FeatureUtilities.getFeaturesFromServer(new File(server.getInstallRoot()));
-        compatibleFeatures = getCompatibleFeatures(allFeatures);
+        allFeatures = FeatureUtilities.getFeaturesFromServer(new File(server.getInstallRoot()), false);
+        compatibleFeatures = getCompatibleFeatures(allFeatures, false);
         incompatibleFeatures = getIncompatibleFeatures(allFeatures, compatibleFeatures);
 
         // Check for typos, every feature we've declared as being compatible or non-compatible should exist
@@ -279,6 +307,7 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         specialEE9Conflicts.put("servlet-5.0", "com.ibm.websphere.appserver.servlet");
         specialEE9Conflicts.put("servlet-4.0", "com.ibm.websphere.appserver.servlet");
         specialEE9Conflicts.put("servlet-3.1", "com.ibm.websphere.appserver.servlet");
+        specialEE9Conflicts.put("servlet-3.0", "com.ibm.websphere.appserver.servlet");
 
         testCompatibility("servlet-5.0", allFeatures, specialEE9Conflicts);
     }
@@ -387,7 +416,7 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
             }
             boolean expectToConflict = incompatibleFeatures.contains(feature);
             Result result = resolver.resolveFeatures(repository, Collections.<ProvisioningFeatureDefinition> emptySet(), featuresToTest, Collections.<String> emptySet(), false);
-            Log.info(c, "checkFeatures", "finished testing: " + feature);
+            Log.info(c, "checkFeatures", "finished testing: " + feature + ", conflict expected: " + expectToConflict + ", conflict found: " + !result.getConflicts().isEmpty());
             Map<String, Collection<Chain>> conflicts = result.getConflicts();
             if (expectToConflict) {
                 if (conflicts.isEmpty()) {

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/FeatureUtilities.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/FeatureUtilities.java
@@ -20,8 +20,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.ibm.websphere.simplicity.OperatingSystem;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.common.apiservices.LocalMachine;
+import componenttest.rules.repeater.EE6FeatureReplacementAction;
 import componenttest.rules.repeater.EE7FeatureReplacementAction;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.rules.repeater.JakartaEE10Action;
@@ -37,13 +40,29 @@ public class FeatureUtilities {
 
     private static final Class<?> c = FeatureUtilities.class;
 
+    private static final boolean isZOS;
+
+    static {
+        boolean zos = false;
+        try {
+            zos = LocalMachine.getInstance().getOperatingSystem() == OperatingSystem.ZOS;
+        } catch (Exception e) {
+            Log.error(c, "<clinit>", e,
+                      "Could not detect OS, assume it is not z/OS.");
+        }
+        isZOS = zos;
+    }
+
     /**
      * Returns the set of all public Java/Jakarta EE feature short names
      *
      * @return the set of short names
      */
-    public static Set<String> allEeFeatures() {
+    public static Set<String> allEeFeatures(boolean openLibertyOnly) {
         Set<String> features = new HashSet<>();
+        if (!openLibertyOnly) {
+            features.addAll(EE6FeatureReplacementAction.EE6_FEATURE_SET);
+        }
         features.addAll(EE7FeatureReplacementAction.EE7_FEATURE_SET);
         features.addAll(EE8FeatureReplacementAction.EE8_FEATURE_SET);
         features.addAll(JakartaEE9Action.EE9_FEATURE_SET);
@@ -107,7 +126,7 @@ public class FeatureUtilities {
      * @param libertyInstallRoot the wlp directory containing the liberty install
      * @return the list of public short names
      */
-    public static Set<String> getFeaturesFromServer(File libertyInstallRoot) {
+    public static Set<String> getFeaturesFromServer(File libertyInstallRoot, boolean openLibertyOnly) {
         try {
             File featureDir = new File(libertyInstallRoot, "lib/features");
             Set<String> features = new HashSet<>();
@@ -116,7 +135,7 @@ public class FeatureUtilities {
                 for (File feature : featureDir.listFiles()) {
                     if (feature.getName().startsWith("io.openliberty.") ||
                         feature.getName().startsWith("com.ibm.")) {
-                        String shortName = parseShortName(feature);
+                        String shortName = parseShortName(feature, openLibertyOnly);
                         if (shortName != null) {
                             features.add(shortName);
                         }
@@ -136,7 +155,7 @@ public class FeatureUtilities {
      * @return the short name, or {@code null} if it could not be found
      * @throws IOException if there is a problem reading the feature file
      */
-    private static String parseShortName(File feature) throws IOException {
+    private static String parseShortName(File feature, boolean openLibertyOnly) throws IOException {
         // Only scan *.mf files
         if (feature.isDirectory() || !feature.getName().endsWith(".mf"))
             return null;
@@ -153,7 +172,7 @@ public class FeatureUtilities {
                 } else if (line.startsWith("Subsystem-SymbolicName:") && !line.contains("visibility:=public")) {
                     Log.info(c, "parseShortName", "Skipping non-public feature: " + feature.getName());
                     return null;
-                } else if (line.startsWith("IBM-ProductID") && !line.contains("io.openliberty")) {
+                } else if (openLibertyOnly && line.startsWith("IBM-ProductID") && !line.contains("io.openliberty")) {
                     Log.info(c, "parseShortName", "Skipping non Open Liberty feature: " + feature.getName());
                     return null;
                 }
@@ -161,6 +180,10 @@ public class FeatureUtilities {
             // some test feature files do not have a short name and do not have IBM-Test-Feature set.
             // We do not want those ones.
             if (shortName != null) {
+                if (!isZOS && (shortName.startsWith("zos") || shortName.startsWith("batchSMFLogging"))) {
+                    Log.info(c, "parseShortName", "Skipping zos feature: " + feature.getName());
+                    return null;
+                }
                 return shortName;
             }
         }

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.jakartaee9.internal.tests;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -39,8 +40,8 @@ import io.openliberty.jakartaee9.internal.apps.jakartaee9.web.WebProfile9TestSer
 @RunWith(FATRunner.class)
 public class JakartaEE9Test extends FATServletClient {
 
-    private static Set<String> getCompatFeatures() {
-        Set<String> compatFeatures = EE9FeatureCompatibilityTest.getAllCompatibleFeatures();
+    private static Set<String> getCompatFeatures(boolean openLibertyOnly) {
+        Set<String> compatFeatures = EE9FeatureCompatibilityTest.getAllCompatibleFeatures(openLibertyOnly);
         // remove features so that they don't cause feature conflicts.
         compatFeatures.remove("jdbc-4.0");
         compatFeatures.remove("jdbc-4.1");
@@ -65,28 +66,58 @@ public class JakartaEE9Test extends FATServletClient {
         compatFeatures.remove("netty-1.0");
         compatFeatures.remove("noShip-1.0");
         compatFeatures.remove("scim-2.0");
+
+        // remove logAnalysis-1.0.  It depends on hpel being configured
+        compatFeatures.remove("logAnalysis-1.0");
+
+        // springBoot-3.0, data-1.0 and nosql-1.0 requires Java 17 so if we are currently not using Java 17 or later, remove it from the list of features.
+        if (JavaInfo.JAVA_VERSION < 17) {
+            compatFeatures.remove("springBoot-3.0");
+            compatFeatures.remove("data-1.0");
+            compatFeatures.remove("nosql-1.0");
+        }
+
         return compatFeatures;
     }
 
+    private static final String ALL_COMPAT_OL_FEATURES = "AllEE9CompatFeatures_OL_ONLY";
     private static final String ALL_COMPAT_FEATURES = "AllEE9CompatFeatures";
 
     @ClassRule
-    public static RepeatTests repeat = RepeatTests
-                    .with(new FeatureReplacementAction()
-                                    .removeFeature("webProfile-9.1")
-                                    .addFeature("jakartaee-9.1")
-                                    .withID("jakartaee91")) //LITE
-                    .andWith(new FeatureReplacementAction()
-                                    .removeFeature("jakartaee-9.1")
-                                    .addFeature("webProfile-9.1")
-                                    .withID("webProfile91")
-                                    .fullFATOnly())
-                    .andWith(new FeatureReplacementAction()
-                                    .removeFeature("webProfile-9.1")
-                                    .removeFeature("jakartaee-9.1")
-                                    .addFeatures(getCompatFeatures())
-                                    .withID(ALL_COMPAT_FEATURES)
-                                    .fullFATOnly());
+    public static RepeatTests repeat;
+
+    static {
+        Set<String> olCompatFeatures = getCompatFeatures(true);
+        Set<String> allCompatFeatures = getCompatFeatures(false);
+        repeat = RepeatTests
+                        .with(new FeatureReplacementAction()
+                                        .removeFeature("webProfile-9.1")
+                                        .addFeature("jakartaee-9.1")
+                                        .withID("jakartaee91")
+                                        .fullFATOnly())
+                        .andWith(new FeatureReplacementAction()
+                                        .removeFeature("jakartaee-9.1")
+                                        .addFeature("webProfile-9.1")
+                                        .withID("webProfile91")
+                                        .fullFATOnly())
+                        .andWith(new FeatureReplacementAction()
+                                        .removeFeature("webProfile-9.1")
+                                        .removeFeature("jakartaee-9.1")
+                                        .addFeatures(olCompatFeatures)
+                                        .withID(ALL_COMPAT_OL_FEATURES)); //LITE
+        if (!olCompatFeatures.equals(allCompatFeatures)) {
+            Set<String> featuresToAdd = new HashSet<>();
+            for (String feature : allCompatFeatures) {
+                if (!olCompatFeatures.contains(feature)) {
+                    featuresToAdd.add(feature);
+                }
+            }
+            repeat = repeat.andWith(new FeatureReplacementAction()
+                            .addFeatures(featuresToAdd)
+                            .withID(ALL_COMPAT_FEATURES)
+                            .fullFATOnly());
+        }
+    }
 
     public static final String APP_NAME = "webProfile9App";
 
@@ -116,15 +147,25 @@ public class JakartaEE9Test extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         String[] toleratedWarnErrors;
-        if (!RepeatTestFilter.isRepeatActionActive(ALL_COMPAT_FEATURES)) {
-            toleratedWarnErrors = new String[] { "SRVE0280E" };// TODO: SRVE0280E tracked by OpenLiberty issue #4857
-        } else {
+        if (RepeatTestFilter.isRepeatActionActive(ALL_COMPAT_OL_FEATURES)) {
             toleratedWarnErrors = new String[] { "SRVE0280E", // TODO: SRVE0280E tracked by OpenLiberty issue #4857
                                                  "CWWKS5207W", // The remaining ones relate to config not done for the server / app
                                                  "CWWWC0002W",
                                                  "CWMOT0010W",
                                                  "TRAS4352W" // Only happens when running with WebSphere Liberty image due to an auto feature
             };
+        } else if (RepeatTestFilter.isRepeatActionActive(ALL_COMPAT_FEATURES)) {
+            toleratedWarnErrors = new String[] { "SRVE0280E", // TODO: SRVE0280E tracked by OpenLiberty issue #4857
+                                                 "CWWKS5207W", // The remaining ones relate to config not done for the server / app
+                                                 "CWWWC0002W",
+                                                 "CWMOT0010W",
+                                                 "CWWKG0033W", // related to missing config for collectives
+                                                 "CWSJY0035E", // wmqJmsClient.rar.location variable not in the server.xml
+                                                 "CWWKE0701E", // wmqJmsClient.rar.location variable not in the server.xml
+                                                 "TRAS4352W" // Only happens when running with WebSphere Liberty image due to an auto feature
+            };
+        } else {
+            toleratedWarnErrors = new String[] { "SRVE0280E" };// TODO: SRVE0280E tracked by OpenLiberty issue #4857
         }
         server.stopServer(toleratedWarnErrors);
     }


### PR DESCRIPTION
- Add repeat to also test with non Open Liberty features when running against a WebSphere Liberty image
- Update EE9 and EE10 feature compatibility test to also run with all features if there are non Open Liberty features.
