### PR TITLE
Create annotation 3.0 Liberty feature for Jakarta EE 11

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
@@ -13,7 +13,7 @@ IBM-SPI-Package: \
 Manifest-Version: 1.0
 IBM-Process-Types: server, \
  client
--features=io.openliberty.jakarta.annotation-2.0; ibm.tolerates:="2.1", \
+-features=io.openliberty.jakarta.annotation-2.0; ibm.tolerates:="2.1, 3.0", \
   com.ibm.websphere.appserver.artifact-1.0
 -bundles=com.ibm.ws.anno
 -jars=com.ibm.websphere.appserver.spi.anno; location:=dev/spi/ibm/

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.beanValidationCore-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.beanValidationCore-1.0.feature
@@ -4,8 +4,7 @@ WLP-DisableAllFeatures-OnConflict: false
 IBM-App-ForceRestart: install, \
  uninstall
 -features=com.ibm.websphere.appserver.injection-1.0, \
-  com.ibm.websphere.appserver.classloading-1.0, \
-  com.ibm.websphere.appserver.anno-1.0
+  com.ibm.websphere.appserver.classloading-1.0
 -bundles=com.ibm.ws.org.apache.commons.lang3, \
  com.ibm.ws.managedobject, \
  com.ibm.ws.org.apache.commons.beanutils.1.9.4, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.managedBeansCore-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.managedBeansCore-1.0.feature
@@ -6,7 +6,6 @@ IBM-API-Package: \
   javax.interceptor; type="spec"
 -features=com.ibm.websphere.appserver.optional.corba-1.5, \
   com.ibm.websphere.appserver.injection-1.0, \
-  com.ibm.websphere.appserver.anno-1.0, \
   com.ibm.websphere.appserver.jndi-1.0
 -bundles=\
   com.ibm.ws.jaxrpc.stub, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.beanValidationCore-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.beanValidationCore-2.0.feature
@@ -3,8 +3,7 @@ symbolicName=io.openliberty.beanValidationCore-2.0
 IBM-App-ForceRestart: install, \
  uninstall
 -features=com.ibm.websphere.appserver.classloading-1.0, \
-  com.ibm.websphere.appserver.injection-2.0, \
-  com.ibm.websphere.appserver.anno-2.0
+  com.ibm.websphere.appserver.injection-2.0
 -bundles=com.ibm.ws.org.apache.commons.lang3, \
  com.ibm.ws.managedobject, \
  com.ibm.ws.org.apache.commons.beanutils.1.9.4, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.annotation-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.annotation-2.1.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.jakarta.annotation-2.1
 singleton=true
 IBM-Process-Types: server, \
  client
--features=com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="11.0"
+-features=com.ibm.websphere.appserver.eeCompatible-10.0
 -bundles=io.openliberty.jakarta.annotation.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.annotation:jakarta.annotation-api:2.1.1"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.annotation-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.annotation-3.0.feature
@@ -1,0 +1,11 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.jakarta.annotation-3.0
+singleton=true
+IBM-Process-Types: server, \
+ client
+-features=com.ibm.websphere.appserver.eeCompatible-11.0, \
+  io.openliberty.noShip-1.0
+-bundles=io.openliberty.jakarta.annotation.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.annotation:jakarta.annotation-api:2.1.1"
+kind=noship
+edition=full
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.data-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.data-1.0.feature
@@ -4,7 +4,7 @@ visibility=private
 singleton=true
 -features=\
   com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="11.0",\
-  io.openliberty.jakarta.annotation-2.1,\
+  io.openliberty.jakarta.annotation-2.1; ibm.tolerates:="3.0",\
   io.openliberty.jakarta.cdi-4.0; ibm.tolerates:="4.1"
 -bundles=\
   io.openliberty.jakarta.data.1.0; location:="dev/api/spec/,lib/"

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.nosql-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.nosql-1.0.feature
@@ -4,7 +4,7 @@ visibility=private
 singleton=true
 -features=\
   com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="11.0",\
-  io.openliberty.jakarta.annotation-2.1,\
+  io.openliberty.jakarta.annotation-2.1; ibm.tolerates:="3.0",\
   io.openliberty.jakarta.cdi-4.0; ibm.tolerates:="4.1",\
   io.openliberty.noShip-1.0
 -bundles=\

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.managedBeansCore-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.managedBeansCore-2.0.feature
@@ -5,7 +5,6 @@ IBM-API-Package: \
   jakarta.interceptor; type="spec"
 -features=com.ibm.websphere.appserver.optional.corba-1.5, \
   com.ibm.websphere.appserver.injection-2.0, \
