### PR TITLE
Fix com.ibm.ws.security.token.ltpa_fat eclipse files

### DIFF
--- a/dev/com.ibm.ws.security.token.ltpa_fat/.classpath
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/.classpath
@@ -1,19 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="bin/main" path="fat/src">
-		<attributes>
-			<attribute name="gradle_scope" value="main"/>
-			<attribute name="gradle_used_by_scope" value="main,test"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
-	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/fattest.simplicity"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.org.osgi.core"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.org.osgi.service.component"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.wsspi.org.osgi.service.component.annotations"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.javaee.servlet.3.0"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.ws.security.token"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.security"/>
-	<classpathentry kind="output" path="bin/default"/>
+	<classpathentry kind="src" output="bin" path="fat/src"/>
+	<classpathentry kind="src" output="bin" path="test-applications/ltpaTest/src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.security.token.ltpa_fat/.project
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/.project
@@ -11,11 +11,6 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>bndtools.core.bndbuilder</name>
 			<arguments>
 			</arguments>
@@ -24,17 +19,5 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>bndtools.core.bndnature</nature>
-		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1686594873722</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/dev/com.ibm.ws.security.token.ltpa_fat/.settings/org.eclipse.buildship.core.prefs
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/.settings/org.eclipse.buildship.core.prefs
@@ -1,2 +1,0 @@
-connection.project.dir=..
-eclipse.preferences.version=1


### PR DESCRIPTION
- Update .project file to not have a gradle project nature
- Update .classpath to use bnd container for classpath
- Remove buildship.core.prefs so eclipse doesn't think we should use gradle to build in eclipse
