### PR TITLE
correct fat test check for windows include file

### DIFF
--- a/dev/com.ibm.ws.config_fat/fat/src/test/server/config/ServerConfigTest.java
+++ b/dev/com.ibm.ws.config_fat/fat/src/test/server/config/ServerConfigTest.java
@@ -260,9 +260,9 @@ public class ServerConfigTest {
 
         try {
             // check all files listed in log
-            assertStringsPresentInLog(server, new String[] { "common" + File.separator + "a.xml" });
-            assertStringsPresentInLog(server, new String[] { "common" + File.separator + "b.xml" });
-            assertStringsPresentInLog(server, new String[] { "common" + File.separator + "c.xml" });
+            assertStringsPresentInLog(server, new String[] { "common.a.xml" });
+            assertStringsPresentInLog(server, new String[] { "common.b.xml" });
+            assertStringsPresentInLog(server, new String[] { "common.c.xml" });
             test(server, "/restart/restart?testName=includeDir");
         } finally {
             server.stopServer();


### PR DESCRIPTION
There is a defect for a failing fat test on windows where the previous implementation wouldn't find the included file. It uses regex to find the file so changing from the slash to a period will find either. 

