### PR TITLE
improve security.client_FAT robustness on windows

### DIFF
--- a/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,11 +18,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
+
 import componenttest.custom.junit.runner.AlwaysPassesTest;
-import componenttest.rules.repeater.EmptyAction;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -40,10 +38,14 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
 
     /*
-     * Run EE10 tests in LITE mode and run all tests in FULL mode.
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                    .andWith(new JakartaEE9Action().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                    .andWith(new JakartaEE10Action());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats();
+
 }


### PR DESCRIPTION
This PR aims to resolve build break 295409.

This FAT is one of many that are prone to having timeout failures when running on Windows VMs where processes tend to run slower. 