### PR TITLE
Set Min Java Level on FeatureSet

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -269,11 +269,6 @@
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio-jvm</artifactId>
-      <version>3.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okio</groupId>
-      <artifactId>okio-jvm</artifactId>
       <version>3.4.0</version>
     </dependency>
     <dependency>

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/tests/CDIExtensionRepeatActions.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/tests/CDIExtensionRepeatActions.java
@@ -15,9 +15,7 @@ package com.ibm.ws.cdi.extension.tests;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import com.ibm.websphere.simplicity.LocalFile;
 
@@ -115,12 +113,11 @@ public class CDIExtensionRepeatActions {
                                                                    .build(EE10_PLUS_ID);
 
     //All CDI FeatureSets - must be descending order
-    private static final FeatureSet[] ALL_SETS_ARRAY = { EE10_PLUS, EE9_PLUS, EE8_PLUS, EE10_PLUS };
-    public static final List<FeatureSet> ALL_SETS_LIST = Collections.unmodifiableList(Arrays.asList(ALL_SETS_ARRAY));
-    public static final Set<FeatureSet> ALL = Collections.unmodifiableSet(new HashSet<>(ALL_SETS_LIST));
+    private static final FeatureSet[] ALL_SETS_ARRAY = { EE10_PLUS, EE9_PLUS, EE8_PLUS, EE7_PLUS };
+    public static final List<FeatureSet> ALL = Collections.unmodifiableList(Arrays.asList(ALL_SETS_ARRAY));
 
     public static RepeatTests repeat(String server, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
-        return RepeatActions.repeat(server, TestMode.FULL, ALL_SETS_LIST, firstFeatureSet, otherFeatureSets);
+        return RepeatActions.repeat(server, TestMode.FULL, ALL, firstFeatureSet, otherFeatureSets);
     }
 
     public static boolean isJakartaActive() {

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/tests/CDIExtensionRepeatActions.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/tests/CDIExtensionRepeatActions.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,7 +16,10 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+
+import com.ibm.websphere.simplicity.LocalFile;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.custom.junit.runner.RepeatTestFilter;
@@ -30,8 +33,6 @@ import componenttest.rules.repeater.RepeatActions;
 import componenttest.rules.repeater.RepeatActions.EEVersion;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
-
-import com.ibm.websphere.simplicity.LocalFile;
 
 public class CDIExtensionRepeatActions {
 
@@ -113,14 +114,13 @@ public class CDIExtensionRepeatActions {
                                                                    .addFeature(getFeatureName(CDI_INTERNALS_BUNDLE_ID, EEVersion.EE10))
                                                                    .build(EE10_PLUS_ID);
 
-    private static final FeatureSet[] ALL_SETS_ARRAY = { EE7_PLUS,
-                                                         EE8_PLUS,
-                                                         EE9_PLUS,
-                                                         EE10_PLUS };
-    private static final Set<FeatureSet> ALL = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ALL_SETS_ARRAY)));
+    //All CDI FeatureSets - must be descending order
+    private static final FeatureSet[] ALL_SETS_ARRAY = { EE10_PLUS, EE9_PLUS, EE8_PLUS, EE10_PLUS };
+    public static final List<FeatureSet> ALL_SETS_LIST = Collections.unmodifiableList(Arrays.asList(ALL_SETS_ARRAY));
+    public static final Set<FeatureSet> ALL = Collections.unmodifiableSet(new HashSet<>(ALL_SETS_LIST));
 
     public static RepeatTests repeat(String server, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
-        return RepeatActions.repeat(server, TestMode.FULL, ALL, firstFeatureSet, otherFeatureSets);
+        return RepeatActions.repeat(server, TestMode.FULL, ALL_SETS_LIST, firstFeatureSet, otherFeatureSets);
     }
 
     public static boolean isJakartaActive() {
@@ -185,8 +185,8 @@ public class CDIExtensionRepeatActions {
     public static void uninstallUserBundle(LibertyServer server, String bundleID) throws Exception {
         String bundleName = getBundleName(bundleID, isJakartaActive());
         server.uninstallUserBundle(bundleName);
-        if(isJakartaActive()) {
-            //Destroy the old file the transformer created to prevent a collision when the next transformation happens. 
+        if (isJakartaActive()) {
+            //Destroy the old file the transformer created to prevent a collision when the next transformation happens.
             //This may or may not fix https://wasrtc.hursley.ibm.com:9443/jazz/resource/itemName/com.ibm.team.workitem.WorkItem/290609
             LocalFile bundleFile = new LocalFile(getBundlePath(bundleName));
             bundleFile.delete();

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/ejb/EJBVisibilityTests.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/ejb/EJBVisibilityTests.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -50,6 +50,9 @@ public class EJBVisibilityTests extends FATServletClient {
 
     public static final String SERVER_NAME = "cdi12EJBServer";
 
+    //Because this test includes Fault Tolerance, the repeat must be done using MicroProfileActions.
+    //Fault Tolerance is included as a feature with CDI extension which can see application BDAs.
+    //This previously caused issues with masked classes.
     @ClassRule
     public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP60, MicroProfileActions.MP14, MicroProfileActions.MP50);
 

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPContextPropActions.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPContextPropActions.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.mp.fat;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Arrays;
+import java.util.List;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.FeatureSet;
@@ -29,12 +29,9 @@ public class MPContextPropActions {
     public static final FeatureSet CTX10 = MicroProfileActions.MP32.addFeature("mpContextPropagation-1.0").build(CTX10_ID);
     public static final FeatureSet CTX12 = MicroProfileActions.MP40.addFeature("mpContextPropagation-1.2").build(CTX12_ID);
 
-    public static final Set<FeatureSet> ALL;
-    static {
-        ALL = new HashSet<>(MicroProfileActions.ALL);
-        ALL.add(CTX10);
-        ALL.add(CTX12);
-    }
+    //All MicroProfile CTX FeatureSets - must be descending order
+    private static final FeatureSet[] ALL_CTX_SETS_ARRAY = { CTX12, CTX10 };
+    private static final List<FeatureSet> ALL = Arrays.asList(ALL_CTX_SETS_ARRAY);
 
     public static RepeatTests repeat(String server, FeatureSet firstVersion, FeatureSet... otherVersions) {
         return RepeatActions.repeat(server, TestMode.LITE, ALL, firstVersion, otherVersions);

--- a/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
@@ -12,9 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance.fat.repeat;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.FeatureReplacementAction;
@@ -22,7 +21,6 @@ import componenttest.rules.repeater.FeatureSet;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatActions;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.impl.JavaInfo;
 
 /**
  * Contains static methods for creating standard RepeatTests rules for Fault Tolerance tests
@@ -47,39 +45,24 @@ public class RepeatFaultTolerance {
 
     public static final FeatureSet MP21_METRICS20 = MicroProfileActions.MP21.removeFeature("mpMetrics-1.1").addFeature("mpMetrics-2.0").build(MP21_METRICS20_ID);
 
-    public static final Set<FeatureSet> ALL;
+    //All MicroProfile ReactiveMessaging FeatureSets - must be descending order
+    private static final List<FeatureSet> ALL;
+
     static {
-        ALL = new HashSet<>(MicroProfileActions.ALL);
-        ALL.add(MP21_METRICS20);
+        ALL = new ArrayList<>(MicroProfileActions.ALL);
+        //put the updated FeatureSet in just before MP21
+        ALL.add(ALL.indexOf(MicroProfileActions.MP21), MP21_METRICS20);
     }
 
     /**
-     * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will always be run in LITE mode.
-     * The others will run in the mode specified.
-     *
      * @param server The server to repeat on
-     * @param otherFeatureSetsTestMode The mode to repeate the other FeatureSets in
-     * @param firstFeatureSet The first FeatureSet
-     * @param otherFeatureSets The other FeatureSets
-     * @return a RepeatTests instance
+     * @param otherFeatureSetsTestMode The test mode to run the otherFeatureSets
+     * @param firstFeatureSet The first FeatureSet to repeat with. This is run in LITE mode.
+     * @param otherFeatureSets The other FeatureSets to repeat with. These are in the mode specified by otherFeatureSetsTestMode
+     * @return A RepeatTests instance
      */
-    public static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
-
-        Set<FeatureSet> otherFeatureSetsSet = new HashSet<>(Arrays.asList(otherFeatureSets));
-
-        int currentJavaLevel = JavaInfo.forCurrentVM().majorVersion();
-        if (currentJavaLevel < firstFeatureSet.getMinJavaLevel().majorVersion()) {
-            // For MP60, just replace it with MP50 (same implementation but running with EE9)
-            if (firstFeatureSet == MicroProfileActions.MP60) {
-                firstFeatureSet = MicroProfileActions.MP50;
-                otherFeatureSetsSet.remove(MicroProfileActions.MP50);
-            } else {
-                // Otherwise fail, this logic needs updating
-                throw new RuntimeException("First feature set is not compatible with Java " + currentJavaLevel);
-            }
-        }
-
-        return RepeatActions.repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, otherFeatureSetsSet);
+    public static RepeatTests repeat(String serverName, TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
+        return RepeatActions.repeat(serverName, otherFeatureSetsTestMode, ALL, firstFeatureSet, otherFeatureSets);
     }
 
     /**
@@ -144,5 +127,4 @@ public class RepeatFaultTolerance {
                       MicroProfileActions.MP40,
                       MicroProfileActions.MP50);
     }
-
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
@@ -68,7 +68,7 @@ public class RepeatFaultTolerance {
         Set<FeatureSet> otherFeatureSetsSet = new HashSet<>(Arrays.asList(otherFeatureSets));
 
         int currentJavaLevel = JavaInfo.forCurrentVM().majorVersion();
-        if (currentJavaLevel < firstFeatureSet.getEEVersion().getMinJavaLevel()) {
+        if (currentJavaLevel < firstFeatureSet.getMinJavaLevel().majorVersion()) {
             // For MP60, just replace it with MP50 (same implementation but running with EE9)
             if (firstFeatureSet == MicroProfileActions.MP60) {
                 firstFeatureSet = MicroProfileActions.MP50;

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckTest.java
@@ -56,7 +56,7 @@ public class KafkaAutoAckTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
@@ -52,7 +52,7 @@ public class KafkaAcknowledgementTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/flatmap/KafkaFlatMapTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/flatmap/KafkaFlatMapTest.java
@@ -52,7 +52,7 @@ public class KafkaFlatMapTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/ConsumerRecordTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/ConsumerRecordTest.java
@@ -61,7 +61,7 @@ public class ConsumerRecordTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);//, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);//, ReactiveMessagingActions.MP61);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseConfiguredTopicTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseConfiguredTopicTest.java
@@ -53,7 +53,7 @@ public class UseConfiguredTopicTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseProducerRecordTopicTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseProducerRecordTopicTest.java
@@ -53,7 +53,7 @@ public class UseProducerRecordTopicTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
@@ -64,7 +64,7 @@ public class KafkaPartitionTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomKeySerializerTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomKeySerializerTest.java
@@ -59,7 +59,7 @@ public class KafkaCustomKeySerializerTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomSerializerTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomSerializerTest.java
@@ -56,7 +56,7 @@ public class KafkaCustomSerializerTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sharedLib/KafkaSharedLibTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sharedLib/KafkaSharedLibTest.java
@@ -57,7 +57,7 @@ public class KafkaSharedLibTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/ReactiveStreamsTckTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/ReactiveStreamsTckTest.java
@@ -49,7 +49,7 @@ import io.smallrye.reactive.streams.Engine;
 public class ReactiveStreamsTckTest {
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(null, ReactiveMessagingActions.MP20);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(null, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BadConnectorIDTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BadConnectorIDTest.java
@@ -51,7 +51,7 @@ public class BadConnectorIDTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);//, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);//, ReactiveMessagingActions.MP61);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BasicReactiveMessagingTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BasicReactiveMessagingTest.java
@@ -37,8 +37,8 @@ public class BasicReactiveMessagingTest extends FATServletClient {
     public static final String SERVER_NAME = "SimpleRxMessagingServer";
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60,
-                                                                  ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30,
+                                                                  ReactiveMessagingActions.MP61_RM30);
 
     @Server(SERVER_NAME)
     @TestServlet(servlet = SimpleReactiveMessagingServlet.class, contextRoot = APP_NAME)

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/KafkaMessagingTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/KafkaMessagingTest.java
@@ -72,7 +72,7 @@ public class KafkaMessagingTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
 
     private static KafkaConsumer<String, String> kafkaConsumer;
     private static KafkaProducer<String, String> kafkaProducer;

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/MissingGroupIDTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/MissingGroupIDTest.java
@@ -55,7 +55,7 @@ public class MissingGroupIDTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/ReactiveMessagingActions.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/ReactiveMessagingActions.java
@@ -10,34 +10,31 @@
 package com.ibm.ws.microprofile.reactive.messaging.fat.suite;
 
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.FeatureSet;
 import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatActions;
+import componenttest.rules.repeater.RepeatActions.SEVersion;
 import componenttest.rules.repeater.RepeatTests;
 
 public class ReactiveMessagingActions {
-    public static final String MP20_ID = MicroProfileActions.MP20_ID + "_MPRM10";
-    public static final String MP41_ID = MicroProfileActions.MP41_ID + "_MPRM10";
-    public static final String MP50_ID = MicroProfileActions.MP50_ID + "_MPRM30";
-    public static final String MP60_ID = MicroProfileActions.MP60_ID + "_MPRM30";
-    public static final String MP61_ID = MicroProfileActions.MP61_ID + "_MPRM30";
-    public static final FeatureSet MP20 = MicroProfileActions.MP20.addFeature("mpReactiveMessaging-1.0").build(MP20_ID);
-    public static final FeatureSet MP41 = MicroProfileActions.MP41.addFeature("mpReactiveMessaging-1.0").build(MP41_ID);
-    public static final FeatureSet MP50 = MicroProfileActions.MP50.addFeature("mpReactiveMessaging-3.0").build(MP50_ID);
-    public static final FeatureSet MP60 = MicroProfileActions.MP60.addFeature("mpReactiveMessaging-3.0").build(MP60_ID);
-    public static final FeatureSet MP61 = MicroProfileActions.MP61.addFeature("mpReactiveMessaging-3.0").build(MP61_ID);
+    public static final String MP20_RM10_ID = MicroProfileActions.MP20_ID + "_RM10";
+    public static final String MP41_RM10_ID = MicroProfileActions.MP41_ID + "_RM10";
+    public static final String MP50_RM30_ID = MicroProfileActions.MP50_ID + "_RM30";
+    public static final String MP60_RM30_ID = MicroProfileActions.MP60_ID + "_RM30";
+    public static final String MP61_RM30_ID = MicroProfileActions.MP61_ID + "_RM30";
+    public static final FeatureSet MP20_RM10 = MicroProfileActions.MP20.addFeature("mpReactiveMessaging-1.0").build(MP20_RM10_ID);
+    public static final FeatureSet MP41_RM10 = MicroProfileActions.MP41.addFeature("mpReactiveMessaging-1.0").build(MP41_RM10_ID);
+    //MP50 runs on Java 8 but RM30 will only run on Java11 or higher
+    public static final FeatureSet MP50_RM30 = MicroProfileActions.MP50.addFeature("mpReactiveMessaging-3.0").setMinJavaLevel(SEVersion.JAVA11).build(MP50_RM30_ID);
+    public static final FeatureSet MP60_RM30 = MicroProfileActions.MP60.addFeature("mpReactiveMessaging-3.0").build(MP60_RM30_ID);
+    public static final FeatureSet MP61_RM30 = MicroProfileActions.MP61.addFeature("mpReactiveMessaging-3.0").build(MP61_RM30_ID);
 
-    public static final Set<FeatureSet> ALL = new HashSet<>(MicroProfileActions.ALL);
-    static {
-        ALL.add(MP20);
-        ALL.add(MP41);
-        ALL.add(MP50);
-        ALL.add(MP60);
-        ALL.add(MP61);
-    }
+    //All MicroProfile ReactiveMessaging FeatureSets - must be descending order
+    private static final FeatureSet[] ALL_RM_SETS_ARRAY = { MP61_RM30, MP60_RM30, MP50_RM30, MP41_RM10, MP20_RM10 };
+    private static final List<FeatureSet> ALL_RM_SETS_LIST = Arrays.asList(ALL_RM_SETS_ARRAY);
 
     /**
      * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in FULL.
@@ -51,7 +48,17 @@ public class ReactiveMessagingActions {
         return repeat(server, TestMode.FULL, firstFeatureSet, otherFeatureSets);
     }
 
+    /**
+     * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in the mode specified.
+     *
+     * @param server The server to repeat on
+     * @param otherFeatureSetsTestMode The mode to run the other FeatureSets
+     * @param firstFeatureSet The first FeatureSet
+     * @param otherFeatureSets The other FeatureSets
+     * @return a RepeatTests instance
+     */
     public static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
-        return MicroProfileActions.repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, Arrays.asList(otherFeatureSets));
+        return RepeatActions.repeat(server, otherFeatureSetsTestMode, ALL_RM_SETS_LIST, firstFeatureSet, Arrays.asList(otherFeatureSets));
     }
+
 }

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/bnd.bnd
@@ -46,6 +46,7 @@ tested.features: mpReactiveStreams-1.0, \
                  mprestclient-3.0,\
                  transportsecurity-1.0,\
                  mpconfig-3.0,\
+                 mpconfig-3.1,\
                  concurrent-2.0,\
                  concurrent-3.0,\
                  jsonb-1.0,\

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/FATSuite.java
@@ -19,7 +19,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.FeatureSet;
 import componenttest.rules.repeater.MicroProfileActions;
-import componenttest.rules.repeater.RepeatActions;
+import componenttest.rules.repeater.RepeatActions.SEVersion;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -30,17 +30,30 @@ import componenttest.rules.repeater.RepeatTests;
                 ReactiveConcurrentWorkTest.class
 })
 public class FATSuite {
-    public static final String MPRS10_ID = MicroProfileActions.MP21_ID + "_" + "MPRS10";
-    public static final String MPRS30_MP60_ID = MicroProfileActions.MP60_ID + "_" + "MPRS30";
+    public static final String MP_REACTIVE_STREAMS_10 = "mpReactiveStreams-1.0";
+    public static final String MP_REACTIVE_STREAMS_30 = "mpReactiveStreams-3.0";
 
-    public static final FeatureSet MPRS10 = MicroProfileActions.MP21.addFeature("mpReactiveStreams-1.0").build(MPRS10_ID);
-    public static final FeatureSet MPRS30_MP60 = MicroProfileActions.MP60.addFeature("mpReactiveStreams-3.0").build(MPRS30_MP60_ID);
+    public static final String MPRSO10_ID = MicroProfileActions.MP21_ID + "_" + "mpRSO10";
+    public static final String MPRSO30_MP50_ID = MicroProfileActions.MP50_ID + "_" + "mpRSO30";
+    public static final String MPRSO30_MP60_ID = MicroProfileActions.MP60_ID + "_" + "mpRSO30";
+    public static final String MPRSO30_MP61_ID = MicroProfileActions.MP61_ID + "_" + "mpRSO30";
+
+    public static final FeatureSet MPRSO10 = MicroProfileActions.MP21.addFeature(MP_REACTIVE_STREAMS_10).build(MPRSO10_ID);
+    public static final FeatureSet MPRSO30_MP50 = MicroProfileActions.MP50.addFeature(MP_REACTIVE_STREAMS_30).setMinJavaLevel(SEVersion.JAVA11).build(MPRSO30_MP50_ID);
+    public static final FeatureSet MPRSO30_MP60 = MicroProfileActions.MP60.addFeature(MP_REACTIVE_STREAMS_30).build(MPRSO30_MP60_ID);
+    public static final FeatureSet MPRSO30_MP61 = MicroProfileActions.MP61.addFeature(MP_REACTIVE_STREAMS_30).build(MPRSO30_MP61_ID);
 
     public static final Set<FeatureSet> ALL;
     static {
         ALL = new HashSet<>(MicroProfileActions.ALL);
-        ALL.add(MPRS10);
-        ALL.add(MPRS30_MP60);
+        ALL.add(MPRSO10);
+        ALL.add(MPRSO30_MP50);
+        ALL.add(MPRSO30_MP60);
+        ALL.add(MPRSO30_MP61);
+    }
+
+    public static RepeatTests repeatDefault(String serverName) {
+        return repeat(serverName, TestMode.LITE, FATSuite.MPRSO30_MP61, FATSuite.MPRSO10, FATSuite.MPRSO30_MP50, FATSuite.MPRSO30_MP60);
     }
 
     /**
@@ -54,6 +67,6 @@ public class FATSuite {
      * @return a RepeatTests instance
      */
     public static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
-        return RepeatActions.repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, otherFeatureSets);
+        return MicroProfileActions.repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, otherFeatureSets);
     }
 }

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/FATSuite.java
@@ -34,23 +34,23 @@ public class FATSuite {
     public static final String MP_REACTIVE_STREAMS_10 = "mpReactiveStreams-1.0";
     public static final String MP_REACTIVE_STREAMS_30 = "mpReactiveStreams-3.0";
 
-    public static final String MP21_RSO10_ID = MicroProfileActions.MP21_ID + "_" + "mpRSO10";
-    public static final String MP50_RSO30_ID = MicroProfileActions.MP50_ID + "_" + "mpRSO30";
-    public static final String MP60_RSO30_ID = MicroProfileActions.MP60_ID + "_" + "mpRSO30";
-    public static final String MP61_RSO30_ID = MicroProfileActions.MP61_ID + "_" + "mpRSO30";
+    public static final String MP21_RS10_ID = MicroProfileActions.MP21_ID + "_" + "RS10";
+    public static final String MP50_RS30_ID = MicroProfileActions.MP50_ID + "_" + "RS30";
+    public static final String MP60_RS30_ID = MicroProfileActions.MP60_ID + "_" + "RS30";
+    public static final String MP61_RS30_ID = MicroProfileActions.MP61_ID + "_" + "RS30";
 
-    public static final FeatureSet MP21_RSO10 = MicroProfileActions.MP21.addFeature(MP_REACTIVE_STREAMS_10).build(MP21_RSO10_ID);
+    public static final FeatureSet MP21_RS10 = MicroProfileActions.MP21.addFeature(MP_REACTIVE_STREAMS_10).build(MP21_RS10_ID);
     //MP50 runs on Java 8 but RSO30 will only run on Java11 or higher
-    public static final FeatureSet MP50_RSO30 = MicroProfileActions.MP50.addFeature(MP_REACTIVE_STREAMS_30).setMinJavaLevel(SEVersion.JAVA11).build(MP50_RSO30_ID);
-    public static final FeatureSet MP60_RSO30 = MicroProfileActions.MP60.addFeature(MP_REACTIVE_STREAMS_30).build(MP60_RSO30_ID);
-    public static final FeatureSet MP61_RSO30 = MicroProfileActions.MP61.addFeature(MP_REACTIVE_STREAMS_30).build(MP61_RSO30_ID);
+    public static final FeatureSet MP50_RS30 = MicroProfileActions.MP50.addFeature(MP_REACTIVE_STREAMS_30).setMinJavaLevel(SEVersion.JAVA11).build(MP50_RS30_ID);
+    public static final FeatureSet MP60_RS30 = MicroProfileActions.MP60.addFeature(MP_REACTIVE_STREAMS_30).build(MP60_RS30_ID);
+    public static final FeatureSet MP61_RS30 = MicroProfileActions.MP61.addFeature(MP_REACTIVE_STREAMS_30).build(MP61_RS30_ID);
 
     //All MicroProfile ReactiveMessaging FeatureSets - must be descending order
-    private static final FeatureSet[] ALL_RSO_SETS_ARRAY = { MP61_RSO30, MP60_RSO30, MP50_RSO30, MP21_RSO10 };
-    private static final List<FeatureSet> ALL = Arrays.asList(ALL_RSO_SETS_ARRAY);
+    private static final FeatureSet[] ALL_RS_SETS_ARRAY = { MP61_RS30, MP60_RS30, MP50_RS30, MP21_RS10 };
+    private static final List<FeatureSet> ALL = Arrays.asList(ALL_RS_SETS_ARRAY);
 
     public static RepeatTests repeatDefault(String serverName) {
-        return repeat(serverName, TestMode.LITE, FATSuite.MP61_RSO30, FATSuite.MP21_RSO10, FATSuite.MP50_RSO30, FATSuite.MP60_RSO30);
+        return repeat(serverName, TestMode.FULL, FATSuite.MP61_RS30, FATSuite.MP60_RS30, FATSuite.MP50_RS30, FATSuite.MP21_RS10);
     }
 
     /**

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/FATSuite.java
@@ -9,8 +9,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.streams.test.suite;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -19,6 +19,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.FeatureSet;
 import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatActions;
 import componenttest.rules.repeater.RepeatActions.SEVersion;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -33,40 +34,35 @@ public class FATSuite {
     public static final String MP_REACTIVE_STREAMS_10 = "mpReactiveStreams-1.0";
     public static final String MP_REACTIVE_STREAMS_30 = "mpReactiveStreams-3.0";
 
-    public static final String MPRSO10_ID = MicroProfileActions.MP21_ID + "_" + "mpRSO10";
-    public static final String MPRSO30_MP50_ID = MicroProfileActions.MP50_ID + "_" + "mpRSO30";
-    public static final String MPRSO30_MP60_ID = MicroProfileActions.MP60_ID + "_" + "mpRSO30";
-    public static final String MPRSO30_MP61_ID = MicroProfileActions.MP61_ID + "_" + "mpRSO30";
+    public static final String MP21_RSO10_ID = MicroProfileActions.MP21_ID + "_" + "mpRSO10";
+    public static final String MP50_RSO30_ID = MicroProfileActions.MP50_ID + "_" + "mpRSO30";
+    public static final String MP60_RSO30_ID = MicroProfileActions.MP60_ID + "_" + "mpRSO30";
+    public static final String MP61_RSO30_ID = MicroProfileActions.MP61_ID + "_" + "mpRSO30";
 
-    public static final FeatureSet MPRSO10 = MicroProfileActions.MP21.addFeature(MP_REACTIVE_STREAMS_10).build(MPRSO10_ID);
-    public static final FeatureSet MPRSO30_MP50 = MicroProfileActions.MP50.addFeature(MP_REACTIVE_STREAMS_30).setMinJavaLevel(SEVersion.JAVA11).build(MPRSO30_MP50_ID);
-    public static final FeatureSet MPRSO30_MP60 = MicroProfileActions.MP60.addFeature(MP_REACTIVE_STREAMS_30).build(MPRSO30_MP60_ID);
-    public static final FeatureSet MPRSO30_MP61 = MicroProfileActions.MP61.addFeature(MP_REACTIVE_STREAMS_30).build(MPRSO30_MP61_ID);
+    public static final FeatureSet MP21_RSO10 = MicroProfileActions.MP21.addFeature(MP_REACTIVE_STREAMS_10).build(MP21_RSO10_ID);
+    //MP50 runs on Java 8 but RSO30 will only run on Java11 or higher
+    public static final FeatureSet MP50_RSO30 = MicroProfileActions.MP50.addFeature(MP_REACTIVE_STREAMS_30).setMinJavaLevel(SEVersion.JAVA11).build(MP50_RSO30_ID);
+    public static final FeatureSet MP60_RSO30 = MicroProfileActions.MP60.addFeature(MP_REACTIVE_STREAMS_30).build(MP60_RSO30_ID);
+    public static final FeatureSet MP61_RSO30 = MicroProfileActions.MP61.addFeature(MP_REACTIVE_STREAMS_30).build(MP61_RSO30_ID);
 
-    public static final Set<FeatureSet> ALL;
-    static {
-        ALL = new HashSet<>(MicroProfileActions.ALL);
-        ALL.add(MPRSO10);
-        ALL.add(MPRSO30_MP50);
-        ALL.add(MPRSO30_MP60);
-        ALL.add(MPRSO30_MP61);
-    }
+    //All MicroProfile ReactiveMessaging FeatureSets - must be descending order
+    private static final FeatureSet[] ALL_RSO_SETS_ARRAY = { MP61_RSO30, MP60_RSO30, MP50_RSO30, MP21_RSO10 };
+    private static final List<FeatureSet> ALL = Arrays.asList(ALL_RSO_SETS_ARRAY);
 
     public static RepeatTests repeatDefault(String serverName) {
-        return repeat(serverName, TestMode.LITE, FATSuite.MPRSO30_MP61, FATSuite.MPRSO10, FATSuite.MPRSO30_MP50, FATSuite.MPRSO30_MP60);
+        return repeat(serverName, TestMode.LITE, FATSuite.MP61_RSO30, FATSuite.MP21_RSO10, FATSuite.MP50_RSO30, FATSuite.MP60_RSO30);
     }
 
     /**
-     * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will always be run in LITE mode.
-     * The others will run in the mode specified.
+     * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in the mode specified.
      *
      * @param server The server to repeat on
-     * @param otherFeatureSetsTestMode The mode to repeate the other FeatureSets in
+     * @param otherFeatureSetsTestMode The mode to run the other FeatureSets
      * @param firstFeatureSet The first FeatureSet
      * @param otherFeatureSets The other FeatureSets
      * @return a RepeatTests instance
      */
     public static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
-        return MicroProfileActions.repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, otherFeatureSets);
+        return RepeatActions.repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, Arrays.asList(otherFeatureSets));
     }
 }

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveConcurrentWorkTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveConcurrentWorkTest.java
@@ -25,15 +25,14 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -57,12 +56,9 @@ public class ReactiveConcurrentWorkTest extends FATServletClient {
 
     public static final String SERVER_NAME = "ReactiveStreamsConcurrentWorkServer";
 
-    @ClassRule
-    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP60);
+    public static RepeatTests r = FATSuite.repeatDefault(SERVER_NAME);
 
     public static final String APP_NAME = "ReactiveConcurrentWorkTest";
