### PR TITLE
Workaround Java 8 NPE in signature not trusted test case

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.3/fat/src/com/ibm/ws/security/saml/fat/common/PkixSAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.3/fat/src/com/ibm/ws/security/saml/fat/common/PkixSAMLTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -82,7 +82,8 @@ public class PkixSAMLTests extends SAMLCommonTest {
      * The jks file does not have the self-signed certificates from the tfim IdP.
      * So, the test fails
      */
-    @AllowedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException", "org.opensaml.messaging.handler.MessageHandlerException" })
+    // a version of Java 8 thows an NPE - test should allow for that
+    @AllowedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException", "org.opensaml.messaging.handler.MessageHandlerException", "java.lang.NullPointerException" })
     @Mode(TestMode.LITE)
     @Test
     public void pkixSAMLTests_badTrustAnchorTest() throws Exception {


### PR DESCRIPTION
For now, allow an NPE out of Java 8 (on MAC) - will add an "AllowedFFDC" for the NPE.

`java version "1.8.0_371"
Java(TM) 2 Runtime Environment, Standard Edition (IBM build 1.8.0_371-b11 14_Apr_2023_07_16 Mac OS X x64(SR8 FP5))
Java HotSpot(TM) 64-Bit Server VM (build 25.371-b11, mixed mode)
IBM Java ORB build orbdev-userlvl-20230413.0323
XML build XL TXE Java 1.0.66
XML build IBM JAXP 1.6.1
XML build XML4J 4.5.34
`
We have a test that 
`Has a pkixTrustEngine which specifies trustAnchor as serverStoreNoTfim. It points to sslServerTrust.jks. The jks file does not have the self-signed certificates from the tfim IdP.` - and expects a failure.
With Java 8 on MAC, we're getting an NPE.
`/com.ibm.ws.security.saml.sso-2.0_fat.3/logs/ffdc/ffdc_23.08.17_18.50.34.0.log
>------Start of DE processing------ = [8/17/23 18:50:34:106 UTC]
>Exception = java.lang.NullPointerException
>Source = com.ibm.ws.security.saml.sso20.acs.SAMLMessageXMLSignatureSecurityPolicyRule
>probeid = 270
>Stack Dump = java.lang.NullPointerException
> at sun.security.provider.certpath.CertPathHelper.setPathToNames(CertPathHelper.java:67)
> at sun.security.provider.certpath.ForwardBuilder.getMatchingCACerts(ForwardBuilder.java:267)
> at sun.security.provider.certpath.ForwardBuilder.getMatchingCerts(ForwardBuilder.java:135)
> at sun.security.provider.certpath.SunCertPathBuilder.depthFirstSearchForward(SunCertPathBuilder.java:267)
> at sun.security.provider.certpath.SunCertPathBuilder.depthFirstSearchForward(SunCertPathBuilder.java:538)
> at sun.security.provider.certpath.SunCertPathBuilder.buildForward(SunCertPathBuilder.java:229)
> at sun.security.provider.certpath.SunCertPathBuilder.buildCertPath(SunCertPathBuilder.java:164)
> at sun.security.provider.certpath.SunCertPathBuilder.build(SunCertPathBuilder.java:132)
> at sun.security.provider.certpath.SunCertPathBuilder.engineBuild(SunCertPathBuilder.java:127)
> at java.security.cert.CertPathBuilder.build(CertPathBuilder.java:292)
> at org.opensaml.security.x509.impl.CertPathPKIXTrustEvaluator.validate(CertPathPKIXTrustEvaluator.java:145)
> at org.opensaml.xmlsec.signature.support.impl.PKIXSignatureTrustEngine.evaluateTrust(PKIXSignatureTrustEngine.java:232)
> at org.opensaml.xmlsec.signature.support.impl.PKIXSignatureTrustEngine.evaluateTrust(PKIXSignatureTrustEngine.java:60)
> at org.opensaml.xmlsec.signature.support.impl.BaseSignatureTrustEngine.validate(BaseSignatureTrustEngine.java:201)
> at org.opensaml.xmlsec.signature.support.impl.PKIXSignatureTrustEngine.doValidate(PKIXSignatureTrustEngine.java:162)
> at org.opensaml.xmlsec.signature.support.impl.BaseSignatureTrustEngine.validate(BaseSignatureTrustEngine.java:105)
> at org.opensaml.xmlsec.signature.support.impl.BaseSignatureTrustEngine.validate(BaseSignatureTrustEngine.java:62)
> at org.opensaml.security.messaging.impl.BaseTrustEngineSecurityHandler.evaluate(BaseTrustEngineSecurityHandler.java:128)
> at org.opensaml.security.messaging.impl.BaseTrustEngineSecurityHandler.evaluate(BaseTrustEngineSecurityHandler.java:114)
> at com.ibm.ws.security.saml.sso20.acs.SAMLMessageXMLSignatureSecurityPolicyRule.doEvaluate(SAMLMessageXMLSignatureSecurityPolicyRule.java:252)
> at com.ibm.ws.security.saml.sso20.acs.SAMLMessageXMLSignatureSecurityPolicyRule.evaluate(SAMLMessageXMLSignatureSecurityPolicyRule.java:200)
> at com.ibm.ws.security.saml.sso20.acs.SAMLMessageXMLSignatureSecurityPolicyRule.evaluateAssertion(SAMLMessageXMLSignatureSecurityPolicyRule.java:151)
> at com.ibm.ws.security.saml.sso20.acs.AssertionValidator.verifyAssertionSignature(AssertionValidator.java:131)
> at com.ibm.ws.security.saml.sso20.acs.AssertionValidator.validateSignature(AssertionValidator.java:104)
> at com.ibm.ws.security.saml.sso20.acs.AssertionValidator.validateAssertion(AssertionValidator.java:76)
> at com.ibm.ws.security.saml.sso20.acs.WebSSOConsumer.handleSAMLResponse(WebSSOConsumer.java:110)
> at com.ibm.ws.security.saml.sso20.acs.UnsolicitedHandler.handleRequest(UnsolicitedHandler.java:128)
> at com.ibm.ws.security.saml.sso20.acs.AcsHandler.handleRequest(AcsHandler.java:101)
> at com.ibm.ws.security.saml.sso20.acs.AcsHandler.handleRequest(AcsHandler.java:56)
> at com.ibm.ws.security.saml.sso20.web.EndpointServices.handleSamlRequest(EndpointServices.java:109)
> at com.ibm.ws.security.saml.sso20.web.EndpointServices.handleSamlRequest(EndpointServices.java:87)
> at com.ibm.ws.security.saml.sso20.web.EndpointServlet.doPost(EndpointServlet.java:84)
> at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
> at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
> at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1260)
> at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:748)
> at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:445)
> at com.ibm.ws.webcontainer.filter.WebAppFilterChain.invokeTarget(WebAppFilterChain.java:197)
> at com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:100)
> at com.ibm.ws.security.saml.sso20.web.RequestFilter.setEndpointRequest(RequestFilter.java:99)
> at com.ibm.ws.security.saml.sso20.web.RequestFilter.doFilter(RequestFilter.java:78)
> at com.ibm.ws.webcontainer.filter.FilterInstanceWrapper.doFilter(FilterInstanceWrapper.java:203)
> at com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:93)
> at com.ibm.ws.app.manager.wab.internal.OsgiDirectoryProtectionFilter.doFilter(OsgiDirectoryProtectionFilter.java:92)
> at com.ibm.ws.webcontainer.filter.FilterInstanceWrapper.doFilter(FilterInstanceWrapper.java:203)
> at com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:93)
> at com.ibm.ws.webcontainer.filter.WebAppFilterManager.doFilter(WebAppFilterManager.java:1068)
> at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1259)
> at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:5079)
> at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:318)
> at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:1038)
> at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:283)
> at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1248)
> at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:470)
> at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:429)
> at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:569)
> at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:503)
> at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:363)
> at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:330)
> at com.ibm.ws.channel.ssl.internal.SSLConnectionLink.determineNextChannel(SSLConnectionLink.java:1135)
> at com.ibm.ws.channel.ssl.internal.SSLConnectionLink$MyReadCompletedCallback.complete(SSLConnectionLink.java:686)
> at com.ibm.ws.channel.ssl.internal.SSLReadServiceContext$SSLReadCompletedCallback.complete(SSLReadServiceContext.java:1826)
> at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:516)
> at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:586)
> at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:970)
> at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1059)
> at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:247)
> at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
> at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
> at java.lang.Thread.run(Thread.java:750)
]`