### PR TITLE
Fix @ExpectedFFDC annotation on OIDC private key jwt FAT

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.SSO.clientTests/fat/src/com/ibm/ws/security/SSO/clientTests/PrivateKeyJwt/PrivateKeyJwtClientTests.java
+++ b/dev/com.ibm.ws.security.fat.common.SSO.clientTests/fat/src/com/ibm/ws/security/SSO/clientTests/PrivateKeyJwt/PrivateKeyJwtClientTests.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.SSO.clientTests.PrivateKeyJwt;
 
@@ -561,7 +558,7 @@ public class PrivateKeyJwtClientTests extends PKCEPrivateKeyJwtCommonTooling {
      * get access to the app because the trustStoreRef should override the trust store from the sslRef and the trustStoreRef
      * points to a trust store that uses a different alias name
      */
-    @ExpectedFFDC({ "io.openliberty.security.oidcclientcore.exceptions.TokenEndpointAuthMethodSettingsException", "java.security.cert.CertificateException" })
+    @AllowedFFDC({ "io.openliberty.security.oidcclientcore.exceptions.TokenEndpointAuthMethodSettingsException", "java.security.cert.CertificateException" })
     @ConditionalIgnoreRule.ConditionalIgnore(condition = SkipIfJava8.class) // Java 8 has trouble with the trust store we're using.
     @Test
     public void PrivateKeyJwtClientTests_accessTokenUsesRS256_privateKeyJwtUsesRS256_mismatchedKeyAliasNames_trustRefSslRefMisMatch() throws Exception {


### PR DESCRIPTION
One test no longer runs on Java 8, so the `@ExpectedFFDC` annotation needs to be changed to `@AllowedFFDC`.