### PR TITLE
Issue #25712: Fix NPE in deferred injection processing

### DIFF
--- a/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/naming/DeferredNonCompInjectionJavaColonHelper.java
+++ b/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/naming/DeferredNonCompInjectionJavaColonHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -36,7 +36,7 @@ public class DeferredNonCompInjectionJavaColonHelper extends InjectionJavaColonH
         // had a chance.
         if (!namespace.isComp()) {
             OSGiInjectionScopeData scopeData = super.getInjectionScopeData(namespace);
-            if (scopeData.processDeferredReferenceData()) {
+            if (scopeData != null && scopeData.processDeferredReferenceData()) {
                 return scopeData;
             }
         }


### PR DESCRIPTION
The deferred injection processing code assumes scope data must exist for java:app and java:module. Update the code to tolerate configurations that do not have data in those scopes.

fixes #25712