### PR TITLE
Remove MP5 repeat to avoid Java8 issue

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/FATSuite.java
@@ -31,18 +31,15 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
     public static final String MPRS10_ID = MicroProfileActions.MP21_ID + "_" + "MPRS10";
-    public static final String MPRS30_MP50_ID = MicroProfileActions.MP50_ID + "_" + "MPRS30";
     public static final String MPRS30_MP60_ID = MicroProfileActions.MP60_ID + "_" + "MPRS30";
 
     public static final FeatureSet MPRS10 = MicroProfileActions.MP21.addFeature("mpReactiveStreams-1.0").build(MPRS10_ID);
-    public static final FeatureSet MPRS30_MP50 = MicroProfileActions.MP50.addFeature("mpReactiveStreams-3.0").build(MPRS30_MP50_ID);
     public static final FeatureSet MPRS30_MP60 = MicroProfileActions.MP60.addFeature("mpReactiveStreams-3.0").build(MPRS30_MP60_ID);
 
     public static final Set<FeatureSet> ALL;
     static {
         ALL = new HashSet<>(MicroProfileActions.ALL);
         ALL.add(MPRS10);
-        ALL.add(MPRS30_MP50);
         ALL.add(MPRS30_MP60);
     }
 

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveConcurrentWorkTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveConcurrentWorkTest.java
@@ -58,7 +58,7 @@ public class ReactiveConcurrentWorkTest extends FATServletClient {
     public static final String SERVER_NAME = "ReactiveStreamsConcurrentWorkServer";
 
     @ClassRule
-    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP50, FATSuite.MPRS30_MP60);
+    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP60);
 
     public static final String APP_NAME = "ReactiveConcurrentWorkTest";
 

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveJaxRSTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveJaxRSTest.java
@@ -46,7 +46,7 @@ public class ReactiveJaxRSTest extends FATServletClient {
     public static final String SERVER_NAME = "ReactiveJaxRSTestServer";
 
     @ClassRule
-    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP50, FATSuite.MPRS30_MP60);
+    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP60);
 
     public static final String APP_NAME = "ReactiveWithJaxRS";
 

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveStreamsContextTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveStreamsContextTest.java
@@ -48,7 +48,7 @@ public class ReactiveStreamsContextTest extends FATServletClient {
     public static final String SERVER_NAME = "ReactiveStreamsContextServer";
 
     @ClassRule
-    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP50, FATSuite.MPRS30_MP60);
+    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP60);
 
     public static final String APP_NAME = "ReactiveStreamsContextTest";
 

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveStreamsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/fat/src/com/ibm/ws/microprofile/reactive/streams/test/suite/ReactiveStreamsTest.java
@@ -46,7 +46,7 @@ public class ReactiveStreamsTest extends FATServletClient {
     public static final String SERVER_NAME = "ReactiveStreamsTestServer";
 
     @ClassRule
-    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP50, FATSuite.MPRS30_MP60);
+    public static RepeatTests r = FATSuite.repeat(SERVER_NAME, TestMode.LITE, FATSuite.MPRS10, FATSuite.MPRS30_MP60);
 
     public static final String APP_NAME = "ReactiveStreamsTest";
 


### PR DESCRIPTION
This is a very simple fix to avoid running mpReactiveStreams-3.0 on Java 8. The feature is compatible with MP50 but only when run on Java 11 or higher.

#build