### PR TITLE
FeatureUtility FAT set up testContainer for http request

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
@@ -39,7 +39,7 @@ fat.project: true
 	com.ibm.ws.install.featureUtility.featureutil;version=latest,\
 	com.ibm.ws.kernel.boot.core;version=latest,\
 	com.ibm.ws.kernel.feature.cmdline;version=latest,\
-	com.ibm.ws.install.map;version=latest, \
+	com.ibm.ws.install.map;version=latest,\
 	com.ibm.ws.kernel.boot.core;version=latest,\
 	com.ibm.ws.kernel.feature;version=latest,\
 	com.ibm.ws.product.utility;version=latest,\
@@ -50,6 +50,7 @@ fat.project: true
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.kernel.feature.cmdline;version=latest,\
 	com.ibm.ws.kernel.feature.core;version=latest,\
+	io.openliberty.org.testcontainers;version=latest,\
 	wlp.lib.extract;version=latest
 
 -testpath: \

--- a/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
@@ -53,6 +53,7 @@ fat.test.container.images: jiwoo/simple-keyserver:1.0
 	com.ibm.ws.kernel.feature.cmdline;version=latest,\
 	com.ibm.ws.kernel.feature.core;version=latest,\
 	io.openliberty.org.testcontainers;version=latest,\
+	com.ibm.ws.org.slf4j.jdk14;version=latest,\
 	wlp.lib.extract;version=latest
 
 -testpath: \
@@ -73,4 +74,4 @@ fat.test.container.images: jiwoo/simple-keyserver:1.0
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.kernel.feature.cmdline;version=latest,\
 	com.ibm.ws.kernel.feature.core;version=latest,\
-	wlp.lib.extract;version=latest
+	wlp.lib.extract;version=latest,\

--- a/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
@@ -18,6 +18,8 @@ src: \
 
 fat.project: true
 
+fat.test.container.images: jiwoo/simple-keyserver:1.0
+
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 #tested.features:\

--- a/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
@@ -74,4 +74,4 @@ fat.test.container.images: jiwoo/simple-keyserver:1.0
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.kernel.feature.cmdline;version=latest,\
 	com.ibm.ws.kernel.feature.core;version=latest,\
-	wlp.lib.extract;version=latest,\
+	wlp.lib.extract;version=latest

--- a/dev/com.ibm.ws.install.featureUtility_fat/build.gradle
+++ b/dev/com.ibm.ws.install.featureUtility_fat/build.gradle
@@ -32,3 +32,5 @@ addRequiredLibraries {
         into "publish/repo/archive"
     }
 }
