### PR TITLE
Log stacks on trace

### DIFF
--- a/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/startupEvents/sharedLib/AbstractObserver.java
+++ b/dev/io.openliberty.cdi.4.0.internal_fat/fat/src/io/openliberty/cdi40/internal/fat/startupEvents/sharedLib/AbstractObserver.java
@@ -50,6 +50,9 @@ public abstract class AbstractObserver {
 
     protected void trace(String method) {
         System.out.println(logMsg(method));
+        for (StackTraceElement ste : Thread.currentThread().getStackTrace()) {
+            System.out.println(ste + System.lineSeparator());
+        }
     }
 
     public void observeInit(@Observes @Initialized(ApplicationScoped.class) Object event) {


### PR DESCRIPTION
Errors in this test will involve things being called out of order, having the stacks so we can check for common classes calling things in the wrong order will be useful.
