### PR TITLE
allow nesting of repository default methods

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
@@ -89,5 +89,12 @@ public interface Counties extends RepositoryAssist {
 
     Stream<County> save(County... c);
 
+    default Object[] topLevelDefaultMethod() {
+        EntityManager emOuter1 = getResource(EntityManager.class).orElseThrow();
+        EntityManager emInner = getAutoClosedEntityManager();
+        EntityManager emOuter2 = getResource(EntityManager.class).orElseThrow();
+        return new Object[] { emOuter1, emOuter2, emOuter1.isOpen(), emOuter2.isOpen(), emInner.isOpen() };
+    }
+
     boolean updateByNameSetZipCodes(String name, int... zipcodes);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -270,6 +270,22 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Verify that an EntityManager remains open when a default method invokes another default method,
+     * and is closed after the outer default method ends.
+     */
+    @Test
+    public void testEntityManagerRemainsOpenAfterNestedDefaultMethod() {
+        Object[] isOpenFromTopLevelDefaultMethod = counties.topLevelDefaultMethod();
+        EntityManager emOuter1 = (EntityManager) isOpenFromTopLevelDefaultMethod[0];
+        EntityManager emOuter2 = (EntityManager) isOpenFromTopLevelDefaultMethod[1];
+        assertEquals(false, emOuter1.isOpen()); // must be closed after default method ends
+        assertEquals(false, emOuter2.isOpen()); // must be closed after default method ends
+        assertEquals(Boolean.TRUE, isOpenFromTopLevelDefaultMethod[2]); // outer1
+        assertEquals(Boolean.TRUE, isOpenFromTopLevelDefaultMethod[3]); // outer2
+        assertEquals(Boolean.FALSE, isOpenFromTopLevelDefaultMethod[4]); // inner
+    }
+
+    /**
      * Query-by-method name repository operation to remove and return one or more entities
      * where the entity has an IdClass.
      */


### PR DESCRIPTION
Add a test and update implementation to permit the nesting of default methods that obtain EntityManager instances.