### PR TITLE
PH55995: Liberty not picking up the correct crypto provider for zOS

### DIFF
--- a/dev/com.ibm.ws.crypto.ltpakeyutil/bnd.bnd
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/bnd.bnd
@@ -32,6 +32,7 @@ Service-Component:\
               com.ibm.ws.crypto.ltpakeyutil.LTPAPublicKey"
 
 -buildpath: \
+	com.ibm.ws.logging;version=latest, \
 	com.ibm.ws.kernel.service;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest
 

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.crypto.ltpakeyutil;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -43,6 +45,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 final class LTPACrypto {
 
+	private static final TraceComponent tc = Tr.register(LTPACrypto.class);
 	private static final String SIGNATURE_ALGORITHM = "SHA1withRSA";
 	private static final String CRYPTO_ALGORITHM = "RSA";
 	private static final String ENCRYPT_ALGORITHM = "DESede";
@@ -1062,6 +1065,13 @@ final class LTPACrypto {
 		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
 			provider = OPENJCEPLUS_NAME;
 		}
+		if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+		if (provider == null){
+			Tr.debug(tc, "getProvider" + " Provider configured by JDK" );
+		}
+		else{
+			Tr.debug(tc, "getProvider" + " Provider configured is "+ provider );
+		}}
 		return provider;
 	}
 }

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -48,6 +48,7 @@ final class LTPACrypto {
 	private static final String ENCRYPT_ALGORITHM = "DESede";
 	private static final String IBMJCE_NAME = "IBMJCE";
 	private static final String OPENJCEPLUS_NAME = "OpenJCEPlus";
+	private static String provider = getProvider();
 
 	private static int MAX_CACHE = 500;
 	private static IvParameterSpec ivs8 = null;
@@ -234,13 +235,7 @@ final class LTPACrypto {
 		BigInteger q = new BigInteger(key[4]);
 		BigInteger d = e.modInverse((p.subtract(BigInteger.ONE)).multiply(q.subtract(BigInteger.ONE)));
 		KeyFactory kFact = null;
-		if (LTPAKeyUtil.isIBMJCEAvailable()) {
-			kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM, IBMJCE_NAME);
-		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
-			kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM, OPENJCEPLUS_NAME);
-		}else {
-			kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM);
-		}
+		kFact = (provider != "")? KeyFactory.getInstance(CRYPTO_ALGORITHM, provider):KeyFactory.getInstance(CRYPTO_ALGORITHM);
 
 		BigInteger pep = new BigInteger(key[5]);
 		BigInteger peq = new BigInteger(key[6]);
@@ -249,13 +244,7 @@ final class LTPACrypto {
 		PrivateKey privKey = kFact.generatePrivate(privCrtKeySpec);
 
 		Signature rsaSig = null;
-		if (LTPAKeyUtil.isIBMJCEAvailable()) {
-			rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM, IBMJCE_NAME);
-		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
-			rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM, OPENJCEPLUS_NAME);
-		}else {
-			rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM);
-		}
+		rsaSig = (provider != "")? Signature.getInstance(SIGNATURE_ALGORITHM, provider):Signature.getInstance(SIGNATURE_ALGORITHM);
 		rsaSig.initSign(privKey);
 		rsaSig.update(data, off, len);
 		byte[] sig = rsaSig.sign();
@@ -518,22 +507,10 @@ final class LTPACrypto {
 		KeyFactory kFact = null;
 		Signature rsaSig = null;
 
-		if (LTPAKeyUtil.isIBMJCEAvailable()) {
-			kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM, IBMJCE_NAME);
-		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
-			kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM, OPENJCEPLUS_NAME);
-		}else {
-			kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM);
-		}
+		kFact = (provider != "")? KeyFactory.getInstance(CRYPTO_ALGORITHM, provider):KeyFactory.getInstance(CRYPTO_ALGORITHM);
 		RSAPublicKeySpec pubKeySpec = new RSAPublicKeySpec(n, e);
 		PublicKey pubKey = kFact.generatePublic(pubKeySpec);
-		if (LTPAKeyUtil.isIBMJCEAvailable()) {
-			rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM, IBMJCE_NAME);
-		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
-			rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM, OPENJCEPLUS_NAME);
-		}else {
-			rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM);
-		}
+		rsaSig = (provider != "")? Signature.getInstance(SIGNATURE_ALGORITHM, provider):Signature.getInstance(SIGNATURE_ALGORITHM);
 		rsaSig.initVerify(pubKey);
 		rsaSig.update(data, off, len);
 		verified = rsaSig.verify(sig);
