### PR TITLE
Test when the timer is scheduled to run and not when it actually runs.

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointEJB/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointEJB/bootstrap.properties
@@ -12,6 +12,6 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
-com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
+com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:Transaction=all
 # TODO the ejb application needs to be updated to work with ejbLite only
 io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointEJB/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointEJB/jvm.options
@@ -1,1 +1,2 @@
 -Xdump:java:events=throw+systhrow,filter=org/eclipse/openj9/criu/JVMCheckpointException,request=exclusive+preempt
+-Xdump:java:events=throw+systhrow,filter=java/lang/NullPointerException,request=exclusive+prepwalk+preempt


### PR DESCRIPTION
Certain background processes can slow things down. Additionally, there are situations where a virtual machine (VM) may not receive any CPU allocation for a brief period, potentially causing a 2 to 3-minute delay in timer execution. EJB timers schedule the next timeout based on the start time of the previous timeout, not its completion. Therefore, subsequent timers do not trigger exactly 1 second after the previous one finishes but instead 1 second after the previously scheduled start time (not the actual start time). If this results in a past timestamp, we execute the timer immediately and continue to do so until we catch up. Hence, checking the accuracy of when a timer runs is going to be very fragile.

