### PR TITLE
Remove older bouncycastle references

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2118,18 +2118,8 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpg-jdk15on</artifactId>
-      <version>1.69</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
       <artifactId>bcpg-jdk18on</artifactId>
       <version>1.75</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.69</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -2138,18 +2128,8 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.69</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
       <version>1.75</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcutil-jdk15on</artifactId>
-      <version>1.69</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -4125,11 +4105,6 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>mongodb</artifactId>
       <version>1.18.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>mongodb</artifactId>
-      <version>1.17.4</version>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -419,13 +419,9 @@ org.apache.wss4j:wss4j-ws-security-stax:2.4.1
 org.apache.wss4j:wss4j-ws-security-web:2.4.1
 org.apache.xbean:xbean-asm8-shaded:4.17
 org.bitbucket.b_c:jose4j:0.9.3
-org.bouncycastle:bcpg-jdk15on:1.69
 org.bouncycastle:bcpg-jdk18on:1.75
-org.bouncycastle:bcpkix-jdk15on:1.69
 org.bouncycastle:bcpkix-jdk18on:1.75
-org.bouncycastle:bcprov-jdk15on:1.69
 org.bouncycastle:bcprov-jdk18on:1.75
-org.bouncycastle:bcutil-jdk15on:1.69
 org.bouncycastle:bcutil-jdk18on:1.75
 org.brotli:dec:0.1.2
 org.checkerframework:checker-compat-qual:2.5.2

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/build.gradle
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -44,9 +44,9 @@ dependencies {
     'org.mock-server:mockserver-core:5.11.2',
     'org.mock-server:mockserver-logging:5.3.0',
     'org.mock-server:mockserver-netty:5.11.2',
-    'org.bouncycastle:bcprov-jdk15on:1.69',
-    'org.bouncycastle:bcpkix-jdk15on:1.69',
-    'org.bouncycastle:bcutil-jdk15on:1.69'
+    'org.bouncycastle:bcprov-jdk18on:1.75',
+    'org.bouncycastle:bcpkix-jdk18on:1.75',
+    'org.bouncycastle:bcutil-jdk18on:1.75'
 }
 
 task addThirdPartyJerseyClient(type: Copy) {

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/build.gradle
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,9 +25,9 @@ dependencies {
     'org.mock-server:mockserver-core:5.11.2',
     'org.mock-server:mockserver-logging:5.3.0',
     'org.mock-server:mockserver-netty:5.11.2',
-    'org.bouncycastle:bcprov-jdk15on:1.69',
-    'org.bouncycastle:bcpkix-jdk15on:1.69',
-    'org.bouncycastle:bcutil-jdk15on:1.69'
+    'org.bouncycastle:bcprov-jdk18on:1.75',
+    'org.bouncycastle:bcpkix-jdk18on:1.75',
+    'org.bouncycastle:bcutil-jdk18on:1.75'
  rxproviders 'io.reactivex:rxjava:1.3.8', // reactivex
     'io.reactivex.rxjava2:rxjava:2.2.2',
     project(':com.ibm.websphere.org.reactivestreams.reactive-streams.1.0'),

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -61,11 +61,12 @@ Private-Package: \
 	com.ibm.websphere.simplicity.configuration
 
 Include-Resource: \
-    @${repo;org.bouncycastle:bcpg-jdk15on;1.69;EXACT},\
-    @${repo;org.bouncycastle:bcpkix-jdk15on;1.69;EXACT},\
-    @${repo;org.bouncycastle:bcprov-jdk15on;1.69;EXACT},\
-    @${repo;org.bouncycastle:bcutil-jdk15on;1.69;EXACT},\
-    init-sqlserver.sql=resources/init-sqlserver.sql
+    @${repo;org.bouncycastle:bcpg-jdk18on;1.75;EXACT},\
+    @${repo;org.bouncycastle:bcpkix-jdk18on;1.75;EXACT},\
+    @${repo;org.bouncycastle:bcprov-jdk18on;1.75;EXACT},\
+    @${repo;org.bouncycastle:bcutil-jdk18on;1.75;EXACT},\
+    init-sqlserver.sql=resources/init-sqlserver.sql, \
+	META-INF=resources/META-INF
 
 test.project: true
 

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -65,8 +65,7 @@ Include-Resource: \
     @${repo;org.bouncycastle:bcpkix-jdk18on;1.75;EXACT},\
     @${repo;org.bouncycastle:bcprov-jdk18on;1.75;EXACT},\
     @${repo;org.bouncycastle:bcutil-jdk18on;1.75;EXACT},\
-    init-sqlserver.sql=resources/init-sqlserver.sql, \
-	META-INF=resources/META-INF
+    init-sqlserver.sql=resources/init-sqlserver.sql
 
 test.project: true
 
@@ -115,7 +114,7 @@ fat.test.container.images: testcontainers/ryuk:0.5.1, testcontainers/sshd:1.1.0,
 	io.openliberty.com.fasterxml.jackson;version=latest,\
 	org.seleniumhq.selenium:selenium-api;version=4.8.3,\
 	org.seleniumhq.selenium:selenium-support;version=4.8.3,\
-	org.bouncycastle:bcpg-jdk15on;version=1.69,\
-	org.bouncycastle:bcpkix-jdk15on;version=1.69,\
-	org.bouncycastle:bcprov-jdk15on;version=1.69
+	org.bouncycastle:bcpg-jdk18on;version=1.75,\
+	org.bouncycastle:bcpkix-jdk18on;version=1.75,\
+	org.bouncycastle:bcprov-jdk18on;version=1.75
 	


### PR DESCRIPTION
- updates to remove older version (1.69) bc jars