### PR TITLE
Update to Gradle 8.10.1

### DIFF
--- a/.ci-orchestrator/pb.yml
+++ b/.ci-orchestrator/pb.yml
@@ -18,16 +18,23 @@ triggers:
     - name: fat.buckets.to.run
       defaultValue: ${PR Changes:fat.buckets.to.run}
       steps:
-      - stepName: Compile Liberty Images
-      - stepName: Compile FATs
-      - stepName: Determine FATs Needed
-      - stepName: Distributed Lite FATs
+        - stepName: Compile Liberty Images
+        - stepName: Compile FATs
+        - stepName: Determine FATs Needed
+        - stepName: Distributed Lite FATs
     # Enable the testing of the checkpoint feature which additionally runs any compiled FATs declaring that they test the checkpoint feature in a CRIU environment.
     # Note: The FATs will run in this step will *only* run the test cases annotated with CheckpointTest. The FATs will also run in the standard FAT steps where they will only run un-annotated test cases.
     - name: spawn.checkpoint
       defaultValue: "true"
       steps:
-      - stepName: Checkpoint FATs (Lite)
+        - stepName: Checkpoint FATs (Lite)
+    # Allow user to override ebc.shortlist for only parent steps.
+    - name: ebc.shortlist
+      defaultValue: parentbuild-personal.yml
+      steps:
+        - stepName: Compile Liberty Images
+        - stepName: Unittest Open Liberty
+        - stepName: Compile FATs
 
 - type: manual
   triggerName: "ol-pbbeta-manual"
@@ -54,7 +61,14 @@ triggers:
     - name: spawn.checkpoint
       defaultValue: "true"
       steps:
-      - stepName: Checkpoint FATs (Lite)
+        - stepName: Checkpoint FATs (Lite)
+    # Allow user to override ebc.shortlist for only parent steps.
+    - name: ebc.shortlist
+      defaultValue: parentbuild-personal.yml
+      steps:
+        - stepName: Compile Liberty Images
+        - stepName: Unittest Open Liberty
+        - stepName: Compile FATs
 
 - type: github
   triggerName: "ol-fullpbbeta"
@@ -91,6 +105,13 @@ triggers:
       defaultValue: "true"
       steps:
         - stepName: Checkpoint FATs (Lite)
+    # Allow user to override ebc.shortlist for only parent steps.
+    - name: ebc.shortlist
+      defaultValue: parentbuild-personal.yml
+      steps:
+        - stepName: Compile Liberty Images
+        - stepName: Unittest Open Liberty
+        - stepName: Compile FATs
 
 steps:
 - stepName: PR Changes

--- a/dev/.gradle-wrapper/gradle-wrapper.properties
+++ b/dev/.gradle-wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Update to Gradle 8.10.1.
- Add propertyDefinition for `ebc.shortlist` so it can be changed by user and only affects the "RTC parent" steps.

Deprecations to fix before upgrading to Gradle 9:
```
The AbstractCompile.destinationDir property has been deprecated.	
This is scheduled to be removed in Gradle 9.0.	
Please use the destinationDirectory property instead.	
Documentation	
2489 usages	

The org.gradle.api.plugins.Convention type has been deprecated.	
This is scheduled to be removed in Gradle 9.0.	
Documentation	
1967 usages	

The Project.getConvention() method has been deprecated.	
This is scheduled to be removed in Gradle 9.0.	
Documentation	
1947 usages	

The org.gradle.api.plugins.JavaPluginConvention type has been deprecated.	
This is scheduled to be removed in Gradle 9.0.	
Documentation	
28 usages	

The GradleVersion.getNextMajor() method has been deprecated.	
This is scheduled to be removed in Gradle 9.0.	
Documentation	
8 usages	

The AbstractArchiveTask.archivePath property has been deprecated.	
This is scheduled to be removed in Gradle 9.0.	
Please use the archiveFile property instead.	
Documentation	
4 usages	

The org.gradle.api.plugins.BasePluginConvention type has been deprecated.	
This is scheduled to be removed in Gradle 9.0.	
Documentation	
2 usages
```