-
-    private static final long FIVE_MINS = 5 * 60 * 1000;
 
     @Server(SERVER_NAME)
     public static LibertyServer server;
@@ -76,7 +72,7 @@ public class ReactiveConcurrentWorkTest extends FATServletClient {
         WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackages(true, "com.ibm.ws.microprofile.reactive.streams.test.concurrent");
 
-        ShrinkHelper.exportDropinAppToServer(server, war);
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveJaxRSTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveJaxRSTest.java
@@ -13,15 +13,14 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -45,8 +44,7 @@ public class ReactiveJaxRSTest extends FATServletClient {
 
     public static final String SERVER_NAME = "ReactiveJaxRSTestServer";
 
-    @ClassRule
-    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP60);
+    public static RepeatTests r = FATSuite.repeatDefault(SERVER_NAME);
 
     public static final String APP_NAME = "ReactiveWithJaxRS";
 
@@ -62,7 +60,7 @@ public class ReactiveJaxRSTest extends FATServletClient {
         WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackages(true, "com.ibm.ws.microprofile.reactive.streams.test.jaxrs");
 
-        ShrinkHelper.exportDropinAppToServer(server, war);
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveStreamsContextTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveStreamsContextTest.java
@@ -14,7 +14,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -24,7 +23,6 @@ import com.ibm.ws.microprofile.reactive.streams.test.context.ReactiveStreamsCont
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -47,8 +45,7 @@ public class ReactiveStreamsContextTest extends FATServletClient {
 
     public static final String SERVER_NAME = "ReactiveStreamsContextServer";
 
-    @ClassRule
-    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP60);
+    public static RepeatTests r = FATSuite.repeatDefault(SERVER_NAME);
 
     public static final String APP_NAME = "ReactiveStreamsContextTest";
 

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveStreamsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveStreamsTest.java
@@ -13,16 +13,15 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.ws.microprofile.reactive.streams.test.basic.ReactiveStreamsTestServlet;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -45,8 +44,7 @@ public class ReactiveStreamsTest extends FATServletClient {
 
     public static final String SERVER_NAME = "ReactiveStreamsTestServer";
 
-    @ClassRule
-    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP60);
+    public static RepeatTests r = FATSuite.repeatDefault(SERVER_NAME);
 
     public static final String APP_NAME = "ReactiveStreamsTest";
 
@@ -63,7 +61,7 @@ public class ReactiveStreamsTest extends FATServletClient {
         WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackages(true, "com.ibm.ws.microprofile.reactive.streams.test.basic");
 
-        ShrinkHelper.exportDropinAppToServer(server, war);
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.tx.jta_fat_hibernate/fat/src/com/ibm/ws/tx/jta/fat/hibernate/FATSuite.java
+++ b/dev/com.ibm.ws.tx.jta_fat_hibernate/fat/src/com/ibm/ws/tx/jta/fat/hibernate/FATSuite.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,6 +18,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatActions.SEVersion;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -30,13 +31,15 @@ public class FATSuite {
     public static RepeatTests r = RepeatTests.withoutModification()
                     .andWith(FeatureReplacementAction.EE8_FEATURES().removeFeature("jdbc-4.1").addFeature("jdbc-4.2"))
                     .andWith(FeatureReplacementAction.EE9_FEATURES()) /* test EE9 with jdbc-4.2 */
-                    .andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("jdbc-4.2").addFeature("jdbc-4.3").withMinJavaLevel(11)) /*
-                                                                                                                                             * test EE9+jdbc4.3. Jdbc4.3 reqs. JSE11
-                                                                                                                                             */
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("jdbc-4.2").addFeature("jdbc-4.3").withMinJavaLevel(SEVersion.JAVA11)) /*
+                                                                                                                                                           * test EE9+jdbc4.3.
+                                                                                                                                                           * Jdbc4.3 reqs. JSE11
+                                                                                                                                                           */
                     .andWith(FeatureReplacementAction.EE10_FEATURES()) /* test EE10 with jdbc-4.2 */
-                    .andWith(FeatureReplacementAction.EE10_FEATURES().removeFeature("jdbc-4.2").addFeature("jdbc-4.3").withMinJavaLevel(11)) /*
-                                                                                                                                              * test EE10+jdbc4.3. Jdbc4.3 reqs.
-                                                                                                                                              * JSE11
-                                                                                                                                              */
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().removeFeature("jdbc-4.2").addFeature("jdbc-4.3").withMinJavaLevel(SEVersion.JAVA11)) /*
+                                                                                                                                                            * test EE10+jdbc4.3.
+                                                                                                                                                            * Jdbc4.3 reqs.
+                                                                                                                                                            * JSE11
+                                                                                                                                                            */
     ;
 }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EERepeatActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EERepeatActions.java
