### PR TITLE
Fix Origin header behavior in OIDC client

### DIFF
--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/OidcClientHttpUtil.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/OidcClientHttpUtil.java
@@ -81,12 +81,12 @@ public class OidcClientHttpUtil {
         return EntityUtils.toString(entity);
     }
 
-    HttpPost setupPost(String url,
-                       @Sensitive List<NameValuePair> params,
-                       String baUsername,
-                       @Sensitive String baPassword,
-                       String accessToken,
-                       String authMethod) throws Exception {
+    public HttpPost setupPost(String url,
+                              @Sensitive List<NameValuePair> params,
+                              String baUsername,
+                              @Sensitive String baPassword,
+                              String accessToken,
+                              String authMethod) throws Exception {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "OIDC _SSO RP POST TO URL [" + WebUtils.stripSecretFromUrl(url, "client_secret") + "]");
             httpUtils.debugPostToEndPoint(url, params, baUsername, baPassword, accessToken, commonHeaders);
@@ -139,6 +139,15 @@ public class OidcClientHttpUtil {
                                               String authMethod, boolean useSystemPropertiesForHttpClientConnections) throws Exception {
 
         HttpPost postMethod = setupPost(url, params, baUsername, baPassword, accessToken, authMethod);
+        return postToEndpoint(url, postMethod, sslSocketFactory, isHostnameVerification, useSystemPropertiesForHttpClientConnections);
+    }
+
+    public Map<String, Object> postToEndpoint(String url,
+                                              HttpPost postMethod,
+                                              SSLSocketFactory sslSocketFactory,
+                                              boolean isHostnameVerification,
+                                              boolean useSystemPropertiesForHttpClientConnections) throws Exception {
+
         HttpResponse response = setupResponse(sslSocketFactory, url, isHostnameVerification, useSystemPropertiesForHttpClientConnections, postMethod);
 
         // Check the response from the endpoint to see if there was an error

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenRequestor.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/TokenRequestor.java
@@ -18,6 +18,7 @@ import java.util.Map.Entry;
 import javax.net.ssl.SSLSocketFactory;
 
 import org.apache.http.NameValuePair;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicNameValuePair;
 
 import com.ibm.json.java.JSONObject;
@@ -116,20 +117,17 @@ public class TokenRequestor {
     }
 
     private Map<String, Object> postToTokenEndpoint() throws Exception {
+        HttpPost httpPost = oidcClientHttpUtil.setupPost(tokenEndpoint, params, clientId, clientSecret, null, authMethod);
         if (originHeaderValue != null) {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "Will add Origin HTTP header with value: [" + originHeaderValue + "]");
             }
-            OidcClientHttpUtil.commonHeaders.add(new BasicNameValuePair("Origin", originHeaderValue));
+            httpPost.addHeader("Origin", originHeaderValue);
         }
         return oidcClientHttpUtil.postToEndpoint(tokenEndpoint,
-                                                 params,
-                                                 clientId,
-                                                 clientSecret,
-                                                 null,
+                                                 httpPost,
                                                  sslSocketFactory,
                                                  isHostnameVerification,
-                                                 authMethod,
                                                  useSystemPropertiesForHttpClientConnections);
     }
 

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenRequestorTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/TokenRequestorTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.token;
 
@@ -23,6 +20,7 @@ import java.util.Map;
 import javax.net.ssl.SSLSocketFactory;
 
 import org.apache.http.NameValuePair;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicNameValuePair;
 import org.jmock.Expectations;
 import org.junit.After;
