### PR TITLE
Update Jakarta EE tests to fix failures with different combinations

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverTcpTransport.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverTcpTransport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -326,12 +326,11 @@ class SipResolverTcpTransport implements SipResolverTransport {
             c_logger.traceExit(this, "SipResolverTcpTransport: ready: exit");
     }
 
-    /**
+    /*
      * This method is called when the socket connection fails during setup.
      * 
      * @see
-     * com.ibm.wsspi.channel.ConnectionReadyCallback#ready(com.ibm.wsspi.channel.
-     * framework.VirtualConnection)
+     * com.ibm.wsspi.channel.ConnectionReadyCallback#ready(com.ibm.wsspi.channel.framework.VirtualConnection)
      */
     public void destroy(Exception e) {
         if (c_logger.isTraceEntryExitEnabled())

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/JakartaEE10Test.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/JakartaEE10Test.java
@@ -79,7 +79,7 @@ public class JakartaEE10Test extends FATServletClient {
         // remove logAnalysis-1.0.  It depends on hpel being configured
         compatFeatures.remove("logAnalysis-1.0");
 
-        // springBoot-3.0, data-1.0 and nosql-1.0 requires Java 17 so if we are currently not using Java 17 or later, remove it from the list of features.
+        // springBoot-3.0, data-1.0 and nosql-1.0 require Java 17 so if we are currently not using Java 17 or later, remove it from the list of features.
         if (JavaInfo.JAVA_VERSION < 17) {
             compatFeatures.remove("springBoot-3.0");
             compatFeatures.remove("data-1.0");
@@ -171,7 +171,8 @@ public class JakartaEE10Test extends FATServletClient {
                                                  "CWWKG0033W", // related to missing config for collectives
                                                  "CWSJY0035E", // wmqJmsClient.rar.location variable not in the server.xml
                                                  "CWWKE0701E", // wmqJmsClient.rar.location variable not in the server.xml
-                                                 "TRAS4352W" // Only happens when running with WebSphere Liberty image due to an auto feature
+                                                 "TRAS4352W", // Only happens when running with WebSphere Liberty image due to an auto feature
+                                                 "CWWKB0758E" // zosAutomaticRestartManager-1.0 error due to missing SAF configuration
             };
         } else {
             toleratedWarnErrors = new String[] { "SRVE0280E" };// TODO: SRVE0280E tracked by OpenLiberty issue #4857

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
@@ -67,12 +67,16 @@ public class JakartaEE9Test extends FATServletClient {
         compatFeatures.remove("noShip-1.0");
         compatFeatures.remove("scim-2.0");
 
+        if (JavaInfo.JAVA_VERSION < 11) {
+            compatFeatures.remove("mpReactiveStreams-3.0");
+            compatFeatures.remove("mpReactiveMessaging-3.0");
+        }
+
         // remove logAnalysis-1.0.  It depends on hpel being configured
         compatFeatures.remove("logAnalysis-1.0");
 
-        // springBoot-3.0, data-1.0 and nosql-1.0 requires Java 17 so if we are currently not using Java 17 or later, remove it from the list of features.
+        // data-1.0 and nosql-1.0 require Java 17 so if we are currently not using Java 17 or later, remove it from the list of features.
         if (JavaInfo.JAVA_VERSION < 17) {
-            compatFeatures.remove("springBoot-3.0");
             compatFeatures.remove("data-1.0");
             compatFeatures.remove("nosql-1.0");
         }
@@ -162,7 +166,8 @@ public class JakartaEE9Test extends FATServletClient {
                                                  "CWWKG0033W", // related to missing config for collectives
                                                  "CWSJY0035E", // wmqJmsClient.rar.location variable not in the server.xml
                                                  "CWWKE0701E", // wmqJmsClient.rar.location variable not in the server.xml
-                                                 "TRAS4352W" // Only happens when running with WebSphere Liberty image due to an auto feature
+                                                 "TRAS4352W", // Only happens when running with WebSphere Liberty image due to an auto feature
+                                                 "CWWKB0758E" // zosAutomaticRestartManager-1.0 error due to missing SAF configuration
             };
         } else {
             toleratedWarnErrors = new String[] { "SRVE0280E" };// TODO: SRVE0280E tracked by OpenLiberty issue #4857


### PR DESCRIPTION
- On z/OS, there is a different error with z/OS features running with the test.  Add that error to the error list.
- When running with Java 8 the EE9 test should not have the mpReactive 3.0 features added since they require a minimum of Java 11
- Small change in SipResolverTcpTransport for netty to look like the channel one and not have it be javadoc comment to avoid errors in eclipse.