### PR TITLE
Issue #25834: CWWKM0483I is for Jakarta EE features only

### DIFF
--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/annocache/internal/AnnotationsAdapterImpl.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/annocache/internal/AnnotationsAdapterImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,16 +12,19 @@
  *******************************************************************************/
 package com.ibm.ws.container.service.annocache.internal;
 
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-
-import com.ibm.wsspi.artifact.overlay.OverlayContainer;
-
+import com.ibm.ws.javaee.version.JavaEEVersion;
 import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
-
 import com.ibm.wsspi.annocache.service.AnnotationCacheService_Service;
+import com.ibm.wsspi.artifact.overlay.OverlayContainer;
 
 /**
  * Common annotations adapter code.
@@ -30,7 +33,66 @@ public abstract class AnnotationsAdapterImpl {
     public static final TraceComponent tc = Tr.register(AnnotationsAdapterImpl.class);
     // private static final String CLASS_NAME = AnnotationsAdapterImpl.class.getSimpleName();
 
-    //
+    /**
+     * Jakarta EE version if Jakarta EE 9 or higher. If 0, assume a lesser EE spec version.
+     */
+    protected volatile int eeVersion;
+
+    /**
+     * Tracks the most recently bound EE version service reference. Only use this within the set/unsetEEVersion methods.
+     */
+    private ServiceReference<JavaEEVersion> eeVersionRef;
+
+    /**
+     * Declarative Services method for setting the Jakarta/Java EE version
+     *
+     * @param ref reference to the service
+     */
+    @Reference(service = JavaEEVersion.class,
+               cardinality = ReferenceCardinality.OPTIONAL,
+               policy = ReferencePolicy.DYNAMIC,
+               policyOption = ReferencePolicyOption.GREEDY)
+    protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
+        String version = (String) ref.getProperty("version");
+        if (version == null) {
+            eeVersion = 0;
+        } else {
+            int dot = version.indexOf('.');
+            String major = dot > 0 ? version.substring(0, dot) : version;
+            eeVersion = Integer.parseInt(major);
+        }
+        eeVersionRef = ref;
+    }
+
+    /**
+     * Declarative Services method for unsetting the Jakarta/Java EE version
+     *
+     * @param ref reference to the service
+     */
+    protected void unsetEEVersion(ServiceReference<JavaEEVersion> ref) {
+        if (eeVersionRef == ref) {
+            eeVersionRef = null;
+            eeVersion = 0;
+        }
+    }
+
+    private ServiceReference<JavaEEVersion> versionRef;
+    protected volatile Version platformVersion = JavaEEVersion.DEFAULT_VERSION;
+
+    @Reference(service = JavaEEVersion.class,
+               cardinality = ReferenceCardinality.OPTIONAL,
+               policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    protected synchronized void setVersion(ServiceReference<JavaEEVersion> reference) {
+        versionRef = reference;
+        platformVersion = Version.parseVersion((String) reference.getProperty("version"));
+    }
+
+    protected synchronized void unsetVersion(ServiceReference<JavaEEVersion> reference) {
+        if (reference == this.versionRef) {
+            versionRef = null;
+            platformVersion = JavaEEVersion.DEFAULT_VERSION;
+        }
+    }
 
     @Reference(service=AnnotationCacheService_Service.class)
     protected AnnotationCacheService_Service annoCacheService;

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/annocache/internal/AnnotationsImpl.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/annocache/internal/AnnotationsImpl.java
@@ -13,7 +13,6 @@
 package com.ibm.ws.container.service.annocache.internal;
 
 import java.net.URL;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -23,15 +22,11 @@ import java.util.TreeSet;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
-
-import com.ibm.wsspi.artifact.ArtifactContainer;
-import com.ibm.wsspi.artifact.ArtifactEntry;
-import com.ibm.wsspi.artifact.overlay.OverlayContainer;
-
+import com.ibm.ws.container.service.annocache.Annotations;
+import com.ibm.ws.container.service.annocache.SpecificAnnotations;
 import com.ibm.wsspi.adaptable.module.Container;
 import com.ibm.wsspi.adaptable.module.Entry;
 import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
-
 import com.ibm.wsspi.annocache.classsource.ClassSource_Aggregate;
 import com.ibm.wsspi.annocache.classsource.ClassSource_Aggregate.ScanPolicy;
 import com.ibm.wsspi.annocache.classsource.ClassSource_ClassLoader;
@@ -47,10 +42,9 @@ import com.ibm.wsspi.annocache.service.AnnotationCacheService_Service;
 import com.ibm.wsspi.annocache.targets.AnnotationTargets_Exception;
 import com.ibm.wsspi.annocache.targets.AnnotationTargets_Factory;
 import com.ibm.wsspi.annocache.targets.AnnotationTargets_Targets;
-
-import com.ibm.ws.container.service.annocache.Annotations;
-import com.ibm.ws.container.service.annocache.SpecificAnnotations;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.wsspi.artifact.ArtifactContainer;
+import com.ibm.wsspi.artifact.ArtifactEntry;
+import com.ibm.wsspi.artifact.overlay.OverlayContainer;
 
 /**
  * Common annotations code.
@@ -69,10 +63,10 @@ public abstract class AnnotationsImpl implements Annotations {
 
     /**
      * Data from a path lookup.
-     * 
+     *
      * When finding the full path above a specified container, tell where
      * a given parent container is relative to the initial container.
-     * 
+     *
      * Set the span values to -1 if the parent container is not a parent
      * of the specified container.
      */
@@ -110,7 +104,7 @@ public abstract class AnnotationsImpl implements Annotations {
 
     /**
      * Obtain the full path to a specified container.
-     * 
+     *
      * Return data which indicates whether the path reaches above
      * a specified parent container.
      *
@@ -119,7 +113,7 @@ public abstract class AnnotationsImpl implements Annotations {
      *
      * @return Path data for the container.
      *
-     * @throws UnableToAdaptException Thrown if traversal from the containre
+     * @throws UnableToAdaptException Thrown if traversal from the container
      *     to its parents fails.
      */
     public static PathData getPathData(
@@ -219,7 +213,7 @@ public abstract class AnnotationsImpl implements Annotations {
             return null; // FFDC
         }
         if ( tc.isDebugEnabled() ) {
-        	Tr.debug(tc, "Module Delegate [ " + modDelegate + " ]");
+                Tr.debug(tc, "Module Delegate [ " + modDelegate + " ]");
         }
 
         ArtifactContainer targetDelegate;
@@ -233,10 +227,10 @@ public abstract class AnnotationsImpl implements Annotations {
         }
 
         ArtifactContainer rootOfRootsModDelegate = getRootOfRoots(modDelegate);
-    	ArtifactContainer rootOfRootsTargetDelegate = getRootOfRoots(targetDelegate);
+        ArtifactContainer rootOfRootsTargetDelegate = getRootOfRoots(targetDelegate);
         if ( tc.isDebugEnabled() ) {
-        	Tr.debug(tc, "Module Delegate Root-of-roots [ " + rootOfRootsModDelegate + " ]");
-        	Tr.debug(tc, "Target Delegate Root-of-roots[ " + rootOfRootsTargetDelegate + " ]");
+                Tr.debug(tc, "Module Delegate Root-of-roots [ " + rootOfRootsModDelegate + " ]");
+                Tr.debug(tc, "Target Delegate Root-of-roots[ " + rootOfRootsTargetDelegate + " ]");
         }
 
         String targetPathCase;
@@ -284,7 +278,7 @@ public abstract class AnnotationsImpl implements Annotations {
     }
 
     //
-    
+
     @SuppressWarnings("unchecked")
     protected static <T> T cacheGet(
         OverlayContainer container,
@@ -330,7 +324,7 @@ public abstract class AnnotationsImpl implements Annotations {
      *     naming from occurring. 
      * @param modName The name of the enclosing module.  Null if there is no enclosing module.
      * @param modCatName A category name for the module.  Used to enable multiple results for
-     *     ths same module.
+     *     the same module.
      */
     public AnnotationsImpl(
         AnnotationsAdapterImpl annotationsAdapter,
@@ -556,7 +550,7 @@ public abstract class AnnotationsImpl implements Annotations {
     }
 
     private final String modCatName;
-    
+
     @Override
     public String getModCategoryName() {
         return modCatName;
@@ -709,7 +703,7 @@ public abstract class AnnotationsImpl implements Annotations {
             Tr.debug(tc, message1);
             Tr.debug(tc, message2);
         }
-        
+
         try {
             return classSourceFactory.createAggregateClassSource(
                 useAppName, useModName, useModCatName,
@@ -744,46 +738,28 @@ public abstract class AnnotationsImpl implements Annotations {
     }
 
     /**
-     * Determine if the Jakarta EE Common Annotations APIs are enabled for the classloader
-     * of the current container.
-     *
-     * @return true if the Jakarta EE Common Annotations APIs are enabled, otherwise false.
-     */
-    @Trivial
-    @FFDCIgnore(ClassNotFoundException.class)
-    private boolean jakartaCommonAnnotationAPIs() {
-        if (classLoader == null) {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Jakarta Common Annotations not present - ClassLoader not set");
-            }
-            return false;
-        }
-        try {
-            classLoader.loadClass(JAKARTA_RESOURCE);
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Jakarta Common Annotations present");
-            }
-            return true;
-        } catch (ClassNotFoundException e) {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Jakarta Common Annotations not present");
-            }
-            return false;
-        }
-    }
-
-    /**
      * Check for use of the wrong package (javax.annotation instead of jakarta.annotation)
      * for the Jakarta Common Annotation APIs where the "javax" version of the annotations
      * were previously included in the JDK. An informational message will be logged to
      * the console for each annotation type found.
      *
-     * @param targets the scanned annotation targets for the current container
+     * @param targets      the scanned annotation targets for the current container
      * @param scanPolicies The policies for which to select annotated classes, as bitwise
-     *            OR of scan policy values.
+     *                         OR of scan policy values.
      */
     private void checkForWrongPackageCommonAnnotations(AnnotationTargets_Targets targets, int scanPolicies) {
-        if (modName == null || !jakartaCommonAnnotationAPIs()) {
+        // Only check EJB and Web modules (non-null module name and classloader)
+        if (classLoader == null || modName == null) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Skip wrong package check - not an EJB or Web module");
+            }
+            return;
+        }
+        // Only check when EE 9+ (jakarta package) features are enabled
+        if (annotationsAdapter.eeVersion < 9) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Skip wrong package check - Jakarta features not enabled : eeVersion = " + annotationsAdapter.eeVersion);
+            }
             return;
         }
 


### PR DESCRIPTION
The message CWWKM0483I is intended to be logged when an application contains a `javax` package injection annotation but is running in a server with `jakarta` package features. Unfortunately this message is also being logged even when not using `jakarta` package features if an application or shared library includes the `jakarta` package annotations. For this scenario, the message causes confusion since it suggests to change the application to use the wrong package annotation.

The code that logs the message will be updated to check whether Jakarta EE features are enabled rather than just looking to see if a `jakarta` package annotation class may be loaded. The message will only be logged for the intended purpose.

fixes #25834 