### PR TITLE
Add repeats to Reactive Messaging Tests

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbTest.java
@@ -39,7 +39,7 @@ public class JsonbTest extends FATServletClient {
     public static final String SERVER_NAME = "SimpleRxMessagingServer";
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10);
 
     @Server(SERVER_NAME)
     @TestServlet(servlet = JsonbServlet.class, contextRoot = APP_NAME)

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,10 +12,13 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.fat.jsonb;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -35,6 +38,9 @@ public class JsonbTest extends FATServletClient {
     public static final String APP_NAME = "jsob-messaging";
     public static final String SERVER_NAME = "SimpleRxMessagingServer";
 
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
+
     @Server(SERVER_NAME)
     @TestServlet(servlet = JsonbServlet.class, contextRoot = APP_NAME)
     public static LibertyServer server;
@@ -42,7 +48,7 @@ public class JsonbTest extends FATServletClient {
     @BeforeClass
     public static void setup() throws Exception {
         WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
-                        .addPackage(JsonbBean.class.getPackage())
+                        .addPackage(JsonbServlet.class.getPackage())
                         .addClasses(AbstractReceptionBean.class, AbstractDeliveryBean.class);
 
         ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckTest.java
@@ -56,12 +56,12 @@ public class KafkaAutoAckTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
 
-        Map<String, String> connectionProps = PlaintextTests.connectionProperties();
+        Map<String, Object> connectionProps = PlaintextTests.connectionProperties();
 
         ConnectorProperties incomingConnection = ConnectorProperties.simpleIncomingChannel(connectionProps, KafkaAutoAckReceptionBean.CHANNEL_IN,
                                                                                            KafkaAutoAckTestServlet.APP_GROUPID);

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/containers/ExtendedKafkaContainer.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/containers/ExtendedKafkaContainer.java
@@ -97,6 +97,10 @@ public class ExtendedKafkaContainer extends GenericContainer<ExtendedKafkaContai
         return this;
     }
 
+    public String getListenerScheme(){
+        return this.listenerScheme;
+    }
+
     public ExtendedKafkaContainer withZookeeperJaasConfig(String zookeeperJaasConfig) {
         this.zookeeperJaasConfig = zookeeperJaasConfig;
         return this;

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
@@ -52,7 +52,7 @@ public class KafkaAcknowledgementTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/flatmap/KafkaFlatMapTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/flatmap/KafkaFlatMapTest.java
@@ -52,7 +52,7 @@ public class KafkaFlatMapTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/flatmap/KafkaFlatMapTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/flatmap/KafkaFlatMapTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaTestClientProvider.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaTestClientProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,11 +12,13 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.RequestScoped;
@@ -37,8 +39,8 @@ public class KafkaTestClientProvider {
     public static final String CONNECTION_PROPERTIES_KEY = "kafka-connection-properties";
 
     @Inject
-    @ConfigProperty(name = CONNECTION_PROPERTIES_KEY, defaultValue = "")
-    private List<String> connectionProps;
+    @ConfigProperty(name = CONNECTION_PROPERTIES_KEY)
+    private Optional<List<String>> connectionProps;
 
     @Produces
     @RequestScoped
@@ -52,7 +54,7 @@ public class KafkaTestClientProvider {
 
     private Map<String, String> getConnectionPropertiesMap() {
         HashMap<String, String> result = new HashMap<>();
-        Iterator<String> propsIterator = connectionProps.iterator();
+        Iterator<String> propsIterator = connectionProps.orElse(Collections.emptyList()).iterator();
         while (propsIterator.hasNext()) {
             String key = propsIterator.next();
             String value = propsIterator.next();

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,10 +25,13 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -56,9 +59,13 @@ public class KafkaBadConfigTest {
 
     private static final String APP_NAME = "KafkaBadConfig";
     private static final String APP_GROUP_ID = "bad-config-test-group";
+    private static final String SERVER_NAME = "SimpleRxMessagingServer";
 
-    @Server("SimpleRxMessagingServer")
+    @Server(SERVER_NAME)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -101,7 +108,12 @@ public class KafkaBadConfigTest {
 
         // Check that the bad config error was emitted
         List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1007E:", server.getDefaultLogFile());
-        assertThat(configErrorLines, hasSize(1));
+        //Due to logging changes older versions of OL emit the expected code less frequently
+        if(server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpReactiveMessaging-1.0")){
+            assertThat(configErrorLines, hasSize(1));
+        } else {
+            assertThat(configErrorLines, hasSize(4));
+        }
         String configErrorLine = configErrorLines.get(0);
         // ...and that it contained the channel name
         assertThat(configErrorLine, containsString(KafkaBadConfigIncomingBean.CHANNEL_NAME));
@@ -137,7 +149,12 @@ public class KafkaBadConfigTest {
 
         // Check that the bad config error was emitted
         List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1007E:", server.getDefaultLogFile());
-        assertThat(configErrorLines, hasSize(1));
+        //Due to logging changes older versions of OL emit the expected code less frequently
+        if(server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpReactiveMessaging-1.0")){
+            assertThat(configErrorLines, hasSize(1));
+        } else {
+            assertThat(configErrorLines, hasSize(2));
+        }
         String configErrorLine = configErrorLines.get(0);
         // ...and that it contained the channel name
         assertThat(configErrorLine, containsString(KafkaBadConfigIncomingBean.CHANNEL_NAME));
@@ -177,7 +194,12 @@ public class KafkaBadConfigTest {
 
         // Check that the bad config error was emitted
         List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1008E:", server.getDefaultLogFile());
-        assertThat(configErrorLines, hasSize(1));
+        //Due to logging changes older versions of OL emit the expected code less frequently
+        if(server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpReactiveMessaging-1.0")){
+            assertThat(configErrorLines, hasSize(1));
+        } else {
+            assertThat(configErrorLines, hasSize(4));
+        }
         String configErrorLine = configErrorLines.get(0);
         // ...and that it contained the channel name
         assertThat(configErrorLine, containsString(KafkaBadConfigOutgoingBean.CHANNEL_NAME));
@@ -214,7 +236,12 @@ public class KafkaBadConfigTest {
 
         // Check that the bad config error was emitted
         List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1008E:", server.getDefaultLogFile());
-        assertThat(configErrorLines, hasSize(1));
+        //Due to logging changes older versions of OL emit the targetted code less frequently
+        if(server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpReactiveMessaging-1.0")){
+            assertThat(configErrorLines, hasSize(1));
+        } else {
+            assertThat(configErrorLines, hasSize(2));
+        }
         String configErrorLine = configErrorLines.get(0);
         // ...and that it contained the channel name
         assertThat(configErrorLine, containsString(KafkaBadConfigOutgoingBean.CHANNEL_NAME));

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigTest.java
@@ -65,7 +65,7 @@ public class KafkaBadConfigTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -108,7 +108,7 @@ public class KafkaBadConfigTest {
 
         // Check that the bad config error was emitted
         List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1007E:", server.getDefaultLogFile());
-        //Due to logging changes older versions of OL emit the expected code less frequently
+        //Due to changes in CDI, older versions emit the expected code less frequently
         if(server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpReactiveMessaging-1.0")){
             assertThat(configErrorLines, hasSize(1));
         } else {
@@ -149,7 +149,7 @@ public class KafkaBadConfigTest {
 
         // Check that the bad config error was emitted
         List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1007E:", server.getDefaultLogFile());
-        //Due to logging changes older versions of OL emit the expected code less frequently
+        //Due to changes in CDI, older versions emit the expected code less frequently
         if(server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpReactiveMessaging-1.0")){
             assertThat(configErrorLines, hasSize(1));
         } else {
@@ -194,7 +194,7 @@ public class KafkaBadConfigTest {
 
         // Check that the bad config error was emitted
         List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1008E:", server.getDefaultLogFile());
-        //Due to logging changes older versions of OL emit the expected code less frequently
+        //Due to changes in CDI, older versions emit the expected code less frequently
         if(server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpReactiveMessaging-1.0")){
             assertThat(configErrorLines, hasSize(1));
         } else {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/nolib/KafkaNoLibTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/nolib/KafkaNoLibTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,10 +19,13 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.ka
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -43,9 +46,13 @@ public class KafkaNoLibTest {
 
     private static final String APP_NAME = "KafkaNoLib";
     private static final String APP_GROUP_ID = "no-lib-test-group";
+    private static final String SERVER_NAME = "SimpleRxMessagingServer";
 
-    @Server("SimpleRxMessagingServer")
+    @Server(SERVER_NAME)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/nolib/KafkaNoLibTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/nolib/KafkaNoLibTest.java
@@ -52,7 +52,7 @@ public class KafkaNoLibTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/LibertyLoginModuleTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/LibertyLoginModuleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,14 +18,19 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProp
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaClientLibs;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaPermissions;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.testcontainers.utility.Base58;
 
@@ -51,10 +56,14 @@ public class LibertyLoginModuleTest {
 
     private static final String APP_NAME = "kafkaLoginModuleTest";
     private static final String APP_GROUP_ID = "login-module-test-group";
+    private static final String SERVER_NAME = "SimpleRxMessagingServer";
 
-    @Server("SimpleRxMessagingServer")
+    @Server(SERVER_NAME)
     @TestServlet(contextRoot = APP_NAME, servlet = LibertyLoginModuleTestServlet.class)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -99,6 +108,11 @@ public class LibertyLoginModuleTest {
     @AfterClass
     public static void teardownTest() throws Exception {
         server.stopServer();
+    }
+
+    @AfterClass
+    public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
+        KafkaUtils.cleanKafka(SaslPlainTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/LibertyLoginModuleTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/LibertyLoginModuleTest.java
@@ -63,7 +63,7 @@ public class LibertyLoginModuleTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -112,7 +112,7 @@ public class LibertyLoginModuleTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.deleteKafkaTopics(SaslPlainTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(SaslPlainTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/LibertyLoginModuleTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/LibertyLoginModuleTest.java
@@ -112,7 +112,7 @@ public class LibertyLoginModuleTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.cleanKafka(SaslPlainTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(SaslPlainTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/invalid/LibertyLoginModuleInvalidTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/invalid/LibertyLoginModuleInvalidTest.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.liberty_login.invalid;
 
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties.simpleIncomingChannel;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties.simpleOutgoingChannel;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaClientLibs;
@@ -63,7 +65,7 @@ public class LibertyLoginModuleInvalidTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -108,8 +110,7 @@ public class LibertyLoginModuleInvalidTest {
 
         // Now deploy the app and check that it fails to start
         server.setMarkToEndOfLog();
-        ShrinkHelper.exportArtifact(war, "tmp/apps");
-        server.copyFileToLibertyServerRoot("tmp/apps", "dropins", war.getName());
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY, DISABLE_VALIDATION);
 
         try {
             String logLine = server.waitForStringInLogUsingMark(APP_START_CODE + "|" + APP_FAIL_CODE + "|" + INVALID_CIPHER_CODE);

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/invalid/LibertyLoginModuleInvalidTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/invalid/LibertyLoginModuleInvalidTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,11 +21,14 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Map;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -50,13 +53,17 @@ public class LibertyLoginModuleInvalidTest {
 
     private static final String APP_NAME = "kafkaLoginModuleInvalidTest";
     private static final String APP_GROUP_ID = "login-module-invalid-test-group";
+    private static final String SERVER_NAME = "SimpleRxMessagingServer";
 
     private static final String APP_START_CODE = "CWWKZ000[13]I";
     private static final String APP_FAIL_CODE = "CWWKZ000[24]E";
     private static final String INVALID_CIPHER_CODE = "CWWKS1857E";
 
-    @Server("SimpleRxMessagingServer")
+    @Server(SERVER_NAME)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/none/LibertyLoginModuleNoEncTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/none/LibertyLoginModuleNoEncTest.java
@@ -60,7 +60,7 @@ public class LibertyLoginModuleNoEncTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -106,7 +106,7 @@ public class LibertyLoginModuleNoEncTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.deleteKafkaTopics(SaslPlainTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(SaslPlainTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/none/LibertyLoginModuleNoEncTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/none/LibertyLoginModuleNoEncTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,13 +18,18 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProp
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaClientLibs;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaPermissions;
 
+import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.PropertiesAsset;
@@ -48,10 +53,14 @@ public class LibertyLoginModuleNoEncTest {
 
     private static final String APP_NAME = "kafkaLoginModuleNoEncTest";
     private static final String APP_GROUP_ID = "login-module-noenc-test-group";
+    private static final String SERVER_NAME = "SimpleRxMessagingServer";
 
-    @Server("SimpleRxMessagingServer")
+    @Server(SERVER_NAME)
     @TestServlet(contextRoot = APP_NAME, servlet = LibertyLoginModuleNoEncTestServlet.class)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -93,6 +102,11 @@ public class LibertyLoginModuleNoEncTest {
     @AfterClass
     public static void teardownTest() throws Exception {
         server.stopServer();
+    }
+
+    @AfterClass
+    public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
+        KafkaUtils.cleanKafka(SaslPlainTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/none/LibertyLoginModuleNoEncTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/none/LibertyLoginModuleNoEncTest.java
@@ -106,7 +106,7 @@ public class LibertyLoginModuleNoEncTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.cleanKafka(SaslPlainTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(SaslPlainTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
@@ -106,7 +106,7 @@ public class LibertyLoginModuleSpecialCharsTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.cleanKafka(SaslPlainTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(SaslPlainTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,13 +18,18 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProp
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaClientLibs;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaPermissions;
 
+import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.PropertiesAsset;
@@ -48,10 +53,14 @@ public class LibertyLoginModuleSpecialCharsTest {
 
     private static final String APP_NAME = "kafkaLoginModuleSpecialCharsTest";
     private static final String APP_GROUP_ID = "login-module-special-chars-test-group";
+    private static final String SERVER_NAME = "SimpleRxMessagingServer";
 
-    @Server("SimpleRxMessagingServer")
+    @Server(SERVER_NAME)
     @TestServlet(contextRoot = APP_NAME, servlet = LibertyLoginModuleSpecialCharsTestServlet.class)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -93,6 +102,11 @@ public class LibertyLoginModuleSpecialCharsTest {
     @AfterClass
     public static void teardownTest() throws Exception {
         server.stopServer();
+    }
+
+    @AfterClass
+    public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
+        KafkaUtils.cleanKafka(SaslPlainTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
@@ -60,7 +60,7 @@ public class LibertyLoginModuleSpecialCharsTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -106,7 +106,7 @@ public class LibertyLoginModuleSpecialCharsTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.deleteKafkaTopics(SaslPlainTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(SaslPlainTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/xor/LibertyLoginModuleXorTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/xor/LibertyLoginModuleXorTest.java
@@ -64,7 +64,7 @@ public class LibertyLoginModuleXorTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -110,7 +110,7 @@ public class LibertyLoginModuleXorTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.deleteKafkaTopics(SaslPlainTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(SaslPlainTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/xor/LibertyLoginModuleXorTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/xor/LibertyLoginModuleXorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,13 +18,18 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProp
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaClientLibs;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaPermissions;
 
+import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.crypto.PasswordUtil;
@@ -52,10 +57,14 @@ public class LibertyLoginModuleXorTest {
 
     private static final String APP_NAME = "kafkaLoginModuleXorTest";
     private static final String APP_GROUP_ID = "login-module-xor-test-group";
+    private static final String SERVER_NAME = "SimpleRxMessagingServer";
 
-    @Server("SimpleRxMessagingServer")
+    @Server(SERVER_NAME)
     @TestServlet(contextRoot = APP_NAME, servlet = LibertyLoginModuleXorTestServlet.class)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -97,6 +106,11 @@ public class LibertyLoginModuleXorTest {
     @AfterClass
     public static void teardownTest() throws Exception {
         server.stopServer();
+    }
+
+    @AfterClass
+    public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
+        KafkaUtils.cleanKafka(SaslPlainTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/xor/LibertyLoginModuleXorTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/xor/LibertyLoginModuleXorTest.java
@@ -110,7 +110,7 @@ public class LibertyLoginModuleXorTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.cleanKafka(SaslPlainTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(SaslPlainTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/ConsumerRecordBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/ConsumerRecordBean.java
@@ -14,8 +14,11 @@ package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.message;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
@@ -30,7 +33,10 @@ public class ConsumerRecordBean {
     public static final String CHANNEL_OUT = "consumer-record-out";
     public static final String GROUP_ID = "consumer-record-app-group";
 
-    public static final String TOPIC = CHANNEL_IN;
+    @Inject
+    @ConfigProperty(name = "mp.messaging.incoming." + CHANNEL_IN + ".topic")
+    private Optional<String> topic;
+
     public static final String KEY = "test_key";
     public static final String VALUE = "hello";
     public static final int PARTITION = 9;
@@ -62,8 +68,8 @@ public class ConsumerRecordBean {
             return Message.of("Wrong ConsumerRecord Value. Expected: " + VALUE + " - Actual: " + incomingValue);
         }
 
-        if (!TOPIC.equals(incomingTopic)) {
-            return Message.of("Wrong ConsumerRecord Topic. Expected: " + TOPIC + " - Actual: " + incomingTopic);
+        if (!topic.orElse("non-existent-topic").equals(incomingTopic)) {
+            return Message.of("Wrong ConsumerRecord Topic. Expected: " + topic.orElse("non-existent-topic") + " - Actual: " + incomingTopic);
         }
 
         if (PARTITION != incomingPartition) {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/ConsumerRecordServlet.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/ConsumerRecordServlet.java
@@ -17,10 +17,13 @@ import static org.junit.Assert.assertEquals;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Optional;
 
+import javax.inject.Inject;
 import javax.servlet.annotation.WebServlet;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.Test;
 
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestConstants;
@@ -33,9 +36,14 @@ public class ConsumerRecordServlet extends AbstractKafkaTestServlet {
 
     private static final long serialVersionUID = 1L;
 
+    @Inject
+    @ConfigProperty(name = "mp.messaging.incoming." + ConsumerRecordBean.CHANNEL_IN + ".topic")
+    private Optional<String> topic;
+
     @Test
     public void testConsumerRecord() throws UnsupportedEncodingException {
-        KafkaWriter<String, String> writer = kafkaTestClient.writerFor(ConsumerRecordBean.CHANNEL_IN);
+
+        KafkaWriter<String, String> writer = kafkaTestClient.writerFor(topic.orElse("non-existent-topic"));
 
         // Server uses the timestamp for things like message expiry, so make it approximately accurate
         // This test relies on the following server config:
@@ -43,7 +51,7 @@ public class ConsumerRecordServlet extends AbstractKafkaTestServlet {
         // * message.timestamp.difference.max.ms > 500 (default is MAX_LONG)
         long timestamp = System.currentTimeMillis() + 500L;
 
-        ProducerRecord<String, String> record = new ProducerRecord<String, String>(ConsumerRecordBean.CHANNEL_IN, ConsumerRecordBean.PARTITION, timestamp, ConsumerRecordBean.KEY, ConsumerRecordBean.VALUE);
+        ProducerRecord<String, String> record = new ProducerRecord<String, String>(topic.orElse("non-existent-topic"), ConsumerRecordBean.PARTITION, timestamp, ConsumerRecordBean.KEY, ConsumerRecordBean.VALUE);
 
         for (int i = 0; i < ConsumerRecordBean.NUM_TEST_HEADERS; i++) {
             record.headers().add(ConsumerRecordBean.HEADER_KEY_PREFIX + i, (ConsumerRecordBean.HEADER_VALUE_PREFIX + i).getBytes("UTF-8"));

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/ConsumerRecordTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/ConsumerRecordTest.java
@@ -63,7 +63,7 @@ public class ConsumerRecordTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);//, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -104,7 +104,7 @@ public class ConsumerRecordTest {
 
     @AfterClass
     public static void teardownKafka() throws Exception{
-        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/ConsumerRecordTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/ConsumerRecordTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -95,6 +95,12 @@ public class ConsumerRecordTest {
     @AfterClass
     public static void teardown() throws Exception {
         server.stopServer();
+
+    }
+
+    @AfterClass
+    public static void tearddownKafka() throws Exception{
+        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseConfiguredTopicTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseConfiguredTopicTest.java
@@ -87,7 +87,7 @@ public class UseConfiguredTopicTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseConfiguredTopicTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseConfiguredTopicTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestCons
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClientProvider;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
 
@@ -37,6 +38,9 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 /**
  *
@@ -79,6 +83,11 @@ public class UseConfiguredTopicTest {
     @AfterClass
     public static void teardown() throws Exception {
         server.stopServer();
+    }
+
+    @AfterClass
+    public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
+        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseConfiguredTopicTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseConfiguredTopicTest.java
@@ -57,7 +57,7 @@ public class UseConfiguredTopicTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -87,7 +87,7 @@ public class UseConfiguredTopicTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseProducerRecordTopicTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseProducerRecordTopicTest.java
@@ -87,7 +87,7 @@ public class UseProducerRecordTopicTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseProducerRecordTopicTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseProducerRecordTopicTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestCons
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClientProvider;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
 
@@ -37,6 +38,9 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 /**
  *
@@ -79,6 +83,11 @@ public class UseProducerRecordTopicTest {
     @AfterClass
     public static void teardown() throws Exception {
         server.stopServer();
+    }
+
+    @AfterClass
+    public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
+        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseProducerRecordTopicTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseProducerRecordTopicTest.java
@@ -57,7 +57,7 @@ public class UseProducerRecordTopicTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -87,7 +87,7 @@ public class UseProducerRecordTopicTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -105,6 +105,7 @@ public class KafkaPartitionTest {
     @AfterClass
     public static void shutdown() throws Exception {
         server.stopServer();
+        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
@@ -65,7 +65,7 @@ public class KafkaPartitionTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -110,7 +110,7 @@ public class KafkaPartitionTest {
     @AfterClass
     public static void shutdown() throws Exception {
         server.stopServer();
-        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTestServlet.java
@@ -55,6 +55,10 @@ public class KafkaPartitionTestServlet extends AbstractKafkaTestServlet {
     private String kafkaBootstrap;
 
     @Inject
+    @ConfigProperty(name = "mp.messaging.incoming." + CHANNEL_NAME + ".topic")
+    private String topic;
+
+    @Inject
     private PartitionTestReceptionBean receptionBean;
 
     /**
@@ -82,9 +86,9 @@ public class KafkaPartitionTestServlet extends AbstractKafkaTestServlet {
         consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, APP_GROUPID);
         consumerConfig.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
         consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        KafkaReader<String, String> reader = kafkaTestClient.readerFor(consumerConfig, CHANNEL_NAME);
+        KafkaReader<String, String> reader = kafkaTestClient.readerFor(consumerConfig, topic);
 
-        List<PartitionInfo> allPartitions = reader.getConsumer().partitionsFor(CHANNEL_NAME);
+        List<PartitionInfo> allPartitions = reader.getConsumer().partitionsFor(topic);
 
         // Assert that the new reader is assigned one partition
         Duration elapsed = Duration.ZERO;
@@ -109,11 +113,11 @@ public class KafkaPartitionTestServlet extends AbstractKafkaTestServlet {
         }
 
         // We want to check that the offset is advanced correctly later, so take a baseline now
-        long testReaderPartitionOffset = kafkaTestClient.getTopicOffset(CHANNEL_NAME, testReaderPartitionId, APP_GROUPID);
-        long receptionBeanPartitionOffset = kafkaTestClient.getTopicOffset(CHANNEL_NAME, receptionBeanPartitionId, APP_GROUPID);
+        long testReaderPartitionOffset = kafkaTestClient.getTopicOffset(topic, testReaderPartitionId, APP_GROUPID);
+        long receptionBeanPartitionOffset = kafkaTestClient.getTopicOffset(topic, receptionBeanPartitionId, APP_GROUPID);
 
         // Send a message to the partition assigned to the test reader and check the new reader receives it and advances the partition offset
-        KafkaWriter<String, String> writer = kafkaTestClient.writerFor(CHANNEL_NAME);
+        KafkaWriter<String, String> writer = kafkaTestClient.writerFor(topic);
         writer.sendMessage("test1", testReaderPartitionId, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
         List<String> testMessagesRead = reader.assertReadMessages(1, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
         assertThat(testMessagesRead, contains("test1"));
@@ -124,7 +128,7 @@ public class KafkaPartitionTestServlet extends AbstractKafkaTestServlet {
         List<String> beanMessagePayloads = beanMessagesRead.stream().map(Message::getPayload).collect(Collectors.toList());
         beanMessagesRead.forEach(Message::ack);
         assertThat(beanMessagePayloads, contains("test2"));
-        kafkaTestClient.assertTopicOffsetAdvancesTo(receptionBeanPartitionOffset + 1, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT, CHANNEL_NAME, receptionBeanPartitionId,
+        kafkaTestClient.assertTopicOffsetAdvancesTo(receptionBeanPartitionOffset + 1, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT, topic, receptionBeanPartitionId,
                                                     APP_GROUPID);
 
         // Close the test reader
@@ -132,7 +136,7 @@ public class KafkaPartitionTestServlet extends AbstractKafkaTestServlet {
 
         // With AUTO_COMMIT_CONFIG, we don't have control over when Kafka commits the partition offset for us
         // but it should happen once we've closed the reader
-        kafkaTestClient.assertTopicOffsetAdvancesTo(testReaderPartitionOffset + 1, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT, CHANNEL_NAME, testReaderPartitionId, APP_GROUPID);
+        kafkaTestClient.assertTopicOffsetAdvancesTo(testReaderPartitionOffset + 1, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT, topic, testReaderPartitionId, APP_GROUPID);
 
         // Send a message to each partition and check that the bean receives both of them and advances the offset of both partitions
         writer.sendMessage("test3", testReaderPartitionId, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
@@ -153,8 +157,8 @@ public class KafkaPartitionTestServlet extends AbstractKafkaTestServlet {
                 m.ack();
             }
 
-            testReaderFinalOffset = kafkaTestClient.getTopicOffset(CHANNEL_NAME, testReaderPartitionId, APP_GROUPID);
-            receptionBeanFinalOffset = kafkaTestClient.getTopicOffset(CHANNEL_NAME, receptionBeanPartitionId, APP_GROUPID);
+            testReaderFinalOffset = kafkaTestClient.getTopicOffset(topic, testReaderPartitionId, APP_GROUPID);
+            receptionBeanFinalOffset = kafkaTestClient.getTopicOffset(topic, receptionBeanPartitionId, APP_GROUPID);
             if (testReaderFinalOffset == testReaderPartitionOffset + 2 && receptionBeanFinalOffset == receptionBeanPartitionOffset + 2) {
                 done = true;
             }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sasl_plain/KafkaSaslPlainTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sasl_plain/KafkaSaslPlainTest.java
@@ -102,7 +102,7 @@ public class KafkaSaslPlainTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.cleanKafka(SaslPlainTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(SaslPlainTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sasl_plain/KafkaSaslPlainTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sasl_plain/KafkaSaslPlainTest.java
@@ -61,7 +61,8 @@ public class KafkaSaslPlainTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
+    
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -102,7 +103,7 @@ public class KafkaSaslPlainTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.deleteKafkaTopics(SaslPlainTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(SaslPlainTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sasl_plain/KafkaSaslPlainTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sasl_plain/KafkaSaslPlainTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,10 +18,13 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProp
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaClientLibs;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaPermissions;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.PropertiesAsset;
@@ -40,6 +43,9 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
 /**
  * Basic test using a kafka broker with TLS enabled
  */
@@ -48,10 +54,14 @@ public class KafkaSaslPlainTest {
 
     private static final String APP_NAME = "kafkaSaslTest";
     private static final String APP_GROUP_ID = "sasl-test-group";
+    private static final String SERVER_NAME = "SimpleRxMessagingServer";
 
-    @Server("SimpleRxMessagingServer")
+    @Server(SERVER_NAME)
     @TestServlet(contextRoot = APP_NAME, servlet = KafkaSaslTestServlet.class)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -88,6 +98,11 @@ public class KafkaSaslPlainTest {
     @AfterClass
     public static void teardownTest() throws Exception {
         server.stopServer();
+    }
+
+    @AfterClass
+    public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
+        KafkaUtils.cleanKafka(SaslPlainTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomKeySerializerTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomKeySerializerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -42,6 +42,9 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 /**
  *
@@ -93,4 +96,8 @@ public class KafkaCustomKeySerializerTest {
         server.stopServer();
     }
 
+    @AfterClass
+    public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
+        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
+    }
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomKeySerializerTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomKeySerializerTest.java
@@ -63,7 +63,7 @@ public class KafkaCustomKeySerializerTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -99,6 +99,6 @@ public class KafkaCustomKeySerializerTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.getAdminClient());
     }
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomKeySerializerTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomKeySerializerTest.java
@@ -32,6 +32,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestConstants;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
 
@@ -98,6 +99,6 @@ public class KafkaCustomKeySerializerTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
     }
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomSerializerTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomSerializerTest.java
@@ -94,7 +94,7 @@ public class KafkaCustomSerializerTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomSerializerTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomSerializerTest.java
@@ -60,7 +60,7 @@ public class KafkaCustomSerializerTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -94,7 +94,7 @@ public class KafkaCustomSerializerTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomSerializerTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomSerializerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,6 +32,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestConstants;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
 
@@ -40,6 +41,9 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 /**
  *
@@ -86,6 +90,11 @@ public class KafkaCustomSerializerTest {
     @AfterClass
     public static void teardownTest() throws Exception {
         server.stopServer();
+    }
+
+    @AfterClass
+    public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
+        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sharedLib/KafkaSharedLibTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sharedLib/KafkaSharedLibTest.java
@@ -60,7 +60,7 @@ public class KafkaSharedLibTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -96,7 +96,7 @@ public class KafkaSharedLibTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sharedLib/KafkaSharedLibTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sharedLib/KafkaSharedLibTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,8 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.ka
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaPermissions;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -32,6 +34,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestConstants;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
 
@@ -89,6 +92,11 @@ public class KafkaSharedLibTest {
     @AfterClass
     public static void teardownTest() throws Exception {
         server.stopServer();
+    }
+
+    @AfterClass
+    public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
+        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sharedLib/KafkaSharedLibTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sharedLib/KafkaSharedLibTest.java
@@ -96,7 +96,7 @@ public class KafkaSharedLibTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tls/KafkaTlsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tls/KafkaTlsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,10 +18,13 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProp
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaClientLibs;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaPermissions;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.PropertiesAsset;
@@ -40,6 +43,9 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
 /**
  * Basic test using a kafka broker with TLS enabled
  */
@@ -48,10 +54,14 @@ public class KafkaTlsTest {
 
     private static final String APP_NAME = "kafkaTlsTest";
     private static final String APP_GROUP_ID = "tls-test-group";
+    private static final String SERVER_NAME = "SimpleRxMessagingServer";
 
-    @Server("SimpleRxMessagingServer")
+    @Server(SERVER_NAME)
     @TestServlet(contextRoot = APP_NAME, servlet = KafkaTlsTestServlet.class)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -87,6 +97,11 @@ public class KafkaTlsTest {
     @AfterClass
     public static void teardownTest() throws Exception {
         server.stopServer();
+    }
+
+    @AfterClass
+    public static void teardownKafka() throws IOException, ExecutionException, InterruptedException {
+        KafkaUtils.cleanKafka(TlsTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tls/KafkaTlsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tls/KafkaTlsTest.java
@@ -61,7 +61,7 @@ public class KafkaTlsTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -101,7 +101,7 @@ public class KafkaTlsTest {
 
     @AfterClass
     public static void teardownKafka() throws IOException, ExecutionException, InterruptedException {
-        KafkaUtils.deleteKafkaTopics(TlsTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(TlsTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tls/KafkaTlsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tls/KafkaTlsTest.java
@@ -101,7 +101,7 @@ public class KafkaTlsTest {
 
     @AfterClass
     public static void teardownKafka() throws IOException, ExecutionException, InterruptedException {
-        KafkaUtils.cleanKafka(TlsTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(TlsTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/loginModuleClassloading/LoginModuleClassloadingTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/loginModuleClassloading/LoginModuleClassloadingTest.java
@@ -51,7 +51,7 @@ public class LoginModuleClassloadingTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/loginModuleClassloading/LoginModuleClassloadingTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/loginModuleClassloading/LoginModuleClassloadingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,11 +16,14 @@ import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONL
 
 import javax.enterprise.inject.spi.Extension;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -41,10 +44,14 @@ import componenttest.topology.utils.FATServletClient;
 @Mode(TestMode.FULL)
 public class LoginModuleClassloadingTest extends FATServletClient {
     private static final String APP_NAME = "loginModuleLoadTest";
+    private static final String SERVER_NAME = "SimpleRxMessagingServer";
 
-    @Server("SimpleRxMessagingServer")
+    @Server(SERVER_NAME)
     @TestServlet(contextRoot = APP_NAME, servlet = LoginModuleClassloadingTestServlet.class)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20, ReactiveMessagingActions.MP50, ReactiveMessagingActions.MP60, ReactiveMessagingActions.MP61);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BadConnectorIDTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BadConnectorIDTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BadConnectorIDTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BadConnectorIDTest.java
@@ -83,8 +83,9 @@ public class BadConnectorIDTest {
 
     @Test
     public void testBadConnectorID() throws Exception {
+        // Message in Reactive Messaging 3.0 added msg identifier and quotes around channel. So string needs to support message id and quotes, but allow for them to be missing as well
         List<String> errors = server
-                        .findStringsInLogs("java.lang.IllegalArgumentException: Unknown connector for " + BasicMessagingBean.CHANNEL_OUT);
+                        .findStringsInLogs("java.lang.IllegalArgumentException:( SRMSG00072:)? Unknown connector for (`)?" + BasicMessagingBean.CHANNEL_OUT+"(`)?");
         assertTrue(errors.size() > 0);
     }
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BadConnectorIDTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BadConnectorIDTest.java
@@ -51,7 +51,7 @@ public class BadConnectorIDTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);//, ReactiveMessagingActions.MP61);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -83,7 +83,7 @@ public class BadConnectorIDTest {
 
     @Test
     public void testBadConnectorID() throws Exception {
-        // Message in Reactive Messaging 3.0 added msg identifier and quotes around channel. So string needs to support message id and quotes, but allow for them to be missing as well
+        // Message in Reactive Messaging 3.0 added msg identifier and quotes around the channel name. So regex needs to support message id and quotes, but allow for them to be missing.
         List<String> errors = server
                         .findStringsInLogs("java.lang.IllegalArgumentException:( SRMSG00072:)? Unknown connector for (`)?" + BasicMessagingBean.CHANNEL_OUT+"(`)?");
         assertTrue(errors.size() > 0);

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BasicReactiveMessagingTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BasicReactiveMessagingTest.java
@@ -37,8 +37,7 @@ public class BasicReactiveMessagingTest extends FATServletClient {
     public static final String SERVER_NAME = "SimpleRxMessagingServer";
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30,
-                                                                  ReactiveMessagingActions.MP61_RM30);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30, ReactiveMessagingActions.MP61_RM30);
 
     @Server(SERVER_NAME)
     @TestServlet(servlet = SimpleReactiveMessagingServlet.class, contextRoot = APP_NAME)

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/KafkaMessagingTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/KafkaMessagingTest.java
@@ -169,7 +169,7 @@ public class KafkaMessagingTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/KafkaMessagingTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/KafkaMessagingTest.java
@@ -73,7 +73,7 @@ public class KafkaMessagingTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     private static KafkaConsumer<String, String> kafkaConsumer;
     private static KafkaProducer<String, String> kafkaProducer;
@@ -169,7 +169,7 @@ public class KafkaMessagingTest {
 
     @AfterClass
     public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
-        KafkaUtils.deleteKafkaTopics(PlaintextTests.kafkaContainer);
+        KafkaUtils.deleteKafkaTopics(PlaintextTests.getAdminClient());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/KafkaMessagingTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/KafkaMessagingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -157,13 +158,18 @@ public class KafkaMessagingTest {
     }
 
     @AfterClass
-    public static void testdownProducer() {
+    public static void teardownProducer() {
         kafkaProducer.close();
     }
 
     @AfterClass
     public static void teardownTest() throws Exception {
         server.stopServer();
+    }
+
+    @AfterClass
+    public static void teardownKafka() throws ExecutionException, InterruptedException, IOException {
+        KafkaUtils.cleanKafka(PlaintextTests.kafkaContainer);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/KafkaUtils.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/KafkaUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,15 +13,25 @@
 package com.ibm.ws.microprofile.reactive.messaging.fat.suite;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.containers.ExtendedKafkaContainer;
 
 import componenttest.topology.impl.LibertyServer;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
 
 /**
  *
@@ -49,6 +59,41 @@ public class KafkaUtils {
         Files.copy(file.toPath(), tmpDest, StandardCopyOption.REPLACE_EXISTING);
         server.copyFileToLibertyServerRootUsingTmp(server.getServerRoot(), tmpDest.toString());
         Files.delete(tmpDest);
+    }
+
+    public static void copyTrustStoreToTest(ExtendedKafkaContainer container) throws IOException {
+        File file = container.getKeystoreFile();
+        Path tmpDest = Paths.get(TRUSTSTORE_FILENAME);
+        Files.copy(file.toPath(), tmpDest, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    public static void cleanKafka(ExtendedKafkaContainer container) throws IOException, ExecutionException, InterruptedException {
+        Map<String, Object> adminClientProps = new HashMap<>();
+        adminClientProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, container.getBootstrapServers());
+
+        //Configure additional settings for SSL and SASL_SSL connections
+        if(!container.getListenerScheme().equals("PLAINTEXT")){
+            KafkaUtils.copyTrustStoreToTest(container);
+            adminClientProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, TRUSTSTORE_FILENAME);
+            adminClientProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, container.getKeystorePassword());
+            if(container.getListenerScheme().equals("SASL_SSL")){
+                adminClientProps.put("security.protocol", "SASL_SSL");
+                adminClientProps.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+                //Admin Credentials are required for use with the Admin Client, otherwise a SSL error is thrown
+                adminClientProps.put(SaslConfigs.SASL_JAAS_CONFIG,
+                        "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                                + "username=\"" + SaslPlainTests.ADMIN_USER + "\" "
+                                + "password=\"" + SaslPlainTests.ADMIN_SECRET + "\";");
+            } else if(container.getListenerScheme().equals("SSL")) {
+                adminClientProps.put("security.protocol", "SSL");
+            }
+        }
+
+        AdminClient adminClient = AdminClient.create(adminClientProps);
+
+        ListTopicsResult topics = adminClient.listTopics();
+        Set<String> topicNames = topics.names().get();
+        adminClient.deleteTopics(topicNames);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/MissingGroupIDTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/MissingGroupIDTest.java
@@ -55,7 +55,7 @@ public class MissingGroupIDTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP20_RM10);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/MissingGroupIDTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/MissingGroupIDTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -57,7 +57,7 @@ import componenttest.containers.TestContainerSuite;
                 MissingGroupIDTest.class,
                 ReactiveStreamsTckTest.class,
                 UseConfiguredTopicTest.class,
-                UseProducerRecordTopicTest.class,
+                UseProducerRecordTopicTest.class
 })
 public class PlaintextTests extends TestContainerSuite {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
+import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -67,7 +68,12 @@ public class PlaintextTests extends TestContainerSuite {
                     .withStartupAttempts(3)
                     .withLogConsumer(new SimpleLogConsumer(PlaintextTests.class, "kafka"));
 
-    public static Map<String, String> connectionProperties() {
+    public static Map<String, Object> connectionProperties() {
         return Collections.singletonMap(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+    }
+
+    public static AdminClient getAdminClient(){
+        Map<String, Object> adminClientProps = connectionProperties();
+        return AdminClient.create(adminClientProps);
     }
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/SaslPlainTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/SaslPlainTests.java
@@ -12,10 +12,13 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.fat.suite;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
@@ -69,6 +72,17 @@ public class SaslPlainTests extends TestContainerSuite {
 
     public static String generateSecret(String prefix) {
         return prefix + "-" + Base58.randomString(6);
+    }
+    
+    public static AdminClient getAdminClient() throws IOException {
+        KafkaUtils.copyTrustStoreToTest(kafkaContainer);
+        Map<String, Object> adminClientProps = connectionProperties();
+        adminClientProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        adminClientProps.replace(SaslConfigs.SASL_JAAS_CONFIG,
+                "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                        + "username=\"" + ADMIN_USER + "\" "
+                        + "password=\"" + ADMIN_SECRET + "\";");
+        return AdminClient.create(adminClientProps);
     }
 
     public static Map<String, Object> connectionProperties() {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/TlsTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/TlsTests.java
@@ -12,10 +12,12 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.fat.suite;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.SslConfigs;
 import org.junit.ClassRule;
@@ -44,13 +46,18 @@ public class TlsTests extends TestContainerSuite {
                     .withStartupAttempts(3)
                     .withLogConsumer(new SimpleLogConsumer(TlsTests.class, "kafka-tls"));
 
-    public static Map<String, String> connectionProperties() {
-        Map<String, String> properties = new HashMap<>();
+    public static Map<String, Object> connectionProperties() {
+        Map<String, Object> properties = new HashMap<>();
         properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
         properties.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, KafkaUtils.TRUSTSTORE_FILENAME);
         properties.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, TlsTests.kafkaContainer.getKeystorePassword());
         properties.put("security.protocol", "SSL");
         return properties;
+    }
+
+    public static AdminClient getAdminClient() throws IOException {
+        KafkaUtils.copyTrustStoreToTest(kafkaContainer);
+        return AdminClient.create(connectionProperties());
     }
 
 }


### PR DESCRIPTION
Add repeats for various MP Reactive Messaging 3.0 combinations to the existing Reactive Messaging tests

Clean out Kafka Topics between executions as this is the quickest means to get a clean environment

Fix config tests to accommodate changes in logging between various JEE and MP

Fix framework to support new versions of MP Config via the use of `Optional` 

Make JsonbTest consistent with the other tests in using the test servlet as source

Fixes #25390 
Some Fixes for #25424 