### PR TITLE
don't revoke refresh tokens issued with offline_access

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilder.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/LogoutTokenBuilder.java
@@ -38,6 +38,7 @@ import com.ibm.ws.security.oauth20.plugins.OidcBaseClientValidator;
 import com.ibm.ws.security.oauth20.plugins.jose4j.JWTData;
 import com.ibm.ws.security.oauth20.plugins.jose4j.JwsSigner;
 import com.ibm.ws.security.oauth20.util.CacheUtil;
+import com.ibm.ws.security.oauth20.util.OIDCConstants;
 import com.ibm.ws.security.oauth20.util.OidcOAuth20Util;
 import com.ibm.ws.security.openidconnect.backchannellogout.BackchannelLogoutException;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
@@ -194,9 +195,22 @@ public class LogoutTokenBuilder {
     void removeRefreshTokenAssociatedWithOAuthTokenFromCache(OAuth20Token cachedToken) {
         CacheUtil cu = new CacheUtil(tokenCache);
         OAuth20Token refreshToken = cu.getRefreshToken(cachedToken);
-        if (refreshToken != null) {
+        if (refreshToken != null && !refreshTokenHasOfflineAccessScope(refreshToken)) {
             tokenCache.remove(refreshToken.getTokenString());
         }
+    }
+
+    boolean refreshTokenHasOfflineAccessScope(OAuth20Token refreshToken) {
+        String[] scopes = refreshToken.getScope();
+        if (scopes == null) {
+            return false;
+        }
+        for (String scope : scopes) {
+            if (OIDCConstants.OIDC_DISC_SCOPES_SUPP_OFFLINE_ACC.equals(scope)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
for #20360 

> **2.7.  Back-Channel Logout Actions**
> ...
> Refresh tokens issued without the offline_access property to a session being logged out SHOULD be revoked. Refresh tokens issued with the offline_access property normally SHOULD NOT be revoked.