### PR TITLE
injection of default managed executors and context service

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -45,14 +45,9 @@ public class ConcurrentCDITest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(server, APP_NAME, "concurrent.cdi.web");
-        // TODO remove "concurrent.cu3.web" below to reproduce the following error:
-        // [7/21/23, 9:03:05:599 CDT] 00000037 SystemOut                                                    O
-        //  Added jakarta.enterprise.concurrent.ManagedExecutorService with qualifiers [@jakarta.enterprise.inject.Default()]
-        // ...
-        // DeploymentException: WELD-001408: Unsatisfied dependencies for type ManagedExecutorService with qualifiers @Default
-        //                  at injection point [BackedAnnotatedField] @Inject private concurrent.cdi4.web.ConcurrentCDI4Servlet.injectedExec
-        //                  at concurrent.cdi4.web.ConcurrentCDI4Servlet.injectedExec(ConcurrentCDI4Servlet.java:0)
-        ShrinkHelper.defaultDropinApp(server, APP_NAME_EE10, "concurrent.cdi4.web", "concurrent.cu3.web");
+        // TODO Adding "concurrent.cu3.web" to the following would cause conflict with app-defined ManagedExecutorService.
+        // There is a spec proposal to detect conflict and avoid automatically adding the bean.
+        ShrinkHelper.defaultDropinApp(server, APP_NAME_EE10, "concurrent.cdi4.web");
         server.startServer();
         runTest(server, APP_NAME_EE10 + '/' + ConcurrentCDI4Servlet.class.getSimpleName(), "initTransactionService");
     }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/server.xml
@@ -31,6 +31,7 @@
     </managedScheduledExecutorService>
 
     <!-- needed to shut down pool of unmanaged threads that is used by the application -->
+    <javaPermission codebase="${server.config.dir}/dropins/concurrentCDIApp.war" className="java.lang.RuntimePermission" name="modifyThread"/>
     <javaPermission codebase="${server.config.dir}/dropins/concurrentCDI4App.war" className="java.lang.RuntimePermission" name="modifyThread"/>
 
 </server>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/resources/WEB-INF/web.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="3.0"
-    xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="5.0"
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee web-app_3_0.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
     id="WebApp_ID">
 
-  <display-name>Concurrent FAT</display-name>
-  <description>FAT for EE Concurrency Utilities</description>
+  <display-name>Concurrent CDI FAT</display-name>
+  <description>FAT for Jakarta Concurrency and CDI</description>
 
   <!-- ENV ENTRIES -->
   <env-entry>
-    <env-entry-name>java:comp/env/entry1</env-entry-name>
+    <env-entry-name>java:comp/env/entry2</env-entry-name>
     <env-entry-type>java.lang.String</env-entry-type>
-    <env-entry-value>value1</env-entry-value>
+    <env-entry-value>value2</env-entry-value>
   </env-entry>
 
 </web-app>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -12,19 +12,30 @@
  *******************************************************************************/
 package concurrent.cdi.web;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import jakarta.enterprise.concurrent.ContextService;
+import jakarta.inject.Inject;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import javax.naming.InitialContext;
 
 import org.junit.Test;
 
