### PR TITLE
generic array return type

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/CustomRepository.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/CustomRepository.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import jakarta.data.repository.OrderBy;
+
 /**
  * Custom repository interface that provides entity and key type parameters.
  */
@@ -19,6 +21,10 @@ public interface CustomRepository<T, K> {
     long countByIdBetween(K minId, K maxId);
 
     long deleteByIdBetween(K minId, K maxId);
+
+    @OrderBy("firstName")
+    @OrderBy("id")
+    T[] findByLastName(String lastName);
 
     void save(Iterable<T> entities);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1590,6 +1590,45 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Inherited repository method with a generic array return type.
+     */
+    @Test
+    public void testGenericArrayReturnType() {
+        people.deleteByIdBetween(100101001l, 100101004l);
+
+        Person p1 = new Person();
+        p1.firstName = "George";
+        p1.lastName = "TestGenericArrayReturnType";
+        p1.ssn_id = 100101001l;
+
+        Person p2 = new Person();
+        p2.firstName = "Gordon";
+        p2.lastName = "TestGenericArrayReturnType";
+        p2.ssn_id = 100101002l;
+
+        Person p3 = new Person();
+        p3.firstName = "Gary";
+        p3.lastName = "TestGenericArrayReturnType-NonMatching";
+        p3.ssn_id = 100101003l;
+
+        Person p4 = new Person();
+        p4.firstName = "Gerald";
+        p4.lastName = "TestGenericArrayReturnType";
+        p4.ssn_id = 100101004l;
+
+        people.save(List.of(p1, p2, p3, p4));
+
+        Person[] found = people.findByLastName("TestGenericArrayReturnType");
+
+        assertEquals(Arrays.toString(found), 3, found.length);
+        assertEquals("George", found[0].firstName);
+        assertEquals("Gerald", found[1].firstName);
+        assertEquals("Gordon", found[2].firstName);
+
+        assertEquals(4l, people.deleteByIdBetween(100101001l, 100101004l));
+    }
+
+    /**
      * Keyset pagination with ignoreCase in the sort criteria.
      */
     @Test


### PR DESCRIPTION
When inheriting repository methods from an interface and the methods have a generic array return type, the result types aren't being processed correctly and methods with multiple results fail with an error that says only 1 result is allowed. This failed the TCK when I switched a few methods over to inheriting from a common interface, and I realized we don't have a test of our own for it, so this pull adds a test as well as fixing the problem.