-  com.ibm.websphere.appserver.anno-2.0, \
   com.ibm.websphere.appserver.jndi-1.0
 -bundles=\
   com.ibm.ws.jaxrpc.stub, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.persistenceService-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.persistenceService-2.0.feature
@@ -5,7 +5,7 @@ IBM-API-Package: com.ibm.websphere.persistence.mbean; type="ibm-api"
 -features=com.ibm.websphere.appserver.eeCompatible-9.0; ibm.tolerates:="10.0, 11.0", \
   com.ibm.websphere.appserver.transaction-2.0, \
   com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
-  io.openliberty.jakarta.annotation-2.0; ibm.tolerates:="2.1"; apiJar=false, \
+  io.openliberty.jakarta.annotation-2.0; ibm.tolerates:="2.1, 3.0"; apiJar=false, \
   com.ibm.websphere.appserver.org.eclipse.persistence-3.0; ibm.tolerates:="3.1, 3.2", \
   com.ibm.websphere.appserver.jndi-1.0
 -bundles=com.ibm.ws.persistence.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.persistentExecutorSubset-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.persistentExecutorSubset-2.0.feature
@@ -2,7 +2,7 @@
 symbolicName=io.openliberty.persistentExecutorSubset-2.0
 visibility=private
 -features=com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3,4.1", \
-  io.openliberty.jakarta.annotation-2.0; ibm.tolerates:="2.1", \
+  io.openliberty.jakarta.annotation-2.0; ibm.tolerates:="2.1, 3.0", \
   com.ibm.websphere.appserver.contextService-1.0, \
   io.openliberty.persistenceService-2.0, \
   com.ibm.websphere.appserver.transaction-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.servlet.internal-6.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.servlet.internal-6.1.feature
@@ -10,7 +10,7 @@ Subsystem-Category: JakartaEE11Application
   com.ibm.websphere.appserver.injection-2.0, \
   com.ibm.websphere.appserver.httptransport-1.0, \
   com.ibm.websphere.appserver.requestProbes-1.0, \
-  io.openliberty.jakarta.annotation-2.1, \
+  io.openliberty.jakarta.annotation-3.0, \
   com.ibm.websphere.appserver.eeCompatible-11.0
 -bundles=com.ibm.ws.app.manager.war.jakarta, \
  com.ibm.ws.managedobject, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.1.feature
@@ -18,7 +18,6 @@ IBM-API-Service: com.ibm.wsspi.uow.UOWManager, \
 -features=io.openliberty.servlet.api-3.0; apiJar=false; ibm.tolerates:="3.1", \
   com.ibm.websphere.appserver.jta-1.1, \
   com.ibm.websphere.appserver.injection-1.0, \
-  com.ibm.websphere.appserver.anno-1.0, \
   com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0", \
   com.ibm.websphere.appserver.javax.connector.internal-1.6
 -bundles=com.ibm.ws.tx.jta.extensions, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.2.feature
@@ -21,7 +21,6 @@ IBM-API-Service: com.ibm.wsspi.uow.UOWManager, \
   com.ibm.websphere.appserver.injection-1.0, \
   com.ibm.websphere.appserver.javax.cdi-1.2; apiJar=false; ibm.tolerates:="2.0", \
   com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="6.0,8.0", \
-  com.ibm.websphere.appserver.anno-1.0, \
   com.ibm.websphere.appserver.javax.connector.internal-1.7
 -bundles=com.ibm.ws.tx.jta.extensions, \
  com.ibm.ws.transaction; start-phase:=CONTAINER_LATE, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-2.0.feature
@@ -16,11 +16,10 @@ IBM-API-Service: com.ibm.wsspi.uow.UOWManager, \
  jakarta.transaction.UserTransaction
 Subsystem-Name: Jakarta Transactions 2.0
 -features=io.openliberty.servlet.api-5.0; apiJar=false; ibm.tolerates:="6.0, 6.1", \
-  io.openliberty.jakarta.annotation-2.0; ibm.tolerates:="2.1"; apiJar=false, \
+  io.openliberty.jakarta.annotation-2.0; ibm.tolerates:="2.1, 3.0"; apiJar=false, \
   com.ibm.websphere.appserver.eeCompatible-9.0; ibm.tolerates:="10.0, 11.0", \
   io.openliberty.jta-2.0, \
   com.ibm.websphere.appserver.injection-2.0, \
