### PR TITLE
Fix JAXRS 2.1 TCK regression related to oddly formated URI

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs/utils/test/InvalidUriTest.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs/utils/test/InvalidUriTest.java
@@ -38,7 +38,25 @@ public class InvalidUriTest {
             // expected
         }
         try {
+            Link.fromUri("http://@").build();
+            Assert.fail("Expected a UriBuilderException");
+        } catch (UriBuilderException e) {
+            // expected
+        }
+        try {
             Link.fromUri("HTTP://:@").build();
+            Assert.fail("Expected a UriBuilderException");
+        } catch (UriBuilderException e) {
+            // expected
+        }
+        try {
+            Link.fromUri("http:///").build();
+            Assert.fail("Expected a UriBuilderException");
+        } catch (UriBuilderException e) {
+            // expected
+        }
+        try {
+            Link.fromUri("http://@/").build();
             Assert.fail("Expected a UriBuilderException");
         } catch (UriBuilderException e) {
             // expected
@@ -60,10 +78,46 @@ public class InvalidUriTest {
             // expected
         }
         try {
+            UriBuilder.fromUri("http://@").build();
+            Assert.fail("Expected a UriBuilderException");
+        } catch (UriBuilderException e) {
+            // expected
+        }
+        try {
             UriBuilder.fromUri("HTTP://:@").build();
             Assert.fail("Expected a UriBuilderException");
         } catch (UriBuilderException e) {
             // expected
         }
+        try {
+            UriBuilder.fromUri("http:///").build();
+            Assert.fail("Expected a UriBuilderException");
+        } catch (UriBuilderException e) {
+            // expected
+        }
+        try {
+            UriBuilder.fromUri("http://@/").build();
+            Assert.fail("Expected a UriBuilderException");
+        } catch (UriBuilderException e) {
+            // expected
+        }
     }
+
+    // Added some valid URI tests as well.  The ones below that have the semicolon after
+    // the host and port are there because there are TCK tests that use the format and expect
+    // not to get an exception.  This caused a regression with the initial version of the changes in 
+    // Rfc3986uriValidator.
+    @Test
+    public void testValidURIs() {
+        Link.fromUri("http://localhost:9080/").build();
+        Link.fromUri("http://[::1]:9080/").build();
+
+        UriBuilder.fromUri("http://localhost:9080/").build();
+        UriBuilder.fromUri("http://[::1]:9080/").build();
+
+        Link.fromUri("http://localhost:9080;x=y").build();
+
+        UriBuilder.fromUri("http://localhost:9080;x=y").build();
+    }
+
 }


### PR DESCRIPTION
- Only do the new logic for processing URIs in Rfc3986UriValidator if URI.getHost() doesn't return null.  If it returns null, do the old processing that uses regular expressions.  On valid normally formatted URIs, the performance will be better.  Only with invalid host names or oddly formatted URIs will we pay the cost of the regular expressions.

The TCK regression was introduced with PR #26057.

#build