### PR TITLE
Update ECJ/JDT to 3.35/4.29 for Java 21 Support in JSP/Pages

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2394,7 +2394,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>ecj</artifactId>
-      <version>3.34.0</version>
+      <version>3.35.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -474,7 +474,7 @@ org.eclipse.birt.runtime.3_7_1:org.apache.xml.serializer:2.7.1
 org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627
 org.eclipse.jdt:ecj:3.26.0
 org.eclipse.jdt:ecj:3.33.0
-org.eclipse.jdt:ecj:3.34.0
+org.eclipse.jdt:ecj:3.35.0
 org.eclipse.jetty.websocket:javax-websocket-client-impl:9.2.2.v20140723
 org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.39.v20210325
 org.eclipse.jetty.websocket:websocket-api:9.2.2.v20140723

--- a/dev/io.openliberty.org.eclipse.jdt.core.java17/bnd.bnd
+++ b/dev/io.openliberty.org.eclipse.jdt.core.java17/bnd.bnd
@@ -10,9 +10,11 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+# 3.35 (aka 4.29) added Java 21 support 
+
 Bundle-Name: JDT Compiler
 Bundle-SymbolicName: io.openliberty.org.eclipse.jdt.core.java17
-Bundle-Description: Eclipse Java Compiler (ECJ) from the Java Development Tools (JDT) Project. Version 3.34.0: June, 2023
+Bundle-Description: Eclipse Java Compiler (ECJ) from the Java Development Tools (JDT) Project. Version 3.35.0: Sept, 2023
 
 javac.source: 17
 javac.target: 17
@@ -21,6 +23,6 @@ Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=17))"
 
 Import-Package: !*
    
-Export-Package: org.eclipse.jdt.*;version=3.34.0;usage=JSP
+Export-Package: org.eclipse.jdt.*;version=3.35.0;usage=JSP
 
--buildpath: org.eclipse.jdt:ecj;strategy=exact;version=3.34.0
+-buildpath: org.eclipse.jdt:ecj;strategy=exact;version=3.35.0


### PR DESCRIPTION
for #25494 & #26088 to allow JSPs to compile against java 21. 

Release Notes: https://eclipse.dev/eclipse/development/readme_eclipse_4.29.php 
- `As shown above, Eclipse 4.29 requires at least a Java SE 17`
  - This jar was updated in the `io.openliberty.org.eclipse.jdt.core.java17` bundle as it requires a java 17 runtime. 

However, if javaSourceLevel is set to 21 then Liberty run be on the Java 21 runtime otherwise they'll be `UnsupportedClassVersionError` since a Java 21 compiled JSP is trying to run on Java 17.


Links: 

https://repo1.maven.org/maven2/org/eclipse/jdt/ecj/3.35.0/

https://download.eclipse.org/eclipse/downloads/drops4/R-4.29-202309031000/  