### PR TITLE
Resolve symbolic links when looking for java

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -786,7 +786,6 @@ serverEnvAndJVMOptions()
 # resolve symbolic links in a path to a file
 findRealPath() {
   file="$1"
-  local REAL_PATH
 
   # Try realpath command 
   if command -v realpath >/dev/null; then
@@ -799,22 +798,34 @@ findRealPath() {
   fi
 
   # If still no luck, try a more basic implementation
-  if [ -n "${REAL_PATH}" ]; then
+  if [ -z "${REAL_PATH}" ]; then
+    # while $file resolves to an existing directory entry for a symbolic link 
     while [ -h "$file" ]; do
-      # Get absolute path to file without symbolic links
+      # Get absolute path to directory without symbolic links
+      # Potential Issue: awk might produce incorrect result if file or directory names contain spaces.
       dir=$(cd -P "$(dirname "$file")" && pwd)
       file=$(ls -l "$file" | awk '{print $NF}')
 
       case "$file" in
-        # absolute path case - do nothing
-        /*) ;;
-        # relative path case - convert to absolute path.
-        *) file="$dir/$file" ;;
+        # absolute path case: 1) Find dir without symlinks 2) Get file name 3) Add file name back to path
+        /*)
+          dir=$(cd -P "$(dirname "$file")" && pwd)
+          file=$(basename "$file")
+          file="$dir/$file" 
+          ;;
+        # relative path case: 1) Make absolute 2) Find dir without symlinks 3) Get file name 4) Add file name back to path
+        *) 
+          file="$dir/$file"
+          dir=$(cd -P "$(dirname "$file")" && pwd)
+          file=$(basename "$file")
+          file="$dir/$file"
+          ;;
       esac
     done
   else
     file="$REAL_PATH"
   fi
+  # return the resolved file path
   echo "$file"
 }
 

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -783,50 +783,95 @@ serverEnvAndJVMOptions()
   return $rc
 }
 
-# resolve symbolic links in a path to a file
+# Resolve symbolic links in a path iteratively
 findRealPath() {
-  file="$1"
+  path="$1"
 
-  # Try realpath command 
+  # Try realpath command
   if command -v realpath >/dev/null; then
-    REAL_PATH=$(realpath "${file}" 2>/dev/null)        
+    resolvedPath=$(realpath "${path}" 2>/dev/null)
+  fi
+  
+  # If realpath is not available, try readlink -e
+  if [ -z "${resolvedPath}" ] && command -v readlink >/dev/null; then
+    resolvedPath=$(readlink -e "${path}" 2>/dev/null)
   fi
 
-  # If realpath is not available, try readlink -e  
-  if [ -z "${REAL_PATH}" ] && command -v readlink >/dev/null; then
-    REAL_PATH=$(readlink -e "${file}" 2>/dev/null)
+  # If neither of those methods work, try a more basic approach
+  if [ -z "${resolvedPath}" ]; then 
+
+    # Loop ends when resolvedPath does not contain any symlinks  
+    while true; do
+
+      resolvedPath=""
+      IFS="/" # Set the delimiter to '/'
+      # Split the path into components.  Purposefully not putting quotes around $path.
+      set -- $path
+      pathContainsSymLink="false"
+      for component; do
+	  
+        if [ -z "$component" ]; then
+          continue # Skip empty components
+        fi
+
+        # Combine the resolved path & component
+        if [ -z "$resolvedPath" ]; then
+          case "$path" in
+          /*)
+            resolvedPath="/$component"
+            ;;
+          *) # If path is relative, then don't add leading slash
+            resolvedPath=$component
+            ;;
+          esac
+        else
+          resolvedPath="$resolvedPath/$component"
+        fi
+
+        if [ -L "$resolvedPath" ]; then
+          pathContainsSymLink="true"
+		  
+          # Get the target of the symbolic link
+          target=$(ls -l "$resolvedPath" | awk '{print $NF}')
+
+          # Don't lose the remaining path past the symlink
+          if [ "$resolvedPath" = "$path" ]; then
+            remaining_path=""
+          else
+            # Remove the resolved part from the original path
+            remaining_path="${path#"${resolvedPath%/}"/}"
+          fi
+
+          # Save the prefix up one level from the symlink
+          savePrefix=$(cd "$(dirname "$resolvedPath")" && pwd)
+		  
+          case "$target" in
+          /*)
+            # Absolute path case
+            resolvedPath="$target/$remaining_path"
+            ;;
+          *)
+            # Relative path case"
+            resolvedPath="$savePrefix/$target/$remaining_path"
+            ;;
+          esac
+
+          break
+        else
+          :  # $resolvedPath is  NOT a symLink
+        fi
+      done  # end for
+
+      if [ "$pathContainsSymLink" = "false" ]; then
+        break
+      fi
+
+      path=$resolvedPath
+    done  # end while
   fi
 
-  # If still no luck, try a more basic implementation
-  if [ -z "${REAL_PATH}" ]; then
-    # while $file resolves to an existing directory entry for a symbolic link 
-    while [ -h "$file" ]; do
-      # Get absolute path to directory without symbolic links
-      # Potential Issue: awk might produce incorrect result if file or directory names contain spaces.
-      dir=$(cd -P "$(dirname "$file")" && pwd)
-      file=$(ls -l "$file" | awk '{print $NF}')
-
-      case "$file" in
-        # absolute path case: 1) Find dir without symlinks 2) Get file name 3) Add file name back to path
-        /*)
-          dir=$(cd -P "$(dirname "$file")" && pwd)
-          file=$(basename "$file")
-          file="$dir/$file" 
-          ;;
-        # relative path case: 1) Make absolute 2) Find dir without symlinks 3) Get file name 4) Add file name back to path
-        *) 
-          file="$dir/$file"
-          dir=$(cd -P "$(dirname "$file")" && pwd)
-          file=$(basename "$file")
-          file="$dir/$file"
-          ;;
-      esac
-    done
-  else
-    file="$REAL_PATH"
-  fi
-  # return the resolved file path
-  echo "$file"
+  # Return the fully resolved path
+  echo "$resolvedPath"
 }
 
 mergeJVMOptions()

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -758,16 +758,37 @@ serverEnvAndJVMOptions()
     mergeJVMOptions "${WLP_INSTALL_DIR}/etc/jvm.options"
   fi
 
+  # Determine location of Java Platform Module System (JPMS) modules directory
   if [ -z "${JAVA_HOME}" ]; then
-    JAVA_PATH_FROM_PATH=$(command -v java)
-    if [ -n "${JAVA_PATH_FROM_PATH}" ] ; then
-      JPMS_MODULE_FILE_LOCATION=$(dirname $(dirname $JAVA_PATH_FROM_PATH))/lib/modules
+
+    # JAVA_HOME not set.  Locate java using the PATH.
+    JAVA_PATH=$(command -v java)
+    if [ -n "${JAVA_PATH}" ] ; then
+
+      # Found java, but path might have symbolic links.  Need to find the real path. 
+      if command -v realpath >/dev/null; then
+        REAL_JAVA_PATH=$(realpath "${JAVA_PATH}" 2>/dev/null)        
+      fi
+
+      # If realpath is not available, try readlink -e  
+      if [ -z "${REAL_JAVA_PATH}" ] && command -v readlink >/dev/null; then
+        REAL_JAVA_PATH=$(readlink -e "${JAVA_PATH}" 2>/dev/null)
+      fi
+
+      # if realpath and readlink failed then try to resolve the hard way
+      if [ -z "${REAL_JAVA_PATH}" ]; then
+         REAL_JAVA_PATH=$(resolve_symlinks "${JAVA_PATH}")
+      fi
+
+      if [ -n "${REAL_JAVA_PATH}" ]; then
+         JPMS_MODULE_FILE_LOCATION=$(dirname "$(dirname "${REAL_JAVA_PATH}")")/lib/modules
+      fi
     fi
   else
     JPMS_MODULE_FILE_LOCATION="${JAVA_HOME}/lib/modules"
   fi
 
-  # If we are running on Java 9, apply Liberty's built-in java 9 options  
+  # If we are running on Java 9 and up, apply Liberty's built-in java 9 options  
   if [ -f "${JPMS_MODULE_FILE_LOCATION}" ]; then
     mergeJVMOptions "${WLP_INSTALL_DIR}/lib/platform/java/java9.options"
   fi
@@ -775,6 +796,23 @@ serverEnvAndJVMOptions()
   return $rc
 }
 
+# resolve symbolic links in a path
+resolve_symlinks() {
+  file="$1"
+  while [ -h "$file" ]; do
+    # Get absolute path to file without symbolic links
+    dir=$(cd -P "$(dirname "$file")" && pwd)
+    file=$(ls -l "$file" | awk '{print $NF}')
+
+    case "$file" in
+      # absolute path case - do nothing
+      /*) ;;
+      # relative path case - convert to absolute path.
+      *) file="$dir/$file" ;;
+    esac
+  done
+  echo "$file"
+}
 
 mergeJVMOptions()
 {
@@ -819,9 +857,9 @@ readServerEnv()
            # "enable_variable_expansion", and nothing else (ignoring case and white space).
            # If found, we use the source command ( . ) which performs all of the server.env
            # variable assignments while resolving any variable references.
-           if [ $variableExpansionEnabled = 0  ] && [ $(echo $line | grep -i "enable_variable_expansion") ]
+           if [ $variableExpansionEnabled = 0  ] && [ $(safeEcho $line | grep -i "enable_variable_expansion") ]
            then
-              processedLine=$(echo $line | tr -d '[:blank:]' | tr '[:upper:]' '[:lower:]')
+              processedLine=$(safeEcho $line | tr -d '[:blank:]' | tr '[:upper:]' '[:lower:]')
               if [ "#enable_variable_expansion" = $processedLine ]
               then
                  eval ". $1"

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -765,20 +765,7 @@ serverEnvAndJVMOptions()
     JAVA_PATH=$(command -v java)
     if [ -n "${JAVA_PATH}" ] ; then
 
-      # Found java, but path might have symbolic links.  Need to find the real path. 
-      if command -v realpath >/dev/null; then
-        REAL_JAVA_PATH=$(realpath "${JAVA_PATH}" 2>/dev/null)        
-      fi
-
-      # If realpath is not available, try readlink -e  
-      if [ -z "${REAL_JAVA_PATH}" ] && command -v readlink >/dev/null; then
-        REAL_JAVA_PATH=$(readlink -e "${JAVA_PATH}" 2>/dev/null)
-      fi
-
-      # if realpath and readlink failed then try to resolve the hard way
-      if [ -z "${REAL_JAVA_PATH}" ]; then
-         REAL_JAVA_PATH=$(resolve_symlinks "${JAVA_PATH}")
-      fi
+      REAL_JAVA_PATH=$(findRealPath "${JAVA_PATH}")
 
       if [ -n "${REAL_JAVA_PATH}" ]; then
          JPMS_MODULE_FILE_LOCATION=$(dirname "$(dirname "${REAL_JAVA_PATH}")")/lib/modules
@@ -796,21 +783,38 @@ serverEnvAndJVMOptions()
   return $rc
 }
 
-# resolve symbolic links in a path
-resolve_symlinks() {
+# resolve symbolic links in a path to a file
+findRealPath() {
   file="$1"
-  while [ -h "$file" ]; do
-    # Get absolute path to file without symbolic links
-    dir=$(cd -P "$(dirname "$file")" && pwd)
-    file=$(ls -l "$file" | awk '{print $NF}')
+  local REAL_PATH
 
-    case "$file" in
-      # absolute path case - do nothing
-      /*) ;;
-      # relative path case - convert to absolute path.
-      *) file="$dir/$file" ;;
-    esac
-  done
+  # Try realpath command 
+  if command -v realpath >/dev/null; then
+    REAL_PATH=$(realpath "${file}" 2>/dev/null)        
+  fi
+
+  # If realpath is not available, try readlink -e  
+  if [ -z "${REAL_PATH}" ] && command -v readlink >/dev/null; then
+    REAL_PATH=$(readlink -e "${file}" 2>/dev/null)
+  fi
+
+  # If still no luck, try a more basic implementation
+  if [ -n "${REAL_PATH}" ]; then
+    while [ -h "$file" ]; do
+      # Get absolute path to file without symbolic links
+      dir=$(cd -P "$(dirname "$file")" && pwd)
+      file=$(ls -l "$file" | awk '{print $NF}')
+
+      case "$file" in
+        # absolute path case - do nothing
+        /*) ;;
+        # relative path case - convert to absolute path.
+        *) file="$dir/$file" ;;
+      esac
+    done
+  else
+    file="$REAL_PATH"
+  fi
   echo "$file"
 }
 

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -799,6 +799,7 @@ findRealPath() {
 
   # If neither of those methods work, try a more basic approach
   if [ -z "${resolvedPath}" ]; then 
+    symLinkCount=0
 
     # Loop ends when resolvedPath does not contain any symlinks  
     while true; do
@@ -830,6 +831,7 @@ findRealPath() {
 
         if [ -L "$resolvedPath" ]; then
           pathContainsSymLink="true"
+          symLinkCount=$((symLinkCount + 1))
 		  
           # Get the target of the symbolic link
           target=$(ls -l "$resolvedPath" | awk '{print $NF}')
@@ -862,7 +864,13 @@ findRealPath() {
         fi
       done  # end for
 
-      if [ "$pathContainsSymLink" = "false" ]; then
+      if [ $pathContainsSymLink = "false" ]; then
+        break
+      fi
+
+      if [ $symLinkCount -gt 100  ]; then
+        issueMessage --message:warning.tooManySymbolicLinks "$1"
+        resolvedPath=""
         break
       fi
 

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -534,8 +534,7 @@ goto:eof
   if NOT defined JAVA_HOME (
     if NOT defined JRE_HOME (
       if NOT defined WLP_DEFAULT_JAVA_HOME (
-        @REM Use whatever java is on the path
-        set JAVA_CMD_QUOTED="java"
+        call :findJavaInPath
       ) else (
         if "!WLP_DEFAULT_JAVA_HOME:~0,17!" == "@WLP_INSTALL_DIR@" (
           set WLP_DEFAULT_JAVA_HOME=!WLP_INSTALL_DIR!!WLP_DEFAULT_JAVA_HOME:~17!
@@ -841,4 +840,14 @@ goto:eof
   ) else (
     set RC=0
   )
+goto:eof
+
+@REM Find the first place java.exe is found in the path.  If java is not found,
+@REM just set the command to "java", which will ultimately fail when executed.
+:findJavaInPath
+set JAVA_CMD_QUOTED="java"
+for /f "delims=" %%i in ('where java.exe 2^>nul') do (
+    set JAVA_CMD_QUOTED="%%~dpni"
+    goto :eof
+)
 goto:eof

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -842,12 +842,40 @@ goto:eof
   )
 goto:eof
 
-@REM Find the first place java.exe is found in the path.  If java is not found,
-@REM just set the command to "java", which will ultimately fail when executed.
+@REM Find the first place java.exe is found in the path.  If java is not found, just set
+@REM the command to "java", which will ultimately fail when executed. Since it's not in the path.
+@REM It would have been simpler to use the where command, but it does not work for directories in
+@REM the path containing spaces:     for /f "delims=" %%i in ('where java.exe 2^>nul') do (
 :findJavaInPath
-set JAVA_CMD_QUOTED="java"
-for /f "delims=" %%i in ('where java.exe 2^>nul') do (
-    set JAVA_CMD_QUOTED="%%~dpni"
-    goto :eof
-)
+
+  call :findInPath "java.exe"
+  if defined foundInPath (
+    set JAVA_CMD_QUOTED="!foundInPath!\java"
+  ) else (
+    set JAVA_CMD_QUOTED="java"
+    goto:eof
+  )
+
+  @REM Set JAVA_HOME.  Loop is single iteration for removing "java" from the path.
+  for %%A in (!JAVA_CMD_QUOTED!) do (
+    pushd "%CD%" 
+    cd "%%~dpA.."
+    set JAVA_HOME=!CD!
+    popd
+  )
 goto:eof
+
+@REM Pass in an executable to find in the PATH.  If the executable is found
+@REM the foundInPath variable will be set to the first directory in which it is found.
+:findInPath
+  set foundInPath= 
+    
+  @REM Split the PATH variable by semicolons and iterate through directories
+  for %%i in (!PATH!) do (
+      
+    if exist "%%~i\%1" (
+      set foundInPath=%%~i
+      goto :eof
+    )
+  )
+goto eof

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -438,6 +438,10 @@ warning.unableToPackageLooseConfigFileMissingPath=CWWKE0095W: The server cannot 
 warning.unableToPackageLooseConfigFileMissingPath.explanation=The specified loose configuration application XML file contains invalid information about the location of the files. For example, it might specify a directory that cannot be found. Paths in this XML file should be relative to the configuration directory of the server. The archive represented by this file will not be included in the packaged server output.
 warning.unableToPackageLooseConfigFileMissingPath.useraction=Modify the paths in the loose configuration application XML file to point to the correct location that contains the application files. 
 
+warning.tooManySymbolicLinks=CWWKE0096W: Too many symbolic links encountered when trying to resolve a path ( {0} ).
+warning.tooManySymbolicLinks.explanation=Symbolic links are shortcuts that point to other files or directories. This error occurs when the system encounters too many symbolic links in a chain, making it unable to resolve the path.
+warning.tooManySymbolicLinks.useraction=To resolve this issue, consider checking the symbolic links in the path, and ensure that they do not create circular references. You may also want to use the 'readlink' command to inspect individual links in the chain.
+
 warn.packageRuntime.include.unknownOption=CWWKE0099W: Unable to use option --include={0}, will use --include=wlp instead.
 warn.packageRuntime.include.unknownOption.explanation=The option was ignored because it was not recognized.
 warn.packageRuntime.include.unknownOption.useraction=Retry the command using valid options. Try using --help for a list of valid options.

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -438,8 +438,8 @@ warning.unableToPackageLooseConfigFileMissingPath=CWWKE0095W: The server cannot 
 warning.unableToPackageLooseConfigFileMissingPath.explanation=The specified loose configuration application XML file contains invalid information about the location of the files. For example, it might specify a directory that cannot be found. Paths in this XML file should be relative to the configuration directory of the server. The archive represented by this file will not be included in the packaged server output.
 warning.unableToPackageLooseConfigFileMissingPath.useraction=Modify the paths in the loose configuration application XML file to point to the correct location that contains the application files. 
 
-warning.tooManySymbolicLinks=CWWKE0096W: Too many symbolic links encountered when trying to resolve a path ( {0} ).
-warning.tooManySymbolicLinks.explanation=Symbolic links are shortcuts that point to other files or directories. This error occurs when the system encounters too many symbolic links in a chain, making it unable to resolve the path.
+warning.tooManySymbolicLinks=CWWKE0096W: Too many symbolic links were encountered when the system tried to resolve the following path: {0}.
+warning.tooManySymbolicLinks.explanation=Symbolic links are shortcuts that point to other files or directories. This error occurs when the system encounters too many symbolic links in a chain and it is unable to resolve the path.
 warning.tooManySymbolicLinks.useraction=To resolve this issue, check the symbolic links in the path and ensure that they do not create circular references. You might also use the 'readlink' command to inspect individual links in the chain.
 
 warn.packageRuntime.include.unknownOption=CWWKE0099W: Unable to use option --include={0}, will use --include=wlp instead.

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -440,7 +440,7 @@ warning.unableToPackageLooseConfigFileMissingPath.useraction=Modify the paths in
 
 warning.tooManySymbolicLinks=CWWKE0096W: Too many symbolic links encountered when trying to resolve a path ( {0} ).
 warning.tooManySymbolicLinks.explanation=Symbolic links are shortcuts that point to other files or directories. This error occurs when the system encounters too many symbolic links in a chain, making it unable to resolve the path.
-warning.tooManySymbolicLinks.useraction=To resolve this issue, consider checking the symbolic links in the path, and ensure that they do not create circular references. You may also want to use the 'readlink' command to inspect individual links in the chain.
+warning.tooManySymbolicLinks.useraction=To resolve this issue, check the symbolic links in the path and ensure that they do not create circular references. You might also use the 'readlink' command to inspect individual links in the chain.
 
 warn.packageRuntime.include.unknownOption=CWWKE0099W: Unable to use option --include={0}, will use --include=wlp instead.
 warn.packageRuntime.include.unknownOption.explanation=The option was ignored because it was not recognized.


### PR DESCRIPTION
Fixes #18412

Tested all 3 implementations on Solaris, Mac, and Ubuntu (in standalone script).   The **realpath** command works on all 3 platforms.  Unfortunately, it doesn't work on z/OS..  Hence the fallback methods. The **readlink -e** command doesn't work on mac, because readlink on mac does not have a "-e" option.   The more basic fallback implementation works on Ubuntu, Mac & Solaris and z/OS (after lots of fiddling on z/OS).  

The whole point of doing this is to find out if we are using version 9 or above.  I'm wondering why we can't just do this:

```
java_version=$("$JAVA_CMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')

# Extract the major version (e.g., 1, 9, 10, 11). 
 # Java switched from using 1.x version numbers in version 9
major_version=$(echo "$java_version" | awk -F. '{print $1}')

 # If we are running on Java 9 and up, apply Liberty's built-in java 9 options 
if [ "$major_version" -ge 9 ]; then
    mergeJVMOptions "${WLP_INSTALL_DIR}/lib/platform/java/java9.options"
fi
```
JAVA_CMD has already been determined by the time we reach this point in the code.