### PR TITLE
Issue 21826: Update keyAliasName description for OIDC clients

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
@@ -199,7 +199,7 @@ tokenEndpointAuthSigningAlgorithm.ES384=Use the ES384 signature algorithm to sig
 tokenEndpointAuthSigningAlgorithm.ES512=Use the ES512 signature algorithm to sign tokens that are used for client authentication
 
 keyAliasName=Key alias name
-keyAliasName.desc=The alias for the private key that is used for signing tokens that are used for client authentication. This must also be the alias for the public key that corresponds to the private key. The private key must be in the keystore that is specified by the SSL configuration that is referenced by sslRef. The public key must be in one of the following: the truststore that is specified by the trustStoreRef attribute, the truststore that is specified by the SSL configuration that is referenced by sslRef, or the keystore that is specified by the SSL configuration that is referenced by sslRef.
+keyAliasName.desc=The alias for the private key that is used for signing client authentication tokens. The public key that corresponds to the private key must also use this alias. The private key must be in the keystore that is specified by the SSL configuration that is referenced by the sslRef attribute. The public key must be in one of the following locations: the truststore that is specified by the trustStoreRef attribute, the truststore that is specified by the SSL configuration that is referenced by the sslRef attribute, or the keystore that is specified by the SSL configuration that is referenced by the sslRef attribute.
 
 authnSessionDisabled=Authentication session cookie disabled
 authnSessionDisabled.desc=An authentication session cookie will not be created for inbound propagation. The client is expected to send a valid OAuth token for every request.

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
@@ -199,7 +199,7 @@ tokenEndpointAuthSigningAlgorithm.ES384=Use the ES384 signature algorithm to sig
 tokenEndpointAuthSigningAlgorithm.ES512=Use the ES512 signature algorithm to sign tokens that are used for client authentication
 
 keyAliasName=Key alias name
-keyAliasName.desc=The alias for the private key that is used for signing tokens that are used for client authentication.
+keyAliasName.desc=The alias for the private key that is used for signing tokens that are used for client authentication. This must also be the alias for the public key that corresponds to the private key. The private key must be in the keystore that is specified by the SSL configuration that is referenced by sslRef. The public key must be in one of the following: the truststore that is specified by the trustStoreRef attribute, the truststore that is specified by the SSL configuration that is referenced by sslRef, or the keystore that is specified by the SSL configuration that is referenced by sslRef.
 
 authnSessionDisabled=Authentication session cookie disabled
 authnSessionDisabled.desc=An authentication session cookie will not be created for inbound propagation. The client is expected to send a valid OAuth token for every request.

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
@@ -107,7 +107,7 @@ tokenEndpointAuthSigningAlgorithm.ES384=Use the ES384 signature algorithm to sig
 tokenEndpointAuthSigningAlgorithm.ES512=Use the ES512 signature algorithm to sign tokens that are used for client authentication
 
 keyAliasName=Key alias name
-keyAliasName.desc=The alias for the private key that is used for signing tokens that are used for client authentication.
+keyAliasName.desc=The alias for the private key that is used for signing tokens that are used for client authentication. This must also be the alias for the public key that corresponds to the private key. The private key must be in the keystore that is specified by the SSL configuration that is referenced by sslRef. The public key must be in one of the following: the truststore that is specified by the trustStoreRef attribute, the truststore that is specified by the SSL configuration that is referenced by sslRef, or the keystore that is specified by the SSL configuration that is referenced by sslRef.
 
 redirectToRPHostAndPort=Callback host and port number
 redirectToRPHostAndPort.desc=Specifies a callback protocol, host, and port number. For example, https://myhost:8020.

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
@@ -107,7 +107,7 @@ tokenEndpointAuthSigningAlgorithm.ES384=Use the ES384 signature algorithm to sig
 tokenEndpointAuthSigningAlgorithm.ES512=Use the ES512 signature algorithm to sign tokens that are used for client authentication
 
 keyAliasName=Key alias name
-keyAliasName.desc=The alias for the private key that is used for signing tokens that are used for client authentication. This must also be the alias for the public key that corresponds to the private key. The private key must be in the keystore that is specified by the SSL configuration that is referenced by sslRef. The public key must be in one of the following: the truststore that is specified by the trustStoreRef attribute, the truststore that is specified by the SSL configuration that is referenced by sslRef, or the keystore that is specified by the SSL configuration that is referenced by sslRef.
+keyAliasName.desc=The alias for the private key that is used for signing client authentication tokens. The public key that corresponds to the private key must also use this alias. The private key must be in the keystore that is specified by the SSL configuration that is referenced by the sslRef attribute. The public key must be in one of the following locations: the truststore that is specified by the trustStoreRef attribute, the truststore that is specified by the SSL configuration that is referenced by the sslRef attribute, or the keystore that is specified by the SSL configuration that is referenced by the sslRef attribute.
 
 redirectToRPHostAndPort=Callback host and port number
 redirectToRPHostAndPort.desc=Specifies a callback protocol, host, and port number. For example, https://myhost:8020.


### PR DESCRIPTION
Expands the metatype description to include how the alias is also used to point to the public key corresponding to the private key used to sign the JWT we create. Also clarifies where those keys are obtained from.