### PR TITLE
Automatic validation per Jakarta Data 1.0 beta 3, and tests

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/bnd.bnd
+++ b/dev/io.openliberty.data.internal.persistence/bnd.bnd
@@ -24,10 +24,21 @@ Bundle-Description: Maps Jakarta Data to Jakarta Persistence; version=${bVersion
 
 WS-TraceGroup: data
 
+DynamicImport-Package: \
+  com.ibm.ws.beanvalidation.service, \
+  jakarta.validation
+
+Import-Package: \
+  !*.internal.*, \
+  !com.ibm.ws.beanvalidation.service, \
+  !jakarta.validation, \
+  *
+
 Private-Package: \
   io.openliberty.data.internal.persistence.*,\
   io.openliberty.data.internal.persistence.cdi.*,\
-  io.openliberty.data.internal.persistence.resources.*
+  io.openliberty.data.internal.persistence.resources.*,\
+  io.openliberty.data.internal.persistence.validation.*
 
 -cdiannotations:
 
@@ -44,6 +55,7 @@ instrument.classesExcludes: io/openliberty/data/internal/persistence/resources/*
   com.ibm.websphere.org.osgi.service.cm;version=latest,\
   com.ibm.websphere.org.osgi.service.component,\
   com.ibm.wsspi.org.osgi.service.component.annotations,\
+  com.ibm.ws.beanvalidation.jakarta;version=latest,\
   com.ibm.ws.cdi.interfaces.jakarta;version=latest, \
   com.ibm.ws.container.service;version=latest,\
   com.ibm.ws.org.objectweb.asm;version=latest,\
@@ -59,4 +71,5 @@ instrument.classesExcludes: io/openliberty/data/internal/persistence/resources/*
   io.openliberty.jakarta.data.1.0,\
   io.openliberty.jakarta.interceptor.2.1,\
   io.openliberty.jakarta.persistence.3.1,\
-  io.openliberty.jakarta.transaction.2.0
+  io.openliberty.jakarta.transaction.2.0,\
+  io.openliberty.jakarta.validation.3.0

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityValidator.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityValidator.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.data.internal.persistence;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Abstraction for a Jakarta Validation Validator.
+ */
+public interface EntityValidator {
+    /**
+     * @return the com.ibm.ws.beanvalidation.service.BeanValidation service that this EntityValidator uses.
+     */
+    Object getValidation();
+
+    /**
+     * Construct a provider for the EntityValidator abstraction.
+     *
+     * @param validation com.ibm.ws.beanvalidation.service.BeanValidation service for this provider to use.
+     * @return the provider.
+     */
+    static EntityValidator newInstance(Object validation) {
+        try {
+            @SuppressWarnings("unchecked")
+            Class<EntityValidator> EntityValidatorImpl = (Class<EntityValidator>) EntityValidator.class.getClassLoader() //
+                            .loadClass("io.openliberty.data.internal.persistence.validation.EntityValidatorImpl");
+            return EntityValidatorImpl.getConstructor(Object.class).newInstance(validation);
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException x) {
+            throw new RuntimeException(x); // internal error
+        } catch (InvocationTargetException x) {
+            throw new RuntimeException(x.getCause()); // internal error
+        }
+    }
+
+    /**
+     * Validates each entity instance per its specified constraints (if any).
+     *
+     * @param entities instances to validate.
+     * @throws ConstraintValidationException if any of the constraints are violated for an entity.
+     */
+    void validate(Iterable<?> entities);
+
+    /**
+     * Validates the entity instance per its specified constraints (if any).
+     *
+     * @param entity instance to validate.
+     * @throws ConstraintValidationException if any of the constraints are violated.
+     */
+    void validate(Object entity);
+
+    /**
+     * Validates each entity instance per its specified constraints (if any).
+     *
+     * @param entities instances to validate.
+     * @param length   number of instances in the array to validate.
+     * @throws ConstraintValidationException if any of the constraints are violated for an entity.
+     */
+    void validate(Object entityArray, int length);
+}

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1812,23 +1812,31 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
                 switch (queryInfo.type) {
                     case MERGE: {
+                        EntityValidator validator = provider.validator();
+
                         em = entityInfo.persister.createEntityManager();
 
                         if (queryInfo.saveParamType.isArray()) {
                             ArrayList<Object> results = new ArrayList<>();
                             Object a = args[0];
                             int length = Array.getLength(a);
+                            if (validator != null)
+                                validator.validate(a, length);
                             for (int i = 0; i < length; i++)
                                 results.add(em.merge(toEntity(Array.get(a, i))));
                             em.flush();
                             returnValue = results;
                         } else if (Iterable.class.isAssignableFrom(queryInfo.saveParamType)) {
+                            if (validator != null)
+                                validator.validate(args[0]);
                             ArrayList<Object> results = new ArrayList<>();
                             for (Object e : ((Iterable<?>) args[0]))
                                 results.add(em.merge(toEntity(e)));
                             em.flush();
                             returnValue = results;
                         } else {
+                            if (validator != null && args[0] != null)
+                                validator.validate(args[0]);
                             returnValue = em.merge(toEntity(args[0]));
                             em.flush();
                         }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1828,7 +1828,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             returnValue = results;
                         } else if (Iterable.class.isAssignableFrom(queryInfo.saveParamType)) {
                             if (validator != null)
-                                validator.validate(args[0]);
+                                validator.validate((Iterable<?>) args[0]);
                             ArrayList<Object> results = new ArrayList<>();
                             for (Object e : ((Iterable<?>) args[0]))
                                 results.add(em.merge(toEntity(e)));

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtensionProvider.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtensionProvider.java
@@ -24,10 +24,14 @@ import java.util.concurrent.ExecutorService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -36,11 +40,13 @@ import com.ibm.ws.LocalTransaction.LocalTransactionCurrent;
 import com.ibm.ws.container.service.metadata.ApplicationMetaDataListener;
 import com.ibm.ws.container.service.metadata.MetaDataEvent;
 import com.ibm.ws.container.service.metadata.MetaDataException;
+import com.ibm.ws.container.service.metadata.ModuleMetaDataListener;
 import com.ibm.ws.runtime.metadata.ApplicationMetaData;
 import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
 import com.ibm.wsspi.resource.ResourceFactory;
 
 import io.openliberty.cdi.spi.CDIExtensionMetadata;
+import io.openliberty.data.internal.persistence.EntityValidator;
 import jakarta.enterprise.inject.spi.Extension;
 
 /**
@@ -79,6 +85,11 @@ public class DataExtensionProvider implements CDIExtensionMetadata, ApplicationM
     @Reference
     public EmbeddableWebSphereTransactionManager tranMgr;
 
+    /**
+     * Abstraction for an optionally available validation service.
+     */
+    private transient EntityValidator validator;
+
     @Override
     @Trivial
     public void applicationMetaDataCreated(MetaDataEvent<ApplicationMetaData> event) throws MetaDataException {
@@ -105,7 +116,7 @@ public class DataExtensionProvider implements CDIExtensionMetadata, ApplicationM
     }
 
     @Deactivate
-    protected void deactivate() {
+    protected void deactivate(ComponentContext cc) {
         // Remove and delete configurations that our extension generated.
         for (Iterator<Map<String, Configuration>> it = dbStoreConfigAllApps.values().iterator(); it.hasNext();) {
             Map<String, Configuration> configurations = it.next();
@@ -134,5 +145,26 @@ public class DataExtensionProvider implements CDIExtensionMetadata, ApplicationM
     @Trivial
     public Set<Class<? extends Extension>> getExtensions() {
         return extensions;
+    }
+
+    @Reference(service = ModuleMetaDataListener.class, // also a BeanValidation.class, but that class might not be available to this bundle
+               target = "(service.pid=com.ibm.ws.beanvalidation.OSGiBeanValidationImpl)",
+               cardinality = ReferenceCardinality.OPTIONAL,
+               policy = ReferencePolicy.DYNAMIC,
+               policyOption = ReferencePolicyOption.GREEDY)
+    protected void setValidation(ModuleMetaDataListener svc) {
+        validator = EntityValidator.newInstance(svc);
+    }
+
+    protected void unsetValidation(ModuleMetaDataListener svc) {
+        if (validator != null && validator.getValidation() == svc)
+            validator = null;
+    }
+
+    /**
+     * @return an abstraction for Jakarta Validation if available, otherwise null.
+     */
+    public EntityValidator validator() {
+        return validator;
     }
 }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/validation/EntityValidatorImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/validation/EntityValidatorImpl.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.data.internal.persistence.validation;
+
+import java.lang.reflect.Array;
+import java.util.Set;
+
+import com.ibm.ws.beanvalidation.service.BeanValidation;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
+
+import io.openliberty.data.internal.persistence.EntityValidator;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+
+/**
+ * Abstraction for a Jakarta Validation Validator.
+ */
+public class EntityValidatorImpl implements EntityValidator {
+    private final BeanValidation validation;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param validation instance of com.ibm.ws.beanvalidation.service.BeanValidation.
+     */
+    public EntityValidatorImpl(Object validation) {
+        this.validation = (BeanValidation) validation;
+    }
+
+    @Override
+    public final Object getValidation() {
+        return validation;
+    }
+
+    /**
+     * Validates each entity instance per its specified constraints (if any).
+     *
+     * @param entities instances to validate.
+     * @throws ConstraintValidationException if any of the constraints are violated for an entity.
+     */
+    @Override
+    public void validate(Iterable<?> entities) {
+        ComponentMetaData cdata = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cdata != null) {
+            Validator validator = validation.getValidator(cdata);
+            Set<ConstraintViolation<Object>> violations;
+            for (Object entity : entities) {
+                violations = validator.validate(entity);
+                if (violations != null)
+                    throw new ConstraintViolationException(violations); // TODO better message? Ensure that message includes at least the first violation.
+                // TODO Should we continue after an invalid entity is found and collect up the violations across all?
+            }
+        }
+    }
+
+    /**
+     * Validates the entity instance per its specified constraints (if any).
+     *
+     * @param entity instance to validate
+     * @throws ConstraintValidationException if any of the constraints are violated.
+     */
+    @Override
+    public void validate(Object entity) {
+        ComponentMetaData cdata = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cdata != null) {
+            Validator validator = validation.getValidator(cdata);
+            Set<ConstraintViolation<Object>> violations = validator.validate(entity);
+            if (violations != null)
+                throw new ConstraintViolationException(violations); // TODO better message? Ensure that message includes at least the first violation.
+        }
+    }
+
+    /**
+     * Validates each entity instance per its specified constraints (if any).
+     *
+     * @param entities instances to validate.
+     * @param length   number of instances in the array to validate.
+     * @throws ConstraintValidationException if any of the constraints are violated for an entity.
+     */
+    @Override
+    public void validate(Object entityArray, int length) {
+        ComponentMetaData cdata = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cdata != null) {
+            Validator validator = validation.getValidator(cdata);
+            Set<ConstraintViolation<Object>> violations;
+            for (int i = 0; i < length; i++) {
+                violations = validator.validate(Array.get(entityArray, i));
+                if (violations != null)
+                    throw new ConstraintViolationException(violations); // TODO better message? Ensure that message includes at least the first violation.
+                // TODO Should we continue after an invalid entity is found and collect up the violations across all?
+            }
+        }
+    }
+}

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/validation/EntityValidatorImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/validation/EntityValidatorImpl.java
@@ -58,7 +58,7 @@ public class EntityValidatorImpl implements EntityValidator {
             Set<ConstraintViolation<Object>> violations;
             for (Object entity : entities) {
                 violations = validator.validate(entity);
-                if (violations != null)
+                if (violations != null && !violations.isEmpty())
                     throw new ConstraintViolationException(violations); // TODO better message? Ensure that message includes at least the first violation.
                 // TODO Should we continue after an invalid entity is found and collect up the violations across all?
             }
@@ -77,7 +77,7 @@ public class EntityValidatorImpl implements EntityValidator {
         if (cdata != null) {
             Validator validator = validation.getValidator(cdata);
             Set<ConstraintViolation<Object>> violations = validator.validate(entity);
-            if (violations != null)
+            if (violations != null && !violations.isEmpty())
                 throw new ConstraintViolationException(violations); // TODO better message? Ensure that message includes at least the first violation.
         }
     }
@@ -97,7 +97,7 @@ public class EntityValidatorImpl implements EntityValidator {
             Set<ConstraintViolation<Object>> violations;
             for (int i = 0; i < length; i++) {
                 violations = validator.validate(Array.get(entityArray, i));
-                if (violations != null)
+                if (violations != null && !violations.isEmpty())
                     throw new ConstraintViolationException(violations); // TODO better message? Ensure that message includes at least the first violation.
                 // TODO Should we continue after an invalid entity is found and collect up the violations across all?
             }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/validation/package-info.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/validation/package-info.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "data", messageBundle = "io.openliberty.data.internal.persistence.resources.CWWKDMessages")
+package io.openliberty.data.internal.persistence.validation;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Creature.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Creature.java
@@ -47,7 +47,7 @@ public class Creature {
     public BigDecimal longitude;
 
     // begin with capital, then any number of characters or space, then space, then begin with lower case, then any number of characters or space
-    @Pattern(regexp = "[A-Z][a-zA-z\\s]*[\\s][a-z][a-zA-z\\s]*")
+    @Pattern(regexp = "[A-Z][a-zA-Z\\s]*[\\s][a-z][a-zA-Z\\s]*")
     public String scientificName;
 
     @Positive

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Creatures.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Creatures.java
@@ -12,13 +12,12 @@
  *******************************************************************************/
 package test.jakarta.data.validation.web;
 
+import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Repository;
-import jakarta.validation.Valid;
 
 /**
  * Repository for a Jakarta Persistence entity with bean validation annotations.
  */
 @Repository(dataStore = "java:module/jdbc/DerbyDataSource")
-public interface Creatures {
-    void save(@Valid Creature c);
+public interface Creatures extends CrudRepository<Creature, Long> {
 }

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
@@ -19,6 +19,8 @@ import java.math.BigDecimal;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import jakarta.annotation.sql.DataSourceDefinition;
@@ -90,7 +92,7 @@ public class DataValidationTestServlet extends FATServlet {
      * Attempt to save a Java class (no entity annotation) that violates constraints for PastOrPresent.
      */
     @Test
-    public void testSaveInvalidPastOrPresent_Class() {
+    public void testInsertInvalidPastOrPresent_Class() {
         Creature c = new Creature(100l, "Black Bear", "Ursus americanus", //
                         BigDecimal.valueOf(44107730l, 6), BigDecimal.valueOf(-92489272l, 6), //
                         ZonedDateTime.now(ZoneId.of("America/Chicago")).plusHours(1).toOffsetDateTime(), //
@@ -110,7 +112,7 @@ public class DataValidationTestServlet extends FATServlet {
      * Attempt to save a Jakarta Persistence entity that violated constraints for Pattern.
      */
     @Test
-    public void testSaveInvalidPattern_PersistenceEntity() {
+    public void testInsertInvalidPattern_PersistenceEntity() {
         Entitlement e = new Entitlement(2, "MEDICARE", "person1@openliberty.io", Frequency.AS_NEEDED, 65, null, null, null);
         Set<?> violations = Collections.emptySet();
         try {
@@ -126,7 +128,7 @@ public class DataValidationTestServlet extends FATServlet {
      * Attempt to save a Jakarta Persistence entity that violated constraints for Pattern.
      */
     @Test
-    public void testSaveInvalidPositiveMax_Record() {
+    public void testInsertInvalidPositiveMax_Record() {
         Rectangle r = new Rectangle("R1", 100l, 150l, -10, 30000);
         Set<?> violations = Collections.emptySet();
         try {
@@ -143,7 +145,7 @@ public class DataValidationTestServlet extends FATServlet {
      * Save a Java class (no entity annotation) that has no constraint violations.
      */
     @Test
-    public void testSaveValidClass() {
+    public void testInsertValidClass() {
         Creature c = new Creature(200l, "White-Tailed Deer", "Odocoileus virginianus", //
                         BigDecimal.valueOf(44040061l, 6), BigDecimal.valueOf(-92470320l, 6), //
                         ZonedDateTime.of(2023, 7, 12, 14, 51, 41, 100, ZoneId.of("America/Chicago")).toOffsetDateTime(), //
@@ -162,7 +164,7 @@ public class DataValidationTestServlet extends FATServlet {
      * Save a Jakarta Persistence entity that has no constraint violations.
      */
     @Test
-    public void testSaveValidPersistenceEntity() {
+    public void testInsertValidPersistenceEntity() {
         Entitlement e = new Entitlement(1, "US-SOCIALSECURITY", "person2@openliberty.io", Frequency.MONTHLY, 62, null, Float.valueOf(0), BigDecimal.valueOf(4555));
         Set<?> violations = Collections.emptySet();
         try {
@@ -182,6 +184,181 @@ public class DataValidationTestServlet extends FATServlet {
         Set<?> violations = Collections.emptySet();
         try {
             rectangles.save(r);
+        } catch (ConstraintViolationException x) {
+            violations = x.getConstraintViolations();
+        }
+        assertEquals(Collections.EMPTY_SET, violations);
+    }
+
+    /**
+     * Attempt to save updates to Java class entities (no entity annotation) where the updates violate one or more constraints.
+     */
+    @Test
+    public void testUpdateInvalidPatternAndMax_Class() {
+        final ZoneId CENTRAL = ZoneId.of("America/Chicago");
+        Iterable<Creature> added = creatures.saveAll(List.of( //
+                                                             new Creature(600l, "Beaver", "Castor canadensis", //
+                                                                             BigDecimal.valueOf(44035314, 6), BigDecimal.valueOf(-92468053, 6), //
+                                                                             ZonedDateTime.of(2023, 7, 27, 12, 54, 6, 600, CENTRAL).toOffsetDateTime(), //
+                                                                             27.5f), //
+                                                             new Creature(700l, "Raccoon", "Procyon lotor", //
+                                                                             BigDecimal.valueOf(44078777, 6), BigDecimal.valueOf(-92480836, 6), //
+                                                                             ZonedDateTime.of(2023, 7, 27, 12, 56, 7, 700, CENTRAL).toOffsetDateTime(), //
+                                                                             18.7f)));
+
+        Iterator<Creature> it = added.iterator();
+        assertEquals(true, it.hasNext());
+        Creature c1 = it.next();
+        assertEquals(true, it.hasNext());
+        Creature c2 = it.next();
+        assertEquals(false, it.hasNext());
+
+        Set<?> violations = Collections.emptySet();
+
+        // First not valid, second valid:
+        c1.scientificName = "Castor Canadensis"; // invalid capital letter at beginning of species name
+        c2.weight = 18.8f; // valid update
+
+        try {
+            Iterable<Creature> updated = creatures.saveAll(List.of(c1, c2));
+            fail("ConstraintViolationException was not raised. Updated: " + updated);
+        } catch (ConstraintViolationException x) {
+            violations = x.getConstraintViolations();
+        }
+        assertEquals(violations.toString(), 1, violations.size());
+
+        // The violation on c1 must prevent the valid update to c2:
+        c2 = creatures.findById(c2.id).orElseThrow();
+        assertEquals(18.7f, c2.weight, 0.00001f);
+
+        // First valid, second not valid:
+        c1.scientificName = "Castor canadensis"; // original value
+        c1.weight = 27.6f; // valid update
+        c2.latitude = BigDecimal.valueOf(94078777, 6); // invalid update
+
+        try {
+            Iterable<Creature> updated = creatures.saveAll(List.of(c1, c2));
+            fail("ConstraintViolationException was not raised. Updated: " + updated);
+        } catch (ConstraintViolationException x) {
+            violations = x.getConstraintViolations();
+        }
+        assertEquals(violations.toString(), 1, violations.size());
+
+        // The violation on c2 must prevent the valid update to c1:
+        c1 = creatures.findById(c1.id).orElseThrow();
+        assertEquals(27.5f, c1.weight, 0.00001f);
+        assertEquals("Castor canadensis", c1.scientificName);
+    }
+
+    /**
+     * Attempt to save updates to record entities where the updates violate one or more constraints.
+     */
+    @Test
+    public void testUpdateInvalidZeroWidth_Records() {
+        rectangles.saveAll(new Rectangle("R6", 600l, 660l, 16, 60),
+                           new Rectangle("R7", 700l, 770l, 17, 70));
+
+        Set<?> violations = Collections.emptySet();
+
+        // First not valid, second valid:
+        Rectangle r6 = new Rectangle("R6", 600l, 660l, 0, 60);
+        Rectangle r7 = new Rectangle("R7", 700l, 770l, 7, 70);
+
+        try {
+            rectangles.saveAll(r6, r7);
+            fail("ConstraintViolationException was not raised.");
+        } catch (ConstraintViolationException x) {
+            violations = x.getConstraintViolations();
+        }
+        assertEquals(violations.toString(), 1, violations.size());
+
+        // The violation on r6 must prevent the valid update to r7:
+        assertEquals(17, rectangles.findWidthById("R7"));
+
+        // First valid, second not valid:
+        r6 = new Rectangle("R6", 600l, 660l, 6, 60);
+        r7 = new Rectangle("R7", 700l, 770l, 0, 70);
+
+        try {
+            rectangles.saveAll(r6, r7);
+            fail("ConstraintViolationException was not raised.");
+        } catch (ConstraintViolationException x) {
+            violations = x.getConstraintViolations();
+        }
+        assertEquals(violations.toString(), 1, violations.size());
+
+        // The violation on r7 must prevent the valid update to r6:
+        assertEquals(16, rectangles.findWidthById("R6"));
+    }
+
+    /**
+     * Save updates to Java class entities (no entity annotation) where the updates have no constraint violations.
+     */
+    @Test
+    public void testUpdateValidClasses() {
+        final ZoneId CENTRAL = ZoneId.of("America/Chicago");
+        Iterable<Creature> added = creatures.saveAll(List.of( //
+                                                             new Creature(300l, "Groundhog", "Marmota monax", //
+                                                                             BigDecimal.valueOf(44074047, 6), BigDecimal.valueOf(-92646106, 6), //
+                                                                             ZonedDateTime.of(2023, 7, 27, 10, 28, 30, 300, CENTRAL).toOffsetDateTime(), //
+                                                                             5.6f), //
+                                                             new Creature(400l, "Ruby-throated Hummingbird", "Archilochus colubris", //
+                                                                             BigDecimal.valueOf(44078371, 6), BigDecimal.valueOf(-92648177, 6), //
+                                                                             ZonedDateTime.of(2023, 7, 27, 10, 32, 40, 400, CENTRAL).toOffsetDateTime(), //
+                                                                             0.0037f),
+                                                             new Creature(500l, "Pileated Woodpecker", "Dyrocopus pileatus", //
+                                                                             BigDecimal.valueOf(44040137, 6), BigDecimal.valueOf(-92471988, 6), //
+                                                                             ZonedDateTime.of(2023, 7, 27, 10, 35, 50, 500, CENTRAL).toOffsetDateTime(), //
+                                                                             0.292f)));
+        Iterator<Creature> it = added.iterator();
+        assertEquals(true, it.hasNext());
+        Creature c1 = it.next();
+        assertEquals(true, it.hasNext());
+        Creature c2 = it.next();
+        assertEquals(true, it.hasNext());
+        Creature c3 = it.next();
+        assertEquals(false, it.hasNext());
+
+        Set<?> violations = Collections.emptySet();
+
+        c1.weight = 5.7f;
+        c3.latitude = BigDecimal.valueOf(44040337, 6);
+        try {
+            creatures.saveAll(Set.of(c1, c3));
+        } catch (ConstraintViolationException x) {
+            violations = x.getConstraintViolations();
+        }
+        assertEquals(Collections.EMPTY_SET, violations);
+
+        c2.longitude = BigDecimal.valueOf(-92647748, 6);
+        try {
+            creatures.save(c2);
+        } catch (ConstraintViolationException x) {
+            violations = x.getConstraintViolations();
+        }
+        assertEquals(Collections.EMPTY_SET, violations);
+    }
+
+    /**
+     * Save updates to records where the updates have no constraint violations.
+     */
+    @Test
+    public void testUpdateValidRecords() {
+        rectangles.saveAll(new Rectangle("R3", 300l, 330l, 13, 30),
+                           new Rectangle("R4", 400l, 440l, 14, 40),
+                           new Rectangle("R5", 500l, 550l, 15, 50));
+
+        Set<?> violations = Collections.emptySet();
+        try {
+            rectangles.saveAll(new Rectangle("R4", 400l, 440l, 14, 44),
+                               new Rectangle("R5", 500l, 550l, 15, 55));
+        } catch (ConstraintViolationException x) {
+            violations = x.getConstraintViolations();
+        }
+        assertEquals(Collections.EMPTY_SET, violations);
+
+        try {
+            rectangles.save(new Rectangle("R3", 300l, 330l, 33, 30));
         } catch (ConstraintViolationException x) {
             violations = x.getConstraintViolations();
         }

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
@@ -90,20 +90,19 @@ public class DataValidationTestServlet extends FATServlet {
      * Attempt to save a Java class (no entity annotation) that violates constraints for PastOrPresent.
      */
     @Test
-    public void testSaveInvalidPastOrPresentClass() {
+    public void testSaveInvalidPastOrPresent_Class() {
         Creature c = new Creature(100l, "Black Bear", "Ursus americanus", //
                         BigDecimal.valueOf(44107730l, 6), BigDecimal.valueOf(-92489272l, 6), //
                         ZonedDateTime.now(ZoneId.of("America/Chicago")).plusHours(1).toOffsetDateTime(), //
                         172.5f);
 
         Set<?> violations = Collections.emptySet();
-        //try {
-        creatures.save(c);
-        // TODO replace the next line with failure and expect to catch ConstraintViolationException once Jakarta Data provider does the validation for us
-        violations = validator.validate(c);
-        //} catch (ConstraintViolationException x) {
-        //    violations = x.getConstraintViolations();
-        //}
+        try {
+            creatures.save(c);
+            fail("ConstraintViolationException was not raised.");
+        } catch (ConstraintViolationException x) {
+            violations = x.getConstraintViolations();
+        }
         assertEquals(violations.toString(), 1, violations.size());
     }
 
@@ -111,16 +110,15 @@ public class DataValidationTestServlet extends FATServlet {
      * Attempt to save a Jakarta Persistence entity that violated constraints for Pattern.
      */
     @Test
-    public void testSaveInvalidPatternPersistenceEntity() {
+    public void testSaveInvalidPattern_PersistenceEntity() {
         Entitlement e = new Entitlement(2, "MEDICARE", "person1@openliberty.io", Frequency.AS_NEEDED, 65, null, null, null);
         Set<?> violations = Collections.emptySet();
-        //try {
-        entitlements.save(e);
-        // TODO replace the next line with failure and expect to catch ConstraintViolationException once Jakarta Data provider does the validation for us
-        violations = validator.validate(e);
-        //} catch (ConstraintViolationException x) {
-        //    violations = x.getConstraintViolations();
-        //}
+        try {
+            entitlements.save(e);
+            fail("ConstraintViolationException was not raised.");
+        } catch (ConstraintViolationException x) {
+            violations = x.getConstraintViolations();
+        }
         assertEquals(violations.toString(), 1, violations.size());
     }
 
@@ -128,16 +126,16 @@ public class DataValidationTestServlet extends FATServlet {
      * Attempt to save a Jakarta Persistence entity that violated constraints for Pattern.
      */
     @Test
-    public void testSaveInvalidPositiveMaxRecord() {
+    public void testSaveInvalidPositiveMax_Record() {
         Rectangle r = new Rectangle("R1", 100l, 150l, -10, 30000);
         Set<?> violations = Collections.emptySet();
-        //try {
-        rectangles.save(r);
-        // TODO replace the next line with failure and expect to catch ConstraintViolationException once Jakarta Data provider does the validation for us
-        violations = validator.validate(r);
-        //} catch (ConstraintViolationException x) {
-        //    violations = x.getConstraintViolations();
-        //}
+        try {
+            rectangles.save(r);
+            fail("ConstraintViolationException was not raised.");
+            violations = validator.validate(r);
+        } catch (ConstraintViolationException x) {
+            violations = x.getConstraintViolations();
+        }
         assertEquals(violations.toString(), 2, violations.size());
     }
 
@@ -154,8 +152,6 @@ public class DataValidationTestServlet extends FATServlet {
         Set<?> violations = Collections.emptySet();
         try {
             creatures.save(c);
-            // TODO the following should be unnecessary once it is done by the Jakarta Data provider:
-            violations = validator.validate(c);
         } catch (ConstraintViolationException x) {
             violations = x.getConstraintViolations();
         }
@@ -171,8 +167,6 @@ public class DataValidationTestServlet extends FATServlet {
         Set<?> violations = Collections.emptySet();
         try {
             entitlements.save(e);
-            // TODO the following should be unnecessary once it is done by the Jakarta Data provider:
-            violations = validator.validate(e);
         } catch (ConstraintViolationException x) {
             violations = x.getConstraintViolations();
         }
@@ -188,8 +182,6 @@ public class DataValidationTestServlet extends FATServlet {
         Set<?> violations = Collections.emptySet();
         try {
             rectangles.save(r);
-            // TODO the following should be unnecessary once it is done by the Jakarta Data provider:
-            violations = validator.validate(r);
         } catch (ConstraintViolationException x) {
             violations = x.getConstraintViolations();
         }

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Entitlements.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Entitlements.java
@@ -14,12 +14,11 @@ package test.jakarta.data.validation.web;
 
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
-import jakarta.validation.Valid;
 
 /**
  * Repository for a Jakarta Persistence entity with bean validation annotations.
  */
 @Repository(dataStore = "java:module/jdbc/DerbyDataSource")
 public interface Entitlements extends DataRepository<Entitlement, Long> {
-    void save(@Valid Entitlement e);
+    void save(Entitlement e);
 }

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Rectangles.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Rectangles.java
@@ -12,14 +12,16 @@
  *******************************************************************************/
 package test.jakarta.data.validation.web;
 
-import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
-import jakarta.validation.Valid;
 
 /**
  * Repository for a record with bean validation annotations.
  */
 @Repository(dataStore = "java:module/jdbc/DerbyDataSource")
-public interface Rectangles extends DataRepository<Rectangle, String> {
-    void save(@Valid Rectangle r);
+public interface Rectangles {
+    int findWidthById(String id);
+
+    void save(Rectangle r);
+
+    void saveAll(Rectangle... rectangles);
 }


### PR DESCRIPTION
Enable tests for validation on insert and add new tests for validation on update, covering both save and saveAll for records and unannotated entity classes.