### PR TITLE
CDI 4.1 repeats (part 1)

### DIFF
--- a/dev/com.ibm.ws.cdi.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.2.0_fat/bnd.bnd
@@ -31,7 +31,14 @@ tested.features:\
 	cdi-4.0,\
 	servlet-6.0,\
 	enterpriseBeansLite-4.0,\
-	componenttest-2.0
+	componenttest-2.0,\
+	expressionlanguage-6.0,\
+	noship-1.0,\
+	cdi-4.1,\
+	pages-4.0,\
+	servlet-6.1,\
+	appsecurity-6.0,\
+	concurrent-3.1
 
 fat.project: true
 

--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/AsyncEventsTest.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/AsyncEventsTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -32,7 +32,6 @@ import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -47,13 +46,12 @@ public class AsyncEventsTest extends FATServletClient {
     public static final String SERVER_NAME = "cdi20AsyncEventsServer";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     public static final String APP_NAME = "asyncEventsApp";
 
     @Server(SERVER_NAME)
     @TestServlets({ @TestServlet(servlet = AsyncEventsServlet.class, contextRoot = APP_NAME) }) //FULL
-
     public static LibertyServer server;
 
     @BeforeClass

--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/BasicCdi20Tests.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/BasicCdi20Tests.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -44,7 +44,6 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.custom.junit.runner.TestModeFilter;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -59,7 +58,7 @@ public class BasicCdi20Tests extends FATServletClient {
     public static final String SERVER_NAME = "cdi20BasicServer";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     public static final String BEAN_MANAGER_LOOKUP_APP_NAME = "beanManagerLookupApp";
     public static final String CONFIGURATION_APP_NAME = "configuratorApp";
@@ -81,7 +80,6 @@ public class BasicCdi20Tests extends FATServletClient {
 
                     @TestServlet(servlet = TrimTestServlet.class, contextRoot = TRIM_TEST_APP_NAME) //FULL
     })
-
     public static LibertyServer server;
 
     @BeforeClass

--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/BuiltinAnnoLiteralsTest.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/BuiltinAnnoLiteralsTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -31,7 +31,6 @@ import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -46,13 +45,12 @@ public class BuiltinAnnoLiteralsTest extends FATServletClient {
     public static final String SERVER_NAME = "cdi20BuiltinAnnoServer";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     public static final String APP_NAME = "builtinAnnoLiteralsApp";
 
     @Server(SERVER_NAME)
     @TestServlets({ @TestServlet(servlet = BuiltinAnnoServlet.class, contextRoot = APP_NAME) }) //LITE
-
     public static LibertyServer server;
 
     @BeforeClass

--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/CDIContainerConfigTest.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/CDIContainerConfigTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -35,7 +35,6 @@ import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -50,7 +49,7 @@ public class CDIContainerConfigTest extends FATServletClient {
     public static final String SERVER_NAME = "cdi20ConfigServer";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     public static final String APP_NAME = "cdiContainerConfigApp";
 

--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/FATSuite.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/FATSuite.java
@@ -1,20 +1,20 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.cdi20.fat.tests;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import componenttest.rules.repeater.EERepeatActions;
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -26,5 +26,9 @@ import org.junit.runners.Suite.SuiteClasses;
                 StartupEventsTest.class
 })
 public class FATSuite {
+
+    public static RepeatTests defaultRepeat(String serverName) {
+        return EERepeatActions.repeat(serverName, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE8);
+    }
 
 }

--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/SecureAsyncEventsTest.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/SecureAsyncEventsTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -31,7 +31,6 @@ import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -46,13 +45,12 @@ public class SecureAsyncEventsTest extends FATServletClient {
     public static final String SERVER_NAME = "cdi20SecureAsyncEventsServer";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     public static final String APP_NAME = "secureAsyncEventsApp";
 
     @Server(SERVER_NAME)
     @TestServlets({ @TestServlet(servlet = SecureAsyncEventsServlet.class, contextRoot = APP_NAME) }) //FULL
-
     public static LibertyServer server;
 
     @BeforeClass

--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/StartupEventsTest.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/StartupEventsTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -34,7 +34,6 @@ import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -47,7 +46,7 @@ public class StartupEventsTest extends FATServletClient {
     public static final String STARTUP_EVENTS_APP_NAME = "StartupEvents";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.annotations_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.annotations_fat/bnd.bnd
@@ -25,7 +25,10 @@ tested.features:\
 	servlet-5.0,\
 	cdi-3.0,\
         servlet-6.0,\
-        cdi-4.0
+        cdi-4.0,\
+        noship-1.0,\
+        cdi-4.1,\
+        servlet-6.1
 	
 	
 fat.project: true

--- a/dev/com.ibm.ws.cdi.annotations_fat/fat/src/com/ibm/ws/cdi/annotations/fat/tests/AnnotationsTests.java
+++ b/dev/com.ibm.ws.cdi.annotations_fat/fat/src/com/ibm/ws/cdi/annotations/fat/tests/AnnotationsTests.java
@@ -62,7 +62,7 @@ public class AnnotationsTests extends FATServletClient {
     public static final String WITH_ANNOTATIONS_APP_NAME = "withAnnotationsApp";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.api_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.api_fat/bnd.bnd
@@ -26,7 +26,10 @@ tested.features:\
         cdi-4.0,\
         servlet-6.0,\
         concurrent-2.0,\
-        concurrent-3.0
+        concurrent-3.0,\
+        cdi-4.1,\
+        servlet-6.1,\
+        concurrent-3.1
 
 fat.project: true
 

--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/tests/CDIAPITests.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/tests/CDIAPITests.java
@@ -86,7 +86,7 @@ public class CDIAPITests extends FATServletClient {
     private static final String THIS_SHOULD_FAIL_SUFFIX = ".thisShouldFail)";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.beansxml.implicit_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.beansxml.implicit_fat/bnd.bnd
@@ -37,7 +37,12 @@ tested.features:\
 	enterprisebeans-4.0,\
 	enterprisebeansremote-4.0,\
 	enterprisebeanshome-4.0,\
-	enterprisebeanspersistenttimer-4.0
+	enterprisebeanspersistenttimer-4.0,\
+	noship-1.0,\
+	cdi-4.1,\
+	servlet-6.1,\
+	expressionlanguage-6.0,\
+	pages-4.0
 
 	
 fat.project: true

--- a/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/FATSuite.java
+++ b/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/FATSuite.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,6 +24,9 @@ import com.ibm.ws.cdi.beansxml.implicit.fat.implicitWar.ImplicitWarTest;
 import com.ibm.ws.cdi.beansxml.implicit.fat.implicitWarLibJars.ImplicitWarLibJarsTest;
 import com.ibm.ws.cdi.beansxml.implicit.fat.noAnnotations.ImplicitBeanArchiveNoAnnotationsTest;
 import com.ibm.ws.fat.util.FatLogHandler;
+
+import componenttest.rules.repeater.EERepeatActions;
+import componenttest.rules.repeater.RepeatTests;
 
 /**
  * Tests specific to cdi-1.2
@@ -45,6 +48,11 @@ public class FATSuite {
     @BeforeClass
     public static void generateHelpFile() {
         FatLogHandler.generateHelpFile();
+    }
+
+    public static RepeatTests defaultRepeat(String serverName) {
+        //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+        return EERepeatActions.repeat(serverName, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7);
     }
 
 }

--- a/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/implicitBeanArchive/ImplicitBeanArchiveTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/implicitBeanArchive/ImplicitBeanArchiveTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -51,7 +51,7 @@ public class ImplicitBeanArchiveTest extends FATServletClient {
 
     //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/implicitBeanArchivesDisabled/ImplicitBeanArchivesDisabledTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/implicitBeanArchivesDisabled/ImplicitBeanArchivesDisabledTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -54,7 +54,7 @@ public class ImplicitBeanArchivesDisabledTest extends FATServletClient {
 
     //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/implicitEJB/ImplicitEJBTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/implicitEJB/ImplicitEJBTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -51,7 +51,7 @@ public class ImplicitEJBTest extends FATServletClient {
 
     //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/implicitWar/ImplicitWarTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/implicitWar/ImplicitWarTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -54,7 +54,7 @@ public class ImplicitWarTest extends FATServletClient {
 
     //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7);
 
     @BeforeClass
     public static void buildShrinkWrap() throws Exception {

--- a/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/implicitWarLibJars/ImplicitWarLibJarsTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/implicitWarLibJars/ImplicitWarLibJarsTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -53,7 +53,7 @@ public class ImplicitWarLibJarsTest extends FATServletClient {
 
     //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/noAnnotations/ImplicitBeanArchiveNoAnnotationsTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml.implicit_fat/fat/src/com/ibm/ws/cdi/beansxml/implicit/fat/noAnnotations/ImplicitBeanArchiveNoAnnotationsTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.ws.cdi.beansxml.implicit.fat.FATSuite;
 import com.ibm.ws.cdi.beansxml.implicit.fat.noAnnotations.archiveWithNoBeansXml.ConstructorInjectionServlet;
 import com.ibm.ws.cdi.beansxml.implicit.fat.noAnnotations.archiveWithNoBeansXml.NoCDIAnnotationsServlet;
 import com.ibm.ws.cdi.beansxml.implicit.fat.noAnnotations.ejbArchiveWithNoAnnotations.EjbArchiveWithNoAnnotationsApp;
@@ -36,7 +37,6 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -52,7 +52,7 @@ public class ImplicitBeanArchiveNoAnnotationsTest extends FATServletClient {
 
     //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.beansxml_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/bnd.bnd
@@ -27,7 +27,9 @@ tested.features:\
 	servlet-5.0,\
 	cdi-4.0,\
 	servlet-6.0,\
-        xmlbinding-4.0
+        xmlbinding-4.0,\
+        cdi-4.1,\
+        servlet-6.1
 	
 fat.project: true
 

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/AfterTypeDiscoveryTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/AfterTypeDiscoveryTest.java
@@ -45,7 +45,7 @@ public class AfterTypeDiscoveryTest extends FATServletClient {
     public static final String AFTER_TYPE_DISCOVERY_APP_NAME = "afterTypeDiscoveryApp";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/BeanDiscoveryModeNoneTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/BeanDiscoveryModeNoneTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -41,7 +41,7 @@ public class BeanDiscoveryModeNoneTest {
     private static final String SERVER_NAME = "cdi12BeanDiscoveryModeNoneServer";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE8, EERepeatActions.EE7);
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/CDIConfigTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/CDIConfigTest.java
@@ -44,7 +44,7 @@ public class CDIConfigTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
 
     @After
     public void setup() throws Exception {

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/ClassExclusionTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/ClassExclusionTest.java
@@ -63,7 +63,7 @@ public class ClassExclusionTest extends FATServletClient {
     public static final String VETO_ALTERNATIVE_APP_NAME = "TestVetoedAlternative";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/CustomerProvidedXMLParserFactoryTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/CustomerProvidedXMLParserFactoryTest.java
@@ -57,7 +57,7 @@ public class CustomerProvidedXMLParserFactoryTest {
     public static final String USER_SAX_PARSER_APP_NAME = "userSAXParserFactory";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/DisablingBeansXmlValidationTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/DisablingBeansXmlValidationTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -45,7 +45,7 @@ public class DisablingBeansXmlValidationTest extends FATServletClient {
     public static final String INVALID_BEANS_XML_APP_NAME = "invalidBeansXml";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE8, EERepeatActions.EE7);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/EmptyCDITest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/EmptyCDITest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -42,7 +42,7 @@ public class EmptyCDITest {
     public static final String SERVER_NAME = "cdi12EmptyServer";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE8, EERepeatActions.EE7);
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/EnablingBeansXmlValidationTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/EnablingBeansXmlValidationTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -43,7 +43,7 @@ public class EnablingBeansXmlValidationTest {
     public static final String SERVER_NAME = "cdi12BeansXmlValidationServer";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE8);
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/MultipleBeansXmlTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/MultipleBeansXmlTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -47,7 +47,7 @@ public class MultipleBeansXmlTest extends FATServletClient {
     public static final String MULTIPLE_BEANS_APP_NAME = "multipleBeansXml";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/WebBeansBeansXmlInWeldTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi/beansxml/fat/tests/WebBeansBeansXmlInWeldTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -47,7 +47,7 @@ public class WebBeansBeansXmlInWeldTest extends FATServletClient {
     public static final String DECORATORS_APP_NAME = "webBeansBeansXmlDecorators";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.ejb_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.ejb_fat/bnd.bnd
@@ -42,7 +42,12 @@ tested.features:\
         enterprisebeanshome-4.0,\
         xmlbinding-3.0,\
         xmlbinding-4.0,\
-        enterprisebeanspersistenttimer-4.0
+        enterprisebeanspersistenttimer-4.0,\
+        expressionlanguage-6.0,\
+        faces-5.0,\
+        noship-1.0,\
+        cdi-4.1,\
+        servlet-6.1
         
 fat.project: true
 

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/AroundConstructEjbTest.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/AroundConstructEjbTest.java
@@ -36,7 +36,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -50,9 +49,8 @@ public class AroundConstructEjbTest extends FATServletClient {
     public static final String POST_CONSTRUCT_ERROR_APP_NAME = "postConstructErrorMessageApp";
     public static final String SERVER_NAME = "cdi12EJB32Server";
 
-    //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/CDIManagedBeanInterceptorTest.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/CDIManagedBeanInterceptorTest.java
@@ -37,7 +37,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -49,9 +48,9 @@ public class CDIManagedBeanInterceptorTest extends FATServletClient {
     public static final String SERVER_NAME = "cdi12ManagedBeanTestServer";
     public static final String MANAGED_BEAN_APP_NAME = "managedBeanApp";
 
-    //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+    //managedBeans-2.0 does not exist in EE11
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = FATSuite.defaultRepeatUpToEE10(SERVER_NAME);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/EjbConstructorInjectionTest.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/EjbConstructorInjectionTest.java
@@ -32,7 +32,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -44,9 +43,8 @@ public class EjbConstructorInjectionTest extends FATServletClient {
     public static final String SERVER_NAME = "cdi12EjbConstructorInjectionServer";
     public static final String EJB_CONSTRUCTOR_INJECTION_APP_NAME = "ejbConstructorInjection";
 
-    //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/EjbDiscoveryTest.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/EjbDiscoveryTest.java
@@ -50,7 +50,7 @@ public class EjbDiscoveryTest extends FATServletClient {
 
     //chosen this one test to run on EE8 as well
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE8, EERepeatActions.EE7);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/EjbScopeTest.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/EjbScopeTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -33,7 +33,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -50,9 +49,8 @@ public class EjbScopeTest extends FATServletClient {
     public static final String MULTIPLE_WAR1_APP_NAME = "multipleWar1";
     public static final String MULTIPLE_WAR2_APP_NAME = "multipleWar2";
 
-    //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/EjbTimerTest.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/EjbTimerTest.java
@@ -33,7 +33,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -50,9 +49,8 @@ public class EjbTimerTest extends FATServletClient {
     public static final String SERVER_NAME = "cdi12EJB32Server";
     public static final String EJB_TIMER_APP_NAME = "EjbTimer";
 
-    //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/FATSuite.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/FATSuite.java
@@ -19,6 +19,9 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.fat.util.FatLogHandler;
 
+import componenttest.rules.repeater.EERepeatActions;
+import componenttest.rules.repeater.RepeatTests;
+
 /**
  * Tests specific to cdi-1.2
  */
@@ -44,6 +47,16 @@ public class FATSuite {
     @BeforeClass
     public static void generateHelpFile() {
         FatLogHandler.generateHelpFile();
+    }
+
+    public static RepeatTests defaultRepeat(String serverName) {
+        //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+        return EERepeatActions.repeat(serverName, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7);
+    }
+
+    public static RepeatTests defaultRepeatUpToEE10(String serverName) {
+        //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
+        return EERepeatActions.repeat(serverName, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
     }
 
 }

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/InjectParameterTest.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/InjectParameterTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -28,7 +28,6 @@ import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -47,9 +46,8 @@ public class InjectParameterTest extends FATServletClient {
     public static final String SERVER_NAME = "cdi12EJB32Server";
     public static final String INJECTED_PARAMS_APP_NAME = "injectParameters";
 
-    //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/InterceptorsTest.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/InterceptorsTest.java
@@ -29,7 +29,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -52,9 +51,8 @@ public class InterceptorsTest extends FATServletClient {
     public static final String INTERCEPTORS_APP_NAME = "interceptorsApp";
     public static final String SERVER_NAME = "interceptorsServer";
 
-    //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE7, EERepeatActions.EE9);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/MultipleNamedEJBTest.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/MultipleNamedEJBTest.java
@@ -32,7 +32,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -47,9 +46,8 @@ public class MultipleNamedEJBTest extends FATServletClient {
     public static final String SERVER_NAME = "cdi12EJB32Server";
     public static final String APP_NAME = "multipleEJBsSingleClass";
 
-    //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/StatefulSessionBeanInjectionTest.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi/ejb/tests/StatefulSessionBeanInjectionTest.java
@@ -37,7 +37,6 @@ import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
-import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -54,9 +53,8 @@ public class StatefulSessionBeanInjectionTest extends FATServletClient {
     public static final String SERVER_NAME = "cdi12StatefulSessionBeanServer";
     public static final String STATEFUL_SESSION_BEAN_APP_NAME = "statefulSessionBeanInjection";
 
-    //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EERepeatActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EERepeatActions.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package componenttest.rules.repeater;
 
@@ -42,7 +39,7 @@ public class EERepeatActions {
     public static final FeatureSet LATEST = EE10;
 
     //All EE FeatureSets - must be descending order
-    private static final FeatureSet[] ALL_SETS_ARRAY = { EE10, EE9, EE8, EE7, EE6 };
+    private static final FeatureSet[] ALL_SETS_ARRAY = { EE11, EE10, EE9, EE8, EE7, EE6 };
     private static final List<FeatureSet> ALL = Collections.unmodifiableList(Arrays.asList(ALL_SETS_ARRAY));
 
     /**


### PR DESCRIPTION
This PR adds EE11 repeats to CDI FAT buckets. To do so also meant fixing the EE11 repeat action. Only four buckets done so far.
