### PR TITLE
Replace TM service reference with TX Mgr factory in JPAComponentImpl

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FacesTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FacesTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package io.openliberty.checkpoint.fat;
 
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.OVERWRITE;
+import static io.openliberty.checkpoint.fat.FATSuite.getTestMethod;
 import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodNameOnly;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -32,11 +34,13 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.Server;
 import componenttest.annotation.SkipIfCheckpointNotSupported;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.HttpUtils;
 import io.openliberty.checkpoint.spi.CheckpointPhase;
 
@@ -54,16 +58,82 @@ public class FacesTest {
     //public static RepeatTests repeatTest = MicroProfileActions.repeat(FRONTEND_SERVER_NAME, TestMode.LITE,
     //                                                                  MicroProfileActions.MP41, MicroProfileActions.MP50);
 
+    @Server(FRONTEND_SERVER_NAME)
     public static LibertyServer frontendUI;
+
+    @Server(BACKEND_SERVER_NAME)
     public static LibertyServer backendServices;
+
+    TestMethod testMethod;
+
+    static WebArchive frontendUIWar;
+    static WebArchive backendServicesWar;
 
     /**
      * Deploy the applications
      */
     @BeforeClass
     public static void setUpClass() throws Exception {
+        frontendUI.saveServerConfiguration();
+        backendServices.saveServerConfiguration();
 
-        frontendUI = LibertyServerFactory.getLibertyServer(FRONTEND_SERVER_NAME);
+        frontendUIWar = assembleFrontendWar();
+        backendServicesWar = assembleBackendServicesWar();
+
+        // Use derby provided in ${shared.resources.dir}
+        //backendServices.copyFileToLibertyServerRoot("publish/shared/resources/derby", "derbyLib", "derby.jar");
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        cleanupSharedResources();
+        ShrinkHelper.cleanAllExportedArchives();
+
+        testMethod = getTestMethod(TestMethod.class, testName);
+        try {
+            Log.info(getClass(), testName.getMethodName(), "Configuring: " + testMethod);
+            switch (testMethod) {
+                case testFacesRestore:
+                    ShrinkHelper.exportAppToServer(frontendUI, frontendUIWar, new DeployOptions[] { OVERWRITE });
+                    ShrinkHelper.exportAppToServer(backendServices, backendServicesWar, new DeployOptions[] { OVERWRITE });
+                    frontendUI.setCheckpoint(CheckpointPhase.AFTER_APP_START, true,
+                                             server -> {
+                                                 assertNotNull("'SRVE0169I: Loading Web Module: frontendUI' message not found in log before restore",
+                                                               server.waitForStringInLogUsingMark("SRVE0169I: Loading Web Module: frontendUI", 0));
+                                                 assertNotNull("'CWWKZ0001I: Application frontendUI started' message not found in log.",
+                                                               server.waitForStringInLogUsingMark("CWWKZ0001I: Application frontendUI started", 0));
+                                             });
+                    // Checkpoint and restore
+                    frontendUI.startServer(getTestMethodNameOnly(testName) + ".log");
+                    break;
+                case testPersistenceRestore:
+                    ShrinkHelper.exportAppToServer(frontendUI, frontendUIWar, new DeployOptions[] { OVERWRITE });
+                    ShrinkHelper.exportAppToServer(backendServices, backendServicesWar, new DeployOptions[] { OVERWRITE });
+                    backendServices.setCheckpoint(CheckpointPhase.AFTER_APP_START, true,
+                                                  server -> {
+                                                      assertNotNull("'SRVE0169I: Loading Web Module: backendServices' message not found in log before restore",
+                                                                    server.waitForStringInLogUsingMark("SRVE0169I: Loading Web Module: backendServices", 0));
+                                                      assertNotNull("'CWWKZ0001I: Application backendServices started' message not found in log.",
+                                                                    server.waitForStringInLogUsingMark("CWWKZ0001I: Application backendServices started", 0));
+                                                  });
+                    // Checkpoint and restore
+                    // At least one server.env var must trigger transaction config update at restore
+                    backendServices.startServer(getTestMethodNameOnly(testName) + ".log");
+                    break;
+                default:
+                    Log.info(getClass(), testName.getMethodName(), "No configuration required: " + testMethod);
+                    break;
+            }
+        } catch (Exception e) {
+            throw new AssertionError("Unexpected error during setupTest.", e);
+        }
+    }
+
+    void cleanupSharedResources() throws Exception {
+        backendServices.deleteDirectoryFromLibertyInstallRoot("/usr/shared/resources/data");
+    }
+
+    static WebArchive assembleFrontendWar() throws Exception {
         WebArchive frontendUIWar = ShrinkWrap.create(WebArchive.class, "frontendUI.war")
                         .addPackages(true, "io.openliberty.guides.event.client")
                         .addPackages(true, "io.openliberty.guides.event.ui")
@@ -91,9 +161,10 @@ public class FacesTest {
                              "/WEB-INF/faces-config.xml")
                         .add(new FileAsset(new File("test-applications/eventMgr/frontendUI/resources/WEB-INF/web.xml")),
                              "/WEB-INF/web.xml");
-        ShrinkHelper.exportAppToServer(frontendUI, frontendUIWar);
+        return frontendUIWar;
+    }
 
-        backendServices = LibertyServerFactory.getLibertyServer(BACKEND_SERVER_NAME);
+    static WebArchive assembleBackendServicesWar() throws Exception {
         WebArchive backendServicesWar = ShrinkWrap.create(WebArchive.class, "backendServices.war")
                         .addPackages(true, "io.openliberty.guides.event.dao")
                         .addPackages(true, "io.openliberty.guides.event.models")
@@ -102,26 +173,32 @@ public class FacesTest {
                              "/WEB-INF/classes/META-INF/persistence.xml")
                         .add(new FileAsset(new File("test-applications/eventMgr/backendServices/resources/META-INF/MANIFEST.MF")),
                              "/META-INF/MANIFEST.MF");
-        ShrinkHelper.exportAppToServer(backendServices, backendServicesWar);
-        // Skip this. Use derby provided in ${shared.resources.dir}
-        //backendServices.copyFileToLibertyServerRoot("publish/shared/resources/derby", "derbyLib", "derby.jar");
-    }
-
-    @Before
-    public void setUp() throws Exception {
-        frontendUI.setCheckpoint(CheckpointPhase.AFTER_APP_START, true,
-                                 server -> {
-                                     assertNotNull("'SRVE0169I: Loading Web Module: frontendUI' message not found in log before restore",
-                                                   server.waitForStringInLogUsingMark("SRVE0169I: Loading Web Module: frontendUI", 0));
-                                     assertNotNull("'CWWKZ0001I: Application frontendUI started' message not found in log.",
-                                                   server.waitForStringInLogUsingMark("CWWKZ0001I: Application frontendUI started", 0));
-                                 });
-        frontendUI.startServer(getTestMethodNameOnly(testName) + ".log");
+        return backendServicesWar;
     }
 
     @After
     public void tearDown() throws Exception {
-        frontendUI.stopServer();
+        TestMethod testMethod = getTestMethod(TestMethod.class, testName);
+        try {
+            Log.info(getClass(), testName.getMethodName(), "Tearing down: " + testMethod);
+            switch (testMethod) {
+                case testFacesRestore:
+                    if (frontendUI.isStarted()) {
+                        frontendUI.stopServer();
+                    }
+                    break;
+                case testPersistenceRestore:
+                    if (backendServices.isStarted()) {
+                        backendServices.stopServer();
+                    }
+                    break;
+                default:
+                    Log.info(getClass(), testName.getMethodName(), "No tear down required: " + testMethod);
+                    break;
+            }
+        } catch (Exception e) {
+            throw new AssertionError("Unexpected error during teardownTest.", e);
+        }
     }
 
     @Test
@@ -141,9 +218,32 @@ public class FacesTest {
         }
     }
 
