### PR TITLE
Improvements to the Checkpoint Transaction FAT suite

### DIFF
--- a/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/RecoveryTestBase.java
+++ b/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/RecoveryTestBase.java
@@ -16,7 +16,6 @@ import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-//import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.AllowedFFDC;
@@ -33,6 +32,7 @@ import io.openliberty.checkpoint.fat.util.FATUtils;
 @SkipIfCheckpointNotSupported
 public class RecoveryTestBase extends FATServletClient {
 
+    static final String SERVER_NAME = "checkpointTransactionRecovery";
     public static final String APP_NAME = "transactionrecovery";
     public static final String SERVLET_NAME = APP_NAME + "/RecoveryServlet";
 
@@ -48,7 +48,7 @@ public class RecoveryTestBase extends FATServletClient {
         //ShrinkHelper.defaultApp(server, APP_NAME, "servlets.recovery.*");
 
         // Restore the server
-        //server.setServerStartTimeout(RecoveryUtils.LOG_SEARCH_TIMEOUT);
+        //server.setServerStartTimeout(FATUtils.LOG_SEARCH_TIMEOUT);
         FATUtils.startServers(server);
     }
 

--- a/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/StartupBeanTest.java
+++ b/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/StartupBeanTest.java
@@ -30,17 +30,20 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipIfCheckpointNotSupported;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
@@ -59,33 +62,40 @@ public class StartupBeanTest extends FATServletClient {
 
     static final String SERVER_NAME = "checkpointTransactionStartupBean";
 
-    @Server(SERVER_NAME)
-    public static LibertyServer server;
-
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
+    public static RepeatTests r = RepeatTests.with(new EE8FeatureReplacementAction().forServers(SERVER_NAME))
                     .andWith(new JakartaEE9Action().forServers(SERVER_NAME).fullFATOnly())
                     .andWith(new JakartaEE10Action().forServers(SERVER_NAME).fullFATOnly());
 
     static final String APP_NAME = "transactionstartupbean";
 
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
     TestMethod testMethod;
-    JavaArchive TxStartupBeanJar;
-    EnterpriseArchive TxStartupBeanEar;
 
     static final String TX_RETRY_INT = "11";
 
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        server.saveServerConfiguration();
+    }
+
     @Before
     public void setUp() throws Exception {
+        ShrinkHelper.cleanAllExportedArchives();
+
         testMethod = getTestMethod(TestMethod.class, testName);
         switch (testMethod) {
             case testStartupBeanRequiresNewAtDeployment:
-                TxStartupBeanJar = ShrinkHelper.buildJavaArchive(APP_NAME, "com.ibm.ws.transaction.ejb.first");
-                TxStartupBeanEar = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
-                TxStartupBeanEar.addAsModule(TxStartupBeanJar);
-                ShrinkHelper.exportDropinAppToServer(server, TxStartupBeanEar);
+                server.restoreServerConfiguration();
 
-                Consumer<LibertyServer> preRestoreLogic = checkpointServer -> {
+                JavaArchive TxStartupBeanJar1 = ShrinkHelper.buildJavaArchive(APP_NAME, "com.ibm.ws.transaction.ejb.first");
+                EnterpriseArchive TxStartupBeanEar1 = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
+                TxStartupBeanEar1.addAsModule(TxStartupBeanJar1);
+                ShrinkHelper.exportDropinAppToServer(server, TxStartupBeanEar1, new DeployOptions[] { DeployOptions.OVERWRITE });
+
+                Consumer<LibertyServer> preRestoreLogic1 = checkpointServer -> {
                     // Env vars that override the application datasource and transaction
                     // configurations at restore
                     File serverEnvFile = new File(checkpointServer.getServerRoot() + "/server.env");
@@ -96,22 +106,26 @@ public class StartupBeanTest extends FATServletClient {
                         throw new UncheckedIOException(e);
                     }
                 };
-                server.setCheckpoint(CheckpointPhase.BEFORE_APP_START, false, preRestoreLogic);
+                server.setCheckpoint(CheckpointPhase.BEFORE_APP_START, false, preRestoreLogic1);
                 break;
             case testStartupBeanRequiresNewAtApplications:
-                TxStartupBeanJar = ShrinkHelper.buildJavaArchive(APP_NAME, "com.ibm.ws.transaction.ejb.first");
-                TxStartupBeanEar = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
-                TxStartupBeanEar.addAsModule(TxStartupBeanJar);
-                ShrinkHelper.exportDropinAppToServer(server, TxStartupBeanEar);
+                server.restoreServerConfiguration();
+
+                JavaArchive TxStartupBeanJar2 = ShrinkHelper.buildJavaArchive(APP_NAME, "com.ibm.ws.transaction.ejb.first");
+                EnterpriseArchive TxStartupBeanEar2 = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
+                TxStartupBeanEar2.addAsModule(TxStartupBeanJar2);
+                ShrinkHelper.exportDropinAppToServer(server, TxStartupBeanEar2, new DeployOptions[] { DeployOptions.OVERWRITE });
 
                 // Expect checkpoint and restore to fail
                 server.setCheckpoint(new CheckpointInfo(CheckpointPhase.AFTER_APP_START, false, true, true, null));
                 break;
             case testStartupBeanUserTranAtApplications:
-                TxStartupBeanJar = ShrinkHelper.buildJavaArchive(APP_NAME, "com.ibm.ws.transaction.ejb.second");
-                TxStartupBeanEar = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
-                TxStartupBeanEar.addAsModule(TxStartupBeanJar);
-                ShrinkHelper.exportDropinAppToServer(server, TxStartupBeanEar);
+                server.restoreServerConfiguration();
+
+                JavaArchive TxStartupBeanJar3 = ShrinkHelper.buildJavaArchive(APP_NAME, "com.ibm.ws.transaction.ejb.second");
+                EnterpriseArchive TxStartupBeanEar3 = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
+                TxStartupBeanEar3.addAsModule(TxStartupBeanJar3);
+                ShrinkHelper.exportDropinAppToServer(server, TxStartupBeanEar3, new DeployOptions[] { DeployOptions.OVERWRITE });
 
                 server.setCheckpoint(new CheckpointInfo(CheckpointPhase.AFTER_APP_START, false, true, true, null));
                 break;
@@ -123,7 +137,6 @@ public class StartupBeanTest extends FATServletClient {
     @After
     public void tearDown() throws Exception {
         stopServer(server);
-        ShrinkHelper.cleanAllExportedArchives();
     }
 
     /**


### PR DESCRIPTION
Some cleanup and improvements to harden the Checkpoint TX FAT suite and enhance its serviceability.

1. Use the EE8 feature replacement action for the initial repeat of all test classes in the suite.  This change helps ensure simplicity uses the expected EE feature set during the initial repeat.

2. For test classes that use different servers or use the same server over multiple tests, apply a pattern where all server instances are injected (`@Server`), all server configurations are saved during `@BeforeClass`, and all configurations are restored during `@Before` of each test. This pattern replaces the use of the `LibertyServerFactory` to create the server configurations and instances during `@Before` of each test.

3. Clean up application artifacts during `@Before`, and deploy all application artifacts using the `OVERWRITE` option.  This change helps ensure each test uses the expected application modules.

4. Modify classes to be consistent with their usage of static constants and methods provided by `FATUtils` and `FATSuite`.

5. Remove unnecessary variables from test classes, and impart a more consistent structure, in order to reduce and more easily identify the critical "moving parts" of all tests.

6. Remove any dead code. useless comments, and unused imports. 