### PR TITLE
LTPA key rotation fixes

### DIFF
--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
@@ -160,9 +160,11 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
 
         if (monitorDirectory) {
             if (monitorInterval <= 0) {
-                Tr.warning(tc, "LTPA_MONITOR_DIRECTORY_TRUE_AND_FILE_MONITOR_NOT_ENABLEDONFIG_DIRECTORY", monitorInterval);
+                Tr.warning(tc, "LTPA_MONITOR_DIRECTORY_TRUE_AND_FILE_MONITOR_NOT_ENABLED", monitorInterval);
             }
             unConfigValidationKeys = getUnConfigValidationKeys();
+        } else {
+            unConfigValidationKeys = null;
         }
 
         combineValidationKeys();
@@ -338,8 +340,7 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
     }
 
     @Override
-    public void performFileBasedAction(Collection<File> modifiedFiles) {
-    }
+    public void performFileBasedAction(Collection<File> modifiedFiles) {}
 
     /**
      * Action is needed if a file is modified or if it is recreated after it was deleted

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/AuthenticateApi.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/AuthenticateApi.java
@@ -324,19 +324,7 @@ public class AuthenticateApi {
      * @param res
      */
     public void simpleLogout(HttpServletRequest req, HttpServletResponse res) {
-        createSubjectAndPushItOnThreadAsNeeded(req, res);
-
-        AuthenticationResult authResult = new AuthenticationResult(AuthResult.SUCCESS, subjectManager.getCallerSubject());
-        authResult.setAuditCredType(req.getAuthType());
-        authResult.setAuditOutcome(AuditEvent.OUTCOME_SUCCESS);
-        Audit.audit(Audit.EventID.SECURITY_API_AUTHN_TERMINATE_01, req, authResult, Integer.valueOf(res.getStatus()));
-
-        removeEntryFromAuthCacheForUser(req, res);
-        invalidateSession(req);
-        ssoCookieHelper.removeSSOCookieFromResponse(res);
-        ssoCookieHelper.createLogoutCookies(req, res);
-        subjectManager.clearSubjects();
-
+        simpleLogout(req, res, true);
     }
 
     /**
@@ -347,8 +335,12 @@ public class AuthenticateApi {
      *
      * @param req
      * @param res
+     * @param createSubjectAndPushItOnThread
      */
