### PR TITLE
Add cssparser to the required libraries list for spnego test

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.spnego/build.gradle
+++ b/dev/com.ibm.ws.security.oidc.client_fat.spnego/build.gradle
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,6 +20,7 @@ dependencies {
                'org.apache.sshd:sshd-core:2.5.1',
                'org.apache.sshd:sshd-scp:2.5.1',
                'net.sourceforge.htmlunit:htmlunit:2.44.0',
+               'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
                'rhino:js:1.6R5',
                project(':io.openliberty.org.apache.commons.codec'), // 1.15 (was 1.4)
                'org.apache.httpcomponents:httpclient:4.1.2',


### PR DESCRIPTION
- htmlunit has a pretty hard dependency on cssparser that some times cause tests to fail