@@ -37,12 +48,19 @@ public class ConcurrentCDIServlet extends HttpServlet {
      */
     private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
 
+    @Inject
+    ContextService defaultContextSvc;
+
+    private ExecutorService unmanagedThreads;
+
     @Override
     public void destroy() {
+        unmanagedThreads.shutdownNow();
     }
 
     @Override
     public void init(ServletConfig config) throws ServletException {
+        unmanagedThreads = Executors.newFixedThreadPool(5); // TODO switch to virtual threads?
     }
 
     @Override
@@ -92,9 +110,18 @@ public class ConcurrentCDIServlet extends HttpServlet {
     }
 
     /**
-     * TODO Inject default instance of ContextService.
+     * Inject default instance of ContextService and use it.
      */
     @Test
-    public void testInjectContextServiceDefaultInstance() {
+    public void testInjectContextServiceDefaultInstance() throws Exception {
+        assertNotNull(defaultContextSvc);
+
+        // Use the ContextService to contextualize a task that require the application's context (to look up a java:comp name)
+        Callable<?> task = defaultContextSvc.contextualCallable(() -> InitialContext.doLookup("java:comp/env/entry2"));
+
+        Future<?> future = unmanagedThreads.submit(task);
+
+        Object found = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertEquals("value2", found);
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
@@ -17,12 +17,15 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 import com.ibm.ws.cdi.CDIServiceUtils;
 
 import io.openliberty.concurrent.internal.cdi.interceptor.AsyncInterceptor;
 import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.concurrent.ContextService;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
@@ -39,9 +42,19 @@ public class ConcurrencyExtension implements Extension {
     private static final Set<Annotation> DEFAULT_QUALIFIER = Set.of(Default.Literal.INSTANCE);
 
     /**
-     * Set of qualifier lists found on injection points.
+     * Set of qualifier lists found on ContextService injection points.
+     */
+    private final Set<Set<Annotation>> contextServiceQualifiers = new HashSet<>();
+
+    /**
+     * Set of qualifier lists found on ManagedExecutorService injection points.
      */
     private final Set<Set<Annotation>> executorQualifiers = new HashSet<>();
+
+    /**
+     * Set of qualifier lists found on ManagedScheduledExecutorService injection points.
+     */
+    private final Set<Set<Annotation>> scheduledExecutorQualifiers = new HashSet<>();
 
     public void beforeBeanDiscovery(@Observes BeforeBeanDiscovery beforeBeanDiscovery, BeanManager beanManager) {
         // register the interceptor binding and the interceptor
@@ -56,11 +69,26 @@ public class ConcurrencyExtension implements Extension {
      *
      * @Inject {@Qualifier1 @Qualifier2 ...} ManagedExecutorService executor;
      *
-     * @param <T>         bean class that has the injection point
-     * @param event       event
-     * @param beanManager bean manager
+     * @param <T>   bean class that has the injection point
+     * @param event event
      */
-    public <T> void processExecutorInjectionPoint(@Observes ProcessInjectionPoint<T, ManagedExecutorService> event, BeanManager beanManager) {
+    public <T> void processContextServiceInjectionPoint(@Observes ProcessInjectionPoint<T, ContextService> event) {
+        if (ConcurrencyExtensionMetadata.eeVersion.getMajor() >= 11) {
+            InjectionPoint injectionPoint = event.getInjectionPoint();
+            Set<Annotation> qualifiers = injectionPoint.getQualifiers();
+            contextServiceQualifiers.add(qualifiers);
+        }
+    }
+
+    /**
+     * Invoked for each matching injection point:
+     *
+     * @Inject {@Qualifier1 @Qualifier2 ...} ManagedExecutorService executor;
+     *
+     * @param <T>   bean class that has the injection point
+     * @param event event
+     */
+    public <T> void processExecutorInjectionPoint(@Observes ProcessInjectionPoint<T, ManagedExecutorService> event) {
         if (ConcurrencyExtensionMetadata.eeVersion.getMajor() >= 11) {
             InjectionPoint injectionPoint = event.getInjectionPoint();
             Set<Annotation> qualifiers = injectionPoint.getQualifiers();
@@ -68,9 +96,44 @@ public class ConcurrencyExtension implements Extension {
         }
     }
 
+    /**
+     * Invoked for each matching injection point:
+     *
+     * @Inject {@Qualifier1 @Qualifier2 ...} ManagedScheduledExecutorService scheduledExecutor;
+     *
+     * @param <T>   bean class that has the injection point
+     * @param event event
+     */
+    public <T> void processScheduledExecutorInjectionPoint(@Observes ProcessInjectionPoint<T, ManagedScheduledExecutorService> event) {
+        if (ConcurrencyExtensionMetadata.eeVersion.getMajor() >= 11) {
+            InjectionPoint injectionPoint = event.getInjectionPoint();
+            Set<Annotation> qualifiers = injectionPoint.getQualifiers();
+            scheduledExecutorQualifiers.add(qualifiers);
+        }
+    }
+
     public void afterBeanDiscovery(@Observes AfterBeanDiscovery event, BeanManager beanManager) {
         if (ConcurrencyExtensionMetadata.eeVersion.getMajor() >= 11) {
             CDI<Object> cdi = CDI.current();
+
+            for (Set<Annotation> qualifiers : contextServiceQualifiers) {
+                if (cdi.select(ContextService.class, qualifiers.toArray(new Annotation[qualifiers.size()])).isResolvable()) {
+                    System.out.println("ContextService with qualifiers " + qualifiers + " already exists.");
+                } else {
+                    // It doesn't already exist, so try to add it:
+                    if (DEFAULT_QUALIFIER.equals(qualifiers)) {
+                        Bean<ContextService> bean = new ConcurrencyResourceBean<>(ContextService.class, //
+                                        "(id=DefaultContextService)", //
+                                        Set.of(ContextService.class), //
+                                        qualifiers);
+                        event.addBean(bean);
+                        System.out.println("Added ContextService with qualifiers " + qualifiers);
+                    } // TODO else configured ContextService instances with qualifiers
+                      // TODO if the same qualifiers list is used for both MES and MSES, create as MSES instead?
+                }
+            }
+            contextServiceQualifiers.clear();
+
             for (Set<Annotation> qualifiers : executorQualifiers) {
                 if (cdi.select(ManagedExecutorService.class, qualifiers.toArray(new Annotation[qualifiers.size()])).isResolvable()) {
                     System.out.println("ManagedExecutorService with qualifiers " + qualifiers + " already exists.");
@@ -84,9 +147,28 @@ public class ConcurrencyExtension implements Extension {
                         event.addBean(bean);
                         System.out.println("Added ManagedExecutorService with qualifiers " + qualifiers);
                     } // TODO else configured ManagedExecutorService instances with qualifiers
+                      // TODO if the same qualifiers list is used for both MES and MSES, create as MSES instead?
                 }
             }
             executorQualifiers.clear();
+
+            for (Set<Annotation> qualifiers : scheduledExecutorQualifiers) {
+                if (cdi.select(ManagedScheduledExecutorService.class, qualifiers.toArray(new Annotation[qualifiers.size()])).isResolvable()) {
+                    System.out.println("ManagedScheduledExecutorService with qualifiers " + qualifiers + " already exists.");
+                } else {
+                    // It doesn't already exist, so try to add it:
+                    if (DEFAULT_QUALIFIER.equals(qualifiers)) {
+                        Bean<ManagedScheduledExecutorService> bean = new ConcurrencyResourceBean<>(ManagedScheduledExecutorService.class, //
+                                        "(id=DefaultManagedScheduledExecutorService)", //
+                                        Set.of(ManagedScheduledExecutorService.class, ScheduledExecutorService.class,
+                                               ManagedExecutorService.class, ExecutorService.class, Executor.class), // TODO will these collide?
+                                        qualifiers);
+                        event.addBean(bean);
+                        System.out.println("Added ManagedScheduledExecutorService with qualifiers " + qualifiers);
+                    } // TODO else configured ManagedScheduledExecutorService instances with qualifiers
+                }
+            }
+            scheduledExecutorQualifiers.clear();
         }
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
@@ -14,7 +14,6 @@ package io.openliberty.concurrent.internal.cdi;
 
 import java.lang.annotation.Annotation;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -55,8 +54,7 @@ public class ConcurrencyExtension implements Extension {
     /**
      * Invoked for each matching injection point:
      *
-     * @Inject @Qualifier1 @Qualifier2 ...
-     *         ManagedExecutorService executor;
+     * @Inject {@Qualifier1 @Qualifier2 ...} ManagedExecutorService executor;
      *
      * @param <T>         bean class that has the injection point
      * @param event       event
@@ -64,19 +62,19 @@ public class ConcurrencyExtension implements Extension {
      */
     public <T> void processExecutorInjectionPoint(@Observes ProcessInjectionPoint<T, ManagedExecutorService> event, BeanManager beanManager) {
         if (ConcurrencyExtensionMetadata.eeVersion.getMajor() >= 11) {
-            // TODO check if producer already exists for the injection point and skip
             InjectionPoint injectionPoint = event.getInjectionPoint();
             Set<Annotation> qualifiers = injectionPoint.getQualifiers();
             executorQualifiers.add(qualifiers);
         }
     }
 
-    public void afterBeanDiscovery(@Observes AfterBeanDiscovery event) {
+    public void afterBeanDiscovery(@Observes AfterBeanDiscovery event, BeanManager beanManager) {
         if (ConcurrencyExtensionMetadata.eeVersion.getMajor() >= 11) {
-            for (Iterator<Set<Annotation>> it = executorQualifiers.iterator(); it.hasNext();) {
-                Set<Annotation> qualifiers = it.next();
-                it.remove();
-                if (CDI.current().select(ManagedExecutorService.class, qualifiers.toArray(new Annotation[qualifiers.size()])).isUnsatisfied()) {
+            CDI<Object> cdi = CDI.current();
+            for (Set<Annotation> qualifiers : executorQualifiers) {
+                if (cdi.select(ManagedExecutorService.class, qualifiers.toArray(new Annotation[qualifiers.size()])).isResolvable()) {
+                    System.out.println("ManagedExecutorService with qualifiers " + qualifiers + " already exists.");
+                } else {
                     // It doesn't already exist, so try to add it:
                     if (DEFAULT_QUALIFIER.equals(qualifiers)) {
                         Bean<ManagedExecutorService> bean = new ConcurrencyResourceBean<>(ManagedExecutorService.class, //
@@ -84,10 +82,11 @@ public class ConcurrencyExtension implements Extension {
                                         Set.of(ManagedExecutorService.class, ExecutorService.class, Executor.class), //
                                         qualifiers);
                         event.addBean(bean);
-                        System.out.println("Added " + bean.getBeanClass().getName() + " with qualifiers " + qualifiers);
+                        System.out.println("Added ManagedExecutorService with qualifiers " + qualifiers);
                     } // TODO else configured ManagedExecutorService instances with qualifiers
                 }
             }
+            executorQualifiers.clear();
         }
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
@@ -142,12 +142,11 @@ public class ConcurrencyExtension implements Extension {
                     if (DEFAULT_QUALIFIER.equals(qualifiers)) {
                         Bean<ManagedExecutorService> bean = new ConcurrencyResourceBean<>(ManagedExecutorService.class, //
                                         "(id=DefaultManagedExecutorService)", //
-                                        Set.of(ManagedExecutorService.class, ExecutorService.class, Executor.class), //
-                                        qualifiers);
+                                        Set.of(ManagedExecutorService.class, ExecutorService.class, Executor.class), qualifiers);
+                        // TODO should ExecutorService.class, Executor.class be removed? If not, must avoid collisions with application's producers
                         event.addBean(bean);
                         System.out.println("Added ManagedExecutorService with qualifiers " + qualifiers);
                     } // TODO else configured ManagedExecutorService instances with qualifiers
-                      // TODO if the same qualifiers list is used for both MES and MSES, create as MSES instead?
                 }
             }
             executorQualifiers.clear();
@@ -160,9 +159,8 @@ public class ConcurrencyExtension implements Extension {
                     if (DEFAULT_QUALIFIER.equals(qualifiers)) {
                         Bean<ManagedScheduledExecutorService> bean = new ConcurrencyResourceBean<>(ManagedScheduledExecutorService.class, //
                                         "(id=DefaultManagedScheduledExecutorService)", //
-                                        Set.of(ManagedScheduledExecutorService.class, ScheduledExecutorService.class,
-                                               ManagedExecutorService.class, ExecutorService.class, Executor.class), // TODO will these collide?
-                                        qualifiers);
+                                        Set.of(ManagedScheduledExecutorService.class, ScheduledExecutorService.class), qualifiers);
+                        // TODO should ScheduledExecutorService.class be removed? If not, must avoid collisions with application's producers
                         event.addBean(bean);
                         System.out.println("Added ManagedScheduledExecutorService with qualifiers " + qualifiers);
                     } // TODO else configured ManagedScheduledExecutorService instances with qualifiers

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -22,6 +22,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
+import com.ibm.ws.cdi.extension.CDIExtensionMetadataInternal;
 import com.ibm.ws.javaee.version.JavaEEVersion;
 
 import io.openliberty.cdi.spi.CDIExtensionMetadata;
@@ -32,7 +33,7 @@ import jakarta.enterprise.inject.spi.Extension;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,
            service = CDIExtensionMetadata.class)
-public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata {
+public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIExtensionMetadataInternal {
     private static final Set<Class<?>> beanClasses = Set.of(ContextService.class,
                                                             ManagedExecutorService.class,
                                                             ManagedScheduledExecutorService.class // TODO ManagedThreadFactory.class ?
@@ -42,6 +43,11 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata {
      * Jakarta EE version.
      */
     public static Version eeVersion;
+
+    @Override
+    public boolean applicationBeansVisible() {
+        return true;
+    }
 
     @Override
     public Set<Class<?>> getBeanClasses() {

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -25,15 +25,28 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 import com.ibm.ws.javaee.version.JavaEEVersion;
 
 import io.openliberty.cdi.spi.CDIExtensionMetadata;
+import jakarta.enterprise.concurrent.ContextService;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.enterprise.inject.spi.Extension;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,
            service = CDIExtensionMetadata.class)
 public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata {
+    private static final Set<Class<?>> beanClasses = Set.of(ContextService.class,
+                                                            ManagedExecutorService.class,
+                                                            ManagedScheduledExecutorService.class // TODO ManagedThreadFactory.class ?
+    );
+
     /**
      * Jakarta EE version.
      */
     public static Version eeVersion;
+
+    @Override
+    public Set<Class<?>> getBeanClasses() {
+        return beanClasses;
+    }
 
     @Override
     public Set<Class<? extends Extension>> getExtensions() {


### PR DESCRIPTION
Automatically allow injection of the default ManagedExecutorService, ManagedScheduledExecutorService, and ContextService.
Also includes some code to try to identify matching pre-existing ManagedExecutorService/ManagedScheduledExecutorService/ContextService beans so that we only add if one isn't already there.