### PR TITLE
add expected iss fallback and endpoint vs providers check

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcRpInitiatedLogout.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcRpInitiatedLogout.java
@@ -222,7 +222,7 @@ public class OidcRpInitiatedLogout {
     }
 
     void sendBackchannelLogoutRequests(String userName, String idTokenString) {
-        BackchannelLogoutRequestHelper bclRequestCreator = new BackchannelLogoutRequestHelper(oidcServerConfig);
+        BackchannelLogoutRequestHelper bclRequestCreator = new BackchannelLogoutRequestHelper(request, oidcServerConfig);
         bclRequestCreator.sendBackchannelLogoutRequests(userName, idTokenString);
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelper.java
@@ -20,6 +20,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
@@ -42,9 +44,11 @@ public class BackchannelLogoutRequestHelper {
 
     private final PrivilegedAction<ExecutorService> getExecutorServiceAction = new GetExecutorServiceAction();
 
+    private final HttpServletRequest request;
     private final OidcServerConfig oidcServerConfig;
 
-    public BackchannelLogoutRequestHelper(OidcServerConfig oidcServerConfig) {
+    public BackchannelLogoutRequestHelper(HttpServletRequest request, OidcServerConfig oidcServerConfig) {
+        this.request = request;
         this.oidcServerConfig = oidcServerConfig;
     }
 
@@ -59,7 +63,7 @@ public class BackchannelLogoutRequestHelper {
         }
         Map<OidcBaseClient, Set<String>> logoutTokens = null;
         try {
-            LogoutTokenBuilder tokenBuilder = new LogoutTokenBuilder(oidcServerConfig);
+            LogoutTokenBuilder tokenBuilder = new LogoutTokenBuilder(request, oidcServerConfig);
             if (idTokenString == null || idTokenString.isEmpty()) {
                 logoutTokens = tokenBuilder.buildLogoutTokensFromUserName(user);
             } else {

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutService.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutService.java
@@ -93,7 +93,7 @@ public class BackchannelLogoutService implements UnprotectedResourceService {
         }
         String idTokenString = request.getParameter(OIDCConstants.OIDC_LOGOUT_ID_TOKEN_HINT);
 
-        sendBackchannelLogoutRequests(oidcServerConfig, userName, idTokenString);
+        sendBackchannelLogoutRequests(request, oidcServerConfig, userName, idTokenString);
         return true;
     }
 
@@ -163,8 +163,8 @@ public class BackchannelLogoutService implements UnprotectedResourceService {
         return null;
     }
 
-    void sendBackchannelLogoutRequests(OidcServerConfig oidcServerConfig, String userName, String idTokenString) {
-        BackchannelLogoutRequestHelper bclRequestCreator = new BackchannelLogoutRequestHelper(oidcServerConfig);
+    void sendBackchannelLogoutRequests(HttpServletRequest request, OidcServerConfig oidcServerConfig, String userName, String idTokenString) {
+        BackchannelLogoutRequestHelper bclRequestCreator = new BackchannelLogoutRequestHelper(request, oidcServerConfig);
         bclRequestCreator.sendBackchannelLogoutRequests(userName, idTokenString);
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelperTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelperTest.java
@@ -9,6 +9,8 @@
  *******************************************************************************/
 package io.openliberty.security.openidconnect.backchannellogout;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -23,6 +25,7 @@ public class BackchannelLogoutRequestHelperTest extends CommonTestClass {
 
     private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("io.openliberty.security.openidconnect.*=all:com.ibm.ws.security.openidconnect*=all");
 
+    private final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
     private final OidcServerConfig oidcServerConfig = mockery.mock(OidcServerConfig.class);
 
     private BackchannelLogoutRequestHelper helper;
@@ -35,7 +38,7 @@ public class BackchannelLogoutRequestHelperTest extends CommonTestClass {
     @Before
     public void setUp() throws Exception {
         System.out.println("Entering test: " + testName.getMethodName());
-        helper = new BackchannelLogoutRequestHelper(oidcServerConfig);
+        helper = new BackchannelLogoutRequestHelper(request, oidcServerConfig);
     }
 
     @After

--- a/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilderTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilderTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.jmock.Expectations;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.MalformedClaimException;
@@ -79,6 +81,7 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
     private final String idToken3Id = "idToken3";
     private final String customIdTokenId = "customIdToken";
 
+    private final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
     private final OidcServerConfig oidcServerConfig = mockery.mock(OidcServerConfig.class);
     private final OAuth20Provider oauth20provider = mockery.mock(OAuth20Provider.class);
     private final OidcOAuth20ClientProvider clientProvider = mockery.mock(OidcOAuth20ClientProvider.class);
@@ -96,8 +99,8 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
     private LogoutTokenBuilder builder;
 
     private class MockLogoutTokenBuilder extends LogoutTokenBuilder {
-        public MockLogoutTokenBuilder(OidcServerConfig oidcServerConfig) {
-            super(oidcServerConfig);
+        public MockLogoutTokenBuilder(HttpServletRequest request, OidcServerConfig oidcServerConfig) {
+            super(request, oidcServerConfig);
         }
 
         @Override
@@ -164,7 +167,7 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
                 will(returnValue(idToken3Id));
             }
         });
-        builder = new MockLogoutTokenBuilder(oidcServerConfig);
+        builder = new MockLogoutTokenBuilder(request, oidcServerConfig);
     }
 
     @After
@@ -438,23 +441,6 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
     }
 
     @Test
-    public void test_verifyIssuer_emptyIss_noIssuerIdentifierConfigured() {
-        JwtClaims claims = getClaims(subject, "", client1Id);
-
-        mockery.checking(new Expectations() {
-            {
-                one(oidcServerConfig).getIssuerIdentifier();
-                will(returnValue(null));
-            }
-        });
-        try {
-            builder.verifyIssuer(claims);
-        } catch (Exception e) {
-            fail("Should not have thrown an exception but did: " + e);
-        }
-    }
-
-    @Test
     public void test_verifyIssuer_issSuperstring() {
         JwtClaims claims = getClaims(subject, issuerIdentifier + "2", client1Id);
 
@@ -475,7 +461,7 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
     }
 
     @Test
-    public void test_verifyIssuer_matchingIss() {
+    public void test_verifyIssuer_matchingIss_issuerIdentifierConfigured() {
         JwtClaims claims = getClaims(subject, issuerIdentifier, client1Id);
 
         mockery.checking(new Expectations() {
@@ -488,6 +474,190 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
             builder.verifyIssuer(claims);
         } catch (Exception e) {
             fail("Should not have thrown an exception but got: " + e);
+        }
+    }
+
+    @Test
+    public void test_verifyIssuer_matchingIss_noIssuerIdentifierConfigured_issOidcEndpoint_reqOidcEndpoint() {
+        final String scheme = "https";
+        final String serverName = "localhost";
+        final String expectedIssuerPath = "/oidc/endpoint/OP";
+        final String requestUri = expectedIssuerPath + "/end_session";
+        final String iss = scheme + "://" + serverName + expectedIssuerPath;
+        JwtClaims claims = getClaims(subject, iss, client1Id);
+
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(null));
+                one(request).getScheme();
+                will(returnValue(scheme));
+                one(request).getServerName();
+                will(returnValue(serverName));
+                one(request).getServerPort();
+                will(returnValue(443));
+                one(request).getRequestURI();
+                will(returnValue(requestUri));
+            }
+        });
+        try {
+            builder.verifyIssuer(claims);
+        } catch (Exception e) {
+            fail("Should not have thrown an exception but got: " + e);
+        }
+    }
+
+    @Test
+    public void test_verifyIssuer_matchingIss_noIssuerIdentifierConfigured_issOidcEndpoint_reqOidcProviders() {
+        final String scheme = "https";
+        final String serverName = "localhost";
+        final String expectedIssuerPath = "/oidc/endpoint/OP";
+        final String requestUri = "/oidc/providers/OP/end_session";
+        final String iss = scheme + "://" + serverName + expectedIssuerPath;
+        JwtClaims claims = getClaims(subject, iss, client1Id);
+
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(null));
+                one(request).getScheme();
+                will(returnValue(scheme));
+                one(request).getServerName();
+                will(returnValue(serverName));
+                one(request).getServerPort();
+                will(returnValue(443));
+                one(request).getRequestURI();
+                will(returnValue(requestUri));
+            }
+        });
+        try {
+            builder.verifyIssuer(claims);
+        } catch (Exception e) {
+            fail("Should not have thrown an exception but got: " + e);
+        }
+    }
+
+    @Test
+    public void test_verifyIssuer_matchingIss_noIssuerIdentifierConfigured_issOidcProviders_reqOidcProviders() {
+        final String scheme = "https";
+        final String serverName = "localhost";
+        final String expectedIssuerPath = "/oidc/providers/OP";
+        final String requestUri = expectedIssuerPath + "/end_session";
+        final String iss = scheme + "://" + serverName + expectedIssuerPath;
+        JwtClaims claims = getClaims(subject, iss, client1Id);
+
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(null));
+                one(request).getScheme();
+                will(returnValue(scheme));
+                one(request).getServerName();
+                will(returnValue(serverName));
+                one(request).getServerPort();
+                will(returnValue(443));
+                one(request).getRequestURI();
+                will(returnValue(requestUri));
+            }
+        });
+        try {
+            builder.verifyIssuer(claims);
+        } catch (Exception e) {
+            fail("Should not have thrown an exception but got: " + e);
+        }
+    }
+
+    @Test
+    public void test_verifyIssuer_matchingIss_noIssuerIdentifierConfigured_issOidcProviders_reqOidcEndpoint() {
+        final String scheme = "https";
+        final String serverName = "localhost";
+        final String expectedIssuerPath = "/oidc/providers/OP";
+        final String requestUri = "/oidc/endpoint/OP/end_session";
+        final String iss = scheme + "://" + serverName + expectedIssuerPath;
+        JwtClaims claims = getClaims(subject, iss, client1Id);
+
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(null));
+                one(request).getScheme();
+                will(returnValue(scheme));
+                one(request).getServerName();
+                will(returnValue(serverName));
+                one(request).getServerPort();
+                will(returnValue(443));
+                one(request).getRequestURI();
+                will(returnValue(requestUri));
+            }
+        });
+        try {
+            builder.verifyIssuer(claims);
+        } catch (Exception e) {
+            fail("Should not have thrown an exception but got: " + e);
+        }
+    }
+
+    @Test
+    public void test_verifyIssuer_notMatchingIss_noIssuerIdentifierConfigured_reqOidcEndpoint() {
+        final String scheme = "https";
+        final String serverName = "localhost";
+        final String expectedIssuerPath = "/oidc/endpoint/OP2";
+        final String requestUri = expectedIssuerPath + "/end_session";
+        JwtClaims claims = getClaims(subject, issuerIdentifier, client1Id);
+
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(null));
+                one(request).getScheme();
+                will(returnValue(scheme));
+                one(request).getServerName();
+                will(returnValue(serverName));
+                one(request).getServerPort();
+                will(returnValue(443));
+                one(request).getRequestURI();
+                will(returnValue(requestUri));
+            }
+        });
+        try {
+            builder.verifyIssuer(claims);
+            fail("Should have thrown an exception but didn't.");
+        } catch (MalformedClaimException e) {
+            fail("Did not through the expected exception. Got: " + e);
+        } catch (IdTokenDifferentIssuerException e) {
+            verifyException(e, CWWKS1646E_ID_TOKEN_ISSUER_NOT_THIS_OP);
+        }
+    }
+
+    @Test
+    public void test_verifyIssuer_notMatchingIss_noIssuerIdentifierConfigured_reqOidcProviders() {
+        final String scheme = "https";
+        final String serverName = "localhost";
+        final String expectedIssuerPath = "/oidc/providers/OP2";
+        final String requestUri = expectedIssuerPath + "/end_session";
+        JwtClaims claims = getClaims(subject, issuerIdentifier, client1Id);
+
+        mockery.checking(new Expectations() {
+            {
+                one(oidcServerConfig).getIssuerIdentifier();
+                will(returnValue(null));
+                one(request).getScheme();
+                will(returnValue(scheme));
+                one(request).getServerName();
+                will(returnValue(serverName));
+                one(request).getServerPort();
+                will(returnValue(443));
+                one(request).getRequestURI();
+                will(returnValue(requestUri));
+            }
+        });
+        try {
+            builder.verifyIssuer(claims);
+            fail("Should have thrown an exception but didn't.");
+        } catch (MalformedClaimException e) {
+            fail("Did not through the expected exception. Got: " + e);
+        } catch (IdTokenDifferentIssuerException e) {
+            verifyException(e, CWWKS1646E_ID_TOKEN_ISSUER_NOT_THIS_OP);
         }
     }
 
