### PR TITLE
Get MP RSO 3.0 working with MP6/EE10

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/bnd.bnd
@@ -28,22 +28,31 @@ tested.features: mpReactiveStreams-1.0, \
                  cdi-1.2,\
                  cdi-2.0,\
                  cdi-3.0,\
+                 cdi-4.0,\
                  servlet-3.1,\
                  servlet-4.0,\
                  servlet-5.0,\
+                 servlet-6.0,\
                  appsecurity-3.0,\
                  appsecurity-4.0,\
+                 appsecurity-5.0,\
                  el-3.0,\
                  expressionlanguage-4.0,\
+                 expressionlanguage-5.0,\
                  restfulws-3.0,\
+                 restfulws-3.1,\
                  restfulwsclient-3.0,\
+                 restfulwsclient-3.1,\
                  mprestclient-3.0,\
                  transportsecurity-1.0,\
                  mpconfig-3.0,\
                  concurrent-2.0,\
+                 concurrent-3.0,\
                  jsonb-1.0,\
                  jsonb-2.0,\
-                 jsonp-2.0
+                 jsonb-3.0,\
+                 jsonp-2.0,\
+                 jsonp-2.1
 
 
 -buildpath: \

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/FATSuite.java
@@ -31,16 +31,19 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
     public static final String MPRS10_ID = MicroProfileActions.MP21_ID + "_" + "MPRS10";
-    public static final String MPRS30_ID = MicroProfileActions.MP50_ID + "_" + "MPRS30";
+    public static final String MPRS30_MP50_ID = MicroProfileActions.MP50_ID + "_" + "MPRS30";
+    public static final String MPRS30_MP60_ID = MicroProfileActions.MP60_ID + "_" + "MPRS30";
 
     public static final FeatureSet MPRS10 = MicroProfileActions.MP21.addFeature("mpReactiveStreams-1.0").build(MPRS10_ID);
-    public static final FeatureSet MPRS30 = MicroProfileActions.MP50.addFeature("mpReactiveStreams-3.0").build(MPRS30_ID);
+    public static final FeatureSet MPRS30_MP50 = MicroProfileActions.MP50.addFeature("mpReactiveStreams-3.0").build(MPRS30_MP50_ID);
+    public static final FeatureSet MPRS30_MP60 = MicroProfileActions.MP60.addFeature("mpReactiveStreams-3.0").build(MPRS30_MP60_ID);
 
     public static final Set<FeatureSet> ALL;
     static {
         ALL = new HashSet<>(MicroProfileActions.ALL);
         ALL.add(MPRS10);
-        ALL.add(MPRS30);
+        ALL.add(MPRS30_MP50);
+        ALL.add(MPRS30_MP60);
     }
 
     /**

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveConcurrentWorkTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveConcurrentWorkTest.java
@@ -58,7 +58,7 @@ public class ReactiveConcurrentWorkTest extends FATServletClient {
     public static final String SERVER_NAME = "ReactiveStreamsConcurrentWorkServer";
 
     @ClassRule
-    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30);
+    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP50, FATSuite.MPRS30_MP60);
 
     public static final String APP_NAME = "ReactiveConcurrentWorkTest";
 

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveJaxRSTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveJaxRSTest.java
@@ -46,7 +46,7 @@ public class ReactiveJaxRSTest extends FATServletClient {
     public static final String SERVER_NAME = "ReactiveJaxRSTestServer";
 
     @ClassRule
-    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30);
+    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP50, FATSuite.MPRS30_MP60);
 
     public static final String APP_NAME = "ReactiveWithJaxRS";
 

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveStreamsContextTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveStreamsContextTest.java
@@ -48,7 +48,7 @@ public class ReactiveStreamsContextTest extends FATServletClient {
     public static final String SERVER_NAME = "ReactiveStreamsContextServer";
 
     @ClassRule
-    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30);
+    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP50, FATSuite.MPRS30_MP60);
 
     public static final String APP_NAME = "ReactiveStreamsContextTest";
 

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveStreamsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveStreamsTest.java
@@ -46,7 +46,7 @@ public class ReactiveStreamsTest extends FATServletClient {
     public static final String SERVER_NAME = "ReactiveStreamsTestServer";
 
     @ClassRule
-    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30);
+    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP50, FATSuite.MPRS30_MP60);
 
     public static final String APP_NAME = "ReactiveStreamsTest";
 

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
@@ -294,10 +294,12 @@ public class MicroProfileActions {
                                                                  "mpReactiveStreams-1.0" };
 
     private static final String[] STANDALONE9_FEATURES_ARRAY = { "mpContextPropagation-1.3",
-                                                                 "mpGraphQL-2.0" };
+                                                                 "mpGraphQL-2.0",
+                                                                 "mpReactiveStreams-3.0" };
 
     private static final String[] STANDALONE10_FEATURES_ARRAY = { "mpContextPropagation-1.3",
-                                                                  "mpGraphQL-2.0" };
+                                                                  "mpGraphQL-2.0",
+                                                                  "mpReactiveStreams-3.0" };
 
     private static final Set<String> STANDALONE8_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(STANDALONE8_FEATURES_ARRAY)));
     private static final Set<String> STANDALONE9_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(STANDALONE9_FEATURES_ARRAY)));

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
@@ -129,7 +129,6 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         compatibleFeatures.remove("springBoot-1.5"); // springBoot 3.0 only supports EE10
         compatibleFeatures.remove("springBoot-2.0");
 
-        compatibleFeatures.remove("mpReactiveStreams-3.0"); //still in development
         compatibleFeatures.remove("mpReactiveMessaging-3.0"); //still in development
 
         // Test features may or may not be compatible, we don't want to assert either way
@@ -145,7 +144,6 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         incompatibleFeatures.addAll(allFeatures);
         incompatibleFeatures.removeAll(compatibleFeatures);
 
-        incompatibleFeatures.remove("mpReactiveStreams-3.0"); //still in development
         incompatibleFeatures.remove("mpReactiveMessaging-3.0"); //still in development
 
         // Test features may or may not be compatible, we don't want to assert either way

--- a/dev/io.openliberty.microprofile.reactive.streams.operators30.cdi/bnd.bnd
+++ b/dev/io.openliberty.microprofile.reactive.streams.operators30.cdi/bnd.bnd
@@ -18,6 +18,10 @@ Export-Package: \
   io.openliberty.microprofile.reactive.streams.operators30.cdi*
     
 Import-Package: \
+  jakarta.enterprise.context; version="[3.0,5)",\
+  jakarta.enterprise.event;version="[3.0,5)",\
+  jakarta.enterprise.inject.spi;version="[3.0,5)",\
+  jakarta.enterprise.inject;version="[3.0,5)",\
   *
     
 Include-Resource: \


### PR DESCRIPTION
- Update the CDI imports to allow EE10
- Add repeats to the basic MP RSO FAT bucket
- Allow the Base Feature test to check for EE10 compatibility

#build