### PR TITLE
Fix ServerLock testRunningServer method for WSL

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/ServerLock.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/ServerLock.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -560,7 +560,9 @@ public class ServerLock {
             FileOutputStream fos = new FileOutputStream(lockFile);
             lockFileChannel = fos.getChannel();
 
-            if (tryServerLock() && !FileUtils.isWSL()) {
+            // Removed check ( && !FileUtils.isWSL()).  It's not clear why it was added,
+            // but it was causing this method to always return true on WSL.
+            if (tryServerLock()) {
                 // we could obtain the server lock, server is not running
                 return false;
             }


### PR DESCRIPTION
Fixes #25782

The ServerLock.testRunningServer() method always returns **true** on Windows SubSystem for Linux (WSL), except when the .slock file doesn't exist.   For other platforms, there is an additional test to see if we can obtain the lock; returning **false** when the lock cannot be obtained.

With this fix, we also test if the lock can be obtained on WSL, and return **false** when it cannot.