+
+addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/com.ibm.ws.install.featureUtility_fat/build.gradle
+++ b/dev/com.ibm.ws.install.featureUtility_fat/build.gradle
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 IBM Corporation and others.
+/* Copyright (c) 2021, 2023 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License 2.0
 * which accompanies this distribution, and is available at
@@ -19,7 +19,8 @@ addRequiredLibraries {
     dependencies {
       usrFeatures 'test.featureUtility_fat:userFeature:1.0@zip'
       features 'test.featureUtility_fat:Archive:1.0@zip'
-      
+      requiredLibs project(':com.ibm.ws.org.slf4j.api'),
+      	project(':com.ibm.ws.org.slf4j.simple')
     }    
     
     copy {
@@ -31,6 +32,6 @@ addRequiredLibraries {
         from configurations.features
         into "publish/repo/archive"
     }
-}
 
-addRequiredLibraries.dependsOn copyTestContainers
+    dependsOn copyTestContainers
+}

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FATSuite.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FATSuite.java
@@ -20,13 +20,15 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.containers.TestContainerSuite;
+
 @RunWith(Suite.class)
 @SuiteClasses({
 
 	InstallFeatureTest.class, InstallServerTest.class, HelpActionTest.class
 
 })
-public class FATSuite {
+public class FATSuite extends TestContainerSuite {
 
     /**
      * Start of FAT suite processing.

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -41,8 +41,6 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 
 	private static final Class<?> c = InstallFeatureTest.class;
 	private static String userFeatureSigPath = "/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa.asc";
-	static String cotainerFilePath = "/public_key";
-	static String localDirPath = mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc";
 
 	@ClassRule
 	public static GenericContainer<?> container = new GenericContainer<>("jiwoo/simple-keyserver:1.0")

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -35,6 +35,8 @@ import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.install.InstallException;
 
+import componenttest.containers.SimpleLogConsumer;
+
 public class InstallFeatureTest extends FeatureUtilityToolTest {
 
 	private static final Class<?> c = InstallFeatureTest.class;
@@ -44,7 +46,8 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 
 	@ClassRule
 	public static GenericContainer<?> container = new GenericContainer<>("jiwoo/simple-keyserver:1.0")
-		.withExposedPorts(8080).waitingFor(Wait.forHttp("/"));
+		.withExposedPorts(8080).waitingFor(Wait.forHttp("/"))
+		.withLogConsumer(new SimpleLogConsumer(InstallFeatureTest.class, "keyserver"));
 
 
 	@BeforeClass
@@ -77,7 +80,6 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 		if (!isZos) {
 			resetOriginalWlpProps();
 		}
-		container.stop();
 	}
 
 	/**
@@ -701,8 +703,6 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    Properties envProps = new Properties();
 	    envProps.put("FEATURE_VERIFY", "all");
 
-	    // start external test server
-	    container.start();
 	    String containerUrl = "http://" + container.getHost() + ":" + container.getMappedPort(8080)
 		    + "/validKey.asc";
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -16,7 +16,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -31,7 +30,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
@@ -45,14 +43,8 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	static String localDirPath = mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc";
 
 	@ClassRule
-	public static GenericContainer<?> container = new GenericContainer<>(//
-		new ImageFromDockerfile()
-			.withDockerfileFromBuilder(
-				builder -> builder.from("python:3-alpine").run("mkdir " + cotainerFilePath)
-					.copy("./validKey.asc", cotainerFilePath + "/validKey.asc").build())
-			.withFileFromFile("./validKey.asc", new File(localDirPath), 644))
-				.withWorkingDirectory(cotainerFilePath).withExposedPorts(8080)
-				.withCommand("python", "-m", "http.server", "8080").waitingFor(Wait.forHttp("/"));
+	public static GenericContainer<?> container = new GenericContainer<>("jiwoo/simple-keyserver:1.0")
+		.withExposedPorts(8080).waitingFor(Wait.forHttp("/"));
 
 
 	@BeforeClass

--- a/dev/com.ibm.ws.install.featureUtility_fat/publish/simple-keyserver/Dockerfile
+++ b/dev/com.ibm.ws.install.featureUtility_fat/publish/simple-keyserver/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3-alpine
+
+RUN mkdir /public_key
+
+WORKDIR /public_key
+
+RUN printf '\
+-----BEGIN PGP PUBLIC KEY BLOCK-----\n\
+Comment: Hostname: \n\
+Version: Hockeypuck 2.1.0-222-g25248d4\n\
+\n\
+xjMEY+1Y6RYJKwYBBAHaRw8BAQdAzgcyMvreUdoUXYofjC+mCm1dW9IaPs+nx9rF\n\
+dc4mKFLOOARj7VjpEgorBgEEAZdVAQUBAQdA52rgXKV5cdmIqXhIhUvT/Hvktcyy\n\
+kKdqt/YJX5GY1CYDAQgHwngEGBYKACACGwwWIQQQyeYjPrW9z8ApyzBx+OYjm2g0\n\
+qgUCY+1ZowAKCRBx+OYjm2g0qtuIAQD64SWKyMBtvr8TZT91mIAsMV+npF58B3v0\n\
+tNyeDipYJQEA74mtwWh9R7i7+7b3jsxFEMSzu8ZbTk25qSIlQLmE9wM=\n\
+=G+gC\n\
+-----END PGP PUBLIC KEY BLOCK-----\n\
+' > "/public_key/validKey.asc"
+
+EXPOSE 8080
+
+
+
+CMD ["python", "-m" , "http.server", "8080"]
+
+# Currently tagged in DockerHub as: jiwoo/simple-keyserver:1.0

--- a/dev/com.ibm.ws.install.featureUtility_fat/publish/simple-keyserver/release.sh
+++ b/dev/com.ibm.ws.install.featureUtility_fat/publish/simple-keyserver/release.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+#Needs to be provided by user
+USER_NAME=jiwoo
+
+#Version of docker image.  Increment if doing a new release
+VERSION=1.0
+
+#Name of the image
+IMAGE_NAME=simple-keyserver
+
+#Docker image signiture in form username/image:version
+CONTAINER=$USER_NAME/$IMAGE_NAME:$VERSION
+
+echo "Attempting to build and push $CONTAINER"
+
+#Ensure user is logged in
+docker login || (echo "Unable to login to DockerHub" && exit 1)
+
+#This script assumes it is in the same directory as the Dockerfile
+docker build --no-cache -t $CONTAINER .
+
+
+#Push image to DockerHub
+docker push "$CONTAINER"
+
+#Add a comment to the Dockerfile and script
+sed -i '' -e '/.*Currently tagged in DockerHub as.*/d' *Dockerfile
+cat << EOF >> *Dockerfile
+
+# Currently tagged in DockerHub as: $CONTAINER
+EOF

--- a/dev/io.openliberty.org.testcontainers/cache/images
+++ b/dev/io.openliberty.org.testcontainers/cache/images
@@ -9,6 +9,7 @@ infinispan/server:10.0.1.Final
 infinispan/server:13.0.10.Final
 jaegertracing/all-in-one:1.39
 jboss/keycloak:16.1.1
+jiwoo/simple-keyserver:1.0
 jonhawkes/postgresql-ssl:1.0
 kyleaure/cloudant-developer:1.0
 kyleaure/couchdb-ssl:1.0

--- a/dev/io.openliberty.org.testcontainers/cache/projects
+++ b/dev/io.openliberty.org.testcontainers/cache/projects
@@ -9,6 +9,7 @@ com.ibm.ws.concurrent.persistent_fat_locking
 com.ibm.ws.concurrent.persistent_fat_multiple
 com.ibm.ws.concurrent.persistent_fat_timers
 com.ibm.ws.couchdb_fat
+com.ibm.ws.install.featureUtility_fat
 com.ibm.ws.jdbc_fat
 com.ibm.ws.jdbc_fat_db2
 com.ibm.ws.jdbc_fat_krb5


### PR DESCRIPTION
Removes dependencies on external http request.
`InstallFeatureTest.testVerifyhttpKeyServer` was added as part of [featureUtility verify signature FAT](https://github.com/OpenLiberty/open-liberty/pull/24724 ) for epic #17220 

Uploaded keyserver image `jiwoo/simple-keyserver:1.0` to Docker Hub. In case public key is updated for the test feature, I provided a script  publish/simple-keyserver/release.sh. Public key should be updated inside the Dockerfile, and the version tag should change so that new image can be cached. 

`fat.test.container.images` adds the keyserver image to the Artifactory cache automatically. If the image does not exist in Artifactory, it will pull the image from the Dockerhub and cache it. 