### PR TITLE
Disable JPA ORM diagnostic during checkpoint

### DIFF
--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2022 IBM Corporation and others.
+# Copyright (c) 2018, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -25,4 +25,5 @@ instrument.disabled: true
 	com.ibm.ws.logging.core,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
 	com.ibm.ws.org.objectweb.asm;version=latest, \
-	com.ibm.ws.kernel.service;version=latest
+	com.ibm.ws.kernel.service;version=latest, \
+	com.ibm.ws.kernel.boot.common;version=latest

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puscanner/PersistenceUnitScannerResults.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puscanner/PersistenceUnitScannerResults.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -59,6 +59,8 @@ import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ValueType;
 import com.ibm.ws.jpa.diagnostics.ormparser.EntityMappingsDefinition;
 import com.ibm.ws.jpa.diagnostics.utils.encapsulation.EncapsulatedData;
 import com.ibm.ws.jpa.diagnostics.utils.encapsulation.EncapsulatedDataGroup;
+
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 
 /**
  *
@@ -142,6 +144,12 @@ public class PersistenceUnitScannerResults {
     }
 
     public void generateORMDump(PrintWriter out) {
+        if (CheckpointPhase.getPhase() != CheckpointPhase.INACTIVE && !CheckpointPhase.getPhase().restored()) {
+            out.print("[JPA ORM diagnostics are unavailable during server checkpoint]\n");
+            out.flush();
+            return;
+        }
+
         // Map Persistence Unit Root URLs to PersistenceUnitInfo instances
         final Map<URL, List<PersistenceUnitInfo>> commonPuRootMap = new HashMap<URL, List<PersistenceUnitInfo>>();
         for (PersistenceUnitInfo pui : puiList) {

--- a/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/fat/src/com/ibm/ws/jpa/tests/container/checkpoint/tests/JPADiagnosticsCheckpointTest.java
+++ b/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/fat/src/com/ibm/ws/jpa/tests/container/checkpoint/tests/JPADiagnosticsCheckpointTest.java
@@ -1,0 +1,241 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.tests.container.checkpoint.tests;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.Application;
+import com.ibm.websphere.simplicity.config.ClassloaderElement;
+import com.ibm.websphere.simplicity.config.ConfigElementList;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.ws.testtooling.vehicle.web.JPAFATServletClient;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.PrivHelper;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
+@RunWith(FATRunner.class)
+@Mode(TestMode.LITE)
+public class JPADiagnosticsCheckpointTest extends JPAFATServletClient {
+
+    private final static String RESOURCE_ROOT = "test-applications/datasourceApp/";
+    private final static String appFolder = "web";
+    private final static String appName = "jpadatasourceWeb";
+    private final static String appNameEar = appName + ".ear";
+
+    private final static String MSG_APP_START = "CWWKZ0001I.*" + appName;
+    private final static String MSG_CHECKPOINT = "CWWKC0451I.*";
+
+    private static final List<String> CHECKPOINT_INACTIVE = Collections.emptyList();
+    private static final List<String> CHECKPOINT_BEFORE_APP_START = Arrays.asList("--internal-checkpoint-at=beforeAppStart");
+    private static final List<String> CHECKPOINT_AFTER_APP_START = Arrays.asList("--internal-checkpoint-at=afterAppStart");
+
+    private static long timestart = 0;
+
+    @Server("JPACheckpointServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        PrivHelper.generateCustomPolicy(server, AbstractFATSuite.JAXB_PERMS);
+        bannerStart(JPADiagnosticsCheckpointTest.class);
+        timestart = System.currentTimeMillis();
+
+        int appStartTimeout = server.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server.setConfigUpdateTimeout(120 * 1000);
+        }
+
+        setupTestApplication();
+    }
+
+    @Before
+    public void configSetUp() throws Exception {
+        // Every server start/stop clears environment variables, set on each test run
+        server.addEnvVar("repeat_phase", AbstractFATSuite.repeatPhase);
+    }
+
+    private static void setupTestApplication() throws Exception {
+        WebArchive webApp = ShrinkWrap.create(WebArchive.class, appName + ".war");
+        webApp.addPackages(true, "com.ibm.ws.jpa.datasource.model");
+        webApp.addPackages(true, "com.ibm.ws.jpa.datasource.testlogic");
+        webApp.addPackages(true, "com.ibm.ws.jpa.datasource.web");
+        ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + appFolder + "/" + appName + ".war");
+
+        final JavaArchive testApiJar = buildTestAPIJar();
+
+        final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appNameEar);
+        app.addAsModule(webApp);
+        app.addAsLibrary(testApiJar);
+        ShrinkHelper.addDirectory(app, RESOURCE_ROOT + appFolder, new org.jboss.shrinkwrap.api.Filter<ArchivePath>() {
+            @Override
+            public boolean include(ArchivePath arg0) {
+                if (arg0.get().startsWith("/META-INF/")) {
+                    return true;
+                }
+                return false;
+            }
+        });
+
+        ShrinkHelper.exportToServer(server, "apps", app);
+
+        Application appRecord = new Application();
+        appRecord.setLocation(appNameEar);
+        appRecord.setName(appName);
+
+        // setup the thirdparty classloader for Hibernate and OpenJPA
+        if (AbstractFATSuite.repeatPhase != null && AbstractFATSuite.repeatPhase.contains("hibernate")) {
+            ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+            ClassloaderElement loader = new ClassloaderElement();
+            loader.getCommonLibraryRefs().add("HibernateLib");
+            cel.add(loader);
+        } else if (AbstractFATSuite.repeatPhase != null && AbstractFATSuite.repeatPhase.contains("openjpa")) {
+            ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+            ClassloaderElement loader = new ClassloaderElement();
+            loader.getCommonLibraryRefs().add("OpenJPALib");
+            cel.add(loader);
+        }
+
+        ServerConfiguration sc = server.getServerConfiguration();
+        sc.getApplications().add(appRecord);
+        server.updateServerConfiguration(sc);
+    }
+
+    private static void setCheckpointPhase(CheckpointPhase phase, LibertyServer server) throws Exception {
+        Map<String, String> jvmOptions = server.getJvmOptionsAsMap();
+        switch (phase) {
+            case BEFORE_APP_START:
+                jvmOptions.put("-Dio.openliberty.checkpoint.stub.criu", "true");
+                server.setExtraArgs(CHECKPOINT_BEFORE_APP_START);
+                break;
+            case AFTER_APP_START:
+                jvmOptions.put("-Dio.openliberty.checkpoint.stub.criu", "true");
+                server.setExtraArgs(CHECKPOINT_AFTER_APP_START);
+                break;
+            default:
+                jvmOptions.remove("-Dio.openliberty.checkpoint.stub.criu");
+                server.setExtraArgs(CHECKPOINT_INACTIVE);
+        }
+        server.setJvmOptions(jvmOptions);
+    }
+
+    @Test
+    public void jpa_AAS_testCheckpointORMDiagnostic() throws Exception {
+        testCheckpointORMDiagnostic(CheckpointPhase.AFTER_APP_START);
+    }
+
+    @Test
+    public void jpa_BAS_testCheckpointORMDiagnostic() throws Exception {
+        testCheckpointORMDiagnostic(CheckpointPhase.BEFORE_APP_START);
+    }
+
+    @Test
+    public void jpa_INACTIVE_testCheckpointORMDiagnostic() throws Exception {
+        testCheckpointORMDiagnostic(CheckpointPhase.INACTIVE);
+    }
+
+    // Java makes the MD5 hash algorithm unavailable during CRIU checkpoint, only.
+    // In order to prevent FFDC events, the JPA ORM diagnostic -- which uses an MD5
+    // MessageDigest -- is temporarily disabled for server checkpoint until java makes
+    // new algorithms available. And once available, the diagnostic can be enabled
+    // using any suitable algorithm for MessageDigest other than MD5 or SHA1.
+    /**
+     * Verify ORM diagnostics disable during server checkpoint, only.
+     *
+     * When the JPMORM trace group is enabled, ORM diagnostics are dumped to trace
+     * for each application while processing the applicationStarting event. Thus,
+     * the diagnostic should not log to trace (disable) during server checkpoint at
+     * AFTER_APP_START. but should log (enable) during normal server operation and
+     * during server restore from a checkpoint at BEFDRE_APP_START.
+     */
+    private void testCheckpointORMDiagnostic(final CheckpointPhase phase) throws Exception {
+        Assert.assertFalse("Server is already started!", server.isStarted());
+
+        // Checkpoint and restore the server using stubbed CRIU support in a single JVM.
+        // Unlike a real checkpoint-restore scenario, this server JVM always makes the MD5
+        // hash algorithm available during checkpoint. The test cannot use unexpected FFDC
+        // events for NoSuchAlgorithmException to verify server behavior.
+        JPADiagnosticsCheckpointTest.setCheckpointPhase(phase, server);
+        server.startServer();
+
+        Assert.assertTrue("The JPAORM trace group should be enabled across checkpoint and restore, but is not",
+                          server.findStringsInTrace("JPAORM=all").size() >= 2);
+
+        Assert.assertNotNull("Application " + appName + " should start, but did not",
+                             server.waitForStringInLog(MSG_APP_START, server.getDefaultTraceFile()));
+
+        switch (phase) {
+            case AFTER_APP_START:
+                Assert.assertTrue("JPA ORM diagnostics should disable during server checkpoint AFTER_APP_START, but did not",
+                                  server.findStringsInTrace("JPA ORM diagnostics are unavailable during server checkpoint").size() >= 1);
+
+                Assert.assertTrue("A server checkpoint was not requested, but should have",
+                                  server.findStringsInTrace(MSG_CHECKPOINT).size() >= 1);
+                break;
+            case BEFORE_APP_START:
+                Assert.assertTrue("JPA ORM diagnostics should log to trace when restoring a server checkpointed BEFORE_APP_START, but did not",
+                                  server.findStringsInTrace("Encapsulated JPA Diagnostic Data").size() >= 1);
+
+                Assert.assertTrue("A server checkpoint was not requested, but should have",
+                                  server.findStringsInTrace(MSG_CHECKPOINT).size() >= 1);
+                break;
+            default: // INACTIVE
+                Assert.assertTrue("JPA ORM diagnostics should log to trace during normal server operation, but did not",
+                                  server.findStringsInTrace("Encapsulated JPA Diagnostic Data").size() >= 1);
+
+                Assert.assertTrue("A server checkpoint was requested unexpectedly",
+                                  server.findStringsInTrace(MSG_CHECKPOINT).isEmpty());
+                break;
+        }
+    }
+
+    @After
+    public void configTearDown() throws Exception {
+        if (server.isStarted()) {
+            server.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
+                              "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
+            );
+        }
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        bannerEnd(JPADiagnosticsCheckpointTest.class, timestart);
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/publish/servers/JPACheckpointServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/publish/servers/JPACheckpointServer/bootstrap.properties
@@ -11,7 +11,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:JPA=all:checkpoint=all
+com.ibm.ws.logging.trace.specification=*=info:JPA=all:JPAORM=all:checkpoint=all
 io.openliberty.checkpoint.allowed.features=servlet-3.1,jdbc-4.1,jpa-2.1,jpaContainer-2.1
 # Exempt from java 2 security because this FAT does dynamic config
 websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/publish/servers/JPACheckpointServer/server.xml
