### PR TITLE
Allow checkpoint bundle error until that issue is resolved

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/MessageConstants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/MessageConstants.java
@@ -22,6 +22,8 @@ public class MessageConstants {
     public static final String CWWKS4105I_LTPA_CONFIG_READY = "CWWKS4105I";
     public static final String CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR = "CWWKG0014E";
 
+    public static final String CWWKE0701E_BUNDLE_ACTIVATOR_FAILURE = "CWWKE0701E";
+
     public static final String CWWKE1102W_QUIESCE_WARNING = "CWWKE1102W";
     public static final String CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE = "CWWKE1106W";
     public static final String CWWKE1107W_QUIESCE_WAITING_ON_THREAD = "CWWKE1107W";

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/BuilderTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/BuilderTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -61,6 +61,8 @@ public class BuilderTests extends CommonJwtssoFat {
         server.addInstalledAppForValidation(JwtFatConstants.APP_FORMLOGIN);
         serverTracker.addServer(server);
         server.startServerUsingExpandedConfiguration("server_withFeature.xml", CommonWaitForAppChecks.getLTPAReadyMsgs(CommonWaitForAppChecks.getSSLChannelReadyMsgs()));
+
+        addServerStartupAllowedErrors(server);
     }
 
     /**

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/ConfigAttributeTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/ConfigAttributeTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.util.Cookie;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import com.ibm.websphere.simplicity.log.Log;
-import com.ibm.ws.security.fat.common.CommonSecurityFat;
 import com.ibm.ws.security.fat.common.actions.TestActions;
 import com.ibm.ws.security.fat.common.apps.jwtbuilder.JwtBuilderServlet;
 import com.ibm.ws.security.fat.common.expectations.Expectation;
@@ -45,6 +44,7 @@ import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwtsso.fat.actions.JwtFatActions;
 import com.ibm.ws.security.jwtsso.fat.utils.CommonExpectations;
+import com.ibm.ws.security.jwtsso.fat.utils.CommonJwtssoFat;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatUtils;
 import com.ibm.ws.security.jwtsso.fat.utils.MessageConstants;
@@ -59,7 +59,7 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
-public class ConfigAttributeTests extends CommonSecurityFat {
+public class ConfigAttributeTests extends CommonJwtssoFat {
 
     protected static Class<?> thisClass = ConfigAttributeTests.class;
 
@@ -85,6 +85,8 @@ public class ConfigAttributeTests extends CommonSecurityFat {
         serverTracker.addServer(server);
         skipRestoreServerTracker.addServer(server);
         server.startServerUsingExpandedConfiguration("server_withFeature.xml", CommonWaitForAppChecks.getLTPAReadyMsgs(CommonWaitForAppChecks.getSSLChannelReadyMsgs()));
+
+        addServerStartupAllowedErrors(server);
     }
 
     @Before

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/CookieExpirationTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/CookieExpirationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,13 +20,13 @@ import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.util.Cookie;
 import com.ibm.websphere.simplicity.log.Log;
-import com.ibm.ws.security.fat.common.CommonSecurityFat;
 import com.ibm.ws.security.fat.common.actions.TestActions;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwtsso.fat.actions.JwtFatActions;
 import com.ibm.ws.security.jwtsso.fat.utils.CommonExpectations;
+import com.ibm.ws.security.jwtsso.fat.utils.CommonJwtssoFat;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatUtils;
 
@@ -39,7 +39,7 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
-public class CookieExpirationTests extends CommonSecurityFat {
+public class CookieExpirationTests extends CommonJwtssoFat {
 
     protected static Class<?> thisClass = CookieExpirationTests.class;
 
@@ -63,6 +63,8 @@ public class CookieExpirationTests extends CommonSecurityFat {
         server.addInstalledAppForValidation(JwtFatConstants.APP_FORMLOGIN);
         serverTracker.addServer(server);
         server.startServerUsingExpandedConfiguration("server_withFeature.xml", CommonWaitForAppChecks.getLTPAReadyMsgs(CommonWaitForAppChecks.getSSLChannelReadyMsgs()));
+
+        addServerStartupAllowedErrors(server);
 
     }
 

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/CookieProcessingTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/CookieProcessingTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -29,7 +29,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import com.ibm.websphere.simplicity.log.Log;
-import com.ibm.ws.security.fat.common.CommonSecurityFat;
 import com.ibm.ws.security.fat.common.actions.TestActions;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
@@ -38,6 +37,7 @@ import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwtsso.fat.actions.JwtFatActions;
 import com.ibm.ws.security.jwtsso.fat.expectations.CookieExpectation;
 import com.ibm.ws.security.jwtsso.fat.utils.CommonExpectations;
+import com.ibm.ws.security.jwtsso.fat.utils.CommonJwtssoFat;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatUtils;
 
@@ -48,7 +48,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-public class CookieProcessingTests extends CommonSecurityFat {
+public class CookieProcessingTests extends CommonJwtssoFat {
 
     protected static Class<?> thisClass = CookieProcessingTests.class;
 
@@ -76,6 +76,8 @@ public class CookieProcessingTests extends CommonSecurityFat {
         server.addInstalledAppForValidation(JwtFatConstants.APP_FORMLOGIN);
         serverTracker.addServer(server);
         server.startServerUsingExpandedConfiguration("server_withFeature.xml", CommonWaitForAppChecks.getLTPAReadyMsgs(CommonWaitForAppChecks.getSSLChannelReadyMsgs()));
+
+        addServerStartupAllowedErrors(server);
 
     }
 

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/EncryptionTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/EncryptionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -76,6 +76,9 @@ public class EncryptionTests extends CommonJwtssoFat {
         for (Provider p : Security.getProviders()) {
             Log.info(thisClass, "setUp", "provider: " + p.getName());
         }
+
+        addServerStartupAllowedErrors(server);
+
     }
 
     @Test

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/FeatureOnlyTest.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/FeatureOnlyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebClient;
-import com.ibm.ws.security.fat.common.CommonSecurityFat;
 import com.ibm.ws.security.fat.common.Constants;
 import com.ibm.ws.security.fat.common.actions.TestActions;
 import com.ibm.ws.security.fat.common.expectations.Expectation;
@@ -29,6 +28,7 @@ import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwtsso.fat.actions.JwtFatActions;
 import com.ibm.ws.security.jwtsso.fat.utils.CommonExpectations;
+import com.ibm.ws.security.jwtsso.fat.utils.CommonJwtssoFat;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatUtils;
 
@@ -40,7 +40,7 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
-public class FeatureOnlyTest extends CommonSecurityFat {
+public class FeatureOnlyTest extends CommonJwtssoFat {
 
     protected static Class<?> thisClass = FeatureOnlyTest.class;
 
@@ -65,6 +65,8 @@ public class FeatureOnlyTest extends CommonSecurityFat {
         server.addInstalledAppForValidation(JwtFatConstants.APP_FORMLOGIN);
         serverTracker.addServer(server);
         server.startServerUsingExpandedConfiguration("server_withFeature.xml", CommonWaitForAppChecks.getLTPAReadyMsgs(CommonWaitForAppChecks.getSSLChannelReadyMsgs()));
+
+        addServerStartupAllowedErrors(server);
 
     }
 

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/ReplayCookieTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/ReplayCookieTests.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package com.ibm.ws.security.jwtsso.fat;
 
-import static org.junit.Assert.assertNotNull;
-
 import java.io.File;
 import java.io.StringReader;
 import java.net.MalformedURLException;
@@ -40,7 +38,6 @@ import com.gargoylesoftware.htmlunit.util.Cookie;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.common.encoder.Base64Coder;
-import com.ibm.ws.security.fat.common.CommonSecurityFat;
 import com.ibm.ws.security.fat.common.actions.TestActions;
 import com.ibm.ws.security.fat.common.apps.CommonFatApplications;
 import com.ibm.ws.security.fat.common.apps.jwtbuilder.JwtBuilderServlet;
@@ -57,6 +54,7 @@ import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.fat.common.web.WebResponseUtils;
 import com.ibm.ws.security.jwtsso.fat.actions.JwtFatActions;
 import com.ibm.ws.security.jwtsso.fat.utils.CommonExpectations;
+import com.ibm.ws.security.jwtsso.fat.utils.CommonJwtssoFat;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatUtils;
 import com.ibm.ws.security.jwtsso.fat.utils.MessageConstants;
@@ -72,7 +70,7 @@ import componenttest.topology.utils.ServerFileUtils;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
-public class ReplayCookieTests extends CommonSecurityFat {
+public class ReplayCookieTests extends CommonJwtssoFat {
 
     protected static Class<?> thisClass = ReplayCookieTests.class;
 
@@ -111,6 +109,8 @@ public class ReplayCookieTests extends CommonSecurityFat {
         serverTracker.addServer(server);
 
         server.startServerUsingExpandedConfiguration(DEFAULT_CONFIG, CommonWaitForAppChecks.getLTPAReadyMsgs(CommonWaitForAppChecks.getSSLChannelReadyMsgs()));
+
+        addServerStartupAllowedErrors(server);
 
     }
 
@@ -353,7 +353,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
         Page response = actions.invokeUrlWithCookie(_testName, protectedUrl, ltpaCookie);
         validationUtils.validateResult(response, currentAction, expectations);
     }
-    
+
     /**
      * Tests:
      * - Log into the protected resource WITHOUT the JWT SSO feature, obtaining an LTPA token/cookie (context root is set)
@@ -388,7 +388,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
         validationUtils.validateResult(response, currentAction, expectations);
         actions.destroyWebClient(webClient);
     }
-    
+
     /**
      * Tests:
      * - Log into the protected resource WITHOUT the JWT SSO feature, obtaining an LTPA token/cookie (context root is set)
@@ -408,7 +408,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
 
         expandAndUpdateServerConfiguration(server, "server_useLtpaIfJwtAbsent_true_configureSecondApp.xml", true, APP_NAME_JWT_BUILDER, JwtFatConstants.APP_FORMLOGIN);
 
-        String currentAction = TestActions.ACTION_INVOKE_PROTECTED_RESOURCE;       
+        String currentAction = TestActions.ACTION_INVOKE_PROTECTED_RESOURCE;
         String newProtectedUrl = httpUrlBase + JwtFatConstants.JWT_BUILDER_CONTEXT_ROOT + "/protected";
 
         Expectations expectations = new Expectations();
@@ -527,7 +527,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
         Page response = actions.invokeUrlWithCookie(_testName, newProtectedUrl, jwtCookie);
         validationUtils.validateResult(response, currentAction, expectations);
     }
-    
+
     /**
      * Tests:
      * - Logs into the protected resource with the JWT SSO feature configured. JWT SSO cookie is created with context root
@@ -554,7 +554,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
         validationUtils.validateResult(response, currentAction, expectations);
         actions.destroyWebClient(wc);
     }
-    
+
     /**
      * Tests:
      * - Logs into the protected resource with the JWT SSO feature configured. JWT SSO cookie is created without context root
@@ -576,7 +576,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
         expectations.addExpectation(new ResponseStatusExpectation(currentAction, HttpServletResponse.SC_OK));
         expectations.addExpectation(new ResponseUrlExpectation(currentAction, JwtFatConstants.STRING_EQUALS, newProtectedUrl, "Did not reach the expected URL."));
         expectations.addExpectation(Expectation.createResponseExpectation(currentAction, String.format(ProtectedServlet.SUCCESS_MESSAGE, defaultUser),
-                                                                         "Did not find the expected success message in the servlet response."));
+                                                                          "Did not find the expected success message in the servlet response."));
         expectations.addExpectations(CommonExpectations.getJwtPrincipalExpectations(currentAction, defaultUser, JwtFatConstants.DEFAULT_ISS_REGEX));
         Page response = actions.invokeUrl(_testName, wc, newProtectedUrl);
         validationUtils.validateResult(response, currentAction, expectations);
@@ -702,7 +702,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
     }
 
     /********************************************** Helper methods **********************************************/
-    
+
     /**
      * Expands any imports in the specified server config and copies the expanded configuration to the server.xml of the server root.
      * <p>
@@ -715,7 +715,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
      * @param configFileName the config file in the publish/configs directory
      * @param featureUpdate whether this config updates features
      * @param appNames names of applications which should start after this update completes
-     * @throws Exception 
+     * @throws Exception
      */
     private void expandAndUpdateServerConfiguration(LibertyServer server, String configFileName, boolean featureUpdate, String... appNames) throws Exception {
         Set<String> appNameSet = new HashSet<>(Arrays.asList(appNames));

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/SigAlgTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/SigAlgTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -69,6 +69,8 @@ public class SigAlgTests extends CommonJwtssoFat {
         server.addInstalledAppForValidation(JwtFatConstants.APP_FORMLOGIN);
         serverTracker.addServer(server);
         server.startServerUsingExpandedConfiguration("server_withFeature.xml", CommonWaitForAppChecks.getLTPAReadyMsgs(CommonWaitForAppChecks.getSSLChannelReadyMsgs()));
+
+        addServerStartupAllowedErrors(server);
 
     }
 

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/utils/CommonJwtssoFat.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/utils/CommonJwtssoFat.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import java.util.Base64;
 
 import javax.json.Json;
@@ -31,6 +32,7 @@ import com.ibm.ws.security.fat.common.CommonSecurityFat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
@@ -73,5 +75,11 @@ public class CommonJwtssoFat extends CommonSecurityFat {
         String jwtHeader = extractAndDecodeJwtHeader(jwt);
         JsonObject header = convertStringToJsonObject(jwtHeader);
         return header;
+    }
+
+    protected static void addServerStartupAllowedErrors(LibertyServer server) throws Exception {
+
+        server.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE0701E_BUNDLE_ACTIVATOR_FAILURE + ": bundle io.openliberty.checkpoint:"));
+
     }
 }


### PR DESCRIPTION
Allow "CWWKE0701E: bundle io.openliberty.checkpoint:" during server startup until the root cause is resolved.