### PR TITLE
JAX-WS: Clean up duplicate classes in com.ibm.ws.jaxws.ejb_fat test apps

### DIFF
--- a/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBJndiTest.java
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBJndiTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -73,7 +73,9 @@ public class EJBJndiTest {
         WebArchive war2 = ShrinkWrap.create(WebArchive.class, ejbjndiwebejbwar + ".war").addPackage("com.ibm.ws.jaxws.ejbjndi.webejb");
         ShrinkHelper.addDirectory(war2, "test-applications/EJBJndiWebEJB/resources/");
 
-        JavaArchive jar2 = ShrinkHelper.buildJavaArchive(ejbjndicommon + ".jar", "com.ibm.ws.jaxws.ejbjndi.*");
+        JavaArchive jar2 = ShrinkHelper.buildJavaArchive(ejbjndicommon + ".jar", "com.ibm.ws.jaxws.ejbjndi.ejb", "com.ibm.ws.jaxws.ejbjndi.common",
+                                                         "com.ibm.ws.jaxws.ejbjndi.webejb", "com.ibm.ws.jaxws.ejbjndi.ejb.client", "com.ibm.ws.jaxws.ejbjndi.webejb.client",
+                                                         "com.ibm.ws.jaxws.ejbjndi.web.client");
         ShrinkHelper.addDirectory(jar2, "test-applications/EJBJndiCommon/resources/");
 
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ejbjndiear + ".ear").addAsModule(jar).addAsModule(war).addAsModule(war2).addAsLibraries(jar2);

--- a/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSBasicTest.java
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSBasicTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -60,9 +60,10 @@ public class EJBWSBasicTest {
     @BeforeClass
     public static void beforeAllTests() throws Exception {
 
-        JavaArchive jar = ShrinkHelper.buildJavaArchive(ejbwsbasicjar + ".jar", "com.ibm.ws.jaxws.ejbbasic.*");
+        JavaArchive jar = ShrinkHelper.buildJavaArchive(ejbwsbasicjar + ".jar", "com.ibm.ws.jaxws.ejbbasic", "com.ibm.ws.jaxws.ejbbasic.view");
 
-        WebArchive war = ShrinkWrap.create(WebArchive.class, ejbwsbasicclientwar + ".war").addPackages(true, "com.ibm.ws.jaxws.ejbbasic");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, ejbwsbasicclientwar + ".war").addPackages(true, "com.ibm.ws.jaxws.ejbbasic.client",
+                                                                                                       "com.ibm.ws.jaxws.ejbbasic.view.client");
         ShrinkHelper.addDirectory(war, "test-applications/EJBWSBasicClient/resources/");
 
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ejbwsbasicear + ".ear").addAsModule(jar).addAsModule(war);
@@ -140,11 +141,7 @@ public class EJBWSBasicTest {
 
     protected void runTest(String responseString) throws Exception {
 
-        // Strip the Test Rerun id's out of the method name
-        String testMethod = testName.getMethodName().replace("_EE9_FEATURES", "");
-
-        // Remove automatically added extension to match proper method name
-        testMethod = testMethod.replace("_EE10_FEATURES", "");
+        String testMethod = testName.getMethodName();
 
         StringBuilder sBuilder = new StringBuilder("http://").append(server.getHostname()).append(":").append(server.getHttpDefaultPort()).append(SERVLET_PATH).append("?testMethod=").append(testMethod);
         String urlStr = sBuilder.toString();

--- a/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSLifeCycleTest.java
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSLifeCycleTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -68,9 +68,10 @@ public class EJBWSLifeCycleTest {
     @Before
     public void before() throws Exception {
 
-        JavaArchive jar = ShrinkHelper.buildJavaArchive(ejbwslifecyclejar + ".jar", "com.ibm.ws.jaxws.ejblifecycle.*");
+        JavaArchive jar = ShrinkHelper.buildJavaArchive(ejbwslifecyclejar + ".jar", "com.ibm.ws.jaxws.ejblifecycle");
 
-        WebArchive war = ShrinkWrap.create(WebArchive.class, ejbwslifecycleclientwar + ".war").addPackages(true, "com.ibm.ws.jaxws.ejblifecycle.client");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, ejbwslifecycleclientwar + ".war").addPackages(true, "com.ibm.ws.jaxws.ejblifecycle.client",
+                                                                                                           "com.ibm.ws.jaxws.ejblifecycle.client.servlet");
         ShrinkHelper.addDirectory(war, "test-applications/EJBWSLifeCycleClient/resources/");
 
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ejbwslifecycleear + ".ear").addAsModule(jar).addAsModule(war);

--- a/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSProviderTest.java
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSProviderTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -96,7 +96,7 @@ public class EJBWSProviderTest {
     @BeforeClass
     public static void beforeAllTests() throws Exception {
 
-        JavaArchive jar = ShrinkHelper.buildJavaArchive(ejbwsproviderjar + ".jar", "com.ibm.ws.jaxws.ejbwsprovider.*");
+        JavaArchive jar = ShrinkHelper.buildJavaArchive(ejbwsproviderjar + ".jar", "com.ibm.ws.jaxws.ejbwsprovider");
 
         ShrinkHelper.addDirectory(jar, "test-applications/EJBWSProvider/resources/");
 


### PR DESCRIPTION
This PR changes all test suites in `com.ibm.ws.jaxws.ejb_fat` that uses a wildcard package declaration (i.e. `test.package.*`) to enumerating all required packages ((i.e. `test.package.client`) to prevent duplication of code in test apps. 