### PR TITLE
ConcurrentCDITest initializationError when accessing Java 17 classes

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -14,6 +14,7 @@ package com.ibm.ws.concurrent.cdi.fat;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -25,7 +26,6 @@ import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
-import concurrent.cdi.web.ConcurrentCDIServlet;
 import concurrent.cdi4.web.ConcurrentCDI4Servlet;
 
 @RunWith(FATRunner.class)
@@ -37,7 +37,6 @@ public class ConcurrentCDITest extends FATServletClient {
 
     @Server("concurrent_fat_cdi")
     @TestServlets({
-                    @TestServlet(servlet = ConcurrentCDIServlet.class, contextRoot = APP_NAME),
                     @TestServlet(servlet = ConcurrentCDI4Servlet.class, contextRoot = APP_NAME_EE10)
     })
     public static LibertyServer server;
@@ -58,5 +57,35 @@ public class ConcurrentCDITest extends FATServletClient {
                           "CWWKC1101E.*scheduled-executor-without-app-context", // tests lack of context from scheduled executor thread
                           "CWWKE1205E" // test case intentionally causes startTimeout to be exceeded
         );
+    }
+
+    @Test
+    public void testInjectContextServiceDefaultInstance() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectContextServiceQualified() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectManagedExecutorServiceDefaultInstance() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectManagedExecutorServiceQualified() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectManagedScheduledExecutorServiceDefaultInstance() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectManagedScheduledExecutorServiceQualified() throws Exception {
+        runTest(server, APP_NAME, testName);
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -49,8 +49,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import org.junit.Test;
-
 @ContextServiceDefinition(name = "java:global/concurrent/with-app-context",
                           propagated = APPLICATION, cleared = ALL_REMAINING)
 @ContextServiceDefinition(name = "java:global/concurrent/without-app-context",
@@ -166,7 +164,6 @@ public class ConcurrentCDIServlet extends HttpServlet {
     /**
      * Inject default instance of ContextService and use it.
      */
-    @Test
     public void testInjectContextServiceDefaultInstance() throws Exception {
         assertNotNull(defaultContextSvc);
 
@@ -183,7 +180,6 @@ public class ConcurrentCDIServlet extends HttpServlet {
      * Inject qualified instances of ContextService and verify that the behavior of each
      * matches the configuration that the qualifier points to.
      */
-    @Test
     public void testInjectContextServiceQualified() throws Exception {
         assertNotNull(withAppContext);
 
@@ -209,7 +205,6 @@ public class ConcurrentCDIServlet extends HttpServlet {
     /**
      * Inject default instance of ManagedExecutorService and use it.
      */
-    @Test
     public void testInjectManagedExecutorServiceDefaultInstance() throws Exception {
         assertNotNull(defaultManagedExecutor);
 
@@ -225,7 +220,6 @@ public class ConcurrentCDIServlet extends HttpServlet {
      * Inject qualified instances of ManagedExecutorService and verify that the behavior of each
      * matches the configuration that the qualifier points to.
      */
-    @Test
     public void testInjectManagedExecutorServiceQualified() throws Exception {
         Callable<?> task = () -> InitialContext.doLookup("java:comp/env/entry2");
 
@@ -252,7 +246,6 @@ public class ConcurrentCDIServlet extends HttpServlet {
     /**
      * Inject default instance of ManagedScheduledExecutorService and use it.
      */
-    @Test
     public void testInjectManagedScheduledExecutorServiceDefaultInstance() throws Exception {
         assertNotNull(defaultManagedScheduledExecutor);
 
@@ -274,7 +267,6 @@ public class ConcurrentCDIServlet extends HttpServlet {
      * Inject qualified instances of ManagedScheduledExecutorService and verify that the behavior of each
      * matches the configuration that the qualifier points to.
      */
-    @Test
     public void testInjectManagedScheduledExecutorServiceQualified() throws Exception {
         Callable<?> task = () -> InitialContext.doLookup("java:comp/env/entry2");
 


### PR DESCRIPTION
The test servlet has annotations from Jakarta Concurrency 3.x which are compiled against a newer Java level.  When attempting to skip this test on Java 8, it still loads the servlet and fails.  We can try to work around this by avoiding direct reference to the servlet in the main test class.

Fixes #26094