+    @Test
+    public void testPersistenceRestore() throws Exception {
+        try {
+            frontendUI.startServer();
+
+            // Hit the event mgr app at http://localhost:8030/eventmanager.jsf
+            URL url = createURL(frontendUI, "eventmanager.jsf");
+            String response = HttpUtils.getHttpResponseAsString(url);
+            assertNotNull(response);
+            assertTrue(response.contains("Event Manager"));
+        } finally {
+            if (frontendUI.isStarted()) {
+                frontendUI.stopServer();
+            }
+        }
+    }
+
     public static URL createURL(LibertyServer server, String path) throws MalformedURLException {
         if (!path.startsWith("/"))
             path = "/" + path;
         return new URL("http://" + server.getHostname() + ":" + server.getHttpSecondaryPort() + path);
+    }
+
+    static enum TestMethod {
+        testFacesRestore,
+        testPersistenceRestore,
+        unknown;
     }
 }

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-backendServices/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-backendServices/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,4 +13,6 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
+#com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:com.ibm.ws.jpa.management.*=all:com.ibm.ws.jpa.container.osgi.internal.*=all:Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled
+#ds.loglevel=DEBUG
 io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-backendServices/server.env
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-backendServices/server.env
@@ -1,1 +1,2 @@
 keystore_password=8hYZD0rQ2cdoNlzhkoEO0eC
