### PR TITLE
PR for Issue 22358: Update check on original redirect URL for OIDC social login clients

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
@@ -1,14 +1,11 @@
 ###############################################################################
-# Copyright (c) 2013, 2022 IBM Corporation and others.
+# Copyright (c) 2013, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 #CMVCPATHNAME com.ibm.ws.security/resources/com/ibm/ws/security/openidconnect/clients/common/resources/OidcClientMessages.nlsprops
 #COMPONENTPREFIX CWWKS
@@ -309,6 +306,11 @@ NO_RECENT_SESSIONS_WITH_CLAIMS.useraction=Ensure that claims that are specified 
 ERROR_SENDING_AUTHORIZATION_REQUEST=CWWKS1553E: The {0} OpenID Connect client encountered an error while sending an authorization request to the OpenID Connect provider. {1}
 ERROR_SENDING_AUTHORIZATION_REQUEST.explanation=The OpenID Connect client configuration might be missing information, or the client encountered an error while communicating with the OpenID Connect provider.
 ERROR_SENDING_AUTHORIZATION_REQUEST.useraction=See the error in the message for more information.
+
+# do not translate hostname, wasReqURLRedirectDomainNames, and webAppSecurity
+MALFORMED_URL_IN_ORIGIN_REQUEST_URL_COOKIE=CWWKS1554E: A request to [{0}] is not valid. A required cookie with a name that begins with [{1}] has an incorrect value. The hostname [{2}] that is used in the cookie does not match the hostname of the request, and the hostname in the cookie is not one of the allowed domain names.
+MALFORMED_URL_IN_ORIGIN_REQUEST_URL_COOKIE.explanation=The request includes a malformed cookie. The hostname in the cookie must match the current request or must match one of the allowed domain names. The cookie might be modified from within the user agent.
+MALFORMED_URL_IN_ORIGIN_REQUEST_URL_COOKIE.useraction=Verify the OpenID Connect provider and client configurations. If the hostname is expected, add it to the wasReqURLRedirectDomainNames attribute of the webAppSecurity element in the server configuration.
 
 #CWWKS1557 used in client bundle, do not use here.
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtil.java
@@ -11,6 +11,7 @@ package com.ibm.ws.security.openidconnect.clients.common;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -218,14 +219,14 @@ public class OidcClientUtil {
     }
 
     @FFDCIgnore(Exception.class)
