### PR TITLE
Fix concurrency tck signature testing on non-LTS java

### DIFF
--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherFull.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherFull.java
@@ -54,8 +54,12 @@ public class ConcurrentTckLauncherFull {
         additionalProps.put("jakarta.concurrent.tck.groupid", "io.openliberty.jakarta.enterprise.concurrent");
         additionalProps.put("jakarta.concurrent.tck.version", "3.1.0-20230802");
 
-        //Jakarta TCK platform - Signature test run as part of web profile
-        additionalProps.put("jakarta.tck.platform", "full & !signature");
+        //Jakarta TCK platform
+        additionalProps.put("jakarta.tck.platform", "full");
+
+        if (!FATSuite.shouldRunSignatureTests(ConcurrentTckLauncherFull.class)) {
+            additionalProps.put("jakarta.tck.platform", "full & !signature");
+        }
 
         Map<String, String> opts = server.getJvmOptionsAsMap();
         opts.put("-Djimage.dir", server.getServerSharedPath() + "jimage/output/");

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherWeb.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherWeb.java
@@ -20,8 +20,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.log.Log;
-
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
@@ -55,10 +53,7 @@ public class ConcurrentTckLauncherWeb {
         //Jakarta TCK platform
         additionalProps.put("jakarta.tck.platform", "web");
 
-        // Skip signature testing on Windows.
-        // So far as I can tell the signature test plugin is not supported on this configuration
-        if (System.getProperty("os.name").contains("Windows")) {
-            Log.info(ConcurrentTckLauncherWeb.class, "setUp", "Skipping Jakarta Concurrency Signature Test on Windows");
+        if (!FATSuite.shouldRunSignatureTests(ConcurrentTckLauncherWeb.class)) {
             additionalProps.put("jakarta.tck.platform", "web & !signature");
         }
 

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/FATSuite.java
@@ -46,7 +46,7 @@ public class FATSuite {
                 return result = false;
             }
 
-            if (System.getProperty("os.name").contains("Windows")) {
+            if (System.getProperty("os.name", "unknown").toLowerCase().contains("windows")) {
                 reason = "signature test plugin not supported on Windows.";
                 return result = false;
             }

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/FATSuite.java
@@ -16,7 +16,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.websphere.simplicity.log.Log;
+
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -25,4 +30,39 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
                 ConcurrentTckLauncherWeb.class //LITE MODE
 })
 public class FATSuite {
+
+    public static boolean shouldRunSignatureTests(Class<?> testClass) {
+        boolean result = false;
+        String reason = "";
+
+        try {
+            if (!testClass.isAnnotationPresent(Mode.class)) {
+                reason = testClass.getCanonicalName() + " is not run in full mode.";
+                return result = false;
+            }
+
+            if (testClass.getAnnotation(Mode.class).value() != TestMode.FULL) {
+                reason = testClass.getCanonicalName() + " is not run in full mode.";
+                return result = false;
+            }
+
+            if (System.getProperty("os.name").contains("Windows")) {
+                reason = "signature test plugin not supported on Windows.";
+                return result = false;
+            }
+
+            if (JavaInfo.JAVA_VERSION != 17 || JavaInfo.JAVA_VERSION != 21) {
+                reason = "signature test not supported on non-LTS java versions: " + JavaInfo.JAVA_VERSION;
+                return result = false;
+            }
+
+            //default option
+            reason = "signature test can run as configured";
+            return result = true;
+
+        } finally {
+            Log.info(testClass, "shouldRunSignatureTests", "Return: " + result + ", because " + reason);
+        }
+
+    }
 }


### PR DESCRIPTION
The concurrency TCK can only run Signature tests on LTS Java versions since minor differences in java byte code can affect the signatures produced.

