### PR TITLE
Fix timing issue in concurrent timer demo

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticDatabase.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticDatabase.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,6 +18,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import javax.sql.DataSource;
+
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
 import jakarta.ejb.Schedule;
@@ -26,7 +28,6 @@ import jakarta.ejb.Stateless;
 import jakarta.ejb.Timer;
 import jakarta.ejb.TransactionAttribute;
 import jakarta.ejb.TransactionAttributeType;
-import javax.sql.DataSource;
 
 /**
  * This class uses the @Schedule annotation.
@@ -40,7 +41,7 @@ public class AutomaticDatabase {
     @Resource(shareable = false)
     private DataSource ds;
 
-    private int count = 0; //Incremented with each execution of timer
+    private static volatile int count = 0; //Incremented with each execution of timer
 
     private static final String name = "DatabaseTimer";
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticIO.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticIO.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -36,7 +36,7 @@ public class AutomaticIO {
     @Resource
     private SessionContext sessionContext; //Used to get information about timer
 
-    private int count; //Incremented with each execution of timers
+    private static volatile int count; //Incremented with each execution of timers
 
     private final File file = new File("files/timertestoutput.txt");
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticMemory.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticMemory.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -29,7 +29,7 @@ public class AutomaticMemory {
     @Resource
     private SessionContext sessionContext; //Used to get information about timer
 
-    private int count; //Incremented with each execution of timers
+    private static volatile int count; //Incremented with each execution of timers
 
     /**
      * Cancels timer execution

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/ProgrammaticTimer.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/ProgrammaticTimer.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -31,7 +31,7 @@ public class ProgrammaticTimer {
     @Resource
     TimerService timerService;
 
-    private int count;
+    private static volatile int count;
 
     /**
      * Creates a timer that runs every 5 minutes,


### PR DESCRIPTION
Using an instance variable in a stateless EJB to count timers is unreliable as multiple instances may be used.  Switch the count variable to static so count is accurate no matter which instance is used to run the timers or report the count.
