### PR TITLE
25259 ltpa key rotation fat - more tests

### DIFF
--- a/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/ContextRootCookiePathTests.java
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/ContextRootCookiePathTests.java
@@ -670,7 +670,7 @@ public class ContextRootCookiePathTests {
             ServerConfiguration configuration = server.getServerConfiguration();
             waSecurity = configuration.getWebAppSecurity();
             waSecurity.useContextRootForSSOCookiePath = useContextRootForSSOCookiePath;
-            updateConfigDynamically(server, configuration, true);
+            updateConfigDynamically(server, configuration);
             return waSecurity;
         } catch (Exception e) {
             e.printStackTrace();
@@ -680,7 +680,7 @@ public class ContextRootCookiePathTests {
     }
 
     // Function to update the server configuration dynamically
-    public static void updateConfigDynamically(LibertyServer server, ServerConfiguration config, boolean waitForAppToStart) throws Exception {
+    public static void updateConfigDynamically(LibertyServer server, ServerConfiguration config) throws Exception {
         server.setMarkToEndOfLog(server.getDefaultLogFile());
         server.setMarkToEndOfLog(server.getMostRecentTraceFile());
 
@@ -688,9 +688,9 @@ public class ContextRootCookiePathTests {
         //CWWKG0017I: The server configuration was successfully updated in {0} seconds.
         //CWWKG0018I: The server configuration was not updated. No functional changes were detected.
         String logLine = server.waitForStringInLogUsingMark("CWWKG001[7-8]I");
-        if (waitForAppToStart && !logLine.contains("CWWKG0018I")) {
-            server.waitForStringInLogUsingMark("CWWKZ0003I", 10000); //CWWKZ0003I: The application userRegistry updated in 0.020 seconds.
-        }
+
+        // Wait for feature update to be completed or LTPA configuration to get ready 
+        Thread.sleep(200);
     }
 
     /**


### PR DESCRIPTION
LTPA Key Rotation Fat Tests

What we're testing: `<ltpa keysFileName="${server.config.dir}/resources/security/ltpa.keys" monitorInterval = "5" monitorDirectory="true" />`

Adding 2 more tests to: `LTPAKeyRotationTests.java`

Created 14 total test cases:
1. `testLTPAFileCreationDeletion_monitorDirectory_true_monitorInterval_5`
2. `testLTPAFileReplacement_newValidKey_monitorDirectory_true_monitorInterval_5`
3. `testLTPAFileReplacement_newInvalidKey_monitorDirectory_true_monitorInterval_5`
4. `testLTPAFileCreationDeletion_monitorDirectory_false_monitorInterval_0`
5. `testLTPAFileReplacement_newValidKey_monitorDirectory_false_monitorInterval_0`
6. `testLTPAFileCreationDeletion_monitorDirectory_false_monitorInterval_5`
7. `testLTPAFileReplacement_newValidKey_monitorDirectory_false_monitorInterval_5`
8. `testLTPAFileCreationDeletion_monitorDirectory_true_monitorInterval_0`
9. `testLTPAFileReplacement_newValidKey_monitorDirectory_true_monitorInterval_0`
10. `testValidationKeys_fileNameAttribute`
11. `testValidationKeys_passwordAttribute`
12. `testValidationKeys_notUseAfterDateAttribute`
13. `testConfiguredValidationKeys`
14. `testNotUseAfterDate_expiringAfterConfigurationAndUsage`