### PR TITLE
grpc: moved flush to after asynch.ctx.complete

### DIFF
--- a/dev/io.openliberty.grpc.1.0.internal/src/io/grpc/servlet/ServletServerStream.java
+++ b/dev/io.openliberty.grpc.1.0.internal/src/io/grpc/servlet/ServletServerStream.java
@@ -243,7 +243,7 @@ final class ServletServerStream extends AbstractServerStream {
         cancel(Status.fromThrowable(e));
       }
     }
-    
+
     @Override
     public void writeFrame(
     		@Nullable 
@@ -285,7 +285,7 @@ final class ServletServerStream extends AbstractServerStream {
             "[{0}] writeTrailers: {1}, headersSent = {2}, status = {3}",
             new Object[] {logId, trailers, headersSent, status});
       }
-     
+      
       if (!headersSent) {
         writeHeadersToServletResponse(trailers);
       } else {
@@ -297,15 +297,15 @@ final class ServletServerStream extends AbstractServerStream {
           trailerSupplier.get().putIfAbsent(key, newValue);
         }
       }
+
+      writer.complete();
       
       try {
-          writer.flush();
+        writer.flush();
       } catch (IOException e) {
-          logger.log(WARNING, String.format("[{%s}] Exception when flushBuffer", logId), e);
-          cancel(Status.fromThrowable(e));
+    	logger.log(WARNING, String.format("[{%s}] Exception when flushBuffer", logId), e);
       }
-      
-      writer.complete();
+
     }
 
     @Override


### PR DESCRIPTION
com.ibm.ws.fat.grpc.ServiceConfigTests:java.lang.Exception: Errors/warnings were found in server GrpcServerOnly logs:
<br>[9/16/23, 6:24:00:106 PDT] 000000a0 com.ibm.ws.webcontainer31.async.AsyncContext31Impl           E SRVE9015E: Cannot obtain the request or response object after an AsyncContext.dispatch() or AsyncContext.complete().
