### PR TITLE
validation of entities on update and return types for saveAll

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1825,7 +1825,12 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             for (int i = 0; i < length; i++)
                                 results.add(em.merge(toEntity(Array.get(a, i))));
                             em.flush();
-                            returnValue = results;
+                            if (queryInfo.returnArrayType == null) {
+                                returnValue = results;
+                            } else {
+                                Object[] newArray = (Object[]) Array.newInstance(queryInfo.returnArrayType, length);
+                                returnValue = results.toArray(newArray);
+                            }
                         } else if (Iterable.class.isAssignableFrom(queryInfo.saveParamType)) {
                             if (validator != null)
                                 validator.validate((Iterable<?>) args[0]);
@@ -1833,7 +1838,12 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             for (Object e : ((Iterable<?>) args[0]))
                                 results.add(em.merge(toEntity(e)));
                             em.flush();
-                            returnValue = results;
+                            if (queryInfo.returnArrayType == null) {
+                                returnValue = results;
+                            } else {
+                                Object[] newArray = (Object[]) Array.newInstance(queryInfo.returnArrayType, results.size());
+                                returnValue = results.toArray(newArray);
+                            }
                         } else {
                             if (validator != null && args[0] != null)
                                 validator.validate(args[0]);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
@@ -63,7 +63,7 @@ public interface Counties {
 
     boolean remove(County c);
 
-    void save(County... c);
+    Stream<County> save(County... c);
 
     boolean updateByNameSetZipCodes(String name, int... zipcodes);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2095,7 +2095,10 @@ public class DataJPATestServlet extends FATServlet {
         County wabasha = new County("Wabasha", "Minnesota", 21387, wabashaZipCodes, "Wabasha", "Bellechester", "Elgin", "Hammond", "Kellogg", "Lake City", "Mazeppa", "Millville", "Minneiska", "Plainview", "Zumbro Falls");
         County fillmore = new County("Fillmore", "Minnesota", 21228, fillmoreZipCodes, "Preston", "Canton", "Chatfield", "Fountain", "Harmony", "Lanesboro", "Mabel", "Ostrander", "Peterson", "Rushford", "Rushford Village", "Spring Valley", "Whalen", "Wykoff");
 
-        counties.save(olmsted, winona, wabasha, fillmore);
+        Stream<County> saved = counties.save(olmsted, winona, wabasha, fillmore);
+
+        assertEquals(List.of("Olmsted", "Winona", "Wabasha", "Fillmore"),
+                     saved.map(s -> s.name).collect(Collectors.toList()));
 
         // find one entity by id as Optional
         County c = counties.findByName("Olmsted").orElseThrow();

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Streamable;
 
 /**
  *
@@ -37,7 +38,7 @@ public interface Employees {
     @OrderBy("badge")
     Stream<Badge> findByLastName(String lastName);
 
-    void save(Employee e);
+    Streamable<Employee> save(Employee... e);
 
     // "IN" is not supported for embeddables, but EclipseLink generates SQL that leads to an SQLDataException rather than rejecting outright
     @Query("SELECT e FROM Employee e WHERE e.badge IN ?1")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ShippingAddresses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ShippingAddresses.java
@@ -13,6 +13,7 @@
 package test.jakarta.data.jpa.web;
 
 import java.util.List;
+import java.util.Set;
 
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
@@ -41,4 +42,6 @@ public interface ShippingAddresses {
     long removeAll();
 
     void save(ShippingAddress entity);
+
+    Set<ShippingAddress> save(Set<ShippingAddress> addresses);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/TaxPayers.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/TaxPayers.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -40,5 +41,7 @@ public interface TaxPayers extends DataRepository<TaxPayer, Long> {
     @OrderBy("ssn")
     Stream<TaxPayer> findByBankAccountsNotEmpty();
 
-    void save(TaxPayer... taxPayers);
+    Iterable<TaxPayer> save(Iterable<TaxPayer> taxPayers);
+
+    Iterator<TaxPayer> save(TaxPayer... taxPayers);
 }

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
@@ -75,7 +75,7 @@ public class DataValidationTestServlet extends FATServlet {
      * should be automatically validated.
      */
     @Test
-    public void testJakartaPersistenceAndValidation() {
+    public void testJakartaPersistenceAndValidation() throws Exception {
         Entitlement e = new Entitlement(3, "ACA", "person3@openliberty.io", Frequency.AS_NEEDED, 0, null, null, null);
         EntityManager em = emf.createEntityManager();
         try {
@@ -198,7 +198,7 @@ public class DataValidationTestServlet extends FATServlet {
         Entitlement[] e = new Entitlement[2];
         e[0] = new Entitlement(4, "US-SNAP", "person4@openliberty.io", Frequency.AS_NEEDED, 50, null, 23.00f, BigDecimal.valueOf(43.00f));
         e[1] = new Entitlement(5, "US-TANF", "person5@openliberty.io", Frequency.MONTHLY, 13, null, 1549.00f, BigDecimal.valueOf(5266.00f));
-        e = entitlements.save(e).toArray(new Entitlement[e.length]); // TODO code needs update to support array return type
+        e = entitlements.save(e);
 
         Set<?> violations = Collections.emptySet();
 
@@ -399,7 +399,7 @@ public class DataValidationTestServlet extends FATServlet {
         e[0] = new Entitlement(5, "US-SOCIALSECURITY", "person4@openliberty.io", Frequency.MONTHLY, 65, null, Float.valueOf(3100), BigDecimal.valueOf(4555));
         e[1] = new Entitlement(6, "US-SOCIALSECURITY", "person5@openliberty.io", Frequency.MONTHLY, 66, null, Float.valueOf(3100), BigDecimal.valueOf(4218));
         e[2] = new Entitlement(7, "US-SOCIALSECURITY", "person6@openliberty.io", Frequency.MONTHLY, 67, null, Float.valueOf(3100), BigDecimal.valueOf(3905));
-        e = entitlements.save(e).toArray(new Entitlement[e.length]); // TODO code needs update to support array return type
+        e = entitlements.save(e);
 
         Set<?> violations = Collections.emptySet();
         try {

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Entitlements.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Entitlements.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package test.jakarta.data.validation.web;
 
-import java.util.ArrayList;
 import java.util.Optional;
 
 import jakarta.data.repository.DataRepository;
@@ -28,5 +27,5 @@ public interface Entitlements extends DataRepository<Entitlement, Long> {
 
     void save(Entitlement e);
 
-    ArrayList<Entitlement> save(Entitlement[] e);
+    Entitlement[] save(Entitlement[] e);
 }

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Entitlements.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Entitlements.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package test.jakarta.data.validation.web;
 
+import java.util.ArrayList;
+import java.util.Optional;
+
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
 
@@ -20,5 +23,10 @@ import jakarta.data.repository.Repository;
  */
 @Repository(dataStore = "java:module/jdbc/DerbyDataSource")
 public interface Entitlements extends DataRepository<Entitlement, Long> {
+
+    Optional<Entitlement> findById(long id);
+
     void save(Entitlement e);
+
+    ArrayList<Entitlement> save(Entitlement[] e);
 }


### PR DESCRIPTION
Adds test cases for updates to JPA entities with validation constraints, for cases where the constraints are violated and not violated.  While working on this, I noticed that the save/saveAll operation doesn't all the full range of return types that are required by the Jakarta Data spec, so this pull also corrects that an adds testing.