@@ -132,7 +132,7 @@ public class EERepeatActions {
 
         // If the firstFeatureSet requires a Java level higher than the one we're running, try to find a suitable replacement so we don't end up not running the test at all in LITE mode
         int currentJavaLevel = JavaInfo.forCurrentVM().majorVersion();
-        if (currentJavaLevel < firstFeatureSet.getEEVersion().getMinJavaLevel()) {
+        if (currentJavaLevel < firstFeatureSet.getMinJavaLevel().majorVersion()) {
 
             List<FeatureSet> allSetsList = new ArrayList<>(Arrays.asList(ALL_SETS_ARRAY));
             Collections.reverse(allSetsList); // Reverse list so newest EE version is first in list
@@ -142,7 +142,7 @@ public class EERepeatActions {
             // Find the newest EE feature set that's in otherFeatureSets and is compatible with the current java version
             Optional<FeatureSet> newestSupportedSet = allSetsList.stream()
                             .filter(s -> candidateFeatureSets.contains(s))
-                            .filter(s -> s.getEEVersion().getMinJavaLevel() <= currentJavaLevel)
+                            .filter(s -> s.getMinJavaLevel().majorVersion() <= currentJavaLevel)
                             .findFirst();
 
             if (newestSupportedSet.isPresent()) {

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EERepeatActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EERepeatActions.java
@@ -14,16 +14,11 @@ package componenttest.rules.repeater;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatActions.EEVersion;
-import componenttest.topology.impl.JavaInfo;
 
 public class EERepeatActions {
 
@@ -46,9 +41,9 @@ public class EERepeatActions {
     //The FeatureSet for the latest EE version
     public static final FeatureSet LATEST = EE10;
 
-    //All EE FeatureSets
-    private static final FeatureSet[] ALL_SETS_ARRAY = { EE6, EE7, EE8, EE9, EE10 };
-    public static final Set<FeatureSet> ALL = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ALL_SETS_ARRAY)));
+    //All EE FeatureSets - must be descending order
+    private static final FeatureSet[] ALL_SETS_ARRAY = { EE10, EE9, EE8, EE7, EE6 };
+    private static final List<FeatureSet> ALL = Collections.unmodifiableList(Arrays.asList(ALL_SETS_ARRAY));
 
     /**
      * Get a RepeatTests instance for all EE versions. The LATEST will be run in LITE mode. The others will be run in FULL.
@@ -57,9 +52,9 @@ public class EERepeatActions {
      * @return        a RepeatTests instance
      */
     public static RepeatTests repeatAll(String server) {
-        Set<FeatureSet> others = new HashSet<>(ALL);
-        others.remove(LATEST);
-        return repeat(server, TestMode.FULL, ALL, LATEST, others);
+        List<FeatureSet> otherFeatureSets = new ArrayList<>(ALL);
+        otherFeatureSets.remove(LATEST);
+        return RepeatActions.repeat(server, TestMode.FULL, ALL, LATEST, otherFeatureSets);
     }
 
     /**
@@ -70,8 +65,8 @@ public class EERepeatActions {
      * @param  otherFeatureSets The other FeatureSets
      * @return                  a RepeatTests instance
      */
-    public static RepeatTests repeat(String server, FeatureSet firstFeatureSet, Set<FeatureSet> otherFeatureSets) {
-        return repeat(server, TestMode.FULL, ALL, firstFeatureSet, otherFeatureSets);
+    public static RepeatTests repeat(String server, FeatureSet firstFeatureSet, List<FeatureSet> otherFeatureSets) {
+        return RepeatActions.repeat(server, TestMode.FULL, ALL, firstFeatureSet, otherFeatureSets);
     }
 
     /**
@@ -113,44 +108,7 @@ public class EERepeatActions {
      * @return                          A RepeatTests instance
      */
     public static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
-        return repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, Arrays.asList(otherFeatureSets));
+        return RepeatActions.repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, Arrays.asList(otherFeatureSets));
     }
 
-    /**
-     * As {@link RepeatActions#repeat(String, TestMode, Set, FeatureSet, Set)} except that if {@code firstFeatureSet} isn't compatible with the current Java version, we try to
-     * replace it with the newest set from {@code otherFeatureSets} that is compatible.
-     *
-     * @param  server                   The server to repeat on
-     * @param  otherFeatureSetsTestMode The test mode to run the otherFeatureSets
-     * @param  allFeatureSets           All known FeatureSets. The features not in the current FeatureSet are removed from the repeat
-     * @param  firstFeatureSet          The first FeatureSet to repeat with. This is run in LITE mode.
-     * @param  otherFeatureSets         The other FeatureSets to repeat with. These are in the mode specified by otherFeatureSetsTestMode
-     * @return                          A RepeatTests instance
-     */
-    private static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, Set<FeatureSet> allFeatureSets, FeatureSet firstFeatureSet,
-                                      Collection<FeatureSet> otherFeatureSets) {
-
-        // If the firstFeatureSet requires a Java level higher than the one we're running, try to find a suitable replacement so we don't end up not running the test at all in LITE mode
-        int currentJavaLevel = JavaInfo.forCurrentVM().majorVersion();
-        if (currentJavaLevel < firstFeatureSet.getMinJavaLevel().majorVersion()) {
-
-            List<FeatureSet> allSetsList = new ArrayList<>(Arrays.asList(ALL_SETS_ARRAY));
-            Collections.reverse(allSetsList); // Reverse list so newest EE version is first in list
-
-            Collection<FeatureSet> candidateFeatureSets = otherFeatureSets;
-
-            // Find the newest EE feature set that's in otherFeatureSets and is compatible with the current java version
-            Optional<FeatureSet> newestSupportedSet = allSetsList.stream()
-                            .filter(s -> candidateFeatureSets.contains(s))
-                            .filter(s -> s.getMinJavaLevel().majorVersion() <= currentJavaLevel)
-                            .findFirst();
-
-            if (newestSupportedSet.isPresent()) {
-                firstFeatureSet = newestSupportedSet.get();
-                otherFeatureSets = new ArrayList<>(otherFeatureSets);
-                otherFeatureSets.remove(newestSupportedSet.get());
-            }
-        }
-        return RepeatActions.repeat(server, otherFeatureSetsTestMode, allFeatureSets, firstFeatureSet, otherFeatureSets);
-    }
 }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
