### PR TITLE
Harden OpenAPI HTTPS Tests

### DIFF
--- a/dev/com.ibm.ws.openapi.ui_fat/fat/src/com/ibm/ws/openapi/ui/fat/tests/UIBasicTest.java
+++ b/dev/com.ibm.ws.openapi.ui_fat/fat/src/com/ibm/ws/openapi/ui/fat/tests/UIBasicTest.java
@@ -102,6 +102,10 @@ public class UIBasicTest {
 
     @Test
     public void testPrivateUI() {
+        //Reduce possibility that Server is not listening on its HTTPS Port
+        //Especially for Windows if certificates are slow to create
+        server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl", 60000);
+
         driver.get("https://admin:test@host.testcontainers.internal:" + server.getHttpDefaultSecurePort() + "/ibm/api/explorer");
         testUI();
     }

--- a/dev/com.ibm.ws.openapi.ui_fat/fat/src/com/ibm/ws/openapi/ui/fat/tests/UIBasicTest.java
+++ b/dev/com.ibm.ws.openapi.ui_fat/fat/src/com/ibm/ws/openapi/ui/fat/tests/UIBasicTest.java
@@ -101,10 +101,10 @@ public class UIBasicTest {
     }
 
     @Test
-    public void testPrivateUI() {
+    public void testPrivateUI() throws Exception {
         //Reduce possibility that Server is not listening on its HTTPS Port
         //Especially for Windows if certificates are slow to create
-        server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl", 60000);
+        server.waitForSSLStart();
 
         driver.get("https://admin:test@host.testcontainers.internal:" + server.getHttpDefaultSecurePort() + "/ibm/api/explorer");
         testUI();

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1111,6 +1111,21 @@ public class LibertyServer implements LogMonitorClient {
     }
 
     /**
+     * Wait for the server to state that it is listening on its SSL port
+     *
+     * @throws Exception
+     */
+    public void waitForSSLStart() throws Exception {
+        //wait for "CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host"
+        String sslStartMsg = waitForStringInLogUsingMark("CWWKO0219I:.*defaultHttpEndpoint-ssl.*");
+        if (sslStartMsg == null) {
+            RuntimeException rx = new RuntimeException("Timed out waiting for the server to initialize defaultHttpEndpoint-ssl");
+            Log.error(c, "waitForSSLStart", rx);
+            throw rx;
+        }
+    }
+
+    /**
      * Start the server and validate that the server was started:
      * prepares/cleans the server directory, then performs a clean start
      *

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIBasicTest.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIBasicTest.java
@@ -101,6 +101,10 @@ public class UIBasicTest {
 
     @Test
     public void testHttpsUI(){
+        //Reduce possibility that Server is not listening on its HTTPS Port
+        //Especially for Windows if certificates are slow to create
+        server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl", 60000);
+
         driver.get("https://host.testcontainers.internal:" + server.getHttpDefaultSecurePort() + "/openapi/ui");
         testUI();
     }

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIBasicTest.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIBasicTest.java
@@ -100,10 +100,10 @@ public class UIBasicTest {
     }
 
     @Test
-    public void testHttpsUI(){
+    public void testHttpsUI() throws Exception{
         //Reduce possibility that Server is not listening on its HTTPS Port
         //Especially for Windows if certificates are slow to create
-        server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl", 60000);
+        server.waitForSSLStart();
 
         driver.get("https://host.testcontainers.internal:" + server.getHttpDefaultSecurePort() + "/openapi/ui");
         testUI();

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIOauthTest.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIOauthTest.java
@@ -126,7 +126,7 @@ public class UIOauthTest {
         server.addEnvVar(UI_PATH_PROPERTY, UI_PATH_VALUE);
 
         server.startServer();
-
+        server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl", 60000);
         OAuthTest(UI_PATH_VALUE);
 
     }
@@ -142,6 +142,9 @@ public class UIOauthTest {
         server.addEnvVar(UI_PATH_PROPERTY, CUSTOM_UI_PATH_VALUE);
 
         server.startServer();
+        //Reduce possibility that Server is not listening on its HTTPS Port
+        //Especially for Windows if certificates are slow to create
+        server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl", 60000);
 
         OAuthTest(CUSTOM_UI_PATH_VALUE);
     }

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/publish/servers/openapi-ui-custom-oauth-test/server.xml
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/publish/servers/openapi-ui-custom-oauth-test/server.xml
@@ -35,7 +35,7 @@
     <oauthProvider id="TestProvider" filter="request-url%=/test">
         <autoAuthorizeClient>client01</autoAuthorizeClient>
         <localStore>
-            <client displayname="MicroProfile OpenAPI UI" name="${clientName}" secret="${clientSecret}" redirect="https://${host}:8020${uiPath}/oauth2-redirect.html" enabled="true"/>
+            <client displayname="MicroProfile OpenAPI UI" name="${clientName}" secret="${clientSecret}" redirect="https://${host}:${httpsPort}${uiPath}/oauth2-redirect.html" enabled="true"/>
         </localStore>
     </oauthProvider>
 


### PR DESCRIPTION
Especially on Windows were certificate creation can be exceedingly slow. >30 seconds has been regularly observed in failed OpenAPI Selenium tests. We should wait for the server to state that the HTTPS endpoint is ready to accept traffic, before connecting the selenium driver to server.

As it does take more 30 seconds on occasion, allow up to 2 minute for the log message to appear. as server will start without the HTTPS Endpoint being ready.

Allow time for JS to execute having logged in for the OAuth tests for the change in button text

Replace hard-coding of the redirect port for the OAuth tests with server defined port.

For RTC295995
For RTC296869
For RTC297048