-  com.ibm.websphere.appserver.anno-2.0, \
   io.openliberty.jakarta.cdi-3.0; apiJar=false; ibm.tolerates:="4.0, 4.1", \
   io.openliberty.jakarta.connectors-2.0; ibm.tolerates:="2.1"
 -bundles=com.ibm.ws.tx.jta.extensions.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/batch-2.1/io.openliberty.batch-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/batch-2.1/io.openliberty.batch-2.1.feature
@@ -18,7 +18,7 @@ IBM-ShortName: batch-2.1
 Subsystem-Name: Jakarta Batch 2.1
 -features=com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
   io.openliberty.batch2.1.internal.ee-10.0; ibm.tolerates:="11.0", \
-  io.openliberty.jakarta.annotation-2.1, \
+  io.openliberty.jakarta.annotation-2.1; ibm.tolerates:="3.0", \
   com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="11.0", \
   com.ibm.websphere.appserver.contextService-1.0, \
   io.openliberty.persistenceService-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-4.1/io.openliberty.cdi-4.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-4.1/io.openliberty.cdi-4.1.feature
@@ -46,7 +46,7 @@ Subsystem-Name: Jakarta Contexts and Dependency Injection 4.1
   io.openliberty.jakarta.cdi-4.1, \
   io.openliberty.jakarta.xmlWS-4.0, \
   io.openliberty.jakarta.xmlBinding-4.0, \
-  io.openliberty.jakarta.annotation-2.1, \
+  io.openliberty.jakarta.annotation-3.0, \
   com.ibm.websphere.appserver.eeCompatible-11.0, \
   com.ibm.websphere.appserver.internal.slf4j-1.7, \
   io.openliberty.jakarta.pages-4.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-4.0/io.openliberty.mpMetrics-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-4.0/io.openliberty.mpMetrics-4.0.feature
@@ -14,7 +14,6 @@ Subsystem-Name: MicroProfile Metrics 4.0
   io.openliberty.mpCompatible-5.0, \
   io.openliberty.cdi-3.0, \
   io.openliberty.org.eclipse.microprofile.metrics-4.0, \
-  com.ibm.websphere.appserver.anno-2.0, \
   com.ibm.websphere.appserver.monitor-1.0
 -bundles=com.ibm.ws.microprofile.metrics.common, \
  io.openliberty.microprofile.metrics.internal.3.0.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-5.0/io.openliberty.mpMetrics-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-5.0/io.openliberty.mpMetrics-5.0.feature
@@ -13,7 +13,6 @@ Subsystem-Name: MicroProfile Metrics 5.0
   io.openliberty.mpCompatible-6.0, \
   io.openliberty.cdi-4.0, \
   io.openliberty.org.eclipse.microprofile.metrics-5.0, \
-  com.ibm.websphere.appserver.anno-2.0, \
   com.ibm.websphere.appserver.monitor-1.0
 -bundles=com.ibm.ws.microprofile.metrics.common, \
  io.openliberty.microprofile.metrics.5.0.internal, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-5.1/io.openliberty.mpMetrics-5.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-5.1/io.openliberty.mpMetrics-5.1.feature
@@ -13,7 +13,6 @@ Subsystem-Name: MicroProfile Metrics 5.1
   io.openliberty.mpCompatible-6.1, \
   io.openliberty.cdi-4.0, \
   io.openliberty.org.eclipse.microprofile.metrics-5.1, \
-  com.ibm.websphere.appserver.anno-2.0, \
   com.ibm.websphere.appserver.monitor-1.0
 -bundles=com.ibm.ws.microprofile.metrics.common, \
  io.openliberty.microprofile.metrics.5.1.internal, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.2/io.openliberty.persistenceContainer-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.2/io.openliberty.persistenceContainer-3.2.feature
@@ -15,7 +15,7 @@ IBM-App-ForceRestart: uninstall, \
  install
 -features=com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
   io.openliberty.xmlBinding.internal-4.0, \
-  io.openliberty.jakarta.annotation-2.1; apiJar=false, \
+  io.openliberty.jakarta.annotation-3.0; apiJar=false, \
   com.ibm.websphere.appserver.eeCompatible-11.0, \
   com.ibm.websphere.appserver.jndi-1.0, \
   io.openliberty.jakarta.persistence-3.2, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-3.1/com.ibm.websphere.appserver.servlet-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-3.1/com.ibm.websphere.appserver.servlet-3.1.feature
