### PR TITLE
Remove hardcoding of port 8020 from OAuthFlow for OpenAPI OAuth UI test

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/app/SecureTestResource.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/app/SecureTestResource.java
@@ -23,8 +23,8 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
 
 
 @SecurityScheme(securitySchemeName = "oauth", type = SecuritySchemeType.OAUTH2,
-        flows = @OAuthFlows(authorizationCode = @OAuthFlow(authorizationUrl = "https://host.testcontainers.internal:8020/oauth2/endpoint/TestProvider/authorize",
-                tokenUrl = "https://host.testcontainers.internal:8020/oauth2/endpoint/TestProvider/token",
+        flows = @OAuthFlows(authorizationCode = @OAuthFlow(authorizationUrl = "/oauth2/endpoint/TestProvider/authorize",
+                tokenUrl = "/oauth2/endpoint/TestProvider/token",
                 scopes = @OAuthScope(name = "test"))))
 @SecurityRequirement(name = "oauth", scopes = "test")
 @RolesAllowed("restricted")

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/publish/servers/openapi-ui-custom-oauth-test/server.xml
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/publish/servers/openapi-ui-custom-oauth-test/server.xml
@@ -15,7 +15,15 @@
         <feature>appSecurity-5.0</feature>
     </featureManager>
 
-    <include location="../fatTestPorts.xml" />
+    <include location="../fatTestCommon.xml"/>
+
+    <!-- HTTP port disabled so that redirects always go to HTTPS port -->
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="-1"
+                  httpsPort="${bvt.prop.HTTP_default.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <keyStore password="testpass" />
 


### PR DESCRIPTION
Previous PR was a partial fix for Oauth Flow URL issue.

Remove host details from OAuth Flow URLs. The URLs can be relative to the application so this is a valid definition for the Urls.

Using the default Fat Test ports, when the new tab is created when clicking `Authorize` will go to the HTTP port causing an SSL error as OAuth flows can only be done via HTTPS. So by disabling HTTP port all redirects go to the https port.

fatTestPorts.xml is not included as on server definition restore the ordering can change meaning that it can appear are the `httpEndpoint` definition in the server.xml and therefore take precedence and re-enable `HTTP`. So fatTestCommon.xml is included with the explicit `httpEndpoint` definition, along with a cut down version of fatTestPorts

#25991 contained an incomplete fix for the issue were the new tab was being opened with the wrong port.

For RTC296869