+++ b/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/publish/servers/JPACheckpointServer/server.xml
@@ -40,7 +40,7 @@
     <javaPermission className="java.io.FilePermission" name="files/timertestoutput.txt" actions="read,write"/>
     <javaPermission className="java.io.FilePermission" name="files" actions="write"/>
 
-    <logging  traceSpecification="*=info:JPA=all:checkpoint=all"
+    <logging  traceSpecification="*=info:JPA=all:JPAORM=all:checkpoint=all"
               traceFileName="trace.log"
               maxFileSize="2000"
               maxFiles="10"

--- a/dev/com.ibm.ws.jpa.tests.container.checkpoint_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/container/checkpoint/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.container.checkpoint_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/container/checkpoint/FATSuite.java
@@ -21,6 +21,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import com.ibm.ws.jpa.tests.container.checkpoint.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.container.checkpoint.tests.JPADataSourceCheckpointTest_EJB;
 import com.ibm.ws.jpa.tests.container.checkpoint.tests.JPADataSourceCheckpointTest_Web;
+import com.ibm.ws.jpa.tests.container.checkpoint.tests.JPADiagnosticsCheckpointTest;
 
 import componenttest.rules.repeater.RepeatTests;
 
@@ -28,6 +29,7 @@ import componenttest.rules.repeater.RepeatTests;
 @SuiteClasses({
                 JPADataSourceCheckpointTest_EJB.class,
                 JPADataSourceCheckpointTest_Web.class,
+                JPADiagnosticsCheckpointTest.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends AbstractFATSuite {

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-backendServices/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-backendServices/bootstrap.properties
@@ -12,7 +12,9 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
-com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-#com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:com.ibm.ws.jpa.management.*=all:com.ibm.ws.jpa.container.osgi.internal.*=all:Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled
+# JPAORM trace is enabled so tests can ensure persistence features do not log FFDC
+# events indicating the MessageDigest algorithm is unavailable during checkpoint
+com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:JPA=all:JPAORM=all
+#com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:JPA=all,JPAORM=all:Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled
 #ds.loglevel=DEBUG
 io.openliberty.checkpoint.dump.threads=true


### PR DESCRIPTION
During server checkpoint, whenever the `JPAORM` trace group is enabled, the persistence features will log FFDC events indicating the MD5 MessageDigest hash algorithm is unavailable. The exception occurs because the trace group includes the computation of the "JPA ORM" diagnostic, which uses an MD5 MessageDigest, and java CRIU support makes the MD5 hash algorithm unavailable during checkpoint.

`Stack Dump = java.security.NoSuchAlgorithmException: MD5 MessageDigest not available
	at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:159)
	at java.base/java.security.MessageDigest.getInstance(MessageDigest.java:185)
	at com.ibm.ws.jpa.diagnostics.utils.encapsulation.EncapsulatedData.setData(EncapsulatedData.java:136)
	at com.ibm.ws.jpa.diagnostics.utils.encapsulation.EncapsulatedData.createEncapsulatedData(EncapsulatedData.java:58)
	at com.ibm.ws.jpa.diagnostics.utils.encapsulation.EncapsulatedData.createEncapsulatedData(EncapsulatedData.java:45)
	at com.ibm.ws.jpa.diagnostics.puscanner.PersistenceUnitScannerResults.generateORMDump(PersistenceUnitScannerResults.java:178)
	at com.ibm.ws.jpa.management.JPAIntrospection.doExecuteTraceAnalysis(JPAIntrospection.java:360)
	at com.ibm.ws.jpa.management.JPAIntrospection.executeTraceAnalysis(JPAIntrospection.java:164)
	at com.ibm.ws.jpa.container.osgi.internal.JPAComponentImpl.applicationStarting(JPAComponentImpl.java:403)
	at com.ibm.ws.container.service.state.internal.ApplicationStateManager.fireStarting(ApplicationStateManager.java:53)
	at com.ibm.ws.container.service.state.internal.StateChangeServiceImpl.fireApplicationStarting(StateChangeServiceImpl.java:52)
	at ...`

To prevent FFDC events **this PR temporarily disables the JPA ORM diagnostic during server checkpoint, only,** until java makes new algorithms available for MessageDigest. And once available, the diagnostic should then be re-enabled using the most suitable algorithm.

**The PR adds test JPADiagnosticsCheckpointTest to the JPA checkpoint FAT**. The new test verifies the JPA ORM diagnostic disables during server checkpoint, only. Specifically, when the JPMORM trace group is enabled an ORM diagnostic for each persistence application will log/dump to trace while processing the applicationStarting event. Thus, the diagnostic should not compute nor log to trace during server checkpoint at AFTER_APP_START, but should successfully compute and log to trace during normal server operation and during server restore from a checkpoint at BEFORE_APP_START.

The JPA checkpoint FAT suite exercises checkpoint and restore within a single server that mocks CRIU support. Unlike a real checkpoint-restore scenario, this server's JVM always makes the MD5 algorithm available during checkpoint. So, the new test cannot use unexpected FFDC events for NoSuchAlgorithmException to verify server behavior. That's why **the PR enables the JPAORM trace group in the "backendServer" of the FacesTest within the InstantOn checkpoint FAT.** The FacesTest exercises persistence features and will fail whenever an unexpected FFDC event occurs during server checkpoint. 
