### PR TITLE
Revert "Incorrect default for session cache id property"

### DIFF
--- a/dev/com.ibm.ws.session.db/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.session.db/resources/OSGI-INF/metatype/metatype.xml
@@ -123,7 +123,7 @@
             name="%optimize.cache.id.increments" 
             description="%optimize.cache.id.increments.desc" 
             ibmui:group="advanced.performance"
-            required="false" type="Boolean" default="false"/>
+            required="false" type="Boolean" default="true"/>
         
         <!-- ibmui:group=db2 -->
         <AD id="db2RowSize" 


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#25840

Possible zero migration issue.