### PR TITLE
Default MP Reactive Messaging to Strict Mode

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/ConsumerRecordTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/ConsumerRecordTest.java
@@ -89,7 +89,8 @@ public class ConsumerRecordTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addAsLibraries(kafkaClientLibs())
                         .addAsManifestResource(kafkaPermissions(), "permissions.xml")
-                        .addPackage(ConsumerRecordServlet.class.getPackage())
+                        .addClass(ConsumerRecordServlet.class)
+                        .addClass(ConsumerRecordBean.class)
                         .addPackage(KafkaTestConstants.class.getPackage())
                         .addPackage(KafkaTestClientProvider.class.getPackage())
                         .addAsResource(appConfig, "META-INF/microprofile-config.properties");

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseConfiguredTopicTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseConfiguredTopicTest.java
@@ -69,7 +69,8 @@ public class UseConfiguredTopicTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addAsLibraries(kafkaClientLibs())
                         .addAsManifestResource(kafkaPermissions(), "permissions.xml")
-                        .addPackage(UseConfiguredTopicServlet.class.getPackage())
+                        .addClass(UseConfiguredTopicServlet.class)
+                        .addClass(ConfiguredTopicBean.class)
                         .addPackage(KafkaTestConstants.class.getPackage())
                         .addPackage(KafkaTestClientProvider.class.getPackage())
                         .addAsResource(appConfig, "META-INF/microprofile-config.properties");

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseProducerRecordTopicTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/message/UseProducerRecordTopicTest.java
@@ -69,7 +69,8 @@ public class UseProducerRecordTopicTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addAsLibraries(kafkaClientLibs())
                         .addAsManifestResource(kafkaPermissions(), "permissions.xml")
-                        .addPackage(UseProducerRecordTopicServlet.class.getPackage())
+                        .addClass(UseProducerRecordTopicServlet.class)
+                        .addClass(ProducerRecordBean.class)
                         .addPackage(KafkaTestConstants.class.getPackage())
                         .addPackage(KafkaTestClientProvider.class.getPackage())
                         .addAsResource(appConfig, "META-INF/microprofile-config.properties");

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomKeySerializerTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomKeySerializerTest.java
@@ -84,6 +84,8 @@ public class KafkaCustomKeySerializerTest {
                         .addPackage(KafkaKeySerializerTestServlet.class.getPackage())
                         .addPackage(AbstractKafkaTestServlet.class.getPackage())
                         .addPackage(KafkaTestConstants.class.getPackage())
+                        .deleteClass(MyDataMessagingBean.class)
+                        .deleteClass(KafkaSerializerTestServlet.class)
                         .addAsResource(appConfig, "META-INF/microprofile-config.properties");
 
         ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomSerializerTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/serializer/KafkaCustomSerializerTest.java
@@ -79,6 +79,8 @@ public class KafkaCustomSerializerTest {
                         .addPackage(KafkaSerializerTestServlet.class.getPackage())
                         .addPackage(AbstractKafkaTestServlet.class.getPackage())
                         .addPackage(KafkaTestConstants.class.getPackage())
+                        .deleteClass(MyDataMessagingBean2.class)
+                        .deleteClass(KafkaKeySerializerTestServlet.class)
                         .addAsResource(appConfig, "META-INF/microprofile-config.properties");
 
         ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatActions.java
@@ -14,6 +14,7 @@ package componenttest.rules.repeater;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -86,7 +87,9 @@ public class RepeatActions {
                                      List<FeatureSet> allFeatureSets,
                                      FeatureSet firstFeatureSet,
                                      List<FeatureSet> otherFeatureSets) {
-        return repeat(new String[] { server }, otherFeatureSetsTestMode, allFeatureSets, firstFeatureSet, otherFeatureSets);
+        // if server is null use an empty array, else return an array with the server as the sole element
+        String[] servers = server != null ? new String[] {server}: new String[] {};
+        return repeat(servers, otherFeatureSetsTestMode, allFeatureSets, firstFeatureSet, otherFeatureSets);
     }
 
     /**

--- a/dev/io.openliberty.io.smallrye.reactive.messaging-provider4/bnd.bnd
+++ b/dev/io.openliberty.io.smallrye.reactive.messaging-provider4/bnd.bnd
@@ -26,7 +26,8 @@ src: src
 -dsannotations: io.openliberty.microprofile.reactive.messaging30.internal.OLReactiveMessaging30Extension
 
 Include-Resource: \
-  META-INF=resources/META-INF
+  META-INF=resources/META-INF, \
+  OSGI-INF/wlp=resources/OSGI-INF/wlp
 
 Import-Package: \
   !io.vertx.*,\
@@ -36,6 +37,8 @@ Import-Package: \
   org.eclipse.microprofile.metrics.*; version="[4.0,6)",\
   jakarta.enterprise.*; version="[3.0,5)",\
   *
+
+IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
 Private-Package: \
 	io.smallrye.reactive.messaging.providers.connectors;-split-package:=merge-first,\

--- a/dev/io.openliberty.io.smallrye.reactive.messaging-provider4/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/io.openliberty.io.smallrye.reactive.messaging-provider4/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -1,0 +1,13 @@
+<!--
+  ~ Copyright (c) 2023 IBM Corporation and others.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License 2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<server>
+    <!-- Default to strict mode=true-->
+    <variable name="smallrye-messaging-strict-binding" defaultValue="true"/>
+</server>

--- a/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/publish/servers/ReactiveMessaging30TCKServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/publish/servers/ReactiveMessaging30TCKServer/bootstrap.properties
@@ -12,5 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:REACTIVESTREAMS=all
-
-smallrye-messaging-strict-binding=true


### PR DESCRIPTION
By default Smallrye RM is not MP Reactive Messaging spec compliant as it emit warnings if in a number of cases should emit a DeploymentException such as when an @Outgoing does not have a corresponding @Incoming.

Strict mode makes Smallrye RM spec compliant based on the tck results.

Add in default property to enable Strict mode when mpReactiveMessaging-3.0 is enabled.

Fixes #26082 