### PR TITLE
Avoid NPE from CDI if app start fails

### DIFF
--- a/dev/com.ibm.ws.cdi.1.2.web/src/com/ibm/ws/cdi/web/factories/Weld24InitialListener.java
+++ b/dev/com.ibm.ws.cdi.1.2.web/src/com/ibm/ws/cdi/web/factories/Weld24InitialListener.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.web.factories;
+
+import javax.servlet.ServletContextEvent;
+
+import org.jboss.weld.manager.BeanManagerImpl;
+import org.jboss.weld.servlet.WeldInitialListener;
+
+public class Weld24InitialListener extends WeldInitialListener {
+
+    private boolean initialized = false;
+
+    public Weld24InitialListener(BeanManagerImpl beanManager) {
+        super(beanManager);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void contextInitialized(ServletContextEvent arg0) {
+        super.contextInitialized(arg0);
+        initialized = true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        if (initialized) {
+            super.contextDestroyed(sce);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.1.2.web/src/com/ibm/ws/cdi/web/factories/WeldListenerFactory.java
+++ b/dev/com.ibm.ws.cdi.1.2.web/src/com/ibm/ws/cdi/web/factories/WeldListenerFactory.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,7 +22,6 @@ import org.jboss.weld.el.WeldELContextListener;
 import org.jboss.weld.el.WeldExpressionFactory;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.servlet.ConversationFilter;
-import org.jboss.weld.servlet.WeldInitialListener;
 import org.jboss.weld.servlet.WeldTerminalListener;
 
 /**
@@ -35,7 +34,7 @@ public class WeldListenerFactory {
     }
 
     public static EventListener newWeldInitialListener(BeanManagerImpl beanManagerImpl) {
-        return new WeldInitialListener(beanManagerImpl);
+        return new Weld24InitialListener(beanManagerImpl);
     }
 
     public static ExpressionFactory newWeldExpressionFactory(ExpressionFactory expressionFactory) {

--- a/dev/com.ibm.ws.cdi.2.0.web/src/com/ibm/ws/cdi/web/factories/Weld30InitialListener.java
+++ b/dev/com.ibm.ws.cdi.2.0.web/src/com/ibm/ws/cdi/web/factories/Weld30InitialListener.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.web.factories;
+
+import javax.servlet.ServletContextEvent;
+
+import org.jboss.weld.manager.BeanManagerImpl;
+import org.jboss.weld.module.web.servlet.WeldInitialListener;
+
+public class Weld30InitialListener extends WeldInitialListener {
+
+    private boolean initialized = false;
+
+    public Weld30InitialListener(BeanManagerImpl beanManager) {
+        super(beanManager);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void contextInitialized(ServletContextEvent arg0) {
+        super.contextInitialized(arg0);
+        initialized = true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        if (initialized) {
+            super.contextDestroyed(sce);
+        }
+    }
+}

--- a/dev/com.ibm.ws.cdi.2.0.web/src/com/ibm/ws/cdi/web/factories/WeldListenerFactory.java
+++ b/dev/com.ibm.ws.cdi.2.0.web/src/com/ibm/ws/cdi/web/factories/WeldListenerFactory.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,7 +22,6 @@ import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.module.web.el.WeldELContextListener;
 import org.jboss.weld.module.web.el.WeldExpressionFactory;
 import org.jboss.weld.module.web.servlet.ConversationFilter;
-import org.jboss.weld.module.web.servlet.WeldInitialListener;
 import org.jboss.weld.module.web.servlet.WeldTerminalListener;
 
 /**
@@ -35,7 +34,7 @@ public class WeldListenerFactory {
     }
 
     public static EventListener newWeldInitialListener(BeanManagerImpl beanManagerImpl) {
-        return new WeldInitialListener(beanManagerImpl);
+        return new Weld30InitialListener(beanManagerImpl);
     }
 
     public static ExpressionFactory newWeldExpressionFactory(ExpressionFactory expressionFactory) {

--- a/dev/com.ibm.ws.cdi.jee_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.jee_fat/bnd.bnd
@@ -19,9 +19,9 @@ src: \
 fat.project: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
-# In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features: \
         cdi-1.2, \
+        servlet-4.0, \
         servlet-5.0, \
         xmlws-3.0, \
         xmlbinding-3.0, \

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/FATSuite.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,6 +21,7 @@ import com.ibm.ws.cdi.jee.jaxrs.inject.InjectIntoPathTest;
 import com.ibm.ws.cdi.jee.jsf.SimpleJSFTest;
 import com.ibm.ws.cdi.jee.jsf.SimpleJSFWithSharedLibTest;
 import com.ibm.ws.cdi.jee.jsp.SimpleJSPTest;
+import com.ibm.ws.cdi.jee.servlet.ServletStartupTest;
 import com.ibm.ws.cdi.jee.webservices.CDI12WebServicesTest;
 
 /**
@@ -31,6 +32,7 @@ import com.ibm.ws.cdi.jee.webservices.CDI12WebServicesTest;
                 CDI12WebServicesTest.class,
                 InjectIntoPathTest.class,
                 JEEInjectionTargetTest.class,
+                ServletStartupTest.class,
                 SimpleJSFTest.class,
                 SimpleJSFWithSharedLibTest.class,
                 SimpleJSPTest.class,

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/servlet/DummyBean.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/servlet/DummyBean.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.jee.servlet;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * Dummy bean to ensure CDI is active
+ */
+@ApplicationScoped
+public class DummyBean {
+
+}

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/servlet/DummyServlet.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/servlet/DummyServlet.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.jee.servlet;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A dummy servlet so there's something valid in the app
+ */
+@SuppressWarnings("serial")
+@WebServlet("/test")
+public class DummyServlet extends HttpServlet {
+
+    /** {@inheritDoc} */
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().println("OK");
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/servlet/ServletInitializer.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/servlet/ServletInitializer.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.jee.servlet;
+
+import java.util.Set;
+
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+/**
+ *
+ */
+public class ServletInitializer implements ServletContainerInitializer {
+
+    /** {@inheritDoc} */
+    @Override
+    public void onStartup(Set<Class<?>> arg0, ServletContext arg1) throws ServletException {
+        // Throwing an error breaks CDI in unfortunate ways
+        throw new Error("Test error");
+    }
+}

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/servlet/ServletStartupTest.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/servlet/ServletStartupTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.jee.servlet;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertNotNull;
+
+import javax.servlet.ServletContainerInitializer;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.EERepeatActions;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * Test a failure during startup
+ */
+@RunWith(FATRunner.class)
+public class ServletStartupTest extends FATServletClient {
+
+    public static final String SERVER_NAME = "cdi12BasicServer";
+
+    @ClassRule
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8, EERepeatActions.EE7);
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "servletStartup.war")
+                                   .addClasses(ServletInitializer.class, DummyServlet.class, DummyBean.class)
+                                   .addAsServiceProvider(ServletContainerInitializer.class, ServletInitializer.class);
+
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY, DISABLE_VALIDATION);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer();
+    }
+
+    @Test
+    public void testGracefulStartupFailure() throws Exception {
+        // Check app fails to start
+        assertNotNull(server.waitForStringInLog("CWWKZ0012I"));;
+
+        // There should not be an NPE
+        assertThat(server.findStringsInLogs("NullPointerException"), empty());
+    }
+
+}

--- a/dev/io.openliberty.cdi.4.0.internal.web/src/com/ibm/ws/cdi/web/factories/Weld50InitialListener.java
+++ b/dev/io.openliberty.cdi.4.0.internal.web/src/com/ibm/ws/cdi/web/factories/Weld50InitialListener.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -28,6 +28,7 @@ import jakarta.servlet.ServletContextEvent;
 public class Weld50InitialListener extends WeldInitialListener {
 
     private final BeanDeploymentModule module;
+    private boolean initialized = false;
 
     public Weld50InitialListener(BeanManagerImpl beanManagerImpl) {
         super(beanManagerImpl);
@@ -38,6 +39,7 @@ public class Weld50InitialListener extends WeldInitialListener {
     @Override
     public void contextInitialized(ServletContextEvent event) {
         super.contextInitialized(event);
+        initialized = true;
         if (this.module != null) {
             module.fireEvent(Startup.class, new Startup(), Any.Literal.INSTANCE);
         }
@@ -48,6 +50,8 @@ public class Weld50InitialListener extends WeldInitialListener {
         if (this.module != null) {
             module.fireEvent(Shutdown.class, new Shutdown(), Any.Literal.INSTANCE);
         }
-        super.contextDestroyed(event);
+        if (initialized) {
+            super.contextDestroyed(event);
+        }
     }
 }


### PR DESCRIPTION
Ensure that if the web container calls contextDestroyed without calling
contextInitialized, we won't throw a NullPointerException.

The code that would throw the NPE is in Weld, this change just guards
calling the contextDestroyed method if contextInitialized wasn't called.

Fixes #26054 