### PR TITLE
Update build.image publishExtract task to work on Windows

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -131,19 +131,20 @@ task publishTemplates (type:Copy) {
     into project.file('wlp/templates')
 }
 
-task publishManifest(type: Copy) {
+task publishExtract {
     dependsOn ':wlp.lib.extract:jar'
-    from(zipTree(new File(project(':wlp.lib.extract').buildDir, 'wlp.lib.extract.jar')))
-    include 'META-INF/MANIFEST.MF'
-    into project.file('wlp/lib/extract')
-}
-
-task publishExtract(type: Copy) {
-    dependsOn ':wlp.lib.extract:jar'
-    dependsOn publishManifest
-    from(zipTree(new File(project(':wlp.lib.extract').buildDir, 'wlp.lib.extract.jar')))
-    exclude 'META-INF/'
-    into project.projectDir
+    doLast {
+        copy {
+            from(zipTree(new File(project(':wlp.lib.extract').buildDir, 'wlp.lib.extract.jar')))
+            exclude 'META-INF/'
+            into project.projectDir
+        }
+        copy {
+            from(zipTree(new File(project(':wlp.lib.extract').buildDir, 'wlp.lib.extract.jar')))
+            include 'META-INF/MANIFEST.MF'
+            into project.file('wlp/lib/extract')
+        }
+    }
 }
 
 jar {


### PR DESCRIPTION
- Update publishExtract to not be of type Copy and to just do the two copies in the task instead of having two tasks with dependencies.

The failure on Windows was:
```
Task :build.image:publishExtract FAILED
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':build.image:publishExtract'.
Cannot access a file in the destination directory. Copying to a directory which contains unreadable content 
is not supported. Declare the task as untracked by using Task.doNotTrackState(). For more information, 
please refer to https://docs.gradle.org/8.3/userguide/incremental_build.html#disable-state-tracking in the 
Gradle documentation.
   > Failed to create MD5 hash for file content.
```

#build