### PR TITLE
Avoid distracting output on stderr after a checkpoint

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1046,7 +1046,12 @@ javaCmd()
     # trap on the signals here to ensure the background tail process ends.
     trap "exit" INT TERM
     trap "killSilent $TAIL_PID" EXIT
-    "${JAVA_CMD}" "$@" >> "${CHECKPOINT_CONSOLE_LOG}" 2>&1 < /dev/null
+    #On some shells (bash) the shell will issue an ugly message to STDERR when criu kills the process.
+    # We direct STDERR to /dev/null to avoid that noise.
+    {
+      #  Launch with stdin set to /dev/null to avoid file-handle complications on criu restore
+      "${JAVA_CMD}" "$@" >> "${CHECKPOINT_CONSOLE_LOG}" 2>&1 < /dev/null
+    } 2> /dev/null
     rc=$?
     if [ $rc -eq 20 ]; then
       # bad checkpoint arg; sleep to allow the message to go to tail


### PR DESCRIPTION
On bash, when criu kills the server process, bash writes a message to standard error containing 'Killed' and the line number and line of the script where java was launched. This is redirected to /dev/null with this change. NOTE this does not affect execution on bourne shell where the message is coming from the STDERR of the java process itself. The message is not as distracting in that case since it's simply the word Killed.