### PR TITLE
Update to get VirtualMachine object before enabling Java security

### DIFF
--- a/dev/com.ibm.ws.jmx.connector.local/bnd.bnd
+++ b/dev/com.ibm.ws.jmx.connector.local/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -29,4 +29,5 @@ Private-Package: com.ibm.ws.jmx.connector.local
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.ws.kernel.service,\
 	com.ibm.wsspi.org.osgi.service.component.annotations,\
-	com.ibm.ws.kernel.feature.core
+	com.ibm.ws.kernel.feature.core,\
+	com.ibm.ws.kernel.boot.core

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/HotSpotJavaDumperImpl.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/HotSpotJavaDumperImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,12 +21,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -35,30 +31,9 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 import com.ibm.ws.kernel.boot.cmdline.Utils;
+import com.ibm.ws.kernel.boot.jmx.service.VirtualMachineHelper;
 
 class HotSpotJavaDumperImpl extends JavaDumper {
-    /**
-     * The current process ID, or null if it could not be determined.
-     */
-    private static final String PID = getPID();
-
-    /**
-     * Return the current process ID.
-     */
-    private static String getPID() {
-        String name = ManagementFactory.getRuntimeMXBean().getName();
-        int index = name.indexOf('@');
-        if (index == -1) {
-            return null;
-        }
-
-        String pid = name.substring(0, index);
-        if (!pid.matches("[0-9]+")) {
-            return null;
-        }
-
-        return pid;
-    }
 
     /**
      * The next sequence number to use for dump file names.
@@ -79,13 +54,6 @@ class HotSpotJavaDumperImpl extends JavaDumper {
      * Name for "com.sun.management:type=DiagnosticCommand".
      */
     private final ObjectName diagnosticCommandName;
-
-    /**
-     * Lazily-initialized VirtualMachine for generating Java dumps.
-     * 
-     * @see #getVirtualMachine
-     */
-    private VirtualMachine vm;
 
     HotSpotJavaDumperImpl(MBeanServer platformMBeanServer, ObjectName diagName, ObjectName diagCommandName) {
         this.platformMBeanServer = platformMBeanServer;
@@ -109,9 +77,9 @@ class HotSpotJavaDumperImpl extends JavaDumper {
 
     /**
      * Create a dump file with a unique name.
-     * 
+     *
      * @param outputDir the directory to contain the file
-     * @param prefix the prefix for the filename
+     * @param prefix    the prefix for the filename
      * @param extension the file extension, not including a leading "."
      * @return the created file
      */
@@ -119,6 +87,7 @@ class HotSpotJavaDumperImpl extends JavaDumper {
         String dateTime = new SimpleDateFormat("yyyyMMdd.HHmmss").format(new Date());
         File outputFile;
         do {
+            String PID = VirtualMachineHelper.getPID();
             String pid = PID == null ? "" : PID + '.';
             int sequenceNumber = nextSequenceNumber.getAndIncrement();
             outputFile = new File(outputDir, String.format("%s.%s.%s%04d.%s", prefix, dateTime, pid, sequenceNumber, extension));
@@ -129,7 +98,7 @@ class HotSpotJavaDumperImpl extends JavaDumper {
 
     /**
      * Create a heap dump. This is the same as jmap -dump:file=...
-     * 
+     *
      * @param outputDir the server output directory
      * @return the resulting file
      */
@@ -157,7 +126,7 @@ class HotSpotJavaDumperImpl extends JavaDumper {
     /**
      * Create a thread dump. This is the same output normally printed to the
      * console when a kill -QUIT or Ctrl-Break is sent to the process.
-     * 
+     *
      * @param outputDir the server output directory
      * @return the resulting file, or null if the dump could not be created
      */
@@ -167,20 +136,20 @@ class HotSpotJavaDumperImpl extends JavaDumper {
         // JREs (not JDKs) and sometimes fails to connect, but we prefer it when
         // available because DiagnosticCommand returns the entire thread dump as
         // a single String, which risks OutOfMemoryError.
-        VirtualMachine vm = null;
+        Method remoteDataDumpMethod = null;
         try {
-            vm = getAttachedVirtualMachine();
-            if (vm == null && diagnosticCommandName == null) {
+            remoteDataDumpMethod = VirtualMachineHelper.getRemoteDumpMethod();
+            if (remoteDataDumpMethod == null && diagnosticCommandName == null) {
                 // Neither Java Attach nor DiagnosticCommand are available, so
                 // it's not possible to create a thread dump.
                 return null;
             }
-        } catch (VirtualMachineException e) {
+        } catch (RuntimeException e) {
             // Sometimes Java Attach fails spuriously.  If DiagnosticCommand is
             // available, try that.  Otherwise, propagate the failure.
             if (diagnosticCommandName == null) {
                 Throwable cause = e.getCause();
-                throw cause instanceof RuntimeException ? (RuntimeException) cause : new RuntimeException(cause);
+                throw cause instanceof RuntimeException ? (RuntimeException) cause : e;
             }
         }
 
@@ -193,8 +162,8 @@ class HotSpotJavaDumperImpl extends JavaDumper {
             // Use a filename that resembles an IBM javacore.
             outputFile = createNewFile(outputDir, "javadump", "txt");
 
-            if (vm != null) {
-                input = vm.remoteDataDump();
+            if (remoteDataDumpMethod != null) {
+                input = remoteDataDump(remoteDataDumpMethod);
                 input = new BufferedInputStream(input);
 
                 output = new FileOutputStream(outputFile);
@@ -237,123 +206,25 @@ class HotSpotJavaDumperImpl extends JavaDumper {
         return outputFile;
     }
 
-    /**
-     * Returns sun.tools.attach.HotSpotVirtualMachine, if possible.
-     */
-    private synchronized VirtualMachine getAttachedVirtualMachine() throws VirtualMachineException {
-        if (PID == null) {
-            // Java Attach requires a PID.
-            return null;
-        }
-
-        if (vm == null) {
-            vm = createVirtualMachine();
-        }
-        return vm.isAttached() ? vm : null;
-    }
-
-    /**
-     * Create a VirtualMachine wrapper.
-     */
-    private VirtualMachine createVirtualMachine() throws VirtualMachineException {
-        ClassLoader toolsClassLoader;
-
-        File toolsJar = getToolsJar();
-        if (toolsJar == null) {
-            // The attach classes are on the boot classpath on Mac.
-            toolsClassLoader = HotSpotJavaDumperImpl.class.getClassLoader();
-        } else {
-            try {
-                toolsClassLoader = new URLClassLoader(new URL[] { toolsJar.getAbsoluteFile().toURI().toURL() });
-            } catch (MalformedURLException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
+    private InputStream remoteDataDump(Method remoteDataDumpMethod) throws IOException {
         try {
-            Class<?> vmClass = toolsClassLoader.loadClass("com.sun.tools.attach.VirtualMachine");
-            Method attachMethod = vmClass.getMethod("attach", new Class<?>[] { String.class });
-            Object toolsVM = attachMethod.invoke(null, new Object[] { PID });
-            Method remoteDataDumpMethod = toolsVM.getClass().getMethod("remoteDataDump", new Class<?>[] { Object[].class });
-            return new VirtualMachine(toolsVM, remoteDataDumpMethod);
-        } catch (ClassNotFoundException e) {
-            // The class isn't found, so we won't be able to create dumps.
+            // Pass -l, which is the jstack argument for a "long listing".
+            Object[] dumpArgs = new Object[] { "-l" };
+            return (InputStream) remoteDataDumpMethod.invoke(VirtualMachineHelper.getVirtualMachine(), new Object[] { dumpArgs });
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException(e);
         } catch (InvocationTargetException e) {
-            throw new VirtualMachineException(e);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        return new VirtualMachine(null, null);
-    }
-
-    /**
-     * Gets tools.jar from the JDK, or null if not found (for example, when
-     * running with a JRE rather than a JDK, or when running on Mac).
-     */
-    private static File getToolsJar() {
-        String javaHome = System.getProperty("java.home");
-        File file = new File(javaHome, "../lib/tools.jar");
-        if (!file.exists()) {
-            file = new File(javaHome, "lib/tools.jar");
-            if (!file.exists()) {
-                return null;
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
             }
-        }
-
-        return file;
-    }
-
-    @SuppressWarnings("serial")
-    private static class VirtualMachineException extends Exception {
-        VirtualMachineException(Throwable cause) {
-            super(cause);
-        }
-    }
-
-    /**
-     * Create a wrapper for sun.tools.attach.HotSpotVirtualMachine.
-     */
-    private static class VirtualMachine {
-        /**
-         * sun.tools.attach.HotSpotVirtualMachine
-         */
-        private final Object vm;
-
-        /**
-         * InputStream sun.tools.attach.HotSpotVirtualMachine.remoteDataDump(Object[])
-         */
-        private final Method remoteDataDumpMethod;
-
-        VirtualMachine(Object vm, Method remoteDataDumpMethod) {
-            this.vm = vm;
-            this.remoteDataDumpMethod = remoteDataDumpMethod;
-        }
-
-        public boolean isAttached() {
-            return vm != null;
-        }
-
-        public InputStream remoteDataDump() throws IOException {
-            try {
-                // Pass -l, which is the jstack argument for a "long listing".
-                Object[] dumpArgs = new Object[] { "-l" };
-                return (InputStream) remoteDataDumpMethod.invoke(vm, new Object[] { dumpArgs });
-            } catch (IllegalAccessException e) {
-                throw new IllegalStateException(e);
-            } catch (InvocationTargetException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof IOException) {
-                    throw (IOException) cause;
-                }
-                if (cause instanceof Error) {
-                    throw (Error) cause;
-                }
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                }
-                throw new RuntimeException(cause);
+            if (cause instanceof Error) {
+                throw (Error) cause;
             }
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new RuntimeException(cause);
         }
     }
 }

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/jmx/service/VirtualMachineHelper.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/jmx/service/VirtualMachineHelper.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.kernel.boot.jmx.service;
+
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * Allows access to the Virtual Machine object that was obtained before setting the security manager
+ * so it does not need to be obtained again. HotSpot Java 17 levels are missing doPrivileged calls
+ * which prevent getting the VirtualMachine object after the security manager is set.
+ */
+public final class VirtualMachineHelper {
+
+    private static final class PIDHolder {
+        static final String PID;
+        static {
+            String pid = null;
+            String name = ManagementFactory.getRuntimeMXBean().getName();
+            int index = name.indexOf('@');
+            if (index >= 0) {
+                pid = name.substring(0, index);
+                if (!pid.matches("[0-9]+")) {
+                    pid = null;
+                }
+            }
+            PID = pid;
+        }
+    }
+
+    private static final class VirtualMachineHolder {
+        static final Object virtualMachine;
+        static final Method remoteDataDumpMethod;
+        static final RuntimeException error;
+        static {
+
+            ClassLoader toolsClassLoader;
+
+            File toolsJar = getToolsJar();
+            if (toolsJar == null) {
+                // The attach classes are on the boot classpath on Mac.
+                toolsClassLoader = VirtualMachineHelper.class.getClassLoader();
+            } else {
+                try {
+                    toolsClassLoader = new URLClassLoader(new URL[] { toolsJar.getAbsoluteFile().toURI().toURL() });
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            Object vm = null;
+            Method dumpMethod = null;
+            Exception ex = null;
+            try {
+                Class<?> vmClass = toolsClassLoader.loadClass("com.sun.tools.attach.VirtualMachine");
+                Method attachMethod = vmClass.getMethod("attach", new Class<?>[] { String.class });
+                vm = attachMethod.invoke(null, new Object[] { getPID() });
+                dumpMethod = vm.getClass().getMethod("remoteDataDump", new Class<?>[] { Object[].class });
+            } catch (ClassNotFoundException e) {
+                // The class isn't found, so we won't be able to create dumps.
+            } catch (Exception e) {
+                ex = new RuntimeException(e);
+            }
+            virtualMachine = vm;
+            remoteDataDumpMethod = dumpMethod;
+            error = ex == null ? null : new RuntimeException(ex);
+        }
+
+        /**
+         * Gets tools.jar from the JDK, or null if not found (for example, when
+         * running with a JRE rather than a JDK, or when running on Mac).
+         */
+        private static File getToolsJar() {
+            String javaHome = System.getProperty("java.home");
+            File file = new File(javaHome, "../lib/tools.jar");
+            if (!file.exists()) {
+                file = new File(javaHome, "lib/tools.jar");
+                if (!file.exists()) {
+                    return null;
+                }
+            }
+
+            return file;
+        }
+
+    }
+
+    public static String getPID() {
+        return PIDHolder.PID;
+    }
+
+    public static Object getVirtualMachine() {
+        if (getPID() == null) {
+            // Java Attach requires a PID.
+            return null;
+        }
+
+        Object vm = VirtualMachineHolder.virtualMachine;
+
+        if (vm != null) {
+            return vm;
+        }
+
+        RuntimeException exception = VirtualMachineHolder.error;
+        if (exception != null) {
+            throw exception;
+        }
+
+        return null;
+    }
+
+    public static Method getRemoteDumpMethod() {
+        if (getPID() == null) {
+            // Java Attach requires a PID.
+            return null;
+        }
+
+        Method dumpMethod = VirtualMachineHolder.remoteDataDumpMethod;
+
+        if (dumpMethod != null) {
+            return dumpMethod;
+        }
+
+        RuntimeException exception = VirtualMachineHolder.error;
+        if (exception != null) {
+            throw exception;
+        }
+
+        return null;
+    }
+}

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2022 IBM Corporation and others.
+ * Copyright (c) 2010, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -84,6 +84,7 @@ import com.ibm.ws.kernel.boot.internal.commands.ServerDumpUtil;
 import com.ibm.ws.kernel.boot.jmx.internal.PlatformMBeanServerBuilder;
 import com.ibm.ws.kernel.boot.jmx.internal.PlatformMBeanServerBuilderListener;
 import com.ibm.ws.kernel.boot.jmx.service.MBeanServerPipeline;
+import com.ibm.ws.kernel.boot.jmx.service.VirtualMachineHelper;
 import com.ibm.ws.kernel.launch.internal.Provisioner.InvalidBundleContextException;
 import com.ibm.ws.kernel.launch.service.ClientRunner;
 import com.ibm.ws.kernel.launch.service.ForcedServerStop;
@@ -256,6 +257,14 @@ public class FrameworkManager {
                 if (javaVersion() >= 18) {
                     Tr.error(tc, "error.set.securitymanager.jdk18", javaVersion());
                 } else {
+                    // Initialize the VirtualMachineHelper here.  HotSpot Java's read the sun.jvmstat.monitor.local system property during class initialization
+                    // on Java 17 when doing Java dump or attaching for the localConnector-1.0 feature.
+                    // The permission cannot be set in security policy due to it being during class initialization.
+                    try {
+                        VirtualMachineHelper.getVirtualMachine();
+                    } catch (RuntimeException re) {
+                        // ignore the exception.
+                    }
                     if (j2secNoRethrow == null || j2secNoRethrow.equals("false")) {
                         try {
                             AccessController.doPrivileged(new java.security.PrivilegedExceptionAction<Void>() {


### PR DESCRIPTION
- When using Java security with HotSpot Java 17, there are missing doPriv's in the JDK that prevents us from running with localConnector-1.0 and doing thread dumps.
- This change gets the VirtualMachine object before enabling Java security so that we do not check security when getting the VirtualMachine object.
