### PR TITLE
Increase the tx timeout in testTransactionEnlistment

### DIFF
--- a/dev/io.openliberty.checkpoint_fat_transaction/test-applications/transactionservlet/src/servlets/simple/SimpleServlet.java
+++ b/dev/io.openliberty.checkpoint_fat_transaction/test-applications/transactionservlet/src/servlets/simple/SimpleServlet.java
@@ -276,7 +276,7 @@ public class SimpleServlet extends FATServlet {
             // UserTransaction Commit
             con.setAutoCommit(false);
             UserTransaction tran = (UserTransaction) context.lookup("java:comp/UserTransaction");
-            tran.setTransactionTimeout(3); // afford two more seconds to commit
+            tran.setTransactionTimeout(5); // afford 4 more seconds to commit
             tran.begin();
             try {
                 stmt = con.createStatement();


### PR DESCRIPTION
Transactions may timeout in `SimpleServlet.testTransactionEnlistment()` due to slow test servers and a big trace spec. Bump the transaction timeout to 5 seconds for now.