@@ -43,6 +43,7 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.custom.junit.runner.TestModeFilter;
+import componenttest.rules.repeater.RepeatActions.SEVersion;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyClientFactory;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -147,7 +148,7 @@ public class FeatureReplacementAction implements RepeatTestAction {
     }
 
     private boolean forceAddFeatures = true;
-    private int minJavaLevel = 8;
+    private SEVersion minJavaLevel = SEVersion.JAVA8;
     protected String currentID = null;
     private final Set<String> optionsToAdd = new HashSet<String>();
     private final Set<File> optionFilesCreated = new HashSet<File>();
@@ -299,12 +300,12 @@ public class FeatureReplacementAction implements RepeatTestAction {
     /**
      * Defines a minimum java level in order for this RepeatTestAction to be enabled
      */
-    public FeatureReplacementAction withMinJavaLevel(int javaLevel) {
+    public FeatureReplacementAction withMinJavaLevel(SEVersion javaLevel) {
         this.minJavaLevel = javaLevel;
         return this;
     }
 
-    public int getMinJavaLevel() {
+    public SEVersion getMinJavaLevel() {
         return this.minJavaLevel;
     }
 
@@ -435,7 +436,7 @@ public class FeatureReplacementAction implements RepeatTestAction {
 
     @Override
     public boolean isEnabled() {
-        if (JavaInfo.forCurrentVM().majorVersion() < minJavaLevel) {
+        if (JavaInfo.forCurrentVM().majorVersion() < minJavaLevel.majorVersion()) {
             Log.info(c, "isEnabled", "Skipping action '" + toString() + "' because the java level is too low.");
             return false;
         }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureSet.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureSet.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package componenttest.rules.repeater;
 
@@ -17,6 +14,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import componenttest.rules.repeater.RepeatActions.EEVersion;
+import componenttest.rules.repeater.RepeatActions.SEVersion;
 
 /**
  * An immutable set of features with an ID
@@ -25,6 +23,7 @@ public class FeatureSet {
     private final String id;
     private final Set<String> features;
     private final EEVersion eeVersion;
+    private final SEVersion minJavaLevel;
 
     /**
      * Create a new FeatureSet with the given ID and set of features
@@ -34,11 +33,24 @@ public class FeatureSet {
      * @param eeVersion The EE Version that the features are based on. May be null.
      */
     public FeatureSet(String id, Set<String> features, EEVersion eeVersion) {
+        this(id, features, eeVersion, eeVersion.getMinJavaLevel());
+    }
+
+    /**
+     * Create a new FeatureSet with the given ID and set of features
+     *
+     * @param id           The ID of the FeatureSet. Must be unique.
+     * @param features     The features to include in the set
+     * @param eeVersion    The EE Version that the features are based on. May be null.
+     * @param minJavaLevel The minimum Java SE Version which this FeatureSet can run on.
+     */
+    public FeatureSet(String id, Set<String> features, EEVersion eeVersion, SEVersion minJavaLevel) {
         if (id == null)
             throw new NullPointerException();
         this.id = id;
         this.features = Collections.unmodifiableSet(new HashSet<>(features));
         this.eeVersion = eeVersion;
+        this.minJavaLevel = minJavaLevel;
     }
 
     /**
@@ -69,6 +81,15 @@ public class FeatureSet {
     }
 
     /**
+     * Get the minimum Java SE Version which this FeatureSet can run on.
+     *
+     * @return the minimum Java SE Version
+     */
+    public SEVersion getMinJavaLevel() {
+        return this.minJavaLevel;
+    }
+
+    /**
      * Create a new FeatureSetBuilder based on this FeatureSet
      *
      * @param  feature the feature to add to the set
@@ -89,6 +110,18 @@ public class FeatureSet {
     public FeatureSetBuilder removeFeature(String feature) {
         FeatureSetBuilder builder = new FeatureSetBuilder(this);
         builder.removeFeature(feature);
+        return builder;
+    }
+
+    /**
+     * Create a new FeatureSetBuilder based on this FeatureSet but with a different min java level.
+     *
+     * @param  minJavaLevel the minimum Java SE Version
+     * @return              a FeatureSetBuilder
+     */
+    public FeatureSetBuilder setMinJavaLevel(SEVersion javaLevel) {
+        FeatureSetBuilder builder = new FeatureSetBuilder(this);
+        builder.setMinJavaLevel(javaLevel);
         return builder;
     }
 
@@ -130,6 +163,7 @@ public class FeatureSet {
 
         private final HashSet<String> features;
         private final EEVersion eeVersion;
+        private SEVersion minJavaLevel;
 
         /**
          * Create a new builder, starting with the same set of features from an existing FeatureSet
@@ -137,26 +171,20 @@ public class FeatureSet {
          * @param featureSet a FeatureSet to copy the features from
          */
         public FeatureSetBuilder(FeatureSet featureSet) {
-            this(featureSet.getFeatures(), featureSet.getEEVersion());
+            this(featureSet.getFeatures(), featureSet.getEEVersion(), featureSet.getMinJavaLevel());
         }
 
         /**
          * Create a new builder, starting with the a given set of features
          *
-         * @param features  a set of features to initially add
-         * @param eeVersion the EE version these features are based on
+         * @param features     a set of features to initially add
+         * @param eeVersion    the EE version these features are based on
+         * @param minJavaLevel the minimum Java SE Version which this FeatureSet can run on.
          */
-        public FeatureSetBuilder(Set<String> features, EEVersion eeVersion) {
+        public FeatureSetBuilder(Set<String> features, EEVersion eeVersion, SEVersion minJavaLevel) {
             this.features = new HashSet<>(features);
             this.eeVersion = eeVersion;
-        }
-
-        /**
-         * Create a new builder, initially with no features.
-         */
-        public FeatureSetBuilder(EEVersion eeVersion) {
-            this.features = new HashSet<>();
-            this.eeVersion = eeVersion;
+            this.minJavaLevel = minJavaLevel;
         }
 
         /**
@@ -180,13 +208,23 @@ public class FeatureSet {
         }
 
         /**
+         * Set the minimum Java SE Version which this FeatureSet can run on.
+         *
+         * @param minJavaLevel the minimum Java SE Version
+         */
+        public FeatureSetBuilder setMinJavaLevel(SEVersion minJavaLevel) {
+            this.minJavaLevel = minJavaLevel;
+            return this;
+        }
+
+        /**
          * Create a new FeatureSet with the given ID and the features currently in the builder
          *
          * @param  id the ID of the new FeatureSet. Must be unique.
          * @return    the new FeatureSet
          */
         public FeatureSet build(String id) {
-            return new FeatureSet(id, this.features, this.eeVersion);
+            return new FeatureSet(id, this.features, this.eeVersion, this.minJavaLevel);
         }
     }
 

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE10Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE10Action.java
@@ -27,6 +27,7 @@ import com.ibm.ws.fat.util.SharedServer;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.rules.repeater.RepeatActions.SEVersion;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.FileUtils;
@@ -130,7 +131,7 @@ public class JakartaEE10Action extends FeatureReplacementAction {
         removeFeatures(JakartaEE9Action.EE9_FEATURE_SET);
         removeFeatures(JakartaEE11Action.EE11_FEATURE_SET);
         forceAddFeatures(false);
-        withMinJavaLevel(11);
+        withMinJavaLevel(SEVersion.JAVA11);
         withID(ID);
     }
 
@@ -182,7 +183,7 @@ public class JakartaEE10Action extends FeatureReplacementAction {
     }
 
     @Override
-    public JakartaEE10Action withMinJavaLevel(int javaLevel) {
+    public JakartaEE10Action withMinJavaLevel(SEVersion javaLevel) {
         return (JakartaEE10Action) super.withMinJavaLevel(javaLevel);
     }
 

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE11Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE11Action.java
@@ -24,6 +24,7 @@ import com.ibm.ws.fat.util.SharedServer;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.rules.repeater.RepeatActions.SEVersion;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.FileUtils;
@@ -124,7 +125,7 @@ public class JakartaEE11Action extends FeatureReplacementAction {
         removeFeatures(JakartaEE9Action.EE9_FEATURE_SET);
         removeFeatures(JakartaEE10Action.EE10_FEATURE_SET);
         forceAddFeatures(false);
-        withMinJavaLevel(17);
+        withMinJavaLevel(SEVersion.JAVA17);
         withID(ID);
     }
 
@@ -176,7 +177,7 @@ public class JakartaEE11Action extends FeatureReplacementAction {
     }
 
     @Override
-    public JakartaEE11Action withMinJavaLevel(int javaLevel) {
+    public JakartaEE11Action withMinJavaLevel(SEVersion javaLevel) {
         return (JakartaEE11Action) super.withMinJavaLevel(javaLevel);
     }
 

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
@@ -35,6 +35,7 @@ import com.ibm.ws.fat.util.SharedServer;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.rules.repeater.RepeatActions.SEVersion;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.FileUtils;
@@ -192,7 +193,7 @@ public class JakartaEE9Action extends FeatureReplacementAction {
     }
 
     @Override
-    public JakartaEE9Action withMinJavaLevel(int javaLevel) {
+    public JakartaEE9Action withMinJavaLevel(SEVersion javaLevel) {
         return (JakartaEE9Action) super.withMinJavaLevel(javaLevel);
     }
 

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
@@ -12,18 +12,14 @@
  *******************************************************************************/
 package componenttest.rules.repeater;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatActions.EEVersion;
-import componenttest.topology.impl.JavaInfo;
 
 public class MicroProfileActions {
 
@@ -297,9 +293,9 @@ public class MicroProfileActions {
     public static final FeatureSet MP60 = new FeatureSet(MP60_ID, MP60_FEATURE_SET, EEVersion.EE10);
     public static final FeatureSet MP61 = new FeatureSet(MP61_ID, MP61_FEATURE_SET, EEVersion.EE10);
 
-    //All MicroProfile FeatureSets, needs to be in order for repeat(String, TestMode, Set, FeatureSet, Set)
-    private static final FeatureSet[] ALL_SETS_ARRAY = { MP10, MP12, MP13, MP14, MP20, MP21, MP22, MP30, MP32, MP33, MP40, MP41, MP50, MP60, MP61 };
-    public static final Set<FeatureSet> ALL = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ALL_SETS_ARRAY)));
+    //All MicroProfile FeatureSets - must be descending order
+    private static final FeatureSet[] ALL_SETS_ARRAY = { MP61, MP60, MP50, MP41, MP40, MP33, MP32, MP30, MP22, MP21, MP20, MP14, MP13, MP12, MP10 };
+    public static final List<FeatureSet> ALL = Collections.unmodifiableList(Arrays.asList(ALL_SETS_ARRAY));
 
     //TODO: These feature sets are only used by the EE Compatibility Tests and don't make sense in other contexts. We should move them to those tests.
 
@@ -334,8 +330,8 @@ public class MicroProfileActions {
     public static final FeatureSet MP_STANDALONE10 = new FeatureSet(STANDALONE10_ID, STANDALONE10_FEATURE_SET, EEVersion.EE10);
 
     //All MicroProfile Standalone FeatureSets
-    private static final FeatureSet[] ALL_STANDALONE_SETS_ARRAY = { MP_STANDALONE8, MP_STANDALONE9, MP_STANDALONE10 };
-    public static final Set<FeatureSet> STANDALONE_ALL = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ALL_STANDALONE_SETS_ARRAY)));
+    private static final FeatureSet[] ALL_STANDALONE_SETS_ARRAY = { MP_STANDALONE10, MP_STANDALONE9, MP_STANDALONE8 };
+    public static final List<FeatureSet> STANDALONE_ALL = Collections.unmodifiableList(Arrays.asList(ALL_STANDALONE_SETS_ARRAY));
 
     /**
      * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in FULL.
@@ -345,8 +341,8 @@ public class MicroProfileActions {
      * @param  otherFeatureSets The other FeatureSets
      * @return                  a RepeatTests instance
      */
-    public static RepeatTests repeat(String server, FeatureSet firstFeatureSet, Set<FeatureSet> otherFeatureSets) {
-        return repeat(server, TestMode.FULL, ALL, firstFeatureSet, otherFeatureSets);
+    public static RepeatTests repeat(String server, FeatureSet firstFeatureSet, List<FeatureSet> otherFeatureSets) {
+        return RepeatActions.repeat(server, TestMode.FULL, ALL, firstFeatureSet, otherFeatureSets);
     }
 
     /**
@@ -390,69 +386,6 @@ public class MicroProfileActions {
      * @return                          A RepeatTests instance
      */
     public static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
-        return repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, otherFeatureSets);
+        return RepeatActions.repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, Arrays.asList(otherFeatureSets));
     }
-
-    /**
-     * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in the mode specified by otherFeatureSetsTestMode
-     * Usage: The following example will repeat the tests using MicroProfile versions 1.2, 1.3, 1.4, 3.3 and 4.0.
-     * 4.0 will be in LITE mode, the others in FULL mode.
-     *
-     * <pre>
-     * <code>
-     * &#64;ClassRule
-     * public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, TestMode.FULL, MicroProfileActions.MP40, MicroProfileActions.MP12,
-     *                                    MicroProfileActions.MP13, MicroProfileActions.MP14, MicroProfileActions.MP33);
-     * </code>
-     * </pre>
-     *
-     * @param  server                   The server to repeat on
-     * @param  otherFeatureSetsTestMode The test mode to run the otherFeatureSets
-     * @param  allFeatureSets           All known FeatureSets. The features not in the current FeatureSet are removed from the repeat
-     * @param  firstFeatureSet          The first FeatureSet to repeat with. This is run in LITE mode.
-     * @param  otherFeatureSets         The other FeatureSets to repeat with. These are in the mode specified by otherFeatureSetsTestMode
-     * @return                          A RepeatTests instance
-     */
-    public static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, Set<FeatureSet> allFeatureSets, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
-        return repeat(server, otherFeatureSetsTestMode, allFeatureSets, firstFeatureSet, Arrays.asList(otherFeatureSets));
-    }
-
-    /**
-     * As {@link RepeatActions#repeat(String, TestMode, Set, FeatureSet, Set)} except that if {@code firstFeatureSet} isn't compatible with the current Java version, we try to
-     * replace it with the newest set from {@code otherFeatureSets} that is compatible.
-     *
-     * @param  server                   The server to repeat on
-     * @param  otherFeatureSetsTestMode The test mode to run the otherFeatureSets
-     * @param  allFeatureSets           All known FeatureSets. The features not in the current FeatureSet are removed from the repeat
-     * @param  firstFeatureSet          The first FeatureSet to repeat with. This is run in LITE mode.
-     * @param  otherFeatureSets         The other FeatureSets to repeat with. These are in the mode specified by otherFeatureSetsTestMode
-     * @return                          A RepeatTests instance
-     */
-    public static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, Set<FeatureSet> allFeatureSets, FeatureSet firstFeatureSet,
-                                     Collection<FeatureSet> otherFeatureSets) {
-
-        // If the firstFeatureSet requires a Java level higher than the one we're running, try to find a suitable replacement so we don't end up not running the test at all in LITE mode
-        int currentJavaLevel = JavaInfo.forCurrentVM().majorVersion();
-        if (currentJavaLevel < firstFeatureSet.getMinJavaLevel().majorVersion()) {
-
-            List<FeatureSet> allSetsList = new ArrayList<>(Arrays.asList(ALL_SETS_ARRAY));
-            Collections.reverse(allSetsList); // Reverse list so newest MP version is first in list
-
-            Collection<FeatureSet> candidateFeatureSets = otherFeatureSets;
-
-            // Find the newest MP feature set that's in otherFeatureSets and is compatible with the current java version
-            Optional<FeatureSet> newestSupportedSet = allSetsList.stream()
-                            .filter(s -> candidateFeatureSets.contains(s))
-                            .filter(s -> s.getMinJavaLevel().majorVersion() <= currentJavaLevel)
-                            .findFirst();
-
-            if (newestSupportedSet.isPresent()) {
-                firstFeatureSet = newestSupportedSet.get();
-                otherFeatureSets = new ArrayList<>(otherFeatureSets);
-                otherFeatureSets.remove(newestSupportedSet.get());
-            }
-        }
-        return RepeatActions.repeat(server, otherFeatureSetsTestMode, allFeatureSets, firstFeatureSet, otherFeatureSets);
-    }
-
 }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
@@ -390,7 +390,31 @@ public class MicroProfileActions {
      * @return                          A RepeatTests instance
      */
     public static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
-        return repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, Arrays.asList(otherFeatureSets));
+        return repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, otherFeatureSets);
+    }
+
+    /**
+     * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in the mode specified by otherFeatureSetsTestMode
+     * Usage: The following example will repeat the tests using MicroProfile versions 1.2, 1.3, 1.4, 3.3 and 4.0.
+     * 4.0 will be in LITE mode, the others in FULL mode.
+     *
+     * <pre>
+     * <code>
+     * &#64;ClassRule
+     * public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, TestMode.FULL, MicroProfileActions.MP40, MicroProfileActions.MP12,
+     *                                    MicroProfileActions.MP13, MicroProfileActions.MP14, MicroProfileActions.MP33);
+     * </code>
+     * </pre>
+     *
+     * @param  server                   The server to repeat on
+     * @param  otherFeatureSetsTestMode The test mode to run the otherFeatureSets
+     * @param  allFeatureSets           All known FeatureSets. The features not in the current FeatureSet are removed from the repeat
+     * @param  firstFeatureSet          The first FeatureSet to repeat with. This is run in LITE mode.
+     * @param  otherFeatureSets         The other FeatureSets to repeat with. These are in the mode specified by otherFeatureSetsTestMode
+     * @return                          A RepeatTests instance
+     */
+    public static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, Set<FeatureSet> allFeatureSets, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
+        return repeat(server, otherFeatureSetsTestMode, allFeatureSets, firstFeatureSet, Arrays.asList(otherFeatureSets));
     }
 
     /**
@@ -409,7 +433,7 @@ public class MicroProfileActions {
 
         // If the firstFeatureSet requires a Java level higher than the one we're running, try to find a suitable replacement so we don't end up not running the test at all in LITE mode
         int currentJavaLevel = JavaInfo.forCurrentVM().majorVersion();
-        if (currentJavaLevel < firstFeatureSet.getEEVersion().getMinJavaLevel()) {
+        if (currentJavaLevel < firstFeatureSet.getMinJavaLevel().majorVersion()) {
 
             List<FeatureSet> allSetsList = new ArrayList<>(Arrays.asList(ALL_SETS_ARRAY));
             Collections.reverse(allSetsList); // Reverse list so newest MP version is first in list
@@ -419,7 +443,7 @@ public class MicroProfileActions {
             // Find the newest MP feature set that's in otherFeatureSets and is compatible with the current java version
             Optional<FeatureSet> newestSupportedSet = allSetsList.stream()
                             .filter(s -> candidateFeatureSets.contains(s))
-                            .filter(s -> s.getEEVersion().getMinJavaLevel() <= currentJavaLevel)
+                            .filter(s -> s.getMinJavaLevel().majorVersion() <= currentJavaLevel)
                             .findFirst();
 
             if (newestSupportedSet.isPresent()) {

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatActions.java
@@ -21,16 +21,31 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 
 public class RepeatActions {
 
-    public static enum EEVersion {
-        EE6(8), EE7(8), EE8(8), EE9(8), EE10(11), EE11(17);
+    public static enum SEVersion {
+        JAVA8(8), JAVA11(11), JAVA17(17), JAVA21(21);
 
-        private EEVersion(int minJavaLevel) {
+        private SEVersion(int majorVersion) {
+            this.majorVersion = majorVersion;
+        }
+
+        private final int majorVersion;
+
+        //minor and micro versions could be added in future
+        public int majorVersion() {
+            return majorVersion;
+        }
+    }
+
+    public static enum EEVersion {
+        EE6(SEVersion.JAVA8), EE7(SEVersion.JAVA8), EE8(SEVersion.JAVA8), EE9(SEVersion.JAVA8), EE10(SEVersion.JAVA11), EE11(SEVersion.JAVA17);
+
+        private EEVersion(SEVersion minJavaLevel) {
             this.minJavaLevel = minJavaLevel;
         }
 
-        private final int minJavaLevel;
+        private final SEVersion minJavaLevel;
 
-        public int getMinJavaLevel() {
+        SEVersion getMinJavaLevel() {
             return minJavaLevel;
         }
     }
@@ -100,6 +115,7 @@ public class RepeatActions {
         } else {
             action = new FeatureReplacementAction();
         }
+        action.withMinJavaLevel(featureSet.getMinJavaLevel());
 
         //add all the features from the primary FeatureSet
         action.addFeatures(featureSet.getFeatures());

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatActions.java
@@ -14,7 +14,6 @@ package componenttest.rules.repeater;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -122,7 +121,7 @@ public class RepeatActions {
      * @param  testMode       The test mode to run the FeatureSet
      * @return                A FeatureReplacementAction instance
      */
