### PR TITLE
Issue #25790: Remove dependencies on ManagedBean

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -178,7 +178,6 @@ instrument.classesExcludes: com/ibm/ws/ejbcontainer/osgi/internal/resources/*.cl
 	com.ibm.ws.artifact.overlay;version=latest,\
 	com.ibm.ws.threading;version=latest,\
 	com.ibm.ws.kernel.boot;version=latest,\
-	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.interceptor.1.1;version=latest,\
 	com.ibm.ws.jndi.url.contexts;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\

--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/ModuleInitDataFactory.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/ModuleInitDataFactory.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2015 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import javax.annotation.ManagedBean;
 import javax.ejb.DependsOn;
 import javax.ejb.Local;
 import javax.ejb.LocalBean;
@@ -171,6 +170,7 @@ public class ModuleInitDataFactory {
     private static final String REFERENCE_SESSION_BEAN_RUNTIME = "sessionBeanRuntime";
     private static final String REFERENCE_MDB_RUNTIME = "mdbRuntime";
     private static final String REFERENCE_MANAGED_BEAN_RUNTIME = "managedBeanRuntime";
+    private static final String MANAGED_BEAN_CLASSNAME = "javax.annotation.ManagedBean";
 
     private final AtomicServiceReference<AnnotationService_Service> annoServiceSRRef = new AtomicServiceReference<AnnotationService_Service>(REFERENCE_ANNOTATION_SERVICE);
     private final AtomicServiceReference<J2EENameFactory> j2eeNameFactorySRRef = new AtomicServiceReference<J2EENameFactory>(REFERENCE_J2EE_NAME_FACTORY);
@@ -283,12 +283,7 @@ public class ModuleInitDataFactory {
         }
 
         J2EENameFactory j2eeNameFactory = j2eeNameFactorySRRef.getService();
-        ModuleInitDataImpl mid = new ModuleInitDataImpl(
-                        modName, appName,
-                        ejbJar == null ? EJBJar.VERSION_3_0 : ejbJar.getVersionID(),
-                        sessionBeanRuntime,
-                        mdbRuntime,
-                        managedBeanRuntimeSRRef.getService());
+        ModuleInitDataImpl mid = new ModuleInitDataImpl(modName, appName, ejbJar == null ? EJBJar.VERSION_3_0 : ejbJar.getVersionID(), sessionBeanRuntime, mdbRuntime, managedBeanRuntimeSRRef.getService());
         mid.container = container;
         mid.ivLogicalName = modLogicalName;
         mid.ivJ2EEName = j2eeNameFactory.create(mid.ivAppName, mid.ivName, null);
@@ -451,7 +446,7 @@ public class ModuleInitDataFactory {
                 // to use SEED | PARTIAL | EXCLUDED in all cases regardless of whether EJB or WEB targets
                 // were obtained.
 
-                classNames.addAll(targets.getAnnotatedClasses(ManagedBean.class.getName(), AnnotationTargets_Targets.POLICY_ALL_EXCEPT_EXTERNAL));
+                classNames.addAll(targets.getAnnotatedClasses(MANAGED_BEAN_CLASSNAME, AnnotationTargets_Targets.POLICY_ALL_EXCEPT_EXTERNAL));
             }
 
             for (String className : classNames) {
@@ -580,8 +575,7 @@ public class ModuleInitDataFactory {
             if (modMergeData.isManagedBeanEnabled()) {
                 mid.managedBeanBinding = container.adapt(ManagedBeanBnd.class);
                 if (mid.managedBeanBinding != null) {
-                    Map<String, com.ibm.ws.javaee.dd.managedbean.ManagedBean> managedBeanBindings =
-                                    getManagedBeanBindings(mid.managedBeanBinding.getManagedBeans());
+                    Map<String, com.ibm.ws.javaee.dd.managedbean.ManagedBean> managedBeanBindings = getManagedBeanBindings(mid.managedBeanBinding.getManagedBeans());
 
                     for (BeanMergeData beanMergeData : modMergeData.getBeans()) {
                         BeanInitDataImpl bid = beanMergeData.getBeanInitData();
@@ -733,7 +727,7 @@ public class ModuleInitDataFactory {
         // If bean merge data already exists then this is not a managed bean
         // as managed beans cannot be defined in XML.
         if (modData.isManagedBeanEnabled()) {
-            AnnotationInfo managedBeanAnn = classInfo.getAnnotation(ManagedBean.class);
+            AnnotationInfo managedBeanAnn = classInfo.getAnnotation(MANAGED_BEAN_CLASSNAME);
             if (managedBeanAnn != null &&
                 !modData.containsBeanMergeDataForClass(classInfo.getName())) {
                 mergeComponentDefiningAnnotation(classInfo, managedBeanAnn,
@@ -862,7 +856,7 @@ public class ModuleInitDataFactory {
     }
 
     private String getManagedBeansName(ClassInfo classInfo) {
-        AnnotationInfo ann = classInfo.getAnnotation(ManagedBean.class);
+        AnnotationInfo ann = classInfo.getAnnotation(MANAGED_BEAN_CLASSNAME);
         return ann == null ? null : getStringValue(ann, "value");
     }
 
@@ -1001,7 +995,7 @@ public class ModuleInitDataFactory {
 
         if (isTraceOn && tc.isDebugEnabled()) {
             Tr.debug(tc, "checked interfaces", new Object[] { "interfaces=" + classInfo.getInterfaceNames(),
-                                                             "eligibleInterfaces=" + eligibleInterfaceNames });
+                                                              "eligibleInterfaces=" + eligibleInterfaceNames });
         }
 
         if (!bid.ivLocalBean) {
@@ -1069,12 +1063,12 @@ public class ModuleInitDataFactory {
 
         if (isTraceOn && tc.isEntryEnabled()) {
             Tr.exit(tc, "mergeSessionInterfaces", new Object[] { "remoteHome=" + bid.ivRemoteHomeInterfaceName,
-                                                                "localHome=" + bid.ivLocalHomeInterfaceName,
-                                                                "localBean=" + bid.ivLocalBean,
-                                                                "remoteBusiness=" + beanMergeData.getRemoteBusinessInterfaceNames(),
-                                                                "localBusiness=" + beanMergeData.getLocalBusinessInterfaceNames(),
-                                                                "webServiceEndpoint=" + bid.ivWebServiceEndpoint,
-                                                                "webServiceEndpointName=" + bid.ivWebServiceEndpointInterfaceName });
+                                                                 "localHome=" + bid.ivLocalHomeInterfaceName,
+                                                                 "localBean=" + bid.ivLocalBean,
+                                                                 "remoteBusiness=" + beanMergeData.getRemoteBusinessInterfaceNames(),
+                                                                 "localBusiness=" + beanMergeData.getLocalBusinessInterfaceNames(),
+                                                                 "webServiceEndpoint=" + bid.ivWebServiceEndpoint,
+                                                                 "webServiceEndpointName=" + bid.ivWebServiceEndpointInterfaceName });
         }
     }
 

--- a/dev/com.ibm.ws.ejbcontainer_test/test/com/ibm/ws/ejbcontainer/osgi/internal/AnnoMockery.java
+++ b/dev/com.ibm.ws.ejbcontainer_test/test/com/ibm/ws/ejbcontainer/osgi/internal/AnnoMockery.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,6 +24,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.annotation.ManagedBean;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -131,12 +133,19 @@ public class AnnoMockery {
                 for (final Annotation ann : element.getAnnotations()) {
                     final AnnotationInfo annInfo = mockAnnotationInfo(ann);
                     Class<? extends Annotation> annType = ann.annotationType();
-                    allowing(info).getAnnotation(annType);
+                    // Class name is used for ManagedBean rather than Class since the Class may not exist
+                    if (ManagedBean.class.equals(annType)) {
+                        allowing(info).getAnnotation(ManagedBean.class.getName());
+                    } else {
+                        allowing(info).getAnnotation(annType);
+                    }
                     will(returnValue(annInfo));
                     allowing(info).isAnnotationPresent(annType.getName());
                     will(returnValue(true));
                 }
                 allowing(info).getAnnotation(with(any(Class.class)));
+                will(returnValue(null));
+                allowing(info).getAnnotation(ManagedBean.class.getName());
                 will(returnValue(null));
                 allowing(info).isAnnotationPresent(with(any(String.class)));
                 will(returnValue(false));
@@ -281,7 +290,7 @@ public class AnnoMockery {
 
                 allowing(targets).scan(with(any(ClassSource_Aggregate.class)));
 
-                // 95160: Update to the new API, which uses 'get' and has a second scan policies parameter.                
+                // 95160: Update to the new API, which uses 'get' and has a second scan policies parameter.
                 allowing(targets).getAnnotatedClasses(with(any(String.class)), with(any(int.class)));
                 will(returnValue(Collections.emptySet()));
 

--- a/dev/com.ibm.ws.injection.core/src/com/ibm/ws/injectionengine/processor/ResourceProcessor.java
+++ b/dev/com.ibm.ws.injection.core/src/com/ibm/ws/injectionengine/processor/ResourceProcessor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 IBM Corporation and others.
+ * Copyright (c) 2006, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,13 +14,13 @@ package com.ibm.ws.injectionengine.processor;
 
 import static com.ibm.wsspi.injectionengine.InjectionConfigConstants.EE5Compatibility;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import javax.annotation.ManagedBean;
 import javax.annotation.Resource;
 import javax.annotation.Resource.AuthenticationType;
 import javax.annotation.Resources;
@@ -68,6 +68,17 @@ import com.ibm.wsspi.injectionengine.factory.ResourceInfoRefAddr;
 public class ResourceProcessor extends InjectionProcessor<Resource, Resources> {
     private static final String CLASS_NAME = ResourceProcessor.class.getName();
     private static final TraceComponent tc = Tr.register(ResourceProcessor.class, InjectionConfigConstants.traceString, InjectionConfigConstants.messageFile);
+    private static final Class<? extends Annotation> MANAGED_BEAN_CLASS;
+
+    static {
+        Class<? extends Annotation> mbClass = null;
+        try {
+            mbClass = (Class<? extends Annotation>) Class.forName("javax.annotation.ManagedBean");
+        } catch (ClassNotFoundException e) {
+            // ManagedBean may be removed from the specification
+        }
+        MANAGED_BEAN_CLASS = mbClass;
+    }
 
     private ResourceRefConfigList ivResRefList; // F48603.7
 
@@ -947,8 +958,10 @@ public class ResourceProcessor extends InjectionProcessor<Resource, Resources> {
 
         boolean result;
 
-        if (injectType != null && injectType != Object.class) {
-            result = injectType.isAnnotationPresent(ManagedBean.class);
+        if (MANAGED_BEAN_CLASS == null) {
+            result = false;
+        } else if (injectType != null && injectType != Object.class) {
+            result = injectType.isAnnotationPresent(MANAGED_BEAN_CLASS);
         } else {
             Set<String> mbClassNames = ivNameSpaceConfig.getManagedBeanClassNames();
             result = mbClassNames != null && mbClassNames.contains(injectTypeName);


### PR DESCRIPTION
Prepare for removal of jakarta.annotation.ManagedBean from the specifications
- Update ModuleInitDataFactory to use class name instead of class
- Update `@Resource` ResourceProcessor to load annotation if available
- Updated unit test for ModuleInitDataFactory to expect getAnnotation(class name) instead of class for ManagedBean

for #25790