### PR TITLE
Add tokenRequestOriginHeader configuration for OIDC clients

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
@@ -297,4 +297,4 @@ pkceCodeChallengeMethod.plain=Plain
 pkceCodeChallengeMethod.S256=S256
 
 tokenRequestOriginHeader=Token request origin header
-tokenRequestOriginHeader.desc=Specifies the value to use in the Origin HTTP header that is included in the HTTP POST request to the token endpoint of the OpenID Connect provider. If not specified, an Origin HTTP header will not be included in the request.
+tokenRequestOriginHeader.desc=Specifies the value to use in the Origin HTTP header that is included in the HTTP POST request to the token endpoint of the OpenID Connect provider. If not specified, an Origin HTTP header is not included in the request.

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
@@ -295,3 +295,6 @@ pkceCodeChallengeMethod.desc=Specifies the challenge method to use for Proof Key
 pkceCodeChallengeMethod.disabled=Disabled
 pkceCodeChallengeMethod.plain=Plain
 pkceCodeChallengeMethod.S256=S256
+
+tokenRequestOriginHeader=Token request origin header
+tokenRequestOriginHeader.desc=Specifies the value to use in the Origin HTTP header that is included in the HTTP POST request to the token endpoint of the OpenID Connect provider. If not specified, an Origin HTTP header will not be included in the request.

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
@@ -162,6 +162,7 @@
                 <Option label="%pkceCodeChallengeMethod.plain" value="plain" />
                 <Option label="%pkceCodeChallengeMethod.S256" value="S256" />
          </AD>
+         <AD id="tokenRequestOriginHeader" name="%tokenRequestOriginHeader" description="%tokenRequestOriginHeader.desc" required="false" type="String" ibm:beta="true" />
      </OCD>
 
     <Designate factoryPid="com.ibm.ws.security.openidconnect.client.oidcClientConfig">

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -175,6 +175,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     public static final String CFG_KEY_ACCESS_TOKEN_CACHE_ENABLED = "accessTokenCacheEnabled";
     public static final String CFG_KEY_ACCESS_TOKEN_CACHE_TIMEOUT = "accessTokenCacheTimeout";
     public static final String CFG_KEY_PKCE_CODE_CHALLENGE_METHOD = "pkceCodeChallengeMethod";
+    public static final String CFG_KEY_TOKEN_REQUEST_ORIGIN_HEADER = "tokenRequestOriginHeader";
 
     public static final String OPDISCOVERY_AUTHZ_EP_URL = "authorization_endpoint";
     public static final String OPDISCOVERY_TOKEN_EP_URL = "token_endpoint";
@@ -273,6 +274,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     private boolean accessTokenCacheEnabled = true;
     private long accessTokenCacheTimeout = 1000 * 60 * 5;
     private String pkceCodeChallengeMethod = null;
+    private String tokenRequestOriginHeader = null;
 
     private String oidcClientCookieName;
     private boolean authnSessionDisabled;
@@ -554,6 +556,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         accessTokenCacheEnabled = configUtils.getBooleanConfigAttribute(props, CFG_KEY_ACCESS_TOKEN_CACHE_ENABLED, accessTokenCacheEnabled);
         accessTokenCacheTimeout = configUtils.getLongConfigAttribute(props, CFG_KEY_ACCESS_TOKEN_CACHE_TIMEOUT, accessTokenCacheTimeout);
         pkceCodeChallengeMethod = configUtils.getConfigAttribute(props, CFG_KEY_PKCE_CODE_CHALLENGE_METHOD);
+        tokenRequestOriginHeader = configUtils.getConfigAttribute(props, CFG_KEY_TOKEN_REQUEST_ORIGIN_HEADER);
         // TODO - 3Q16: Check the validationEndpointUrl to make sure it is valid
         // before continuing to process this config
         // checkValidationEndpointUrl();
