### PR TITLE
Enable skipped jsf.2.2_fat tests via selenium

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsf.2.2_fat/bnd.bnd
@@ -89,32 +89,32 @@ tested.features: \
 
 
 -buildpath: \
+    com.google.guava:guava;version=latest,\
+    com.ibm.websphere.appserver.thirdparty.jsf-2.2;version=latest,\
+    com.ibm.websphere.javaee.annotation.1.2;version=latest,\
+    com.ibm.websphere.javaee.cdi.1.2;version=latest,\
+    com.ibm.websphere.javaee.el.3.0;version=latest,\
+    com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
+    com.ibm.websphere.javaee.jsf.2.2;version=latest,\
+    com.ibm.websphere.javaee.jsp.2.3;version=latest,\
+    com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+    com.ibm.websphere.javaee.validation.1.1;version=latest,\
+    com.ibm.ws.jsf.2.2;version=latest,\
+    com.ibm.ws.jsp.2.3;version=latest,\
+    com.ibm.ws.org.apache.httpcomponents;version=latest, \
+    io.openliberty.org.apache.commons.codec;version=latest,\
+    io.openliberty.org.apache.commons.logging;version=latest,\
+    io.openliberty.org.apache.xercesImpl;version=latest,\
     io.openliberty.org.testcontainers;version=latest,\
+    net.sourceforge.htmlunit:htmlunit-cssparser;version=1.6.0,\
+    net.sourceforge.htmlunit:htmlunit;version=2.44.0,\
+    net.sourceforge.htmlunit:neko-htmlunit;strategy=exact;version=2.44.0,\
+    net.sourceforge.htmlunit:webdriver;version=2.6,\
+    org.brotli:dec;version=0.1.2,\
     org.seleniumhq.selenium:selenium-api;version=4.8.3,\
     org.seleniumhq.selenium:selenium-chrome-driver;version=4.8.3,\
     org.seleniumhq.selenium:selenium-chromium-driver;version=4.8.3,\
     org.seleniumhq.selenium:selenium-remote-driver;version=4.8.3,\
     org.seleniumhq.selenium:selenium-support;version=4.8.3,\
-    com.ibm.websphere.javaee.annotation.1.2;version=latest,\
-    com.ibm.ws.org.apache.httpcomponents;version=latest, \
-    net.sourceforge.htmlunit:htmlunit;version=2.44.0,\
-    net.sourceforge.htmlunit:webdriver;version=2.6,\
-    net.sourceforge.htmlunit:neko-htmlunit;strategy=exact;version=2.44.0,\
     org.seleniumhq.webdriver:webdriver-common;version=0.9.7376,\
-    org.brotli:dec;version=0.1.2,\
-    net.sourceforge.htmlunit:htmlunit-cssparser;version=1.6.0,\
-    xml-apis:xml-apis;version=1.4.01,\
-    com.ibm.websphere.appserver.thirdparty.jsf-2.2;version=latest,\
-    com.ibm.websphere.javaee.cdi.1.2;version=latest,\
-    com.ibm.websphere.javaee.jsf.2.2;version=latest,\
-    com.ibm.websphere.javaee.validation.1.1;version=latest,\
-    com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-    com.ibm.websphere.javaee.el.3.0;version=latest,\
-    com.ibm.ws.jsp.2.3;version=latest,\
-    com.ibm.ws.jsf.2.2;version=latest,\
-    com.ibm.websphere.javaee.jsp.2.3;version=latest,\
-    com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
-    io.openliberty.org.apache.commons.logging;version=latest,\
-    io.openliberty.org.apache.commons.codec;version=latest,\
-    io.openliberty.org.apache.xercesImpl;version=latest,\
-    com.google.guava:guava;version=latest
+    xml-apis:xml-apis;version=1.4.01

--- a/dev/com.ibm.ws.jsf.2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsf.2.2_fat/bnd.bnd
@@ -10,6 +10,11 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+fat.test.container.images: \
+    seleniarm/standalone-chromium:4.8.3,\
+    selenium/standalone-chrome:4.8.3,\
+    alpine:3.16
+
 src: \
     fat/src,\
     test-applications/TestJSF2.2.war/src,\
@@ -84,7 +89,13 @@ tested.features: \
 
 
 -buildpath: \
-	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
+    io.openliberty.org.testcontainers;version=latest,\
+    org.seleniumhq.selenium:selenium-api;version=4.8.3,\
+    org.seleniumhq.selenium:selenium-chrome-driver;version=4.8.3,\
+    org.seleniumhq.selenium:selenium-chromium-driver;version=4.8.3,\
+    org.seleniumhq.selenium:selenium-remote-driver;version=4.8.3,\
+    org.seleniumhq.selenium:selenium-support;version=4.8.3,\
+    com.ibm.websphere.javaee.annotation.1.2;version=latest,\
     com.ibm.ws.org.apache.httpcomponents;version=latest, \
     net.sourceforge.htmlunit:htmlunit;version=2.44.0,\
     net.sourceforge.htmlunit:webdriver;version=2.6,\
@@ -105,4 +116,5 @@ tested.features: \
     com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
     io.openliberty.org.apache.commons.logging;version=latest,\
     io.openliberty.org.apache.commons.codec;version=latest,\
-    io.openliberty.org.apache.xercesImpl;version=latest
+    io.openliberty.org.apache.xercesImpl;version=latest,\
+    com.google.guava:guava;version=latest

--- a/dev/com.ibm.ws.jsf.2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jsf.2.2_fat/build.gradle
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'

--- a/dev/com.ibm.ws.jsf.2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jsf.2.2_fat/build.gradle
@@ -11,9 +11,12 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
 dependencies {
-    requiredLibs 'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
+    requiredLibs 'org.seleniumhq.selenium:selenium-java:4.8.3',
+      "com.google.guava:guava:32.0.1-jre",
+      'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
       'net.sourceforge.htmlunit:htmlunit:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:neko-htmlunit:2.44.0',
@@ -40,7 +43,7 @@ dependencies {
       project(':io.openliberty.org.apache.xercesImpl'),
       'xalan:xalan:2.7.2',
       'xml-apis:xml-apis:1.4.01'
-    }
+}
 
 addRequiredLibraries.dependsOn addJakartaTransformer
