### PR TITLE
Allow a longer connection timeout

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/Constants.java
@@ -101,6 +101,7 @@ public class Constants extends com.ibm.ws.security.fat.common.Constants {
 
     public static final int DEFAULT_JWKS_CONN_TIMEOUT = 500;
     public static final int DEFAULT_JWKS_READ_TIMEOUT = 500;
+    public static final int OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT = 30000;
     public static final int OVERRIDE_DEFAULT_JWKS_READ_TIMEOUT = 60000;
     public static final int DEFAULT_TOKEN_MIN_VALIDITY = 10 * 1000;
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/servlets/BaseOpenIdConfig.java
@@ -336,9 +336,9 @@ public class BaseOpenIdConfig extends MinimumBaseOpenIdConfig {
 
     public int getJwksConnectTimeoutExpression() {
 
-        int value = Constants.DEFAULT_JWKS_CONN_TIMEOUT;
+        int value = Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT;
         if (config.containsKey(Constants.JWKSCONNECTTIMEOUTEXPRESSION)) {
-            value = getIntValue(Constants.JWKSCONNECTTIMEOUTEXPRESSION, Constants.DEFAULT_JWKS_CONN_TIMEOUT);
+            value = getIntValue(Constants.JWKSCONNECTTIMEOUTEXPRESSION, Constants.OVERRIDE_DEFAULT_JWKS_CONN_TIMEOUT);
         }
 
         return value;


### PR DESCRIPTION
On some platforms the connection is taking longer than expected - I'm increasing the default connection timeout that the tests use.  We'll still test the default value, but, will generally use a longer timeout.