### PR TITLE
Add fromEnv for Java 21 and set auto-download to false

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -48,3 +48,7 @@ systemProp.org.gradle.internal.http.connectionTimeout=180000
 systemProp.org.gradle.internal.http.socketTimeout=180000
 systemProp.org.gradle.internal.repository.max.tentatives=11
 systemProp.org.gradle.internal.repository.initial.backoff=125
+
+# Env variable to compile with Java 21
+org.gradle.java.installations.auto-download=false
+org.gradle.java.installations.fromEnv=JAVA_21_HOME


### PR DESCRIPTION
- Adds an environment variable from which a Java 21 JDK should be located for compiling.