### PR TITLE
Avoid reactivating when optional CDIJSFInitializer service goes away

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2/bnd.bnd
+++ b/dev/com.ibm.ws.jsf.2.2/bnd.bnd
@@ -39,6 +39,7 @@ Service-Component: \
     cdiJSFInitializerService=com.ibm.ws.jsf.shared.cdi.CDIJSFInitializer; \
     greedy:="cdiJSFInitializerService"; \
     optional:="cdiJSFInitializerService"; \
+    dynamic:="cdiJSFInitializerService"; \
     properties:="service.vendor=IBM", \
   com.ibm.ws.jsf_2_2.taglib; \
     implementation:=com.ibm.ws.jsf.extprocessor.JSFGlobalTagLibConfig; \

--- a/dev/io.openliberty.faces.4.0.internal/bnd.bnd
+++ b/dev/io.openliberty.faces.4.0.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.faces.4.0.internal/bnd.bnd
+++ b/dev/io.openliberty.faces.4.0.internal/bnd.bnd
@@ -41,6 +41,7 @@ Service-Component: \
         cdiJSFInitializerService=com.ibm.ws.jsf.shared.cdi.CDIJSFInitializer; \
         greedy:="cdiJSFInitializerService"; \
         optional:="cdiJSFInitializerService"; \
+        dynamic:="cdiJSFInitializerService"; \
         properties:="service.vendor=IBM", \
     io.openliberty.myfaces_4_0.initializer; \
         implementation:=io.openliberty.faces40.internal.ee.WASMyFacesContainerInitializer; \

--- a/dev/io.openliberty.faces.internal/bnd.bnd
+++ b/dev/io.openliberty.faces.internal/bnd.bnd
@@ -37,6 +37,7 @@ Service-Component: \
     cdiJSFInitializerService=com.ibm.ws.jsf.shared.cdi.CDIJSFInitializer; \
     greedy:="cdiJSFInitializerService"; \
     optional:="cdiJSFInitializerService"; \
+    dynamic:="cdiJSFInitializerService"; \
     properties:="service.vendor=IBM", \
   io.openliberty.myfaces.initializer; \
     implementation:=com.ibm.ws.jsf.ee.WASMyFacesContainerInitializer; \

--- a/dev/io.openliberty.faces.internal/bnd.bnd
+++ b/dev/io.openliberty.faces.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at


### PR DESCRIPTION
Avoid reactivation of com.ibm.wsspi.webcontainer.extension.ExtensionFactory service implementations to avoid causing the WebContainer to be reactivated during startup.

