### PR TITLE
ignore CWWKO0801E SSL unknown_certificate exception message as tests …

### DIFF
--- a/dev/com.ibm.ws.jaxws.clientcontainer_fat/fat/src/com/ibm/ws/jaxws/clientcontainer/fat/ClientSecurityTest.java
+++ b/dev/com.ibm.ws.jaxws.clientcontainer_fat/fat/src/com/ibm/ws/jaxws/clientcontainer/fat/ClientSecurityTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -72,7 +72,7 @@ public class ClientSecurityTest {
         }
 
         if (server.isStarted()) {
-            server.stopServer();
+            server.stopServer("CWWKO0801E");
         }
     }
 


### PR DESCRIPTION
PR for adding an ignore for CWWKO0801E message when stopping the server. it is flagging an intermittent SSLHandshake Exception causing builds to break. the tests themselves are passing.

