### PR TITLE
More modifications for LDAP and z/OS

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.claimPropagation/CommonClaimPropagation.gradle
+++ b/dev/com.ibm.ws.security.fat.common.claimPropagation/CommonClaimPropagation.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,9 @@ dependencies {
                 fileTree("${project(':com.ibm.ws.security.oauth.oidc_fat.common').buildDir}/collectedJars") { include '*.jar' },
                 'jtidy:jtidy:4aug2000r7-dev',
                 'rhino:js:1.6R5',
-                'org.apache.commons:commons-compress:1.20'
+                'org.apache.commons:commons-compress:1.20',
+                project(':com.ibm.ws.com.unboundid'),
+                'com.unboundid:unboundid-ldapsdk:5.1.0'
  
   // NOTE: More current js versions have a bug that prevents multiple redirects - this causes
   // a couple of our tests to fail.

--- a/dev/com.ibm.ws.security.fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.fat.common/bnd.bnd
@@ -68,7 +68,9 @@ generate.replacement: true
 	org.glassfish:javax.json;version=1.0,\
 	com.ibm.ws.org.jose4j;version=latest,\
 	com.ibm.json4j;version=latest,\
-	org.bitbucket.b_c.jose4j
+	org.bitbucket.b_c.jose4j,\
+	com.unboundid:unboundid-ldapsdk;version=latest,\
+    com.ibm.ws.com.unboundid;version=latest
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     com.ibm.ws.junit.extensions;version=latest, \

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/ldaputils/CommonLocalLDAPServerSuite.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/ldaputils/CommonLocalLDAPServerSuite.java
@@ -27,38 +27,66 @@ import componenttest.topology.utils.LDAPUtils;
 
 public class CommonLocalLDAPServerSuite {
     private static final Class<?> c = CommonLocalLDAPServerSuite.class;
+    private static boolean useNewerLdap = false;
 
     @BeforeClass
     public static void ldapSetUp() throws Exception {
 
-        // We prefer to use in-memory LDAP to avoid network issues
+        // We prefer to use in-memory LDAP to avoid network issues, but, the apache ldap servers are not running on z/OS
+        // the old unbounded ldap server works, so, we'll try to use that on z/OS - use the apache tooling with z/OS and java 17 - that
+        // path will result in z/OS with Java 17 using the remote servers.
         String os = System.getProperty("os.name").toLowerCase();
-        if (!(os.startsWith("z/os") && JavaInfo.forCurrentVM().majorVersion() >= 17)) {
+
+        if ((os.startsWith("z/os") && JavaInfo.forCurrentVM().majorVersion() >= 17)) {
+            System.setProperty("fat.test.really.use.local.ldap", "false");
+        } else {
             System.setProperty("fat.test.really.use.local.ldap", "true");
         }
 
-        HashMap<String, ArrayList<String>> testServers = LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_8_NAME, LDAPUtils.LDAP_SERVER_8_SSL_PORT, true,
-                LDAPUtils.LDAP_SERVER_8_BINDDN, LDAPUtils.LDAP_SERVER_8_BINDPWD,
-                LDAPUtils.LDAP_SERVER_4_NAME, LDAPUtils.LDAP_SERVER_4_SSL_PORT, true,
-                LDAPUtils.LDAP_SERVER_4_BINDDN, LDAPUtils.LDAP_SERVER_4_BINDPWD, null);
+        //  chc - uncomment      useNewerLdap = (!os.startsWith("z/os")) || (os.startsWith("z/os") && JavaInfo.forCurrentVM().majorVersion() >= 17);
+        // non-z/OS and even z/OS with Java 17 and above - use the standard LDAP setup (in-memory for non-z/OS and remote servers with z/OS)
+        // for z/OS with older versions of Java, use the old in-memory (unbounded LDAP)
+        if (useNewerLdap) {
+            Log.info(c, "setUp", "Calling LocalLDAPServerSuite.setUpUsingServers()");
+            try {
+                HashMap<String, ArrayList<String>> testServers = LocalLDAPServerSuite.addTestServer(LDAPUtils.LDAP_SERVER_8_NAME, LDAPUtils.LDAP_SERVER_8_SSL_PORT, true,
+                        LDAPUtils.LDAP_SERVER_8_BINDDN, LDAPUtils.LDAP_SERVER_8_BINDPWD,
+                        LDAPUtils.LDAP_SERVER_4_NAME, LDAPUtils.LDAP_SERVER_4_SSL_PORT, true,
+                        LDAPUtils.LDAP_SERVER_4_BINDDN, LDAPUtils.LDAP_SERVER_4_BINDPWD, null);
 
-        Log.info(c, "setUp", "Calling LocalLDAPServerSuite.setUpUsingServers()");
-        try {
-            LocalLDAPServerSuite.setUpUsingServers(testServers);
-        } catch (Exception e) {
-            Log.info(c, "setUp", "######################################################");
-            Log.info(c, "setUp", "##### Failed setting up LDAP Servers for FAT     #####");
-            Log.info(c, "setUp", "##### The Failure is being logged, but the       #####");
-            Log.info(c, "setUp", "##### FAT will continue - expect other failures. #####");
-            Log.info(c, "setUp", "######################################################");
-            Log.info(c, "setUp", e.getMessage());
+                LocalLDAPServerSuite.setUpUsingServers(testServers);
+            } catch (Exception e) {
+                Log.info(c, "setUp", "######################################################");
+                Log.info(c, "setUp", "##### Failed setting up LDAP Servers for FAT     #####");
+                Log.info(c, "setUp", "##### The Failure is being logged, but the       #####");
+                Log.info(c, "setUp", "##### FAT will continue - expect other failures. #####");
+                Log.info(c, "setUp", "######################################################");
+                Log.info(c, "setUp", e.getMessage());
+            }
+        } else {
+            Log.info(c, "setUp", "Calling CommonZOSLocalLDAP.ldapSetUp()");
+            try {
+                CommonZOSLocalLDAP.ldapSetUp();
+            } catch (Exception e) {
+                Log.info(c, "setUp", "######################################################");
+                Log.info(c, "setUp", "##### Failed setting up LDAP Servers for FAT     #####");
+                Log.info(c, "setUp", "##### The Failure is being logged, but the       #####");
+                Log.info(c, "setUp", "##### FAT will continue - expect other failures. #####");
+                Log.info(c, "setUp", "######################################################");
+                Log.info(c, "setUp", e.getMessage());
+            }
+
         }
-
     }
 
     @AfterClass
-    public static void ldapTearDown() throws InterruptedException {
-        Log.info(c, "tearDown", "Calling LocalLDAPServerSuite.tearDown()");
-        LocalLDAPServerSuite.tearDown();
+    public static void ldapTearDown() throws Exception {
+        if (useNewerLdap) {
+            Log.info(c, "tearDown", "Calling LocalLDAPServerSuite.tearDown()");
+            LocalLDAPServerSuite.tearDown();
+        } else {
+            Log.info(c, "tearDown", "Calling CommonZOSLocalLDAP.tearDown()");
+            CommonZOSLocalLDAP.ldapTearDown();
+        }
     }
 }

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/ldaputils/CommonLocalLDAPServerSuite.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/ldaputils/CommonLocalLDAPServerSuite.java
@@ -32,9 +32,10 @@ public class CommonLocalLDAPServerSuite {
     @BeforeClass
     public static void ldapSetUp() throws Exception {
 
-        // We prefer to use in-memory LDAP to avoid network issues, but, the apache ldap servers are not running on z/OS
-        // the old unbounded ldap server works, so, we'll try to use that on z/OS - use the apache tooling with z/OS and java 17 - that
-        // path will result in z/OS with Java 17 using the remote servers.
+        // We prefer to use in-memory LDAP to avoid network issues, but, the Apache LDAP servers are not running on z/OS
+        // the old unbounded LDAP server works, so, we'll try to use that on z/OS - attempt to use the Apache tooling for 
+        // distributed and z/OS with java 17 - that path will result in distributed using Apache in memory and z/OS 
+        // with Java 17 using the remote servers.
         String os = System.getProperty("os.name").toLowerCase();
 
         if ((os.startsWith("z/os") && JavaInfo.forCurrentVM().majorVersion() >= 17)) {
@@ -43,7 +44,7 @@ public class CommonLocalLDAPServerSuite {
             System.setProperty("fat.test.really.use.local.ldap", "true");
         }
 
-        //  chc - uncomment      useNewerLdap = (!os.startsWith("z/os")) || (os.startsWith("z/os") && JavaInfo.forCurrentVM().majorVersion() >= 17);
+        useNewerLdap = (!os.startsWith("z/os")) || (os.startsWith("z/os") && JavaInfo.forCurrentVM().majorVersion() >= 17);
         // non-z/OS and even z/OS with Java 17 and above - use the standard LDAP setup (in-memory for non-z/OS and remote servers with z/OS)
         // for z/OS with older versions of Java, use the old in-memory (unbounded LDAP)
         if (useNewerLdap) {

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/ldaputils/CommonZOSLocalLDAP.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/ldaputils/CommonZOSLocalLDAP.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.fat.common.utils.ldaputils;
+
+import org.junit.AfterClass;
+
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.com.unboundid.InMemoryLDAPServer;
+import com.ibm.ws.security.fat.common.Constants;
+import com.unboundid.ldap.sdk.Entry;
+
+public class CommonZOSLocalLDAP {
+    private static final Class<?> thisClass = CommonZOSLocalLDAP.class;
+
+    private static InMemoryLDAPServer ds;
+
+    private static final String LDAP_PARTITION_1_DN = "O=IBM,C=US";
+
+    private static int ldapPort;
+    private static int ldapSSLPort;
+
+    public static int getLdapPort() {
+        return ldapPort;
+    }
+
+    public int getLdapSSLPort() {
+        Log.info(thisClass, "getLdapSSLPort", "LDAP SSL Port is not supported by this tool at this time");
+        return ldapSSLPort;
+    }
+
+    private static String buildDN(String user) throws Exception {
+        return "CN=" + user + "," + LDAP_PARTITION_1_DN;
+    }
+
+    // we use the same value for the uid, sn and cn - we also use that value in the DN
+    // use this shortcut to create a new user
+    private static void addUser(String uid, String password) throws Exception {
+        addUser(buildDN(uid), uid, password, uid, uid);
+
+    }
+
+    private static void addUser(String dn, String uid, String password, String sn, String cn) throws Exception {
+        Log.info(thisClass, "addUser", "Adding user: " + uid + " to LDAP Registry");
+        Entry entry = new Entry(dn);
+        entry.addAttribute("objectclass", "inetorgperson");
+        entry.addAttribute("uid", uid);
+        entry.addAttribute("sn", sn);
+        entry.addAttribute("cn", cn);
+        entry.addAttribute("mail", uid);
+        entry.addAttribute("userpassword", password);
+        ds.add(entry);
+    }
+
+    /**
+     * Configure the LDAP server.
+     *
+     * @throws Exception
+     *             If the server failed to start for some reason.
+     */
+    public static void ldapSetUp() throws Exception {
+        // Choose a port for LDAP - we ran into an instance where 8020 and 8021 were chosen
+        // This caused problems starting one of the other servers that the tests use
+        // ds = new InMemoryLDAPServer(LDAP_PARTITION_1_DN);
+        //        ds = new InMemoryLDAPServer(true, Constants.DEFAULT_LDAP_PORT + instance, Constants.DEFAULT_LDAP_SECURE_PORT + instance, LDAP_PARTITION_1_DN);
+        try {
+            Log.info(thisClass, "ldapSetUp", "Setting up LDAP");
+            Log.info(thisClass, "ldapSetUp", "LDAP Port " + Constants.DEFAULT_LDAP_PORT);
+            Log.info(thisClass, "ldapSetUp", "LDAP Secure Port " + Constants.DEFAULT_LDAP_SECURE_PORT);
+            ds = new InMemoryLDAPServer(true, Constants.DEFAULT_LDAP_PORT, Constants.DEFAULT_LDAP_SECURE_PORT, LDAP_PARTITION_1_DN);
+
+            ldapPort = ds.getLdapPort();
+            ldapSSLPort = ds.getLdapsPort();
+            Log.info(thisClass, "ldapSetUp", "LDAP Port is: " + ldapPort);
+            Log.info(thisClass, "ldapSetUp", "LDAP SSL Port is: " + ldapSSLPort);
+
+            // override the default port values that get saved in bootstrap.properties (by LDAPUtils) - the code updating bootstrap will read the system properties
+            System.setProperty("ldap.1.port", Integer.toString(ldapPort));
+            System.setProperty("ldap.2.port", Integer.toString(ldapPort));
+            System.setProperty("ldap.3.port", Integer.toString(ldapPort));
+            System.setProperty("ldap.1.ssl.port", Integer.toString(ldapSSLPort));
+            System.setProperty("ldap.2.ssl.port", Integer.toString(ldapSSLPort));
+            System.setProperty("ldap.3.ssl.port", Integer.toString(ldapSSLPort));
+
+            /*
+             * Add the partition entries.
+             */
+            Entry entry = new Entry(LDAP_PARTITION_1_DN);
+            entry.addAttribute("objectclass", "organization");
+            entry.addAttribute("o", "ibm");
+            ds.add(entry);
+
+            /*
+             * Create the users.
+             */
+            addUser(LDAPConstants.TEST_USER_NAME, LDAPConstants.TEST_USER_PWD);
+            addUser(LDAPConstants.USER_1_NAME, LDAPConstants.USER_1_PWD);
+            addUser(LDAPConstants.USER_2_NAME, LDAPConstants.USER_2_PWD);
+            addUser(LDAPConstants.USER_3_NAME, LDAPConstants.USER_3_PWD);
+            addUser(LDAPConstants.USER_4_NAME, LDAPConstants.USER_4_PWD);
+            addUser(LDAPConstants.USER_5_NAME, LDAPConstants.USER_5_PWD);
+            //        addUser(buildDN(SAMLConstants.IDP_USER_NAME), SAMLConstants.IDP_USER_NAME, SAMLConstants.IDP_USER_PWD, SAMLConstants.IDP_USER_NAME, SAMLConstants.IDP_USER_NAME);
+            // logout test users (keep these odd names JUST in case we need to fail over to a real LDAP server)
+            addUser("john_vmmUser", "john_vmmUser");
+            addUser("ping_vmmUser", "ping_vmmUser");
+            addUser("pong_vmmUser", "pong_vmmUser");
+            addUser("connect_vmmUser", "connect_vmmUser");
+
+        } catch (Exception e) {
+            Log.info(thisClass, "ldapSetUp", "Exception setting up the unbounded in Memory LDAP server: " + e.getMessage());
+            throw e;
+        }
+    }
+
+    @AfterClass
+    public static void ldapTearDown() throws InterruptedException {
+        if (ds != null) {
+            try {
+                Log.info(thisClass, "ldapTearDown", "Stopping Local LDAP service");
+                ds.shutDown();
+                Log.info(thisClass, "ldapTearDown", "Local LDAP service has been stopped");
+            } catch (Exception e) {
+                Log.error(thisClass, "ldapTearDown", e, "LDAP server threw error while stopping. " + e.getMessage());
+            }
+        }
+    }
+}

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/ldaputils/LDAPConstants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/ldaputils/LDAPConstants.java
@@ -34,4 +34,24 @@ public class LDAPConstants extends Constants {
     public static final String USER_5_NAME = "user5";
     public static final String USER_5_PWD = "security";
 
+    public static final String LDAP_USER_1_NAME = "LDAPUser1";
+    public static final String LDAP_USER_1_PWD = "security";
+    public static final String LDAP_USER_2_NAME = "LDAPUser2";
+    public static final String LDAP_USER_2_PWD = "security";
+    public static final String LDAP_USER_3_NAME = "LDAPUser3";
+    public static final String LDAP_USER_3_PWD = "security";
+    public static final String LDAP_USER_4_NAME = "LDAPUser4";
+    public static final String LDAP_USER_4_PWD = "security";
+    public static final String LDAP_USER_5_NAME = "LDAPUser5";
+    public static final String LDAP_USER_5_PWD = "security";
+    public static final String LDAP_USER_6_NAME = "LDAPUser6";
+    public static final String LDAP_USER_6_PWD = "security";
+    public static final String LDAP_USER_7_NAME = "LDAPUser7";
+    public static final String LDAP_USER_7_PWD = "security";
+    public static final String LDAP_USER_8_NAME = "LDAPUser8";
+    public static final String LDAP_USER_8_PWD = "security";
+
+    public static final String LDAP_GROUP_1 = "group1";
+    public static final String LDAP_GROUP_2 = "group2";
+
 }

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/ldaputils/LDAPConstants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/ldaputils/LDAPConstants.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.fat.common.utils.ldaputils;
+
+import com.ibm.ws.security.fat.common.Constants;
+
+public class LDAPConstants extends Constants {
+
+    public LDAPConstants() {
+        super();
+    }
+
+    /* Users/passwords */
+    public static final String TEST_USER_NAME = "testuser";
+    public static final String TEST_USER_PWD = "testuserpwd";
+    public static final String USER_1_NAME = "user1";
+    public static final String USER_1_PWD = "security";
+    public static final String USER_2_NAME = "user2";
+    public static final String USER_2_PWD = "security";
+    public static final String USER_3_NAME = "user3";
+    public static final String USER_3_PWD = "security";
+    public static final String USER_4_NAME = "user4";
+    public static final String USER_4_PWD = "security";
+    public static final String USER_5_NAME = "user5";
+    public static final String USER_5_PWD = "security";
+
+}

--- a/dev/com.ibm.ws.security.jwt_fat.builder/build.gradle
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/build.gradle
@@ -38,7 +38,7 @@ dependencies {
       'xalan:xalan:2.7.2',
       project(':com.ibm.ws.org.apache.commons.io'),
       project(':com.ibm.ws.org.slf4j.api'),
-      'com.unboundid:unboundid-ldapsdk:4.0.9'
+      'com.unboundid:unboundid-ldapsdk:5.1.0'
       
 }
 

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTest.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/build.gradle
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,9 @@ dependencies {
                 project(':com.ibm.ws.security.oauth.oidc_fat.common'),
                 project(':com.ibm.ws.com.meterware.httpunit.1.7'),
                 'jtidy:jtidy:4aug2000r7-dev',
-                'rhino:js:1.5R4.1' // See NOTE below
+                'rhino:js:1.5R4.1',  // See NOTE below
+                project(':com.ibm.ws.com.unboundid'),
+               'com.unboundid:unboundid-ldapsdk:5.1.0' 
 
   // NOTE: More current js versions have a bug that prevents multiple redirects - this causes
   // a couple of our tests to fail.

--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml/bnd.bnd.disabled
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml/bnd.bnd.disabled
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -26,7 +26,9 @@ fat.project: true
 publish.wlp.jar.disabled: true
 
 # added extra features when ee9 was enabled: 
-tested.features: transportsecurity-1.0, expressionlanguage-4.0, servlet-5.0, pages-3.0, appsecurity-4.0, cdi-3.0, restfulwsclient-3.0, concurrent-2.0, restfulws-3.0, jsonp-2.0
+tested.features: transportsecurity-1.0, expressionlanguage-4.0, servlet-5.0, pages-3.0, appsecurity-4.0, cdi-3.0, \
+		restfulwsclient-3.0, concurrent-2.0, restfulws-3.0, jsonp-2.0n \
+		expressionlanguage-5.0, restfulwsclient-3.1, appsecurity-5.0, jsonp-2.1, restfulws-3.1, pages-3.1, cdi-4.0, servlet-6.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\

--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml/fat/src/com/ibm/ws/security/backchannelLogout/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml/fat/src/com/ibm/ws/security/backchannelLogout/fat/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,32 +18,36 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
+import com.ibm.ws.security.fat.common.utils.ldaputils.CommonLocalLDAPServerSuite;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
         AlwaysPassesTest.class,
-        BasicBCLTests.class
+        // HttpMethodsTests.class,  doesn't need to run with SAML as this is a client only test
+        // LogoutTokenValidationTests.class,  doesn't need to run with SAML as this is a client only test
+        BasicBCLTests.class,
+//        MultiServerBCLTests.class
 
 })
 /**
  * Purpose: This suite collects and runs all known good test suites.
  */
-public class FATSuite {
+public class FATSuite extends CommonLocalLDAPServerSuite {
 
     /*
-     * Run EE9 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
      *
-     * This was done to increase coverage of EE9 while not adding a large amount of of test runtime.
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().alwaysAddFeature("servlet-5.0").fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats("servlet-5.0", "servlet-6.0");
 
 }

--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -26,7 +26,10 @@ fat.project: true
 publish.wlp.jar.disabled: true
 
 # added extra features when ee9 was enabled: restfulwsclient-3.0, transportsecurity-1.0, appsecurity-4.0, expressionlanguage-4.0, servlet-5.0, concurrent-2.0, restfulws-3.0, jsonp-2.0, cdi-3.0, pages-3.0
-tested.features: openidconnectclient-1.0, jsp-2.2, servlet-3.1, osgiconsole-1.0, openidconnectserver-1.0, jsp-2.3, jaxrs-2.0, jaxrsclient-2.0, el-3.0, restfulwsclient-3.0, transportsecurity-1.0, appsecurity-4.0, expressionlanguage-4.0, servlet-5.0, concurrent-2.0, restfulws-3.0, jsonp-2.0, cdi-3.0, pages-3.0
+tested.features: openidconnectclient-1.0, jsp-2.2, servlet-3.1, osgiconsole-1.0, openidconnectserver-1.0, jsp-2.3, jaxrs-2.0, jaxrsclient-2.0, el-3.0, \
+		restfulwsclient-3.0, transportsecurity-1.0, appsecurity-4.0, \
+		expressionlanguage-4.0, servlet-5.0, concurrent-2.0, restfulws-3.0, jsonp-2.0, cdi-3.0, pages-3.0, \
+		expressionlanguage-5.0, restfulwsclient-3.1, appsecurity-5.0, jsonp-2.1, restfulws-3.1, pages-3.1, cdi-4.0, servlet-6.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\

--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,11 +18,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.security.fat.common.actions.SecurityTestFeatureEE9RepeatAction;
-import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
+import com.ibm.ws.security.fat.common.actions.LargeProjectRepeatActions;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
-import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -39,13 +37,15 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
 
     /*
-     * Run EE9 tests in only FULL mode and run EE7/EE8 tests only in LITE mode.
+     * On Windows, always run the default/empty/EE7/EE8 tests.
+     * On other Platforms:
+     * - if Java 8, run default/empty/EE7/EE8 tests.
+     * - All other Java versions
+     * -- If LITE mode, run EE9
+     * -- If FULL mode, run EE10
      *
-     * This was done to increase coverage of EE9 while not adding a large amount of of test runtime.
      */
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().liteFATOnly())
-            .andWith(new SecurityTestRepeatAction().onlyOnWindows().fullFATOnly())
-            .andWith(new SecurityTestFeatureEE9RepeatAction().notOnWindows().alwaysAddFeature("servlet-5.0").fullFATOnly());
+    public static RepeatTests repeat = LargeProjectRepeatActions.createEE9OrEE10Repeats("servlet-5.0", "servlet-6.0");
 
 }

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/SAMLCommon.gradle
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/SAMLCommon.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,9 @@ dependencies {
                'httpunit:httpunit:1.6.2',                           // 1.7 has issues noted above
                'jtidy:jtidy:4aug2000r7-dev',
                'rhino:js:1.6R5',
-               'xml-apis:xml-apis:1.4.01'
+               'xml-apis:xml-apis:1.4.01',
+               project(':com.ibm.ws.com.unboundid'),
+               'com.unboundid:unboundid-ldapsdk:5.1.0'
 
   /*
    * Previously we had an uber jar named htmlunit-2.20-OSGi.jar. It appears to have contained all of

--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/bnd.bnd
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.backchannelLogout/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ fat.project: true
 publish.wlp.jar.disabled: true
 
 tested.features:  transportsecurity-1.0, appsecurity-4.0, restfulws-3.0, pages-3.0, \
-                  appsecurity-5.0, restfulws-3.1, pages-3.1
+                  appsecurity-5.0, restfulws-3.1, pages-3.1, expressionlanguage-5.0, restfulwsclient-3.1, appsecurity-5.0, jsonp-2.1, restfulws-3.1, pages-3.1, cdi-4.0, servlet-6.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/bnd.bnd
@@ -88,4 +88,6 @@ tested.features:\
   com.ibm.ws.org.apache.wss4j.ws.security.stax;version=latest,\
   com.ibm.ws.org.apache.wss4j.ws.security.web;version=latest,\
   com.ibm.ws.org.apache.santuario.xmlsec.2.2.0;version=latest,\
-  com.ibm.ws.org.apache.directory.server;version=latest
+  com.ibm.ws.org.apache.directory.server;version=latest,\
+  com.ibm.ws.com.unboundid;version=latest,\
+  com.unboundid:unboundid-ldapsdk;version=latest

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/build.gradle
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/build.gradle
@@ -33,7 +33,8 @@ dependencies {
                'net.sourceforge.htmlunit:neko-htmlunit:2.44.0',
                'xalan:xalan:2.7.2',
                project(':io.openliberty.org.apache.xercesImpl'),
-               'xml-apis:xml-apis:1.4.01'
+               'com.unboundid:unboundid-ldapsdk:5.1.0',
+               project(':com.ibm.ws.com.unboundid')
                
                         
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/bnd.bnd
@@ -80,4 +80,6 @@ tested.features:\
   com.ibm.websphere.org.osgi.core;version=latest,\
   com.ibm.websphere.org.osgi.service.component;version=latest,\
   net.sourceforge.htmlunit:htmlunit;version=2.44.0,\
-  com.ibm.ws.org.apache.directory.server;version=latest
+  com.ibm.ws.org.apache.directory.server;version=latest,\
+  com.ibm.ws.com.unboundid;version=latest,\
+  com.unboundid:unboundid-ldapsdk;version=latest

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/build.gradle
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/build.gradle
@@ -33,7 +33,8 @@ dependencies {
                'net.sourceforge.htmlunit:neko-htmlunit:2.44.0',
                'xalan:xalan:2.7.2',
                project(':io.openliberty.org.apache.xercesImpl'),
-               'xml-apis:xml-apis:1.4.01' 
+               'com.unboundid:unboundid-ldapsdk:5.1.0',
+               project(':com.ibm.ws.com.unboundid') 
                         
 }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/bnd.bnd
@@ -83,4 +83,6 @@ tested.features:\
   com.ibm.websphere.org.osgi.core;version=latest,\
   com.ibm.websphere.org.osgi.service.component;version=latest,\
   net.sourceforge.htmlunit:htmlunit;version=2.44.0,\
-  com.ibm.ws.org.apache.directory.server;version=latest
+  com.ibm.ws.org.apache.directory.server;version=latest,\
+  com.ibm.ws.com.unboundid;version=latest,\
+  com.unboundid:unboundid-ldapsdk;version=latest

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/build.gradle
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/build.gradle
@@ -34,7 +34,8 @@ project(':com.ibm.ws.org.apache.commons.io'),               project(':io.openlib
                'net.sourceforge.htmlunit:neko-htmlunit:2.44.0',
                'xalan:xalan:2.7.2',
                project(':io.openliberty.org.apache.xercesImpl'),
-               'xml-apis:xml-apis:1.4.01' 
+               'com.unboundid:unboundid-ldapsdk:5.1.0',
+               project(':com.ibm.ws.com.unboundid') 
                         
 }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/bnd.bnd
@@ -80,5 +80,7 @@ tested.features:\
   com.ibm.websphere.org.osgi.core;version=latest,\
   com.ibm.websphere.org.osgi.service.component;version=latest,\
   net.sourceforge.htmlunit:htmlunit;version=2.44.0,\
-  com.ibm.ws.org.apache.directory.server;version=latest
+  com.ibm.ws.org.apache.directory.server;version=latest,\
+  com.ibm.ws.com.unboundid;version=latest,\
+  com.unboundid:unboundid-ldapsdk;version=latest
   

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/build.gradle
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/build.gradle
@@ -33,7 +33,8 @@ dependencies {
                'net.sourceforge.htmlunit:neko-htmlunit:2.44.0',
                'xalan:xalan:2.7.2',
                project(':io.openliberty.org.apache.xercesImpl'),
-               'xml-apis:xml-apis:1.4.01'
+               'com.unboundid:unboundid-ldapsdk:5.1.0',
+               project(':com.ibm.ws.com.unboundid')
                                  
 }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/bnd.bnd
@@ -88,6 +88,8 @@ tested.features:\
   com.ibm.ws.org.apache.santuario.xmlsec.2.2.0;version=latest,\
   com.ibm.ws.wssecurity.3.4.1;version=latest,\
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
-  com.ibm.ws.org.apache.directory.server;version=latest
+  com.ibm.ws.org.apache.directory.server;version=latest,\
+  com.ibm.ws.com.unboundid;version=latest,\
+  com.unboundid:unboundid-ldapsdk;version=latest
 
   

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/build.gradle
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/build.gradle
@@ -34,7 +34,8 @@ dependencies {
                'net.sourceforge.htmlunit:neko-htmlunit:2.44.0',
                'xalan:xalan:2.7.2',
                project(':io.openliberty.org.apache.xercesImpl'),
-               'xml-apis:xml-apis:1.4.01'
+               'com.unboundid:unboundid-ldapsdk:5.1.0',
+               project(':com.ibm.ws.com.unboundid')
                
                         
 }


### PR DESCRIPTION
We have tooling in place to startup up in memory LDAP servers for use with security FATs.  The in memory LDAP servers weren't stopping on z/OS with Java 17.  I updated the tests to use the remote/real LDAP servers with Java 17.  Those changes ended up switching the tests to use the apache in memory LDAP servers instead of the unbounded.  These won't start on z/OS.
I'm now updating the security FAT tooling to use apache on all platforms exception z/OS.  We'll use the unbounded LDAP on z/OS for everything except Java 17 and above - in those cases, we'll use the real LDAP servers.
I had originally planned to just use the real LDAP servers for our z/OS testing, but, we're worried that we may put too much of a load on those servers.