### PR TITLE
PR for Issue 25927: Fix JWK retrieval logic for JWKs missing 'use' entry

### DIFF
--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 IBM Corporation and others.
+ * Copyright (c) 2016, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.common.jwk.impl;
 
@@ -197,7 +194,7 @@ public class JwKRetriever {
 
     @Sensitive
     private Key getJwkFromJWKSet(@Sensitive String setId, String kid, String x5t, String use, @Sensitive String keyText, JwkKeyType keyType) {
-        boolean isKeyIdentifierUsed = (kid != null || x5t != null || use != null);
+        boolean isKeyIdentifierUsed = (kid != null || x5t != null);
         Key key = null;
         if (kid != null) {
             key = jwkSet.getKeyBySetIdAndKid(setId, kid, keyType);

--- a/dev/com.ibm.ws.security.common.jsonwebkey/test/com/ibm/ws/security/common/jwk/impl/jwk_minimum_test.json
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/test/com/ibm/ws/security/common/jwk/impl/jwk_minimum_test.json
@@ -1,0 +1,5 @@
+{
+  "kty": "RSA",
+  "n": "rkCYJj7QPIURA+T0arwFkBWK/8PemAW/gppsY5p+uqwASoFNnHLOiUpS6k3NJRcb0QEu2MHjt7IKZ/mya4NgoAMfM+lm0+QmDhY1XFUrmKj0WQhp/Oc6X48kX2zDmu00GXjO3H2446IofTnBeWxIpClpH+aQ0rcCZlLOu/O/CDIHz30qpe4NT4MlkYUeKNltUBctNQP7VMJw4iPHCdsXlIfpVqzONWIdbsFTsk1r3ynrReOeIbP4JA2/sI03LdSS0XxMVYe7zwIb9dHmWlOjMcejNTEh4fRdNnwQYbU3aWhj55gNYpDxUvwazwN52Rm9XoTsv+pi0pj3SK0PeE3s1w==",
+  "e": "AQAB"
+}


### PR DESCRIPTION
This change boils down to no longer considering `"use"` to be a key identifier. That entry denotes how the key is expected to be used, and can still be used to look for the appropriate key with the corresponding value if one is available. However if `"use"` is not in the JWK, the current logic cannot successfully re-load that JWK from the internal cache if our internal calls are looking for a specific `"use"`. This change should allow our logic to essentially fall back to loading a JWK without a `"use"` entry in the event we don't find one cached.

Resolves #25927