### PR TITLE
Deal with servlet 6 slash behaviour in FileHandler

### DIFF
--- a/dev/com.ibm.ws.jmx.connector.server.rest/src/com/ibm/ws/jmx/connector/server/rest/handlers/FileHandler.java
+++ b/dev/com.ibm.ws.jmx.connector.server.rest/src/com/ibm/ws/jmx/connector/server/rest/handlers/FileHandler.java
@@ -101,6 +101,7 @@ public class FileHandler implements RESTHandler {
 
     private void download(RESTRequest request, RESTResponse response) {
         String filePath = RESTHelper.getRequiredParam(request, APIConstants.PARAM_FILEPATH);
+        filePath = RESTHelper.repairSlashes(filePath, request);
         String startOffsetValue = RESTHelper.getQueryParam(request, APIConstants.PARAM_START_OFFSET);
         String endOffsetValue = RESTHelper.getQueryParam(request, APIConstants.PARAM_END_OFFSET);
 
@@ -188,6 +189,7 @@ public class FileHandler implements RESTHandler {
         }
         if (filePath == null && !nodeDeployment) {
             filePath = RESTHelper.getRequiredParam(request, APIConstants.PARAM_FILEPATH);
+            filePath = RESTHelper.repairSlashes(filePath, request);
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "file path: " + filePath);
             }
@@ -257,6 +259,7 @@ public class FileHandler implements RESTHandler {
 
     private void delete(RESTRequest request, RESTResponse response) {
         String filePath = RESTHelper.getRequiredParam(request, APIConstants.PARAM_FILEPATH);
+        filePath = RESTHelper.repairSlashes(filePath, request);
         String recursiveDelete = RESTHelper.getQueryParam(request, APIConstants.PARAM_RECURSIVE_DELETE);
 
         final boolean recursive = recursiveDelete != null && "true".compareToIgnoreCase(recursiveDelete) == 0;

--- a/dev/com.ibm.ws.jmx.connector.server.rest/src/com/ibm/ws/jmx/connector/server/rest/helpers/RESTHelper.java
+++ b/dev/com.ibm.ws.jmx.connector.server.rest/src/com/ibm/ws/jmx/connector/server/rest/helpers/RESTHelper.java
@@ -366,13 +366,19 @@ public class RESTHelper {
         }
         JSONConverter converter = JSONConverter.getConverter();
         String decodedURI = RESTHelper.URLDecoder(request.getURI(), converter);
-        String regexPattern = "\\Q" + objectName.replaceAll("/", "\\\\E/+\\\\Q") + "\\E";
+        String regexPattern = "/*" + "\\Q" + objectName.replaceAll("/", "\\\\E/+\\\\Q") + "\\E";
         Pattern pattern = Pattern.compile(regexPattern);
         Matcher matcher = pattern.matcher(decodedURI);
         boolean matchFound = matcher.find();
         if (matchFound) {
-            // The group is in fact what we want, it is the new version of objectName
-            return matcher.group();
+            // The group is what we want, it is the version of objectName from the original URI
+            // without the collapsed slashes. 
+            // May need to might trim off an initial '/' as the URI path separator '/' is matched by the regex
+            String newName = matcher.group();
+            if (newName.charAt(0) == '/') {
+                return newName.substring(1);
+            }
+            return newName;
         } 
         // This shouldn't happen. The regex should at least match the original object
         // name in the URI. It's unsafe to continue as there is no obvious way to

--- a/dev/com.ibm.ws.jmx.connector.server.rest/test/com/ibm/ws/jmx/connector/server/rest/helpers/RESTHelperTest.java
+++ b/dev/com.ibm.ws.jmx.connector.server.rest/test/com/ibm/ws/jmx/connector/server/rest/helpers/RESTHelperTest.java
@@ -67,10 +67,14 @@ public class RESTHelperTest {
         assertEquals("com.foo.mybean/with//slash:foo=bar", RESTHelper.repairSlashes("com.foo.mybean/with/slash:foo=bar", new RESTRequestTestImpl(" https://9.20.198.170:9443/IBMJMXConnectorREST/mbeans/com.foo.mybean/with//slash:foo=bar/seg1/seg2")));
         assertEquals("com.foo.mybean/with//slash:foo=bar", RESTHelper.repairSlashes("com.foo.mybean/with/slash:foo=bar", new RESTRequestTestImpl(" https://9.20.198.170:9443/IBMJMXConnectorREST/mbeans/com.foo.mybean%2Fwith%2F%2Fslash%3Afoo%3Dbar/seg1/seg2")));
 
-        // Tests with more thatn 2 repeated slashes
+        // Tests with more than 2 repeated slashes
         assertEquals("com.foo.mybean/with///slash:foo=bar", RESTHelper.repairSlashes("com.foo.mybean/with/slash:foo=bar", new RESTRequestTestImpl(" https://9.20.198.170:9443/IBMJMXConnectorREST/mbeans/com.foo.mybean/with///slash:foo=bar")));
         assertEquals("com.foo.mybean//with///slash:foo=bar", RESTHelper.repairSlashes("com.foo.mybean/with/slash:foo=bar", new RESTRequestTestImpl(" https://9.20.198.170:9443/IBMJMXConnectorREST/mbeans/com.foo.mybean%2F%2Fwith%2F%2F%2Fslash%3Afoo%3Dbar")));
 
+        // Tests with leading slashes
+        assertEquals("/home/bob/wlp/foo.xsd", RESTHelper.repairSlashes("home/bob/wlp/foo.xsd", new RESTRequestTestImpl("https://:password@liberty.ibm.com:9447/IBMJMXConnectorREST/file//home/bob/wlp/foo.xsd")));
+        assertEquals("/home/bob/wlp/foo.xsd/", RESTHelper.repairSlashes("home/bob/wlp/foo.xsd/", new RESTRequestTestImpl("https://:password@liberty.ibm.com:9447/IBMJMXConnectorREST/file//home/bob/wlp/foo.xsd/")));
+        assertEquals("/home/bob//wlp/foo.xsd//", RESTHelper.repairSlashes("home/bob/wlp/foo.xsd/", new RESTRequestTestImpl("https://:password@liberty.ibm.com:9447/IBMJMXConnectorREST/file//home/bob//wlp/foo.xsd//")));
  
         // Tests for fail cases.
         // There is only one case, which is where the object name can't be found in the request URI. It


### PR DESCRIPTION
Only for download and delete at the moment.

This is a further follow up on the issues raised by #23570