### PR TITLE
Fix trailing comma in feature files

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWS-3.0/io.openliberty.restfulWS-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWS-3.0/io.openliberty.restfulWS-3.0.feature
@@ -2,7 +2,7 @@
 symbolicName=io.openliberty.restfulWS-3.0
 visibility=public
 singleton=true
-IBM-API-Package: com.ibm.websphere.jaxrs.server; type="ibm-api", \
+IBM-API-Package: com.ibm.websphere.jaxrs.server; type="ibm-api"
 IBM-App-ForceRestart: uninstall, \
  install
 IBM-ShortName: restfulWS-3.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWS-3.1/io.openliberty.restfulWS-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWS-3.1/io.openliberty.restfulWS-3.1.feature
@@ -2,7 +2,7 @@
 symbolicName=io.openliberty.restfulWS-3.1
 visibility=public
 singleton=true
-IBM-API-Package: com.ibm.websphere.jaxrs.server; type="ibm-api", \
+IBM-API-Package: com.ibm.websphere.jaxrs.server; type="ibm-api"
 IBM-App-ForceRestart: uninstall, \
  install
 IBM-ShortName: restfulWS-3.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWS-4.0/io.openliberty.restfulWS-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWS-4.0/io.openliberty.restfulWS-4.0.feature
@@ -2,7 +2,7 @@
 symbolicName=io.openliberty.restfulWS-4.0
 visibility=public
 singleton=true
-IBM-API-Package: com.ibm.websphere.jaxrs.server; type="ibm-api", \
+IBM-API-Package: com.ibm.websphere.jaxrs.server; type="ibm-api"
 IBM-App-ForceRestart: uninstall, \
  install
 IBM-ShortName: restfulWS-4.0


### PR DESCRIPTION
- With the trailing comma, it makes it look like `IBM-App-ForceRestart: uninstall` and `install` are IBM API package names with no package type specified.  Additionally applications are not restarted when the feature is restarted because IBM-App-ForceRestart is not actually a property in the feature file.  Luckily REST features depend on restfulWSClient and other features which do have the IBM-App-ForceRestart on them so it may not cause problems.
