### PR TITLE
Add support for MPOpenAPI custom endpoints for proxies

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/utils/ProxySupportUtil.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/utils/ProxySupportUtil.java
@@ -20,6 +20,9 @@ import javax.servlet.http.HttpServletRequest;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import io.openliberty.microprofile.openapi.internal.common.services.OpenAPIEndpointProvider;
+import org.osgi.framework.BundleContext;
+import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * Handle proxy requests
@@ -33,13 +36,45 @@ public class ProxySupportUtil {
     private static URL extractURL(HttpServletRequest request) {
         String urlString;
         String refererHeader = request.getHeader(HTTP_HEADER_REFERER);
+
+        String docPath = "/openapi";
+        String uiPath = docPath+"/ui";
+
+        // retrieve the context from the request so that we can retrieve the values of the OpenAPI endpoints
+        BundleContext bundleContext = (BundleContext) request.getServletContext().getAttribute("osgi-bundlecontext");
+        //ensure we have a context in case for some reason this is activated with the bundle having stopped
+        if(bundleContext != null) {
+            ServiceTracker<OpenAPIEndpointProvider,OpenAPIEndpointProvider> openAPIEndpointTracker = new ServiceTracker<>(bundleContext, OpenAPIEndpointProvider.class, null);
+            openAPIEndpointTracker.open();
+            docPath = openAPIEndpointTracker.getService().getOpenAPIDocUrl();
+            uiPath = openAPIEndpointTracker.getService().getOpenAPIUIUrl();
+            openAPIEndpointTracker.close();
+        }
+
         if (refererHeader != null) {
             if (OpenAPIUtils.isEventEnabled(tc)) {
                 Tr.event(tc, "Using referer header to generate servers: " + refererHeader);
             }
             refererHeader = refererHeader.endsWith("/") ? refererHeader.substring(0, refererHeader.length() - 1) : refererHeader;
-            if (!refererHeader.endsWith("/ui") && !refererHeader.endsWith("/openapi")) {
-                refererHeader = null;
+            //Original behavior based on default expected paths
+            if(docPath.equals("/openapi") && (uiPath.equals("/openapi/ui"))) {
+                if (!refererHeader.endsWith("/ui") && !refererHeader.endsWith("/openapi")) {
+                    refererHeader = null;
+                }
+            } else {
+                // If either path has been modified to not be default do an exact match
+                try {
+                    URL refURL = new URL(refererHeader);
+                    String refPath = refURL.getPath();
+                    if (!refPath.equals(docPath) && !refPath.equals(uiPath)) {
+                        refererHeader = null;
+                    }
+                } catch (MalformedURLException e){
+                    if (OpenAPIUtils.isEventEnabled(tc)) {
+                        Tr.event(tc, "Failed to create URL for " + refererHeader + ": " + e.getMessage());
+                    }
+                    refererHeader=null;
+                }
             }
             if (refererHeader != null) {
                 urlString = refererHeader;

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/utils/ProxySupportUtil.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/utils/ProxySupportUtil.java
@@ -87,11 +87,14 @@ public class ProxySupportUtil {
             }
             if (refererHeader != null) {
                 urlString = refererHeader;
+                if (OpenAPIUtils.isEventEnabled(tc)) {
+                    Tr.event(tc, "Using Referer header to generate servers: " + urlString);
+                }
             } else {
                 //fall back to using request url
                 urlString = request.getRequestURL().toString();
                 if (OpenAPIUtils.isEventEnabled(tc)) {
-                    Tr.warning(tc, "Unable to use Referer header, using request url to generate servers: " + urlString);
+                    Tr.event(tc, "Unable to use Referer header, using request url to generate servers: " + urlString);
                 }
             }
         } else {

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/utils/ProxySupportUtil.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/utils/ProxySupportUtil.java
@@ -12,17 +12,15 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.openapi.utils;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-
-import javax.servlet.http.HttpServletRequest;
-
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import io.openliberty.microprofile.openapi.internal.common.services.OpenAPIEndpointProvider;
 import org.osgi.framework.BundleContext;
-import org.osgi.util.tracker.ServiceTracker;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 /**
  * Handle proxy requests
@@ -30,25 +28,35 @@ import org.osgi.util.tracker.ServiceTracker;
 public class ProxySupportUtil {
 
     private static final String HTTP_HEADER_REFERER = "Referer";
-    private static TraceComponent tc = Tr.register(ProxySupportUtil.class);
+    private static final String DEFAULT_DOC_PATH = "/openapi";
+    private static final String DEFAULT_UI_PATH = "/ui";
+    private static final TraceComponent tc = Tr.register(ProxySupportUtil.class);
 
     @FFDCIgnore(MalformedURLException.class)
     private static URL extractURL(HttpServletRequest request) {
         String urlString;
         String refererHeader = request.getHeader(HTTP_HEADER_REFERER);
 
-        String docPath = "/openapi";
-        String uiPath = docPath+"/ui";
+        //Default endpoints
+        String docPath = DEFAULT_DOC_PATH;
+        String uiPath = docPath + DEFAULT_UI_PATH;
 
-        // retrieve the context from the request so that we can retrieve the values of the OpenAPI endpoints
         BundleContext bundleContext = (BundleContext) request.getServletContext().getAttribute("osgi-bundlecontext");
-        //ensure we have a context in case for some reason this is activated with the bundle having stopped
-        if(bundleContext != null) {
-            ServiceTracker<OpenAPIEndpointProvider,OpenAPIEndpointProvider> openAPIEndpointTracker = new ServiceTracker<>(bundleContext, OpenAPIEndpointProvider.class, null);
-            openAPIEndpointTracker.open();
-            docPath = openAPIEndpointTracker.getService().getOpenAPIDocUrl();
-            uiPath = openAPIEndpointTracker.getService().getOpenAPIUIUrl();
-            openAPIEndpointTracker.close();
+        //Ensure we have a context as change this will be null if bundle is STOPPED
+        if (bundleContext != null) {
+            OpenAPIEndpointProvider endpointProvider = bundleContext.getService(bundleContext.getServiceReference(OpenAPIEndpointProvider.class));
+            if (endpointProvider != null) {
+                docPath = endpointProvider.getOpenAPIDocUrl();
+                uiPath = endpointProvider.getOpenAPIUIUrl();
+            }
+        }
+
+        //Ensure that in case somehow the values retrieved are null
+        if (docPath == null) {
+            docPath = DEFAULT_DOC_PATH;
+        }
+        if (uiPath == null) {
+            uiPath = docPath + DEFAULT_UI_PATH;
         }
 
         if (refererHeader != null) {
@@ -56,24 +64,25 @@ public class ProxySupportUtil {
                 Tr.event(tc, "Using referer header to generate servers: " + refererHeader);
             }
             refererHeader = refererHeader.endsWith("/") ? refererHeader.substring(0, refererHeader.length() - 1) : refererHeader;
-            //Original behavior based on default expected paths
-            if(docPath.equals("/openapi") && (uiPath.equals("/openapi/ui"))) {
+            //Follow original behavior if path values match their defaults
+            if (docPath.equals(DEFAULT_UI_PATH) && uiPath.equals(DEFAULT_DOC_PATH + DEFAULT_UI_PATH)) {
                 if (!refererHeader.endsWith("/ui") && !refererHeader.endsWith("/openapi")) {
                     refererHeader = null;
                 }
+                // If either path has been modified to not be default do a better check
             } else {
-                // If either path has been modified to not be default do an exact match
                 try {
                     URL refURL = new URL(refererHeader);
                     String refPath = refURL.getPath();
                     if (!refPath.equals(docPath) && !refPath.equals(uiPath)) {
                         refererHeader = null;
                     }
-                } catch (MalformedURLException e){
+                } catch (MalformedURLException e) {
                     if (OpenAPIUtils.isEventEnabled(tc)) {
                         Tr.event(tc, "Failed to create URL for " + refererHeader + ": " + e.getMessage());
                     }
-                    refererHeader=null;
+                    // Given url in header is invalid, remove the value
+                    refererHeader = null;
                 }
             }
             if (refererHeader != null) {
@@ -81,6 +90,9 @@ public class ProxySupportUtil {
             } else {
                 //fall back to using request url
                 urlString = request.getRequestURL().toString();
+                if (OpenAPIUtils.isEventEnabled(tc)) {
+                    Tr.warning(tc, "Unable to use Referer header, using request url to generate servers: " + urlString);
+                }
             }
         } else {
             urlString = request.getRequestURL().toString();

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/config/OpenAPIConfigTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/config/OpenAPIConfigTest.java
@@ -287,14 +287,14 @@ public class OpenAPIConfigTest {
         // Default HTTP protocol port with different host and matching docPath returns
         // single server entry
         OpenAPI model = new OpenAPIConnection(server, "/foo").header("Referer", "http://testurl1/foo").downloadModel();
-        assertThat(model.getServers().size(), Matchers.is(1));
+        assertThat(model.getServers(), Matchers.hasSize(1));
         // check that the server hostname has changed to supplied value
         assertThat("Check that the servers entry use the host from the referer header",
             model.getServers().get(0).getUrl(), Matchers.containsString("http://testurl1/" + APP_NAME));
 
         // Default HTTPS protocol port with matching uiPath returns single server entry
         model = new OpenAPIConnection(server, "/foo").header("Referer", "https://testurl2/bar").downloadModel();
-        assertThat(model.getServers().size(), Matchers.is(1));
+        assertThat(model.getServers(), Matchers.hasSize(1));
         ;
         // check that the host name has changed and has maintained HTTPS protocol
         assertThat("Check that the servers entry use the host from the referer header",
@@ -308,7 +308,7 @@ public class OpenAPIConfigTest {
         System.out.println(model.toString());
         // Path mismatch, should revert to server host and server http port
         // Only a single server should be returned as HTTPS is disabled
-        assertThat(model.getServers().size(), Matchers.is(1));
+        assertThat(model.getServers(), Matchers.hasSize(1));
         ;
         // Server in String should correspond to the Request URL
         assertThat("Check host reverts to the requestUrl host", model.getServers().get(0).getUrl(),
@@ -320,7 +320,7 @@ public class OpenAPIConfigTest {
         model = new OpenAPIConnection(server, "/foo").header("Referer", "http://testurl4/random/ui").downloadModel();
         System.out.println(model.toString());
         // Only a single server should be returned as HTTPS is disabled
-        assertThat(model.getServers().size(), Matchers.is(1));
+        assertThat(model.getServers(), Matchers.hasSize(1));
         // Server in should correspond to the Request URL
         assertThat("Check host reverts to the requestUrl host", model.getServers().get(0).getUrl(),
             Matchers

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/config/OpenAPIConfigTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/config/OpenAPIConfigTest.java
@@ -13,7 +13,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 
@@ -51,7 +50,7 @@ public class OpenAPIConfigTest {
     private static final String SERVER_NAME = "OpenAPIConfigServer";
 
     private static String DEFAULT_DOC_PATH = "/openapi";
-    private static String DEFAULT_UI_PATH = DEFAULT_DOC_PATH+"/ui";
+    private static String DEFAULT_UI_PATH = DEFAULT_DOC_PATH + "/ui";
 
     private static String APP_NAME = "mpOpenAPIConfigTest";
 
@@ -70,7 +69,8 @@ public class OpenAPIConfigTest {
     public void setup() throws Exception {
         // Set guards
         server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true", "-Dopen_api_path_enabled=true"));
-        // Test application startup is only checked in one case where is expected to fail to start
+        // Test application startup is only checked in one case where is expected to
+        // fail to start
         server.setValidateApps(false);
         // Deploy test app
         WebArchive war = ShrinkWrap.create(WebArchive.class, "mpOpenAPIConfigTest.war")
@@ -81,16 +81,16 @@ public class OpenAPIConfigTest {
     @After
     public void teardown() throws Exception {
         server.stopServer(
-                "CWWKO1670E", // Expected
-                "CWWKO1671E", // Expected
-                "CWWKO1672E", // Expected
-                "CWWKO1675E", // Expected
-                "CWWKO1676E", // Expected
-                "CWWKO1677E", // Expected
-                "SRVE0164E", // Expected
-                "CWWKZ0002E", // Expected
-                "CWWKZ0202E" //Expected
-                );
+            "CWWKO1670E", // Expected
+            "CWWKO1671E", // Expected
+            "CWWKO1672E", // Expected
+            "CWWKO1675E", // Expected
+            "CWWKO1676E", // Expected
+            "CWWKO1677E", // Expected
+            "SRVE0164E", // Expected
+            "CWWKZ0002E", // Expected
+            "CWWKZ0202E" // Expected
+        );
     }
 
     @Mode(TestMode.FULL)
@@ -140,10 +140,10 @@ public class OpenAPIConfigTest {
 
         server.startServer(false);
 
-        //check conflict with default Doc Path
+        // check conflict with default Doc Path
         assertWebAppStarts(DEFAULT_DOC_PATH);
         assertNotNull("UI Web Appplication is not available at /openapi/",
-                server.waitForStringInLog("CWWKO1672E")); // check that error indicating that Doc endpoint conflict error is thrown
+            server.waitForStringInLog("CWWKO1672E")); // check that error indicating that Doc endpoint conflict is thrown
         assertWebAppStarts(DEFAULT_UI_PATH);
 
         assertDocumentPath(DEFAULT_DOC_PATH);
@@ -151,13 +151,13 @@ public class OpenAPIConfigTest {
 
         server.setMarkToEndOfLog();
 
-        //change both Doc and UI paths to be the same
+        // change both Doc and UI paths to be the same
         config.getMpOpenAPIElement().setDocPath("/foo");
         config.getMpOpenAPIElement().setUiPath("/foo");
         server.updateServerConfiguration(config);
 
         assertNotNull("UI Web Appplication is not available at /foo/",
-                server.waitForStringInLogUsingMark("CWWKO1672E")); // check that error indicating that conflict is thrown
+            server.waitForStringInLogUsingMark("CWWKO1672E")); // check that error indicating that conflict is thrown
 
         assertWebAppStarts("/foo/");
         assertWebAppStarts("/foo/ui/");
@@ -177,15 +177,15 @@ public class OpenAPIConfigTest {
         server.startServer(false);
 
         assertNotNull("Document Web Appplication path contains invalid characters",
-                server.waitForStringInLog("CWWKO1676E")); // check that error indicating that conflict is thrown
+            server.waitForStringInLog("CWWKO1676E")); // check that error indicating that conflict is thrown
         assertNotNull("Document Web Appplication path is invalid",
-                server.waitForStringInLog("CWWKO1671E")); // check that error indicating that conflict is thrown
+            server.waitForStringInLog("CWWKO1671E")); // check that error indicating that conflict is thrown
         assertNotNull("UI Web Appplication path contains invalid characters",
-                server.waitForStringInLog("CWWKO1675E")); // check that error indicates invalid characters is logged
+            server.waitForStringInLog("CWWKO1675E")); // check that error indicates invalid characters is logged
         assertNotNull("UI Web Appplication path is invalid",
-                server.waitForStringInLog("CWWKO1670E")); // check that error indicating that a failure has occurred has been thrown
+            server.waitForStringInLog("CWWKO1670E")); // check that error indicating that a failure has occurred
 
-        //check paths revert to defaults
+        // Check paths revert to defaults
         assertWebAppStarts(DEFAULT_DOC_PATH);
         assertWebAppStarts(DEFAULT_UI_PATH);
 
@@ -199,16 +199,17 @@ public class OpenAPIConfigTest {
         server.updateServerConfiguration(config);
 
         assertNotNull("UI Web Appplication path is invalid",
-                server.waitForStringInLog("CWWKO1670E")); // check that error indicates invalid characters is logged
+            server.waitForStringInLog("CWWKO1670E")); // check that error indicates invalid characters is logged
         assertNotNull("Document Web Appplication path is invalid",
-                server.waitForStringInLog("CWWKO1671E")); // check that error indicates invalid characters is logged
+            server.waitForStringInLog("CWWKO1671E")); // check that error indicates invalid characters is logged
 
         // both Web Apps will return the same error code for
         assertNotNull("Web Appplication path contains invalid segments",
-                server.waitForStringInLog("CWWKO1677E")); // check that error indicating that a failure has occurred has been thrown
+            server.waitForStringInLog("CWWKO1677E")); // check that error indicating that a failure has occurred has
+                                                      // been thrown
 
         assertNull("Web apps not restarted when config set to invalid values ",
-                server.waitForStringInLogUsingMark("CWWKT0016I", 1000));
+            server.waitForStringInLogUsingMark("CWWKT0016I", 1000));
 
         assertDocumentPath(DEFAULT_DOC_PATH);
         assertUiPath(DEFAULT_UI_PATH);
@@ -218,22 +219,26 @@ public class OpenAPIConfigTest {
     @Test
     @AllowedFFDC
     public void testApplicationPathConfict() throws Exception {
-        // Test if initial config has a conflict - as Test app starts last, expect it to fail to start
+        // Test if initial config has a conflict - as Test app starts last, expect it to
+        // fail to start
         ServerConfiguration config = server.getServerConfiguration();
         config.getMpOpenAPIElement().setDocPath(null);
         config.getMpOpenAPIElement().setUiPath("/mpOpenAPIConfigTest");
         server.updateServerConfiguration(config);
 
         server.startServer(false);
-        // Web Application OpenAPIUI uses the context root /mpOpenAPIConfigTest/*, which is already in use by Web Application mpOpenAPIConfigTest. Web Application OpenAPIUI will not be loaded.
-        assertNotNull("Web Application fails to start due to context path conflict with OPENAPIUI bundle", server.waitForStringInLog("SRVE0164E.*OpenAPIUI"));
+        // Web Application OpenAPIUI uses the context root /mpOpenAPIConfigTest/*, which
+        // is already in use by Web Application mpOpenAPIConfigTest. Web Application
+        // OpenAPIUI will not be loaded.
+        assertNotNull("Web Application fails to start due to context path conflict with OPENAPIUI bundle",
+            server.waitForStringInLog("SRVE0164E.*OpenAPIUI"));
 
         assertWebAppStarts(DEFAULT_DOC_PATH);
         assertWebAppStarts("/mpOpenAPIConfigTest");
 
         assertDocumentPath(DEFAULT_DOC_PATH);
 
-        server.stopServer("SRVE0164E","CWWKZ0002E");
+        server.stopServer("SRVE0164E", "CWWKZ0002E");
 
         // Test if on configuration change such that OpenAPI
         config.getMpOpenAPIElement().setDocPath(null);
@@ -252,15 +257,17 @@ public class OpenAPIConfigTest {
         config.getMpOpenAPIElement().setUiPath("/mpOpenAPIConfigTest");
         server.updateServerConfiguration(config);
 
-        // Unable to install bundle com.ibm.ws.microprofile.openapi.ui_* with context root /mpOpenAPIConfigTest into the web container.
-        assertNotNull("OpenAPI UI bundle fails to start due to context root conflict", server.waitForStringInLog("CWWKZ0202E.*openapi.ui"));
+        // Unable to install bundle com.ibm.ws.microprofile.openapi.ui_* with context
+        // root /mpOpenAPIConfigTest into the web container.
+        assertNotNull("OpenAPI UI bundle fails to start due to context root conflict",
+            server.waitForStringInLog("CWWKZ0202E.*openapi.ui"));
 
         assertMissing("/mpOpenAPIConfigTest");
     }
 
     @Test
     @Mode(TestMode.FULL)
-    public void testCustomizedEndpointProxyRefererHeader() throws Exception{
+    public void testCustomizedEndpointProxyRefererHeader() throws Exception {
         // Defaults are tested in the ProxySupportTest.class
         ServerConfiguration config = server.getServerConfiguration();
         config.getMpOpenAPIElement().setDocPath("/foo");
@@ -269,41 +276,56 @@ public class OpenAPIConfigTest {
 
         server.startServer(false);
 
+        // Esnure that OpenAPI endpoints ara available where they say they are.
         assertWebAppStarts("/foo");
         assertWebAppStarts("/bar");
-
         assertDocumentPath("/foo");
         assertUiPath("/bar");
 
         // Test changed path with various referer headers
 
-        //Default HTTP port with matching docPath
-        OpenAPI model = new OpenAPIConnection(server, "/foo").header("Referer","http://testurl1/foo").downloadModel();
-        //as ports is not a liberty report, only return a single server
-        assertTrue("Check that the list of servers is not empty",model.getServers().size()==1);
-        //check that the server name has changed to allow for either http:// or https:// to be first
-        assertTrue("check that the servers entry use the server from the referer header",model.getServers().get(0).getUrl().contains("http://testurl1/"+APP_NAME));
+        // Default HTTP protocol port with different host and matching docPath returns
+        // single server entry
+        OpenAPI model = new OpenAPIConnection(server, "/foo").header("Referer", "http://testurl1/foo").downloadModel();
+        assertThat(model.getServers().size(), Matchers.is(1));
+        // check that the server hostname has changed to supplied value
+        assertThat("Check that the servers entry use the host from the referer header",
+            model.getServers().get(0).getUrl(), Matchers.containsString("http://testurl1/" + APP_NAME));
 
-        //Default HTTPS port with matching uiPath
-        model = new OpenAPIConnection(server, "/foo").header("Referer","https://testurl2/bar").downloadModel();
-        //as ports is not a liberty report, only return a single server
-        assertTrue("Check that the list of servers is not empty",model.getServers().size()==1);
-        //check that the host name has changed to allow for either http:// or https:// to be first
-        assertTrue("check that the servers entry use the server from the referer header",model.getServers().get(0).getUrl().contains("https://testurl2/"+APP_NAME));
+        // Default HTTPS protocol port with matching uiPath returns single server entry
+        model = new OpenAPIConnection(server, "/foo").header("Referer", "https://testurl2/bar").downloadModel();
+        assertThat(model.getServers().size(), Matchers.is(1));
+        ;
+        // check that the host name has changed and has maintained HTTPS protocol
+        assertThat("Check that the servers entry use the host from the referer header",
+            model.getServers().get(0).getUrl(),
+            Matchers.containsString("https://testurl2/" + APP_NAME));
 
-        //Rerun Test that if the referer path does not match the endpoints that the original hostname is used when config is not default
-        model = new OpenAPIConnection(server, "/foo").header("Referer","http://testurl3:"+server.getHttpDefaultPort()+"/random/").downloadModel();
-        // Path mismatch, should revert to server host and server http port - https not enabled so only single server should be returned
-        assertTrue("Check that the list of servers has single entries",model.getServers().size() == 1);
-        assertTrue("Check host reverts to the requestUrl host", model.getServers().get(0).getUrl().contains("http://" + server.getHostname()+ ":" + server.getHttpDefaultPort() + "/" + APP_NAME));
+        // If the referer path does not match either UI or Doc endpoints that the
+        // original hostname is used when config is not default
+        model = new OpenAPIConnection(server, "/foo")
+            .header("Referer", "http://testurl3:" + server.getHttpDefaultPort() + "/random/").downloadModel();
+        System.out.println(model.toString());
+        // Path mismatch, should revert to server host and server http port
+        // Only a single server should be returned as HTTPS is disabled
+        assertThat(model.getServers().size(), Matchers.is(1));
+        ;
+        // Server in String should correspond to the Request URL
+        assertThat("Check host reverts to the requestUrl host", model.getServers().get(0).getUrl(),
+            Matchers
+                .containsString("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + APP_NAME));
 
-        //path does not match, but ends in `/ui`, so should revert to default host, however as port differs from server ports, only a single entry should be being returned
-        model = new OpenAPIConnection(server, "/foo").header("Referer","http://testurl4/random/ui").downloadModel();
-        // Path mismatch with `/ui`, should revert to server host and server http port - https not enabled so only single server should be returned
-        assertTrue("Check that the list of servers has a single entries",model.getServers().size() == 1);
-        assertTrue("Check host reverts to the requestUrl host", model.getServers().get(0).getUrl().contains("http://"+server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + APP_NAME));
+        // Path does not match either doc or ui paths, but does end in `/ui`, so server
+        // entries should revert to default host
+        model = new OpenAPIConnection(server, "/foo").header("Referer", "http://testurl4/random/ui").downloadModel();
+        System.out.println(model.toString());
+        // Only a single server should be returned as HTTPS is disabled
+        assertThat(model.getServers().size(), Matchers.is(1));
+        // Server in should correspond to the Request URL
+        assertThat("Check host reverts to the requestUrl host", model.getServers().get(0).getUrl(),
+            Matchers
+                .containsString("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + APP_NAME));
     }
-
 
     @Test
     public void testConfigureDynamicUpdate() throws Exception {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/ProxySupportUtil.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/ProxySupportUtil.java
@@ -103,11 +103,14 @@ public class ProxySupportUtil {
             }
             if (refererHeader != null) {
                 urlString = refererHeader;
+                if (LoggingUtils.isEventEnabled(tc)) {
+                    Tr.event(tc, "Using Referer header to generate servers: " + urlString);
+                }
             } else {
                 //fall back to using request url
                 urlString = request.getRequestURL().toString();
                 if (LoggingUtils.isEventEnabled(tc)) {
-                    Tr.warning(tc, "Unable to use Referer header, using request url to generate servers: " + urlString);
+                    Tr.event(tc, "Unable to use Referer header, using request url to generate servers: " + urlString);
                 }
             }
         } else {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/ProxySupportUtil.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/ProxySupportUtil.java
@@ -12,17 +12,15 @@
  *******************************************************************************/
 package io.openliberty.microprofile.openapi20.internal.utils;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-
-import javax.servlet.http.HttpServletRequest;
-
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import io.openliberty.microprofile.openapi.internal.common.services.OpenAPIEndpointProvider;
 import org.osgi.framework.BundleContext;
-import org.osgi.util.tracker.ServiceTracker;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 /**
  * Handle proxy requests
@@ -30,7 +28,9 @@ import org.osgi.util.tracker.ServiceTracker;
 public class ProxySupportUtil {
 
     private static final String HTTP_HEADER_REFERER = "Referer";
-    private static TraceComponent tc = Tr.register(ProxySupportUtil.class);
+    private static final String DEFAULT_DOC_PATH = "/openapi";
+    private static final String DEFAULT_UI_PATH = "/ui";
+    private static final TraceComponent tc = Tr.register(ProxySupportUtil.class);
 
     public static void processRequest(HttpServletRequest request, ServerInfo serverInfo) {
         URL url = extractURL(request);
@@ -55,17 +55,24 @@ public class ProxySupportUtil {
         String refererHeader = request.getHeader(HTTP_HEADER_REFERER);
 
         //default endpoints
-        String docPath = "/openapi";
-        String uiPath = docPath+"/ui";
+        String docPath = DEFAULT_DOC_PATH;
+        String uiPath = docPath + DEFAULT_UI_PATH;
 
         BundleContext bundleContext = (BundleContext) request.getServletContext().getAttribute("osgi-bundlecontext");
         //ensure we have a context as change this will be null if bundle is STOPPED
-        if(bundleContext != null) {
-            ServiceTracker<OpenAPIEndpointProvider,OpenAPIEndpointProvider> openAPIEndpointTracker = new ServiceTracker<>(bundleContext, OpenAPIEndpointProvider.class, null);
-            openAPIEndpointTracker.open();
-            docPath = openAPIEndpointTracker.getService().getOpenAPIDocUrl();
-            uiPath = openAPIEndpointTracker.getService().getOpenAPIUIUrl();
-            openAPIEndpointTracker.close();
+        if (bundleContext != null) {
+            OpenAPIEndpointProvider endpointProvider = bundleContext.getService(bundleContext.getServiceReference(OpenAPIEndpointProvider.class));
+            if (endpointProvider != null) {
+                docPath = endpointProvider.getOpenAPIDocUrl();
+                uiPath = endpointProvider.getOpenAPIUIUrl();
+            }
+        }
+
+        if (docPath == null) {
+            docPath = DEFAULT_DOC_PATH;
+        }
+        if (uiPath == null) {
+            uiPath = docPath + DEFAULT_UI_PATH;
         }
 
         if (refererHeader != null) {
@@ -73,12 +80,12 @@ public class ProxySupportUtil {
                 Tr.event(tc, "Using referer header to generate servers: " + refererHeader);
             }
             refererHeader = refererHeader.endsWith("/") ? refererHeader.substring(0, refererHeader.length() - 1) : refererHeader;
-            //original behavior based on default paths
-            if(docPath.equals("/openapi") && uiPath.equals("/openapi/ui")) {
+            //Follow original behavior if path values match their defaults
+            if (docPath.equals(DEFAULT_UI_PATH) && uiPath.equals(DEFAULT_DOC_PATH + DEFAULT_UI_PATH)) {
                 if (!refererHeader.endsWith("/ui") && !refererHeader.endsWith("/openapi")) {
                     refererHeader = null;
                 }
-            // If either path has been modified to not be default do a better check
+                // If either path has been modified to not be default do a better check
             } else {
                 try {
                     URL refURL = new URL(refererHeader);
@@ -86,7 +93,7 @@ public class ProxySupportUtil {
                     if (!refPath.equals(docPath) && !refPath.equals(uiPath)) {
                         refererHeader = null;
                     }
-                } catch (MalformedURLException e){
+                } catch (MalformedURLException e) {
                     if (LoggingUtils.isEventEnabled(tc)) {
                         Tr.event(tc, "Failed to create URL for " + refererHeader + ": " + e.getMessage());
                     }
@@ -99,6 +106,9 @@ public class ProxySupportUtil {
             } else {
                 //fall back to using request url
                 urlString = request.getRequestURL().toString();
+                if (LoggingUtils.isEventEnabled(tc)) {
+                    Tr.warning(tc, "Unable to use Referer header, using request url to generate servers: " + urlString);
+                }
             }
         } else {
             urlString = request.getRequestURL().toString();

--- a/dev/io.openliberty.microprofile.openapi.internal.common/src/io/openliberty/microprofile/openapi/internal/common/OpenAPIEndpointManager.java
+++ b/dev/io.openliberty.microprofile.openapi.internal.common/src/io/openliberty/microprofile/openapi/internal/common/OpenAPIEndpointManager.java
@@ -10,17 +10,22 @@
 
 package io.openliberty.microprofile.openapi.internal.common;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.kernel.productinfo.ProductInfo;
-import io.openliberty.microprofile.openapi.internal.common.services.OpenAPIEndpointProvider;
-import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.*;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.regex.Pattern;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
+import io.openliberty.microprofile.openapi.internal.common.services.OpenAPIEndpointProvider;
 
 @Component(configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true, configurationPid = "io.openliberty.microprofile.openapi")
 public class OpenAPIEndpointManager implements OpenAPIEndpointProvider {


### PR DESCRIPTION
Retrieve Config to get the MPOpenAPI UI and Document endpoints and use those for comparing against a `referer` header and improve checks if custom endpoints used. if default values for the endpoints then old behavior is maintained

Add proxy test for customized endpoints - existing Proxy tests cover defaults and wider values

Fix OpenAPIEndpointManager imports

fixes #25439