### PR TITLE
Suppressed CloneNotSupportedException For Issue #25830

### DIFF
--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/BasicAuthCacheKeyProvider.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/BasicAuthCacheKeyProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -207,7 +207,7 @@ public class BasicAuthCacheKeyProvider implements CacheKeyProvider {
         try {
             return (MessageDigest) CLONEABLE_MESSAGE_DIGEST.clone();
         } catch (CloneNotSupportedException cnse) {
-            //Since implementation of clone is optional in Java, if clone does not work, just return a new instance.
+            //Since implementation of clone is optional in Java, if the clone does not work, just return a new instance.
             return MessageDigest.getInstance(SHA_512);
         }
     }

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/BasicAuthCacheKeyProvider.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/BasicAuthCacheKeyProvider.java
@@ -207,14 +207,7 @@ public class BasicAuthCacheKeyProvider implements CacheKeyProvider {
         try {
             return (MessageDigest) CLONEABLE_MESSAGE_DIGEST.clone();
         } catch (CloneNotSupportedException cnse) {
-            if (tc.isDebugEnabled()) {
-                /*
-                 * commented out to suppress CloneNotSupportedException
-                 * Tr.debug(tc, "CloneNotSupportedException caught while trying to clone MessageDigest with algorithm " + SHA_512
-                 * + ". This is pretty unlikely, and we need to get details about the JDK which is in use.",
-                 * cnse);
-                 */
-            }
+            //Since implementation of clone is optional in Java, if clone does not work, just return a new instance.
             return MessageDigest.getInstance(SHA_512);
         }
     }

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/BasicAuthCacheKeyProvider.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/BasicAuthCacheKeyProvider.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -208,9 +208,12 @@ public class BasicAuthCacheKeyProvider implements CacheKeyProvider {
             return (MessageDigest) CLONEABLE_MESSAGE_DIGEST.clone();
         } catch (CloneNotSupportedException cnse) {
             if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "CloneNotSupportedException caught while trying to clone MessageDigest with algorithm " + SHA_512
-                             + ". This is pretty unlikely, and we need to get details about the JDK which is in use.",
-                         cnse);
+                /*
+                 * commented out to suppress CloneNotSupportedException
+                 * Tr.debug(tc, "CloneNotSupportedException caught while trying to clone MessageDigest with algorithm " + SHA_512
+                 * + ". This is pretty unlikely, and we need to get details about the JDK which is in use.",
+                 * cnse);
+                 */
             }
             return MessageDigest.getInstance(SHA_512);
         }


### PR DESCRIPTION
This PR is to suppress the exception called "CloneNotSupportedException" which is caught while trying to clone MessageDigest with algorithm SHA-512 on Liberty.