### PR TITLE
Add repeats to the Reactive TCKs

### DIFF
--- a/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/bnd.bnd
@@ -24,7 +24,12 @@ javac.target: 11
 
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 
-tested.features: concurrent-3.0
+tested.features: \
+    concurrent-3.0,\
+    mpconfig-3.1,\
+    mpmetrics-4.0,\
+    mpmetrics-5.1,\
+    servlet-5.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/build.gradle
+++ b/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/build.gradle
@@ -1,0 +1,3 @@
+apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
+
+addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/fat/src/io/openliberty/microprofile/reactive/messaging30/tck/FATSuite.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/fat/src/io/openliberty/microprofile/reactive/messaging30/tck/FATSuite.java
@@ -13,9 +13,17 @@
 package io.openliberty.microprofile.reactive.messaging30.tck;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.rules.repeater.FeatureSet;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import java.util.Arrays;
+import java.util.List;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -24,4 +32,45 @@ import org.junit.runners.Suite.SuiteClasses;
 })
 
 public class FATSuite {
+    public static final String MP50_RM30_ID = MicroProfileActions.MP50_ID + "_RM30";
+    public static final String MP60_RM30_ID = MicroProfileActions.MP60_ID + "_RM30";
+    public static final String MP61_RM30_ID = MicroProfileActions.MP61_ID + "_RM30";
+    //MP50 runs on Java 8 but RM30 will only run on Java11 or higher
+    public static final FeatureSet MP50_RM30 = MicroProfileActions.MP50.addFeature("mpReactiveMessaging-3.0").setMinJavaLevel(RepeatActions.SEVersion.JAVA11).build(MP50_RM30_ID);
+    public static final FeatureSet MP60_RM30 = MicroProfileActions.MP60.addFeature("mpReactiveMessaging-3.0").build(MP60_RM30_ID);
+    public static final FeatureSet MP61_RM30 = MicroProfileActions.MP61.addFeature("mpReactiveMessaging-3.0").build(MP61_RM30_ID);
+
+    //All MicroProfile ReactiveMessaging FeatureSets - must be descending order
+    private static final FeatureSet[] ALL_RM_SETS_ARRAY = { MP61_RM30, MP60_RM30, MP50_RM30};
+    private static final List<FeatureSet> ALL_RM_SETS_LIST = Arrays.asList(ALL_RM_SETS_ARRAY);
+
+
+    public static RepeatTests repeatDefault(String serverName) {
+        return repeat(serverName, Mode.TestMode.FULL, FATSuite.MP61_RM30, FATSuite.MP60_RM30, FATSuite.MP50_RM30);
+    }
+
+    /**
+     * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in FULL.
+     *
+     * @param server The server to repeat on
+     * @param firstFeatureSet The first FeatureSet
+     * @param otherFeatureSets The other FeatureSets
+     * @return a RepeatTests instance
+     */
+    public static RepeatTests repeat(String server, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
+        return repeat(server, Mode.TestMode.FULL, firstFeatureSet, otherFeatureSets);
+    }
+
+    /**
+     * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in the mode specified.
+     *
+     * @param server The server to repeat on
+     * @param otherFeatureSetsTestMode The mode to run the other FeatureSets
+     * @param firstFeatureSet The first FeatureSet
+     * @param otherFeatureSets The other FeatureSets
+     * @return a RepeatTests instance
+     */
+    public static RepeatTests repeat(String server, Mode.TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
+        return RepeatActions.repeat(server, otherFeatureSetsTestMode, ALL_RM_SETS_LIST, firstFeatureSet, Arrays.asList(otherFeatureSets));
+    }
 }

--- a/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/fat/src/io/openliberty/microprofile/reactive/messaging30/tck/ReactiveMessagingTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/fat/src/io/openliberty/microprofile/reactive/messaging30/tck/ReactiveMessagingTCKLauncher.java
@@ -17,11 +17,13 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -31,7 +33,12 @@ import org.junit.runner.RunWith;
 @RunWith(FATRunner.class)
 public class ReactiveMessagingTCKLauncher {
 
-    @Server("ReactiveMessaging30TCKServer")
+    public static final String SERVER_NAME = "ReactiveMessaging30TCKServer";
+
+    @ClassRule
+    public static RepeatTests r = FATSuite.repeatDefault(SERVER_NAME);
+
+    @Server(SERVER_NAME)
     public static LibertyServer server;
 
     @BeforeClass
@@ -46,7 +53,7 @@ public class ReactiveMessagingTCKLauncher {
 
     @Test
     @Mode(TestMode.FULL)
-    @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
+    @AllowedFFDC({ "org.jboss.weld.exceptions.DeploymentException", "com.ibm.ws.container.service.state.StateChangeException" }) // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchReactiveMessaging30Tck() throws Exception {
         String bucketName = "io.openliberty.microprofile.reactive.messaging30.internal_fat_tck";
         String testName = this.getClass() + ":launchReactiveMessaging30Tck";

--- a/dev/io.openliberty.microprofile.reactive.streams.operators30.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.reactive.streams.operators30.internal_fat_tck/bnd.bnd
@@ -24,7 +24,11 @@ javac.target: 11
 
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 
-tested.features: concurrent-3.0
+tested.features: \
+    concurrent-3.0,\
+    cdi-3.0,\
+    servlet-5.0
+
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.microprofile.reactive.streams.operators30.internal_fat_tck/fat/src/io/openliberty/microprofile/reactive/streams/operators30/tck/FATSuite.java
+++ b/dev/io.openliberty.microprofile.reactive.streams.operators30.internal_fat_tck/fat/src/io/openliberty/microprofile/reactive/streams/operators30/tck/FATSuite.java
@@ -12,11 +12,19 @@
  *******************************************************************************/
 package io.openliberty.microprofile.reactive.streams.operators30.tck;
 
+import componenttest.custom.junit.runner.Mode;
+import componenttest.rules.repeater.FeatureSet;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+
+import java.util.Arrays;
+import java.util.List;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -24,4 +32,37 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
                 ReactiveStreams30TCKLauncher.class
 })
 
