### PR TITLE
Move bouncycastle bundles into a private feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.wss4j-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.wss4j-2.3.feature
@@ -18,9 +18,6 @@ singleton=true
  com.ibm.ws.org.apache.neethi.3.1.1, \
  com.ibm.ws.org.joda.time.2.9.9, \
  com.ibm.ws.org.opensaml.opensaml.core.3.4.5, \
- com.ibm.ws.net.shibboleth.utilities.java.support.7.5.1, \
- io.openliberty.org.bouncycastle.bcpkix-jdk18on, \
- io.openliberty.org.bouncycastle.bcprov-jdk18on, \
- io.openliberty.org.bouncycastle.bcutil-jdk18on
+ com.ibm.ws.net.shibboleth.utilities.java.support.7.5.1
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.bouncycastle.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.bouncycastle.feature
@@ -1,0 +1,10 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.org.bouncycastle
+WLP-DisableAllFeatures-OnConflict: false
+-bundles= \
+ io.openliberty.org.bouncycastle.bcpkix-jdk18on, \
+ io.openliberty.org.bouncycastle.bcprov-jdk18on, \
+ io.openliberty.org.bouncycastle.bcutil-jdk18on
+kind=ga
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.samlWeb2.0.internal.ee9.opensaml-3.4.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.samlWeb2.0.internal.ee9.opensaml-3.4.feature
@@ -14,9 +14,6 @@ singleton=true
   com.ibm.ws.org.opensaml.opensaml.messaging.api.3.4.5.jakarta, \
   com.ibm.ws.org.opensaml.opensaml.messaging.impl.3.4.5.jakarta, \
   com.ibm.ws.org.opensaml.opensaml.storage.api.3.4.5.jakarta, \
-  com.ibm.ws.security.saml.websso.2.0.jakarta, \
-  io.openliberty.org.bouncycastle.bcpkix-jdk18on, \
-  io.openliberty.org.bouncycastle.bcprov-jdk18on, \
-  io.openliberty.org.bouncycastle.bcutil-jdk18on
+  com.ibm.ws.security.saml.websso.2.0.jakarta
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.samlWeb2.0.internal.opensaml-3.4.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.samlWeb2.0.internal.opensaml-3.4.feature
@@ -13,9 +13,6 @@ singleton=true
   com.ibm.ws.org.opensaml.opensaml.messaging.api.3.4.5, \
   com.ibm.ws.org.opensaml.opensaml.messaging.impl.3.4.5, \
   com.ibm.ws.org.opensaml.opensaml.storage.api.3.4.5, \
-  com.ibm.ws.security.saml.websso.2.0, \
-  io.openliberty.org.bouncycastle.bcpkix-jdk18on, \
-  io.openliberty.org.bouncycastle.bcprov-jdk18on, \
-  io.openliberty.org.bouncycastle.bcutil-jdk18on
+  com.ibm.ws.security.saml.websso.2.0
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wss4j-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wss4j-2.3.feature
@@ -17,9 +17,6 @@ singleton=true
  com.ibm.ws.org.apache.neethi.3.1.1, \
  com.ibm.ws.org.joda.time.2.9.9, \
  com.ibm.ws.org.opensaml.opensaml.core.3.4.5.jakarta, \
- com.ibm.ws.net.shibboleth.utilities.java.support.7.5.1.jakarta, \
- io.openliberty.org.bouncycastle.bcpkix-jdk18on, \
- io.openliberty.org.bouncycastle.bcprov-jdk18on, \
- io.openliberty.org.bouncycastle.bcutil-jdk18on
+ com.ibm.ws.net.shibboleth.utilities.java.support.7.5.1.jakarta
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/acmeCA-2.0/com.ibm.websphere.appserver.acmeCA-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/acmeCA-2.0/com.ibm.websphere.appserver.acmeCA-2.0.feature
@@ -10,10 +10,7 @@ Subsystem-Name: Automatic Certificate Management Environment (ACME) Support 2.0
   com.ibm.websphere.appserver.restHandler-1.0, \
   com.ibm.websphere.appserver.servlet-4.0; ibm.tolerates:="3.1,5.0,6.0,6.1", \
   io.openliberty.acmeCA2.0.internal.ee-7.0; ibm.tolerates:="9.0", \
-  com.ibm.websphere.appserver.transportSecurity-1.0
--bundles=\
-  io.openliberty.org.bouncycastle.bcpkix-jdk18on, \
-  io.openliberty.org.bouncycastle.bcprov-jdk18on, \
-  io.openliberty.org.bouncycastle.bcutil-jdk18on
+  com.ibm.websphere.appserver.transportSecurity-1.0, \
+  io.openliberty.org.bouncycastle
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/samlWeb-2.0/com.ibm.websphere.appserver.samlWeb-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/samlWeb-2.0/com.ibm.websphere.appserver.samlWeb-2.0.feature
@@ -7,7 +7,8 @@ Subsystem-Name: SAML Web Single Sign-On 2.0
 -features=io.openliberty.samlWeb2.0.internal.ee-6.0; ibm.tolerates:="9.0, 10.0, 11.0", \
   com.ibm.wsspi.appserver.webBundleSecurity-1.0, \
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1", \
-  com.ibm.websphere.appserver.ssoCommon-1.0
+  com.ibm.websphere.appserver.ssoCommon-1.0, \
+  io.openliberty.org.bouncycastle
 -bundles=\
   io.openliberty.org.apache.commons.logging, \
   com.ibm.json4j, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/wsSecurity-1.1/com.ibm.websphere.appserver.wsSecurity-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/wsSecurity-1.1/com.ibm.websphere.appserver.wsSecurity-1.1.feature
@@ -12,7 +12,8 @@ IBM-ShortName: wsSecurity-1.1
 Subsystem-Name: Web Service Security 1.1
 -features=io.openliberty.servlet.api-3.0; apiJar=false; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1", \
   com.ibm.websphere.appserver.ssoCommon-1.0, \
-  io.openliberty.wsSecurity1.1.internal.jaxws-2.2; ibm.tolerates:="3.0,4.0,11.0"
+  io.openliberty.wsSecurity1.1.internal.jaxws-2.2; ibm.tolerates:="3.0,4.0,11.0", \
+  io.openliberty.org.bouncycastle
 -bundles=\
   io.openliberty.org.apache.commons.logging
 kind=ga


### PR DESCRIPTION
- Create io.openliberty.org.bouncycastle private feature
- Update features to depend on the private features instead of listing the bundles in each feature
- Move the bouncycastle dependency into the main feature instead of the private features since there is no difference for the different EE levels on use of bouncycastle
