### PR TITLE
handle windows line endings when comparing files

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -4128,11 +4128,6 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>mongodb</artifactId>
-      <version>1.17.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
       <artifactId>mssqlserver</artifactId>
       <version>1.18.3</version>
     </dependency>

--- a/dev/io.openliberty.org.jboss.weld5/build.gradle
+++ b/dev/io.openliberty.org.jboss.weld5/build.gradle
@@ -177,17 +177,19 @@ task updateWeldPackages {
     }
 }
 
-//commented out because it wasn't working for everyone
 task checkWeldPackages {
     dependsOn bndMagic
 
     doFirst {
         if (! Files.exists(Paths.get(pathToNewManifest))) {
-       //     throw new GradleException('check-me-in-if-i-change.bnd does not exist. You really should not have seen this error, running the task updateWeldPackages should fix it, but make sure you understand how you got here')
+            throw new GradleException('check-me-in-if-i-change.bnd does not exist. You really should not have seen this error, running the task updateWeldPackages should fix it, but make sure you understand how you got here')
         }
 
-        if (Files.mismatch(Paths.get(tempPathToNewManifest), Paths.get(pathToNewManifest)) != -1L) {
-    //        throw new GradleException('The generated bnd file did not mach the pre-existing bnd file. If you are updating weld this means the upstream manifest has changed, run updateWeldPackages and remember to check in the updated bnd file')
+        String tempFileString = Files.readString(Paths.get(tempPathToNewManifest)).replaceAll("\\r\\n?", "\n")
+        String newFileString = Files.readString(Paths.get(pathToNewManifest)).replaceAll("\\r\\n?", "\n")
+
+        if (! tempFileString.equals(newFileString)) {
+            throw new GradleException('The generated bnd file did not mach the pre-existing bnd file. If you are updating weld this means the upstream manifest has changed, run updateWeldPackages and remember to check in the updated bnd file')
         }
     }
 }


### PR DESCRIPTION
The previous version of this check failed on Windows, to avoid this we convert windows line characters to unix before comparing the temp file with the pre-existing file.  