### PR TITLE
Improve thread safety in ThreadBasedHashMap

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -139,7 +139,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>30.1-android</version>
+      <version>32.0.1-android</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi/bnd.bnd
@@ -32,7 +32,7 @@ Import-Package: \
 # If you need use MESSAGE, you must enable this Private-Package, or message will translate wrong
 Private-Package:\
    com.ibm.ws.jaxrs20.cdi.*
-
+ 
 -dsannotations: com.ibm.ws.jaxrs20.cdi.component.*    
 
 instrument.classesExcludes: com/ibm/ws/jaxrs20/cdi/internal/resources/*.class
@@ -56,4 +56,5 @@ instrument.classesExcludes: com/ibm/ws/jaxrs20/cdi/internal/resources/*.class
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.websphere.appserver.spi.kernel.service,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.ws.injection;version=latest,\
 	com.ibm.ws.javaee.version;version=latest

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi/src/com/ibm/ws/jaxrs20/cdi/component/ThreadBasedHashMap.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi/src/com/ibm/ws/jaxrs20/cdi/component/ThreadBasedHashMap.java
@@ -30,6 +30,16 @@ import com.ibm.wsspi.injectionengine.ReferenceContext;
  *
  */
 public class ThreadBasedHashMap extends ConcurrentHashMap<Class<?>, ManagedObject<?>> {
+    /*
+     * A problem that was identified as possible under https://github.com/OpenLiberty/open-liberty/pull/206 occurred (see comment added in
+     * com.ibm.ws.jaxrs20.cdi.component.JaxRsFactoryImplicitBeanCDICustomizer.
+     * ("because we are using a ThreadBasedHashMap here, we not actually clobbering data, but we have the potential for problems as
+     * multiple threads are access the same CDI-managed, per-request resource concurrently.")
+     * We have attempted to address this in https://github.com/OpenLiberty/open-liberty/pull/26069 by extending ConcurrentHashMap, but this was
+     * initially prevented because ConcurrentHashMaps cannot store null-valued entries that are required here. To resolved this we've created the
+     * NULL_MANAGED_OBJECT and added code to accommodate it.
+     * TO-DO: With the change to extend ConcurrentHashMap the ThreadLocal map may no longer be needed.
+     */
 
     private static final long serialVersionUID = 3759994379932861970L;
 

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi/src/com/ibm/ws/jaxrs20/cdi/component/ThreadBasedHashMap.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi/src/com/ibm/ws/jaxrs20/cdi/component/ThreadBasedHashMap.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,23 +12,35 @@
  *******************************************************************************/
 package com.ibm.ws.jaxrs20.cdi.component;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.ibm.ws.managedobject.ManagedObject;
 
 /**
  *
  */
-public class ThreadBasedHashMap extends HashMap<Class<?>, ManagedObject<?>> {
+public class ThreadBasedHashMap extends ConcurrentHashMap<Class<?>, ManagedObject<?>> {
 
+    private static final long serialVersionUID = 3759994379932861970L;
     ThreadLocal<Map<Class<?>, ManagedObject<?>>> tlMap = new ThreadLocal<Map<Class<?>, ManagedObject<?>>>() {
         @Override
         protected Map<Class<?>, ManagedObject<?>> initialValue() {
             return new WeakHashMap<>();
         }
     };
+
+    @Override
+    public boolean isEmpty() {
+        return (tlMap.get().isEmpty() && super.isEmpty());
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return (tlMap.get().containsKey(key) || super.containsKey(key));
+    }
+
 
     @Override
     public ManagedObject<?> get(Object key) {

--- a/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
@@ -72,8 +72,8 @@ public class LibertyJaxRsServerFactoryBean extends JAXRSServerFactoryBean {
 
     private final static TraceComponent tc = Tr.register(LibertyJaxRsServerFactoryBean.class);
 
-    private final CopyOnWriteArrayList<JaxRsFactoryBeanCustomizer> beanCustomizers = new CopyOnWriteArrayList<JaxRsFactoryBeanCustomizer>();
-    private ConcurrentHashMap<String, Object> beanCustomizerContexts;
+    private final List<JaxRsFactoryBeanCustomizer> beanCustomizers = new CopyOnWriteArrayList<JaxRsFactoryBeanCustomizer>();
+    private Map<String, Object> beanCustomizerContexts;
     private final EndpointInfo endpointInfo;
     private final JaxRsModuleMetaData moduleMetadata;
     private ServletConfig servletConfig;
@@ -101,7 +101,7 @@ public class LibertyJaxRsServerFactoryBean extends JAXRSServerFactoryBean {
         this.setBus(serverBus);
 
         //Get the beanCustomizerContexts from the bus or create a new map
-        this.beanCustomizerContexts = (ConcurrentHashMap<String, Object>) serverBus.getProperty(JaxRsConstants.ENDPOINT_BEANCUSTOMIZER_CONTEXTOBJ);
+        this.beanCustomizerContexts = (Map<String, Object>) serverBus.getProperty(JaxRsConstants.ENDPOINT_BEANCUSTOMIZER_CONTEXTOBJ);
         if (this.beanCustomizerContexts == null) {
             this.beanCustomizerContexts = new ConcurrentHashMap<String, Object>();
         }

--- a/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
@@ -23,11 +23,10 @@ import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
@@ -72,7 +71,7 @@ public class LibertyJaxRsServerFactoryBean extends JAXRSServerFactoryBean {
 
     private final static TraceComponent tc = Tr.register(LibertyJaxRsServerFactoryBean.class);
 
-    private final List<JaxRsFactoryBeanCustomizer> beanCustomizers = new CopyOnWriteArrayList<JaxRsFactoryBeanCustomizer>();
+    private final List<JaxRsFactoryBeanCustomizer> beanCustomizers = new LinkedList<JaxRsFactoryBeanCustomizer>();
     private Map<String, Object> beanCustomizerContexts;
     private final EndpointInfo endpointInfo;
     private final JaxRsModuleMetaData moduleMetadata;
@@ -103,7 +102,7 @@ public class LibertyJaxRsServerFactoryBean extends JAXRSServerFactoryBean {
         //Get the beanCustomizerContexts from the bus or create a new map
         this.beanCustomizerContexts = (Map<String, Object>) serverBus.getProperty(JaxRsConstants.ENDPOINT_BEANCUSTOMIZER_CONTEXTOBJ);
         if (this.beanCustomizerContexts == null) {
-            this.beanCustomizerContexts = new ConcurrentHashMap<String, Object>();
+            this.beanCustomizerContexts = new HashMap<String, Object>();
         }
 
         beanCustomizers.addAll(originalBeanCustomizers);

--- a/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
@@ -23,10 +23,11 @@ import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
@@ -71,8 +72,8 @@ public class LibertyJaxRsServerFactoryBean extends JAXRSServerFactoryBean {
 
     private final static TraceComponent tc = Tr.register(LibertyJaxRsServerFactoryBean.class);
 
-    private final List<JaxRsFactoryBeanCustomizer> beanCustomizers = new LinkedList<JaxRsFactoryBeanCustomizer>();
-    private Map<String, Object> beanCustomizerContexts;
+    private final CopyOnWriteArrayList<JaxRsFactoryBeanCustomizer> beanCustomizers = new CopyOnWriteArrayList<JaxRsFactoryBeanCustomizer>();
+    private ConcurrentHashMap<String, Object> beanCustomizerContexts;
     private final EndpointInfo endpointInfo;
     private final JaxRsModuleMetaData moduleMetadata;
     private ServletConfig servletConfig;
@@ -100,9 +101,9 @@ public class LibertyJaxRsServerFactoryBean extends JAXRSServerFactoryBean {
         this.setBus(serverBus);
 
         //Get the beanCustomizerContexts from the bus or create a new map
-        this.beanCustomizerContexts = (Map<String, Object>) serverBus.getProperty(JaxRsConstants.ENDPOINT_BEANCUSTOMIZER_CONTEXTOBJ);
+        this.beanCustomizerContexts = (ConcurrentHashMap<String, Object>) serverBus.getProperty(JaxRsConstants.ENDPOINT_BEANCUSTOMIZER_CONTEXTOBJ);
         if (this.beanCustomizerContexts == null) {
-            this.beanCustomizerContexts = new HashMap<String, Object>();
+            this.beanCustomizerContexts = new ConcurrentHashMap<String, Object>();
         }
 
         beanCustomizers.addAll(originalBeanCustomizers);


### PR DESCRIPTION
Fixes #26076 

ThreadBasedHashMap extends HashMap, that is not thread safe. To avoid problems a ThreadLocal Map is maintained in addition, however the isEmpty() and containsKey() methods were not overridden to check both the ThreadLocal Map in addition to the HashMap. This could result in injected values being lost.