@@ -607,13 +584,7 @@ final class LTPACrypto {
 		} else {
 			DESedeKeySpec kSpec = new DESedeKeySpec(key);
 			SecretKeyFactory kFact = null;
-			if (LTPAKeyUtil.isIBMJCEAvailable()) {
-				kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM, IBMJCE_NAME);
-			} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
-				kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM, OPENJCEPLUS_NAME);
-			}else {
-				kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM);
-			}
+			kFact = (provider != "")? SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM, provider):SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM);
 			sKey = kFact.generateSecret(kSpec);
 		}
 		return sKey;
@@ -634,14 +605,8 @@ final class LTPACrypto {
 			InvalidAlgorithmParameterException, NoSuchProviderException {
 
 		Cipher ci = null;
-
-		if (LTPAKeyUtil.isIBMJCEAvailable()) {
-			ci = Cipher.getInstance(cipher, IBMJCE_NAME);
-		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
-			ci = Cipher.getInstance(cipher, OPENJCEPLUS_NAME);
-		}else {
-			ci = Cipher.getInstance(cipher);
-		}
+		
+		ci = (provider != "")? Cipher.getInstance(cipher, provider):Cipher.getInstance(cipher);
 		if (cipher.indexOf("ECB") == -1) {
 			if (cipher.indexOf("AES") != -1) {
 				if (ivs16 == null) {
@@ -1055,15 +1020,8 @@ final class LTPACrypto {
 		KeyPairGenerator keyGen = null;
 		try {
 
-			if (LTPAKeyUtil.isIBMJCEAvailable()) {
-				// IBMJCE_NAME needed for hardware crypto
-				keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, IBMJCE_NAME);
-			} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
-				keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, OPENJCEPLUS_NAME);
-			}else {
-				keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM);
-			}
-			
+			keyGen = (provider != "")? KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, provider):KeyPairGenerator.getInstance(CRYPTO_ALGORITHM);
+
 			keyGen.initialize(len * 8, new SecureRandom());
 			pair = keyGen.generateKeyPair();
 			RSAPublicKey rsaPubKey = (RSAPublicKey) pair.getPublic();
@@ -1097,4 +1055,13 @@ final class LTPACrypto {
 		return key;
 	}
 
+	private static String getProvider(){
+		String provider = "";
+		if (LTPAKeyUtil.isIBMJCEAvailable()) {
+			provider = IBMJCE_NAME;
+		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
+			provider = OPENJCEPLUS_NAME;
+		}
+		return provider;
+	}
 }

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -42,6 +42,7 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.DESedeKeySpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+import com.ibm.websphere.ras.annotation.Trivial;
 
 final class LTPACrypto {
 
@@ -56,6 +57,7 @@ final class LTPACrypto {
 	private static int MAX_CACHE = 500;
 	private static IvParameterSpec ivs8 = null;
 	private static IvParameterSpec ivs16 = null;
+	@Trivial
 	private static class CachingKey {
 
 		private boolean reused = false;
@@ -66,7 +68,7 @@ final class LTPACrypto {
 		private final int len;
 		private int hashcode;
 		private byte[] result;
-
+		@Trivial
 		private CachingKey(byte[][] key, byte[] data, int off, int len) {
 			this.key = key;
 			this.data = data;
@@ -93,7 +95,7 @@ final class LTPACrypto {
 			}
 			hashcode *= 2;
 		}
-
+		@Trivial
 		@Override
 		public boolean equals(Object to) {
 			if (!(to instanceof CachingKey)) {
@@ -171,6 +173,7 @@ final class LTPACrypto {
 		}
 
 		@Override
+		@Trivial
 		public int hashCode() {
 			return hashcode;
 		}
@@ -192,6 +195,7 @@ final class LTPACrypto {
 	 *            The length of the data
 	 * @return The signature of the data
 	 */
+	@Trivial
 	protected static final byte[] signISO9796(byte[][] key, byte[] data, int off, int len) throws Exception {
 		CachingKey ck = new CachingKey(key, data, off, len);
 		CachingKey result = cryptoKeysMap.get(ck);
@@ -260,7 +264,7 @@ final class LTPACrypto {
 	}
 
 	private static final ConcurrentHashMap<CachingVerifyKey, CachingVerifyKey> verifyKeysMap = new ConcurrentHashMap<CachingVerifyKey, CachingVerifyKey>();
-
+	@Trivial
 	private static class CachingVerifyKey {
 
 		private long successfulUses;
@@ -273,7 +277,7 @@ final class LTPACrypto {
 		private final int sigLen;
 		private int hashcode;
 		private boolean result;
-
+		@Trivial
 		private CachingVerifyKey(byte[][] key, byte[] data, int off, int len, byte[] sig, int sigOff, int sigLen) {
 			this.key = key;
 			this.data = data;
@@ -307,6 +311,7 @@ final class LTPACrypto {
 		}
 
 		@Override
+		@Trivial
 		public boolean equals(Object to) {
 			if (!(to instanceof CachingVerifyKey)) {
 				return false;
@@ -410,14 +415,15 @@ final class LTPACrypto {
 		}
 
 		@Override
+		@Trivial
 		public int hashCode() {
 			return this.hashcode;
 		}
 
 	}
-
 	private static final Comparator<CachingVerifyKey> cachingVerifyKeyComparator = new Comparator<CachingVerifyKey>() {
 		@Override
+		@Trivial
 		public int compare(CachingVerifyKey o1, CachingVerifyKey o2) {
 			if (o1.successfulUses < o2.successfulUses) {
 				return -1;
@@ -428,9 +434,9 @@ final class LTPACrypto {
 			}
 		}
 	};
-
 	private static final Comparator<CachingKey> cachingKeyComparator = new Comparator<CachingKey>() {
 		@Override
+		@Trivial
 		public int compare(CachingKey o1, CachingKey o2) {
 			if (!o1.reused) {
 				if (o2.reused) {
@@ -470,6 +476,7 @@ final class LTPACrypto {
 	 *            The length of the signature
 	 * @return True if the signature of the data is correct
 	 */
+	@Trivial
 	protected static final boolean verifyISO9796(byte[][] key, byte[] data, int off, int len, byte[] sig, int sigOff,
 			int sigLen) throws Exception {
 		CachingVerifyKey ck = new CachingVerifyKey(key, data, off, len, sig, sigOff, sigLen);
@@ -531,6 +538,7 @@ final class LTPACrypto {
 	 * @param key
 	 *            The key
 	 */
+	@Trivial
 	protected static final void setRSAKey(byte[][] key) {
 		BigInteger[] k = new BigInteger[8];
 		for (int i = 0; i < 8; i++) {
@@ -578,6 +586,7 @@ final class LTPACrypto {
 	 * @throws NoSuchAlgorithmException
 	 * @throws InvalidKeySpecException
 	 */
+	@Trivial
 	private static SecretKey constructSecretKey(byte[] key, String cipher)
 			throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException, NoSuchProviderException {
 		SecretKey sKey = null;
@@ -603,6 +612,7 @@ final class LTPACrypto {
 	 * @throws InvalidKeyException
 	 * @throws InvalidAlgorithmParameterException
 	 */
+	@Trivial
 	private static Cipher createCipher(int cipherMode, byte[] key, String cipher, SecretKey sKey)
 			throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException,
 			InvalidAlgorithmParameterException, NoSuchProviderException {
@@ -639,6 +649,7 @@ final class LTPACrypto {
 	 *            The cipher algorithm
 	 * @return The encrypted data (ciphertext)
 	 */
+	@Trivial
 	protected static final byte[] encrypt(byte[] data, byte[] key, String cipher) throws Exception {
 		SecretKey sKey = constructSecretKey(key, cipher);
 		Cipher ci = createCipher(Cipher.ENCRYPT_MODE, key, cipher, sKey);
@@ -656,6 +667,7 @@ final class LTPACrypto {
 	 *            The cipher algorithm
 	 * @return The decrypted data (plaintext)
 	 */
+	@Trivial
 	protected static final byte[] decrypt(byte[] msg, byte[] key, String cipher) throws Exception {
 		SecretKey sKey = constructSecretKey(key, cipher);
 		Cipher ci = createCipher(Cipher.DECRYPT_MODE, key, cipher, sKey);
@@ -667,6 +679,7 @@ final class LTPACrypto {
 	 *
 	 * @param maxCache The maximam size of the cache
 	 */
+	@Trivial
 	protected static void setMaxCache(int maxCache) {
 		MAX_CACHE = maxCache;
 	}
@@ -676,6 +689,7 @@ final class LTPACrypto {
 	 *
 	 * @param key The key
 	 */
+	@Trivial
 	private static final synchronized void setIVS8(byte[] key) {
 		if (ivs8 == null) {
 			byte[] iv8 = new byte[8];
@@ -691,7 +705,7 @@ final class LTPACrypto {
 	 *
 	 * @param key The key
 	 */
-
+	@Trivial
 	private static final synchronized void setIVS16(byte[] key) {
 		if (ivs16 == null) {
 			byte[] iv16 = new byte[16];
@@ -701,7 +715,7 @@ final class LTPACrypto {
 			ivs16 = new IvParameterSpec(iv16);
 		}
 	}
-
+    @Trivial
 	static final int lsbf(byte[] data, int i, int n) {
 		int v = 0;
 		do {
@@ -709,39 +723,39 @@ final class LTPACrypto {
 		} while (n > 0);
 		return v;
 	}
-
+    @Trivial
 	static final int lsbf4(byte[] data, int i) {
 		return (data[i] & 0xFF) | ((data[i + 1] & 0xFF) << 8) | ((data[i + 2] & 0xFF) << 16) | (data[i + 3] << 24);
 	}
-
+    @Trivial
 	static final void lsbf4(int v, byte[] data, int i) {
 		data[i] = (byte) v;
 		data[i + 1] = (byte) (v >>> 8);
 		data[i + 2] = (byte) (v >>> 16);
 		data[i + 3] = (byte) (v >>> 24);
 	}
-
+    @Trivial
 	static void lsbf2(int v, byte[] data, int i) {
 		data[i] = (byte) v;
 		data[i + 1] = (byte) (v >>> 8);
 	}
-
+    @Trivial
 	private static final int FF(int a, int b, int c, int d, int x, int l, int r, int ac) {
 		return (((a += ((b & c) | (~b & d)) + x + ac) << l) | (a >>> r)) + b;
 	}
-
+    @Trivial
 	private static final int GG(int a, int b, int c, int d, int x, int l, int r, int ac) {
 		return (((a += ((b & d) | (c & ~d)) + x + ac) << l) | (a >>> r)) + b;
 	}
-
+    @Trivial
 	private static final int HH(int a, int b, int c, int d, int x, int l, int r, int ac) {
 		return (((a += (b ^ c ^ d) + x + ac) << l) | (a >>> r)) + b;
 	}
-
+    @Trivial
 	private static final int II(int a, int b, int c, int d, int x, int l, int r, int ac) {
 		return (((a += (c ^ (b | ~d)) + x + ac) << l) | (a >>> r)) + b;
 	}
-
+    @Trivial
 	static final void md5(int[] state, byte[] data, int off, int len, byte[] to, int pos) {
 		int a, b, c, d;
 		{
@@ -879,7 +893,7 @@ final class LTPACrypto {
 	private static int[] samples = new int[56];
 	private static int[] ones = new int[16];
 	private static int[] block = new int[16];
-
+	@Trivial
 	static final void trng(byte[] to, int off, int len) {
 		long accu = 0;
 		int bits = 0, i, m, j;
@@ -963,7 +977,7 @@ final class LTPACrypto {
 
 	static byte[][][] rsaKeys;
 	static byte[][][] dsaKeys;
-
+	@Trivial
 	static final void random(byte[] to, int off, int n) {
 		if (!seedInitialized) {
 			trng(seed, 0, 32);
@@ -1008,7 +1022,7 @@ final class LTPACrypto {
 			}
 		}
 	}
-
+    @Trivial
 	static final byte[] generate3DESKey() {
 		byte[] rndSeed = null;
 		int len = 24; // 3DES
@@ -1016,7 +1030,7 @@ final class LTPACrypto {
 		random(rndSeed, 0, len);
 		return rndSeed;
 	}
-
+    @Trivial
 	static final byte[][] rsaKey(int len, boolean crt, boolean f4) {
 		byte[][] key = new byte[crt ? 8 : 3][];
 		KeyPair pair = null;
@@ -1057,7 +1071,7 @@ final class LTPACrypto {
 
 		return key;
 	}
-
+	
 	private static String getProvider(){
 		String provider = null;
 		if (LTPAKeyUtil.isIBMJCEAvailable()) {

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -235,7 +235,7 @@ final class LTPACrypto {
 		BigInteger q = new BigInteger(key[4]);
 		BigInteger d = e.modInverse((p.subtract(BigInteger.ONE)).multiply(q.subtract(BigInteger.ONE)));
 		KeyFactory kFact = null;
-		kFact = (provider != "")? KeyFactory.getInstance(CRYPTO_ALGORITHM, provider):KeyFactory.getInstance(CRYPTO_ALGORITHM);
+		kFact = (provider == null)? KeyFactory.getInstance(CRYPTO_ALGORITHM):KeyFactory.getInstance(CRYPTO_ALGORITHM, provider);
 
 		BigInteger pep = new BigInteger(key[5]);
 		BigInteger peq = new BigInteger(key[6]);
@@ -244,7 +244,7 @@ final class LTPACrypto {
 		PrivateKey privKey = kFact.generatePrivate(privCrtKeySpec);
 
 		Signature rsaSig = null;
-		rsaSig = (provider != "")? Signature.getInstance(SIGNATURE_ALGORITHM, provider):Signature.getInstance(SIGNATURE_ALGORITHM);
+		rsaSig = (provider == null)? Signature.getInstance(SIGNATURE_ALGORITHM):Signature.getInstance(SIGNATURE_ALGORITHM, provider);
 		rsaSig.initSign(privKey);
 		rsaSig.update(data, off, len);
 		byte[] sig = rsaSig.sign();
@@ -507,10 +507,10 @@ final class LTPACrypto {
 		KeyFactory kFact = null;
 		Signature rsaSig = null;
 
-		kFact = (provider != "")? KeyFactory.getInstance(CRYPTO_ALGORITHM, provider):KeyFactory.getInstance(CRYPTO_ALGORITHM);
+		kFact = (provider == null)? KeyFactory.getInstance(CRYPTO_ALGORITHM):KeyFactory.getInstance(CRYPTO_ALGORITHM, provider);
 		RSAPublicKeySpec pubKeySpec = new RSAPublicKeySpec(n, e);
 		PublicKey pubKey = kFact.generatePublic(pubKeySpec);
-		rsaSig = (provider != "")? Signature.getInstance(SIGNATURE_ALGORITHM, provider):Signature.getInstance(SIGNATURE_ALGORITHM);
+		rsaSig = (provider == null)? Signature.getInstance(SIGNATURE_ALGORITHM):Signature.getInstance(SIGNATURE_ALGORITHM, provider);
 		rsaSig.initVerify(pubKey);
 		rsaSig.update(data, off, len);
 		verified = rsaSig.verify(sig);
@@ -584,7 +584,7 @@ final class LTPACrypto {
 		} else {
 			DESedeKeySpec kSpec = new DESedeKeySpec(key);
 			SecretKeyFactory kFact = null;
-			kFact = (provider != "")? SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM, provider):SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM);
+			kFact = (provider == null)? SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM):SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM, provider);
 			sKey = kFact.generateSecret(kSpec);
 		}
 		return sKey;
@@ -606,7 +606,7 @@ final class LTPACrypto {
 
 		Cipher ci = null;
 		
-		ci = (provider != "")? Cipher.getInstance(cipher, provider):Cipher.getInstance(cipher);
+		ci = (provider == null)? Cipher.getInstance(cipher):Cipher.getInstance(cipher, provider);
 		if (cipher.indexOf("ECB") == -1) {
 			if (cipher.indexOf("AES") != -1) {
 				if (ivs16 == null) {
@@ -1020,7 +1020,7 @@ final class LTPACrypto {
 		KeyPairGenerator keyGen = null;
 		try {
 
-			keyGen = (provider != "")? KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, provider):KeyPairGenerator.getInstance(CRYPTO_ALGORITHM);
+			keyGen = (provider == null)? KeyPairGenerator.getInstance(CRYPTO_ALGORITHM):KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, provider);
 
 			keyGen.initialize(len * 8, new SecureRandom());
 			pair = keyGen.generateKeyPair();
@@ -1056,7 +1056,7 @@ final class LTPACrypto {
 	}
 
 	private static String getProvider(){
-		String provider = "";
+		String provider = null;
 		if (LTPAKeyUtil.isIBMJCEAvailable()) {
 			provider = IBMJCE_NAME;
 		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2011 IBM Corporation and others.
+ * Copyright (c) 1997, 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
  * Copyright (c) 1997, 2011 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -45,12 +47,11 @@ final class LTPACrypto {
 	private static final String CRYPTO_ALGORITHM = "RSA";
 	private static final String ENCRYPT_ALGORITHM = "DESede";
 	private static final String IBMJCE_NAME = "IBMJCE";
+	private static final String OPENJCEPLUS_NAME = "OpenJCEPlus";
 
 	private static int MAX_CACHE = 500;
-
 	private static IvParameterSpec ivs8 = null;
 	private static IvParameterSpec ivs16 = null;
-
 	private static class CachingKey {
 
 		private boolean reused = false;
@@ -235,7 +236,9 @@ final class LTPACrypto {
 		KeyFactory kFact = null;
 		if (LTPAKeyUtil.isIBMJCEAvailable()) {
 			kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM, IBMJCE_NAME);
-		} else {
+		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
+			kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM, OPENJCEPLUS_NAME);
+		}else {
 			kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM);
 		}
 
@@ -248,7 +251,9 @@ final class LTPACrypto {
 		Signature rsaSig = null;
 		if (LTPAKeyUtil.isIBMJCEAvailable()) {
 			rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM, IBMJCE_NAME);
-		} else {
+		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
+			rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM, OPENJCEPLUS_NAME);
+		}else {
 			rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM);
 		}
 		rsaSig.initSign(privKey);
@@ -515,14 +520,18 @@ final class LTPACrypto {
 
 		if (LTPAKeyUtil.isIBMJCEAvailable()) {
 			kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM, IBMJCE_NAME);
-		} else {
+		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
+			kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM, OPENJCEPLUS_NAME);
+		}else {
 			kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM);
 		}
 		RSAPublicKeySpec pubKeySpec = new RSAPublicKeySpec(n, e);
 		PublicKey pubKey = kFact.generatePublic(pubKeySpec);
 		if (LTPAKeyUtil.isIBMJCEAvailable()) {
 			rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM, IBMJCE_NAME);
-		} else {
+		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
+			rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM, OPENJCEPLUS_NAME);
+		}else {
 			rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM);
 		}
 		rsaSig.initVerify(pubKey);
@@ -600,7 +609,9 @@ final class LTPACrypto {
 			SecretKeyFactory kFact = null;
 			if (LTPAKeyUtil.isIBMJCEAvailable()) {
 				kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM, IBMJCE_NAME);
-			} else {
+			} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
+				kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM, OPENJCEPLUS_NAME);
+			}else {
 				kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM);
 			}
 			sKey = kFact.generateSecret(kSpec);
@@ -626,7 +637,9 @@ final class LTPACrypto {
 
 		if (LTPAKeyUtil.isIBMJCEAvailable()) {
 			ci = Cipher.getInstance(cipher, IBMJCE_NAME);
-		} else {
+		} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
+			ci = Cipher.getInstance(cipher, OPENJCEPLUS_NAME);
+		}else {
 			ci = Cipher.getInstance(cipher);
 		}
 		if (cipher.indexOf("ECB") == -1) {
@@ -1045,9 +1058,12 @@ final class LTPACrypto {
 			if (LTPAKeyUtil.isIBMJCEAvailable()) {
 				// IBMJCE_NAME needed for hardware crypto
 				keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, IBMJCE_NAME);
-			} else {
+			} else if(LTPAKeyUtil.isZOSandRunningJava11orHigher() && LTPAKeyUtil.isOpenJCEPlusAvailable()){
+				keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, OPENJCEPLUS_NAME);
+			}else {
 				keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM);
 			}
+			
 			keyGen.initialize(len * 8, new SecureRandom());
 			pair = keyGen.generateKeyPair();
 			RSAPublicKey rsaPubKey = (RSAPublicKey) pair.getPublic();
@@ -1080,4 +1096,5 @@ final class LTPACrypto {
 
 		return key;
 	}
+
 }

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
@@ -12,7 +12,7 @@ package com.ibm.ws.crypto.ltpakeyutil;
 
 import java.security.Provider;
 import java.security.Security;
-import com.ibm.ws.kernel.service.util.JavaInfo; 
+import com.ibm.ws.kernel.service.util.JavaInfo;
 
 public final class LTPAKeyUtil {
 
@@ -28,8 +28,7 @@ public final class LTPAKeyUtil {
   public static boolean isZOS = false;
   public static boolean osVersionChecked = false;
 
-
-  public static String IBM_JCE_PROVIDER = "com.ibm.crypto.provider.IBMJCE"; 
+  public static String IBM_JCE_PROVIDER = "com.ibm.crypto.provider.IBMJCE";
   public static String OPENJCEPLUS_PROVIDER = "com.ibm.crypto.plus.provider.OpenJCEPlus";
 
   public static byte[] encrypt(byte[] data, byte[] key, String cipher) throws Exception {
@@ -40,7 +39,8 @@ public final class LTPAKeyUtil {
     return LTPACrypto.decrypt(msg, key, cipher);
   }
 
-  public static boolean verifyISO9796(byte[][] key, byte[] data, int off, int len, byte[] sig, int sigOff, int sigLen) throws Exception {
+  public static boolean verifyISO9796(byte[][] key, byte[] data, int off, int len, byte[] sig, int sigOff, int sigLen)
+      throws Exception {
     return LTPACrypto.verifyISO9796(key, data, off, len, sig, sigOff, sigLen);
   }
 
@@ -71,8 +71,7 @@ public final class LTPAKeyUtil {
   public static boolean isIBMJCEAvailable() {
     if (providerChecked) {
       return ibmJCEAvailable;
-    }
-    else {
+    } else {
       ibmJCEAvailable = JavaInfo.isSystemClassAvailable(IBM_JCE_PROVIDER);
       providerChecked = true;
       return ibmJCEAvailable;
@@ -80,44 +79,40 @@ public final class LTPAKeyUtil {
 
   }
 
-    public static boolean isOpenJCEPlusAvailable() {
-      //change to z
+  public static boolean isOpenJCEPlusAvailable() {
+    // change to z
     if (zosProviderChecked) {
       return openJCEPlusAvailable;
-    }
-    else {
-     openJCEPlusAvailable = JavaInfo.isSystemClassAvailable(OPENJCEPLUS_PROVIDER);
+    } else {
+      openJCEPlusAvailable = JavaInfo.isSystemClassAvailable(OPENJCEPLUS_PROVIDER);
       zosProviderChecked = true;
       return openJCEPlusAvailable;
     }
 
   }
 
-  public static boolean isJava11orHigher(){
-    if(javaVersionChecked){
-    return isJava11orHigher;
-    }
-    else {
-      javaVersionChecked = true;
-      isJava11orHigher = JavaInfo.majorVersion() >= 11;
+  private static boolean isJava11orHigher() {
+    if (javaVersionChecked) {
       return isJava11orHigher;
-    } 
-  }
-
-  public static boolean isZOS(){
-    if(osVersionChecked){
-    return isZOS;
+    } else {
+      isJava11orHigher = JavaInfo.majorVersion() >= 11;
+      javaVersionChecked = true;
+      return isJava11orHigher;
     }
-    else {
-      osVersionChecked = true;
-      isZOS = (osName.equalsIgnoreCase("z/OS") || osName.equalsIgnoreCase("OS/390"));
-      return isZOS;
-    } 
   }
 
-  public static boolean isZOSandRunningJava11orHigher(){
+  private static boolean isZOS() {
+    if (osVersionChecked) {
+      return isZOS;
+    } else {
+      isZOS = (osName.equalsIgnoreCase("z/OS") || osName.equalsIgnoreCase("OS/390"));
+      osVersionChecked = true;
+      return isZOS;
+    }
+  }
+
+  public static boolean isZOSandRunningJava11orHigher() {
     return isJava11orHigher() && isZOS();
   }
-
 
 }

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
@@ -24,6 +24,9 @@ public final class LTPAKeyUtil {
   public static boolean javaVersionChecked = false;
   public static boolean isJava11orHigher = false;
 
+  public static boolean zOSAndJAVA11orHigherChecked = false; 
+  public static boolean iszOSAndJava11orHigher = false; 
+
   public static String osName = System.getProperty("os.name");
   public static boolean isZOS = false;
   public static boolean osVersionChecked = false;
@@ -112,7 +115,14 @@ public final class LTPAKeyUtil {
   }
 
   public static boolean isZOSandRunningJava11orHigher() {
-    return isJava11orHigher() && isZOS();
+    if (zOSAndJAVA11orHigherChecked){
+      return iszOSAndJava11orHigher;
+    }
+    else {
+      iszOSAndJava11orHigher = isJava11orHigher() && isZOS();
+      zOSAndJAVA11orHigherChecked = true;
+      return iszOSAndJava11orHigher;
+    }
   }
 
 }

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
@@ -17,8 +17,20 @@ import com.ibm.ws.kernel.service.util.JavaInfo;
 public final class LTPAKeyUtil {
 
   public static boolean ibmJCEAvailable = false;
+  public static boolean openJCEPlusAvailable = false;
   public static boolean providerChecked = false;
+  public static boolean zosProviderChecked = false;
+
+  public static boolean javaVersionChecked = false;
+  public static boolean isJava11orHigher = false;
+
+  public static String osName = System.getProperty("os.name");
+  public static boolean isZOS = false;
+  public static boolean osVersionChecked = false;
+
+
   public static String IBM_JCE_PROVIDER = "com.ibm.crypto.provider.IBMJCE"; 
+  public static String OPENJCEPLUS_PROVIDER = "com.ibm.crypto.plus.provider.OpenJCEPlus";
 
   public static byte[] encrypt(byte[] data, byte[] key, String cipher) throws Exception {
     return LTPACrypto.encrypt(data, key, cipher);
@@ -67,5 +79,45 @@ public final class LTPAKeyUtil {
     }
 
   }
+
+    public static boolean isOpenJCEPlusAvailable() {
+      //change to z
+    if (zosProviderChecked) {
+      return openJCEPlusAvailable;
+    }
+    else {
+     openJCEPlusAvailable = JavaInfo.isSystemClassAvailable(OPENJCEPLUS_PROVIDER);
+      zosProviderChecked = true;
+      return openJCEPlusAvailable;
+    }
+
+  }
+
+  public static boolean isJava11orHigher(){
+    if(javaVersionChecked){
+    return isJava11orHigher;
+    }
+    else {
+      javaVersionChecked = true;
+      isJava11orHigher = JavaInfo.majorVersion() >= 11;
+      return isJava11orHigher;
+    } 
+  }
+
+  public static boolean isZOS(){
+    if(osVersionChecked){
+    return isZOS;
+    }
+    else {
+      osVersionChecked = true;
+      isZOS = (osName.equalsIgnoreCase("z/OS") || osName.equalsIgnoreCase("OS/390"));
+      return isZOS;
+    } 
+  }
+
+  public static boolean isZOSandRunningJava11orHigher(){
+    return isJava11orHigher() && isZOS();
+  }
+
 
 }

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
@@ -83,7 +83,6 @@ public final class LTPAKeyUtil {
   }
 
   public static boolean isOpenJCEPlusAvailable() {
-    // change to z
     if (zosProviderChecked) {
       return openJCEPlusAvailable;
     } else {


### PR DESCRIPTION
We discovered that when we let the JDK pick up the crypto provider the provider that is being used is not valid and gives us a ltpa.key file with the size of 1070 vs the expected size which should be 897.

This leads us to this exception:
```
Stack Dump = com.ibm.websphere.security.auth.InvalidTokenException: BigInteger not invertible.
        at com.ibm.ws.security.token.ltpa.internal.LTPAToken2.getBytes(LTPAToken2.java:381)
        at com.ibm.ws.security.token.internal.AbstractTokenImpl.getBytes(AbstractTokenImpl.java:177)
        at com.ibm.ws.security.authentication.internal.cache.keyproviders.SSOTokenBytesCacheKeyProvider.getSingleSignonTokenBytes(SSOTokenBytesCacheKeyProvider.java:56)
        at com.ibm.ws.security.authentication.internal.cache.keyproviders.SSOTokenBytesCacheKeyProvider.provideKey(SSOTokenBytesCacheKeyProvider.java:39)
        at com.ibm.ws.security.authentication.internal.cache.AuthCacheServiceImpl.commonInsert(AuthCacheServiceImpl.java:118)
        at com.ibm.ws.security.authentication.internal.cache.AuthCacheServiceImpl.insert(AuthCacheServiceImpl.java:76)
        at com.ibm.ws.security.authentication.internal.AuthenticationServiceImpl.insertSubjectInAuthCache(AuthenticationServiceImpl.java:582)
        at com.ibm.ws.security.authentication.internal.AuthenticationServiceImpl.authenticate(AuthenticationServiceImpl.java:224)
        at com.ibm.ws.webcontainer.security.internal.BasicAuthAuthenticator.basicAuthenticate(BasicAuthAuthenticator.java:130)
        at com.ibm.ws.webcontainer.security.internal.FormLoginExtensionProcessor.formLogin(FormLoginExtensionProcessor.java:180)
        at com.ibm.ws.webcontainer.security.internal.FormLoginExtensionProcessor.handleRequest(FormLoginExtensionProcessor.java:115)
```

Fixes #26267


