### PR TITLE
Expect an additional error message for WasReqURLTests

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientWasReqURLTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientWasReqURLTests.java
@@ -804,6 +804,9 @@ public class OidcClientWasReqURLTests extends CommonTest {
                     "Did not receive error message " + MessageConstants.CWOAU0073E_FRONT_END_ERROR + " in the response", null,
                     MessageConstants.CWOAU0073E_FRONT_END_ERROR);
             expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.LOGIN_USER, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS,
+                    "Server log did not contain an error message about an invalid hostname in the WASReqURLOidc cookie.",
+                    MessageConstants.CWWKS1554E_PRIVATE_KEY_JWT_MISSING_ALIAS + ".*" + updatedHost + ".*");
+            expectations = validationTools.addMessageExpectation(testRPServer, expectations, Constants.LOGIN_USER, Constants.MESSAGES_LOG, Constants.STRING_CONTAINS,
                     "Server log did not contain an error message about the missing WASReqURLOidc cookie.",
                     MessageConstants.CWWKS1532E_MALFORMED_URL_IN_COOKIE + ".*" + updatedHost + ".*");
 


### PR DESCRIPTION
Several WasReqURLTests expected error message CWWKS1532E.  They will now also expect error message CWWKS1554E.  The 2 messages are very similar, but, each does contain unique information.
I've updated the tests to expect/require both messages be issued now.