### PR TITLE
JAX-WS: SOAP Attributes- prefix cannot be null when creaing QName Error

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/soapEnvelopePrefix/src/com/ibm/ws/jaxws/test/soapenv/prefix/SoapEnvelopePrefixTestServlet.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/soapEnvelopePrefix/src/com/ibm/ws/jaxws/test/soapenv/prefix/SoapEnvelopePrefixTestServlet.java
@@ -113,6 +113,42 @@ public class SoapEnvelopePrefixTestServlet extends FATServlet {
     }
 
     /*
+     * A positive test where the default namespace is set to the SOAP 1.1 Envelope NS, and the header then sets attributes that
+     * inherit the default namespace
+     *
+     * Default Envelope Namespace: SOAP 1.1 NS - http://schemas.xmlsoap.org/soap/envelope/
+     *
+     * Valid Element QNames:
+     *
+     * Envelope QName: {http://schemas.xmlsoap.org/soap/envelope/}Envelope
+     * Body QName: {http://schemas.xmlsoap.org/soap/envelope/}Body
+     * hello QName: {http://server.wsr.test.jaxws.ws.ibm.com}hello
+     * arg0 QName: {}arg0
+     */
+    @Test
+    public void testSoap11DefaultAttributePrefixInHeaderValidXML() throws Exception {
+
+        String msgString = "<Envelope xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                           + "<Header boo=\"1\"/>"
+                           + "  <Body>\n"
+                           + "    <ser:hello xmlns=\"\" xmlns:ser=\"http://server.wsr.test.jaxws.ws.ibm.com\">\n"
+                           + "       <arg0>from dispatch World</arg0>\n"
+                           + "    </ser:hello>\n"
+                           + "  </Body>\n"
+                           + "</Envelope>";
+
+        if (dispatch == null) {
+            throw new RuntimeException("dispatch  is null!");
+        }
+
+        StreamSource response = dispatch.invoke(new StreamSource(new StringReader(msgString)));
+        String parsedResponse = parseSourceResponse(response);
+        assertTrue("Expected parsed string to contain: " + EXPECTED_PASSING_RESPONSE + " but was actually: " + parsedResponse,
+                   parsedResponse.contains(EXPECTED_PASSING_RESPONSE));
+        //assertNull(notFoundString + " is expected to be in generated schema: " + schemaString, notFoundString);
+    }
+
+    /*
      * A positive test where an additional optional eleement is added to the request, to ensure that service will ignore it and process the request successfully.
      * Additionally this test sends multiple requests that a unmarshaller obtained from the poll can also process the optional element in the second request.
      *


### PR DESCRIPTION
This PR does the following:

1.) Adds a fix for the following failure 

```
Caused by: java.lang.IllegalArgumentException: prefix cannot be "null" when creating a QName
	at java.xml/javax.xml.namespace.QName.<init>(QName.java:192)
	at java.xml/com.sun.xml.internal.stream.events.AttributeImpl.<init>(AttributeImpl.java:80)
	at java.xml/com.sun.xml.internal.stream.events.AttributeImpl.<init>(AttributeImpl.java:76)
	at java.xml/com.sun.xml.internal.stream.events.XMLEventFactoryImpl.createAttribute(XMLEventFactoryImpl.java:68)
	at org.apache.cxf.binding.soap.interceptor.ReadHeadersInterceptor$HeadersProcessor.process(ReadHeadersInterceptor.java:418)
	at org.apache.cxf.binding.soap.interceptor.ReadHeadersInterceptor.handleMessage(ReadHeadersInterceptor.java:217)
	at org.apache.cxf.binding.soap.interceptor.ReadHeadersInterceptor.handleMessage(ReadHeadersInterceptor.java:78)
	at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:307)
	... 35 more
```
2.) Adds a test to SoapEnvelopePrefixTestServlet to test a SOAP Request that contains a header with a default prefix on the attribute.
