### PR TITLE
experiment with bean for default instance

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -45,7 +45,13 @@ public class ConcurrentCDITest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(server, APP_NAME, "concurrent.cdi.web");
-        // TODO remove concurrent.cu3.web once default resources are automatically made available via @Inject
+        // TODO remove "concurrent.cu3.web" below to reproduce the following error:
+        // [7/21/23, 9:03:05:599 CDT] 00000037 SystemOut                                                    O
+        //  Added jakarta.enterprise.concurrent.ManagedExecutorService with qualifiers [@jakarta.enterprise.inject.Default()]
+        // ...
+        // DeploymentException: WELD-001408: Unsatisfied dependencies for type ManagedExecutorService with qualifiers @Default
+        //                  at injection point [BackedAnnotatedField] @Inject private concurrent.cdi4.web.ConcurrentCDI4Servlet.injectedExec
+        //                  at concurrent.cdi4.web.ConcurrentCDI4Servlet.injectedExec(ConcurrentCDI4Servlet.java:0)
         ShrinkHelper.defaultDropinApp(server, APP_NAME_EE10, "concurrent.cdi4.web", "concurrent.cu3.web");
         server.startServer();
         runTest(server, APP_NAME_EE10 + '/' + ConcurrentCDI4Servlet.class.getSimpleName(), "initTransactionService");

--- a/dev/io.openliberty.concurrent.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.concurrent.internal.cdi/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2022 IBM Corporation and others.
+# Copyright (c) 2021, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -40,7 +40,6 @@ Private-Package: \
 
 instrument.classesExcludes: io/openliberty/concurrent/internal/cdi/resources/*.class
 
-# TODO: switch to cdi 4.0, interceptor 2.1 and annotation 2.1 once no longer allow with EE9
 -buildpath: \
   com.ibm.websphere.appserver.spi.logging,\
   com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
@@ -50,9 +49,11 @@ instrument.classesExcludes: io/openliberty/concurrent/internal/cdi/resources/*.c
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.cdi.interfaces.jakarta;version=latest, \
   com.ibm.ws.concurrent,\
+  com.ibm.ws.javaee.version,\
+  com.ibm.ws.kernel.service,\
   com.ibm.ws.threading,\
-  io.openliberty.jakarta.annotation.2.0,\
-  io.openliberty.jakarta.cdi.3.0,\
+  io.openliberty.jakarta.annotation.2.1,\
+  io.openliberty.jakarta.cdi.4.0,\
   io.openliberty.jakarta.concurrency.3.0,\
-  io.openliberty.jakarta.interceptor.2.0,\
+  io.openliberty.jakarta.interceptor.2.1,\
   io.openliberty.jakarta.transaction.2.0

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,23 +12,82 @@
  *******************************************************************************/
 package io.openliberty.concurrent.internal.cdi;
 
