### PR TITLE
Allow different cert ffdc with different jdks

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.SSO.clientTests/fat/src/com/ibm/ws/security/SSO/clientTests/PrivateKeyJwt/PrivateKeyJwtClientTests.java
+++ b/dev/com.ibm.ws.security.fat.common.SSO.clientTests/fat/src/com/ibm/ws/security/SSO/clientTests/PrivateKeyJwt/PrivateKeyJwtClientTests.java
@@ -545,7 +545,7 @@ public class PrivateKeyJwtClientTests extends PKCEPrivateKeyJwtCommonTooling {
      * the keystore is a different cert.
      * We should not have access to the protected app.
      */
-    @AllowedFFDC({ "io.openliberty.security.oidcclientcore.http.BadPostRequestException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException" })
+    @AllowedFFDC({ "io.openliberty.security.oidcclientcore.http.BadPostRequestException", "sun.security.validator.ValidatorException", "javax.net.ssl.SSLHandshakeException", "java.security.cert.CertPathValidatorException" })
     @Test
     public void PrivateKeyJwtClientTests_accessTokenUsesRS256_privateKeyJwtUsesRS256_sameAliasDiffCert() throws Exception {
 


### PR DESCRIPTION
Newly created tests have hit an equivalent, but different ffdc using another version of Java.
I just need to also allow java.security.cert.CertPathValidatorException.