-    public static FeatureReplacementAction forFeatureSet(Collection<FeatureSet> allFeatureSets, FeatureSet featureSet, String server, TestMode testMode) {
+    public static FeatureReplacementAction forFeatureSet(List<FeatureSet> allFeatureSets, FeatureSet featureSet, String server, TestMode testMode) {
         //First create a base FeatureReplacementAction
         //Need to use a FeatureReplacementAction which is specific to the EE version because it also contains the transformation code
         FeatureReplacementAction action = null;

--- a/dev/io.openliberty.microprofile.internal_fat/fat/src/io/openliberty/microprofile/internal/test/suite/BasicJAXRSCDITest.java
+++ b/dev/io.openliberty.microprofile.internal_fat/fat/src/io/openliberty/microprofile/internal/test/suite/BasicJAXRSCDITest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,8 +20,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -50,7 +50,7 @@ public class BasicJAXRSCDITest {
 
     //MP41 will be run in LITE mode. The others will be run in FULL.
     private static RepeatTests repeatAll() {
-        Set<FeatureSet> others = new HashSet<>(MicroProfileActions.ALL);
+        List<FeatureSet> others = new ArrayList<>(MicroProfileActions.ALL);
         others.remove(MicroProfileActions.MP41);
         return MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP41, others);
     }

--- a/dev/io.openliberty.microprofile.internal_fat/fat/src/io/openliberty/microprofile/internal/test/suite/ConfiguredJAXRSCDITest.java
+++ b/dev/io.openliberty.microprofile.internal_fat/fat/src/io/openliberty/microprofile/internal/test/suite/ConfiguredJAXRSCDITest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,8 +20,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -52,7 +52,7 @@ public class ConfiguredJAXRSCDITest {
 
     //Get a RepeatTests instance for all MP versions that have mpConfig. MP41 will be run in LITE mode. The others will be run in FULL.
     public static RepeatTests repeatAllWithConfig() {
-        Set<FeatureSet> others = new HashSet<>(MicroProfileActions.ALL);
+        List<FeatureSet> others = new ArrayList<>(MicroProfileActions.ALL);
         others.remove(MicroProfileActions.MP41);
         others.remove(MicroProfileActions.MP10); //Does not contain mpConfig
         return MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP41, others);


### PR DESCRIPTION
The MP Reactive Streams Operators FAT needs to repeat with mpReactiveStream-3.0. That feature is compatible with EE9 but only when running on Java 11 or higher. Previously the min java level was tied to the EEVersion. This PR allows for that to be overridden.

- Create `SEVersion` enum and use it throughout
- Add minJavaLevel to FeatureSet
- Move the code which checks the JavaSE version for the "first FeatureSet" into RepeatActions to make it common
- Add repeats to MP Reactive Streams Operators FAT which require setting of a min Java level