-
+addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
@@ -54,6 +54,8 @@ import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.JavaInfo;
 
+import  org.testcontainers.utility.DockerImageName;
+
 /**
  * JSF 2.2 Tests
  *
@@ -134,6 +136,14 @@ public class FATSuite {
             repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
                             .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly())
                             .andWith(FeatureReplacementAction.EE9_FEATURES());
+        }
+    }
+
+    public static DockerImageName getChromeImage() {
+        if (FATRunner.ARM_ARCHITECTURE) {
+            return DockerImageName.parse("seleniarm/standalone-chromium:4.8.3").asCompatibleSubstituteFor("selenium/standalone-chrome");
+        } else {
+            return DockerImageName.parse("selenium/standalone-chrome:4.8.3");
         }
     }
 }

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
@@ -56,6 +56,8 @@ import componenttest.topology.impl.JavaInfo;
 
 import  org.testcontainers.utility.DockerImageName;
 
+import componenttest.containers.TestContainerSuite;
+
 /**
  * JSF 2.2 Tests
  *
@@ -101,7 +103,7 @@ import  org.testcontainers.utility.DockerImageName;
                 JSF22AparTests.class,
                 JSF22ThirdPartyApiTests.class
 })
-public class FATSuite {
+public class FATSuite extends TestContainerSuite {
 
     /**
      * @see {@link FatLogHandler#generateHelpFile()}

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/JSFUtils.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/JSFUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -50,6 +50,30 @@ public class JSFUtils {
         StringBuilder sb = new StringBuilder();
         sb.append("http://")
                         .append(server.getHostname())
+                        .append(":")
+                        .append(server.getHttpDefaultPort())
+                        .append("/")
+                        .append(contextRoot)
+                        .append("/")
+                        .append(path);
+
+        return sb.toString();
+    }
+
+    /**
+     * Construct a URL for for the testcontainer selenium docker image. Relies on 'host.testcontainers.internal' address
+     *
+     * @param server      - The server that is under test, this is used to get the port and host name.
+     * @param contextRoot - The context root of the application
+     * @param path        - Additional path information for the request.
+     * @return - A fully formed URL string.
+     * @throws Exception
+     */
+    public static String createSeleniumURLString(LibertyServer server, String contextRoot, String path) {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("http://")
+                        .append("host.testcontainers.internal")
                         .append(":")
                         .append(server.getHttpDefaultPort())
                         .append("/")

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/selenium_util/CustomDriver.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/selenium_util/CustomDriver.java
@@ -1,0 +1,133 @@
+package com.ibm.ws.jsf22.fat.selenium_util;
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+/**
+*  Used in conjunction with WebPage to behave similarly as HTMLUnit's HtmlPage
+* 
+* Copied over from ChromeDevtoolsDriver 
+* - https://github.com/jakartaee/faces/blob/1d71aae51f7d5ae684a3f43db0521b7e7e6aa4f6/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
+* Modified because chrome dev tools is unavailable via Test Containers 
+* - Created https://github.com/testcontainers/testcontainers-java/issues/7242 requesting chrome dev tool support 
+* 
+*/
+public class CustomDriver implements ExtendedWebDriver {
+
+    RemoteWebDriver driver;
+
+    public CustomDriver(RemoteWebDriver driver){
+        this.driver = driver;
+    }
+
+    public RemoteWebDriver getRemoteWebDriver(){
+        return this.driver;
+    }
+
+    @Override
+    public String getPageText() {
+        String head = this.driver.findElement(By.tagName("head")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
+        String body = this.driver.findElement(By.tagName("body")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
+        return head + " " + body;
+    }
+
+    @Override
+    public String getPageTextReduced() {
+        String head = this.driver.findElement(By.tagName("head")).getAttribute("innerText");
+        String body = this.driver.findElement(By.tagName("body")).getAttribute("innerText");
+        // handle blanks and nbsps
+        return (head + " " + body).replaceAll("[\\s\\u00A0]+", " ");
+    }
+
+    @Override
+    public WebDriver.Options manage() {
+        return driver.manage();
+    }
+
+    @Override
+    public WebDriver.Navigation navigate() {
+        return driver.navigate();
+    }
+    
+    public Set<String> getWindowHandles() {
+        return driver.getWindowHandles();
+    }
+
+    public String getWindowHandle() {
+        return driver.getWindowHandle();
+    }
+
+    public WebDriver.TargetLocator switchTo() {
+        return driver.switchTo();
+    }
+
+    public void close() {
+        driver.close();
+    }
+
+    public void quit() {
+        driver.quit();
+    }
+
+    public void get(String url) {
+        driver.get(url);
+    }
+
+    public String getCurrentUrl() {
+        return driver.getCurrentUrl();
+    }
+
+    public String getTitle() {
+        return driver.getTitle();
+    }
+
+    public String getPageSource() {
+        return driver.getPageSource();
+    }
+
+
+    public WebElement findElement(By by) {
+        return driver.findElement(by);
+    }
+
+    public List<WebElement> findElements(By by) {
+        return driver.findElements(by);
+    }
+
+}

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/selenium_util/CustomDriver.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/selenium_util/CustomDriver.java
@@ -1,4 +1,3 @@
-package com.ibm.ws.jsf22.fat.selenium_util;
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
@@ -14,6 +13,7 @@ package com.ibm.ws.jsf22.fat.selenium_util;
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
  */
+package com.ibm.ws.jsf22.fat.selenium_util;
 
 import java.net.URI;
 import java.net.URLDecoder;

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/selenium_util/ExtendedWebDriver.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/selenium_util/ExtendedWebDriver.java
@@ -1,21 +1,19 @@
-package com.ibm.ws.jsf22.fat.selenium_util;
-
-/**
- * Copyright Werner Punz
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
  */
-// Original code stemming 100% from me, hence relicense from EPL
+package com.ibm.ws.jsf22.fat.selenium_util;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/selenium_util/ExtendedWebDriver.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/selenium_util/ExtendedWebDriver.java
@@ -1,0 +1,54 @@
+package com.ibm.ws.jsf22.fat.selenium_util;
+
+/**
+ * Copyright Werner Punz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Original code stemming 100% from me, hence relicense from EPL
+
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+/**
+ * an extended web driver interface which takes the response into consideration
+ * selenium does not have an official api but several webdrivers
+ * allow access to the data via various means
+ *
+ * Another possibility would have been a proxy, but I could not find any properly
+ * working proxy for selenium
+ * 
+ * Copied and Modified from https://github.com/jakartaee/faces/blob/1d71aae51f7d5ae684a3f43db0521b7e7e6aa4f6/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ExtendedWebDriver.java
+ */
+public interface ExtendedWebDriver extends WebDriver {
+
+    /**
+     * @return the innerText of the Page
+     */
+    String getPageText();
+
+    /**
+     * returns the innerText of the page in a blank reduced state (more than one blank is reduced to one
+     * invisible blanks like nbsp are replaced by normal blanks)
+     * @return 
+     */
+    String getPageTextReduced();
+
+    /*
+     * Return the wrapped remote web driver
+     */
+    RemoteWebDriver getRemoteWebDriver();
+
+
+}

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/selenium_util/WebPage.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/selenium_util/WebPage.java
@@ -1,0 +1,299 @@
+/**
+ * Copyright Werner Punz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Original code stemming 100% from me, hence relicense from EPL
+package com.ibm.ws.jsf22.fat.selenium_util;
+
+import org.openqa.selenium.*;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Mimics the html unit webpage
+ * Modified from original source as Chrome Dev Tools are not accessible when used with TestContainers
+ * See issue https://github.com/testcontainers/testcontainers-java/issues/7242
+ */
+public class WebPage {
+
+    public static final Duration STD_TIMEOUT = Duration.ofMillis(8000);
+    public static final Duration LONG_TIMEOUT = Duration.ofMillis(16000);
+
+    protected ExtendedWebDriver webDriver;
+
+    public WebPage(ExtendedWebDriver webDriver) {
+        this.webDriver = webDriver;
+    }
+
+    public WebDriver getWebDriver() {
+        return (WebDriver) webDriver;
+    }
+
+    public void setWebDriver(ExtendedWebDriver webDriver) {
+        this.webDriver = webDriver;
+    }
+
+    public void get(String url) {
+        webDriver.get(url);
+    }
+
+    public String getTitle() {
+        return webDriver.getTitle();
+    }
+
+    /**
+     * waits for a certain condition is met, until a timeout is hit. In case of exceeding the condition, a runtime exception
+     * is thrown!
+     *
+     * @param isTrue the condition lambda to check
+     * @param timeout timeout duration
+     */
+    public <V> void waitForCondition(Function<? super WebDriver, V> isTrue, Duration timeout) {
+        synchronized (webDriver) {
+            WebDriverWait wait = new WebDriverWait(webDriver, timeout);
+            wait.until(isTrue);
+        }
+    }
+
+    /**
+     * The same as before, but with the long default timeout of LONG_TIMEOUT (16000ms)
+     *
+     * @param isTrue condition lambda
+     */
+    public <V> void waitForCondition(Function<? super WebDriver, V> isTrue) {
+        synchronized (webDriver) {
+            WebDriverWait wait = new WebDriverWait(webDriver, LONG_TIMEOUT);
+            wait.until(isTrue);
+        }
+    }
+
+    /**
+     * Wait for a certain period of time
+     *
+     * @param timeout the timeout to wait (note due to the asynchronous nature of the web drivers, any code running on the
+     * browser itself will proceed (aka javascript) only the client operations are stalled.
+     */
+    public void wait(Duration timeout) {
+        synchronized (webDriver) {
+            try {
+                webDriver.wait(timeout.toMillis());
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * wait until the current Ajax request targeting the same page has stopped and then tests for blocking running scripts
+     * still running. A small initial delay cannot hurt either
+     */
+    public void waitReqJs() {
+        this.wait(STD_TIMEOUT);
+    }
+
+    /**
+     * waits for backgrounds processes on the browser to complete
+     *
+     * @param timeOut the timeout duration until the wait can proceed before being interupopted
+     */
+    public void waitForPageToLoad(Duration timeOut) {
+        ExpectedCondition<Boolean> expectation =
+            driver -> webDriver.getRemoteWebDriver().executeScript("return document.readyState")
+                               .equals("complete");
+
+        synchronized (webDriver) {
+            WebDriverWait wait = new WebDriverWait(webDriver, timeOut);
+            wait.until(expectation);
+        }
+    }
+
+        /**
+     * wait until the page load is finished
+     */
+    public void waitForPageToLoad() {
+        waitForPageToLoad(STD_TIMEOUT);
+    }
+
+    /**
+     * conditional waiter and checker which checks whether the page text is present we add our own waiter internally,
+     * because pageSource always delivers
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isInPageText(String text) {
+        try {
+            // values are not returned by getPageText
+            String values = getInputValues();
+
+            waitForCondition(webDriver1 -> (webDriver.getPageText() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    public boolean isInPageTextReduced(String text) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> (webDriver.getPageTextReduced() + values.replaceAll("\\s+", " ")).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    public boolean matchesPageText(String regexp) {
+        try {
+            waitForCondition(webDriver1 -> webDriver.getPageText().matches(regexp), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * adds the reduced page text functionality to the regexp match
+     *
+     * @param regexp
+     * @return
+     */
+    public boolean matchesPageTextReduced(String regexp) {
+        try {
+            waitForCondition(webDriver1 -> webDriver.getPageTextReduced().matches(regexp), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is not in the page we add our own waiter internally,
+     * because pageSource always delivers
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isNotInPageText(String text) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> !(webDriver.getPageText() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is in the page we add our own waiter internally, because
+     * pageSource always delivers this version of isInPage checks explicitly the full markup not only the text
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isInPage(String text) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> (webDriver.getPageSource() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is not in the page we add our own waiter internally,
+     * because pageSource always delivers we need to add two different condition checkers herte because a timeout
+     * automatically throws internally an error which is mapped to false We therefore cannot simply wait for the condition
+     * either being met or timeout with one method
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isNotInPage(String text) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> !(webDriver.getPageSource() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is in the page we add our own waiter internally, because
+     * pageSource always delivers we need to add two different condition checkers herte because a timeout automatically
+     * throws internally an error which is mapped to false We therefore cannot simply wait for the condition either being
+     * met or timeout with one method
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isInPage(String text, boolean allowExceptions) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> (webDriver.getPageSource() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException exception) {
+            if (allowExceptions) {
+                throw exception;
+            }
+            exception.printStackTrace();
+            return false;
+        }
+    }
+
+
+    public WebElement findElement(By by) {
+        return webDriver.findElement(by);
+    }
+
+    public List<WebElement> findElements(By by) {
+        return webDriver.findElements(by);
+    }
+
+        public String getPageSource() {
+        return webDriver.getPageSource();
+    }
+
+    /**
+     * Convenience method to get all anchor elmements
+     *
+     * @return a list of a hrefs as WebElements
+     */
+    public List<WebElement> getAnchors() {
+        return webDriver.findElements(By.cssSelector("a[href]"));
+    }
+
+        private String getInputValues() {
+        return webDriver.findElements(By.cssSelector("input, textarea, select")).stream()
+                .map(webElement -> webElement.getAttribute("value")).reduce("", (str1, str2) -> str1 + " " + str2);
+    }
+
+}

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/selenium_util/WebPage.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/selenium_util/WebPage.java
@@ -1,19 +1,18 @@
-/**
- * Copyright Werner Punz
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
  */
-// Original code stemming 100% from me, hence relicense from EPL
 package com.ibm.ws.jsf22.fat.selenium_util;
 
 import org.openqa.selenium.*;

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ClientWindowTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ClientWindowTests.java
@@ -108,7 +108,6 @@ public class JSF22ClientWindowTests {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
         String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
-        System.out.println(url);
         WebPage page = new WebPage(driver);
         page.get(url);
         page.waitForPageToLoad();
@@ -135,7 +134,6 @@ public class JSF22ClientWindowTests {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
         String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
-        System.out.println(url);
         WebPage page = new WebPage(driver);
         page.get(url);
         page.waitForPageToLoad();
@@ -168,7 +166,6 @@ public class JSF22ClientWindowTests {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
         String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
-        System.out.println(url);
         WebPage page = new WebPage(driver);
         page.get(url);
         page.waitForPageToLoad();
@@ -196,7 +193,6 @@ public class JSF22ClientWindowTests {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
         String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
-        System.out.println(url);
         WebPage page = new WebPage(driver);
         page.get(url);
         page.waitForPageToLoad();
@@ -235,7 +231,6 @@ public class JSF22ClientWindowTests {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
         String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
-        System.out.println(url);
         WebPage page = new WebPage(driver);
         page.get(url);
         page.waitForPageToLoad();
@@ -249,7 +244,6 @@ public class JSF22ClientWindowTests {
         // Click link to execute the methods and update the page
         page.findElement(By.id("testForm:submitCommandButton1")).click();
         page.waitReqJs();
-        System.out.println(page.getPageSource());
 
         String firstName = page.findElement(By.id("testFormPage2:firstName")).getText();
         String lastName = page.findElement(By.id("testFormPage2:lastName")).getText();
@@ -274,7 +268,6 @@ public class JSF22ClientWindowTests {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
         String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
-        System.out.println(url);
         WebPage page = new WebPage(driver);
         page.get(url);
         page.waitForPageToLoad();
@@ -288,7 +281,6 @@ public class JSF22ClientWindowTests {
         // Click link to execute the methods and update the page
         page.findElement(By.id("testForm:commandLink1")).click();
         page.waitReqJs();
-        System.out.println(page.getPageSource());
 
         String firstName = page.findElement(By.id("testFormPage2:firstName")).getText();
         String lastName = page.findElement(By.id("testFormPage2:lastName")).getText();
@@ -313,7 +305,6 @@ public class JSF22ClientWindowTests {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
         String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
-        System.out.println(url);
         WebPage page = new WebPage(driver);
         page.get(url);
         page.waitForPageToLoad();
@@ -346,7 +337,6 @@ public class JSF22ClientWindowTests {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
         String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
-        System.out.println(url);
         WebPage page = new WebPage(driver);
         page.get(url);
         page.waitForPageToLoad();
@@ -354,10 +344,10 @@ public class JSF22ClientWindowTests {
         String clientWindowJS = page.findElement(By.id("clientWindowDisplay")).getText();
 
         page.findElement(By.id("testForm:button2Disabled")).click();
-        // Look for the correct results
+        // Look for the "Test Passed". The page2Disabled.xhtml page has the logic to compare the IDs.
         assertTrue(page.isInPageTextReduced("Test Passed"));
 
-        // check that the client window ids match
+        // We still should be able to get the id from the ExternalContext (in the bean), check to make sure that it isn't null
         String windowIdBean = page.findElement(By.id("form2Disabled:outputWindowIdBean")).getText();
 
         assertTrue(windowIdBean != null && windowIdBean != "");
@@ -374,7 +364,6 @@ public class JSF22ClientWindowTests {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
         String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
-        System.out.println(url);
         WebPage page = new WebPage(driver);
         page.get(url);
         page.waitForPageToLoad();
@@ -385,7 +374,6 @@ public class JSF22ClientWindowTests {
         String windowIdParam = page.findElement(By.id("testFormPage2:windowIdParam")).getText();
 
         String url2 = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index2.jsf");
-        System.out.println(url2);
         WebPage page2 = new WebPage(driver);
         page2.get(url2);
         page2.waitForPageToLoad();
@@ -394,7 +382,7 @@ public class JSF22ClientWindowTests {
         page.waitForPageToLoad();
 
         String windowIdParam2 = page.findElement(By.id("testFormPage2:windowIdParam")).getText();
-        
+        // check that the client window ids do not match
         assertFalse(windowIdParam.equals(windowIdParam2));
     }
 }

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ClientWindowTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ClientWindowTests.java
@@ -9,42 +9,44 @@
  *******************************************************************************/
 package com.ibm.ws.jsf22.fat.tests;
 
-import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.net.URL;
+import java.util.ArrayList;
 
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.BrowserWebDriverContainer;
 
-import com.gargoylesoftware.htmlunit.NicelyResynchronizingAjaxController;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlElement;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jsf22.fat.FATSuite;
 import com.ibm.ws.jsf22.fat.JSFUtils;
+import com.ibm.ws.jsf22.fat.selenium_util.CustomDriver;
+import com.ibm.ws.jsf22.fat.selenium_util.ExtendedWebDriver;
+import com.ibm.ws.jsf22.fat.selenium_util.WebPage;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
+import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.topology.impl.LibertyServer;
-import junit.framework.Assert;
 
 /**
  * Tests to execute on the jsfTestServer2 that use HtmlUnit.
  */
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
-@SkipForRepeat(EE10_FEATURES) // Skipped due to HTMLUnit / JavaScript Incompatabilty (New JS in RC5)
 public class JSF22ClientWindowTests {
     @Rule
     public TestName name = new TestName();
@@ -57,6 +59,13 @@ public class JSF22ClientWindowTests {
 
     @Server("jsfTestServer2")
     public static LibertyServer jsfTestServer2;
+
+    @Rule
+    public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>(FATSuite.getChromeImage()).withCapabilities(new ChromeOptions())
+                    .withAccessToHost(true)
+                    .withLogConsumer(new SimpleLogConsumer(JSF22ClientWindowTests.class, "selenium-driver"));
+
+    private ExtendedWebDriver driver;
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -71,6 +80,8 @@ public class JSF22ClientWindowTests {
         }
 
         jsfTestServer2.startServer(c.getSimpleName() + ".log");
+
+        Testcontainers.exposeHostPorts(jsfTestServer2.getHttpDefaultPort(), jsfTestServer2.getHttpDefaultSecurePort());
     }
 
     @AfterClass
@@ -79,6 +90,11 @@ public class JSF22ClientWindowTests {
         if (jsfTestServer2 != null && jsfTestServer2.isStarted()) {
             jsfTestServer2.stopServer();
         }
+    }
+
+    @Before
+    public void setupTest() {
+        driver = new CustomDriver(new RemoteWebDriver(chrome.getSeleniumAddress(), new ChromeOptions().setAcceptInsecureCerts(true)));
     }
 
     /**
@@ -91,30 +107,21 @@ public class JSF22ClientWindowTests {
     public void JSF22ClientWindow_TestSimpleLink() throws Exception {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
-        try (WebClient webClient = new WebClient()) {
+        String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
+        System.out.println(url);
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-            URL url = JSFUtils.createHttpUrl(jsfTestServer2, contextRoot, "index.jsf");
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
+        String clientWindowJS = page.findElement(By.id("clientWindowDisplay")).getText();
 
-            if (page == null) {
-                Assert.fail("index.xhtml did not render properly.");
-            }
-            //get the window id from javascript
-            HtmlElement clientWindowElement = (HtmlElement) page.getElementById("clientWindowDisplay");
-            String clientWindowJS = clientWindowElement.asText();
+        page.findElement(By.id("testForm:link1")).click();
+        // Look for the correct results
+        assertTrue(page.isInPageTextReduced("Window ID from parameter: " + clientWindowJS));
 
-            // Click link to execute the methods and update the page
-            HtmlElement link = (HtmlElement) page.getElementById("testForm:link1");
-            page = link.click();
-
-            HtmlElement output = (HtmlElement) page.getElementById("testFormPage2:windowIdParam");
-
-            // Look for the correct results
-            assertTrue(page.asText().contains("Window ID from parameter: " + output.asText()));
-
-            //check that the client window ids match
-            assertTrue(clientWindowJS.equals(output.asText()));
-        }
+        // check that the client window ids match
+        String outputText = page.findElement(By.id("testFormPage2:windowIdParam")).getText();
+        assertTrue(clientWindowJS.equals(outputText));
     }
 
     /**
@@ -127,29 +134,27 @@ public class JSF22ClientWindowTests {
     public void JSF22ClientWindow_TestSimpleLinkNewWindow() throws Exception {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
-        try (WebClient webClient = new WebClient()) {
+        String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
+        System.out.println(url);
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-            URL url = JSFUtils.createHttpUrl(jsfTestServer2, contextRoot, "index.jsf");
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
+        String clientWindowJS = page.findElement(By.id("clientWindowDisplay")).getText();
 
-            if (page == null) {
-                Assert.fail("index.xhtml did not render properly.");
-            }
-            //get the window id from javascript
-            HtmlElement clientWindowElement = (HtmlElement) page.getElementById("clientWindowDisplay");
-            String clientWindowJS = clientWindowElement.asText();
+        String currentHandle = driver.getWindowHandle();
 
-            // Click link to execute the methods and update the page
-            HtmlElement link = (HtmlElement) page.getElementById("testForm:link2");
-            page = link.click();
+        page.findElement(By.id("testForm:link2")).click(); // opens new tab
+        ArrayList<String> wid = new ArrayList<String>(driver.getWindowHandles());
+        // switch to the new tab
+        wid.remove(currentHandle);
+        driver.switchTo().window(wid.get(0));
+        // Look for the correct results
+        assertTrue(page.isInPageTextReduced("Window ID from parameter: " + clientWindowJS));
 
-            HtmlElement output = (HtmlElement) page.getElementById("testFormPage2:windowIdParam");
-
-            // Look for the correct results
-            assertTrue(page.asText().contains("Window ID from parameter: " + output.asText()));
-            //check that the client window ids match
-            assertTrue(clientWindowJS.equals(output.asText()));
-        }
+        // check that the client window ids match
+        String outputText = page.findElement(By.id("testFormPage2:windowIdParam")).getText();
+        assertTrue(clientWindowJS.equals(outputText));
     }
 
     /**
@@ -162,21 +167,20 @@ public class JSF22ClientWindowTests {
     public void JSF22ClientWindow_TestDisabledLink() throws Exception {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
-        try (WebClient webClient = new WebClient()) {
+        String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
+        System.out.println(url);
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
+        String currentHandle = driver.getWindowHandle();
 
-            URL url = JSFUtils.createHttpUrl(jsfTestServer2, contextRoot, "index.jsf");
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
+        page.findElement(By.id("testForm:linkDisabled1")).click();
+        ArrayList<String> wid = new ArrayList<String>(driver.getWindowHandles());
+        // switch to the new tab
+        wid.remove(currentHandle);
+        driver.switchTo().window(wid.get(0));
 
-            if (page == null) {
-                Assert.fail("index.xhtml did not render properly.");
-            }
-            // Click link to execute the methods and update the page
-            HtmlElement link = (HtmlElement) page.getElementById("testForm:linkDisabled1");
-            page = link.click();
-
-            // Look for the "Test Passed".  The page2Disabled.xhtml page has the logic to compare the IDs.
-            assertTrue(page.asText().contains("Test Passed"));
-        }
+        assertTrue(page.isInPage("Test Passed"));
     }
 
     /**
@@ -191,42 +195,31 @@ public class JSF22ClientWindowTests {
     public void JSF22ClientWindow_TestAjax() throws Exception {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
-        try (WebClient webClient = new WebClient()) {
-            // Use a synchronizing ajax controller to allow proper ajax updating
-            webClient.setAjaxController(new NicelyResynchronizingAjaxController());
+        String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
+        System.out.println(url);
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-            URL url = JSFUtils.createHttpUrl(jsfTestServer2, contextRoot, "index.jsf");
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
+        String clientWindowJS = page.findElement(By.id("clientWindowDisplay")).getText();
 
-            if (page == null) {
-                Assert.fail("index.xhtml did not render properly.");
-            }
+        // fill out fields
+        page.findElement(By.id("testForm:firstName")).sendKeys("John");
+        page.findElement(By.id("testForm:lastName")).sendKeys("Doe");
 
-            //get the window id from javascript
-            HtmlElement clientWindowElement = (HtmlElement) page.getElementById("clientWindowDisplay");
-            String clientWindowJS = clientWindowElement.asText();
+        // Click link to execute the methods and update the page
+        page.findElement(By.id("testForm:buttonAjax1")).click();
+        page.waitReqJs();
 
-            // fill out fields
-            HtmlTextInput input = (HtmlTextInput) page.getElementById("testForm:firstName");
-            input.type("John");
+        String firstName = page.findElement(By.id("testForm:ajaxFirstName")).getText();
+        String lastName = page.findElement(By.id("testForm:ajaxLastName")).getText();
+        String ajaxWindowId = page.findElement(By.id("testForm:ajaxWindowId")).getText();
 
-            HtmlTextInput input2 = (HtmlTextInput) page.getElementById("testForm:lastName");
-            input2.type("Doe");
+        // Look for the correct results
+        assertTrue(firstName.equals("John"));
+        assertTrue(lastName.equals("Doe"));
+        assertTrue(ajaxWindowId.equals(clientWindowJS));
 
-            // Click link to execute the methods and update the page
-            HtmlElement button = (HtmlElement) page.getElementById("testForm:buttonAjax1");
-
-            page = button.click();
-
-            HtmlElement firstName = (HtmlElement) page.getElementById("testForm:ajaxFirstName");
-            HtmlElement lastName = (HtmlElement) page.getElementById("testForm:ajaxLastName");
-            HtmlElement ajaxWindowId = (HtmlElement) page.getElementById("testForm:ajaxWindowId");
-
-            // Look for the correct results
-            assertTrue(firstName.asText().equals("John"));
-            assertTrue(lastName.asText().equals("Doe"));
-            assertTrue(ajaxWindowId.asText().equals(clientWindowJS));
-        }
     }
 
     /**
@@ -241,39 +234,31 @@ public class JSF22ClientWindowTests {
     public void JSF22ClientWindow_TestCommandButton() throws Exception {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
-        try (WebClient webClient = new WebClient()) {
+        String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
+        System.out.println(url);
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-            URL url = JSFUtils.createHttpUrl(jsfTestServer2, contextRoot, "index.jsf");
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
+        String clientWindowJS = page.findElement(By.id("clientWindowDisplay")).getText();
 
-            if (page == null) {
-                Assert.fail("index.xhtml did not render properly.");
-            }
+        // fill out fields
+        page.findElement(By.id("testForm:firstName")).sendKeys("Bill");
+        page.findElement(By.id("testForm:lastName")).sendKeys("Smith");
 
-            //get the window id from javascript
-            HtmlElement clientWindowElement = (HtmlElement) page.getElementById("clientWindowDisplay");
-            String clientWindowJS = clientWindowElement.asText();
+        // Click link to execute the methods and update the page
+        page.findElement(By.id("testForm:submitCommandButton1")).click();
+        page.waitReqJs();
+        System.out.println(page.getPageSource());
 
-            // fill out fields
-            HtmlTextInput input = (HtmlTextInput) page.getElementById("testForm:firstName");
-            input.type("Bill");
-            HtmlTextInput input2 = (HtmlTextInput) page.getElementById("testForm:lastName");
-            input2.type("Smith");
+        String firstName = page.findElement(By.id("testFormPage2:firstName")).getText();
+        String lastName = page.findElement(By.id("testFormPage2:lastName")).getText();
+        String windowIdBean = page.findElement(By.id("testFormPage2:windowIdBean")).getText();
 
-            // Click link to execute the methods and update the page
-            HtmlElement button = (HtmlElement) page.getElementById("testForm:submitCommandButton1");
-
-            page = button.click();
-
-            HtmlElement firstName = (HtmlElement) page.getElementById("testFormPage2:firstName");
-            HtmlElement lastName = (HtmlElement) page.getElementById("testFormPage2:lastName");
-            HtmlElement windowIdBean = (HtmlElement) page.getElementById("testFormPage2:windowIdBean");
-
-            // Look for the correct results
-            assertTrue(firstName.asText().equals("Bill"));
-            assertTrue(lastName.asText().equals("Smith"));
-            assertTrue(windowIdBean.asText().equals(clientWindowJS));
-        }
+        // Look for the correct results
+        assertTrue(firstName.equals("Bill"));
+        assertTrue(lastName.equals("Smith"));
+        assertTrue(windowIdBean.equals(clientWindowJS));
     }
 
     /**
@@ -288,39 +273,31 @@ public class JSF22ClientWindowTests {
     public void JSF22ClientWindow_TestCommandLink() throws Exception {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
-        try (WebClient webClient = new WebClient()) {
+        String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
+        System.out.println(url);
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-            URL url = JSFUtils.createHttpUrl(jsfTestServer2, contextRoot, "index.jsf");
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
+        String clientWindowJS = page.findElement(By.id("clientWindowDisplay")).getText();
 
-            if (page == null) {
-                Assert.fail("index.xhtml did not render properly.");
-            }
+        // fill out fields
+        page.findElement(By.id("testForm:firstName")).sendKeys("Jane");
+        page.findElement(By.id("testForm:lastName")).sendKeys("Jones");
 
-            //get the window id from javascript
-            HtmlElement clientWindowElement = (HtmlElement) page.getElementById("clientWindowDisplay");
-            String clientWindowJS = clientWindowElement.asText();
+        // Click link to execute the methods and update the page
+        page.findElement(By.id("testForm:commandLink1")).click();
+        page.waitReqJs();
+        System.out.println(page.getPageSource());
 
-            // fill out fields
-            HtmlTextInput input = (HtmlTextInput) page.getElementById("testForm:firstName");
-            input.type("Jane");
-            HtmlTextInput input2 = (HtmlTextInput) page.getElementById("testForm:lastName");
-            input2.type("Jones");
+        String firstName = page.findElement(By.id("testFormPage2:firstName")).getText();
+        String lastName = page.findElement(By.id("testFormPage2:lastName")).getText();
+        String windowIdBean = page.findElement(By.id("testFormPage2:windowIdBean")).getText();
 
-            // Click link to execute the methods and update the page
-            HtmlElement button = (HtmlElement) page.getElementById("testForm:commandLink1");
-
-            page = button.click();
-
-            HtmlElement firstName = (HtmlElement) page.getElementById("testFormPage2:firstName");
-            HtmlElement lastName = (HtmlElement) page.getElementById("testFormPage2:lastName");
-            HtmlElement windowIdBean = (HtmlElement) page.getElementById("testFormPage2:windowIdBean");
-
-            // Look for the correct results
-            assertTrue(firstName.asText().equals("Jane"));
-            assertTrue(lastName.asText().equals("Jones"));
-            assertTrue(windowIdBean.asText().equals(clientWindowJS));
-        }
+        // Look for the correct results
+        assertTrue(firstName.equals("Jane"));
+        assertTrue(lastName.equals("Jones"));
+        assertTrue(windowIdBean.equals(clientWindowJS));
     }
 
     /**
@@ -335,31 +312,24 @@ public class JSF22ClientWindowTests {
     public void JSF22ClientWindow_TestButton() throws Exception {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
-        try (WebClient webClient = new WebClient()) {
+        String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
+        System.out.println(url);
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-            URL url = JSFUtils.createHttpUrl(jsfTestServer2, contextRoot, "index.jsf");
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
+        String clientWindowJS = page.findElement(By.id("clientWindowDisplay")).getText();
 
-            if (page == null) {
-                Assert.fail("index.xhtml did not render properly.");
-            }
+        page.findElement(By.id("testForm:button1")).click();
+        page.waitForPageToLoad();
 
-            //get the window id from javascript
-            HtmlElement clientWindowElement = (HtmlElement) page.getElementById("clientWindowDisplay");
-            String clientWindowJS = clientWindowElement.asText();
+        String windowIdParam = page.findElement(By.id("testFormPage2:windowIdParam")).getText();
 
-            // Click link to execute the methods and update the page
-            HtmlElement button = (HtmlElement) page.getElementById("testForm:button1");
+        String windowIdBean = page.findElement(By.id("testFormPage2:windowIdBean")).getText();
 
-            page = button.click();
+        assertTrue(windowIdBean.equals(clientWindowJS));
+        assertTrue(windowIdBean.equals(windowIdParam));
 
-            HtmlElement windowIdParam = (HtmlElement) page.getElementById("testFormPage2:windowIdParam");
-            HtmlElement windowIdBean = (HtmlElement) page.getElementById("testFormPage2:windowIdBean");
-
-            // Look for the correct results
-            assertTrue(windowIdBean.asText().equals(clientWindowJS));
-            assertTrue(windowIdBean.asText().equals(windowIdParam.asText()));
-        }
     }
 
     /**
@@ -375,27 +345,22 @@ public class JSF22ClientWindowTests {
     public void JSF22ClientWindow_TestButtonDisabled() throws Exception {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
-        try (WebClient webClient = new WebClient()) {
+        String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
+        System.out.println(url);
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-            URL url = JSFUtils.createHttpUrl(jsfTestServer2, contextRoot, "index.jsf");
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
+        String clientWindowJS = page.findElement(By.id("clientWindowDisplay")).getText();
 
-            if (page == null) {
-                Assert.fail("index.xhtml did not render properly.");
-            }
+        page.findElement(By.id("testForm:button2Disabled")).click();
+        // Look for the correct results
+        assertTrue(page.isInPageTextReduced("Test Passed"));
 
-            // Click link to execute the methods and update the page
-            HtmlElement button = (HtmlElement) page.getElementById("testForm:button2Disabled");
+        // check that the client window ids match
+        String windowIdBean = page.findElement(By.id("form2Disabled:outputWindowIdBean")).getText();
 
-            page = button.click();
-
-            HtmlElement windowIdBean = (HtmlElement) page.getElementById("form2Disabled:outputWindowIdBean");
-
-            // Look for the "Test Passed".  The page2Disabled.xhtml page has the logic to compare the IDs.
-            assertTrue(page.asText().contains("Test Passed"));
-            //We still should be able to get the id from the ExternalContext (in the bean), check to make sure that it isn't null.
-            assertTrue(windowIdBean.asText() != null);
-        }
+        assertTrue(windowIdBean != null && windowIdBean != "");
     }
 
     /**
@@ -408,37 +373,28 @@ public class JSF22ClientWindowTests {
     public void JSF22ClientWindow_TestMultipleBasePages() throws Exception {
         String contextRoot = isEE10 ? APP_NAME_FACES40 : APP_NAME;
 
-        try (WebClient webClient = new WebClient()) {
+        String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index.jsf");
+        System.out.println(url);
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-            //index.xhtml link
-            URL url = JSFUtils.createHttpUrl(jsfTestServer2, contextRoot, "index.jsf");
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
+        page.findElement(By.id("testForm:link1")).click();
+        page.waitForPageToLoad();
 
-            if (page == null) {
-                Assert.fail("index.xhtml did not render properly.");
-            }
+        String windowIdParam = page.findElement(By.id("testFormPage2:windowIdParam")).getText();
 
-            // Click link to execute the methods and update the page
-            HtmlElement link = (HtmlElement) page.getElementById("testForm:link1");
-            page = link.click();
+        String url2 = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "index2.jsf");
+        System.out.println(url2);
+        WebPage page2 = new WebPage(driver);
+        page2.get(url2);
+        page2.waitForPageToLoad();
 
-            HtmlElement output1 = (HtmlElement) page.getElementById("testFormPage2:windowIdParam");
+        page2.findElement(By.id("testForm:link1")).click();
+        page.waitForPageToLoad();
 
-            //index2.xhtml link
-            url = JSFUtils.createHttpUrl(jsfTestServer2, contextRoot, "index2.jsf");
-            HtmlPage page2 = (HtmlPage) webClient.getPage(url);
-
-            if (page2 == null) {
-                Assert.fail("index2.xhtml did not render properly.");
-            }
-
-            // Click link to execute the methods and update the page
-            HtmlElement link2 = (HtmlElement) page2.getElementById("testForm:link1");
-            page2 = link2.click();
-
-            HtmlElement output2 = (HtmlElement) page2.getElementById("testFormPage2:windowIdParam");
-            //check that the client window ids do not match
-            assertFalse(output1.asText().equals(output2.asText()));
-        }
+        String windowIdParam2 = page.findElement(By.id("testFormPage2:windowIdParam")).getText();
+        
+        assertFalse(windowIdParam.equals(windowIdParam2));
     }
 }

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22MiscellaneousTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22MiscellaneousTests.java
@@ -233,7 +233,8 @@ public class JSF22MiscellaneousTests {
 
             String input = page.findElement(By.id("form1:firstName")).getAttribute("value");
             Log.info(c, name.getMethodName(), "form1:firstName value (expecting empty string) = " + input);
-
+            
+            // Look for the correct results. The "John" text should not exist in the page.
             assertFalse(input.contains("John"));
     }
 

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ResetValuesAndAjaxDelayTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ResetValuesAndAjaxDelayTests.java
@@ -120,6 +120,7 @@ public class JSF22ResetValuesAndAjaxDelayTests {
         Log.info(c, name.getMethodName(), "On save, the validation should have failed.  Message displayed: " + message);
         assertNotNull("A validation error should have been displayed", message);
 
+        // click the link again, the value should still increment which means the Ajax reset is working
         page.findElement(By.id("form1:link1")).click();
         page.waitReqJs();
 
@@ -127,6 +128,7 @@ public class JSF22ResetValuesAndAjaxDelayTests {
         Log.info(c, name.getMethodName(), "The input1 field should have a value of 2, actual: " + input1Value);
         assertEquals("2", input1Value);
 
+        // click the resetButton and ensure the fields are reset to 0 each, which means the f:resetValues component is working.
         page.findElement(By.id("form1:resetButton")).click();
         page.waitReqJs();
 

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFCompELTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFCompELTests.java
@@ -9,8 +9,8 @@
  *******************************************************************************/
 package com.ibm.ws.jsf22.fat.tests;
 
-import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
 import java.util.List;
@@ -21,17 +21,25 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.BrowserWebDriverContainer;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jsf22.fat.FATSuite;
 import com.ibm.ws.jsf22.fat.JSFUtils;
+import com.ibm.ws.jsf22.fat.selenium_util.CustomDriver;
+import com.ibm.ws.jsf22.fat.selenium_util.ExtendedWebDriver;
+import com.ibm.ws.jsf22.fat.selenium_util.WebPage;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
+import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -56,6 +64,12 @@ public class JSFCompELTests {
     @Server("jsfTestServer2")
     public static LibertyServer jsfTestServer2;
 
+
+    @Rule
+    public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>(FATSuite.getChromeImage()).withCapabilities(new ChromeOptions())
+                                                                                  .withAccessToHost(true)
+                                                                                  .withLogConsumer(new SimpleLogConsumer(JSFCompELTests.class, "selenium-driver"));
+
     @BeforeClass
     public static void setup() throws Exception {
         boolean isEE10 = JakartaEE10Action.isActive();
@@ -65,6 +79,8 @@ public class JSFCompELTests {
                                       "com.ibm.ws.jsf22.el.components");
 
         jsfTestServer2.startServer(c.getSimpleName() + ".log");
+
+        Testcontainers.exposeHostPorts(jsfTestServer2.getHttpDefaultPort(), jsfTestServer2.getHttpDefaultSecurePort());
     }
 
     @AfterClass
@@ -242,13 +258,18 @@ public class JSFCompELTests {
 
     //tests ValueExpression support in f:ajax event=#{bean.method} - https://issues.apache.org/jira/browse/MYFACES-3233
     @Test
-    @SkipForRepeat(EE10_FEATURES) // Skipped due to HTMLUnit / JavaScript Incompatabilty (New JS in RC5)
     public void testAjaxEvent() throws Exception {
         // Fix the response once RTC is fixed
-        String[] expectedInResponse = {
-                                        "true"
-        };
-        this.verifyXmlResponse(contextRoot, "AjaxEvent.xhtml", "true");
+
+        ExtendedWebDriver driver = new CustomDriver(new RemoteWebDriver(chrome.getSeleniumAddress(), new ChromeOptions().setAcceptInsecureCerts(true)));
+
+        String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "AjaxEvent.xhtml");
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
+
+        assertTrue("true not found in page", page.isInPage("true"));
+
     }
 
 }


### PR DESCRIPTION
For the jsf 2.2 section of #24387

JSF22ComponentTesterTests
- JSF22ComponentTester_TestCommandLinkOrder

JSF22MiscellaneousTests
- testResetValues

JSF22ClientWindowTests
- JSF22ClientWindow_TestAjax
- JSF22ClientWindow_TestSimpleLink
- JSF22ClientWindow_TestSimpleLinkNewWindow 
- JSF22ClientWindow_TestDisabledLink
- JSF22ClientWindow_TestCommandButton
- JSF22ClientWindow_TestCommandLink
- JSF22ClientWindow_TestButton
- JSF22ClientWindow_TestButtonDisabled
- JSF22ClientWindow_TestMultipleBasePages

JSFCompELTests.java
- testAjaxEvent

JSF22ResetValuesAndAjaxDelayTests.java
- testResetValues
- testAjaxZeroDelay
- testAjaxDelayNone (previously disabled due to HTMLUnit 'none' bug) 