-import jakarta.enterprise.event.Observes;
-import jakarta.enterprise.inject.spi.AnnotatedType;
-import jakarta.enterprise.inject.spi.BeanManager;
-import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
-import jakarta.enterprise.inject.spi.Extension;
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 import com.ibm.ws.cdi.CDIServiceUtils;
 
 import io.openliberty.concurrent.internal.cdi.interceptor.AsyncInterceptor;
 import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.AnnotatedType;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.ProcessInjectionPoint;
 
 public class ConcurrencyExtension implements Extension {
+    private static final Set<Annotation> DEFAULT_QUALIFIER = Set.of(Default.Literal.INSTANCE);
+
+    /**
+     * Set of qualifier lists found on injection points.
+     */
+    private final Set<Set<Annotation>> executorQualifiers = new HashSet<>();
+
     public void beforeBeanDiscovery(@Observes BeforeBeanDiscovery beforeBeanDiscovery, BeanManager beanManager) {
         // register the interceptor binding and the interceptor
         AnnotatedType<Asynchronous> bindingType = beanManager.createAnnotatedType(Asynchronous.class);
         beforeBeanDiscovery.addInterceptorBinding(bindingType);
         AnnotatedType<AsyncInterceptor> interceptorType = beanManager.createAnnotatedType(AsyncInterceptor.class);
         beforeBeanDiscovery.addAnnotatedType(interceptorType, CDIServiceUtils.getAnnotatedTypeIdentifier(interceptorType, this.getClass()));
+    }
+
+    /**
+     * Invoked for each matching injection point:
+     *
+     * @Inject @Qualifier1 @Qualifier2 ...
+     *         ManagedExecutorService executor;
+     *
+     * @param <T>         bean class that has the injection point
+     * @param event       event
+     * @param beanManager bean manager
+     */
+    public <T> void processExecutorInjectionPoint(@Observes ProcessInjectionPoint<T, ManagedExecutorService> event, BeanManager beanManager) {
+        if (ConcurrencyExtensionMetadata.eeVersion.getMajor() >= 11) {
+            // TODO check if producer already exists for the injection point and skip
+            InjectionPoint injectionPoint = event.getInjectionPoint();
+            Set<Annotation> qualifiers = injectionPoint.getQualifiers();
+            executorQualifiers.add(qualifiers);
+        }
+    }
+
+    public void afterBeanDiscovery(@Observes AfterBeanDiscovery event) {
+        if (ConcurrencyExtensionMetadata.eeVersion.getMajor() >= 11) {
+            for (Iterator<Set<Annotation>> it = executorQualifiers.iterator(); it.hasNext();) {
+                Set<Annotation> qualifiers = it.next();
+                it.remove();
+                if (CDI.current().select(ManagedExecutorService.class, qualifiers.toArray(new Annotation[qualifiers.size()])).isUnsatisfied()) {
+                    // It doesn't already exist, so try to add it:
+                    if (DEFAULT_QUALIFIER.equals(qualifiers)) {
+                        Bean<ManagedExecutorService> bean = new ConcurrencyResourceBean<>(ManagedExecutorService.class, //
+                                        "(id=DefaultManagedExecutorService)", //
+                                        Set.of(ManagedExecutorService.class, ExecutorService.class, Executor.class), //
+                                        qualifiers);
+                        event.addBean(bean);
+                        System.out.println("Added " + bean.getBeanClass().getName() + " with qualifiers " + qualifiers);
+                    } // TODO else configured ManagedExecutorService instances with qualifiers
+                }
+            }
+        }
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,18 +15,41 @@ package io.openliberty.concurrent.internal.cdi;
 import java.util.Collections;
 import java.util.Set;
 
-import jakarta.enterprise.inject.spi.Extension;
-
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import com.ibm.ws.javaee.version.JavaEEVersion;
 
 import io.openliberty.cdi.spi.CDIExtensionMetadata;
+import jakarta.enterprise.inject.spi.Extension;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,
            service = CDIExtensionMetadata.class)
 public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata {
+    /**
+     * Jakarta EE version.
+     */
+    public static Version eeVersion;
+
     @Override
     public Set<Class<? extends Extension>> getExtensions() {
         return Collections.singleton(ConcurrencyExtension.class);
+    }
+
+    /**
+     * The service ranking of JavaEEVersion ensures we get the highest
+     * Jakarta EE version for the configured features.
+     */
+    @Reference(policyOption = ReferencePolicyOption.GREEDY)
+    protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
+        String version = (String) ref.getProperty("version");
+        eeVersion = Version.parseVersion(version);
+    }
+
+    protected void unsetEEVersion(ServiceReference<JavaEEVersion> ref) {
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyResourceBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyResourceBean.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.concurrent.internal.cdi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.security.AccessController;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.kernel.service.util.SecureAction;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.PassivationCapable;
+
+/**
+ * Bean that delegates to the OSGi service registry to obtain resources.
+ *
+ * @param <T> type of resource (such as ManagedExecutorService or ContextService)
+ */
+public class ConcurrencyResourceBean<T> implements Bean<T>, PassivationCapable {
+    private final static TraceComponent tc = Tr.register(ConcurrencyResourceBean.class);
+
+    // TODO eventually remove for code that only applies to EE 11+
+    final static SecureAction priv = AccessController.doPrivileged(SecureAction.get());
+
+    /**
+     * Injectable bean types.
+     */
+    private final Set<Type> beanTypes;
+
+    /**
+     * OSGi filter for the resource.
+     */
+    private final String filter;
+
+    /**
+     * Qualifiers for the injection points for this bean.
+     */
+    private final Set<Annotation> qualifiers;
+
+    /**
+     * Type of resource.
+     */
+    private final Class<T> resourceType;
+
+    /**
+     * Construct a new Producer/ProducerFactory for this resource.
+     *
+     * @param resourceType type of resource.
+     * @param filter       OSGi filter for the resource.
+     * @param types        bean types.
+     * @param qualifiers   qualifiers for the bean.
+     */
+    public ConcurrencyResourceBean(Class<T> resourceType, String filter, Set<Type> types, Set<Annotation> qualifiers) {
+        this.filter = filter;
+        this.resourceType = resourceType;
+        this.beanTypes = types;
+        this.qualifiers = qualifiers;
+    }
+
+    @Override
+    @Trivial
+    public T create(CreationalContext<T> cc) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "create", cc, resourceType, filter, qualifiers);
+
+        T instance;
+        Bundle bundle = FrameworkUtil.getBundle(ConcurrencyResourceBean.class);
+        BundleContext bundleContext = priv.getBundleContext(bundle);
+        Collection<ServiceReference<T>> refs;
+        try {
+            refs = priv.getServiceReferences(bundleContext, resourceType, filter);
+        } catch (InvalidSyntaxException x) {
+            throw new IllegalArgumentException(x); // internal error forming the filter?
+        }
+        Iterator<ServiceReference<T>> it = refs.iterator();
+        if (it.hasNext())
+            instance = priv.getService(bundleContext, it.next());
+        else
+            throw new IllegalStateException("The " + resourceType.getName() + " resource with " + filter + " filter cannot be found or is unavailable."); // TODO NLS
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "create", instance);
+        return instance;
+    }
+
+    @Override
+    public void destroy(T instance, CreationalContext<T> creationalContext) {
+    }
+
+    @Override
+    public Class<T> getBeanClass() {
+        return resourceType;
+    }
+
+    /**
+     * @return unique identifier for PassivationCapable.
+     */
+    @Override
+    public String getId() {
+        return new StringBuilder(getClass().getName()) //
+                        .append(':').append(resourceType.getClass().getSimpleName()) //
+                        .append(":").append(qualifiers) //
+                        .append(':').append(filter) //
+                        .toString();
+    }
+
+    @Override
+    public Set<InjectionPoint> getInjectionPoints() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        return qualifiers;
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return ApplicationScoped.class;
+    }
+
+    @Override
+    public Set<Class<? extends Annotation>> getStereotypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<Type> getTypes() {
+        return beanTypes;
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(getClass().getSimpleName()).append('@').append(Integer.toHexString(hashCode())) //
+                        .append(' ').append(resourceType.getClass().getSimpleName()) //
+                        .append(' ').append(filter) //
+                        .append(" with qualifiers ").append(qualifiers) //
+                        .toString();
+    }
+}


### PR DESCRIPTION
Supplies a bean via the CDI extension to attempt to provide the default ManagedExecutorService instance for `@Inject ManagedExecutorService`, following along the pattern that will be needed for configured instances.  The test case remains disabled because it isn't working yet.