### PR TITLE
Create initial Java 21 project and put out error for missing env variable

### DIFF
--- a/dev/io.openliberty.java21.internal/.classpath
+++ b/dev/io.openliberty.java21.internal/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.java21.internal/.project
+++ b/dev/io.openliberty.java21.internal/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.java21.internal</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.java21.internal/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.java21.internal/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.java21.internal/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.java21.internal/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=17

--- a/dev/io.openliberty.java21.internal/bnd.bnd
+++ b/dev/io.openliberty.java21.internal/bnd.bnd
@@ -1,0 +1,20 @@
+#*******************************************************************************
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+javac.source: 21
+javac.target: 21
+
+Bundle-Name: Require Java 21
+Bundle-SymbolicName: io.openliberty.java21.internal
+Bundle-Description: Bundle to force a Java 21 dependency; version=${bVersion}
+
+Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=21))"

--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -191,6 +191,15 @@ if (javaVersion < 17) {
 
 }
 
+if (System.getenv("JAVA_21_HOME") == null) {
+  print "ERROR: Building this repository requires JAVA_21_HOME to be set to a path for a Java 21 SDK.  Please follow these steps:\n" +
+    "  1) You can download a copy for your OS here if you don't already have it: " + 
+    "https://jdk.java.net/21/\n" +
+    "  2) export 'JAVA_21_HOME=/path/to/your/java21' in the shell or set in your ~/.bashrc\n" +
+    "  3) Restart your gradle daemon with './gradlew --stop'\n";
+  throw new GradleException('JAVA_21_HOME is not set.')
+}
+
 //DirectoryScanner.removeDefaultExclude("**/.gitignore")
 //DirectoryScanner.removeDefaultExclude("**/.gitattributes")
 


### PR DESCRIPTION
- Create io.openliberty.java21.internal project to add to features that require a minimum level of Java 21
- Update gradle checking to make sure that JAVA_21_HOME variable is configured to support building projects that require Java 21.