+TX_RETRY_INT=20

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-backendServices/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-backendServices/server.xml
@@ -33,5 +33,27 @@
     <properties.derby.embedded databaseName="EventDB" createDatabase="create" />
   </dataSource>
   <!-- end::data-source[] -->
- 
+
+  <!-- Override at restore to force transaction config update -->
+  <variable name="TX_RETRY_INT" defaultValue="10"/>
+
+  <!-- Log transactions to RDB -->
+  <transaction
+      dataSourceRef="tranlogDataSource"
+      recoverOnStartup="true"
+      waitForRecovery="false"
+      heuristicRetryInterval="${TX_RETRY_INT}"
+  />
+
+  <dataSource
+      id="tranlogDataSource"
+      jndiName="jdbc/tranlogDataSource"
+      transactional="false">
+    <jdbcDriver libraryRef="derbyJDBCLib" />
+    <properties
+        databaseName="${shared.resource.dir}/data/tranlogdb"
+        createDatabase="create"
+    />
+  </dataSource>
+
 </server>


### PR DESCRIPTION
For issue #25216 

The `JPAComponent` service component does not tolerate dynamic updates to the `TransactionManagerService`. Doing so causes `JPAComponentImpl` to reactivate, which is problematic whenever applications do not also restart. Alleviate the problem by modifying `JPAComponentImpl` to use the `EmbeddableTransactionManagerFactory (ETMF)`, instead of the `TransactionManagerService`, to access the `EmbeddableWebSphereTransactionManager` singleton and the `UOWCurrent` implementations. Notice the `TransactionManagerService` impl wraps the `ETMF` and exports the same behaviors.

This solution is preferable to modifying the `TMS` reference from `static+mandatory` to `dynamic+optional`, because the `TMS` is required for the Persistence/JPA and Persistence/JPA Container feature runtimes. However, doing so would solve the problem as declarative services would simply inject the updated service reference into the existing JPAComponentImpl rather than reactivate it (i.e. deactivate > unbind svc refs > rebind svc refs > reactivate.) Also, note that a `dynamic+mandatory` reference does not solve the problem.

The ideal solution would modify the `JPAComponentImpl` to tolerate service updates w/o requiring applications to restart, which IMHO, would require managing application state within some other class. Also, the solution must ensure the service component activates before it is used. This behavior can be enabled by 1) configuring the `JCAComponent` service component to `immediate`; 2) by tracking the `TMS` and consuming the `JPAComponent` service (i.e. getService(JPAC)) when the updated `TMS` service registers with OSGi; or 3) by changing the `JPAComponent` service component's dependency graph to ensure some service always consumes the `JPAComponent` service after deactivation, before it used to process work.