### PR TITLE
id type results for find and delete

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityDefiner.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityDefiner.java
@@ -439,7 +439,7 @@ public class EntityDefiner implements Runnable {
                 Queue<String> relationPrefixes = new LinkedList<>();
                 Queue<List<Member>> relationAccessors = new LinkedList<>();
                 Class<?> recordClass = generatedToRecordClass.get(entityType.getJavaType());
-                Class<?> idClass = null;
+                Class<?> idType = null;
                 SortedMap<String, Member> idClassAttributeAccessors = null;
                 String versionAttrName = null;
 
@@ -465,13 +465,15 @@ public class EntityDefiner implements Runnable {
                             collectionElementTypes.put(attributeName, ((PluralAttribute<?, ?, ?>) attr).getElementType().getJavaType());
                     } else {
                         SingularAttribute<?, ?> singleAttr = attr instanceof SingularAttribute ? (SingularAttribute<?, ?>) attr : null;
-                        if (singleAttr != null && singleAttr.isId())
+                        if (singleAttr != null && singleAttr.isId()) {
                             attributeNames.put("id", attributeName);
-                        else if (singleAttr != null && singleAttr.isVersion())
+                            idType = singleAttr.getJavaType();
+                        } else if (singleAttr != null && singleAttr.isVersion()) {
                             versionAttrName = attributeName;
-                        else if (Collection.class.isAssignableFrom(attr.getJavaType()))
+                        } else if (Collection.class.isAssignableFrom(attr.getJavaType())) {
                             // collection attribute that is not annotated with ElementCollection
                             collectionElementTypes.put(attributeName, Object.class);
+                        }
                     }
                 }
 
@@ -528,10 +530,12 @@ public class EntityDefiner implements Runnable {
                                 collectionElementTypes.put(fullAttributeName, ((PluralAttribute<?, ?, ?>) relAttr).getElementType().getJavaType());
                         } else if (relAttr instanceof SingularAttribute) {
                             SingularAttribute<?, ?> singleAttr = ((SingularAttribute<?, ?>) relAttr);
-                            if (singleAttr.isId())
+                            if (singleAttr.isId()) {
                                 attributeNames.put("id", fullAttributeName);
-                            else if (singleAttr.isVersion())
+                                idType = singleAttr.getJavaType();
+                            } else if (singleAttr.isVersion()) {
                                 versionAttrName = relationAttributeName_; // to be suitable for query-by-method
+                            }
                         }
                     }
                 }
