### PR TITLE
experiment with validation conditional on valid annotation

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -188,6 +188,11 @@ class QueryInfo {
     Type type;
 
     /**
+     * For save operations, indicates if validation should be attempted when Jakarta Validation is available.
+     */
+    boolean validatable;
+
+    /**
      * Construct partially complete query information.
      */
     QueryInfo(Method method, Class<?> returnArrayType, List<Class<?>> returnTypeAtDepth) {
@@ -665,6 +670,7 @@ class QueryInfo {
         q.saveParamType = saveParamType;
         q.sorts = sorts;
         q.type = type;
+        q.validatable = validatable;
         return q;
     }
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -23,6 +24,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -62,6 +64,7 @@ import com.ibm.ws.LocalTransaction.LocalTransactionCoordinator;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
+import io.openliberty.data.internal.persistence.cdi.DataExtension;
 import io.openliberty.data.internal.persistence.cdi.DataExtensionProvider;
 import io.openliberty.data.repository.Compare;
 import io.openliberty.data.repository.Count;
@@ -131,15 +134,22 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
     private static final ThreadLocal<Deque<EntityManager>> defaultMethodResources = new ThreadLocal<>();
 
+    private final Class<?> defaultEntityClass; // entity class as specified by the user (not generated for records)
     private final CompletableFuture<EntityInfo> defaultEntityInfoFuture;
     private final AtomicBoolean isDisposed = new AtomicBoolean();
     private final DataExtensionProvider provider;
     final Map<Method, CompletableFuture<QueryInfo>> queries = new HashMap<>();
     private final Class<R> repositoryInterface;
+    private final boolean requestsValidation; // indicates if repository superinterface is annotated with jakarta.validation.Valid
+    private final Class<? extends Annotation> Valid; // the jakarta.validation.Valid, if available
 
-    public RepositoryImpl(DataExtensionProvider provider, EntityDefiner definer, Class<R> repositoryInterface, Class<?> defaultEntityClass) {
-        this.provider = provider;
+    public RepositoryImpl(DataExtension extension, EntityDefiner definer, Class<R> repositoryInterface, Class<?> defaultEntityClass, boolean requestsValidation) {
+        this.defaultEntityClass = defaultEntityClass;
+        this.provider = extension.provider;
         this.repositoryInterface = repositoryInterface;
+        this.requestsValidation = requestsValidation;
+        this.Valid = extension.Valid;
+
         boolean inheritance = defaultEntityClass.getAnnotation(Inheritance.class) != null;
         Class<?> recordClass = null;
 
@@ -395,9 +405,13 @@ public class RepositoryImpl<R> implements InvocationHandler {
             } else if (queryInfo.method.getName().startsWith("save")) {
                 queryInfo.type = QueryInfo.Type.MERGE;
                 Class<?>[] paramTypes = queryInfo.method.getParameterTypes();
-                if (paramTypes.length == 0)
-                    throw new UnsupportedOperationException(queryInfo.method.getName() + " without any parameters");
+                if (paramTypes.length != 1)
+                    throw new UnsupportedOperationException("Repository save operations must have exactly 1 parameter," +
+                                                            " which can be the entity or a collection or array of entities. The " + queryInfo.method.getName() +
+                                                            " method has " + paramTypes.length + " parameters."); // TODO NLS
                 queryInfo.saveParamType = paramTypes[0];
+                if (Valid != null)
+                    queryInfo.validatable = isValidatable(queryInfo.method, queryInfo.saveParamType);
             } else {
                 // Query by method name
                 q = generateMethodNameQuery(queryInfo, countPages);//keyset queries before orderby
@@ -1885,20 +1899,20 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             results = new ArrayList<>();
                             Object a = args[0];
                             int length = Array.getLength(a);
-                            if (validator != null)
+                            if (queryInfo.validatable && validator != null)
                                 validator.validate(a, length);
                             for (int i = 0; i < length; i++)
                                 results.add(em.merge(toEntity(Array.get(a, i))));
                             em.flush();
                         } else if (Iterable.class.isAssignableFrom(queryInfo.saveParamType)) {
-                            if (validator != null)
+                            if (queryInfo.validatable && validator != null)
                                 validator.validate((Iterable<?>) args[0]);
                             results = new ArrayList<>();
                             for (Object e : ((Iterable<?>) args[0]))
                                 results.add(em.merge(toEntity(e)));
                             em.flush();
                         } else {
-                            if (validator != null && args[0] != null)
+                            if (queryInfo.validatable && validator != null && args[0] != null)
                                 validator.validate(args[0]);
                             results = List.of(em.merge(toEntity(args[0])));
                             em.flush();
@@ -2272,6 +2286,80 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 Tr.exit(this, tc, "invoke " + repositoryInterface.getSimpleName() + '.' + method.getName(), x);
             throw x;
         }
+    }
+
+    /**
+     * Determine whether or not the parameter to the method should be validated.
+     * Prerequisites: the Valid field must contain the jakarta.validation.Valid class and not be null.
+     *
+     * @param method    repository method.
+     * @param arg0Class class of the first argument to the method.
+     * @return whether or not the first parameter to the method should be validated.
+     */
+    @Trivial
+    private boolean isValidatable(Method method, Class<?> arg0Class) {
+        // TODO based on outcome of Jakarta Data issue 216, either remove this method and requestsValidation
+        // or switch to use it and also implement validation for remove.
+        if (true)
+            return true;
+
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "isValidatable", method, arg0Class);
+
+        if (method.isAnnotationPresent(Valid)) {
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "isValidatable", "true: method has @Valid");
+            return true;
+        }
+
+        for (Annotation paramAnno : method.getParameterAnnotations()[0])
+            if (paramAnno.annotationType().equals(Valid)) {
+                if (trace && tc.isEntryEnabled())
+                    Tr.exit(this, tc, "isValidatable", "true: first arg has @Valid");
+                return true;
+            }
+
+        if (requestsValidation && (Object.class.equals(arg0Class) || defaultEntityClass.isAssignableFrom(arg0Class))) {
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "isValidatable", "true: first arg type matches or is generic");
+            return true;
+        }
+
+        if (requestsValidation) {
+            Class<?> arrayComponentClass = arg0Class.componentType();
+            if (arrayComponentClass != null
+                && (Object.class.equals(arrayComponentClass) || defaultEntityClass.isAssignableFrom(arrayComponentClass))) {
+                if (trace && tc.isEntryEnabled())
+                    Tr.exit(this, tc, "isValidatable", "true: first arg array class matches or is generic");
+                return true;
+            } else if (trace && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "array component " + arrayComponentClass + " is non-matching and non-generic");
+            }
+
+            if (Iterable.class.isAssignableFrom(arg0Class)) {
+                Type iterableComponentType = method.getGenericParameterTypes()[0];
+                if (iterableComponentType instanceof ParameterizedType) {
+                    Type[] typeParams = ((ParameterizedType) iterableComponentType).getActualTypeArguments();
+                    if (typeParams == null || typeParams.length == 0 || typeParams[0] instanceof TypeVariable // generic
+                        || typeParams[0] instanceof Class && defaultEntityClass.isAssignableFrom((Class<?>) typeParams[0])) {
+                        if (trace && tc.isEntryEnabled())
+                            Tr.exit(this, tc, "isValidatable", "true: first arg Iterable class matches or is generic");
+                        return true;
+                    } else if (trace && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "iterable component " + typeParams[0] + " is non-matching and non-generic");
+                    }
+                } else {
+                    if (trace && tc.isEntryEnabled())
+                        Tr.exit(this, tc, "isValidatable", "true: " + iterableComponentType + " is not a parameterized type");
+                    return true;
+                }
+            }
+        }
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "isValidatable", "false, requestsValidation? " + requestsValidation);
+        return false;
     }
 
     @Trivial

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -51,13 +51,15 @@ public class RepositoryProducer<R, P> implements Producer<R> {
         private final BeanManager beanMgr;
         private final Class<?> entityClass;
         private final EntityDefiner entityDefiner;
-        private final DataExtensionProvider provider;
+        private final DataExtension extension;
+        private final boolean requestsValidation;
 
-        Factory(BeanManager beanMgr, DataExtensionProvider provider, EntityDefiner entityDefiner, Class<?> entityClass) {
+        Factory(BeanManager beanMgr, DataExtension extension, EntityDefiner entityDefiner, Class<?> entityClass, boolean requestsValidation) {
             this.beanMgr = beanMgr;
             this.entityClass = entityClass;
             this.entityDefiner = entityDefiner;
-            this.provider = provider;
+            this.extension = extension;
+            this.requestsValidation = requestsValidation;
         }
 
         @Override
@@ -121,7 +123,8 @@ public class RepositoryProducer<R, P> implements Producer<R> {
                         Tr.debug(this, tc, "add " + anno + " for " + method.getAnnotated().getJavaMember());
                 }
 
-        RepositoryImpl<R> handler = new RepositoryImpl<>(factory.provider, factory.entityDefiner, repositoryInterface, factory.entityClass);
+        RepositoryImpl<R> handler = new RepositoryImpl<>(factory.extension, factory.entityDefiner, //
+                        repositoryInterface, factory.entityClass, factory.requestsValidation);
 
         R instance = repositoryInterface.cast(Proxy.newProxyInstance(repositoryInterface.getClassLoader(),
                                                                      new Class<?>[] { repositoryInterface },

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Creatures.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Creatures.java
@@ -14,11 +14,12 @@ package test.jakarta.data.validation.web;
 
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Repository;
+import jakarta.validation.Valid;
 
 /**
  * Repository for a Jakarta Persistence entity with bean validation annotations.
  */
 @Repository(dataStore = "java:module/jdbc/DerbyDataSource")
-public interface Creatures extends CrudRepository<Creature, Long> {
+public interface Creatures extends CrudRepository<@Valid Creature, Long> {
     boolean updateByIdSetWeight(long id, float newWeight);
 }

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Entitlements.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Entitlements.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
+import jakarta.validation.Valid;
 
 /**
  * Repository for a Jakarta Persistence entity with bean validation annotations.
@@ -25,7 +26,9 @@ public interface Entitlements extends DataRepository<Entitlement, Long> {
 
     Optional<Entitlement> findById(long id);
 
-    void save(Entitlement e);
+    @Valid
+    Entitlement save(Entitlement e);
 
+    @Valid
     Entitlement[] save(Entitlement[] e);
 }

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Rectangles.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Rectangles.java
@@ -13,6 +13,7 @@
 package test.jakarta.data.validation.web;
 
 import jakarta.data.repository.Repository;
+import jakarta.validation.Valid;
 
 /**
  * Repository for a record with bean validation annotations.
@@ -21,7 +22,7 @@ import jakarta.data.repository.Repository;
 public interface Rectangles {
     int findWidthById(String id);
 
-    void save(Rectangle r);
+    void save(@Valid Rectangle r);
 
-    void saveAll(Rectangle... rectangles);
+    void saveAll(@Valid Rectangle... rectangles);
 }


### PR DESCRIPTION
Update code to try out a proposal to opt-in to bean validation with the Valid annotation.  Given that this isn't in the spec, this code path is not currently used, but can be switched on by removing the immediate return from the isValidatable method near the TODO comment.