### PR TITLE
Add support for PBKDF2withHmacSHA256 to wlp.encoding.key

### DIFF
--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/websphere/crypto/InvalidPasswordDecodingException.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/websphere/crypto/InvalidPasswordDecodingException.java
@@ -25,4 +25,8 @@ public class InvalidPasswordDecodingException extends Exception {
         super();
     }
 
+    public InvalidPasswordDecodingException(String message) {
+        super(message);
+    }
+
 }

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/websphere/crypto/PasswordUtil.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/websphere/crypto/PasswordUtil.java
@@ -157,7 +157,7 @@ public class PasswordUtil {
                 // don't accept unsupported crypto algorithm
                 throw new UnsupportedCryptoAlgorithmException();
             } else {
-                throw new InvalidPasswordDecodingException();
+                throw new InvalidPasswordDecodingException(crypto_algorithm);
             }
         }
 

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/AESKeyManager.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/AESKeyManager.java
@@ -30,8 +30,48 @@ import com.ibm.wsspi.security.crypto.KeyStringResolver;
  *
  */
 public class AESKeyManager {
-    private static final AtomicReference<KeyHolder> _key = new AtomicReference<KeyHolder>();
-    private static final AtomicReference<KeyStringResolver> _resolver = new AtomicReference<KeyStringResolver>();
+   private static final AtomicReference<KeyStringResolver> _resolver = new AtomicReference<KeyStringResolver>();
+
+    public static enum KeyVersion {
+        PBKDF2_SHA1("PBKDF2WithHmacSHA1", 84756, 128, new byte[] { -89, -94, -125, 57, 76, 90, -77, 79, 50, 21, 10, -98, 47, 23, 17, 56, -61, 46, 125, -128 }),
+        PBKDF2_SHA256("PBKDF2WithHmacSHA256", 84756, 128, new byte[] { 73, -125, -10, -15, 48, 90, -50, -73, -3, -25, -61, 14, -74, 48, -59, 122, -70, 34, 36, 52, 105, 48, -39, -80, -94, -46, 122, 109, -7, 59, 101, -105, 66, -58, 33, 6, -80, -128, 29, 50, 114, 104, 37, -119, -45, -8, -41, -123, 19, 108, -3, 21, 127, 48, 84, 62, 13, -89, 94, 2, -43, 101, -72, 15 });
+
+        private final AtomicReference<KeyHolder> _key = new AtomicReference<KeyHolder>();
+
+        private String alg;
+        private byte[] salt;
+        private int iterations;
+        private int len;
+
+        private KeyVersion(String a, int i, int l, byte[] s) {
+            alg = a;
+            salt = s;
+            iterations = i;
+            len = l;
+        }
+
+        private KeyHolder get(char[] keyChars) {
+            KeyHolder holder = _key.get();
+            if (holder == null || !!!holder.matches(keyChars)) {
+                try {
+                    SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(alg);
+                    KeySpec aesKey = new PBEKeySpec(keyChars, salt, iterations, len);
+                    byte[] data = keyFactory.generateSecret(aesKey).getEncoded();
+                    KeyHolder holder2 = new KeyHolder(keyChars, new SecretKeySpec(data, "AES"), new IvParameterSpec(data));
+                    _key.compareAndSet(holder, holder2);
+                    // Still use this holder for returns even if I do not end up caching it.
+                    holder = holder2;
+                } catch (InvalidKeySpecException e) {
+                    return null;
+                } catch (NoSuchAlgorithmException e) {
+                    return null;
+                }
+    
+            }
+
+            return holder;
+        }
+    }
 
     private static class KeyHolder {
         private final char[] keyChars;
@@ -63,9 +103,17 @@ public class AESKeyManager {
         setKeyStringResolver(null);
     }
 
+    public static Key getKey(KeyVersion version, String key) {
+
+        KeyHolder holder = getHolder(version, key);
+
+        return holder.getKey();
+    }
+
+    @Deprecated
     public static Key getKey(String key) {
 
-        KeyHolder holder = getHolder(key);
+        KeyHolder holder = getHolder(KeyVersion.PBKDF2_SHA1, key);
 
         return holder.getKey();
     }
@@ -75,26 +123,10 @@ public class AESKeyManager {
      * @param keyChars
      * @return
      */
-    private static KeyHolder getHolder(String key) {
+    private static KeyHolder getHolder(KeyVersion version, String key) {
         char[] keyChars = _resolver.get().getKey(key == null ? "${wlp.password.encryption.key}" : key);
-        KeyHolder holder = _key.get();
-        if (holder == null || !!!holder.matches(keyChars)) {
-            try {
-                SecretKeyFactory keyFactory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
-                KeySpec aesKey = new PBEKeySpec(keyChars, new byte[] { -89, -94, -125, 57, 76, 90, -77, 79, 50, 21, 10, -98, 47, 23, 17, 56, -61, 46, 125, -128 }, 84756, 128);
-                byte[] data = keyFactory.generateSecret(aesKey).getEncoded();
-                KeyHolder holder2 = new KeyHolder(keyChars, new SecretKeySpec(data, "AES"), new IvParameterSpec(data));
-                _key.compareAndSet(holder, holder2);
-                // Still use this holder for returns even if I do not end up caching it.
-                holder = holder2;
-            } catch (InvalidKeySpecException e) {
-                return null;
-            } catch (NoSuchAlgorithmException e) {
-                return null;
-            }
 
-        }
-        return holder;
+        return version.get(keyChars);
     }
 
     /**
@@ -117,7 +149,20 @@ public class AESKeyManager {
      * @param cryptoKey
      * @return
      */
+    public static IvParameterSpec getIV(KeyVersion version, String cryptoKey) {
+        if (version == KeyVersion.PBKDF2_SHA1) {
+            return getHolder(version, cryptoKey).getIv();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @param cryptoKey
+     * @return
+     */
+    @Deprecated
     public static IvParameterSpec getIV(String cryptoKey) {
-        return getHolder(cryptoKey).getIv();
+        return getHolder(KeyVersion.PBKDF2_SHA1, cryptoKey).getIv();
     }
 }

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/PasswordCipherUtil.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/PasswordCipherUtil.java
@@ -14,12 +14,16 @@
 package com.ibm.ws.crypto.util;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
+import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +34,8 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
 
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
@@ -50,6 +56,8 @@ import com.ibm.ws.crypto.util.custom.CustomUtils;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.security.crypto.CustomPasswordEncryption;
 import com.ibm.wsspi.security.crypto.EncryptedInfo;
+
+import static com.ibm.ws.crypto.util.AESKeyManager.KeyVersion.*;
 
 /**
  * Utility class for password enciphering and deciphering.
@@ -89,12 +97,14 @@ public class PasswordCipherUtil {
     static {
         try {
             initialize();
+        } catch (InvocationTargetException e) {
+            throw new ExceptionInInitializerError(e.getTargetException());
         } catch (Exception e) {
             throw new ExceptionInInitializerError(e);
         }
     }
 
-    static protected void initialize() throws IOException, ClassNotFoundException, IllegalAccessException, InstantiationException {
+    static protected void initialize() throws IOException, ClassNotFoundException, IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
 //        if (CustomUtils.isCommandLine() && CustomUtils.isCustomEnabled()) {
         if (CustomUtils.isCommandLine()) {
             cms = CustomUtils.findCustomEncryption(CustomUtils.CUSTOM_ENCRYPTION_DIR);
@@ -102,7 +112,7 @@ public class PasswordCipherUtil {
                 // only support one custom encryption
                 if (cms.size() == 1) {
                     Class<?> c = Class.forName(cms.get(0).getImplClass());
-                    cpeImpl = (CustomPasswordEncryption) c.newInstance();
+                    cpeImpl = (CustomPasswordEncryption) c.getDeclaredConstructor().newInstance();
                     SUPPORTED_CRYPTO_ALGORITHMS = SUPPORTED_CRYPTO_ALGORITHMS_CUSTOM;
                 }
             }
@@ -199,7 +209,7 @@ public class PasswordCipherUtil {
         byte[] decrypted_bytes = null;
 
         if (AES.equalsIgnoreCase(crypto_algorithm)) {
-            decrypted_bytes = aesDecipher(encrypted_bytes, decrypted_bytes);
+            decrypted_bytes = aesDecipher(encrypted_bytes);
         } else if (XOR.equalsIgnoreCase(crypto_algorithm)) {
             decrypted_bytes = xor(encrypted_bytes);
         } else if (HASH.equalsIgnoreCase(crypto_algorithm)) {
@@ -246,34 +256,67 @@ public class PasswordCipherUtil {
      * @throws UnsupportedCryptoAlgorithmException
      * @throws InvalidPasswordCipherException
      */
-    private static byte[] aesDecipher(byte[] encrypted_bytes, byte[] decrypted_bytes) throws UnsupportedCryptoAlgorithmException, InvalidPasswordCipherException {
+    private static byte[] aesDecipher(byte[] encrypted_bytes) throws UnsupportedCryptoAlgorithmException, InvalidPasswordCipherException {
         if (encrypted_bytes[0] == 0) { // we only process if we understand the encoding scheme.
-            Cipher c;
-            try {
-                c = Cipher.getInstance("AES/CBC/PKCS5Padding");
-                c.init(Cipher.DECRYPT_MODE, AESKeyManager.getKey(null), AESKeyManager.getIV(null));
-                byte[] decrypted = c.doFinal(encrypted_bytes, 1, encrypted_bytes.length - 1);
-                if (decrypted != null) {
-                    decrypted_bytes = new byte[decrypted.length - decrypted[0] - 1];
-                    System.arraycopy(decrypted, decrypted[0] + 1, decrypted_bytes, 0, decrypted_bytes.length);
-                }
-            } catch (NoSuchAlgorithmException e) {
-                throw (UnsupportedCryptoAlgorithmException) new UnsupportedCryptoAlgorithmException().initCause(e);
-            } catch (NoSuchPaddingException e) {
-                throw (UnsupportedCryptoAlgorithmException) new UnsupportedCryptoAlgorithmException().initCause(e);
-            } catch (InvalidKeyException e) {
-                throw (InvalidPasswordCipherException) new InvalidPasswordCipherException().initCause(e);
-            } catch (IllegalBlockSizeException e) {
-                throw (UnsupportedCryptoAlgorithmException) new UnsupportedCryptoAlgorithmException().initCause(e);
-            } catch (BadPaddingException e) {
-                throw (UnsupportedCryptoAlgorithmException) new UnsupportedCryptoAlgorithmException().initCause(e);
-            } catch (InvalidAlgorithmParameterException e) {
-                throw (InvalidPasswordCipherException) new InvalidPasswordCipherException().initCause(e);
-            }
+            return aesDecipherV0(encrypted_bytes);
+        } else if (encrypted_bytes[0] == 1) {
+            return aesDecipherV1(encrypted_bytes);
         } else {
             throw new InvalidPasswordCipherException();
         }
+    }
+
+    private static byte[] aesDecipherV0(byte[] encrypted_bytes) throws UnsupportedCryptoAlgorithmException, InvalidPasswordCipherException {
+        byte[] decrypted_bytes = null;
+
+        byte[] decrypted = aesDecipherCommon("AES/CBC/PKCS5Padding", PBKDF2_SHA1, AESKeyManager.getIV(PBKDF2_SHA1, null), encrypted_bytes, 1, encrypted_bytes.length - 1);
+
+        if (decrypted != null) {
+            decrypted_bytes = new byte[decrypted.length - decrypted[0] - 1];
+            System.arraycopy(decrypted, decrypted[0] + 1, decrypted_bytes, 0, decrypted_bytes.length);
+        }
+
         return decrypted_bytes;
+    }
+
+    private static byte[] aesDecipherV1(byte[] encrypted_bytes) throws UnsupportedCryptoAlgorithmException, InvalidPasswordCipherException {
+        byte[] decrypted_bytes = null;
+
+        int ivLen = encrypted_bytes[1];
+        int cipherBytesStart = ivLen + 2;
+
+        GCMParameterSpec iv = new GCMParameterSpec(128, encrypted_bytes, 2, ivLen);
+
+        byte[] decrypted = aesDecipherCommon("AES/GCM/NoPadding", PBKDF2_SHA256, iv, encrypted_bytes, cipherBytesStart, encrypted_bytes.length - cipherBytesStart);
+
+        if (decrypted != null) {
+            decrypted_bytes = new byte[decrypted.length - decrypted[0] - 1];
+            System.arraycopy(decrypted, decrypted[0] + 1, decrypted_bytes, 0, decrypted_bytes.length);
+        }
+
+        return decrypted_bytes;
+    }
+
+    private static byte[] aesDecipherCommon(String cipher, AESKeyManager.KeyVersion kv, AlgorithmParameterSpec ps, byte[] cipherText, int start, int len) throws InvalidPasswordCipherException, UnsupportedCryptoAlgorithmException {
+        try {
+            Key key = AESKeyManager.getKey(kv, null);
+            Cipher c = Cipher.getInstance(cipher);
+
+            c.init(Cipher.DECRYPT_MODE, key, ps);
+            return c.doFinal(cipherText, start, len);
+        } catch (NoSuchAlgorithmException e) {
+            throw (UnsupportedCryptoAlgorithmException) new UnsupportedCryptoAlgorithmException().initCause(e);
+        } catch (NoSuchPaddingException e) {
+            throw (UnsupportedCryptoAlgorithmException) new UnsupportedCryptoAlgorithmException().initCause(e);
+        } catch (InvalidKeyException e) {
+            throw (InvalidPasswordCipherException) new InvalidPasswordCipherException().initCause(e);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw (InvalidPasswordCipherException) new InvalidPasswordCipherException().initCause(e);
+        } catch (IllegalBlockSizeException e) {
+            throw (UnsupportedCryptoAlgorithmException) new UnsupportedCryptoAlgorithmException().initCause(e);
+        } catch (BadPaddingException e) {
+            throw (UnsupportedCryptoAlgorithmException) new UnsupportedCryptoAlgorithmException().initCause(e);
+        }
     }
 
     /**
@@ -314,7 +357,7 @@ public class PasswordCipherUtil {
             if (properties != null) {
                 cryptoKey = properties.get(PasswordUtil.PROPERTY_CRYPTO_KEY);
             }
-            info = aesEncipher(decrypted_bytes, cryptoKey, info, encrypted_bytes);
+            info = aesEncipher(decrypted_bytes, cryptoKey);
         } else if (XOR.equalsIgnoreCase(crypto_algorithm)) {
             encrypted_bytes = xor(decrypted_bytes);
             if (encrypted_bytes != null)
@@ -446,6 +489,27 @@ public class PasswordCipherUtil {
     }
 
     /**
+     * This method takes some plain text bytes and encodes it into a byte array using the provided
+     * cryptoKey. If null is provided a default crypto key is used by looking up the value as a 
+     * variable and using what is returned.
+     * 
+     * <p>The first byte of the encrypted data indicates the version of the encrypted payload, this is so in the future AES encryption can be
+     *   updated to improve security while continuing to decode previously encrypted passwords. A number of 0 means the encoding key that was
+     *   used to encode it was generated using PBKDF2withHmacSHA1, 1 means it was generated with PBKDF2withHmacSHA256. The remaining data is 
+     *   the encrypted payload.
+     * </p>
+     * 
+     * <p>The encrypted payload is generated by encrypting the following data:
+     * 
+     * <ol>
+     *   <li>byte: len of the seed<li>
+     *   <li>byte array: the seed bytes<li>
+     *   <li>byte array: the plain text bytes<li>
+     * </ol>
+     * 
+     * <p>This allows the salt size to be increased without changing the version of the encrypted format.</p>
+     * 
+     * 
      * @param decrypted_bytes
      * @param cryptoKey
      * @param info
@@ -454,30 +518,37 @@ public class PasswordCipherUtil {
      * @throws UnsupportedCryptoAlgorithmException
      * @throws InvalidPasswordCipherException
      */
-    private static EncryptedInfo aesEncipher(byte[] decrypted_bytes, String cryptoKey, EncryptedInfo info,
-                                             byte[] encrypted_bytes) throws UnsupportedCryptoAlgorithmException, InvalidPasswordCipherException {
+    private static EncryptedInfo aesEncipher(byte[] decrypted_bytes, String cryptoKey) throws UnsupportedCryptoAlgorithmException, InvalidPasswordCipherException {
         byte[] seed = null;
+        EncryptedInfo info = null;
         SecureRandom rand = new SecureRandom();
         Provider provider = rand.getProvider();
         String providerName = provider.getName();
+
+        byte seedSize = 64;
+
         if (providerName.equals(HW_PROVIDER)) {
-            seed = new byte[20];
+            seed = new byte[seedSize];
             rand.nextBytes(seed);
         } else {
-            seed = rand.generateSeed(20);
+            seed = rand.generateSeed(seedSize);
         }
-        byte[] preEncrypted = new byte[decrypted_bytes.length + 21];
-        preEncrypted[0] = 20; // how many seed bytes there are.
-        System.arraycopy(seed, 0, preEncrypted, 1, 20);
-        System.arraycopy(decrypted_bytes, 0, preEncrypted, 21, decrypted_bytes.length);
+        byte[] preEncrypted = new byte[decrypted_bytes.length + seedSize + 1];
+        preEncrypted[0] = seedSize; // how many seed bytes there are.
+        System.arraycopy(seed, 0, preEncrypted, 1, seedSize);
+        System.arraycopy(decrypted_bytes, 0, preEncrypted, seedSize + 1, decrypted_bytes.length);
         try {
-            Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
-            c.init(Cipher.ENCRYPT_MODE, AESKeyManager.getKey(cryptoKey), AESKeyManager.getIV(cryptoKey));
-            encrypted_bytes = c.doFinal(preEncrypted);
+            Cipher c = Cipher.getInstance("AES/GCM/NoPadding");
+            GCMParameterSpec ps = new GCMParameterSpec(128, rand.generateSeed(c.getBlockSize()));
+            c.init(Cipher.ENCRYPT_MODE, AESKeyManager.getKey(AESKeyManager.KeyVersion.PBKDF2_SHA256, cryptoKey), ps);
+            byte[] encrypted_bytes = c.doFinal(preEncrypted);
             if (encrypted_bytes != null) {
-                byte[] updatedBytes = new byte[encrypted_bytes.length + 1];
-                updatedBytes[0] = 0; // indicates how we encoded so later on we can decode
-                System.arraycopy(encrypted_bytes, 0, updatedBytes, 1, encrypted_bytes.length);
+                byte[] ivBytes = ps.getIV();
+                byte[] updatedBytes = new byte[ivBytes.length + encrypted_bytes.length + 2];
+                updatedBytes[0] = 1; // indicates how we encoded so later on we can decode
+                updatedBytes[1] = (byte)ivBytes.length;
+                System.arraycopy(ivBytes, 0, updatedBytes, 2, ivBytes.length);
+                System.arraycopy(encrypted_bytes, 0, updatedBytes, ivBytes.length + 2, encrypted_bytes.length);
                 info = new EncryptedInfo(updatedBytes, "");
             }
         } catch (NoSuchAlgorithmException e) {

--- a/dev/com.ibm.ws.crypto.passwordutil/test/com/ibm/websphere/crypto/PasswordUtilTest.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/test/com/ibm/websphere/crypto/PasswordUtilTest.java
@@ -38,7 +38,7 @@ public class PasswordUtilTest {
      * 
      * @throws Exception
      */
-    @BeforeClass
+    //@BeforeClass
     public static void setUpBeforeClass() throws Exception {
         outputMgr = SharedOutputManager.getInstance();
         outputMgr.captureStreams();
@@ -49,7 +49,7 @@ public class PasswordUtilTest {
      * 
      * @throws Exception
      */
-    @AfterClass
+    //@AfterClass
     public static void tearDownAfterClass() throws Exception {
         // Make stdout and stderr "normal"
         outputMgr.restoreStreams();
@@ -60,7 +60,7 @@ public class PasswordUtilTest {
      * 
      * @throws Exception
      */
-    @After
+    //@After
     public void tearDown() throws Exception {
         // Clear the output generated after each method invocation
         outputMgr.resetStreams();
@@ -129,7 +129,6 @@ public class PasswordUtilTest {
 
     @Test
     public void testAESEncoding() throws Exception {
-        assertEquals("The password was not decoded correctly", "alternatepwd", PasswordUtil.decode("{aes}AEmVKa+jOeA7pos+sSfpHNmH1MVfwg8ZoV29iDi6I0ZGcov6hSZsAxMhFr91jTSBYQ=="));
         String encoding = PasswordUtil.encode("WebAS", "aes");
         assertTrue("The encoded password should start with {aes} " + encoding, encoding.startsWith("{aes}"));
         String encoding2 = PasswordUtil.encode("WebAS", "aes");
@@ -138,6 +137,9 @@ public class PasswordUtilTest {
         assertEquals("The password was not decoded correctly", "WebAS", PasswordUtil.decode(encoding));
         assertEquals("The password was not decoded correctly", "WebAS", PasswordUtil.decode(encoding2));
         assertEquals("The password was not decoded correctly", "WebAS", PasswordUtil.decode("{aes}AGTpzRDW//VE3Jshg1fd89rxw/JMjHfFM9UdYdVNIUt2"));
+
+        assertEquals("Did not decode password encoded with PBKDF2withHmacSHA1 encoded password", "alternatepwd", PasswordUtil.decode("{aes}AEmVKa+jOeA7pos+sSfpHNmH1MVfwg8ZoV29iDi6I0ZGcov6hSZsAxMhFr91jTSBYQ=="));
+        assertEquals("Did not decode password encoded with PBKDF2withHmacSHA256 encoded password", "alternatepwd", PasswordUtil.decode("{aes}ARABI+HrHnU1lZbb4/MydV8HJMlvxhjF3+KVvgpaUr1Kd386Zq77MfZL6/YrHeLG+T+mICHPqYpaXPmawtNkVfxBJo/TsZ212HxpZeYpN39CreAnSQmoz63FU/n5oxQ8VHSW2/yWssbCTZmVOYFA"));
     }
 
     @Test

--- a/dev/com.ibm.ws.crypto.passwordutil/test/com/ibm/ws/crypto/util/PasswordCipherUtilTest.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/test/com/ibm/ws/crypto/util/PasswordCipherUtilTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -114,7 +115,7 @@ public class PasswordCipherUtilTest {
      * @throws
      */
     @Test
-    public void testListCustom() throws UnsupportedConfigurationException, ClassNotFoundException, IllegalAccessException, InstantiationException, IOException {
+    public void testListCustom() throws UnsupportedConfigurationException, ClassNotFoundException, IllegalAccessException, InstantiationException, IOException, NoSuchMethodException, InvocationTargetException {
         final String expected = "[{\"name\":\"custom\",\"featurename\":\"usr:simpleCustomEncryption-1.0\",\"description\":\"simpleCustomEncryption default resource\"}]";
 
         String currentDir = System.clearProperty(KEY_PROP_INSTALL_DIR);


### PR DESCRIPTION
Currently Liberty uses PBKDF2withHmacSHA1 which isn't a good practice anymore since SHA1 is considered weak. Need to implement support for PBKDF2withHmacSHA256, but without breaking the ability to read previously encrypted AES encrypted passwords.

