### PR TITLE
We're unsure why this wasn passing before, after investigating the op…

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/spanexporter/InMemorySpanExporter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/common/spanexporter/InMemorySpanExporter.java
@@ -227,8 +227,19 @@ public class InMemorySpanExporter implements SpanExporter {
         Iterator<SpanData> iter = lSpans.listIterator();
         while (iter.hasNext()) {
             SpanData span = iter.next();
-            // Remove readspans and FAT servlet spans
-            if (span.getName().contains("readspans") || span.getName().matches("^/.*/test.*$")) {
+            /*
+             * Remove readspans and FAT servlet spans.
+             *
+             * REGEX breakdown:
+             * Match start of line.
+             * Match 0 or 1 of the string "GET " (note whitespace) using a non-capturing group.
+             * Match a literal "/"
+             * Match anything
+             * Match a literal /
+             * match the string "test"
+             * Match anything until the end of the line.
+             */
+            if (span.getName().contains("readspans") || span.getName().matches("^(?:GET )?/.*/test.*$")) {
                 iter.remove();
             }
         }


### PR DESCRIPTION
…en telemetry source code telemty 1.29 should be appending GET here

These tests have passed both locally and in personal builds, but when making unrelated changes they started failing for me. After analysing the source code I am confident that GET should be present. 

See https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v1.29.0/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanNameExtractor.java#L36

That method is the GET, which should be coming out in the span name we mark a regex against.