### PR TITLE
296448 Add permission to Java FAT

### DIFF
--- a/dev/io.openliberty.java.internal_fat/publish/servers/java-illegal-access-exception-server/bootstrap.properties
+++ b/dev/io.openliberty.java.internal_fat/publish/servers/java-illegal-access-exception-server/bootstrap.properties
@@ -9,3 +9,4 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info
+websphere.java.security.exempt=true

--- a/dev/io.openliberty.java.internal_fat/publish/servers/java17-cdi-server/bootstrap.properties
+++ b/dev/io.openliberty.java.internal_fat/publish/servers/java17-cdi-server/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,3 +12,4 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info
+websphere.java.security.exempt=true

--- a/dev/io.openliberty.java.internal_fat/publish/servers/java17-server/bootstrap.properties
+++ b/dev/io.openliberty.java.internal_fat/publish/servers/java17-server/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,3 +12,4 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info
+websphere.java.security.exempt=true


### PR DESCRIPTION
When running the Java 17 FAT with Java 2 security turned on, it fails with:

```
<div id="error"> Exception thrown by application class 'org.apache.cxf.service.invoker.AbstractInvoker.createFault:167'
</div>
<div id="code">
org.apache.cxf.interceptor.Fault: java.util.random.RandomGenerator: Unable to load jdk.random.L32X64MixRandom<br>
<div id="stack">at 
org.apache.cxf.service.invoker.AbstractInvoker.createFault(AbstractInvoker.java:167)<br>at
 [internal classes]<br>
</div>Caused by: 
java.util.ServiceConfigurationError: java.util.random.RandomGenerator: Unable to load jdk.random.L32X64MixRandom<br>
</div>Caused by: 
java.security.AccessControlException: Access denied &#40;&quot;java.lang.RuntimePermission&quot; &quot;accessClassInPackage.jdk.internal.util.random&quot;&#41;<br>
</div>
```

Java 2 security is not necessary for this test.  Added a Java 2 security bypass in the bootstrap.properties file for testing.