### PR TITLE
sync up spec API with Jakarta Data 1.0 beta 3

### DIFF
--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/Limit.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/Limit.java
@@ -15,38 +15,27 @@ package jakarta.data.repository;
 /**
  * Method signatures are copied from the jakarta.data.repository.Limit from the Jakarta Data repo.
  */
-public class Limit {
-    private final int max;
-    private final long start;
+public record Limit(int maxResults,
+                long startAt) {
 
-    private Limit(long startAt, int maxResults) {
-        start = startAt;
-        max = maxResults;
-        if (start < 1)
-            throw new IllegalArgumentException("startAt: " + start);
-        if (max < 1)
-            throw new IllegalArgumentException("maxResults: " + max);
-    }
-
-    public int maxResults() {
-        return max;
+    public Limit {
+        if (startAt < 1)
+            throw new IllegalArgumentException("startAt: " + startAt);
+        if (maxResults < 1)
+            throw new IllegalArgumentException("maxResults: " + maxResults);
     }
 
     public static Limit of(int maxResults) {
-        return new Limit(1L, maxResults);
+        return new Limit(maxResults, 1L);
     }
 
     public static Limit range(long startAt, long endAt) {
-        if (startAt >= endAt)
+        if (startAt > endAt)
             throw new IllegalArgumentException("startAt: " + startAt + ", endAt: " + endAt);
 
         if (Integer.MAX_VALUE <= endAt - startAt)
             throw new IllegalArgumentException("startAt: " + startAt + ", endAt: " + endAt + ", maxResults > " + Integer.MAX_VALUE);
 
-        return new Limit(startAt, 1 + (int) (endAt - startAt));
-    }
-
-    public long startAt() {
-        return start;
+        return new Limit(1 + (int) (endAt - startAt), startAt);
     }
 }

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/Pagination.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/Pagination.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,104 +14,55 @@ package jakarta.data.repository;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+
+import jakarta.data.repository.Pageable.Cursor;
+import jakarta.data.repository.Pageable.Mode;
 
 /**
  * Method signatures are copied from jakarta.data.repository.Pageable from the Jakarta Data repo.
  */
-class Pagination implements Pageable {
-    private final Cursor cursor;
-    private final Mode mode;
-    private final List<Sort> order;
-    private final long pageNumber;
-    private final int pageSize;
-    private final int hash;
+record Pagination(long page,
+                int size,
+                List<Sort> sorts,
+                Mode mode,
+                Cursor cursor)
+                implements Pageable {
 
-    Pagination(long pageNumber, int pageSize, List<Sort> order, Mode mode, Cursor cursor) {
-        if (pageNumber < 1)
-            throw new IllegalArgumentException("pageNumber: " + pageNumber);
-        if (pageSize < 1)
-            throw new IllegalArgumentException("pageSize: " + pageSize);
+    Pagination {
+        if (page < 1)
+            throw new IllegalArgumentException("pageNumber: " + page);
+        if (size < 1)
+            throw new IllegalArgumentException("maxPageSize: " + size);
         if (mode != Mode.OFFSET && (cursor == null || cursor.size() == 0))
             throw new IllegalArgumentException("No keyset values were provided.");
-        this.cursor = cursor;
-        this.mode = mode;
-        this.order = order;
-        this.pageNumber = pageNumber;
-        this.pageSize = pageSize;
-        this.hash = Objects.hash(pageSize, pageNumber, order, mode, cursor);
     }
 
     @Override
     public Pageable afterKeyset(Object... keyset) {
-        return new Pagination(pageNumber, pageSize, order, Mode.CURSOR_NEXT, new KeysetCursor(keyset));
+        return new Pagination(page, size, sorts, Mode.CURSOR_NEXT, new KeysetCursor(keyset));
     }
 
     @Override
     public Pageable afterKeysetCursor(Pageable.Cursor cursor) {
-        return new Pagination(pageNumber, pageSize, order, Mode.CURSOR_NEXT, cursor);
+        return new Pagination(page, size, sorts, Mode.CURSOR_NEXT, cursor);
     }
 
     @Override
     public Pageable beforeKeyset(Object... keyset) {
-        return new Pagination(pageNumber, pageSize, order, Mode.CURSOR_PREVIOUS, new KeysetCursor(keyset));
+        return new Pagination(page, size, sorts, Mode.CURSOR_PREVIOUS, new KeysetCursor(keyset));
     }
 
     @Override
     public Pageable beforeKeysetCursor(Pageable.Cursor cursor) {
-        return new Pagination(pageNumber, pageSize, order, Mode.CURSOR_PREVIOUS, cursor);
-    }
-
-    @Override
-    public Cursor cursor() {
-        return cursor;
-    }
-
-    @Override
-    public boolean equals(Object p) {
-        Pagination pagination;
-        return this == p
-               || p != null
-                  && p.getClass() == getClass()
-                  && (pagination = (Pagination) p).hash == hash
-                  && pagination.mode == mode
-                  && pagination.pageNumber == pageNumber
-                  && pagination.pageSize == pageSize
-                  && pagination.order.equals(order)
-                  && Objects.equals(pagination.cursor, cursor);
-    }
-
-    @Override
-    public final int hashCode() {
-        return hash;
-    }
-
-    @Override
-    public Mode mode() {
-        return mode;
-    }
-
-    @Override
-    public long page() {
-        return pageNumber;
-    }
-
-    @Override
-    public int size() {
-        return pageSize;
-    }
-
-    @Override
-    public List<Sort> sorts() {
-        return order;
+        return new Pagination(page, size, sorts, Mode.CURSOR_PREVIOUS, cursor);
     }
 
     @Override
     public Pagination next() {
         if (mode == Mode.OFFSET)
-            return new Pagination(pageNumber + 1, pageSize, order, mode, null);
+            return new Pagination(page + 1, size, sorts, mode, null);
         else
             throw new UnsupportedOperationException("Not supported for keyset pagination. Instead use afterKeyset or afterKeysetCursor to provide the next keyset values or obtain the nextPageable from a KeysetAwareSlice.");
     }
@@ -125,13 +76,13 @@ class Pagination implements Pageable {
     }
 
     @Override
-    public Pagination page(long page) {
-        return new Pagination(page, pageSize, order, mode, cursor);
+    public Pagination page(long pageNumber) {
+        return new Pagination(pageNumber, size, sorts, mode, cursor);
     }
 
     @Override
-    public Pagination size(int size) {
-        return new Pagination(pageNumber, size, order, mode, cursor);
+    public Pagination size(int maxPageSize) {
+        return new Pagination(page, maxPageSize, sorts, mode, cursor);
     }
 
     @Override
@@ -142,7 +93,7 @@ class Pagination implements Pageable {
         else
             order = StreamSupport.stream(sorts.spliterator(), false).collect(Collectors.toUnmodifiableList());
 
-        return new Pagination(pageNumber, pageSize, order, mode, cursor);
+        return new Pagination(page, size, order, mode, cursor);
     }
 
     @Override
@@ -150,18 +101,19 @@ class Pagination implements Pageable {
         @SuppressWarnings("unchecked")
         List<Sort> order = sorts == null ? Collections.EMPTY_LIST : List.of(sorts);
 
-        return new Pagination(pageNumber, pageSize, order, mode, cursor);
+        return new Pagination(page, size, order, mode, cursor);
     }
 
     @Override
     public String toString() {
-        StringBuilder b = new StringBuilder("Pageable{page=").append(pageNumber).append(", size=").append(pageSize);
+        StringBuilder b = new StringBuilder("Pageable{page=").append(page).append(", size=").append(size);
 
         if (cursor != null)
             b.append(", mode=").append(mode).append(", ").append(cursor.size()).append(" keys");
 
-        for (Sort o : order)
-            b.append(", ").append(o.property()).append(o.isDescending() ? " DESC" : " ASC");
+        for (Sort o : sorts) {
+            b.append(", ").append(o.property()).append(o.ignoreCase() ? " IGNORE CASE" : "").append(o.isDescending() ? " DESC" : " ASC");
+        }
 
         b.append("}");
 

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/Sort.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/Sort.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,87 +12,42 @@
  *******************************************************************************/
 package jakarta.data.repository;
 
-import java.util.Objects;
-
 /**
  * Method signatures copied from jakarta.data.repository.Sort from the Jakarta Data repo.
  */
-public final class Sort {
-    private final boolean asc;
-    private final boolean ignoreCase;
-    private final String prop;
-    private final int hash;
+public record Sort(String property,
+                boolean isAscending,
+                boolean ignoreCase) {
 
-    private Sort(Direction direction, String property, boolean ignoreCase) {
-        asc = direction == Direction.ASC;
-        this.ignoreCase = ignoreCase;
-        prop = property;
-        hash = Objects.hash(property, direction, ignoreCase);
-
+    public Sort {
         if (property == null)
             throw new NullPointerException("property is required");
     }
 
     public static Sort asc(String property) {
-        return new Sort(Direction.ASC, property, false);
+        return new Sort(property, true, false);
     }
 
     public static Sort ascIgnoreCase(String property) {
-        return new Sort(Direction.ASC, property, true);
+        return new Sort(property, true, true);
     }
 
     public static Sort desc(String property) {
-        return new Sort(Direction.DESC, property, false);
+        return new Sort(property, false, false);
     }
 
     public static Sort descIgnoreCase(String property) {
-        return new Sort(Direction.DESC, property, true);
+        return new Sort(property, false, true);
     }
 
     public static Sort of(String property, Direction direction, boolean ignoreCase) {
         if (direction == null)
             throw new NullPointerException("direction is required");
 
-        return new Sort(direction, property, ignoreCase);
-    }
-
-    @Override
-    public boolean equals(Object s) {
-        Sort sort;
-        return this == s
-               || s != null
-                  && s.getClass() == getClass()
-                  && (sort = (Sort) s).hash == hash
-                  && sort.asc == asc
-                  && sort.ignoreCase == ignoreCase
-                  && sort.prop.equals(prop);
-    }
-
-    @Override
-    public int hashCode() {
-        return hash;
-    }
-
-    public boolean ignoreCase() {
-        return ignoreCase;
-    }
-
-    public boolean isAscending() {
-        return asc;
+        return new Sort(property, direction.equals(Direction.ASC), ignoreCase);
     }
 
     public boolean isDescending() {
-        return !asc;
-    }
-
-    public String property() {
-        return prop;
-    }
-
-    @Override
-    public String toString() {
-        return "Sort{property='" + prop +
-               "', direction=" + (asc ? "ASC" : "DESC") +
-               (ignoreCase ? ", ignore case}" : "}");
+        return !isAscending;
     }
 }


### PR DESCRIPTION
Now that beta 3 for Jakarta Data 1.0 is out, we should update our copy of the API to match it.  Specifically this concerns 3 classes that are switched over to Java records.