### PR TITLE
Log stack trace in HttpDispatcherLink

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2022 IBM Corporation and others.
+ * Copyright (c) 2009, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.http.dispatcher.internal.channel;
 
@@ -19,6 +16,7 @@ import java.net.InetAddress;
 import java.nio.charset.Charset;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -1249,7 +1247,7 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
             } catch (Throwable t) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
                     Tr.event(tc, "Unhandled exception during dispatch (bad container); " + t);
-                    Tr.event(tc, "stack trace: \n" + t.getStackTrace().toString());
+                    Tr.event(tc, "stack trace: \n" + Arrays.toString(t.getStackTrace()));
                 }
                 // if the link is ready and not destroyed, try sending a response
                 if (ic.linkIsReady) {


### PR DESCRIPTION
Logs showed the object rather than the contents:

`[9/7/23, 16:29:10:661 PDT] 00000041 id=00000000 m.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink 1 stack trace: Ljava.lang.StackTraceElement;[@c497da14`

This update should log the stack instead. 

This is to assist in debugging defect 293864