### PR TITLE
Handle prepare/rollback race

### DIFF
--- a/dev/com.ibm.ws.wsat.common/src/com/ibm/ws/wsat/common/impl/WSATTransaction.java
+++ b/dev/com.ibm.ws.wsat.common/src/com/ibm/ws/wsat/common/impl/WSATTransaction.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,10 +14,12 @@ package com.ibm.ws.wsat.common.impl;
 
 import org.apache.cxf.ws.addressing.EndpointReferenceType;
 
+import com.ibm.tx.remote.Vote;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.wsat.service.WSATContext;
+import com.ibm.ws.wsat.service.WSATException;
 import com.ibm.ws.wsat.tm.impl.TranManagerImpl;
 
 /**
@@ -163,5 +165,31 @@ public class WSATTransaction {
     @Override
     public String toString() {
         return getClass().getSimpleName() + ": " + globalId;
+    }
+
+    // Protocol message handlers are here so they can be synchronized
+
+    /**
+     * @throws WSATException
+     *
+     */
+    public synchronized void rollback() throws WSATException {
+        tranService.rollbackTransaction(globalId);
+    }
+
+    /**
+     * @return
+     * @throws WSATException
+     */
+    public synchronized Vote prepare() throws WSATException {
+        return tranService.prepareTransaction(globalId);
+    }
+
+    /**
+     * @throws WSATException
+     *
+     */
+    public synchronized void commit() throws WSATException {
+        tranService.commitTransaction(globalId);
     }
 }

