### PR TITLE
Report app started after all hooks run

### DIFF
--- a/dev/com.ibm.ws.app.manager/bnd.bnd
+++ b/dev/com.ibm.ws.app.manager/bnd.bnd
@@ -58,7 +58,8 @@ instrument.classesExcludes: com/ibm/ws/app/manager/internal/resources/*.class
 	com.ibm.ws.classloading;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.ws.kernel.boot.common;version=latest
+	com.ibm.ws.kernel.boot.common;version=latest,\
+	com.ibm.ws.kernel.feature.core;version=latest
 
 -testpath: \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \


### PR DESCRIPTION
A more accurate time to print that the application has started on restore is after all the restore hooks have run.  Here we listen for the ServerStarted service to print the app started messages.