### PR TITLE
Update Jakarta Data TCK

### DIFF
--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/build.gradle
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,31 +11,5 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-//The following artifacts need to be available to the server at runtime
-configurations {
-  junit5  { transitive = false; } 
-  sigTest { transitive = false; } 
-}
-
-dependencies {
-  junit5 'org.junit.jupiter:junit-jupiter:5.9.0'
-  sigTest 'org.netbeans.tools:sigtest-maven-plugin:1.6'
-}
-
-task copyJunit5(type: Copy) {
-  mustRunAfter jar
-  from configurations.junit5
-  into new File(autoFvtDir, 'publish/shared/resources/junit5/5.9.0')
-}
-
-task copySigTest(type: Copy) {
-  mustRunAfter jar
-  from configurations.sigTest
-  into new File(autoFvtDir, 'publish/shared/resources/sigtest/1.6')
-  rename 'sigtest-maven-plugin-.*.jar', 'sigtest.jar'
-}
-
 addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn copyJdbcDrivers
-addRequiredLibraries.dependsOn copyJunit5
-addRequiredLibraries.dependsOn copySigTest

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
@@ -20,8 +20,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.log.Log;
-
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
@@ -48,7 +46,9 @@ public class DataCoreTckLauncher {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer(
+                          "CWWKE0955E" //websphere.java.security java 18+
+        );
     }
 
     /**
@@ -64,16 +64,9 @@ public class DataCoreTckLauncher {
         //FIXME Always skip signature tests since our implementation has experimental API
         additionalProps.put("included.groups", "core & persistence & !signature");
 
-        // Skip signature testing on Windows.
-        // So far as I can tell the signature test plugin is not supported on this configuration
-        if (System.getProperty("os.name").contains("Windows")) {
-            Log.info(DataWebTckLauncher.class, "launchDataTckWeb", "Skipping Jakarta Data Signature Test on Windows");
-            additionalProps.put("included.groups", "core & persistence & !signature");
-        }
-
         //TODO Remove once TCK is available from stagging repo
         additionalProps.put("jakarta.data.groupid", "io.openliberty.jakarta.data");
-        additionalProps.put("jakarta.data.tck.version", "1.0.0-05112023");
+        additionalProps.put("jakarta.data.tck.version", "1.0.0-20230802");
 
         String bucketName = "io.openliberty.jakarta.data.1.0_fat_tck";
         String testName = this.getClass() + ":launchDataTckCore";

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataStandaloneTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataStandaloneTckLauncher.java
@@ -19,8 +19,6 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.log.Log;
-
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
@@ -55,16 +53,9 @@ public class DataStandaloneTckLauncher {
         //FIXME Always skip signature tests since our implementation has experimental API
         additionalProps.put("included.groups", "standalone & persistence & !signature");
 
-        // Skip signature testing on Windows.
-        // So far as I can tell the signature test plugin is not supported on this configuration
-        if (System.getProperty("os.name").contains("Windows")) {
-            Log.info(DataStandaloneTckLauncher.class, "launchDataTckStandalone", "Skipping Jakarta Data Signature Test on Windows");
-            additionalProps.put("included.groups", "standalone & persistence & !signature");
-        }
-
         //TODO Remove once TCK is available from stagging repo
         additionalProps.put("jakarta.data.groupid", "io.openliberty.jakarta.data");
-        additionalProps.put("jakarta.data.tck.version", "1.0.0-05112023");
+        additionalProps.put("jakarta.data.tck.version", "1.0.0-20230802");
 
         String bucketName = "io.openliberty.jakarta.data.1.0_fat_tck";
         String testName = this.getClass() + ":launchDataTckStandalone";

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataStandaloneTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataStandaloneTckLauncher.java
@@ -50,6 +50,7 @@ public class DataStandaloneTckLauncher {
     public void launchDataTckStandalone() throws Exception {
         // Test groups to run
         Map<String, String> additionalProps = new HashMap<>();
+        additionalProps.put("jimage.dir", "/jimage/output/");
         additionalProps.put("jakarta.tck.profile", "none");
         //FIXME Always skip signature tests since our implementation has experimental API
         additionalProps.put("included.groups", "standalone & persistence & !signature");

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
@@ -49,7 +49,9 @@ public class DataWebTckLauncher {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer(
+                          "CWWKE0955E" //websphere.java.security java 18+
+        );
     }
 
     /**
@@ -67,7 +69,7 @@ public class DataWebTckLauncher {
 
         //TODO Remove once TCK is available from stagging repo
         additionalProps.put("jakarta.data.groupid", "io.openliberty.jakarta.data");
-        additionalProps.put("jakarta.data.tck.version", "1.0.0-05112023");
+        additionalProps.put("jakarta.data.tck.version", "1.0.0-20230802");
 
         String bucketName = "io.openliberty.jakarta.data.1.0_fat_tck";
         String testName = this.getClass() + ":launchDataTckWeb";

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
@@ -18,6 +18,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.topology.database.container.DatabaseContainerFactory;
 
@@ -27,7 +28,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 DataCoreTckLauncher.class,
                 DataWebTckLauncher.class //full mode
 })
-public class FATSuite {
+public class FATSuite extends TestContainerSuite {
     @ClassRule
     public static JdbcDatabaseContainer<?> jdbcContainer = DatabaseContainerFactory.create();
 }

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/servers/io.openliberty.org.jakarta.data.1.0.core/server.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/servers/io.openliberty.org.jakarta.data.1.0.core/server.xml
@@ -28,9 +28,6 @@
     
     <include location="../fatTestPorts.xml" />
 
-    <!-- Allow Arquillian to monitor application -->
-    <applicationMonitor updateTrigger="mbean"/>
-
     <!-- Allow Arquillian access to dropins directory for application installation -->
     <remoteFileAccess>
         <writeDir>${server.config.dir}/dropins</writeDir>
@@ -48,9 +45,6 @@
 
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
-
-    <!-- Signature test application permissions -->
-    <javaPermission codeBase="${server.config.dir}/dropins/signatureTest.war" className="java.security.AllPermission"/>
 	
     <!-- Permission needed for Oracle driver -->
     <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers" />

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/servers/io.openliberty.org.jakarta.data.1.0.core/server.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/servers/io.openliberty.org.jakarta.data.1.0.core/server.xml
@@ -45,26 +45,13 @@
       <jdbcDriver libraryRef="dbRotationLib"/>
       <properties.derby.embedded createDatabase="create" databaseName="memory:testdb" user="dbuser1" password="dbpwd1"/>
     </dataSource>
-    
-    <!-- Include test dependencies needed on the server at runtime at a global scope -->
-    <library id="global">
-               <fileset dir="${shared.resource.dir}/junit5/5.9.0" includes="*.jar"/>
-               <fileset dir="${shared.resource.dir}/sigtest/1.6" includes="*.jar"/>
-    </library>
 
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 
     <!-- Signature test application permissions -->
-    <javaPermission codeBase="${shared.resource.dir}/sigtest/sigtest-maven-plugin.jar" className="java.security.AllPermission"/>
     <javaPermission codeBase="${server.config.dir}/dropins/signatureTest.war" className="java.security.AllPermission"/>
-    
-    <!-- Signature test plugin permissions -->
-    <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.security.AllPermission" />
-    <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal" />
-    <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal.reflect" />
-    <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal.vm.annotation" />
-    
+	
     <!-- Permission needed for Oracle driver -->
     <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers" />
     
@@ -74,5 +61,4 @@
     <!-- Permission needed for SQLServer driver -->
     <javaPermission className="java.util.PropertyPermission" name="java.specification.version" actions="read"/>
     <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
-
 </server>

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/servers/io.openliberty.org.jakarta.data.1.0.web/server.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/servers/io.openliberty.org.jakarta.data.1.0.web/server.xml
@@ -29,9 +29,6 @@
     
     <include location="../fatTestPorts.xml" />
 
-    <!-- Allow Arquillian to monitor application -->
-    <applicationMonitor updateTrigger="mbean"/>
-
     <!-- Allow Arquillian access to dropins directory for application installation -->
     <remoteFileAccess>
         <writeDir>${server.config.dir}/dropins</writeDir>
@@ -49,9 +46,6 @@
     
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
-
-    <!-- Signature test application permissions -->
-    <javaPermission codeBase="${server.config.dir}/dropins/signatureTest.war" className="java.security.AllPermission"/>
 	
     <!-- Permission needed for Oracle driver -->
     <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers" />

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/servers/io.openliberty.org.jakarta.data.1.0.web/server.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/servers/io.openliberty.org.jakarta.data.1.0.web/server.xml
@@ -47,25 +47,12 @@
       <properties.derby.embedded createDatabase="create" databaseName="memory:testdb" user="dbuser1" password="dbpwd1"/>
     </dataSource>
     
-    <!-- Include test dependencies needed on the server at runtime at a global scope -->
-    <library id="global">
-               <fileset dir="${shared.resource.dir}/junit5/5.9.0" includes="*.jar"/>
-               <fileset dir="${shared.resource.dir}/sigtest/1.6" includes="*.jar"/>
-    </library>
-
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 
     <!-- Signature test application permissions -->
-    <javaPermission codeBase="${shared.resource.dir}/sigtest/sigtest-maven-plugin.jar" className="java.security.AllPermission"/>
     <javaPermission codeBase="${server.config.dir}/dropins/signatureTest.war" className="java.security.AllPermission"/>
-    
-    <!-- Signature test plugin permissions -->
-    <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.security.AllPermission" />
-    <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal" />
-    <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal.reflect" />
-    <javaPermission codeBase="${shared.resource.dir}/sigtest/1.6/sigtest.jar" className="java.lang.RuntimePermission"  name="accessClassInPackage.jdk.internal.vm.annotation" />
-    
+	
     <!-- Permission needed for Oracle driver -->
     <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers" />
     

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/core/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/core/pom.xml
@@ -12,10 +12,14 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	
+	<parent>
+		<groupId>io.openliberty.jakarta.data</groupId>
+		<artifactId>tck.runner</artifactId>
+	    <version>1.0-SNAPSHOT</version>
+	</parent>
 
-	<groupId>io.openliberty.jakarta.data</groupId>
 	<artifactId>tck.runner.core</artifactId>
-	<version>1.0-SNAPSHOT</version>
 	<name>Jakarta Data TCK Runner TCK Module</name>
 
 	<repositories>
@@ -40,51 +44,10 @@
 	</repositories>
 
 	<properties>
-		<!-- Global Maven settings -->
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
-		<maven.compiler.release>17</maven.compiler.release>
-
-		<!-- Jakarta EE API -->
-		<jakarta.data.groupid>jakarta.data</jakarta.data.groupid>
-		<jakarta.data.version>1.0.0-SNAPSHOT</jakarta.data.version>
-		<jakarta.data.tck.version>1.0.0-SNAPSHOT</jakarta.data.tck.version>
-		<jakarta.cdi.version>4.0.1</jakarta.cdi.version>
-
-		<!-- Test Infrastructure versions -->
-		<arquillian.version>1.7.0.Alpha13</arquillian.version>
-		<arquillian.wlp.version>2.1.2</arquillian.wlp.version>
-		<junit.version>5.9.2</junit.version>
-		<sigtest.version>1.6</sigtest.version>
-
 		<!-- Used in arquillian.xml passed from test suite -->
 		<wlp>${wlp}</wlp>
-
 		<targetDirectory>${project.basedir}/target</targetDirectory>
 	</properties>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.jboss.arquillian</groupId>
-				<artifactId>arquillian-bom</artifactId>
-				<version>${arquillian.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.junit</groupId>
-				<artifactId>junit-bom</artifactId>
-				<version>${junit.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 
 	<dependencies>
 		<!-- tck - data - external TCK -->
@@ -157,6 +120,11 @@
 			<artifactId>sigtest-maven-plugin</artifactId>
 			<version>${sigtest.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.jboss.shrinkwrap.resolver</groupId>
+			<artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+		</dependency>
+		
 	</dependencies>
 
 	<build>
@@ -183,10 +151,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
 				<configuration>
-					<source>17</source>
-					<target>17</target>
+					<source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/core/src/test/resources/arquillian.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/core/src/test/resources/arquillian.xml
@@ -24,9 +24,9 @@
 			<property name="appDeployTimeout">${tck_appDeployTimeout}</property>
 			<property name="appUndeployTimeout">${tck_appUndeployTimeout}</property>
 			
-			<!-- Custom properties needed for tests to run without using a servlet -->
-			<property name="allowConnectingToRunningServer">true</property>
+			<!-- Specific to core profiles -->
 			<property name="testProtocol">rest</property>
+			<property name="allowConnectingToRunningServer">true</property>
 		</configuration>
 	</container>
 </arquillian> 

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/pom.xml
@@ -22,10 +22,45 @@
     <name>Jakarta Data TCK Runner</name>
 
     <properties>
+        <!-- Global Maven settings -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
+
+        <!-- Jakarta EE API -->
+        <jakarta.data.groupid>jakarta.data</jakarta.data.groupid>
+        <jakarta.data.version>1.0.0-SNAPSHOT</jakarta.data.version>
+        <jakarta.data.tck.version>1.0.0-SNAPSHOT</jakarta.data.tck.version>
+        <jakarta.cdi.version>4.0.1</jakarta.cdi.version>
+
+        <!-- Test Infrastructure versions -->
+        <arquillian.version>1.7.0.Final</arquillian.version>
+        <arquillian.wlp.version>2.1.3</arquillian.wlp.version>
+        <junit.version>5.9.2</junit.version>
+        <sigtest.version>1.6</sigtest.version>
     </properties>
+    
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <modules>
         <module>standalone</module>
@@ -41,8 +76,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>2.3.2</version>
                     <configuration>
-                        <source>17</source>
-                        <target>17</target>
+                        <source>${maven.compiler.source}</source>
+                        <target>${maven.compiler.target}</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/standalone/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/standalone/pom.xml
@@ -13,9 +13,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>io.openliberty.jakarta.data</groupId>
+	<parent>
+		<groupId>io.openliberty.jakarta.data</groupId>
+		<artifactId>tck.runner</artifactId>
+	    <version>1.0-SNAPSHOT</version>
+	</parent>
+	
 	<artifactId>tck.runner.standalone</artifactId>
-	<version>1.0-SNAPSHOT</version>
 	<name>Jakarta Data TCK Runner TCK Module</name>
 
 	<repositories>
@@ -40,38 +44,8 @@
 	</repositories>
 
 	<properties>
-		<!-- Global Maven settings -->
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
-		<maven.compiler.release>17</maven.compiler.release>
-
-		<!-- Jakarta EE API -->
-		<jakarta.data.groupid>jakarta.data</jakarta.data.groupid>
-		<jakarta.data.version>1.0.0-SNAPSHOT</jakarta.data.version>
-		<jakarta.data.tck.version>1.0.0-SNAPSHOT</jakarta.data.tck.version>
-
-		<!-- Test Infrastructure versions -->
-		<junit.version>5.9.2</junit.version>
-		<sigtest.version>1.6</sigtest.version>
-
 		<targetDirectory>${project.basedir}/target</targetDirectory>
 	</properties>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.junit</groupId>
-				<artifactId>junit-bom</artifactId>
-				<version>${junit.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 
 	<dependencies>
 		<!-- tck - data - external TCK -->

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/web/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/web/pom.xml
@@ -12,10 +12,14 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	
+	<parent>
+		<groupId>io.openliberty.jakarta.data</groupId>
+		<artifactId>tck.runner</artifactId>
+	    <version>1.0-SNAPSHOT</version>
+	</parent>
 
-	<groupId>io.openliberty.jakarta.data</groupId>
 	<artifactId>tck.runner.web</artifactId>
-	<version>1.0-SNAPSHOT</version>
 	<name>Jakarta Data TCK Runner TCK Module</name>
 
 	<repositories>
@@ -40,51 +44,10 @@
 	</repositories>
 
 	<properties>
-		<!-- Global Maven settings -->
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
-		<maven.compiler.release>17</maven.compiler.release>
-
-		<!-- Jakarta EE API -->
-		<jakarta.data.groupid>jakarta.data</jakarta.data.groupid>
-		<jakarta.data.version>1.0.0-SNAPSHOT</jakarta.data.version>
-		<jakarta.data.tck.version>1.0.0-SNAPSHOT</jakarta.data.tck.version>
-		<jakarta.cdi.version>4.0.1</jakarta.cdi.version>
-
-		<!-- Test Infrastructure versions -->
-		<arquillian.version>1.7.0.Alpha13</arquillian.version>
-		<arquillian.wlp.version>2.1.2</arquillian.wlp.version>
-		<junit.version>5.9.2</junit.version>
-		<sigtest.version>1.6</sigtest.version>
-
 		<!-- Used in arquillian.xml passed from test suite -->
 		<wlp>${wlp}</wlp>
-
 		<targetDirectory>${project.basedir}/target</targetDirectory>
 	</properties>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.jboss.arquillian</groupId>
-				<artifactId>arquillian-bom</artifactId>
-				<version>${arquillian.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.junit</groupId>
-				<artifactId>junit-bom</artifactId>
-				<version>${junit.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 
 	<dependencies>
 		<!-- tck - data - external TCK -->
@@ -157,6 +120,11 @@
 			<artifactId>sigtest-maven-plugin</artifactId>
 			<version>${sigtest.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.jboss.shrinkwrap.resolver</groupId>
+			<artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+		</dependency>
+        
 	</dependencies>
 
 	<build>
@@ -183,10 +151,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
 				<configuration>
-					<source>17</source>
-					<target>17</target>
+					<source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/web/src/test/resources/arquillian.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/web/src/test/resources/arquillian.xml
@@ -23,6 +23,10 @@
 			<property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
 			<property name="appDeployTimeout">${tck_appDeployTimeout}</property>
 			<property name="appUndeployTimeout">${tck_appUndeployTimeout}</property>
+			
+			
+			<!-- Specific to web/full profiles -->
+			<property name="testProtocol">servlet</property>
 			<property name="allowConnectingToRunningServer">true</property>
 		</configuration>
 	</container>


### PR DESCRIPTION
Implement changes to Jakarta Data TCK from PR: https://github.com/jakartaee/data/pull/190

Also, removed junit and signature test libraries from the server as they are packaged within the applications when they are deployed. 

And cleaned up the maven projects to make them more concise. 

Draft: until the above pull is merged.

