### PR TITLE
Update CountdownLatch Usage in com.ibm.ws.ejbcontainer.timer.np_fat

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.np_fat/test-applications/NpTimersEJB.jar/src/com/ibm/ws/ejbcontainer/timer/np/ejb/XMLTxBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np_fat/test-applications/NpTimersEJB.jar/src/com/ibm/ws/ejbcontainer/timer/np/ejb/XMLTxBean.java
@@ -122,9 +122,9 @@ public class XMLTxBean implements XMLTxLocal {
             svLogger.entering(CLASSNAME, "createTimer", info);
         }
 
+        svNextTimeoutLatch = new CountDownLatch(1);
         Timer t = TimerHelper.createTimer(ivTS, DURATION, null, info, false, null);
         svTimer = t;
-        svNextTimeoutLatch = new CountDownLatch(1);
 
         if (svLogger.isLoggable(Level.FINER)) {
             svLogger.exiting(CLASSNAME, "createTimer - created timer: " + t);
@@ -138,9 +138,9 @@ public class XMLTxBean implements XMLTxLocal {
             svLogger.entering(CLASSNAME, "createIntervalTimer", info);
         }
 
+        svNextTimeoutLatch = new CountDownLatch(1);
         Timer t = TimerHelper.createTimer(ivTS, DURATION, null, info, false, INTERVAL);
         svTimer = t;
-        svNextTimeoutLatch = new CountDownLatch(1);
 
         if (svLogger.isLoggable(Level.FINER)) {
             svLogger.exiting(CLASSNAME, "createIntervalTimer - created timer: " + t);

--- a/dev/com.ibm.ws.ejbcontainer.timer.np_fat/test-applications/NpTimersEJB.jar/src/com/ibm/ws/ejbcontainer/timer/np/ejb/XMLTxBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np_fat/test-applications/NpTimersEJB.jar/src/com/ibm/ws/ejbcontainer/timer/np/ejb/XMLTxBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corporation and others.
+ * Copyright (c) 2009, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -82,7 +82,6 @@ public class XMLTxBean implements XMLTxLocal {
 
         svLogger.info("svNextTimeout = " + svNextTimeout);
         svNextTimeoutLatch.countDown();
-        svNextTimeoutLatch = new CountDownLatch(1);
     }
 
     @Override
@@ -125,6 +124,7 @@ public class XMLTxBean implements XMLTxLocal {
 
         Timer t = TimerHelper.createTimer(ivTS, DURATION, null, info, false, null);
         svTimer = t;
+        svNextTimeoutLatch = new CountDownLatch(1);
 
         if (svLogger.isLoggable(Level.FINER)) {
             svLogger.exiting(CLASSNAME, "createTimer - created timer: " + t);
@@ -140,6 +140,7 @@ public class XMLTxBean implements XMLTxLocal {
 
         Timer t = TimerHelper.createTimer(ivTS, DURATION, null, info, false, INTERVAL);
         svTimer = t;
+        svNextTimeoutLatch = new CountDownLatch(1);
 
         if (svLogger.isLoggable(Level.FINER)) {
             svLogger.exiting(CLASSNAME, "createIntervalTimer - created timer: " + t);


### PR DESCRIPTION
Updating the bean's logic to initialize the CountdownLatch during timer creation.

This matches the other beans in this test bucket, so no additional changes are warranted beyond the one needed to clean up the known intermittent failure.

fixes #26343 