### PR TITLE
JAX-RS 2.1: Undo CXF change to JAXRSUtils' SubResouce Option Check

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -641,7 +641,7 @@ public final class JAXRSUtils {
                                     if (matchProduceTypes(acceptType, ori)) {
                                         candidateList.put(ori, map);
                                         added = true;
-                                        resourceMethodsAdded = true;
+                                        resourceMethodsAdded = true; // Liberty Change
                                         break;
                                     }
                                 }
@@ -663,8 +663,8 @@ public final class JAXRSUtils {
         // We may get several matching candidates with different HTTP methods which match subresources
         // and resources. Before excluding subresources, let us make sure we have at least one matching
         // HTTP method candidate.
-        boolean isOptions = HttpMethod.OPTIONS.equalsIgnoreCase(httpMethod);
-        if (finalPathSubresources != null && (methodMatched > 0 || isOptions)
+        // boolean isOptions = HttpMethod.OPTIONS.equalsIgnoreCase(httpMethod); // Liberty Change 
+        if (finalPathSubresources != null && resourceMethodsAdded // Liberty Change
             && !MessageUtils.getContextualBoolean(message, KEEP_SUBRESOURCE_CANDIDATES, false)) {
             for (OperationResourceInfo key : finalPathSubresources) {
                 candidateList.remove(key);


### PR DESCRIPTION
This pull request fixes the following test failure:

```
ClassSubResTestServlet.testMultipleMultiArgConstructors:junit.framework.AssertionFailedError: 2023-07-16-10:31:22:737 ClassSubResTestServlet.testMultipleMultiArgConstructors: expected:<200> but was:<404>
at jaxrs21.fat.classSubRes.ClassSubResTestServlet.testMultipleMultiArgConstructors(ClassSubResTestServlet.java:84)
at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at componenttest.app.FATServlet.doGet(FATServlet.java:69)

```
By removing a change done to CXF that was copied over as a part of the CXF 3.5.5 upgrade. 