-    public void simpleLogoutForInvalidToken(HttpServletRequest req, HttpServletResponse res) {
+    public void simpleLogout(HttpServletRequest req, HttpServletResponse res, boolean createSubjectAndPushItOnThread) {
+        if (createSubjectAndPushItOnThread)
+            createSubjectAndPushItOnThreadAsNeeded(req, res);
+
         AuthenticationResult authResult = new AuthenticationResult(AuthResult.SUCCESS, subjectManager.getCallerSubject());
         authResult.setAuditCredType(req.getAuthType());
         authResult.setAuditOutcome(AuditEvent.OUTCOME_SUCCESS);
@@ -359,7 +351,6 @@ public class AuthenticateApi {
         ssoCookieHelper.removeSSOCookieFromResponse(res);
         ssoCookieHelper.createLogoutCookies(req, res);
         subjectManager.clearSubjects();
-
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/AuthenticateApi.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/AuthenticateApi.java
@@ -195,13 +195,7 @@ public class AuthenticateApi {
         logoutUnprotectedResourceServiceRef(req, res);
         createSubjectAndPushItOnThreadAsNeeded(req, res);
 
-        AuthenticationResult authResult = new AuthenticationResult(AuthResult.SUCCESS, subjectManager.getCallerSubject());
-        JaspiService jaspiService = getJaspiService();
-        if (jaspiService == null) {
-            authResult.setAuditCredType(req.getAuthType());
-            authResult.setAuditOutcome(AuditEvent.OUTCOME_SUCCESS);
-            Audit.audit(Audit.EventID.SECURITY_API_AUTHN_TERMINATE_01, req, authResult, Integer.valueOf(res.getStatus()));
-        }
+        commonLogoutAuditAuthResultSuccess(req, res);
 
         removeEntryFromAuthCache(req, res, config);
         invalidateSession(req);
@@ -231,6 +225,22 @@ public class AuthenticateApi {
         postLogout(req, res);
         subjectManager.clearSubjects();
 
+    }
+
+    /**
+     * Audits the appropriate message if the JaspiService is enabled
+     *
+     * @param req
+     * @param res
+     */
+    private void commonLogoutAuditAuthResultSuccess(HttpServletRequest req, HttpServletResponse res) {
+        AuthenticationResult authResult = new AuthenticationResult(AuthResult.SUCCESS, subjectManager.getCallerSubject());
+        JaspiService jaspiService = getJaspiService();
+        if (jaspiService == null) {
+            authResult.setAuditCredType(req.getAuthType());
+            authResult.setAuditOutcome(AuditEvent.OUTCOME_SUCCESS);
+            Audit.audit(Audit.EventID.SECURITY_API_AUTHN_TERMINATE_01, req, authResult, Integer.valueOf(res.getStatus()));
+        }
     }
 
     /**
@@ -322,31 +332,20 @@ public class AuthenticateApi {
      *
      * @param req
      * @param res
-     */
-    public void simpleLogout(HttpServletRequest req, HttpServletResponse res) {
-        simpleLogout(req, res, true);
-    }
-
-    /**
-     * Perform logout an user by doing the following:
-     * 1) Invalidate the session
-     * 2) Remove cookie if SSO is enabled
-     * 3) Clear out the client subject
-     *
-     * @param req
-     * @param res
      * @param createSubjectAndPushItOnThread
      */
-    public void simpleLogout(HttpServletRequest req, HttpServletResponse res, boolean createSubjectAndPushItOnThread) {
+    public void simpleLogout(HttpServletRequest req, HttpServletResponse res, WebAppSecurityConfig config, boolean createSubjectAndPushItOnThread) {
         if (createSubjectAndPushItOnThread)
             createSubjectAndPushItOnThreadAsNeeded(req, res);
 
+        //TODO: check for jaspic service null, use common method
         AuthenticationResult authResult = new AuthenticationResult(AuthResult.SUCCESS, subjectManager.getCallerSubject());
         authResult.setAuditCredType(req.getAuthType());
         authResult.setAuditOutcome(AuditEvent.OUTCOME_SUCCESS);
         Audit.audit(Audit.EventID.SECURITY_API_AUTHN_TERMINATE_01, req, authResult, Integer.valueOf(res.getStatus()));
 
-        removeEntryFromAuthCacheForUser(req, res);
+        removeEntryFromAuthCacheForToken(req, res, config);
+
         invalidateSession(req);
         ssoCookieHelper.removeSSOCookieFromResponse(res);
         ssoCookieHelper.createLogoutCookies(req, res);

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/AuthenticateApi.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/AuthenticateApi.java
@@ -340,6 +340,29 @@ public class AuthenticateApi {
     }
 
     /**
+     * Perform logout an user by doing the following:
+     * 1) Invalidate the session
+     * 2) Remove cookie if SSO is enabled
+     * 3) Clear out the client subject
+     *
+     * @param req
+     * @param res
+     */
+    public void simpleLogoutForInvalidToken(HttpServletRequest req, HttpServletResponse res) {
+        AuthenticationResult authResult = new AuthenticationResult(AuthResult.SUCCESS, subjectManager.getCallerSubject());
+        authResult.setAuditCredType(req.getAuthType());
+        authResult.setAuditOutcome(AuditEvent.OUTCOME_SUCCESS);
+        Audit.audit(Audit.EventID.SECURITY_API_AUTHN_TERMINATE_01, req, authResult, Integer.valueOf(res.getStatus()));
+
+        removeEntryFromAuthCacheForUser(req, res);
+        invalidateSession(req);
+        ssoCookieHelper.removeSSOCookieFromResponse(res);
+        ssoCookieHelper.createLogoutCookies(req, res);
+        subjectManager.clearSubjects();
+
+    }
+
+    /**
      * Add the ltpa token string to the logged out token distributed map.
      *
      * @param tokenString

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -898,9 +898,7 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
             WSCredential credential = it.next();
             try {
                 extraAuditData.put("REALM", credential.getRealmName());
-            } catch (CredentialExpiredException e) {
-            } catch (CredentialDestroyedException e) {
-            }
+            } catch (CredentialExpiredException e) {} catch (CredentialDestroyedException e) {}
         }
 
         ArrayList<String> delUsers = new ArrayList<String>();

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -898,7 +898,9 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
             WSCredential credential = it.next();
             try {
                 extraAuditData.put("REALM", credential.getRealmName());
-            } catch (CredentialExpiredException e) {} catch (CredentialDestroyedException e) {}
+            } catch (CredentialExpiredException e) {
+            } catch (CredentialDestroyedException e) {
+            }
         }
 
         ArrayList<String> delUsers = new ArrayList<String>();

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
@@ -18,7 +18,6 @@ import javax.security.auth.Subject;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -193,7 +192,8 @@ public class SSOAuthenticator implements WebAuthenticator {
                         // Perform logout steps
                         // If the ltpa.keys are changed, and an existing LTPA token cookie is no longer valid.
                         // we will logout the user, so they are properly redirected to the login page to login again and get a new LTPA token
-                        logoutWhenTokenIsInvalid(req, res);
+                        //TODO - Only do this if the key rotation feature is enabled to
+                        new AuthenticateApi(ssoCookieHelper, authenticationService).simpleLogout(req, res, false);
 
                         //TODO - Remove authentication cache.
                     }
@@ -251,14 +251,6 @@ public class SSOAuthenticator implements WebAuthenticator {
     private void cleanupLoggedOutToken(HttpServletRequest req, HttpServletResponse res) {
         AuthenticateApi aa = new AuthenticateApi(ssoCookieHelper, authenticationService);
         aa.simpleLogout(req, res);
-    }
-
-    /*
-     * simple logout needed to clean up session and sso cookie
-     */
-    private void logoutWhenTokenIsInvalid(HttpServletRequest req, HttpServletResponse res) {
-        AuthenticateApi aa = new AuthenticateApi(ssoCookieHelper, authenticationService);
-        aa.simpleLogoutForInvalidToken(req, res);
     }
 
     /**
@@ -371,23 +363,6 @@ public class SSOAuthenticator implements WebAuthenticator {
         }
         //If no authFilterRef or SSO authFilter service, we will process all request
         return true;
-    }
-
-    /**
-     * Invalidates the session associated with the request.
-     *
-     * @param req
-     */
-    private void invalidateSession(HttpServletRequest req) {
-        HttpSession session = req.getSession(false);
-        if (session != null) {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                Tr.debug(tc, "invalidating existing HTTP Session");
-            session.invalidate();
-        } else {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                Tr.debug(tc, "Existing HTTP Session does not exist, nothing to invalidate");
-        }
     }
 
 }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
@@ -176,7 +176,7 @@ public class SSOAuthenticator implements WebAuthenticator {
                     boolean checkLoggedOutToken = webAppSecurityConfig != null && (webAppSecurityConfig.isTrackLoggedOutSSOCookiesEnabled()
                                                                                    || LoggedOutTokenCacheImpl.getInstance().shouldTrackTokens());
                     if (checkLoggedOutToken && isTokenLoggedOut(ltpa64)) {
-                        cleanupLoggedOutToken(req, res);
+                        cleanupLoggedOutToken(req, res, true);
                         return authResult;
                     }
 
@@ -193,7 +193,7 @@ public class SSOAuthenticator implements WebAuthenticator {
                         // If the ltpa.keys are changed, and an existing LTPA token cookie is no longer valid.
                         // we will logout the user, so they are properly redirected to the login page to login again and get a new LTPA token
                         //TODO - Only do this if the key rotation feature is enabled to
-                        new AuthenticateApi(ssoCookieHelper, authenticationService).simpleLogout(req, res, false);
+                        cleanupLoggedOutToken(req, res, false);
 
                         //TODO - Remove authentication cache.
                     }
@@ -248,9 +248,9 @@ public class SSOAuthenticator implements WebAuthenticator {
     /*
      * simple logout needed to clean up session and sso cookie
      */
-    private void cleanupLoggedOutToken(HttpServletRequest req, HttpServletResponse res) {
+    private void cleanupLoggedOutToken(HttpServletRequest req, HttpServletResponse res, boolean createSubjectAndPushItOnThread) {
         AuthenticateApi aa = new AuthenticateApi(ssoCookieHelper, authenticationService);
-        aa.simpleLogout(req, res);
+        aa.simpleLogout(req, res, webAppSecurityConfig, createSubjectAndPushItOnThread);
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/SSOAuthenticatorTest.java
+++ b/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/SSOAuthenticatorTest.java
@@ -241,6 +241,12 @@ public class SSOAuthenticatorTest {
                 one(authService).authenticate(with(equal(JaasLoginConfigConstants.SYSTEM_WEB_INBOUND)), with(any(AuthenticationData.class)), with(equal((Subject) null)));
                 will(throwException(new AuthenticationException("Invalid LTPAToken")));
 
+                //add logoutforInvalidToken expectations
+                one(req).getAuthType();
+                one(req).getSession(false);
+                one(ssoCookieHelper).removeSSOCookieFromResponse(resp);
+                one(ssoCookieHelper).createLogoutCookies(req, resp);
+                one(resp).getStatus();
             }
         });
 
@@ -323,6 +329,13 @@ public class SSOAuthenticatorTest {
                 will(throwException(new AuthenticationException("Authentication failed")));
 
                 one(ssoCookieHelper).createLogoutCookies(req, resp);
+
+                //add logoutforInvalidToken expectations
+                one(req).getAuthType();
+                one(req).getSession(false);
+                one(ssoCookieHelper).removeSSOCookieFromResponse(resp);
+                one(ssoCookieHelper).createLogoutCookies(req, resp);
+                one(resp).getStatus();
             }
         });
 


### PR DESCRIPTION
Fixes:
1. Blank login page fixed by doing a modified simple logout after the LTPA token is invalidated after LTPA keys changed.
2. Fixed monitorDirectory=true, monitorInterval=0 warning message:
`[WARNING ] CWWKS4113W: The monitorDirectory attribute is set to true but the monitor interval is 0. No dynamic reload occurs when validation keys files are created, modified or deleted in the directory.`
3. Remove the non-configured validation keys from usage when monitorDirectory=false