### PR TITLE
Update BouncyCastle libs for install

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -134,7 +134,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>32.0.1-android</version>
+      <version>30.1-android</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -2125,6 +2125,11 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpg-jdk15on</artifactId>
       <version>1.69</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpg-jdk18on</artifactId>
+      <version>1.75</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -421,6 +421,7 @@ org.apache.wss4j:wss4j-ws-security-web:2.3.0
 org.apache.xbean:xbean-asm8-shaded:4.17
 org.bitbucket.b_c:jose4j:0.9.3
 org.bouncycastle:bcpg-jdk15on:1.69
+org.bouncycastle:bcpg-jdk18on:1.75
 org.bouncycastle:bcpkix-jdk15on:1.69
 org.bouncycastle:bcpkix-jdk18on:1.75
 org.bouncycastle:bcprov-jdk15on:1.69

--- a/dev/com.ibm.ws.install/bnd.bnd
+++ b/dev/com.ibm.ws.install/bnd.bnd
@@ -30,8 +30,8 @@ instrument.disabled: true
 
 -includeresource: \
 	@${repo;org.fusesource.jansi;1.18.0;EXACT}!/!META-INF/MANIFEST.MF|META-INF/maven/* \
-	@${repo;org.bouncycastle:bcpg-jdk15on;1.69;EXACT},\
-    @${repo;org.bouncycastle:bcprov-jdk15on;1.69;EXACT}
+	@${repo;org.bouncycastle:bcpg-jdk18on;1.75;EXACT},\
+    @${repo;org.bouncycastle:bcprov-jdk18on;1.75;EXACT}
 
 -buildpath: \
 	com.ibm.ws.crypto.passwordutil;version=latest,\
@@ -52,8 +52,8 @@ instrument.disabled: true
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.kernel.feature.cmdline;version=latest,\
 	com.ibm.ws.kernel.feature.core;version=latest,\
-	org.bouncycastle:bcpg-jdk15on;version=1.69,\
-	org.bouncycastle:bcprov-jdk15on;version=1.69,\
+	org.bouncycastle:bcpg-jdk18on;version=1.75,\
+	org.bouncycastle:bcprov-jdk18on;version=1.75,\
 	org.glassfish.javax.json
 
 

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/VerifySignatureUtility.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/VerifySignatureUtility.java
@@ -322,7 +322,7 @@ public class VerifySignatureUtility {
             }
             return pgpPubRingCollection;
 
-        } catch (IOException | PGPException e) {
+        } catch (IOException e) {
             throw new InstallException(e.getMessage());
         }
     }


### PR DESCRIPTION
Updated BC libs to 1.75. 
Fixes https://github.ibm.com/websphere/wlp-scan/issues/286 