### PR TITLE
Fix log message checking for KafkaBadConfigTest

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,18 +15,15 @@ package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.invalid.badconfig;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties.simpleIncomingChannel;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaPermissions;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 import java.util.List;
 
-import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
-import componenttest.rules.repeater.RepeatTests;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -39,12 +36,14 @@ import com.ibm.websphere.simplicity.PropertiesAsset;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.KafkaConnectorConstants;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -65,7 +64,8 @@ public class KafkaBadConfigTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10,
+                                                                  ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -108,12 +108,8 @@ public class KafkaBadConfigTest {
 
         // Check that the bad config error was emitted
         List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1007E:", server.getDefaultLogFile());
-        //Due to changes in CDI, older versions emit the expected code less frequently
-        if(server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpReactiveMessaging-1.0")){
-            assertThat(configErrorLines, hasSize(1));
-        } else {
-            assertThat(configErrorLines, hasSize(4));
-        }
+        // (exact number of error lines can vary due to CDI changes and FFDC log messages)
+        assertThat(configErrorLines, not(empty()));
         String configErrorLine = configErrorLines.get(0);
         // ...and that it contained the channel name
         assertThat(configErrorLine, containsString(KafkaBadConfigIncomingBean.CHANNEL_NAME));
@@ -149,12 +145,8 @@ public class KafkaBadConfigTest {
 
         // Check that the bad config error was emitted
         List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1007E:", server.getDefaultLogFile());
-        //Due to changes in CDI, older versions emit the expected code less frequently
-        if(server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpReactiveMessaging-1.0")){
-            assertThat(configErrorLines, hasSize(1));
-        } else {
-            assertThat(configErrorLines, hasSize(2));
-        }
+        // (exact number of error lines can vary due to CDI changes and FFDC log messages)
+        assertThat(configErrorLines, not(empty()));
         String configErrorLine = configErrorLines.get(0);
         // ...and that it contained the channel name
         assertThat(configErrorLine, containsString(KafkaBadConfigIncomingBean.CHANNEL_NAME));
@@ -194,12 +186,8 @@ public class KafkaBadConfigTest {
 
         // Check that the bad config error was emitted
         List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1008E:", server.getDefaultLogFile());
-        //Due to changes in CDI, older versions emit the expected code less frequently
-        if(server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpReactiveMessaging-1.0")){
-            assertThat(configErrorLines, hasSize(1));
-        } else {
-            assertThat(configErrorLines, hasSize(4));
-        }
+        // (exact number of error lines can vary due to CDI changes and FFDC log messages)
+        assertThat(configErrorLines, not(empty()));
         String configErrorLine = configErrorLines.get(0);
         // ...and that it contained the channel name
         assertThat(configErrorLine, containsString(KafkaBadConfigOutgoingBean.CHANNEL_NAME));
@@ -236,12 +224,8 @@ public class KafkaBadConfigTest {
 
         // Check that the bad config error was emitted
         List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1008E:", server.getDefaultLogFile());
-        //Due to logging changes older versions of OL emit the targetted code less frequently
-        if(server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpReactiveMessaging-1.0")){
-            assertThat(configErrorLines, hasSize(1));
-        } else {
-            assertThat(configErrorLines, hasSize(2));
-        }
+        // (exact number of error lines can vary due to CDI changes and FFDC log messages)
+        assertThat(configErrorLines, not(empty()));
         String configErrorLine = configErrorLines.get(0);
         // ...and that it contained the channel name
         assertThat(configErrorLine, containsString(KafkaBadConfigOutgoingBean.CHANNEL_NAME));


### PR DESCRIPTION
The number of log messages varies depending on what order the tests run as well as the feature version in use because the first time it happens there will be an FFDC but on later runs there will not be.

Just have the test check that at least one log message is output.

For RTC297037