### PR TITLE
If criu fails to restore the process display the restore.log

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1532,7 +1532,11 @@ restoreServer()
       issueMessage --message:error.checkpoint.restore.failed.no.recovery "${X_LOG_DIR}/checkpoint/restore.log"
     else
       issueMessage --message:info.checkpoint.restore.failed "${X_LOG_DIR}/checkpoint/restore.log"
-    fi    
+    fi
+
+    if [ -f "${X_LOG_DIR}/checkpoint/restore.log" ]; then
+      cat "${X_LOG_DIR}/checkpoint/restore.log"
+    fi
   fi
   return $rc
 }

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/CheckpointFailTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/CheckpointFailTest.java
@@ -174,10 +174,13 @@ public class CheckpointFailTest {
         testSystemCheckpointFailed("SYSTEM_CHECKPOINT_FAILED", true, 74, ".*CWWKE0962E.*TESTING CHECKPOINT.LOG.*"),
         testUnknownCheckpointFailed("UNKNOWN_CHECKPOINT", true, 75),
         // Note that 1 is by criu when it fails to restore
-        testCriuRestoreFailed("SYSTEM_RESTORE_FAILED", false, 1, ".*CWWKE0964E: Restoring the checkpoint server process failed.*The server did not launch.*"),
+        testCriuRestoreFailed("SYSTEM_RESTORE_FAILED", false, 1, //
+                              ".*CWWKE0964E: Restoring the checkpoint server process failed.*The server did not launch.*", //
+                              ".*No IDS for root task.*"),
         testCriuRestoreFailedWithRecover("SYSTEM_RESTORE_FAILED", false, 0, // expect final RC of success from auto-recovery
                                          ".*CWWKE0961I: Restoring the checkpoint server process failed.*Launching the server without using the checkpoint image.*"
-                                                                            + "Server.*started with process ID.*"),
+                                                                            + "Server.*started with process ID.*", //
+                                         ".*No IDS for root task.*"),
         testSystemRestoreFailed("SYSTEM_RESTORE_FAILED", false, 80),
         testJvmRestoreFailed("JVM_RESTORE_FAILED", false, 81),
         testLibertyRestoreFailed("LIBERTY_RESTORE_FAILED", false, 82),


### PR DESCRIPTION
Fixes #26193

This fix always displays the `restore.log` if a failure to restore happened at the criu layer.