### PR TITLE
Improve OpenAPI ProxySupportUtil performance

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/ApplicationProcessor.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/ApplicationProcessor.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
+import io.openliberty.microprofile.openapi.internal.common.services.OpenAPIEndpointProvider;
 import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.OASModelReader;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
@@ -79,6 +80,9 @@ public class ApplicationProcessor {
     private static final TraceComponent tc = Tr.register(ApplicationProcessor.class);
 
     private static final ThreadContextAccessor THREAD_CONTEXT_ACCESSOR = AccessController.doPrivileged(ThreadContextAccessor.getPrivilegedAction());
+
+    @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL)
+    private volatile OpenAPIEndpointProvider openAPIEndpointProvider;
 
     public enum DocType {
         JSON,
@@ -560,7 +564,7 @@ public class ApplicationProcessor {
             synchronized (serverInfo) {
                 reqServerInfo = new ServerInfo(serverInfo);
             }
-            ProxySupportUtil.processRequest(request, reqServerInfo);
+            ProxySupportUtil.processRequest(request, openAPIEndpointProvider, reqServerInfo);
             if (OpenAPIUtils.isEventEnabled(tc)) {
                 Tr.event(tc, "Request server info : " + reqServerInfo);
             }

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/utils/ProxySupportUtil.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/utils/ProxySupportUtil.java
@@ -33,7 +33,7 @@ public class ProxySupportUtil {
     private static final TraceComponent tc = Tr.register(ProxySupportUtil.class);
 
     @FFDCIgnore(MalformedURLException.class)
-    private static URL extractURL(HttpServletRequest request) {
+    private static URL extractURL(HttpServletRequest request, OpenAPIEndpointProvider openAPIEndpointProvider) {
         String urlString;
         String refererHeader = request.getHeader(HTTP_HEADER_REFERER);
 
@@ -41,14 +41,10 @@ public class ProxySupportUtil {
         String docPath = DEFAULT_DOC_PATH;
         String uiPath = docPath + DEFAULT_UI_PATH;
 
-        BundleContext bundleContext = (BundleContext) request.getServletContext().getAttribute("osgi-bundlecontext");
         //Ensure we have a context as change this will be null if bundle is STOPPED
-        if (bundleContext != null) {
-            OpenAPIEndpointProvider endpointProvider = bundleContext.getService(bundleContext.getServiceReference(OpenAPIEndpointProvider.class));
-            if (endpointProvider != null) {
-                docPath = endpointProvider.getOpenAPIDocUrl();
-                uiPath = endpointProvider.getOpenAPIUIUrl();
-            }
+        if (openAPIEndpointProvider != null) {
+            docPath = openAPIEndpointProvider.getOpenAPIDocUrl();
+            uiPath = openAPIEndpointProvider.getOpenAPIUIUrl();
         }
 
         //Ensure that in case somehow the values retrieved are null
@@ -115,8 +111,8 @@ public class ProxySupportUtil {
         return url;
     }
 
-    public static void processRequest(HttpServletRequest request, ServerInfo serverInfo) {
-        URL url = extractURL(request);
+    public static void processRequest(HttpServletRequest request, OpenAPIEndpointProvider openAPIEndpointProvider, ServerInfo serverInfo) {
+        URL url = extractURL(request, openAPIEndpointProvider);
         if (url == null)
             return;
         serverInfo.setHost(url.getHost());


### PR DESCRIPTION
Due to ProxySupportUtil always going to fetch the bundle it has caused a performance degredation of ~7%. Instead of getting the context on every request, use a ServiceTracker instead to get the OpenAPIEndpointProvider and use that instead which should return the performance to marginally slower then it was previously.

 Instead of getting the context on every request, use a ServiceTracker instead to get the OpenAPIEndpointProvider and use that instead which should return the performance to closer to the original.
 
 As both com.ibm.ws.microprofile.openapi and io.openliberty.microprofile.openapi.2.0.internal have different code paths, then the source of the bundleContext is different for each. For the older we can use the ApplicationProcessor instead of the servlet so that we reduce the number of methods we would have to pass it through and for the newer version as the Serlvet calls ProxySupportUtils, then it can hold the tracker
 
 The Look up for the UI to inject the doc endpoint were already done by a service tracker, as such no changes are being made there.
 
 Null checks are used based on prior experience with both were activation can seemingly occur during feature shutdown. 

Fixes #26023 