### PR TITLE
Add wait for Derby start in JCA FAT

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/fat/src/fat/concurrent/persistent/jca/PersistRATest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/fat/src/fat/concurrent/persistent/jca/PersistRATest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -105,6 +105,10 @@ public class PersistRATest {
                       server.waitForStringInLog("CWWKF0008I"));
         assertNotNull("Server should report it has started",
                       server.waitForStringInLog("CWWKF0011I"));
+
+        // Starting the RAR will asynchronously schedule a persistent task, initializing Derby. 
+        // Wait for the Derby start messages to avoid a test trying to concurrently start Derby.
+        server.waitForStringInLog("DSRA8206I"); // connected to Derby
     }
 
     @AfterClass


### PR DESCRIPTION
- Wait for adapter start to access the database so Derby starts before running other test methods.
