### PR TITLE
Reduce TCK maven request timeout

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/settings.xml
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/settings.xml
@@ -4,19 +4,31 @@
     <localRepository>${env.MAVEN_USER_HOME}/repository</localRepository>
     <servers>
         <server>
-            <username>${env.MVNW_USERNAME}</username>
-            <password>${env.MVNW_PASSWORD}</password>
             <id>central-mirror</id>
-        </server>
-        <server>
             <username>${env.MVNW_USERNAME}</username>
             <password>${env.MVNW_PASSWORD}</password>
+            <configuration>
+                <!-- 5 mins, reduced from default 30 minutes to avoid timeouts -->
+                <requestTimeout>300000</requestTimeout>
+            </configuration>
+        </server>
+        <server>
             <id>plugin-central-mirror</id>
-        </server>
-        <server>
             <username>${env.MVNW_USERNAME}</username>
             <password>${env.MVNW_PASSWORD}</password>
+            <configuration>
+                <!-- 5 mins, reduced from default 30 minutes to avoid timeouts -->
+                <requestTimeout>300000</requestTimeout>
+            </configuration>
+        </server>
+        <server>
             <id>artifactory</id>
+            <username>${env.MVNW_USERNAME}</username>
+            <password>${env.MVNW_PASSWORD}</password>
+            <configuration>
+                <!-- 5 mins, reduced from default 30 minutes to avoid timeouts -->
+                <requestTimeout>300000</requestTimeout>
+            </configuration>
         </server>
     </servers>
     <profiles>


### PR DESCRIPTION
Reduce the request timeout (the time that maven is willing to wait for the repository to send the next bit of data) to try to avoid hitting the timeout for the whole project.

The default request timeout is 30 minutes and the whole test timeout is one hour in LITE mode. We've occasionally seen one download from the maven repository appear to hang, causing the project to timeout.

For RTC296737

I found docs for configuring the timeout here: https://maven.apache.org/guides/mini/guide-resolver-transport.html