### PR TITLE
Fix for Trace SB3 test and other start failure issues

### DIFF
--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/EnableSpringBootTraceTests30.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/EnableSpringBootTraceTests30.java
@@ -14,8 +14,9 @@ package com.ibm.ws.springboot.support.fat;
 
 import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -27,91 +28,6 @@ import componenttest.annotation.MinimumJavaLevel;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 
-// Disabled: Failing to start web server.
-
-// org.springframework.context.ApplicationContextException: Unable to start web serve
-// 	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.onRefresh(ServletWebServerApplicationContext.java:164) ~[spring-boot-3.0.4.jar:3.0.4
-// 	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:578) ~[spring-context-6.0.6.jar:6.0.6
-// 	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146) ~[spring-boot-3.0.4.jar:3.0.4
-// 	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:732) ~[spring-boot-3.0.4.jar:3.0.4
-// 	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:434) ~[spring-boot-3.0.4.jar:3.0.4
-// 	at org.springframework.boot.SpringApplication.run(SpringApplication.java:310) ~[spring-boot-3.0.4.jar:3.0.4
-// 	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1304) ~[spring-boot-3.0.4.jar:3.0.4
-// 	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1293) ~[spring-boot-3.0.4.jar:3.0.4
-// 	at com.ibm.ws.springboot.fat30.test.app.TestApplication.main(TestApplication.java:36) ~[com.ibm.ws.springboot.fat30.app-0.0.1-SNAPSHOT.spring:na
-// 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na
-// 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na
-// 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na
-// 	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na
-// 	at com.ibm.ws.app.manager.springboot.internal.SpringBootRuntimeContainer.lambda$invokeSpringMain$6(SpringBootRuntimeContainer.java:139) ~[na:na
-// 	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:247) ~[na:na
-// 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[na:na
-// 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[na:na
-// 	at java.base/java.lang.Thread.run(Thread.java:857) ~[na:na
-// Caused by: org.springframework.boot.web.server.WebServerException: Unable to start embedded Tomca
-// 	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.initialize(TomcatWebServer.java:142) ~[spring-boot-3.0.4.jar:3.0.4
-// 	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.<init>(TomcatWebServer.java:104) ~[spring-boot-3.0.4.jar:3.0.4
-// 	at org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory.getTomcatWebServer(TomcatServletWebServerFactory.java:488) ~[spring-boot-3.0.4.jar:3.0.4
-// 	at org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory.getWebServer(TomcatServletWebServerFactory.java:210) ~[spring-boot-3.0.4.jar:3.0.4
-// 	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.createWebServer(ServletWebServerApplicationContext.java:183) ~[spring-boot-3.0.4.jar:3.0.4
-// 	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.onRefresh(ServletWebServerApplicationContext.java:161) ~[spring-boot-3.0.4.jar:3.0.4
-// 	... 17 common frames omitte
-// Caused by: org.apache.catalina.LifecycleException: A child container failed during star
-// 	at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:890) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.core.StandardEngine.startInternal(StandardEngine.java:241) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.core.StandardService.startInternal(StandardService.java:428) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.core.StandardServer.startInternal(StandardServer.java:913) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.startup.Tomcat.start(Tomcat.java:485) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.initialize(TomcatWebServer.java:123) ~[spring-boot-3.0.4.jar:3.0.4
-// 	... 22 common frames omitte
-// Caused by: java.util.concurrent.ExecutionException: org.apache.catalina.LifecycleException: A child container failed during star
-// 	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122) ~[na:na
-// 	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191) ~[na:na
-// 	at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:878) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	... 30 common frames omitte
-// Caused by: org.apache.catalina.LifecycleException: A child container failed during star
-// 	at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:890) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.core.StandardHost.startInternal(StandardHost.java:846) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1332) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1322) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[na:na
-// 	at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at java.base/java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:145) ~[na:na
-// 	at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:871) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	... 30 common frames omitte
-// Caused by: java.util.concurrent.ExecutionException: org.apache.catalina.LifecycleException: Failed to initialize component [org.apache.catalina.webresources.StandardRoot@f618ee6e
-// 	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122) ~[na:na
-// 	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191) ~[na:na
-// 	at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:878) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	... 38 common frames omitte
-// Caused by: org.apache.catalina.LifecycleException: Failed to initialize component [org.apache.catalina.webresources.StandardRoot@f618ee6e
-// 	at org.apache.catalina.util.LifecycleBase.handleSubClassException(LifecycleBase.java:440) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:139) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:173) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.core.StandardContext.resourcesStart(StandardContext.java:4567) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:4700) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1332) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1322) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[na:na
-// 	at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at java.base/java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:145) ~[na:na
-// 	at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:871) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	... 38 common frames omitte
-// Caused by: java.lang.Error: factory already define
-// 	at java.base/java.net.URL.setURLStreamHandlerFactory(URL.java:1228) ~[na:na
-// 	at org.apache.catalina.webresources.TomcatURLStreamHandlerFactory.<init>(TomcatURLStreamHandlerFactory.java:121) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.webresources.TomcatURLStreamHandlerFactory.getInstanceInternal(TomcatURLStreamHandlerFactory.java:52) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.webresources.TomcatURLStreamHandlerFactory.register(TomcatURLStreamHandlerFactory.java:73) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.webresources.StandardRoot.registerURLStreamHandlerFactory(StandardRoot.java:699) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.webresources.StandardRoot.initInternal(StandardRoot.java:686) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:136) ~[tomcat-embed-core-10.1.8.jar:10.1.8
-// 	... 48 common frames omitted
-
 @RunWith(FATRunner.class)
 @Mode(FULL)
 @MinimumJavaLevel(javaLevel = 17)
