### PR TITLE
Set content-length header to match size of updated content

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/servlet/filter/HtmlResponseWrapper.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/servlet/filter/HtmlResponseWrapper.java
@@ -81,7 +81,6 @@ public class HtmlResponseWrapper extends HttpServletResponseWrapper {
 
     @Override
     public void flushBuffer() throws IOException {
-        super.flushBuffer();
         if (writer != null) {
             writer.flush();
         } else if (outputStream != null) {

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/servlet/filter/OpenAPIEndpointFilter.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/servlet/filter/OpenAPIEndpointFilter.java
@@ -59,6 +59,7 @@ public class OpenAPIEndpointFilter implements Filter {
                     // replace the default URL for the document endpoint with the value that is being used
                     content = content.replaceAll("/openapi", openAPIEndpointTracker.getService().getOpenAPIDocUrl());
                 }
+                resp.setContentLength(content.length());
                 resp.getWriter().write(content);
             }
         }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/com/ibm/ws/microprofile/openapi/servlet/filter/HtmlResponseWrapper.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/com/ibm/ws/microprofile/openapi/servlet/filter/HtmlResponseWrapper.java
@@ -81,7 +81,6 @@ public class HtmlResponseWrapper extends HttpServletResponseWrapper {
 
     @Override
     public void flushBuffer() throws IOException {
-        super.flushBuffer();
         if (writer != null) {
             writer.flush();
         } else if (outputStream != null) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/com/ibm/ws/microprofile/openapi/servlet/filter/OpenAPIEndpointFilter.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/com/ibm/ws/microprofile/openapi/servlet/filter/OpenAPIEndpointFilter.java
@@ -60,6 +60,7 @@ public class OpenAPIEndpointFilter implements Filter {
                     // replace the default URL for the document endpoint with the value that is being used
                     content = content.replaceAll("/openapi", openAPIEndpointTracker.getService().getOpenAPIDocUrl());
                 }
+                resp.setContentLength(content.length());
                 resp.getWriter().write(content);
             }
         }

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UICustomPathTest.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UICustomPathTest.java
@@ -57,7 +57,7 @@ public class UICustomPathTest {
     public static final String UI_PROPERTY_NAME = "customUIPath";
     public static final String DOC_PROPERTY_NAME = "customDocPath";
     public static final String UI_PATH_VALUE = "/foo/bar";
-    public static final String DOC_PATH_VALUE = "/bar/foo";
+    public static final String DOC_PATH_VALUE = "/get/docs/here";
     /**
      * Wait for "long" tasks like initial page load or making a test request to the server
      */


### PR DESCRIPTION
The Content-length header was not being updated when the document path was changed. such that only paths of 7 characters could work.

Remove super.flushBuffer() from wrapper to prevent early commit of content before the filter updates the response.

Update test to not have a doc path value that is the same length of path as `/openapi`