### PR TITLE
Bump SmallRye Metrics to 5.0.1 and update API usage in MP Metrics 5.0 feature

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -929,7 +929,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-metrics</artifactId>
-      <version>5.0.0</version>
+      <version>5.0.1</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -181,7 +181,7 @@ io.smallrye:smallrye-graphql-schema-builder:1.0.26
 io.smallrye:smallrye-graphql-schema-model:1.0.26
 io.smallrye:smallrye-graphql-servlet:1.0.26
 io.smallrye:smallrye-graphql:1.0.26
-io.smallrye:smallrye-metrics:5.0.0
+io.smallrye:smallrye-metrics:5.0.1
 io.smallrye:smallrye-open-api-core:3.1.1
 io.smallrye:smallrye-open-api-jaxrs:3.1.1
 io.zipkin.reporter2:zipkin-reporter:2.16.3

--- a/dev/io.openliberty.io.smallrye.metrics/bnd.bnd
+++ b/dev/io.openliberty.io.smallrye.metrics/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -33,6 +33,6 @@ WS-TraceGroup: METRICS
 publish.wlp.jar.suffix: lib
 
 -buildpath: \
-    io.smallrye:smallrye-metrics;version=5.0.0
+    io.smallrye:smallrye-metrics;version=5.0.1
 	
 instrument.disabled: true

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/SharedMetricRegistries.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/SharedMetricRegistries.java
@@ -60,7 +60,7 @@ public class SharedMetricRegistries {
          * Unsuccessful activation. SmallRye and Micrometer classes were not loaded
          * properly.
          */
-        if (!smallryeMetricsCDIMetadata.isSuccesfulActivation()) {
+        if (!smallryeMetricsCDIMetadata.isSuccessfulActivation()) {
             return null;
         }
 
@@ -93,7 +93,7 @@ public class SharedMetricRegistries {
          * Unsuccessful activation. SmallRye and Micrometer classes were not loaded
          * properly.
          */
-        if (!smallryeMetricsCDIMetadata.isSuccesfulActivation()) {
+        if (!smallryeMetricsCDIMetadata.isSuccessfulActivation()) {
             return;
         }
 
@@ -127,7 +127,7 @@ public class SharedMetricRegistries {
          * Unsuccessful activation. SmallRye and Micrometer classes were not loaded
          * properly.
          */
-        if (!smallryeMetricsCDIMetadata.isSuccesfulActivation()) {
+        if (!smallryeMetricsCDIMetadata.isSuccessfulActivation()) {
             return null;
         }
 

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/ApplicationListener50.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/ApplicationListener50.java
@@ -14,6 +14,7 @@ package io.openliberty.microprofile.metrics50.internal;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.osgi.service.component.annotations.Component;
@@ -59,9 +60,23 @@ public class ApplicationListener50 implements ApplicationStateListener {
     @Override
     public void applicationStopped(ApplicationInfo appInfo) {
 
-        MetricRegistry[] registryArray = new MetricRegistry[] {
-                sharedMetricRegistry.getOrCreate(MetricRegistry.APPLICATION_SCOPE),
-                sharedMetricRegistry.getOrCreate(MetricRegistry.BASE_SCOPE) };
+        Set<String> scopeNamesSet = sharedMetricRegistry.getMetricRegistryScopeNames();
+        if (scopeNamesSet.contains(MetricRegistry.VENDOR_SCOPE)) {
+            scopeNamesSet.remove(MetricRegistry.VENDOR_SCOPE);
+        } else if (!scopeNamesSet.contains(MetricRegistry.APPLICATION_SCOPE)) {
+            scopeNamesSet.add(MetricRegistry.APPLICATION_SCOPE);
+        } else if (!scopeNamesSet.contains(MetricRegistry.BASE_SCOPE)) {
+            scopeNamesSet.add(MetricRegistry.BASE_SCOPE);
+        }
+
+        MetricRegistry[] registryArray = new MetricRegistry[scopeNamesSet.size()];
+
+        int i = 0;
+        for (String scope : scopeNamesSet) {
+            registryArray[i] = sharedMetricRegistry.getOrCreate(scope);
+            i++;
+        }
+
         for (MetricRegistry registry : registryArray) {
             if (Util.SR_LEGACY_METRIC_REGISTRY_CLASS.isInstance(registry)) {
                 try {

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/SmallryeMetricsCDIMetadata.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/SmallryeMetricsCDIMetadata.java
@@ -76,7 +76,7 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
 
     private ClassLoadingService classLoadingService;
     private volatile Library sharedLib = null;
-    private static boolean isSuccesfulActivation = true;
+    private static boolean isSuccessfulActivation = true;
     private MetricsConfig metricsConfig;
 
     /**
@@ -91,8 +91,8 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
      *
      * @return boolean did SmallryeMetricsCDIMetadata activate properly
      */
-    public boolean isSuccesfulActivation() {
-        return isSuccesfulActivation;
+    public boolean isSuccessfulActivation() {
+        return isSuccessfulActivation;
     }
 
     @Modified
@@ -110,7 +110,7 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
         try {
             smallRyeMetricsJarFile = resolveSmallRyeMetricsJar();
         } catch (FileNotFoundException e) {
-            isSuccesfulActivation = false;
+            isSuccessfulActivation = false;
             return;
         }
 
@@ -128,7 +128,7 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
                 File micrometerJarFile = resolveMicrometerJar();
                 classPath.add(micrometerJarFile);
             } catch (FileNotFoundException e) {
-                isSuccesfulActivation = false;
+                isSuccessfulActivation = false;
                 return;
             }
         }
@@ -142,14 +142,14 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
              * Probable cause: Bundle add-on class-loader was null
              */
             Tr.error(tc, "nullBundleAddOnClassLoader.error.CWMMC0011E");
-            isSuccesfulActivation = false;
+            isSuccessfulActivation = false;
         } catch (ClassNotFoundException e) { // for loadSmallRyeClasses()
             /*
              * Probable cause: classes that need to be loaded from embedded SmallRye Metrics
              * JAR are missing
              */
             Tr.error(tc, "missingSmallRyeClasses.error.CWMMC0012E");
-            isSuccesfulActivation = false;
+            isSuccessfulActivation = false;
         } catch (NoClassDefFoundError e) {
             /*
              * Probable cause: Missing dependent class(es) during runtime initialization.
@@ -163,7 +163,7 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
              */
 
             Tr.error(tc, "missingDependencyClasses.error.CWMMC0013E");
-            isSuccesfulActivation = false;
+            isSuccessfulActivation = false;
         }
     }
 
@@ -173,7 +173,7 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
          * If activation did not complete properly, we should prevent CDI extension
          * registration.
          */
-        if (!isSuccesfulActivation) {
+        if (!isSuccessfulActivation) {
             return null;
         }
         Set<Class<? extends Extension>> extensions = new HashSet<Class<? extends Extension>>();

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/smallrye/metrics/adapters/SRSharedMetricRegistriesAdapter.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/smallrye/metrics/adapters/SRSharedMetricRegistriesAdapter.java
@@ -145,7 +145,7 @@ public class SRSharedMetricRegistriesAdapter {
             if (setAppNameResolverMethod == null) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc,
-                            "Unable to load by reflection the expected SharedMetricRegistries.setVendorAppNameResolverMethod(AppNameResolver) method");
+                            "Unable to load by reflection the expected SharedMetricRegistries.setAppNameResolver(AppNameResolver) method");
                 }
             }
         }

--- a/dev/io.openliberty.microprofile.metrics.5.0.private.internal/src/io/openliberty/microprofile/metrics/internal/privateapi/PrivateMetricsRESTHandler.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.private.internal/src/io/openliberty/microprofile/metrics/internal/privateapi/PrivateMetricsRESTHandler.java
@@ -49,6 +49,9 @@ public class PrivateMetricsRESTHandler extends MetricRESTHandler {
         for (String registry : Constants.REGISTRY_NAMES_LIST) {
             sharedMetricRegistry.getOrCreate(registry);
         }
+        
+        sharedMetricRegistry.setAppNameResolver();
+        
         Util.SHARED_METRIC_REGISTRIES = sharedMetricRegistry;
 
     }

--- a/dev/io.openliberty.microprofile.metrics.5.0.public.internal/src/io/openliberty/microprofile/metrics/internal/publicapi/PublicMetricsRESTHandler.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.public.internal/src/io/openliberty/microprofile/metrics/internal/publicapi/PublicMetricsRESTHandler.java
@@ -48,6 +48,9 @@ public class PublicMetricsRESTHandler extends MetricRESTHandler {
         for (String registry : Constants.REGISTRY_NAMES_LIST) {
             sharedMetricRegistry.getOrCreate(registry);
         }
+        
+        sharedMetricRegistry.setAppNameResolver();
+        
         Util.SHARED_METRIC_REGISTRIES = sharedMetricRegistry;
     }
 


### PR DESCRIPTION
Fixes #25878 and #25879

#build


Updates the `mpMetrics-5.0` to pull in the `5.0.1` SmallRye Metrics Implementation.

The new release has an updated API allowing for retrieval for scope names from the SharedMetricRegistries and a method for providing an `ApplicationNameResolver` explicitly.

Also see: https://github.com/smallrye/smallrye-metrics/pull/621