### PR TITLE
Update buildpath and classes for references to classes removed in Java 9

### DIFF
--- a/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/caching/AnnoCachingTest.java
+++ b/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/caching/AnnoCachingTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -420,7 +420,7 @@ public abstract class AnnoCachingTest extends LoggingTest {
     	LOG.info("zipLocationOnDisk:  " + zipLocationOnDisk);
 
     	Path zipFilePath = Paths.get(zipLocationOnDisk);
-    	try( FileSystem fs = FileSystems.newFileSystem(zipFilePath, null) ){
+    	try( FileSystem fs = FileSystems.newFileSystem(zipFilePath, (ClassLoader) null) ){
     	  	Path sourcePath = fs.getPath(sourceEntry);
     		Path destPath = fs.getPath(destinationEntry);
     		
@@ -444,7 +444,7 @@ public abstract class AnnoCachingTest extends LoggingTest {
     	LOG.info("zipLocationOnDisk:  " + zipLocationOnDisk); 
 
     	Path zipFilePath = Paths.get(zipLocationOnDisk);
-    	try( FileSystem fs = FileSystems.newFileSystem(zipFilePath, null) ){
+    	try( FileSystem fs = FileSystems.newFileSystem(zipFilePath, (ClassLoader) null) ){
     	  	Path sourcePath = fs.getPath(sourceEntry);
     		Path destPath = fs.getPath(destinationEntry);
     		

--- a/dev/com.ibm.ws.cloudant_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cloudant_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -28,6 +28,7 @@ fat.project: true
 fat.test.container.images: kyleaure/couchdb-ssl:1.0
 
 -buildpath: \
+    com.ibm.websphere.javaee.annotation.1.1;version=latest,\
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
     com.ibm.websphere.javaee.transaction.1.1;version=latest,\
     com.cloudant:cloudant-client;version=2.16.0,\

--- a/dev/com.ibm.ws.couchdb_fat/bnd.bnd
+++ b/dev/com.ibm.ws.couchdb_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -30,6 +30,7 @@ tested.features:\
 fat.test.container.images: kyleaure/couchdb-ssl:1.0
 
 -buildpath: \
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	io.openliberty.com.fasterxml.jackson;version=latest,\
 	io.openliberty.org.apache.commons.codec;version=latest,\

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -42,10 +42,13 @@ tested.features: \
 	servlet-6.0
 
 -buildpath: \
+	com.ibm.websphere.javaee.activity.1.0;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest, \
 	com.ibm.websphere.javaee.transaction.1.2;version=latest, \
 	com.ibm.ws.ejbcontainer.core; version=latest, \
 	com.ibm.ws.ejbcontainer.fat_tools; version=latest,\
+	com.ibm.ws.org.apache.yoko.corba.spec.1.5;version=latest,\
+	com.ibm.ws.org.apache.yoko.rmi.spec.1.5;version=latest,\
 	io.openliberty.ejbcontainer.jakarta.fat_tools; version=latest

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -78,5 +78,6 @@ tested.features: \
 	com.ibm.websphere.javaee.connector.1.7;version=latest, \
 	com.ibm.ws.jdbc;version=latest, \
 	com.ibm.ws.jca.cm;version=latest, \
+	com.ibm.ws.org.apache.yoko.rmi.spec.1.5;version=latest,\
 	com.ibm.ws.security.jaas.common;version=latest,\
 	io.openliberty.ejbcontainer.jakarta.fat_tools; version=latest

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -50,4 +50,5 @@ tested.features: \
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.ws.ejbcontainer.fat_tools;version=latest,\
+	com.ibm.ws.org.apache.yoko.rmi.spec.1.5;version=latest,\
 	io.openliberty.ejbcontainer.jakarta.fat_tools; version=latest

--- a/dev/com.ibm.ws.ejbcontainer.mdb.jms_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.mdb.jms_fat/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -48,10 +48,12 @@ tested.features: \
 	servlet-6.0
 
 -buildpath: \
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.1;version=latest,\
 	com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
 	com.ibm.websphere.javaee.jms.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.ws.ejbcontainer.fat_tools;version=latest,\
+	com.ibm.ws.org.apache.yoko.rmi.spec.1.5;version=latest,\
 	io.openliberty.ejbcontainer.jakarta.fat_tools; version=latest

--- a/dev/com.ibm.ws.event.logging_fat/bnd.bnd
+++ b/dev/com.ibm.ws.event.logging_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -21,4 +21,5 @@ fat.project: true
 
 -buildpath: \
 	com.ibm.ws.event.logging;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ProgressBar.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ProgressBar.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,7 +16,6 @@ import java.util.HashMap;
 
 import org.fusesource.jansi.Ansi;
 import org.fusesource.jansi.AnsiConsole;
-import org.omg.PortableInterceptor.SYSTEM_EXCEPTION;
 
 public class ProgressBar {
     private static ProgressBar progressBar;

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi/bnd.bnd
@@ -19,8 +19,11 @@ Bundle-Description: IBM JAX-RS-2.0 CDI support; version=${bVersion}
 
 WS-TraceGroup: JAXRS
 
-
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
+  javax.annotation;version=!,\
   javax.enterprise.context;version="[1.1,3)",\
   javax.enterprise.context.spi;version="[1.1,3)",\
   javax.enterprise.inject.spi;version="[1.1,3)",\
@@ -45,6 +48,7 @@ instrument.classesExcludes: com/ibm/ws/jaxrs20/cdi/internal/resources/*.class
 	com.ibm.ws.adaptable.module;version=latest,\
 	com.ibm.ws.webcontainer;version=latest,\
 	com.ibm.ws.jaxrs.2.0.web;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
 	com.ibm.websphere.appserver.spi.logging,\
 	com.ibm.wsspi.org.osgi.service.component.annotations,\

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -39,6 +39,7 @@ tested.features: \
   com.ibm.websphere.javaee.annotation.1.2,\
   com.ibm.websphere.javaee.cdi.1.2,\
   com.ibm.websphere.javaee.ejb.3.2,\
+  com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
   com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
   com.ibm.websphere.javaee.jsonb.1.0,\
   com.ibm.websphere.javaee.servlet.3.1,\

--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -36,7 +36,11 @@ Service-Component: \
 
 WS-TraceGroup: JAXRS
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
+    javax.annotation;version=!, \
     com.ibm.websphere.servlet.container, \
     javax.servlet; version="[2.6,3)", \
     !*.internal.*,*
@@ -57,6 +61,7 @@ Liberty-Monitoring-Components:
 -buildpath: \
 	com.ibm.ws.classloading,\
 	com.ibm.ws.monitor,\
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	com.ibm.websphere.javaee.jaxrs.2.0,\
 	com.ibm.websphere.org.osgi.core;version=latest,\

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -68,9 +68,12 @@ tested.features: jaxws-2.3, \
 
 
 -buildpath: \
+	com.ibm.websphere.javaee.activation.1.1;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.2,\
 	com.ibm.websphere.javaee.ejb.3.2,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1,\
 	com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
 	com.ibm.ws.jaxws.2.3.common;version=latest,\

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/bnd.bnd
@@ -64,6 +64,8 @@ tested.features: jaxws-2.3, \
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2,\
 	com.ibm.websphere.javaee.ejb.3.2,\
+	com.ibm.websphere.javaee.jws.1.0,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2,\
 	com.ibm.websphere.javaee.servlet.3.1,\
 	com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/test-applications/policyAttachmentsClient1/src/com/ibm/ws/policyattachments/client1/service1/HelloClientReplyToHandler.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/test-applications/policyAttachmentsClient1/src/com/ibm/ws/policyattachments/client1/service1/HelloClientReplyToHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,6 +17,7 @@ import java.util.Set;
 
 import javax.xml.namespace.QName;
 import javax.xml.soap.Name;
+import javax.xml.soap.Node;
 import javax.xml.soap.SOAPElement;
 import javax.xml.soap.SOAPException;
 import javax.xml.soap.SOAPHeader;
@@ -60,11 +61,11 @@ public class HelloClientReplyToHandler implements SOAPHandler<SOAPMessageContext
                 QName replyToQn = new QName("http://www.w3.org/2005/08/addressing", "ReplyTo");
 
                 SOAPElement replyTo = null;
-                Iterator<SOAPElement> elements = header.getChildElements();
+                Iterator<Node> elements = header.getChildElements();
                 if (elements != null) {
                     while (elements.hasNext()) {
 
-                        SOAPElement element = elements.next();
+                        SOAPElement element = (SOAPElement) elements.next();
 
                         Name name = element.getElementName();
 

--- a/dev/com.ibm.ws.jaxws.X.wsat_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.X.wsat_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2022 IBM Corporation and others.
+# Copyright (c) 2021, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -44,6 +44,7 @@ tested.features: \
   servlet-6.0
 
 -buildpath: \
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
 	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.sun.xml.messaging.saaj:saaj-impl;version=1.4.0,\

--- a/dev/com.ibm.ws.jaxws.cdi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.cdi_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -40,5 +40,9 @@ tested.features: \
 # fattest.simplicity, and componenttest-1.0 will be automatically added to the buildpath
 -buildpath: \
 	com.ibm.ws.jaxws.cdi;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
+	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest

--- a/dev/com.ibm.ws.jaxws.clientcontainer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.clientcontainer_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -53,6 +53,9 @@ tested.features: \
 # For all project names that match the pattern "*_fat*", dependencies for junit,
 # fattest.simplicity, and componenttest-1.0 will be automatically added to the buildpath
 -buildpath: \
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
 	io.openliberty.org.apache.commons.logging;version=latest

--- a/dev/com.ibm.ws.jaxws.ejb/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.ejb/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017,2022 IBM Corporation and others.
+# Copyright (c) 2017,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -53,8 +53,12 @@ Service-Component: \
 Export-Package: \
    com.ibm.ws.jaxws.ejb
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
   !com.ibm.ws.jaxws.ejb, \
+  javax.xml.soap;version=!, \
   javax.xml.ws.*;version="[2.2,3)", \
   org.apache.cxf.*;version="[3.2,4.0)", \
   *
@@ -74,6 +78,8 @@ instrument.classesExcludes: com/ibm/ws/jaxws/ejb/internal/resources/*.class
   com.ibm.websphere.appserver.spi.kernel.service,\
   com.ibm.websphere.appserver.spi.logging,\
   com.ibm.websphere.javaee.ejb.3.1;version=latest,\
+  com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+  com.ibm.websphere.javaee.jws.1.0;version=latest,\
   com.ibm.websphere.javaee.servlet.3.0;version=latest,\
   com.ibm.websphere.org.osgi.core,\
   com.ibm.websphere.org.osgi.service.component,\

--- a/dev/com.ibm.ws.jaxws.ejb_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -55,6 +55,8 @@ tested.features: \
   servlet-6.0
 
 -buildpath: \
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
 	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.sun.xml.messaging.saaj:saaj-impl;version=1.4.0,\

--- a/dev/com.ibm.ws.jbatch.jms/bnd.bnd
+++ b/dev/com.ibm.ws.jbatch.jms/bnd.bnd
@@ -10,7 +10,11 @@ Import-Package: *
 WS-TraceGroup: wsbatch
 
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
+  javax.xml.bind;version=!, \
   com.ibm.ws.kernel.boot.security;resolution:=optional, \
   *
 
@@ -30,6 +34,7 @@ Include-Resource: \
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
 	com.ibm.websphere.appserver.spi.logging;version=latest,\
 	com.ibm.websphere.javaee.batch.1.0;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
 	com.ibm.websphere.javaee.jms.2.0;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\

--- a/dev/com.ibm.ws.jdbc_fat_db2/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_db2/bnd.bnd
@@ -27,6 +27,7 @@ fat.project: true
 fat.test.container.images: kyleaure/db2-ssl:3.0
 
 -buildpath: \
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.db2:jcc;version=1.4.0,\

--- a/dev/com.ibm.ws.jdbc_fat_krb5/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/bnd.bnd
@@ -35,6 +35,7 @@ tested.features: \
 #fat.test.use.remote.docker: true
 
 -buildpath: \
+    com.ibm.websphere.javaee.annotation.1.1;version=latest,\
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
     com.ibm.websphere.javaee.transaction.1.1;version=latest,\
     com.ibm.db2:jcc;version=1.4.0,\

--- a/dev/com.ibm.ws.jsp.2.3_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsp.2.3_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -38,6 +38,7 @@ tested.features:\
 
 
 -buildpath: \
+    com.ibm.websphere.javaee.annotation.1.1;version=latest,\
     com.ibm.websphere.javaee.cdi.1.2;version=latest,\
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
     com.ibm.websphere.javaee.el.3.0;version=latest,\

--- a/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -73,6 +73,7 @@ tested.features: needsNewEe-1.0, newEe-1.0, \
 	com.ibm.ws.runtime.update;version=latest,\
 	com.ibm.ws.kernel.feature.core;version=latest,\
 	com.ibm.ws.kernel.feature;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1,\
 	com.ibm.ws.org.osgi.annotation.versioning,\
 	com.ibm.websphere.javaee.ejb.3.1

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -42,4 +42,7 @@ tested.features:\
 	com.ibm.websphere.rest.handler;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
+	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.metrics.2.0;version=latest

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2022 IBM Corporation and others.
+# Copyright (c) 2018, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -40,4 +40,7 @@ fat.project: true
 	com.ibm.websphere.rest.handler;version=latest, \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest, \
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
+	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.metrics.1.0;version=latest

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -43,6 +43,7 @@ tested.features=mpRestClient-1.2,jdbc-4.2,appSecurity-3.0,mpRestClient-1.3,mpRes
   com.ibm.websphere.javaee.annotation.1.2;version=latest,\
   com.ibm.websphere.javaee.cdi.2.0;version=latest,\
   com.ibm.websphere.javaee.ejb.3.2;version=latest,\
+  com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
   com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
   com.ibm.websphere.javaee.servlet.3.1;version=latest,\
   com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -170,6 +170,7 @@ instrument.classesExcludes: \
 -buildpath: \
   javax.activation:activation;version=1.1, \
   com.ibm.websphere.javaee.jaxb.2.2;version=latest, \
+  com.ibm.websphere.javaee.jaxws.2.2;version=latest, \
   org.apache.cxf:cxf-core;strategy=exact;version=${importVer}, \
   com.ibm.ws.logging.core, \
   org.apache.cxf:cxf-rt-transports-http;strategy=exact;version=${importVer}, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/bnd.bnd
@@ -19,6 +19,9 @@ bVersion=1.0
 cxfImportVersion=3.5.5
 cxfExportVersion=3.4.3
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
   !java.*, \
   !org.apache.aries.*;version="[0.3,2)", \
@@ -30,10 +33,10 @@ Import-Package: \
   com.ibm.websphere.ras, \
   com.ibm.websphere.ras.annotation, \
   com.ibm.ws.ffdc, \
-  javax.activation;resolution:=optional, \
+  javax.activation;resolution:=optional;version=!, \
   javax.annotation, \
   javax.xml.bind.annotation;version="[2.2,3)", \
-  javax.jws.soap, \
+  javax.jws.soap;version=!, \
   javax.wsdl, \
   javax.wsdl.extensions, \
   javax.wsdl.extensions.mime, \
@@ -41,7 +44,7 @@ Import-Package: \
   javax.wsdl.extensions.soap12, \
   javax.wsdl.factory, \
   javax.xml.namespace, \
-  javax.xml.soap;resolution:=optional, \
+  javax.xml.soap;resolution:=optional;version=!, \
   javax.xml.stream, \
   javax.xml.stream.events, \
   javax.xml.transform, \
@@ -108,6 +111,8 @@ Export-Package: \
   org.apache.cxf:cxf-rt-bindings-soap;strategy=exact;version=${cxfImportVersion}, \
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest, \
   com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2, \
+  com.ibm.websphere.javaee.activation.1.1;version=latest, \
+  com.ibm.websphere.javaee.jws.1.0;version=latest, \
   com.ibm.websphere.javaee.wsdl4j.1.2, \
   com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
   com.ibm.websphere.org.osgi.core, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.3.2/bnd.bnd
@@ -17,7 +17,9 @@
 bVersion=1.0
 cxfVersion=3.5.5
 
-
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
   !org.apache.cxf.ws.addressing.wsdl, \
   !com.ctc.wstx.*, \
@@ -32,10 +34,12 @@ Import-Package: \
   !org.apache.aries.*, \
   org.apache.cxf.transport.https, \
   !org.osgi.service.blueprint.*, \
+  javax.activation;version=!, \
   javax.xml.bind;version=!, \
   javax.xml.bind.annotation;version=!, \
   javax.xml.bind.annotation.adapters;version=!, \
   javax.xml.bind.attachment;version=!, \
+  javax.xml.bind.helpers;version=!, \
   org.apache.cxf.binding.xml, \
   org.apache.cxf.binding.xml.wsdl11, \
   *
@@ -53,6 +57,8 @@ instrument.ffdc: false
 -buildpath: \
   org.apache.cxf:cxf-rt-databinding-jaxb;strategy=exact;version=${cxfVersion}, \
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest, \
+  com.ibm.websphere.javaee.activation.1.1;version=latest, \
+  com.ibm.websphere.javaee.jaxb.2.2;version=latest, \
   com.ibm.websphere.org.osgi.core, \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
   com.ibm.ws.logging.core, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/bnd.bnd
@@ -18,6 +18,9 @@ bVersion=1.0
 cxfVersion=3.5.5
 
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
   org.apache.cxf.binding.soap, \
   !java.*, \
@@ -35,7 +38,11 @@ Import-Package: \
   !org.apache.aries.*, \
   !org.apache.cxf.transport.https, \
   !org.osgi.service.blueprint.*, \
+  javax.activation;version=!, \
+  javax.jws;version=!, \
+  javax.jws.soap;version=!, \
   javax.xml.bind.*;version=!, \
+  javax.xml.soap;version=!, \
   javax.xml.ws.*;version="[2.2,3)", \
   org.apache.cxf.*;version="[3.2.4,4)", \
   com.ibm.ws.ffdc, \
@@ -69,6 +76,10 @@ instrument.ffdc: false
 
 -buildpath: \
   org.apache.cxf:cxf-rt-frontend-jaxws;strategy=exact;version=${cxfVersion}, \
+  com.ibm.websphere.javaee.activation.1.1;version=latest, \
+  com.ibm.websphere.javaee.jaxb.2.2;version=latest, \
+  com.ibm.websphere.javaee.jaxws.2.2;version=latest, \
+  com.ibm.websphere.javaee.jws.1.0;version=latest, \
   com.ibm.websphere.javaee.wsdl4j.1.2;version=latest, \
   com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2;version=latest, \
   com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2;version=latest, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.bnd
@@ -28,10 +28,15 @@ Export-Package: \
   org.apache.cxf.transports.http.configuration;version=${cxfVersion}, \
   com.ibm.ws.cxf.exceptions;version=${cxfVersion}
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
   !java.*, \
   !org.apache.aries.*, \
   !org.springframework.*, \
+  javax.activation;version=!, \
+  javax.xml.bind.*;version=!, \
   javax.wsdl.*;resolution:=optional, \
   org.apache.cxf.ws.policy.*;resolution:=optional, \
   org.apache.cxf.wsdl;resolution:=optional, \
@@ -55,8 +60,9 @@ Service-Component: \
 -buildpath: \
   org.apache.cxf:cxf-rt-transports-http;strategy=exact;version=${cxfVersion}, \
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest, \
+  com.ibm.websphere.javaee.activation.1.1;version=latest, \
+  com.ibm.websphere.javaee.jaxb.2.2;version=latest, \
   com.ibm.websphere.javaee.servlet.4.0;version=latest, \
   com.ibm.ws.logging.core, \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
-  com.ibm.wsspi.org.osgi.core, \
-  javax.activation:activation;version=1.1
+  com.ibm.wsspi.org.osgi.core

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr.3.2/bnd.bnd
@@ -54,6 +54,8 @@ Export-Package: \
   org.apache.cxf:cxf-rt-ws-addr;strategy=exact;version=${cxfVersion},\
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
   com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2, \
+  com.ibm.websphere.javaee.jaxb.2.2;version=latest, \
+  com.ibm.websphere.javaee.jaxws.2.2;version=latest, \
   com.ibm.websphere.javaee.wsdl4j.1.2, \
   com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
   com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2;version=latest,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/bnd.bnd
@@ -18,6 +18,9 @@ bVersion=1.0
 cxfVersion=3.5.5
 
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
   !java.*, \
   !com.ctc.wstx.*, \
@@ -32,6 +35,7 @@ Import-Package: \
   !org.apache.aries.*, \
   !org.apache.cxf.transport.https, \
   !org.osgi.service.blueprint.*, \
+  javax.annotation;version=!, \
   javax.xml.bind;version=!, \
   javax.xml.bind.annotation;version=!, \
   javax.xml.bind.annotation.adapters;version=!, \
@@ -58,6 +62,7 @@ instrument.ffdc: false
 
 -buildpath: \
   org.apache.cxf:cxf-rt-ws-policy;strategy=exact;version=${cxfVersion}, \
+  com.ibm.websphere.javaee.annotation.1.1;version=latest, \
   com.ibm.websphere.javaee.wsdl4j.1.2;version=latest, \
   com.ibm.websphere.org.osgi.core, \
   com.ibm.ws.logging.core, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/bnd.bnd
@@ -57,6 +57,7 @@ instrument.classesIncludes: \
 -buildpath: \
   org.apache.cxf:cxf-rt-wsdl;strategy=exact;version=${cxfVersion}, \
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest, \
+  com.ibm.websphere.javaee.jaxb.2.2;version=latest, \
   com.ibm.websphere.org.osgi.core, \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
   com.ibm.ws.logging.core, \

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/bnd.bnd
@@ -21,11 +21,17 @@ WS-TraceGroup: WSSECURITY
 
 Bundle-ActivationPolicy: lazy
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package:  \
   !org.apache.cxf.ws.mex.*, \
   !com.ctc.wstx.*, \
   !org.codehaus.stax2.*, \
   !net.sf.ehcache.*, \
+  javax.jws;version=!, \
+  javax.jws.soap;version=!, \
+  javax.xml.soap;version=!, \
   org.apache.neethi, \
   org.apache.neethi.builders, \
   org.apache.wss4j.*, \
@@ -101,5 +107,6 @@ instrument.classesIncludes: \
   com.ibm.ws.org.ehcache.ehcache.107.3.8.1;version=latest, \
   com.ibm.ws.org.opensaml.opensaml.core.3.4.5;version=latest, \
   com.ibm.websphere.appserver.spi.logging, \
+  com.ibm.websphere.javaee.jws.1.0;version=latest, \
   org.codehaus.woodstox:stax2-api;version='4.2', \
   org.codehaus.woodstox:woodstox-core-asl;version='4.2.0'

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax/bnd.bnd
@@ -27,5 +27,6 @@ instrument.classesExcludes: org/apache/wss4j/stax/setup/*.class
 	com.ibm.ws.org.slf4j.api;version=latest,\
 	com.ibm.ws.org.apache.wss4j.bindings;version=latest,\
 	com.ibm.ws.org.apache.santuario.xmlsec.2.2.0;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	io.openliberty.xmlBinding.3.0.internal.tools, \
 	com.ibm.ws.org.joda.time.2.9.9;version=latest

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.stax/bnd.overrides
@@ -19,7 +19,11 @@ WS-TraceGroup: WSS4J
 Export-Package: \
  org.apache.wss4j.stax.*;version=${bVersion}
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
+ javax.xml.bind;version=!,\
  org.glassfish.jaxb.runtime.v2;resolution:=optional,\
  *
 

--- a/dev/com.ibm.ws.repository.parsers/src/com/ibm/ws/repository/parsers/EsaParser.java
+++ b/dev/com.ibm.ws.repository.parsers/src/com/ibm/ws/repository/parsers/EsaParser.java
@@ -425,7 +425,7 @@ public class EsaParser extends ParserBase implements Parser<EsaResourceWritable>
 
         // build a set of capabilities of each of manifests in the bundles and the subsystem
         // manifest in the feature
-        try (final FileSystem zipSystem = FileSystems.newFileSystem(zipfile, null)) {
+        try (final FileSystem zipSystem = FileSystems.newFileSystem(zipfile, (ClassLoader) null)) {
 
             // get the paths of each bundle jar in the root directory of the esa
             Iterable<Path> roots = zipSystem.getRootDirectories();

--- a/dev/com.ibm.ws.repository.parsers/src/com/ibm/ws/repository/parsers/ParserBase.java
+++ b/dev/com.ibm.ws.repository.parsers/src/com/ibm/ws/repository/parsers/ParserBase.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -131,7 +131,8 @@ public abstract class ParserBase {
     /**
      * The constructor used for any Parser ... a RepositoryConnection is not needed
      */
-    public ParserBase() {}
+    public ParserBase() {
+    }
 
     /**
      * Enum declaring the productEdition component of appliesTo
@@ -214,21 +215,21 @@ public abstract class ParserBase {
      * deleted when the jvm exits.
      *
      * @param fileName
-     *            The name of the archive file to extract the file from
+     *                     The name of the archive file to extract the file from
      * @param regex
-     *            A regular expression, that is used to match the file to be
-     *            extracted from the archive. If more than one file matches the
-     *            regular expression only the first file is extracted
+     *                     A regular expression, that is used to match the file to be
+     *                     extracted from the archive. If more than one file matches the
+     *                     regular expression only the first file is extracted
      * @return A file object representing the temporary file where the file in
      *         the jar was extracted to.
      * @throws MassiveArchiveException
-     *             if the archive could not be read or the file could not be
-     *             extracted to disk
+     *                                                     if the archive could not be read or the file could not be
+     *                                                     extracted to disk
      * @throws RepositoryArchiveException
      * @throws RepositoryArchiveIOException
      * @throws RepositoryArchiveEntryNotFoundException
-     *             If no file matching the supplied regular expression could be
-     *             found
+     *                                                     If no file matching the supplied regular expression could be
+     *                                                     found
      */
     protected ExtractedFileInformation extractFileFromArchive(String fileName,
                                                               String regex) throws RepositoryArchiveException, RepositoryArchiveEntryNotFoundException, RepositoryArchiveIOException {
@@ -425,9 +426,9 @@ public abstract class ParserBase {
      * and the metadata file may not be co-located e.g. when pulling them out
      * of different parts of the build.
      *
-     * @param archiveFile - the .jar or .esa file to look for a sibling zip for
+     * @param archiveFile  - the .jar or .esa file to look for a sibling zip for
      * @param metadataFile - the *.metadata.zip file or null to use one
-     *            co-located with the archiveFile
+     *                         co-located with the archiveFile
      * @return The artifact metadata from the sibling zip or <code>null</code>
      *         if none was found
      * @throws IOException
@@ -586,7 +587,7 @@ public abstract class ParserBase {
             }
         }
 
-        try (FileSystem archiveFS = FileSystems.newFileSystem(archive.toPath(), null)) {
+        try (FileSystem archiveFS = FileSystems.newFileSystem(archive.toPath(), (ClassLoader) null)) {
             // Somewhere to put the unpacked license files.
             Path tempDir = Files.createTempDirectory("unpackedEsa");
             tempDir.toFile().deleteOnExit();
@@ -795,9 +796,9 @@ public abstract class ParserBase {
      * Process icons from the properties file
      *
      * @param amd
-     *            Metadata
+     *                Metadata
      * @param res
-     *            Resource to add icons to
+     *                Resource to add icons to
      * @throws RepositoryException
      */
     protected void processIcons(ArtifactMetadata amd, RepositoryResourceWritable res) throws RepositoryException {
@@ -877,7 +878,7 @@ public abstract class ParserBase {
     /**
      * Returns <code>true</code> if the supplied <code>file</code> is a valid zip and contains at least one entry of each of the supplied <code>fileTypes</code>.
      *
-     * @param file The zip file to check
+     * @param file      The zip file to check
      * @param fileTypes The types of files to look for
      * @return <code>true</code> if file types found
      */

--- a/dev/com.ibm.ws.request.probe.jdbc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.request.probe.jdbc_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -26,4 +26,5 @@ tested.features:\
 
 -buildpath: \
 	com.ibm.ws.request.probe.jdbc;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest

--- a/dev/com.ibm.ws.request.probe.servlet_fat/bnd.bnd
+++ b/dev/com.ibm.ws.request.probe.servlet_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -26,4 +26,5 @@ tested.features:\
 
 -buildpath: \
 	com.ibm.ws.request.probe.servlet;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest

--- a/dev/com.ibm.ws.request.probes_fat/bnd.bnd
+++ b/dev/com.ibm.ws.request.probes_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -22,4 +22,5 @@ fat.project: true
 
 -buildpath: \
 	com.ibm.ws.request.probes;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest

--- a/dev/com.ibm.ws.request.timing_fat/bnd.bnd
+++ b/dev/com.ibm.ws.request.timing_fat/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -26,5 +26,6 @@ tested.features: \
 
 -buildpath: \
 	com.ibm.ws.request.timing;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest
 

--- a/dev/com.ibm.ws.security.acme_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.acme_fat/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -38,6 +38,7 @@ fat.test.container.images: mariadb:10.3, \
     org.shredzone.acme4j:acme4j-client;version=2.7,\
     org.shredzone.acme4j:acme4j-utils;version=2.7,\
     com.ibm.ws.logging;version=latest,\
+    com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\
     com.ibm.ws.org.jose4j;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\

--- a/dev/com.ibm.ws.security.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.client_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -43,6 +43,7 @@ src:\
 -buildpath: \
   io.openliberty.org.apache.commons.codec;version=latest,\
   io.openliberty.org.apache.commons.logging;version=latest,\
+  com.ibm.websphere.javaee.annotation.1.1;version=latest,\
   com.ibm.websphere.javaee.ejb.3.2;version=latest,\
   com.ibm.websphere.javaee.mail.1.5;version=latest,\
   com.ibm.websphere.security;version=latest,\
@@ -51,6 +52,7 @@ src:\
   com.ibm.ws.com.meterware.httpunit.1.7;version=latest,\
   com.ibm.ws.kernel.service;version=latest,\
   com.ibm.ws.logging;version=latest,\
+  com.ibm.ws.org.apache.yoko.rmi.spec.1.5;version=latest,\
   com.ibm.ws.security.credentials;version=latest,\
   com.ibm.ws.security.jaas.common;version=latest,\
   com.ibm.ws.security.fat.common;version=latest,\

--- a/dev/com.ibm.ws.security.fat.common.jwt/bnd.bnd
+++ b/dev/com.ibm.ws.security.fat.common.jwt/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2018,2020 IBM Corporation and others.
+# Copyright (c) 2018,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -69,6 +69,7 @@ generate.replacement: true
 	io.openliberty.org.apache.commons.codec;version=latest,\
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.ws.org.jose4j;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.json4j;version=latest,\
 	com.ibm.ws.org.glassfish.json.1.1,\

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/bnd.bnd
@@ -84,6 +84,7 @@ test.project: true
     cglib:cglib;version=3.3.0, \
     com.ibm.ws.org.objectweb.asm;version=latest, \
     com.ibm.websphere.javaee.jsonp.1.1;version=latest, \
+    com.ibm.websphere.javaee.jws.1.0;version=latest,\
     com.ibm.ws.junit.extensions;version=latest, \
     com.ibm.ws.kernel.boot.logging;version=latest, \
     com.ibm.ws.kernel.security.thread;version=latest, \

--- a/dev/com.ibm.ws.security.oauth_test.servlets/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth_test.servlets/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -20,6 +20,7 @@ test.project: true
 
 -buildpath: \
     com.ibm.json4j;version=latest,\
+    com.ibm.websphere.javaee.annotation.1.1;version=latest,\
     com.ibm.websphere.javaee.servlet.3.0;version=latest,\
     com.ibm.websphere.org.osgi.core;version=latest,\
     com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -36,6 +36,7 @@ test.project: true
     io.openliberty.org.apache.commons.codec;version=latest, \
     com.ibm.ws.logging;version=latest, \
     com.ibm.websphere.security;version=latest, \
+    com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
     com.ibm.websphere.javaee.servlet.3.0;version=latest, \
     com.ibm.ws.webcontainer.security_test.servlets;version=latest, \
     com.ibm.ws.security.fat.common;version=latest, \

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2022 IBM Corporation and others.
+# Copyright (c) 2021, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -25,6 +25,7 @@ tested.features: jdbc-4.1, restfulwsclient-3.0, restfulws-3.0, jsonp-2.0, \
     restfulws-3.1, pages-3.1, appsecurity-5.0
 
 -buildpath: \
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	com.ibm.ws.com.meterware.httpunit.1.7;version=latest,\
 	com.ibm.ws.security.fat.common;version=latest,\

--- a/dev/com.ibm.ws.sipcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.sipcontainer/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -37,9 +37,13 @@ Private-Package: \
   com.ibm.wsspi.webcontainer.extension, \
   com.ibm.wsspi.sip.channel*
  
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
   javax.servlet.resources;version=2.6, \
   !javax.servlet.sip*, \
+  javax.annotation;version=!, \
   javax.servlet.*, \
   javax.xml.ws.*;version=!,\
   io.openliberty.netty.internal*,\
@@ -85,6 +89,7 @@ instrument.disabled: true
 -buildpath: \
 	com.ibm.websphere.appserver.spi.logging;version=latest,\
 	com.ibm.ws.logging.core;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.sip.1.1;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\

--- a/dev/com.ibm.ws.transaction.db_fat/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.db_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -26,6 +26,7 @@ tested.features:\
   servlet-5.0, servlet-6.0
 
 -buildpath: \
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.tx.jta;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/CatalogAPI.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/CatalogAPI.java
@@ -1,18 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.ui.internal.rest.v1;
-
-import javax.xml.ws.Response;
 
 import com.ibm.websphere.jsonsupport.JSON;
 import com.ibm.websphere.ras.Tr;

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/ToolDataAPI.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/ToolDataAPI.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,8 +16,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import javax.xml.ws.Response;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -116,10 +114,10 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
             toolDataService.promoteIfPossible(request.getUserPrincipal().getName(), child);
             Object object = toolDataService.getToolData(request.getUserPrincipal().getName(), child);
             if (object != null) {
-                if(!Utils.isValidJsonString(object.toString())) {
+                if (!Utils.isValidJsonString(object.toString())) {
                     throw new RESTException(HTTP_INTERNAL_ERROR);
                 }
-                
+
                 String md5 = Utils.getMD5String(object.toString());
                 response.setResponseHeader(HTTP_HEADER_ETAG, md5);
                 return object;
@@ -160,7 +158,7 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
 
                 String tooldata = getReaderContents(request.getInputStream(), POST_MAX_PLAIN_TEXT_SIZE);
 
-                if(!Utils.isValidJsonString(tooldata)) {
+                if (!Utils.isValidJsonString(tooldata)) {
                     throw new RESTException(HTTP_INTERNAL_ERROR);
                 }
 
@@ -251,7 +249,7 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
                 }
                 String originalData = toolDataService.getToolData(request.getUserPrincipal().getName(), child);
 
-                if(!Utils.isValidJsonString(originalData.toString())) {
+                if (!Utils.isValidJsonString(originalData.toString())) {
                     throw new RESTException(HTTP_INTERNAL_ERROR);
                 }
 
@@ -265,7 +263,7 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
 
                 String tooldata = getReaderContents(request.getInputStream(), POST_MAX_PLAIN_TEXT_SIZE);
                 // validate user input data
-                if(!Utils.isValidJsonString(tooldata)) {
+                if (!Utils.isValidJsonString(tooldata)) {
                     throw new RESTException(HTTP_INTERNAL_ERROR);
                 }
 

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/ToolboxAPI.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/ToolboxAPI.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,8 +16,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
-import javax.xml.ws.Response;
 
 import com.ibm.websphere.jsonsupport.JSON;
 import com.ibm.websphere.ras.Tr;
@@ -40,10 +38,10 @@ import com.ibm.ws.ui.internal.v1.pojo.DuplicateException;
 import com.ibm.ws.ui.internal.v1.pojo.Message;
 import com.ibm.ws.ui.internal.v1.pojo.NoSuchToolException;
 import com.ibm.ws.ui.internal.v1.pojo.ToolEntry;
+import com.ibm.ws.ui.internal.v1.utils.Utils;
 import com.ibm.ws.ui.internal.validation.InvalidToolException;
 import com.ibm.wsspi.rest.handler.RESTRequest;
 import com.ibm.wsspi.rest.handler.RESTResponse;
-import com.ibm.ws.ui.internal.v1.utils.Utils;
 
 /**
  * <p>Defines the toolbox API for the version 1 of the adminCenter REST API.</p>
@@ -227,7 +225,7 @@ public class ToolboxAPI extends CommonJSONRESTHandler implements V1Constants {
         if (CHILD_RESOURCE_TOOL_ENTRIES.equals(child)) {
             ToolEntry toAdd = readJSONPayload(request, ToolEntry.class);
 
-            if(!Utils.isValidJsonString(toAdd.toString(), "ToolEntry ")) {
+            if (!Utils.isValidJsonString(toAdd.toString(), "ToolEntry ")) {
                 throw new RESTException(HTTP_INTERNAL_ERROR);
             }
 
@@ -250,7 +248,7 @@ public class ToolboxAPI extends CommonJSONRESTHandler implements V1Constants {
         } else if (CHILD_RESOURCE_BOOKMARKS.equals(child)) {
             Bookmark toAdd = readJSONPayload(request, Bookmark.class);
 
-            if(!Utils.isValidJsonString(toAdd.toString(), "Bookmark ")) {
+            if (!Utils.isValidJsonString(toAdd.toString(), "Bookmark ")) {
                 throw new RESTException(HTTP_INTERNAL_ERROR);
             }
 
@@ -289,7 +287,7 @@ public class ToolboxAPI extends CommonJSONRESTHandler implements V1Constants {
             @SuppressWarnings("unchecked")
             Map<String, Object> preferences = readJSONPayload(request, Map.class);
 
-            if(!Utils.isValidJsonString(preferences.toString())) {
+            if (!Utils.isValidJsonString(preferences.toString())) {
                 throw new RESTException(HTTP_INTERNAL_ERROR);
             }
 

--- a/dev/com.ibm.ws.wsat.common/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.common/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -22,7 +22,11 @@ IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
 WS-TraceGroup: WSAT
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
+ javax.xml.soap;version=!, \
  !com.ibm.ws.wsat.interceptor, \
  javax.xml.ws.*;version="[2.2,3)", \
  javax.xml.bind.*;version="[2.2,3)", \
@@ -67,6 +71,7 @@ instrument.classesExcludes: com/ibm/ws/wsat/resources/*.class
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
 	com.ibm.websphere.appserver.spi.logging;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\

--- a/dev/com.ibm.ws.wsat.webclient/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.webclient/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2022 IBM Corporation and others.
+# Copyright (c) 2021, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -20,7 +20,12 @@ bVersion=1.0
 
 WS-TraceGroup: WSAT
   
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
+ javax.jws;version=!, \
+ javax.jws.soap;version=!, \
  javax.xml.ws.*;version="[2.2,3)", \
  org.apache.cxf.*;version="[3.2, 4)", \
  com.ibm.ws.jaxws.wsat.components, \
@@ -49,6 +54,7 @@ javac.endorsedDirs: \
 	com.ibm.websphere.appserver.spi.ssl;version=latest,\
 	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.wsat.webservice/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.webservice/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -23,8 +23,15 @@ Web-ContextPath: /ibm/wsatservice
 
 WS-TraceGroup: WSAT
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
  !com.ibm.ws.wsat.interceptor, \
+ javax.annotation;version=!, \
+ javax.jws;version=!, \
+ javax.jws.soap;version=!, \
+ javax.xml.soap;version=!, \
  javax.xml.ws.*;version="[2.2,3)", \
  javax.xml.bind.*;version="[2.2,3)", \
  org.apache.cxf.*;version="[3.2,4)", \
@@ -71,7 +78,10 @@ Service-Component: \
 	com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2;version=latest,\
 	com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2;version=latest,\
 	com.ibm.websphere.appserver.spi.logging;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -79,6 +79,7 @@ tested.features:\
 	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
 	com.ibm.websphere.javaee.jsp.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/bnd.bnd
@@ -69,6 +69,7 @@ tested.features: \
 	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
 	com.ibm.websphere.javaee.jsp.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/bnd.bnd
@@ -77,6 +77,7 @@ tested.features: \
 	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
 	com.ibm.websphere.javaee.jsp.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -72,6 +72,7 @@ tested.features:\
 	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
 	com.ibm.websphere.javaee.jsp.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/bnd.bnd
@@ -71,6 +71,7 @@ tested.features:\
   com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
   com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
   com.ibm.websphere.javaee.jsp.2.2;version=latest,\
+  com.ibm.websphere.javaee.jws.1.0;version=latest,\
   com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
   com.ibm.websphere.org.osgi.core;version=latest,\
   com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/test-applications/samltoken/src/com/ibm/ws/wssecurity/fat/samltoken/utils.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/test-applications/samltoken/src/com/ibm/ws/wssecurity/fat/samltoken/utils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,10 +14,10 @@
 package com.ibm.ws.wssecurity.fat.samltoken;
 import java.util.Iterator;
 
+import javax.xml.soap.Node;
 import javax.xml.soap.SOAPMessage;
 import javax.xml.ws.Provider;
 
-import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 public class utils {
@@ -32,7 +32,7 @@ public class utils {
                 if (n.getNodeName().equals("wsse:Security")) {
                     NodeList nl = n.getChildNodes();
                     for (int j=0 ; j < nl.getLength(); j++) {
-                        Node cn = nl.item(j) ;
+                        org.w3c.dom.Node cn = nl.item(j) ;
                         String nodeName = cn.getNodeName() ;
                         System.out.println("child node: " + nodeName) ;
                         if (nodeName.contains("saml") && nodeName.contains(":Assertion")) {  // match saml2:Assertion or saml:Assertion

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -75,6 +75,7 @@ tested.features:\
   com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
   com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
   com.ibm.websphere.javaee.jsp.2.2;version=latest,\
+  com.ibm.websphere.javaee.jws.1.0;version=latest,\
   com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
   com.ibm.websphere.org.osgi.core;version=latest,\
   com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/test-applications/samltoken/src/com/ibm/ws/wssecurity/fat/samltoken/utils.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/test-applications/samltoken/src/com/ibm/ws/wssecurity/fat/samltoken/utils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,10 +14,10 @@
 package com.ibm.ws.wssecurity.fat.samltoken;
 import java.util.Iterator;
 
+import javax.xml.soap.Node;
 import javax.xml.soap.SOAPMessage;
 import javax.xml.ws.Provider;
 
-import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 public class utils {
@@ -32,7 +32,7 @@ public class utils {
                 if (n.getNodeName().equals("wsse:Security")) {
                     NodeList nl = n.getChildNodes();
                     for (int j=0 ; j < nl.getLength(); j++) {
-                        Node cn = nl.item(j) ;
+                        org.w3c.dom.Node cn = nl.item(j) ;
                         String nodeName = cn.getNodeName() ;
                         System.out.println("child node: " + nodeName) ;
                         if (nodeName.contains("saml") && nodeName.contains(":Assertion")) {  // match saml2:Assertion or saml:Assertion

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -78,6 +78,7 @@ tested.features:\
   com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
   com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
   com.ibm.websphere.javaee.jsp.2.2;version=latest,\
+  com.ibm.websphere.javaee.jws.1.0;version=latest,\
   com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
   com.ibm.websphere.org.osgi.core;version=latest,\
   com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/test-applications/samltoken/src/com/ibm/ws/wssecurity/fat/samltoken/utils.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/test-applications/samltoken/src/com/ibm/ws/wssecurity/fat/samltoken/utils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,10 +14,10 @@
 package com.ibm.ws.wssecurity.fat.samltoken;
 import java.util.Iterator;
 
+import javax.xml.soap.Node;
 import javax.xml.soap.SOAPMessage;
 import javax.xml.ws.Provider;
 
-import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 public class utils {
@@ -32,7 +32,7 @@ public class utils {
                 if (n.getNodeName().equals("wsse:Security")) {
                     NodeList nl = n.getChildNodes();
                     for (int j=0 ; j < nl.getLength(); j++) {
-                        Node cn = nl.item(j) ;
+                        org.w3c.dom.Node cn = nl.item(j) ;
                         String nodeName = cn.getNodeName() ;
                         System.out.println("child node: " + nodeName) ;
                         if (nodeName.contains("saml") && nodeName.contains(":Assertion")) {  // match saml2:Assertion or saml:Assertion

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -75,6 +75,7 @@ tested.features:\
   com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
   com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
   com.ibm.websphere.javaee.jsp.2.2;version=latest,\
+  com.ibm.websphere.javaee.jws.1.0;version=latest,\
   com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
   com.ibm.websphere.org.osgi.core;version=latest,\
   com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/test-applications/samltoken/src/com/ibm/ws/wssecurity/fat/samltoken/utils.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/test-applications/samltoken/src/com/ibm/ws/wssecurity/fat/samltoken/utils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,10 +14,10 @@
 package com.ibm.ws.wssecurity.fat.samltoken;
 import java.util.Iterator;
 
+import javax.xml.soap.Node;
 import javax.xml.soap.SOAPMessage;
 import javax.xml.ws.Provider;
 
-import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 public class utils {
@@ -32,7 +32,7 @@ public class utils {
                 if (n.getNodeName().equals("wsse:Security")) {
                     NodeList nl = n.getChildNodes();
                     for (int j=0 ; j < nl.getLength(); j++) {
-                        Node cn = nl.item(j) ;
+                        org.w3c.dom.Node cn = nl.item(j) ;
                         String nodeName = cn.getNodeName() ;
                         System.out.println("child node: " + nodeName) ;
                         if (nodeName.contains("saml") && nodeName.contains(":Assertion")) {  // match saml2:Assertion or saml:Assertion

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -69,6 +69,7 @@ tested.features:\
   com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
   com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
   com.ibm.websphere.javaee.jsp.2.2;version=latest,\
+  com.ibm.websphere.javaee.jws.1.0;version=latest,\
   com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
   com.ibm.websphere.org.osgi.core;version=latest,\
   com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/test-applications/samltoken/src/com/ibm/ws/wssecurity/fat/samltoken/utils.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/test-applications/samltoken/src/com/ibm/ws/wssecurity/fat/samltoken/utils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,10 +14,10 @@
 package com.ibm.ws.wssecurity.fat.samltoken;
 import java.util.Iterator;
 
+import javax.xml.soap.Node;
 import javax.xml.soap.SOAPMessage;
 import javax.xml.ws.Provider;
 
-import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 public class utils {
@@ -32,7 +32,7 @@ public class utils {
                 if (n.getNodeName().equals("wsse:Security")) {
                     NodeList nl = n.getChildNodes();
                     for (int j=0 ; j < nl.getLength(); j++) {
-                        Node cn = nl.item(j) ;
+                        org.w3c.dom.Node cn = nl.item(j) ;
                         String nodeName = cn.getNodeName() ;
                         System.out.println("child node: " + nodeName) ;
                         if (nodeName.contains("saml") && nodeName.contains(":Assertion")) {  // match saml2:Assertion or saml:Assertion

--- a/dev/io.openliberty.injection.jakarta_fat/bnd.bnd
+++ b/dev/io.openliberty.injection.jakarta_fat/bnd.bnd
@@ -24,6 +24,7 @@ tested.features: \
 	servlet-6.0
 
 -buildpath: \
+	com.ibm.websphere.javaee.annotation.1.3;version=latest,\
 	com.ibm.ws.componenttest.2.0;version=latest,\
 	io.openliberty.jakarta.annotation.2.0; version=latest,\
 	io.openliberty.jakarta.enterpriseBeans.4.0; version=latest,\

--- a/dev/io.openliberty.jaxws.globalhandler.internal/bnd.bnd
+++ b/dev/io.openliberty.jaxws.globalhandler.internal/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
@@ -15,7 +15,13 @@ bVersion=1.0
 Export-Package: \
   com.ibm.ws.jaxws.globalhandler;version="2.3"
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
+  javax.activation;version=!, \
+  javax.xml.soap;version=!, \
+  javax.xml.ws.*;version=!, \
   *
 
 -dsannotations:\
@@ -43,6 +49,10 @@ Import-Package: \
   com.ibm.websphere.org.osgi.service.component;version=latest,\
   com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
   com.ibm.ws.kernel.service;version=latest,\
+  com.ibm.websphere.javaee.activation.1.1;version=latest,\
+  com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
+  com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+  com.ibm.websphere.javaee.jws.1.0;version=latest,\
   com.ibm.websphere.javaee.servlet.3.0;version=latest,\
   com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
   com.ibm.ws.webservices.handler;version=latest

--- a/dev/io.openliberty.jaxws.security_fat.1/bnd.bnd
+++ b/dev/io.openliberty.jaxws.security_fat.1/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -46,7 +46,9 @@ tested.features: jaxws-2.3, \
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2,\
 	com.ibm.websphere.javaee.ejb.3.2,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1,\
 	com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
 	com.ibm.ws.jaxws.2.3.common;version=latest,\

--- a/dev/io.openliberty.jaxws.security_fat.ssl/bnd.bnd
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -47,7 +47,9 @@ tested.features: jaxws-2.3, \
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2,\
 	com.ibm.websphere.javaee.ejb.3.2,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1,\
 	com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
 	com.ibm.ws.jaxws.2.3.common;version=latest,\

--- a/dev/io.openliberty.jaxws.security_fat/bnd.bnd
+++ b/dev/io.openliberty.jaxws.security_fat/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -53,7 +53,9 @@ tested.features: jaxws-2.3, \
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2,\
 	com.ibm.websphere.javaee.ejb.3.2,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1,\
 	com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\
 	com.ibm.ws.jaxws.2.3.common;version=latest,\

--- a/dev/io.openliberty.mail.2.0.internal_fat/fat/src/io/openliberty/mail/fat/IMAPTest.java
+++ b/dev/io.openliberty.mail.2.0.internal_fat/fat/src/io/openliberty/mail/fat/IMAPTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -30,7 +30,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.omg.CORBA.UserException;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
@@ -149,7 +148,6 @@ public class IMAPTest {
      * The BeforeClass method sets up the GreenMail test server, so that the "server" is waiting
      * before even the Liberty class is set up.
      *
-     * @throws UserException
      * @throws Exception
      */
     @BeforeClass

--- a/dev/io.openliberty.mail.2.0.internal_fat/fat/src/io/openliberty/mail/fat/POP3Test.java
+++ b/dev/io.openliberty.mail.2.0.internal_fat/fat/src/io/openliberty/mail/fat/POP3Test.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -26,7 +26,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.omg.CORBA.UserException;
 
 import com.ibm.websphere.simplicity.log.Log;
 
@@ -129,7 +128,6 @@ public class POP3Test {
      * and all that needs to be set is passed a handler and a port number which for the pop3
      * server has been set to 3110
      *
-     * @throws UserException
      * @throws Exception
      */
     @BeforeClass

--- a/dev/io.openliberty.mail.2.0.internal_fat/test-applications/fvtweb/src/fvtweb/ejb/JavamailTestBean.java
+++ b/dev/io.openliberty.mail.2.0.internal_fat/test-applications/fvtweb/src/fvtweb/ejb/JavamailTestBean.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,8 +12,7 @@
  *******************************************************************************/
 package fvtweb.ejb;
 
-import javax.annotation.Resource;
-
+import jakarta.annotation.Resource;
 import jakarta.ejb.Stateless;
 import jakarta.mail.MailSessionDefinition;
 

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -43,4 +43,7 @@ tested.features:\
 	com.ibm.websphere.rest.handler;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
+	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	io.openliberty.org.eclipse.microprofile.metrics.3.0;version=latest

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/complex/src/io/openliberty/restfulWS30/cdi30/fat/complex/SimpleBean.java
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/complex/src/io/openliberty/restfulWS30/cdi30/fat/complex/SimpleBean.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package io.openliberty.restfulWS30.cdi30.fat.complex;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 
 import jakarta.enterprise.context.Dependent;
 

--- a/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/disable/src/io/openliberty/restfulWS30/cdi30/fat/disable/SimpleBean.java
+++ b/dev/io.openliberty.restfulWS.3.0.cdi.3.0_fat/test-applications/disable/src/io/openliberty/restfulWS30/cdi30/fat/disable/SimpleBean.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package io.openliberty.restfulWS30.cdi30.fat.disable;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 
 import jakarta.enterprise.context.Dependent;
 

--- a/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/bnd.bnd
+++ b/dev/io.openliberty.ws.jaxrs.2.1.jaxws.2.2_fat/bnd.bnd
@@ -23,7 +23,9 @@ fat.project: true
 -buildpath: \
   io.openliberty.com.fasterxml.jackson,\
   com.ibm.websphere.javaee.servlet.3.1,\
+  com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
   com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
   com.ibm.websphere.javaee.jaxrs.2.0,\
+  com.ibm.websphere.javaee.jws.1.0;version=latest,\
   fattest.simplicity
 

--- a/dev/io.openliberty.ws.jaxrs.global.handler.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.ws.jaxrs.global.handler.internal_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2021,2022 IBM Corporation and others.
+# Copyright (c) 2021,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -62,7 +62,10 @@ tested.features= \
 	com.ibm.websphere.javaee.annotation.1.3;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxrs.2.0;version=latest,\
+	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\

--- a/dev/io.openliberty.ws.jaxws.global.handler.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.ws.jaxws.global.handler.internal_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2021,2022 IBM Corporation and others.
+# Copyright (c) 2021,2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -80,8 +80,10 @@ tested.features=appSecurity-3.0, \
 	com.ibm.websphere.javaee.annotation.1.3;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxrs.2.0;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.javaee.wsdl4j.1.2;version=latest,\

--- a/dev/io.openliberty.ws.jaxws.tools_fat/bnd.bnd
+++ b/dev/io.openliberty.ws.jaxws.tools_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -26,4 +26,5 @@ tested.features:\
 	xmlws-3.0
 	
 -buildpath:\
+    com.ibm.websphere.javaee.jws.1.0;version=latest,\
     com.ibm.ws.jaxws.tools.2.2.10;version=latest

--- a/dev/io.openliberty.wsoc.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.wsoc.internal_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -47,6 +47,7 @@ tested.features: \
     appsecurity-5.0
 
 -buildpath: \
+    com.ibm.websphere.javaee.annotation.1.1;version=latest,\
     com.ibm.websphere.javaee.ejb.3.2;version=latest,\
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
     com.ibm.websphere.javaee.websocket.1.1;version=latest,\


### PR DESCRIPTION
- Update bnd buildpath to reference liberty bundles for Java EE classes that were in Java 8, but were later removed
- Update import in classes to use jakarta instead of javax where we were using the wrong import
- Add cast for ClassLoader for the FileSystems.newFileSystem method that has a new version of the method in later Java versions that makes passing null ambiguous
- Remove imports of classes that are not used in the classes so we don't need to update the buildpath
- Update SOAPMessage.getSOAPHeader().getChildElements to process as an iterator of SOAP Nodes instead of DOM Nodes so that it is happy in newer Java versions
- Update manifest package imports to not have a version range to match the previous import behavior so that we load from Java 8 classes instead of our own for classes that are in Java 8.

This PR is a refresh of similar work I did 4 years ago with PR #7076