### PR TITLE
Gradle build.image change date format

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -981,9 +981,14 @@ if (isAutomatedBuild && !isIFIXBuild) {
 
             def rpms = file("./packaging/rpmbuild/RPMS/noarch/openliberty-" + bnd.get('libertyServiceVersion') + "-1.noarch.rpm")
             def debs = file("./packaging/debuild/openliberty_" + bnd.get('libertyServiceVersion') + "-1ubuntu1_all.deb")
-            def packageDate = new Date()
-            def formattedRPMDate = packageDate.format("E MMM d y")
-            def formattedDEBDate = packageDate.format("E, d MMM y hh:mm:ss Z")
+
+            ZonedDateTime packageDate = ZonedDateTime.now();
+            def formatter = java.time.format.DateTimeFormatter.ofPattern("E MMM d y", Locale.ENGLISH);
+            def formattedRPMDate = packageDate.format(formatter)
+
+            formatter = java.time.format.DateTimeFormatter.ofPattern("E, d MMM y hh:mm:ss Z", Locale.ENGLISH);
+            def formattedDEBDate = packageDate.format(formatter);
+	    
 
             inputs.dir('packaging/tempPackagingDir')
             outputs.file(rpms)


### PR DESCRIPTION
It looks like there was a change in Locale in the build definition which affected the date format. The expected output is `Fri Sep 1 2023` but it was `Fri Sept 1 2023`

The followings are formatted output for each locale.

Locale.UK:
`Fri Sept 1 2023`

Locale.CANADA:
`Fri. Sep. 1 2023`

Locale.US:
`Fri Sep 1 2023`

Locale.ENGLISH:
`Fri Sep 1 2023`


We changed the locale to use Locale.ENGLISH and updated Java date time API to use newer API.