-public class FATSuite {}
+public class FATSuite {
+    public static final String MP_REACTIVE_STREAMS_30 = "mpReactiveStreams-3.0";
+
+    public static final String MP50_RS30_ID = MicroProfileActions.MP50_ID + "_" + "RS30";
+    public static final String MP60_RS30_ID = MicroProfileActions.MP60_ID + "_" + "RS30";
+    public static final String MP61_RS30_ID = MicroProfileActions.MP61_ID + "_" + "RS30";
+
+    //MP50 runs on Java 8 but RSO30 will only run on Java11 or higher
+    public static final FeatureSet MP50_RS30 = MicroProfileActions.MP50.addFeature(MP_REACTIVE_STREAMS_30).setMinJavaLevel(RepeatActions.SEVersion.JAVA11).build(MP50_RS30_ID);
+    public static final FeatureSet MP60_RS30 = MicroProfileActions.MP60.addFeature(MP_REACTIVE_STREAMS_30).build(MP60_RS30_ID);
+    public static final FeatureSet MP61_RS30 = MicroProfileActions.MP61.addFeature(MP_REACTIVE_STREAMS_30).build(MP61_RS30_ID);
+
+    //All MicroProfile ReactiveMessaging FeatureSets - must be descending order
+    private static final FeatureSet[] ALL_RS_SETS_ARRAY = { MP61_RS30, MP60_RS30, MP50_RS30};
+    private static final List<FeatureSet> ALL = Arrays.asList(ALL_RS_SETS_ARRAY);
+
+    public static RepeatTests repeatDefault(String serverName) {
+        return repeat(serverName, Mode.TestMode.FULL, FATSuite.MP61_RS30, FATSuite.MP60_RS30, FATSuite.MP50_RS30);
+    }
+
+    /**
+     * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in the mode specified.
+     *
+     * @param server The server to repeat on
+     * @param otherFeatureSetsTestMode The mode to run the other FeatureSets
+     * @param firstFeatureSet The first FeatureSet
+     * @param otherFeatureSets The other FeatureSets
+     * @return a RepeatTests instance
+     */
+    public static RepeatTests repeat(String server, Mode.TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
+        return RepeatActions.repeat(server, otherFeatureSetsTestMode, ALL, firstFeatureSet, Arrays.asList(otherFeatureSets));
+    }
+
+}

--- a/dev/io.openliberty.microprofile.reactive.streams.operators30.internal_fat_tck/fat/src/io/openliberty/microprofile/reactive/streams/operators30/tck/ReactiveStreams30TCKLauncher.java
+++ b/dev/io.openliberty.microprofile.reactive.streams.operators30.internal_fat_tck/fat/src/io/openliberty/microprofile/reactive/streams/operators30/tck/ReactiveStreams30TCKLauncher.java
@@ -12,8 +12,10 @@ package io.openliberty.microprofile.reactive.streams.operators30.tck;
 import java.util.HashMap;
 import java.util.Map;
 
+import componenttest.rules.repeater.RepeatTests;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,7 +35,12 @@ import componenttest.topology.utils.tck.TCKRunner;
 @RunWith(FATRunner.class)
 public class ReactiveStreams30TCKLauncher {
 
-    @Server("ReactiveStreams30TCKServer")
+    public static final String SERVER_NAME = "ReactiveStreams30TCKServer";
+
+    @ClassRule
+    public static RepeatTests r = FATSuite.repeatDefault(SERVER_NAME);
+
+    @Server(SERVER_NAME)
     public static LibertyServer server;
 
     @BeforeClass
@@ -54,7 +61,6 @@ public class ReactiveStreams30TCKLauncher {
 
     @Test
     @Mode(TestMode.FULL) //The TCK takes around 15mins and is difficult to break up so running in FULL mode
-    @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchReactiveStreams30Tck() throws Exception {
         String bucketName = "io.openliberty.microprofile.reactive.streams.operators30.internal_fat_tck";
         String testName = this.getClass() + ":launchReactiveStreams30Tck";


### PR DESCRIPTION
Run repeats for MP RM and RSO 3.0 with MP 5.0, 6.0 and 6.1

The MP combinations cover Jakarta EE 9 and EE 10

ReactiveStreams TCK does not throw any FFDCs, so remove the allow all, so if one does occur then the failure will appear.

ReactiveMessaing TCK, does throw FFDCs, so be explicit about the ones we expect.

As the TCKs now run repeats. it interacts with the transformers that check for EE9+ FFDC exception classes that fail if the addJakartaTransformer step is not included via build.gradle as the `/autofvt_templates` directory is not copied into the build directory. This is despite the fact all the repeats are EE9+. The removal of `@AllowedFFDC` from the ReactiveStreams TCK resolved the issue for that project, while ReactiveMessaging does throw FFDCs so does not to copy the directory

Fixes #25424 
Fixes #25423 