### PR TITLE
Fix performance regression in JAXRS 2.1

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/impl/Rfc3986UriValidator.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/impl/Rfc3986UriValidator.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.jaxrs.impl;
+
+import java.net.URI;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.cxf.jaxrs.utils.HttpUtils;
+
+final class Rfc3986UriValidator {
+    private static final String SCHEME = "(?i)(http|https):";
+
+    private static final String USERINFO = "([^@\\[/?#]*)";
+
+    private static final String HOST = "([^/?#]*)";
+
+    private static final String PATH = "([^?#]*)";
+
+    private static final String QUERY = "([^#]*)";
+
+    private static final String LAST = "#(.*)";
+
+    private static final Pattern HTTP_URL = Pattern.compile("^" + SCHEME 
+        + "(//(" + USERINFO + "@)?" + HOST  + ")?" + PATH
+        + "(\\?" + QUERY + ")?" + "(" + LAST + ")?");
+
+    private Rfc3986UriValidator() {
+    }
+
+    /**
+     * Validate the HTTP URL according to https://datatracker.ietf.org/doc/html/rfc3986#appendix-B  
+     * @param uri HTTP schemed URI to validate
+     * @return "true" if URI matches RFC-3986 validation rules, "false" otherwise
+     */
+    public static boolean validate(final URI uri) {
+        // Only validate the HTTP(s) URIs
+        if (HttpUtils.isHttpScheme(uri.getScheme())) { 
+            final Matcher matcher = HTTP_URL.matcher(uri.toString());
+            if (matcher.matches()) {
+                final String host = matcher.group(5);
+                // There is no host component in the HTTP URI, it is required
+                return !(StringUtils.isEmpty(host));
+            } else {
+                return false;
+            }
+        } else {
+            // not HTTP URI, skipping
+            return true;
+        }
+    }
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/impl/Rfc3986UriValidator.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/impl/Rfc3986UriValidator.java
@@ -20,14 +20,15 @@
 package org.apache.cxf.jaxrs.impl;
 
 import java.net.URI;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+//import java.util.regex.Matcher; // Liberty change
+//import java.util.regex.Pattern; // Liberty change
 
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.jaxrs.utils.HttpUtils;
 
 final class Rfc3986UriValidator {
-    private static final String SCHEME = "(?i)(http|https):";
+    // Liberty change start
+    /*private static final String SCHEME = "(?i)(http|https):";
 
     private static final String USERINFO = "([^@\\[/?#]*)";
 
@@ -41,7 +42,8 @@ final class Rfc3986UriValidator {
 
     private static final Pattern HTTP_URL = Pattern.compile("^" + SCHEME 
         + "(//(" + USERINFO + "@)?" + HOST  + ")?" + PATH
-        + "(\\?" + QUERY + ")?" + "(" + LAST + ")?");
+        + "(\\?" + QUERY + ")?" + "(" + LAST + ")?");*/
+    // Liberty change end
 
     private Rfc3986UriValidator() {
     }
@@ -53,15 +55,10 @@ final class Rfc3986UriValidator {
      */
     public static boolean validate(final URI uri) {
         // Only validate the HTTP(s) URIs
-        if (HttpUtils.isHttpScheme(uri.getScheme())) { 
-            final Matcher matcher = HTTP_URL.matcher(uri.toString());
-            if (matcher.matches()) {
-                final String host = matcher.group(5);
-                // There is no host component in the HTTP URI, it is required
-                return !(StringUtils.isEmpty(host));
-            } else {
-                return false;
-            }
+        if (HttpUtils.isHttpScheme(uri.getScheme())) {
+            final String host = uri.getHost(); // Liberty change
+            // There is no host component in the HTTP URI, it is required
+            return !(StringUtils.isEmpty(host));
         } else {
             // not HTTP URI, skipping
             return true;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
@@ -102,8 +102,17 @@ public final class HttpUtils {
         new HashSet<>(Arrays.asList(new String[]{"GET", "HEAD", "OPTIONS", "TRACE"}));
     private static final Set<String> KNOWN_HTTP_VERBS_WITH_NO_RESPONSE_CONTENT =
         new HashSet<>(Arrays.asList(new String[]{"HEAD", "OPTIONS"}));
-    
-    private static final Pattern HTTP_SCHEME_PATTERN = Pattern.compile("^(?i)(http|https)$");
+
+    // Liberty change start
+    // private static final Pattern HTTP_SCHEME_PATTERN = Pattern.compile("^(?i)(http|https)$");
+
+    private static final HashSet<String> HTTP_SCHEMES = new HashSet<>();
+
+    static {
+        HTTP_SCHEMES.add("http");
+        HTTP_SCHEMES.add("https");
+    }
+    // Liberty change end
 
     private HttpUtils() {
     }
@@ -834,6 +843,6 @@ public final class HttpUtils {
     }
     
     public static boolean isHttpScheme(final String scheme) {
-        return scheme != null && HTTP_SCHEME_PATTERN.matcher(scheme).matches();
+        return scheme != null && HTTP_SCHEMES.contains(scheme.toLowerCase()); // Liberty change
     }
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs/utils/test/InvalidUriTest.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs/utils/test/InvalidUriTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.utils.test;
+
+import org.junit.Assert;
+
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriBuilderException;
+
+import org.junit.Test;
+
+/**
+ * This test makes sure that the updates that were done for Rfc3986UriValidator work correctly for what is tested in CXF.
+ * The tests are based off of the tests done in LinkBuilderImplTest and URiBuilderImplTest in the CXF repo.
+ */
+public class InvalidUriTest {
+
+    @Test
+    public void testLinkBuilderNoHost() {
+        try {
+            Link.fromUri("http://@").build();
+            Assert.fail("Expected a UriBuilderException");
+        } catch (UriBuilderException e) {
+            // expected
+        }
+        try {
+            Link.fromUri("http://:@").build();
+            Assert.fail("Expected a UriBuilderException");
+        } catch (UriBuilderException e) {
+            // expected
+        }
+        try {
+            Link.fromUri("HTTP://:@").build();
+            Assert.fail("Expected a UriBuilderException");
+        } catch (UriBuilderException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testUriBuilderNoHost() {
+        try {
+            UriBuilder.fromUri("http://@").build();
+            Assert.fail("Expected a UriBuilderException");
+        } catch (UriBuilderException e) {
+            // expected
+        }
+        try {
+            UriBuilder.fromUri("http://:@").build();
+            Assert.fail("Expected a UriBuilderException");
+        } catch (UriBuilderException e) {
+            // expected
+        }
+        try {
+            UriBuilder.fromUri("HTTP://:@").build();
+            Assert.fail("Expected a UriBuilderException");
+        } catch (UriBuilderException e) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
- Update HttpUtils to just do a Set.contains() instead of a regular expression to determine if the scheme is either http or https
- Update Rfc3986UriValidator to just get the host from the Uri instead of using Uri.toString and then using a regex to process the String of the uri.
- Add test case that CXF uses from the TCK to make sure that the changes done still work and continue to work.

Fixes #26026 
