### PR TITLE
Enable session property ConnectionRetryCount

### DIFF
--- a/dev/com.ibm.ws.session.db/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.session.db/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -67,6 +67,9 @@ only.check.in.cache.during.pre.invoke.desc=A value of true indicates that the la
 
 optimize.cache.id.increments=Optimize cache identifier increments
 optimize.cache.id.increments.desc=If the user's browser session is moving back and forth across multiple web applications, you might see extra persistent store activity as the in-memory sessions for a web module are refreshed from the persistent store. As a result, the cache identifiers are continually increasing and the in-memory session attributes are overwritten by those of the persistent copy.  Set this property to true if you want to prevent the cache identifiers from continually increasing. A value of true indicates that the session manager should assess whether the in-memory session for a web module is older than the copy in persistent store. If the configuration is a cluster, ensure that the system times of each cluster member are as identical as possible.
+
+connection.retry.count.name=Database connection retry attempt
+connection.retry.count.desc=Use this property to select the number of retry attempts on a database connection. The default value for this property is 2. For example, when ConnectionRetryCount set to 0, the session manager attempts a database connection once only, with no retry attempt.
 
 table.name=Table name
 table.name.desc=The database table name.

--- a/dev/com.ibm.ws.session.db/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.session.db/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2012, 2021 IBM Corporation and others.
+    Copyright (c) 2012, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -124,6 +124,12 @@
             description="%optimize.cache.id.increments.desc" 
             ibmui:group="advanced.performance"
             required="false" type="Boolean" default="true"/>
+            
+        <AD id="connectionRetryCount" 
+            name="%connection.retry.count.name" 
+            description="%connection.retry.count.desc" 
+            ibmui:group="advanced.performance"
+            required="false" type="Integer" default="2"/>    
         
         <!-- ibmui:group=db2 -->
         <AD id="db2RowSize" 


### PR DESCRIPTION
Session property ConnectionRetryCount is not visible on  httpSessionDatabase configuration, enable the property in Liberty Kernel configuration metatype.xml.

WebSphere Application Server document for ConnectionRetryCount 
https://www.ibm.com/docs/en/was-nd/9.0.5?topic=tracking-session-management-custom-properties#ConnectionRetryCount