### PR TITLE
XML-WS 4.0: Add Client Container Test for StAX Provider

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.clientcontainer/src/com/ibm/ws/jaxws/utils/StAXUtils.java
+++ b/dev/com.ibm.ws.jaxws.2.3.clientcontainer/src/com/ibm/ws/jaxws/utils/StAXUtils.java
@@ -52,6 +52,7 @@ public class StAXUtils {
      * EE8 - When running on Java 8 and WLP returns XLXP StAX provider, otherwise defaults to JRE's StAX Provider
      *
      */
+    @FFDCIgnore(ClassNotFoundException.class)
     public static ClassLoader getStAXProviderClassLoader() {
         ClassLoader cl;
         // We don't use XLXP with EE9 so just use the JRE's StAX provider

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/utils/StAXUtils.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/utils/StAXUtils.java
@@ -52,6 +52,7 @@ public class StAXUtils {
      * EE8 - When running on Java 8 and WLP returns XLXP StAX provider, otherwise defaults to JRE's StAX Provider
      *
      */
+    @FFDCIgnore(ClassNotFoundException.class)
     public static ClassLoader getStAXProviderClassLoader() {
         ClassLoader cl;
         // We don't use XLXP with EE9 so just use the JRE's StAX provider

--- a/dev/com.ibm.ws.jaxws.clientcontainer_fat/fat/src/com/ibm/ws/jaxws/clientcontainer/fat/AppClientTest.java
+++ b/dev/com.ibm.ws.jaxws.clientcontainer_fat/fat/src/com/ibm/ws/jaxws/clientcontainer/fat/AppClientTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -29,6 +29,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyClient;
 import componenttest.topology.impl.LibertyServer;
@@ -164,12 +165,27 @@ public class AppClientTest {
         CommonApi.createClientWithArgs(testName, testName, response, packages, testName, "helloClient/src/" + testName, getServerInfo());
     }
 
+    // This test does a simple check in the messages.log for the instance type of XMLEventFactory in EE10, it should be the WoodStox StAX implementation - WstxEventFactory
+    // TODO: Add test for the disabling the Woodstox provider in CXF, won't be possible until we can read from the client/logs/trace.log file.
+    @Test
+    @SkipForRepeat({ SkipForRepeat.NO_MODIFICATION, SkipForRepeat.EE9_FEATURES })
+    public void testClientWoodstoxEnabled() throws Exception {
+        String testName = "ClientHandler";
+        List<String> response = new ArrayList<String>();
+        // Since there is no real way to get the framework to check the trace.log, need to check the messages.log for the class name.
+        response.add("WstxEventFactory");
+        List<String> packages = Arrays.asList("com.ibm.ws.jaxws.test.wsr.client", "com.ibm.ws.jaxws.test.wsr.server.stub", "com.ibm.ws.jaxws.test.wsr.clienthandler");
+        CommonApi.createClientWithArgs(testName, testName, response, packages, testName, "helloClient/src/" + testName, getServerInfo());
+
+    }
+
     private List<String> getServerInfo() {
         return serverInfo;
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
+
         if (server.isStarted()) {
             Log.info(c, "tearDown", "Server was not stopped at the end of the test suite, stopping: " + server.getServerName());
             server.stopServer();

--- a/dev/com.ibm.ws.jaxws.clientcontainer_fat/fat/src/com/ibm/ws/jaxws/test/wsr/clienthandler/ClientHandler.java
+++ b/dev/com.ibm.ws.jaxws.clientcontainer_fat/fat/src/com/ibm/ws/jaxws/test/wsr/clienthandler/ClientHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,6 +14,7 @@ package com.ibm.ws.jaxws.test.wsr.clienthandler;
 
 import javax.annotation.Resource;
 import javax.jws.HandlerChain;
+import javax.xml.stream.XMLEventFactory;
 import javax.xml.ws.BindingProvider;
 import javax.xml.ws.WebServiceRef;
 
@@ -34,6 +35,9 @@ public class ClientHandler {
     public static void main(String[] args) {
 
         try {
+
+            // Simple Check for StAXProvider used in Liberty's client container
+            System.out.println("XMLEventFactory.newInstance().toString() returns: " + XMLEventFactory.newInstance().toString());
 
             SayHelloService portFromRes = serviceFromRes.getHelloServicePort();
             SayHelloService portFromRef = serviceFromRef.getHelloServicePort();

--- a/dev/com.ibm.ws.jaxws.clientcontainer_fat/publish/clients/ClientHandler/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxws.clientcontainer_fat/publish/clients/ClientHandler/bootstrap.properties
@@ -1,1 +1,2 @@
 com.ibm.ws.timedexit.timetolive=120000
+com.ibm.ws.logging.trace.specification=*=info=enabled:com.ibm.ws.jaxws.utils.*=all


### PR DESCRIPTION
This PR does the following:

- Add FFDCIgnores for expected ClassNofFoundExceptions to StAXUtils
- Uses existing tests, to add a new simple tests that makes sure that on EE10, the StAX Impl is correctly picking up Woodstox on EE10 and xmlWS-4.0.

Note: The test framework currently lacks the ability to check the Client trace.log file after a client has run, and the logs have been copied to the output directory. If this were corrected, this test could benefit from being updated to check the trace.log output for the correct debugging statement from StAXUtils. 