### PR TITLE
ZOS tests require more time in server shutdown

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -34,6 +34,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.HttpSessionCache;
 import com.ibm.websphere.simplicity.config.Monitor;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -106,6 +107,19 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         } finally {
             server.stopServer();
         }
+
+        if (isZOS()) {
+            Log.info(SessionCacheConfigUpdateTest.class, "tearDown", "Allow more time for ZOS shutdown");
+            TimeUnit.SECONDS.sleep(20);
+        }
+    }
+
+    private static final boolean isZOS() {
+        String osName = System.getProperty("os.name");
+        if (osName.contains("OS/390") || osName.contains("z/OS") || osName.contains("zOS")) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheErrorPathsTest.java
@@ -80,9 +80,7 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
                 }
             }
         } finally {
-            server.setMarkToEndOfLog();
             server.updateServerConfiguration(savedConfig);
-            server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
         }
         System.out.println("server configuration restored");
     }

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheOneServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheOneServerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheOneServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheOneServerTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,12 +21,15 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -72,6 +75,19 @@ public class SessionCacheOneServerTest extends FATServletClient {
     public static void tearDown() throws Exception {
         executor.shutdownNow();
         server.stopServer();
+
+        if (isZOS()) {
+            Log.info(SessionCacheOneServerTest.class, "tearDown", "Allow more time for ZOS shutdown");
+            TimeUnit.SECONDS.sleep(20);
+        }
+    }
+
+    private static final boolean isZOS() {
+        String osName = System.getProperty("os.name");
+        if (osName.contains("OS/390") || osName.contains("z/OS") || osName.contains("zOS")) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -85,6 +85,19 @@ public class SessionCacheTimeoutTest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer();
+
+        if (isZOS()) {
+            Log.info(c, "tearDown", "Allow more time for ZOS shutdown");
+            TimeUnit.SECONDS.sleep(20);
+        }
+    }
+
+    private static final boolean isZOS() {
+        String osName = System.getProperty("os.name");
+        if (osName.contains("OS/390") || osName.contains("z/OS") || osName.contains("zOS")) {
+            return true;
+        }
+        return false;
     }
 
     @After

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTest.java
@@ -113,6 +113,19 @@ public class SessionCacheTwoServerTest extends FATServletClient {
                 }
             }
         }
+
+        if (isZOS()) {
+            Log.info(SessionCacheTwoServerTest.class, "tearDown", "Allow more time for ZOS shutdown");
+            TimeUnit.SECONDS.sleep(20);
+        }
+    }
+
+    private static final boolean isZOS() {
+        String osName = System.getProperty("os.name");
+        if (osName.contains("OS/390") || osName.contains("z/OS") || osName.contains("zOS")) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTimeoutTest.java
@@ -122,6 +122,20 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
             Log.info(c, "tearDown", "Start server B shutdown");
             serverB.stopServer();
         }
+
+        if (isZOS()) {
+            Log.info(c, "tearDown", "Allow more time for ZOS shutdown");
+            TimeUnit.SECONDS.sleep(20);
+        }
+
+    }
+
+    private static final boolean isZOS() {
+        String osName = System.getProperty("os.name");
+        if (osName.contains("OS/390") || osName.contains("z/OS") || osName.contains("zOS")) {
+            return true;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
On z/OS, the servers stops slower than the other platforms, update test cases to allow more time in server tearDown() method

Stopping server com.ibm.ws.session.cache.fat.infinispan.server.
The command stop failed because of a communication error with the server.
Server com.ibm.ws.session.cache.fat.infinispan.server is not running.

java.net.ConnectException: EDC8128I Connection refused.
    at java.base/sun.nio.ch.Net.connect0(Native Method)
    at java.base/sun.nio.ch.Net.connect(Net.java:579)
    at java.base/sun.nio.ch.Net.connect(Net.java:586)
    at java.base/sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:858)
    at com.ibm.ws.kernel.boot.internal.commands.ServerCommandClient.write(ServerCommandClient.java:109)
    at com.ibm.ws.kernel.boot.internal.commands.ServerCommandClient.stopServer(ServerCommandClient.java:256)
    at com.ibm.ws.kernel.boot.internal.commands.ProcessControlHelper.stop(ProcessControlHelper.java:101)
    at com.ibm.ws.kernel.boot.Launcher.handleActions(Launcher.java:263)
    at com.ibm.ws.kernel.boot.Launcher.createPlatform(Launcher.java:119)
    at com.ibm.ws.kernel.boot.cmdline.EnvCheck.main(EnvCheck.java:61)
    at com.ibm.ws.kernel.boot.cmdline.EnvCheck.main(EnvCheck.java:37)
