### PR TITLE
Avoid NullPointerException on null input

### DIFF
--- a/dev/com.ibm.tx.jta/src/com/ibm/ws/Transaction/JTA/Util.java
+++ b/dev/com.ibm.tx.jta/src/com/ibm/ws/Transaction/JTA/Util.java
@@ -6,7 +6,7 @@ package com.ibm.ws.Transaction.JTA;
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -266,6 +266,9 @@ public final class Util {
      * Converts a byte array to a hexadecimal string.
      */
     public static String toHexString(byte[] b) {
+        if (b == null) {
+            return "null";
+        }
         StringBuffer result = new StringBuffer(b.length * 2);
         for (int i = 0; i < b.length; i++) {
             result.append(digits.charAt((b[i] >> 4) & 0xf));


### PR DESCRIPTION
Fix a NullPointerException introduced in PR #25465 for when trace is enabled.  For example, when running the checkpoint transactions FATs:

```
Stack Dump = java.lang.NullPointerException
    at com.ibm.ws.Transaction.JTA.Util.toHexString(Util.java:269)
    at com.ibm.ws.transaction.services.JTMConfigurationProvider.getApplId(JTMConfigurationProvider.java:740)
    at com.ibm.tx.jta.impl.TxRecoveryAgentImpl.<init>(TxRecoveryAgentImpl.java:127)
    at com.ibm.tx.jta.embeddable.impl.EmbeddableRecoveryAgentImpl.<init>(EmbeddableRecoveryAgentImpl.java:35)
    at com.ibm.tx.jta.embeddable.impl.EmbeddableTMHelper.createRecoveryAgent(EmbeddableTMHelper.java:34)
    at com.ibm.tx.jta.util.TxTMHelper.startRecovery(TxTMHelper.java:394)
    at com.ibm.tx.jta.util.TxTMHelper.start(TxTMHelper.java:274)
    at com.ibm.tx.jta.util.TxTMHelper.start(TxTMHelper.java:636)
    at com.ibm.tx.util.TMHelper.start(TMHelper.java:45)
    at com.ibm.tx.jta.util.TxTMHelper.checkTMState(TxTMHelper.java:674)
    at com.ibm.tx.util.TMHelper.checkTMState(TMHelper.java:77)
    at com.ibm.tx.jta.impl.TranManagerSet.beginUserTran(TranManagerSet.java:105)
    at com.ibm.tx.jta.impl.UserTransactionImpl.begin(UserTransactionImpl.java:66)
    at com.ibm.tx.jta.embeddable.impl.EmbeddableUserTransactionImpl.begin(EmbeddableUserTransactionImpl.java:71)
    at com.ibm.ws.transaction.services.UserTransactionService.begin(UserTransactionService.java:67)
    at servlets.startup.StartupServlet.init(StartupServlet.java:35)
    at javax.servlet.GenericServlet.init(GenericServlet.java:244)
    at com.ibm.ws.webcontainer.servlet.ServletWrapper.init(ServletWrapper.java:301)
    at com.ibm.ws.webcontainer.servlet.ServletWrapper.loadOnStartupCheck(ServletWrapper.java:1403)
    at com.ibm.ws.webcontainer.webapp.WebApp.doLoadOnStartupActions(WebApp.java:1232)
    at com.ibm.ws.webcontainer.webapp.WebApp.commonInitializationFinally(WebApp.java:1200)
    at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:1085)
    at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:6705)
    at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost.startWebApp(DynamicVirtualHost.java:474)
    at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost.startWebApplication(DynamicVirtualHost.java:469)
    at com.ibm.ws.webcontainer.osgi.WebContainer.startWebApplication(WebContainer.java:1197)
    at com.ibm.ws.webcontainer.osgi.WebContainer.startModule(WebContainer.java:986)
    at com.ibm.ws.app.manager.module.internal.ModuleHandlerBase.deployModule(ModuleHandlerBase.java:101)
    at com.ibm.ws.app.manager.module.internal.DeployedModuleInfoImpl.installModule(DeployedModuleInfoImpl.java:51)
    at com.ibm.ws.app.manager.module.internal.SimpleDeployedAppInfoBase.deployModules(SimpleDeployedAppInfoBase.java:599)
    at com.ibm.ws.app.manager.module.internal.SimpleDeployedAppInfoBase.installApp(SimpleDeployedAppInfoBase.java:513)
    at com.ibm.ws.app.manager.module.internal.DeployedAppInfoBase.deployApp(DeployedAppInfoBase.java:351)
    at com.ibm.ws.app.manager.war.internal.WARApplicationHandlerImpl.install(WARApplicationHandlerImpl.java:67)
    at com.ibm.ws.app.manager.internal.statemachine.StartAction.execute(StartAction.java:184)
    at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.enterState(ApplicationStateMachineImpl.java:1369)
    at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.run(ApplicationStateMachineImpl.java:912)
    at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:247)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:839)
```