### PR TITLE
Adding exception to fail tests quickly and clearly if default HTTP port is unavailable

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -763,7 +763,6 @@ public class LibertyServer implements LogMonitorClient {
 
         // TODO: Verify the micro version matches the files under 'installRoot/lib'.
 
-
         // Allow user directory name to be provided in bootstrap properties.
         // It is optional and if it is not set, setup() will set it.
         userDir = b.getValue("libertyUserDir");
@@ -1326,7 +1325,7 @@ public class LibertyServer implements LogMonitorClient {
         }
     }
 
-    protected void checkPortsOpen(boolean retry) {
+    protected void checkPortsOpen(boolean retry) throws Exception {
         ServerSocket socket = null;
         try {
             // Create unbounded socket
@@ -1346,6 +1345,11 @@ public class LibertyServer implements LogMonitorClient {
                 }
                 // Do this out of the try block, even if we are interrupted we want to try once more
                 checkPortsOpen(false);
+            } else {
+                //Fail fast if http port unavailable
+                Exception e = new Exception("Default http port unavailable");
+                e.initCause(ex);
+                throw e;
             }
         } finally {
             if (null != socket) {

--- a/dev/io.openliberty.data.internal_fat_nosql/fat/src/test/jakarta/data/nosql/DataNoSQLTest.java
+++ b/dev/io.openliberty.data.internal_fat_nosql/fat/src/test/jakarta/data/nosql/DataNoSQLTest.java
@@ -51,7 +51,7 @@ public class DataNoSQLTest extends FATServletClient {
         server.addEnvVar("MONGO_DBNAME", "testdb");
         server.addEnvVar("MONGO_HOST", mongoDBContainer.getHost() + ":" + String.valueOf(mongoDBContainer.getMappedPort(27017)));
 
-        server.startServer();
+        server.startServerAndValidate(false, false, true);
     }
 
     @AfterClass


### PR DESCRIPTION
Adds an Exception if port validation is being used and fails. This allows the tests to fail quickly with a clear message instead of running the entire suite with each test failing with FileNotFound exceptions.