--- a/dev/com.ibm.ws.wsat.common/src/com/ibm/ws/wsat/service/impl/ProtocolImpl.java
+++ b/dev/com.ibm.ws.wsat.common/src/com/ibm/ws/wsat/service/impl/ProtocolImpl.java
@@ -150,7 +150,7 @@ public class ProtocolImpl {
             final WSATTransaction tran = WSATTransaction.getTran(globalId);
             if (tran != null) {
                 try {
-                    Vote vote = tranService.prepareTransaction(globalId);
+                    Vote vote = tran.prepare();
                     WSATParticipantState resp = (vote == Vote.VoteCommit) ? WSATParticipantState.PREPARED : (vote == Vote.VoteReadOnly) ? WSATParticipantState.READONLY : WSATParticipantState.ABORTED;
                     participantResponse(tran, globalId, wrapper.getResponseEpr(), resp);
                 } catch (WSATException e) {
@@ -242,7 +242,7 @@ public class ProtocolImpl {
         DistributableTransaction t = null;
 
         if (tran != null) {
-            tranService.commitTransaction(globalId);
+            tran.commit();
         } else {
             t = tranService.getRemoteTranMgr().getTransactionForID(globalId);
         }
@@ -260,6 +260,7 @@ public class ProtocolImpl {
         }
     }
 
+    @FFDCIgnore(WSATException.class)
     public void rollback(ProtocolServiceWrapper wrapper) throws WSATException {
         if (recoveryId != null && wrapper.getRecoveryID() != null && !recoveryId.equals(wrapper.getRecoveryID())) {
             rerouteToCorrectParticipant(wrapper, WSATParticipantState.ROLLBACK);
@@ -270,7 +271,13 @@ public class ProtocolImpl {
         final WSATTransaction tran = WSATTransaction.getTran(globalId);
 
         if (tran != null) {
-            tranService.rollbackTransaction(globalId);
+            try {
+                tran.rollback();
+            } catch (WSATException e) {
+                if (TC.isDebugEnabled()) {
+                    Tr.debug(TC, "Transaction is probably gone already: {0}", e);
+                }
+            }
         }
 
         participantResponse(tran, globalId, wrapper.getResponseEpr(), WSATParticipantState.ABORTED);


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.jta_fat,com.ibm.ws.transaction.cloud_fat.base,com.ibm.ws.transaction.cloud_fat.db2.0,com.ibm.ws.transaction.cloud_fat.db2.1,com.ibm.ws.transaction.cloud_fat.db2.2,com.ibm.ws.transaction.cloud_fat.derby.0,com.ibm.ws.transaction.cloud_fat.derby.1,com.ibm.ws.transaction.cloud_fat.derby.2,com.ibm.ws.transaction.cloud_fat.dualFS,com.ibm.ws.transaction.cloud_fat.oracle.0,com.ibm.ws.transaction.cloud_fat.oracle.1,com.ibm.ws.transaction.cloud_fat.oracle.2,com.ibm.ws.transaction.cloud_fat.peerlocking.1,com.ibm.ws.transaction.cloud_fat.peerlocking.2,com.ibm.ws.transaction.cloud_fat.postgresql.0,com.ibm.ws.transaction.cloud_fat.postgresql.1,com.ibm.ws.transaction.cloud_fat.postgresql.2,com.ibm.ws.transaction.cloud_fat.simpleFS,com.ibm.ws.transaction.cloud_fat.sqlserver.0,com.ibm.ws.transaction.cloud_fat.sqlserver.1,com.ibm.ws.transaction.cloud_fat.sqlserver.2,com.ibm.ws.transaction.core_fat.base,com.ibm.ws.transaction.core_fat.baseDB,com.ibm.ws.transaction.core_fat.cdi,com.ibm.ws.transaction.core_fat.commitPriority,com.ibm.ws.transaction.core_fat.heuristics,com.ibm.ws.transaction.core_fat.heuristicsDB,com.ibm.ws.transaction.core_fat.misc,com.ibm.ws.transaction.core_fat.startMultiEJB,com.ibm.ws.transaction.core_fat.startup,com.ibm.ws.transaction.core_fat.xa,com.ibm.ws.transaction.core_fat.xaDB,com.ibm.ws.transaction.db_fat,com.ibm.ws.transaction.hadb_fat.db2.1,com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.db2.retriablecodes,com.ibm.ws.transaction.hadb_fat.derby.1,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.derby.retriablecodes,com.ibm.ws.transaction.hadb_fat.oracle.1,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.oracle.retriablecodes,com.ibm.ws.transaction.hadb_fat.postgresql.1,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.postgresql.retriablecodes,com.ibm.ws.transaction.hadb_fat.sqlserver.1,com.ibm.ws.transaction.hadb_fat.sqlserver.2,com.ibm.ws.transaction.hadb_fat.sqlserver.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes,com.ibm.ws.transaction.recovery_fat.1,com.ibm.ws.transaction.recovery_fat.2,com.ibm.ws.transaction.recovery_fat.3,com.ibm.ws.tx.jta_fat,com.ibm.ws.tx.jta_fat_hibernate,com.ibm.ws.wsat.common_fat,com.ibm.ws.wsat.concurrent_fat,com.ibm.ws.wsat.migration_fat.1,com.ibm.ws.wsat.migration_fat.2,com.ibm.ws.wsat.migration_fat.3,com.ibm.ws.wsat.migration_fat.4,com.ibm.ws.wsat.migration_fat.5,com.ibm.ws.wsat.migration_fat.6,com.ibm.ws.wsat.migration_fat.7,com.ibm.ws.wsat.recovery_fat.lps,com.ibm.ws.wsat.recovery_fat.multi.1,com.ibm.ws.wsat.recovery_fat.multi.2,com.ibm.ws.wsat.recovery_fat.multi.3,com.ibm.ws.wsat.recovery_fat.multi.4,com.ibm.ws.wsat.recovery_fat.multi.5,com.ibm.ws.wsat.recovery_fat.multi.6,com.ibm.ws.wsat.recovery_fat.multi.7,com.ibm.ws.wsat.recovery_fat.single.1,com.ibm.ws.wsat.recovery_fat.single.2,com.ibm.ws.wsat_fat.assertion,com.ibm.ws.wsat_fat.db,com.ibm.ws.wsat_fat.db_optional,com.ibm.ws.wsat_fat.dbs,com.ibm.ws.wsat_fat.dbs_optional,com.ibm.ws.wsat_fat.multi,com.ibm.ws.wsat_fat.ssl.misroute,com.ibm.ws.wsat_fat.ssl