### PR TITLE
Attempt to fix com.ibm.ws.jbatch.fat.common build break

### DIFF
--- a/dev/com.ibm.ws.jbatch.open.bonuspayout_fat/build.gradle
+++ b/dev/com.ibm.ws.jbatch.open.bonuspayout_fat/build.gradle
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,7 +23,7 @@ dependencies {
 }
 
 task copyTestApps {
-  dependsOn ':com.ibm.ws.jbatch.fat.common:autoFVT'
+  dependsOn ':com.ibm.ws.jbatch.fat.common:assemble'
   doLast {
     // Sources to enable application compilation and shrinkwrap operations
     copy {

--- a/dev/com.ibm.ws.jbatch.open.partition_fat/build.gradle
+++ b/dev/com.ibm.ws.jbatch.open.partition_fat/build.gradle
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,7 +23,7 @@ dependencies {
 }
 
 task copyTestApps {
-  dependsOn ':com.ibm.ws.jbatch.fat.common:autoFVT'
+  dependsOn ':com.ibm.ws.jbatch.fat.common:assemble'
   doLast {
     // Sources to enable application compilation and shrinkwrap operations
     copy {

--- a/dev/com.ibm.ws.jbatch.open.security_fat/build.gradle
+++ b/dev/com.ibm.ws.jbatch.open.security_fat/build.gradle
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,7 +23,7 @@ dependencies {
 }
 
 task copyTestApps {
-  dependsOn ':com.ibm.ws.jbatch.fat.common:autoFVT'
+  dependsOn ':com.ibm.ws.jbatch.fat.common:assemble'
   doLast {
     // Sources to enable application compilation and shrinkwrap operations
     copy {

--- a/dev/com.ibm.ws.jbatch.open_fat/build.gradle
+++ b/dev/com.ibm.ws.jbatch.open_fat/build.gradle
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,7 +23,7 @@ dependencies {
 }
 
 task copyTestApps(type: Copy) {
-  dependsOn ':com.ibm.ws.jbatch.fat.common:autoFVT'
+  dependsOn ':com.ibm.ws.jbatch.fat.common:assemble'
 
   doLast {
     // Sources to enable application compilation and shrinkwrap operations


### PR DESCRIPTION
- Update to depend on assemble instead of autoFVT since the fat directory doesn't exist in com.ibm.ws.jbatch.fat.common so the autoFVT task isn't enabled.
