### PR TITLE
Wait for ServerStarted service before resuming the non persistant timer on restore

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBRuntimeImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBRuntimeImpl.java
@@ -150,6 +150,7 @@ import com.ibm.ws.exception.WsRuntimeFwException;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.javaee.dd.DeploymentDescriptor;
+import com.ibm.ws.kernel.feature.ServerStarted;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.ws.managedobject.ManagedObjectContext;
 import com.ibm.ws.managedobject.ManagedObjectService;
@@ -271,19 +272,18 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
         }
     }
 
-    @Reference(service = CheckpointPhase.class, //
-               target = "(" + CheckpointPhase.CHECKPOINT_RESTORED_PROPERTY + "=true)", //
+    @Reference(service = ServerStarted.class, //
                cardinality = ReferenceCardinality.OPTIONAL, //
                policy = ReferencePolicy.DYNAMIC, //
-               unbind = "ignoreCheckpointRestored")
-    protected final void checkpointRestored(ServiceReference<?> checkpoint) {
+               unbind = "ignoreUnbindOnRestore")
+    protected final void resumeTimerNpOnRestore(ServiceReference<?> checkpoint) {
         // Resume all non-persistent timers on checkpoint restore
         if (checkpointPhase != CheckpointPhase.INACTIVE) {
             TimerNpRunnable.resume();
         }
     }
 
-    protected final void ignoreCheckpointRestored(ServiceReference<?> checkpoint) {
+    protected final void ignoreUnbindOnRestore(ServiceReference<?> checkpoint) {
         // we really don't care about this, but needed to avoid compile errors
     }
 


### PR DESCRIPTION
Timed operations are running before the running condition of the transaction is registered. 
```
[8/26/23, 10:40:52:076 UTC] 00000036 id=00000000 com.ibm.ejs.container.LocalExceptionMappingStrategy          E CNTR0019E: EJB threw an unexpected (non-declared) exception during invocation of method "everyOneSeconds". Exception data: com.ibm.websphere.csi.CSIException: Begin global tx failed; nested exception is: 
	java.lang.NullPointerException
	at com.ibm.ejs.csi.TranStrategy.beginGlobalTx(TranStrategy.java:625)
	at com.ibm.ejs.csi.Required.preInvoke(Required.java:57)
	at com.ibm.ejs.csi.TransactionControlImpl.preInvoke(TransactionControlImpl.java:223)
	at com.ibm.ejs.container.EJSContainer.preInvokeActivate(EJSContainer.java:2943)
	at com.ibm.ejs.container.EJSContainer.EjbPreInvoke(EJSContainer.java:2392)
	at com.ibm.ejs.container.TimedObjectWrapper.invokeCallback(TimedObjectWrapper.java:85)
	at com.ibm.ejs.container.TimerNpRunnable.doWork(TimerNpRunnable.java:232)
	at com.ibm.ejs.container.TimerNpRunnable.run(TimerNpRunnable.java:146)
	at com.ibm.ws.context.service.serializable.ContextualRunnable.run(ContextualRunnable.java:81)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:247)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:839)
Caused by: java.lang.NullPointerException
	at com.ibm.ws.recoverylog.spi.FileFailureScope.<init>(FileFailureScope.java:95)
	at com.ibm.ws.recoverylog.spi.FileFailureScope.<init>(FileFailureScope.java:80)
	at com.ibm.ws.recoverylog.spi.RecoveryDirectorImpl.currentFailureScope(RecoveryDirectorImpl.java:495)
	at com.ibm.ws.Transaction.JTS.Configuration.getFailureScopeController(Configuration.java:171)
	at com.ibm.tx.jta.impl.TransactionImpl.<init>(TransactionImpl.java:326)
	at com.ibm.tx.jta.embeddable.impl.EmbeddableTransactionImpl.<init>(EmbeddableTransactionImpl.java:89)
	at com.ibm.tx.jta.embeddable.impl.EmbeddableTranManagerImpl.createNewTransaction(EmbeddableTranManagerImpl.java:78)
	at com.ibm.tx.jta.embeddable.impl.EmbeddableTranManagerImpl.begin(EmbeddableTranManagerImpl.java:65)
	at com.ibm.tx.jta.impl.TranManagerSet.begin(TranManagerSet.java:90)
	at com.ibm.ejs.csi.TranStrategy.beginGlobalTx(TranStrategy.java:593)
```