-    public static boolean isReferrerHostValid(HttpServletRequest req, @Sensitive String requestUrl) {
+    public static void verifyReferrerHostIsValid(HttpServletRequest req, @Sensitive String requestUrl, String cookieNameOrPrefix) throws Exception {
         try {
             // Get the redirection domain names from the global security configuration, <webAppSecurity wasReqURLRedirectDomainNames="mydomain"/>
             ReferrerURLCookieHandler.isReferrerHostValid(PasswordNullifier.nullifyParams(req.getRequestURL().toString()), PasswordNullifier.nullifyParams(requestUrl),
                     getWebAppSecurityConfig().getWASReqURLRedirectDomainNames());
-            return true;
         } catch (Exception re) {
-            return false;
+            String errorMsg = Tr.formatMessage(tc, "MALFORMED_URL_IN_ORIGIN_REQUEST_URL_COOKIE", req.getRequestURL(), cookieNameOrPrefix, (new URL(requestUrl)).getHost());
+            throw new Exception(errorMsg, re);
         }
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/RedirectionProcessor.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/RedirectionProcessor.java
@@ -124,7 +124,7 @@ public class RedirectionProcessor {
             OidcClientUtil.verifyReferrerHostIsValid(request, requestUrl, OidcStorageUtils.getOriginalReqUrlStorageKey(state));
         } catch (Exception e) {
             Tr.error(tc, e.getMessage());
-            redirectionEntry.sendError(request, response);
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return;
         }
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/RedirectionProcessor.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/RedirectionProcessor.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- * IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
@@ -21,6 +18,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.web.WebUtils;
 import com.ibm.ws.webcontainer.security.CookieHelper;
 
@@ -107,6 +105,7 @@ public class RedirectionProcessor {
         out.flush();
     }
 
+    @FFDCIgnore(Exception.class)
     private void continueWithRedirection(RedirectionEntry redirectionEntry, String state) throws IOException {
         if (state == null || state.isEmpty()) {
             redirectionEntry.handleNoState(request, response);
@@ -119,6 +118,13 @@ public class RedirectionProcessor {
             String errorMsg = Tr.formatMessage(tc, "OIDC_CLIENT_BAD_REQUEST_NO_COOKIE", request.getRequestURL()); // CWWKS1750E
             Tr.error(tc, errorMsg);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
+        try {
+            OidcClientUtil.verifyReferrerHostIsValid(request, requestUrl, OidcStorageUtils.getOriginalReqUrlStorageKey(state));
+        } catch (Exception e) {
+            Tr.error(tc, e.getMessage());
+            redirectionEntry.sendError(request, response);
             return;
         }
 

--- a/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
+++ b/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
@@ -655,8 +655,3 @@ BACKCHANNEL_REQUEST_NOT_SUPPORTED_CONFIG.useraction=Use the logout endpoint that
 CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD=CWWKS2351E: The {0} OpenID Connect client uses the {1} token endpoint authentication method. This authentication method requires a client secret, but a client secret is not configured.
 CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD.explanation=The token endpoint authentication method that is specified in the message requires a client secret to authenticate with the token endpoint of the OpenID Connect provider.
 CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD.useraction=Configure a client secret for the OpenID Connect client, or switch the token endpoint authentication method of the client to one that does not require a client secret.
-
-# do not translate hostname, wasReqURLRedirectDomainNames, and webAppSecurity
-MALFORMED_URL_IN_ORIGIN_REQUEST_URL_COOKIE=CWWKS2352E: A request to [{0}] is not valid. A required cookie with a name that begins with [{1}] has an incorrect value. The hostname [{2}] that is used in the cookie does not match the hostname of the request, and the hostname in the cookie is not one of the allowed domain names.
-MALFORMED_URL_IN_ORIGIN_REQUEST_URL_COOKIE.explanation=The request includes a malformed cookie. The hostname in the cookie must match the current request or must match one of the allowed domain names. The cookie might be modified from within the user agent.
-MALFORMED_URL_IN_ORIGIN_REQUEST_URL_COOKIE.useraction=Verify the OpenID Connect provider and client configurations. If the hostname is expected, add it to the wasReqURLRedirectDomainNames attribute of the webAppSecurity element in the server configuration.

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/EndpointServices.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/EndpointServices.java
@@ -306,10 +306,8 @@ public class EndpointServices {
 
         try {
             SocialUtil.validateEndpointWithQuery(requestUrl);
-            if (!OidcClientUtil.isReferrerHostValid(request, requestUrl)) {
-                throw new SocialLoginException("MALFORMED_URL_IN_ORIGIN_REQUEST_URL_COOKIE", null, new Object[] { request.getRequestURL(), ClientConstants.COOKIE_NAME_REQ_URL_PREFIX, (new URL(requestUrl)).getHost() });
-            }
-        } catch (SocialLoginException e) {
+            OidcClientUtil.verifyReferrerHostIsValid(request, requestUrl, ClientConstants.COOKIE_NAME_REQ_URL_PREFIX);
+        } catch (Exception e) {
             Tr.error(tc, "REQUEST_URL_NOT_VALID", new Object[] { requestUrl, e.getMessage() });
             ErrorHandlerImpl.getInstance().handleErrorResponse(response);
             return;

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/test/CommonTestClass.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/test/CommonTestClass.java
@@ -126,7 +126,7 @@ public class CommonTestClass extends com.ibm.ws.security.test.common.CommonTestC
     protected final static String CWWKS6102E_SUBJECT_MAPPING_MISSING_ATTR = "CWWKS6102E";
     protected final static String CWWKS6104W_CONFIG_REQUIRED_ATTRIBUTE_NULL = "CWWKS6104W";
 
-    protected final static String CWWKS2352E_MALFORMED_URL_IN_ORIGIN_REQUEST_URL_COOKIE = "CWWKS2352E";
+    protected final static String CWWKS1554E_MALFORMED_URL_IN_ORIGIN_REQUEST_URL_COOKIE = "CWWKS1554E";
 
     /****************************************** Helper methods ******************************************/
 

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/web/EndpointServicesTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/web/EndpointServicesTest.java
@@ -1137,7 +1137,7 @@ public class EndpointServicesTest extends CommonTestClass {
 
             services.doRedirect(request, response, socialLoginConfig);
 
-            verifyLogMessage(outputMgr, CWWKS5499E_REQUEST_URL_NOT_VALID + ".+" + CWWKS2352E_MALFORMED_URL_IN_ORIGIN_REQUEST_URL_COOKIE);
+            verifyLogMessage(outputMgr, CWWKS5499E_REQUEST_URL_NOT_VALID + ".+" + CWWKS1554E_MALFORMED_URL_IN_ORIGIN_REQUEST_URL_COOKIE);
 
         } catch (Throwable t) {
             outputMgr.failWithThrowable(testName.getMethodName(), t);


### PR DESCRIPTION
Updates the code to verify that the redirect URL stored in the WASReqUrlSocial cookie is within the same domain as the inbound request, or that the domain in the redirect URL is one of the allowed domains in the wasReqURLRedirectDomainNames attribute of the <webAppSecurity> element.

This change is specific to OIDC-related social login clients.

Resolves https://github.com/OpenLiberty/open-liberty/issues/22358