@@ -42,8 +42,7 @@ Subsystem-Category: JavaEE7Application
   com.ibm.websphere.appserver.requestProbes-1.0, \
   com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:="1.1", \
   com.ibm.websphere.appserver.injection-1.0, \
-  com.ibm.websphere.appserver.javaeePlatform-7.0, \
-  com.ibm.websphere.appserver.anno-1.0
+  com.ibm.websphere.appserver.javaeePlatform-7.0
 -bundles=com.ibm.ws.app.manager.war, \
  com.ibm.ws.managedobject, \
  com.ibm.ws.org.apache.commons.io, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-4.0/com.ibm.websphere.appserver.servlet-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-4.0/com.ibm.websphere.appserver.servlet-4.0.feature
@@ -42,8 +42,7 @@ Subsystem-Category: JavaEE8Application
   com.ibm.websphere.appserver.httptransport-1.0, \
   com.ibm.websphere.appserver.requestProbes-1.0, \
   com.ibm.websphere.appserver.javax.annotation-1.3, \
-  com.ibm.websphere.appserver.injection-1.0, \
-  com.ibm.websphere.appserver.anno-1.0
+  com.ibm.websphere.appserver.injection-1.0
 -bundles=com.ibm.ws.app.manager.war, \
  com.ibm.ws.managedobject, \
  com.ibm.ws.org.apache.commons.io, \

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EERepeatActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EERepeatActions.java
@@ -36,7 +36,7 @@ public class EERepeatActions {
     public static final FeatureSet EE8 = new FeatureSet(EE8_ID, EE8FeatureReplacementAction.EE8_FEATURE_SET, EEVersion.EE8);
     public static final FeatureSet EE9 = new FeatureSet(EE9_ID, JakartaEE9Action.EE9_FEATURE_SET, EEVersion.EE9);
     public static final FeatureSet EE10 = new FeatureSet(EE10_ID, JakartaEE10Action.EE10_FEATURE_SET, EEVersion.EE10);
-    public static final FeatureSet EE11 = new FeatureSet(EE11_ID, JakartaEE10Action.EE10_FEATURE_SET, EEVersion.EE11);
+    public static final FeatureSet EE11 = new FeatureSet(EE11_ID, JakartaEE11Action.EE11_FEATURE_SET, EEVersion.EE11);
 
     //The FeatureSet for the latest EE version
     public static final FeatureSet LATEST = EE10;

--- a/dev/io.openliberty.jakarta/annotation.3.0.bnd
+++ b/dev/io.openliberty.jakarta/annotation.3.0.bnd
@@ -1,0 +1,32 @@
+#*******************************************************************************
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Bundle-SymbolicName: io.openliberty.jakarta.annotation.3.0; singleton:=true
+
+javac.source: 17
+javac.target: 17
+
+Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=17))"
+
+Export-Package: \
+  jakarta.annotation;version="2.1.1",\
+  jakarta.annotation.security;version="2.1.1",\
+  jakarta.annotation.sql;version="2.1.1"
+
+# Until we have the 3.0 API, remove ManagedBean from the 2.1 jar since that is the major change in 3.0.
+-includeresource: \
+  @${repo;jakarta.annotation:jakarta.annotation-api;2.1.1;EXACT}!/!(META-INF/maven/*|module-info.class|jakarta/annotation/ManagedBean.class)
+
+-maven-dependencies: \
+   dep1;groupId=jakarta.annotation;artifactId=jakarta.annotation-api;version=2.1.1;scope=runtime
+
+   


### PR DESCRIPTION
- Annotation 3.0 was added to EE 11 late and I hadn't created the feature updates for it yet.
- Remove eeCompatible 11 tolerates from annotations 2.1
- Remove anno-1.0 and anno-2.0 references from features that already have injection-1.0 and 2.0 since those already bring in the anno feature
- Create API annotation 3.0 feature and have anno-2.0 tolerate the 3.0 feature
- Update other EE 11 features that currently were refernecing 2.1 to now reference 3.0
- Update tolerates of features not updated in EE 11 to have 3.0 added to their tolerates
- Create io.openliberty.jakarta.annotation.3.0 bundle with 2.1 API with the ManagedBean API removed from the bundle since that is the main change in 3.0.  This is temporary until there is a 3.0 API published

fixes #26166 
#build