### PR TITLE
Create test that uses TelemetryClientFilter without CDI

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/ClientWithNoCdi.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/ClientWithNoCdi.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.regex.Pattern;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.CDIArchiveHelper;
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpRequest;
+
+import io.openliberty.microprofile.telemetry.internal_fat.apps.clientnocdi.ClientTriggeringServlet;
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class ClientWithNoCdi {
+
+    public static final String SERVER_NAME = "Telemetry10JaxWithLogging";
+    public static final String NO_CDI_APP_NAME = "clientNoCDI";
+
+    @TestServlets({
+                    @TestServlet(contextRoot = NO_CDI_APP_NAME, servlet = ClientTriggeringServlet.class),
+    })
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        PropertiesAsset appConfig = new PropertiesAsset()
+                        .addProperty("otel.sdk.disabled", "false")
+                        .addProperty("otel.traces.exporter", "in-memory")
+                        .addProperty("otel.bsp.schedule.delay", "100");
+
+        WebArchive noCDIApp = ShrinkWrap.create(WebArchive.class, NO_CDI_APP_NAME + ".war")
+                        .addPackage(ClientTriggeringServlet.class.getPackage());
+        CDIArchiveHelper.addBeansXML(noCDIApp, com.ibm.websphere.simplicity.beansxml.BeansAsset.DiscoveryMode.NONE);//Not strictly needed unless we expand this test to cover MP rest client.
+
+
+        ShrinkHelper.exportAppToServer(server, noCDIApp, SERVER_ONLY);
+        server.startServer();
+    }
+
+    //This test does not use open telemetry directly, but it does trigger io.openliberty.microprofile.telemetry.internal.rest.TelemetryClientFilter.java for an app with no CDI and ensures it does not throw an exception
+    @Test
+    public void testClientWithNoCDi() throws Exception {
+        HttpRequest httpRequest = new HttpRequest(server, "/" + NO_CDI_APP_NAME + "/ClientTriggeringServlet");
+        assertEquals(io.openliberty.microprofile.telemetry.internal_fat.apps.clientnocdi.ClientInvokedServlet.TEST_PASSED, httpRequest.run(String.class));
+
+        assertFalse("The test did not use a TelemetryClientFilter object", 
+                     server.findStringsInLogsUsingMark("microprofile.telemetry.internal.rest.TelemetryClientFilter < isEnabled Exit", server.getDefaultTraceFile())
+                     .isEmpty());
+
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
@@ -18,6 +18,7 @@ import componenttest.annotation.MinimumJavaLevel;
 @RunWith(Suite.class)
 @MinimumJavaLevel(javaLevel = 11)
 @SuiteClasses({
+//                ClientWithNoCdi.class, This test was written to reproduce a known bug, enable it when issue 25986 is resolved
                 JaxRsIntegration.class,
                 JaxRsIntegrationWithConcurrency.class,
                 Telemetry10.class,

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/clientnocdi/ClientInvokedServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/clientnocdi/ClientInvokedServlet.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.clientnocdi;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet("ClientInvokedServlet")
+public class ClientInvokedServlet extends HttpServlet {
+
+    public static final String TEST_PASSED = "Test Passed";
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        PrintWriter pw = response.getWriter();
+        pw.write(TEST_PASSED);
+        pw.flush();
+        pw.close();
+
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/clientnocdi/ClientTriggeringServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/clientnocdi/ClientTriggeringServlet.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.clientnocdi;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+
+/**
+ * Tests MP Telemetry class TelemetryClientFilter on an app that is not CDI enabled
+ */
+@WebServlet("/ClientTriggeringServlet")
+public class ClientTriggeringServlet extends HttpServlet {
+
+    private static final Logger LOGGER = Logger.getLogger(ClientTriggeringServlet.class.getName());
+
+    private Client client;
+
+    @PostConstruct
+    private void openClient() {
+        LOGGER.info("Creating JAX-RS client");
+        client = ClientBuilder.newClient();
+    }
+
+    @PreDestroy
+    private void closeClient() {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+    }
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        LOGGER.info(">>> testClientWithNoCDIJaxClient");
+
+        //Verify that CDI is disabled.
+        try {
+          CDI.current().getBeanManager();
+          //fail("We found a bean manager. CDI is enabled");
+        } catch (Exception e) {
+            //ignore
+        }
+
+        String url = request.getRequestURL().toString();
+        url = url.replace("ClientTriggeringServlet", "ClientInvokedServlet"); //The jaxrsclient will use the URL as given so it needs the final part to be provided.
+
+        String result = client.target(url).request(MediaType.TEXT_PLAIN).get(String.class);
+        
+        PrintWriter pw = response.getWriter();
+        pw.write(result);
+        pw.flush();
+        pw.close();
+
+        LOGGER.info("<<< testClientWithNoCDIJaxClient");      
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithLogging/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithLogging/bootstrap.properties
@@ -1,0 +1,1 @@
+bootstrap.include=../testports.properties

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithLogging/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithLogging/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithLogging/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithLogging/server.xml
@@ -1,0 +1,21 @@
+<server description="Server for testing Telemetry10">
+
+    <include location="../fatTestPorts.xml" />
+
+    <featureManager>
+        <feature>servlet-6.0</feature>
+        <feature>mpTelemetry-1.0</feature>
+        <feature>componentTest-2.0</feature>
+        <feature>restfulWS-3.1</feature>
+        <feature>mpRestClient-3.0</feature>
+    </featureManager>
+
+    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+
+    <application id="clientNoCDI" name="clientNoCDI" type="war" location="clientNoCDI.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
+    <logging traceSpecification="TELEMETRY=all"/>
+
+</server>


### PR DESCRIPTION
This creates a test for #25986 but is disabled until the fix is delivered.