@@ -119,7 +35,7 @@ public class EnableSpringBootTraceTests30 extends CommonWebServerTests {
 
     @Override
     public Set<String> getFeatures() {
-        return Collections.singleton("springBoot-3.0");
+        return new HashSet<>(Arrays.asList("springBoot-3.0", "servlet-6.0"));
     }
 
     @Override

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/FATSuite.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/FATSuite.java
@@ -37,14 +37,12 @@ import com.ibm.ws.springboot.support.fat.utility.SpringBootUtilityThinTest;
                 WarmStartTests30.class,
                 SSLTests30.class,
                 SSLMutualAuthTests30.class,
-                    // SpringSecurityTests30.class,
-                    // Disabled due to application failures.
+                // SpringSecurityTests30.class,
+                // Disabled due to application failures.
                 JSPTests30.class,
-                    // MissingServletTests30.class,
-                    // Disabled: The jakarta servlet class is being provisioned even without the servlet feature!
+                MissingServletTests30.class,
                 MissingSslFeatureTests30.class,
-                    // MissingWebsocketFeatureTests30.class,
-                    // Disabled: The jakarta web socket class is being provisioned even without the web socket feature!
+                MissingWebsocketFeatureTests30.class,
                 MultiContextTests30.class,
                 MultipleApplicationsNotSupported30.class,
                 NeedSpringBootFeatureTests30.class,
@@ -53,12 +51,11 @@ import com.ibm.ws.springboot.support.fat.utility.SpringBootUtilityThinTest;
                 SpringBootUtilityThinTest.class,
                 WebAnnotationTests30.class,
                 ExtractedAppTests30.class,
-                    // WebSocketTests30.class,
-                    // Disabled due to application failures.
+                // WebSocketTests30.class,
+                // Disabled due to application failures.
                 MimeMapping30.class,
                 ErrorPage30Test.class,
-                    // EnableSpringBootTraceTests30.class,
-                    // Disabled: Failing to start web server.  See the test class for details.
+                EnableSpringBootTraceTests30.class,
                 ExceptionOccuredAfterAppIsAvailableTest30.class,
                 JakartaFeatureTests30.class,
                 TemplateTests30.class,

--- a/dev/io.openliberty.springboot.fat30_fat/publish/servers/SpringBootTests/jvm.options
+++ b/dev/io.openliberty.springboot.fat30_fat/publish/servers/SpringBootTests/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true


### PR DESCRIPTION
#build 

This Fixes the SB test error for the Trace test case as mentioned in 25764.  This also fixes the beta = true for the test bucket that was causing the server to not start properly due to thinning.