@@ -81,6 +79,7 @@ public class TokenRequestorTest extends CommonTestClass {
 
     private final OidcClientHttpUtil oidcClientHttpUtil = mockery.mock(OidcClientHttpUtil.class);
     private final SSLSocketFactory sslSocketFactory = mockery.mock(SSLSocketFactory.class);
+    private final HttpPost httpPost = mockery.mock(HttpPost.class);
 
     private List<NameValuePair> params;
     private List<NameValuePair> refreshParams;
@@ -125,7 +124,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, false, TokenConstants.METHOD_POST, false);
+                one(oidcClientHttpUtil).setupPost(tokenEndpoint, params, clientId, clientSecret, null, TokenConstants.METHOD_POST);
+                will(returnValue(httpPost));
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, httpPost, null, false, false);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -147,8 +148,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpointSecure, params, clientId, clientSecret, null, sslSocketFactory, false,
-                                                       TokenConstants.METHOD_POST, false);
+                one(oidcClientHttpUtil).setupPost(tokenEndpointSecure, params, clientId, clientSecret, null, TokenConstants.METHOD_POST);
+                will(returnValue(httpPost));
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpointSecure, httpPost, sslSocketFactory, false, false);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -169,7 +171,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, true, TokenConstants.METHOD_POST, false);
+                one(oidcClientHttpUtil).setupPost(tokenEndpoint, params, clientId, clientSecret, null, TokenConstants.METHOD_POST);
+                will(returnValue(httpPost));
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, httpPost, null, true, false);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -193,7 +197,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, false, TokenConstants.METHOD_BASIC, false);
+                one(oidcClientHttpUtil).setupPost(tokenEndpoint, params, clientId, clientSecret, null, TokenConstants.METHOD_BASIC);
+                will(returnValue(httpPost));
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, httpPost, null, false, false);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -214,7 +220,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, false, TokenConstants.METHOD_CLIENT_SECRET_POST, false);
+                one(oidcClientHttpUtil).setupPost(tokenEndpoint, params, clientId, clientSecret, null, TokenConstants.METHOD_CLIENT_SECRET_POST);
+                will(returnValue(httpPost));
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, httpPost, null, false, false);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -242,7 +250,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, false, TokenConstants.METHOD_POST, false);
+                one(oidcClientHttpUtil).setupPost(tokenEndpoint, params, clientId, clientSecret, null, TokenConstants.METHOD_POST);
+                will(returnValue(httpPost));
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, httpPost, null, false, false);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -264,7 +274,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, params, clientId, clientSecret, null, null, false, TokenConstants.METHOD_POST, true);
+                one(oidcClientHttpUtil).setupPost(tokenEndpoint, params, clientId, clientSecret, null, TokenConstants.METHOD_POST);
+                will(returnValue(httpPost));
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, httpPost, null, false, true);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -286,7 +298,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpointSecure, params, clientId, clientSecret, null, sslSocketFactory, true, TokenConstants.METHOD_POST, true);
+                one(oidcClientHttpUtil).setupPost(tokenEndpointSecure, params, clientId, clientSecret, null, TokenConstants.METHOD_POST);
+                will(returnValue(httpPost));
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpointSecure, httpPost, sslSocketFactory, true, true);
                 will(returnValue(postResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postResponseMap);
                 will(returnValue(tokenResponseEntity));
@@ -307,7 +321,9 @@ public class TokenRequestorTest extends CommonTestClass {
 
         mockery.checking(new Expectations() {
             {
-                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, refreshParams, clientId, clientSecret, null, null, false, TokenConstants.METHOD_POST, false);
+                one(oidcClientHttpUtil).setupPost(tokenEndpoint, refreshParams, clientId, clientSecret, null, TokenConstants.METHOD_POST);
+                will(returnValue(httpPost));
+                one(oidcClientHttpUtil).postToEndpoint(tokenEndpoint, httpPost, null, false, false);
                 will(returnValue(postRefreshResponseMap));
                 one(oidcClientHttpUtil).extractEntityFromTokenResponse(postRefreshResponseMap);
                 will(returnValue(tokenRefreshResponseEntity));


### PR DESCRIPTION
The OIDC client token request code has a quirk where the Origin HTTP header will be added to _all_ token endpoint requests once it has been sent initially. That was the effect of me quickly adding the Origin header to a static `commonHeaders` variable in the `OidcClientHttpUtil` class to get the functionality initially working.

I updated an existing `setupPost()` method to now be public, allowing me to create an `HttpPost` object local to the `TokenRequestor.postToTokenEndpoint()` method. That now lets me add the Origin header to only that particular request (if a header value is configured) instead of all subsequent requests.