### PR TITLE
Allow more time for the JWT Builder to run secureRandom

### DIFF
--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/actions/JwtBuilderActions.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/actions/JwtBuilderActions.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -69,6 +69,7 @@ public class JwtBuilderActions extends TestActions {
         List<NameValuePair> requestParams = setRequestParms(builderId, parms);
 
         WebClient webClient = new WebClient();
+        webClient.getOptions().setTimeout(2 * 60 * 1000); // give the builder 2 minutes - secureRandom is pretty slow
         Page response = null;
         try {
             response = invokeUrlWithParameters(testName, webClient, jwtBuilderUrl, requestParams);


### PR DESCRIPTION
Allow the JWT builder more time to create a JWT Token.  The tests that are using secureRandom can timeout since that method can be slow.