@@ -1241,6 +1411,76 @@ public class LogoutTokenBuilderTest extends CommonTestClass {
         } catch (LogoutTokenBuilderException e) {
             verifyException(e, CWWKS1647E_ID_TOKEN_MISSING_REQUIRED_CLAIMS + ".+" + "sub");
         }
+    }
+
+    @Test
+    public void test_getIssuerFromRequest_standardHttpPort() throws Exception {
+        final String scheme = "http";
+        final String serverName = "myserver";
+        final String expectedIssuerPath = "/some/path/to/the/OP";
+        final String requestUri = expectedIssuerPath + "/end_session";
+        mockery.checking(new Expectations() {
+            {
+                one(request).getScheme();
+                will(returnValue(scheme));
+                one(request).getServerName();
+                will(returnValue(serverName));
+                one(request).getServerPort();
+                will(returnValue(80));
+                one(request).getRequestURI();
+                will(returnValue(requestUri));
+            }
+        });
+        String expectedIssuer = scheme + "://" + serverName + expectedIssuerPath;
+        String result = builder.getIssuerFromRequest();
+        assertEquals("Issuer value did not match expected value.", expectedIssuer, result);
+    }
+
+    @Test
+    public void test_getIssuerFromRequest_standardHttpsPort() throws Exception {
+        final String scheme = "https";
+        final String serverName = "myserver";
+        final String expectedIssuerPath = "/some/path/to/the/OP";
+        final String requestUri = expectedIssuerPath + "/end_session";
+        mockery.checking(new Expectations() {
+            {
+                one(request).getScheme();
+                will(returnValue(scheme));
+                one(request).getServerName();
+                will(returnValue(serverName));
+                one(request).getServerPort();
+                will(returnValue(443));
+                one(request).getRequestURI();
+                will(returnValue(requestUri));
+            }
+        });
+        String expectedIssuer = scheme + "://" + serverName + expectedIssuerPath;
+        String result = builder.getIssuerFromRequest();
+        assertEquals("Issuer value did not match expected value.", expectedIssuer, result);
+    }
+
+    @Test
+    public void test_getIssuerFromRequest_nonStandardPort() throws Exception {
+        final String scheme = "https";
+        final String serverName = "myserver";
+        final int port = 98765;
+        final String expectedIssuerPath = "/some/path/to/the/OP";
+        final String requestUri = expectedIssuerPath + "/end_session";
+        mockery.checking(new Expectations() {
+            {
+                one(request).getScheme();
+                will(returnValue(scheme));
+                one(request).getServerName();
+                will(returnValue(serverName));
+                one(request).getServerPort();
+                will(returnValue(port));
+                one(request).getRequestURI();
+                will(returnValue(requestUri));
+            }
+        });
+        String expectedIssuer = scheme + "://" + serverName + ":" + port + expectedIssuerPath;
+        String result = builder.getIssuerFromRequest();
+        assertEquals("Issuer value did not match expected value.", expectedIssuer, result);
     }
 
     private void verifyCachedIdTokensMapContainsExpectedClients(Map<OidcBaseClient, List<OAuth20Token>> clientsToCachedIdTokens, OidcBaseClient... expectedClientEntries) {


### PR DESCRIPTION
for #25526

- puts back the code for the expected issuer to fallback to getting it from the request url (https://github.com/OpenLiberty/open-liberty/pull/24811)
- added code to check if the expected issuer from the request url doesn't match the iss in the id token, then see if switching `/oidc/endpoint/` to `/oidc/providers/` and vice-versa would match. if still not, then throw an exception.

**note:** i _did not_ undo the part in https://github.com/OpenLiberty/open-liberty/pull/24811 that sets the logout token `iss` as the id token `iss`. the reason for keeping this change is because if the id token was issued by `/oidc/endpoint` and the logout happened on `/oidc/providers`, the iss check on the OP will now pass due to the new code, but `/oidc/endpoint` should be used as the issuer in the logout token, otherwise the iss check will fail on the RP.