@@ -633,6 +636,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
             Tr.debug(tc, "accessTokenCacheEnabled:" + accessTokenCacheEnabled);
             Tr.debug(tc, "accessTokenCacheTimeout:" + accessTokenCacheTimeout);
             Tr.debug(tc, "pkceCodeChallengeMethod:" + pkceCodeChallengeMethod);
+            Tr.debug(tc, "tokenRequestOriginHeader:" + tokenRequestOriginHeader);
         }
     }
 
@@ -1931,6 +1935,11 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     @Override
     public String getPkceCodeChallengeMethod() {
         return pkceCodeChallengeMethod;
+    }
+
+    @Override
+    public String getTokenRequestOriginHeader() {
+        return tokenRequestOriginHeader;
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandler.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandler.java
@@ -161,6 +161,7 @@ public class AuthorizationCodeHandler {
         tokenRequestBuilder.useSystemPropertiesForHttpClientConnections(clientConfig.getUseSystemPropertiesForHttpClientConnections());
         String tokenEndpointAuthMethod = clientConfig.getTokenEndpointAuthMethod();
         tokenRequestBuilder.authMethod(tokenEndpointAuthMethod);
+        tokenRequestBuilder.originHeaderValue(clientConfig.getTokenRequestOriginHeader());
         setAuthMethodSpecificSettings(tokenRequestBuilder, tokenEndpointAuthMethod);
 
         TokenRequestor tokenRequestor = tokenRequestBuilder.build();

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ConvergedClientConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ConvergedClientConfig.java
@@ -140,4 +140,6 @@ public interface ConvergedClientConfig extends JwtConsumerConfig {
 
     public String getPkceCodeChallengeMethod();
 
+    public String getTokenRequestOriginHeader();
+
 }

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
@@ -297,4 +297,4 @@ pkceCodeChallengeMethod.plain=Plain
 pkceCodeChallengeMethod.S256=S256
 
 tokenRequestOriginHeader=Token request origin header
-tokenRequestOriginHeader.desc=Specifies the value to use in the Origin HTTP header that is included in the HTTP POST request to the token endpoint of the OpenID Connect provider. If not specified, an Origin HTTP header will not be included in the request.
+tokenRequestOriginHeader.desc=Specifies the value to use in the Origin HTTP header that is included in the HTTP POST request to the token endpoint of the OpenID Connect provider. If not specified, an Origin HTTP header is not included in the request.

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
@@ -295,3 +295,6 @@ pkceCodeChallengeMethod.desc=Specifies the code challenge method to use for Proo
 pkceCodeChallengeMethod.disabled=Disabled
 pkceCodeChallengeMethod.plain=Plain
 pkceCodeChallengeMethod.S256=S256
+
+tokenRequestOriginHeader=Token request origin header
+tokenRequestOriginHeader.desc=Specifies the value to use in the Origin HTTP header that is included in the HTTP POST request to the token endpoint of the OpenID Connect provider. If not specified, an Origin HTTP header will not be included in the request.

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
@@ -463,6 +463,7 @@
             <Option label="%pkceCodeChallengeMethod.plain" value="plain" />
             <Option label="%pkceCodeChallengeMethod.S256" value="S256" />
         </AD>
+        <AD id="tokenRequestOriginHeader" name="%tokenRequestOriginHeader" description="%tokenRequestOriginHeader.desc" required="false" type="String" ibm:beta="true" />
     </OCD>
 
      <OCD id="com.ibm.ws.security.social.client.param.metatype" name="%oidcClientCustomRequestParam" description="%oidcClientCustomRequestParam.desc"

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
@@ -140,6 +140,8 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
     private String pkceCodeChallengeMethod = null;
     public static final String CFG_KEY_TOKEN_ENDPOINT_AUTH_SIGNING_ALGORITHM = "tokenEndpointAuthSigningAlgorithm";
     private String tokenEndpointAuthSigningAlgorithm = null;
+    public static final String CFG_KEY_TOKEN_REQUEST_ORIGIN_HEADER = "tokenRequestOriginHeader";
+    private String tokenRequestOriginHeader = null;
 
     HttpUtils httputils = new HttpUtils();
     ConfigUtils oidcConfigUtils = new ConfigUtils(null);
@@ -222,6 +224,7 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
         forwardLoginParameter = oidcConfigUtils.readAndSanitizeForwardLoginParameter(props, uniqueId, CFG_KEY_FORWARD_LOGIN_PARAMETER);
         keyManagementKeyAlias = configUtils.getConfigAttribute(props, CFG_KEY_KEY_MANAGEMENT_KEY_ALIAS);
         pkceCodeChallengeMethod = configUtils.getConfigAttribute(props, CFG_KEY_PKCE_CODE_CHALLENGE_METHOD);
+        tokenRequestOriginHeader = configUtils.getConfigAttribute(props, CFG_KEY_TOKEN_REQUEST_ORIGIN_HEADER);
 
         if (discovery) {
             String OIDC_CLIENT_DISCOVERY_COMPLETE = "CWWKS6110I: The client [{" + getId() + "}] configuration has been established with the information from the discovery endpoint URL [{" + discoveryEndpointUrl + "}]. This information enables the client to interact with the OpenID Connect provider to process the requests such as authorization and token.";
@@ -972,6 +975,11 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements Conver
     @Override
     public String getPkceCodeChallengeMethod() {
         return pkceCodeChallengeMethod;
+    }
+
+    @Override
+    public String getTokenRequestOriginHeader() {
+        return tokenRequestOriginHeader;
     }
 
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenRequestor.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenRequestor.java
@@ -48,6 +48,7 @@ public class TokenRequestor {
     private final List<NameValuePair> params;
     private final HashMap<String, String> customParams;
     private final boolean useSystemPropertiesForHttpClientConnections;
+    private final String originHeaderValue;
 
     OidcClientHttpUtil oidcClientHttpUtil = OidcClientHttpUtil.getInstance();
 
@@ -65,6 +66,7 @@ public class TokenRequestor {
         this.resources = builder.resources;
         this.customParams = builder.customParams;
         this.useSystemPropertiesForHttpClientConnections = builder.useSystemPropertiesForHttpClientConnections;
+        this.originHeaderValue = builder.originHeaderValue;
 
         List<NameValuePair> params = getBasicParams();
         mergeCustomParams(params, customParams);
@@ -114,6 +116,12 @@ public class TokenRequestor {
     }
 
     private Map<String, Object> postToTokenEndpoint() throws Exception {
+        if (originHeaderValue != null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Will add Origin HTTP header with value: [" + originHeaderValue + "]");
+            }
+            OidcClientHttpUtil.commonHeaders.add(new BasicNameValuePair("Origin", originHeaderValue));
+        }
         return oidcClientHttpUtil.postToEndpoint(tokenEndpoint,
                                                  params,
                                                  clientId,
@@ -143,6 +151,7 @@ public class TokenRequestor {
         private String resources = null;
         private HashMap<String, String> customParams = null;
         private boolean useSystemPropertiesForHttpClientConnections = false;
+        private String originHeaderValue;
 
         public Builder(String tokenEndpoint, String clientId, @Sensitive String clientSecret, String redirectUri, String code) {
             this.tokenEndpoint = tokenEndpoint;
@@ -193,6 +202,11 @@ public class TokenRequestor {
 
         public Builder useSystemPropertiesForHttpClientConnections(boolean useSystemPropertiesForHttpClientConnections) {
             this.useSystemPropertiesForHttpClientConnections = useSystemPropertiesForHttpClientConnections;
+            return this;
+        }
+
+        public Builder originHeaderValue(String originHeaderValue) {
+            this.originHeaderValue = originHeaderValue;
             return this;
         }
 


### PR DESCRIPTION
Adds the `tokenRequestOriginHeader` configuration attribute to the `<openidConnectClient>` and `<oidcLogin>` elements. The value of this attribute will be set as the value for the Origin header in the HTTP POST request to the OpenID Connect provider's token endpoint.