### PR TITLE
JAX-WS: Remove unnecessary try/catch in WebServiceRefTest

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceRefTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceRefTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -56,13 +56,7 @@ public class WebServiceRefTest {
                                       "com.ibm.ws.jaxws.test.wsr.server.impl",
                                       "com.ibm.ws.jaxws.fat.util");
 
-        // Make sure we don't fail because we try to start an
-        // already started server
-        try {
-            server.startServer("WebServiceRefTest.log");
-        } catch (Exception e) {
-            System.out.println(e.toString());
-        }
+        server.startServer("WebServiceRefTest.log");
 
         // Pause for application to start successfully
         server.waitForStringInLog("CWWKZ0001I.*helloServer");


### PR DESCRIPTION
This PR removes an unnecessary try/catcch block in `WebServiceRefTest.setup()`