@@ -546,13 +550,13 @@ public class EntityDefiner implements Runnable {
                         Set<SingularAttribute<?, ?>> idClassAttributes = (Set<SingularAttribute<?, ?>>) (Set<?>) entityType.getIdClassAttributes();
                         if (idClassAttributes != null) {
                             attributeNames.remove("id");
-                            idClass = idClassType.getJavaType();
+                            idType = idClassType.getJavaType();
                             idClassAttributeAccessors = new TreeMap<>();
                             for (SingularAttribute<?, ?> attr : idClassAttributes) {
                                 Member entityMember = attr.getJavaMember();
                                 Member idClassMember = entityMember instanceof Field //
-                                                ? idClass.getField(entityMember.getName()) //
-                                                : idClass.getMethod(entityMember.getName());
+                                                ? idType.getField(entityMember.getName()) //
+                                                : idType.getMethod(entityMember.getName());
                                 idClassAttributeAccessors.put(attr.getName().toLowerCase(), idClassMember);
                             }
                         }
@@ -570,7 +574,7 @@ public class EntityDefiner implements Runnable {
                                 attributeTypes, //
                                 collectionElementTypes, //
                                 relationAttributeNames, //
-                                idClass, //
+                                idType, //
                                 idClassAttributeAccessors, //
                                 versionAttrName, //
                                 punit);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -42,7 +42,7 @@ class EntityInfo {
     final Map<String, Class<?>> collectionElementTypes;
 
     final Class<?> entityClass; // will be a generated class for entity records
-    final Class<?> idClass; // null if no IdClass
+    final Class<?> idType; // type of the id, which could be a JPA IdClass for composite ids
     final SortedMap<String, Member> idClassAttributeAccessors; // null if no IdClass
     final boolean inheritance;
     final String name;
@@ -63,7 +63,7 @@ class EntityInfo {
                SortedMap<String, Class<?>> attributeTypes,
                Map<String, Class<?>> collectionElementTypes,
                Map<Class<?>, List<String>> relationAttributeNames,
-               Class<?> idClass,
+               Class<?> idType,
                SortedMap<String, Member> idClassAttributeAccessors,
                String versionAttributeName,
                PersistenceServiceUnit persister) {
@@ -74,7 +74,7 @@ class EntityInfo {
         this.attributeTypes = attributeTypes;
         this.collectionElementTypes = collectionElementTypes;
         this.relationAttributeNames = relationAttributeNames;
-        this.idClass = idClass;
+        this.idType = idType;
         this.idClassAttributeAccessors = idClassAttributeAccessors;
         this.persister = persister;
         this.recordClass = recordClass;
@@ -90,7 +90,7 @@ class EntityInfo {
             if ("All".equals(name))
                 attributeName = null; // Special case for CrudRepository.deleteAll and CrudRepository.findAll
             else if ("id".equals(lowerName))
-                if (idClass == null && failIfNotFound)
+                if (idClassAttributeAccessors == null && failIfNotFound)
                     throw new MappingException("Entity class " + getType().getName() + " does not have a property named " + name +
                                                " or which is designated as the @Id."); // TODO NLS
                 else

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -420,8 +420,9 @@ class QueryInfo {
                 && !type.equals(Object.class)
                 && !wrapperClassIfPrimitive(type).equals(wrapperClassIfPrimitive(entityInfo.idType)))
                 throw new MappingException("Results for find-and-delete repository queries must be the entity class (" +
-                                           entityInfo.entityClass.getName() + ") or the id class (" +
-                                           entityInfo.idType + "), not the " + type.getName() + " class."); // TODO NLS
+                                           (entityInfo.recordClass == null ? entityInfo.entityClass : entityInfo.recordClass).getName() +
+                                           ") or the id class (" + entityInfo.idType +
+                                           "), not the " + type.getName() + " class."); // TODO NLS
         }
 
         return isFindAndDelete;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1986,8 +1986,9 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                                 value = to(entityInfo.idType, result, false);
                                                 if (value == result) // unable to convert value
                                                     throw new MappingException("Results for find-and-delete repository queries must be the entity class (" +
-                                                                               entityInfo.entityClass.getName() + ") or the id class (" +
-                                                                               entityInfo.idType + "), not the " + result.getClass().getName() + " class."); // TODO NLS
+                                                                               (entityInfo.recordClass == null ? entityInfo.entityClass : entityInfo.recordClass).getName() +
+                                                                               ") or the id class (" + entityInfo.idType +
+                                                                               "), not the " + result.getClass().getName() + " class."); // TODO NLS
                                             }
 
                                             jakarta.persistence.Query delete = em.createQuery(queryInfo.jpqlDelete);

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -98,4 +98,12 @@ public class DataTest extends FATServletClient {
     public void testFindAndDeleteMultipleAnnotated() throws Exception {
         runTest(server, "DataTestApp", "testFindAndDeleteMultipleAnnotated&jdbcJarName=" + jdbcJarName);
     }
+
+    /**
+     * This test has conditional logic based on the JDBC driver/database.
+     */
+    @Test
+    public void testFindAndDeleteReturnsIds() throws Exception {
+        runTest(server, "DataTestApp", "testFindAndDeleteReturnsIds&jdbcJarName=" + jdbcJarName);
+    }
 }

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -106,4 +106,12 @@ public class DataTest extends FATServletClient {
     public void testFindAndDeleteReturnsIds() throws Exception {
         runTest(server, "DataTestApp", "testFindAndDeleteReturnsIds&jdbcJarName=" + jdbcJarName);
     }
+
+    /**
+     * This test has conditional logic based on the JDBC driver/database.
+     */
+    @Test
+    public void testFindAndDeleteReturnsObjects() throws Exception {
+        runTest(server, "DataTestApp", "testFindAndDeleteReturnsObjects&jdbcJarName=" + jdbcJarName);
+    }
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -32,6 +32,7 @@ import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -1287,6 +1288,64 @@ public class DataTestServlet extends FATServlet {
         ids = packages.deleteFirst2(sorts);
         assertEquals(Arrays.toString(ids), 1, ids.length);
         assertEquals(remaining.iterator().next(), Integer.valueOf(ids[0]));
+    }
+
+    /**
+     * Find-and-delete repository operations that return one or more objects, corresponding to removed entities.
+     */
+    // Test annotation is present on corresponding method in DataTest
+    public void testFindAndDeleteReturnsObjects(HttpServletRequest request, HttpServletResponse response) {
+        String jdbcJarName = request.getParameter("jdbcJarName").toLowerCase();
+        boolean supportsOrderByForUpdate = !jdbcJarName.startsWith("derby");
+
+        packages.deleteAll();
+
+        packages.save(new Package(70071, 17.0f, 17.1f, 7.7f, "testFindAndDeleteReturnsObjects#70071"));
+        packages.save(new Package(70070, 70.0f, 70.0f, 7.0f, "testFindAndDeleteReturnsObjects#70070"));
+        packages.save(new Package(70077, 77.0f, 17.7f, 7.7f, "testFindAndDeleteReturnsObjects#70077"));
+        packages.save(new Package(70007, 70.0f, 10.7f, 0.7f, "testFindAndDeleteReturnsObjects#70007"));
+
+        Set<Integer> remaining = new TreeSet<>();
+        remaining.addAll(Set.of(70007, 70070, 70071, 70077));
+
+        Sort sort = supportsOrderByForUpdate ? Sort.desc("width") : null;
+        Object[] deleted = packages.delete(Limit.of(1), sort);
+        assertEquals("Deleted " + Arrays.toString(deleted), 1, deleted.length);
+        Package p = (Package) deleted[0];
+        if (supportsOrderByForUpdate) {
+            assertEquals(70070, p.id);
+            assertEquals(70.0f, p.length, 0.001f);
+            assertEquals(70.0f, p.width, 0.001f);
+            assertEquals(7.0f, p.height, 0.001f);
+            assertEquals("testFindAndDeleteReturnsObjects#70070", p.description);
+        }
+        assertEquals("Found " + p.id + "; expected one of " + remaining, true, remaining.remove(p.id));
+
+        Sort[] sorts = supportsOrderByForUpdate ? new Sort[] { Sort.desc("height"), Sort.asc("length") } : null;
+        LinkedList<?> deletesList = packages.deleteFirst2ByHeightLessThan(8.0f, sorts);
+        assertEquals("Deleted " + deletesList, 2, deletesList.size());
+        Package p0 = (Package) deletesList.get(0);
+        Package p1 = (Package) deletesList.get(1);
+        if (supportsOrderByForUpdate) {
+            assertEquals(70071, p0);
+            assertEquals(17.0f, p.length, 0.001f);
+            assertEquals(17.1f, p.width, 0.001f);
+            assertEquals(7.7f, p.height, 0.001f);
+            assertEquals("testFindAndDeleteReturnsObjects#70071", p.description);
+            assertEquals(70077, p1);
+            assertEquals(77.0f, p.length, 0.001f);
+            assertEquals(17.7f, p.width, 0.001f);
+            assertEquals(7.7f, p.height, 0.001f);
+            assertEquals("testFindAndDeleteReturnsObjects#70077", p.description);
+        }
+        assertEquals("Found " + p0.id + "; expected one of " + remaining, true, remaining.remove(p0.id));
+        assertEquals("Found " + p1.id + "; expected one of " + remaining, true, remaining.remove(p1.id));
+
+        // TODO test for Number return type could be added here
+        // should have only 1 remaining
+        deleted = packages.delete(Limit.of(4), sort);
+        assertEquals("Deleted " + Arrays.toString(deleted), 1, deleted.length);
+        assertEquals(remaining.iterator().next(), Integer.valueOf(((Package) deleted[0]).id));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -41,6 +41,10 @@ public interface Packages extends PageableRepository<Package, Integer> {
 
     Package[] deleteByDescriptionEndsWith(String ending, Sort... sorts);
 
+    Optional<Integer> deleteFirst(Sort sorts);
+
+    int[] deleteFirst2(Sort... sorts);
+
     List<Package> findByHeightBetween(float minHeight, float maxHeight);
 
     @OrderBy(value = "width", descending = true)

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -12,11 +12,13 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
 import jakarta.data.repository.KeysetAwarePage;
 import jakarta.data.repository.KeysetAwareSlice;
+import jakarta.data.repository.Limit;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Pageable;
 import jakarta.data.repository.PageableRepository;
@@ -37,13 +39,17 @@ import io.openliberty.data.repository.Update;
  */
 @Repository
 public interface Packages extends PageableRepository<Package, Integer> {
+    Object[] delete(Limit limit, Sort sort);
+
     Optional<Package> deleteByDescription(String description);
 
     Package[] deleteByDescriptionEndsWith(String ending, Sort... sorts);
 
-    Optional<Integer> deleteFirst(Sort sorts);
+    Optional<Integer> deleteFirst(Sort sort);
 
     int[] deleteFirst2(Sort... sorts);
+
+    LinkedList<?> deleteFirst2ByHeightLessThan(float maxHeight, Sort... sorts);
 
     List<Package> findByHeightBetween(float minHeight, float maxHeight);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -50,6 +51,12 @@ public interface Packages extends PageableRepository<Package, Integer> {
     int[] deleteFirst2(Sort... sorts);
 
     LinkedList<?> deleteFirst2ByHeightLessThan(float maxHeight, Sort... sorts);
+
+    long[] deleteFirst3(Sort sort); // invalid return type is not the entity or id
+
+    List<String> deleteFirst4(Sort sort); // invalid return type is not the entity or id
+
+    Collection<Number> deleteFirst5(Sort sort); // invalid return type is not the entity or id
 
     List<Package> findByHeightBetween(float minHeight, float maxHeight);
 


### PR DESCRIPTION
Results for find-and-delete operations can be a list of the id type or an `Optional` of the id type.
This also covers some other result types such as rejecting invalid and testing list/optional of Object/unparameterized.