### PR TITLE
initial steps for query by method parameters

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1962,6 +1962,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
     private void generateWhereClause(QueryInfo queryInfo, StringBuilder q) {
         Parameter[] params = queryInfo.method.getParameters();
 
+        // TODO reject special parameters on methods other than find with a meaningful error
         int numQueryConditions = params.length;
         while (numQueryConditions > 0 && SPECIAL_PARAM_TYPES.contains(params[numQueryConditions - 1].getType()))
             numQueryConditions--;

--- a/dev/io.openliberty.data.internal_fat/build.gradle
+++ b/dev/io.openliberty.data.internal_fat/build.gradle
@@ -26,3 +26,9 @@ dependencies {
   requiredLibs project(':io.openliberty.data')
   requiredLibs project(':io.openliberty.jakarta.data.1.0')
 }
+
+apply plugin: 'java'
+
+compileJava {
+  options.compilerArgs << '-parameters'
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -571,6 +571,17 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Count method that uses the query-by-parameters pattern.
+     */
+    @Test
+    public void testCountQueryByParameters() {
+        assertEquals(1, primes.count(1, true));
+        assertEquals(0, primes.count(1, false));
+        assertEquals(0, primes.count(2, true));
+        assertEquals(3, primes.count(2, false));
+    }
+
+    /**
      * Count the number of matching entries in the database using annotatively defined queries.
      */
     @Test
@@ -898,6 +909,25 @@ public class DataTestServlet extends FATServlet {
 
         // Query and order by embeddable attributes
 
+        List<House> list = houses.findWithGarageDoorDimensions(12, 8);
+        assertEquals(1, list.size());
+        h = list.get(0);
+        assertEquals("TestEmbeddable-204-2992-20", h.parcelId);
+        assertEquals(2000, h.area);
+        assertNotNull(h.garage);
+        assertEquals(220, h.garage.area);
+        assertEquals(Garage.Type.Detached, h.garage.type);
+        assertNotNull(h.garage.door);
+        assertEquals(8, h.garage.door.getHeight());
+        assertEquals(12, h.garage.door.getWidth());
+        assertNotNull(h.kitchen);
+        assertEquals(16, h.kitchen.length);
+        assertEquals(13, h.kitchen.width);
+        assertEquals(0.18f, h.lotSize, 0.001f);
+        assertEquals(4, h.numBedrooms);
+        assertEquals(188000f, h.purchasePrice, 0.001f);
+        assertEquals(Year.of(2020), h.sold);
+
         List<House> found = houses.findByGarageTypeOrderByGarageDoorWidthDesc(Garage.Type.Detached);
         assertEquals(found.toString(), 2, found.size());
 
@@ -1084,6 +1114,16 @@ public class DataTestServlet extends FATServlet {
         assertEquals(true, primes.anyLessThanEndingWithBitPattern(25L, "1101"));
         assertEquals(false, primes.anyLessThanEndingWithBitPattern(25L, "1111"));
         assertEquals(false, primes.anyLessThanEndingWithBitPattern(12L, "1101"));
+    }
+
+    /**
+     * Exists method that uses the query-by-parameters pattern.
+     */
+    @Test
+    public void testExistsQueryByParameters() {
+        assertEquals(true, primes.existsWith(47, "2F"));
+        assertEquals(false, primes.existsWith(41, "2F")); // 2F is not hex for 41 decimal
+        assertEquals(false, primes.existsWith(15, "F")); // not prime
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1601,6 +1601,28 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Find method that uses the query-by-parameter name pattern.
+     */
+    @Test
+    public void testFindQueryByParameters() {
+        Prime prime = primes.findHexadecimal("2B").orElseThrow();
+        assertEquals(43, prime.numberId);
+        assertEquals(false, prime.even);
+        assertEquals("2B", prime.hex);
+        assertEquals("forty-three", prime.name);
+        assertEquals("XLIII", prime.romanNumeral);
+        assertEquals(List.of("X", "L", "I", "I", "I"), prime.romanNumeralSymbols);
+        assertEquals(4, prime.sumOfBits);
+
+        assertEquals(false, primes.findHexadecimal("2A").isPresent());
+
+        assertEquals(List.of("thirty-seven", "thirteen", "seven", "nineteen"),
+                     primes.find(false, 3, Limit.of(4), Sort.asc("even"), Sort.desc("name"))
+                                     .map(p -> p.name)
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
      * Find a subset of attributes of the entity.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -563,9 +563,9 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(15, primes.countByIdLessThan(50));
 
-        assertEquals(Integer.valueOf(0), primes.countNumberIdBetween(32, 36));
+        assertEquals(Integer.valueOf(0), primes.countByNumberIdBetween(32, 36));
 
-        assertEquals(Integer.valueOf(3), primes.countNumberIdBetween(40, 50));
+        assertEquals(Integer.valueOf(3), primes.countByNumberIdBetween(40, 50));
 
         assertEquals(Short.valueOf((short) 14), primes.countByIdBetweenAndEvenNot(0, 50, true).get(TIMEOUT_MINUTES, TimeUnit.MINUTES));
     }
@@ -1072,8 +1072,8 @@ public class DataTestServlet extends FATServlet {
         assertEquals(true, primes.existsByNumberId(19));
         assertEquals(false, primes.existsByNumberId(9));
 
-        assertEquals(Boolean.TRUE, primes.existsIdBetween(Long.valueOf(14), Long.valueOf(18)));
-        assertEquals(Boolean.FALSE, primes.existsIdBetween(Long.valueOf(24), Long.valueOf(28)));
+        assertEquals(Boolean.TRUE, primes.existsByIdBetween(Long.valueOf(14), Long.valueOf(18)));
+        assertEquals(Boolean.FALSE, primes.existsByIdBetween(Long.valueOf(24), Long.valueOf(28)));
     }
 
     /**
@@ -1313,13 +1313,13 @@ public class DataTestServlet extends FATServlet {
         remaining.addAll(Set.of(80008, 80080, 80081, 80088));
 
         Sort sort = supportsOrderByForUpdate ? Sort.desc("width") : null;
-        Integer id = packages.deleteFirst(sort).orElseThrow();
+        Integer id = packages.deleteFirstBy(sort).orElseThrow();
         if (supportsOrderByForUpdate)
             assertEquals(Integer.valueOf(80080), id);
         assertEquals("Found " + id + "; expected one of " + remaining, true, remaining.remove(id));
 
         Sort[] sorts = supportsOrderByForUpdate ? new Sort[] { Sort.desc("height"), Sort.asc("length") } : null;
-        int[] ids = packages.deleteFirst2(sorts);
+        int[] ids = packages.deleteFirst2By(sorts);
         assertEquals(Arrays.toString(ids), 2, ids.length);
         if (supportsOrderByForUpdate) {
             assertEquals(80081, ids[0]);
@@ -1329,7 +1329,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals("Found " + ids[1] + "; expected one of " + remaining, true, remaining.remove(ids[1]));
 
         // should have only 1 remaining
-        ids = packages.deleteFirst2(sorts);
+        ids = packages.deleteFirst2By(sorts);
         assertEquals(Arrays.toString(ids), 1, ids.length);
         assertEquals(remaining.iterator().next(), Integer.valueOf(ids[0]));
     }
@@ -1478,7 +1478,7 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testFindFirstWithoutBy() {
-        Prime first = primes.findFirst(Sort.asc("numberId"));
+        Prime first = primes.findFirst(Sort.asc("numberId"), Limit.of(1));
         assertEquals(2, first.numberId);
     }
 
@@ -1605,7 +1605,7 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testFindSubsetOfAttributes() {
-        List<Object[]> all = primes.findIdAndName(Sort.asc("numberId"));
+        List<Object[]> all = primes.findIdAndNameBy(Sort.asc("numberId"));
 
         Object[] idAndName = all.get(5);
         assertEquals(13L, idAndName[0]);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -678,6 +678,98 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Delete method that uses the query-by-parameters pattern.
+     */
+    @Test
+    public void testDeleteQueryByParameters() {
+        houses.deleteAll();
+
+        House h1 = new House();
+        h1.area = 1600;
+        h1.garage = new Garage();
+        h1.garage.area = 190;
+        h1.garage.door = new GarageDoor();
+        h1.garage.door.setHeight(9);
+        h1.garage.door.setWidth(9);
+        h1.garage.type = Garage.Type.Detached;
+        h1.kitchen = new Kitchen();
+        h1.kitchen.length = 14;
+        h1.kitchen.width = 13;
+        h1.lotSize = 0.16f;
+        h1.numBedrooms = 2;
+        h1.parcelId = "TestDeleteQueryByParameters-1";
+        h1.purchasePrice = 116000;
+        h1.sold = Year.of(2016);
+        houses.insert(h1);
+
+        House h2 = new House();
+        h2.area = 2200;
+        h2.garage = new Garage();
+        h2.garage.area = 230;
+        h2.garage.door = new GarageDoor();
+        h2.garage.door.setHeight(9);
+        h2.garage.door.setWidth(10);
+        h2.garage.type = Garage.Type.Attached;
+        h2.kitchen = new Kitchen();
+        h2.kitchen.length = 14;
+        h2.kitchen.width = 18;
+        h2.lotSize = 0.22f;
+        h2.numBedrooms = 5;
+        h2.parcelId = "TestDeleteQueryByParameters-2";
+        h2.purchasePrice = 212000;
+        h2.sold = Year.of(2022);
+        houses.insert(h2);
+
+        House h3 = new House();
+        h3.area = 1300;
+        h3.kitchen = new Kitchen();
+        h3.kitchen.length = 13;
+        h2.kitchen.width = 12;
+        h3.lotSize = 0.13f;
+        h3.numBedrooms = 2;
+        h3.parcelId = "TestDeleteQueryByParameters-3";
+        h3.purchasePrice = 83000;
+        h3.sold = Year.of(2013);
+        houses.insert(h3);
+
+        House h4 = new House();
+        h4.area = 2400;
+        h4.garage = new Garage();
+        h4.garage.area = 240;
+        h4.garage.door = new GarageDoor();
+        h4.garage.door.setHeight(9);
+        h4.garage.door.setWidth(12);
+        h4.garage.type = Garage.Type.Detached;
+        h4.kitchen = new Kitchen();
+        h4.kitchen.length = 17;
+        h4.kitchen.width = 14;
+        h4.lotSize = 0.24f;
+        h4.numBedrooms = 5;
+        h4.parcelId = "TestDeleteQueryByParameters-4";
+        h4.purchasePrice = 144000;
+        h4.sold = Year.of(2014);
+        houses.insert(h4);
+
+        assertEquals(2, houses.deleteBasedOnGarage(Garage.Type.Detached, 9));
+
+        House h = houses.remove("TestDeleteQueryByParameters-2").orElseThrow();
+        assertEquals(2200, h.area);
+        assertEquals(230, h.garage.area);
+        assertEquals(9, h.garage.door.getHeight());
+        assertEquals(10, h.garage.door.getWidth());
+        assertEquals(Garage.Type.Attached, h.garage.type);
+        assertEquals(14, h.kitchen.length);
+        assertEquals(18, h.kitchen.width);
+        assertEquals(0.22f, h.lotSize, 0.001f);
+        assertEquals(5, h.numBedrooms);
+        assertEquals("TestDeleteQueryByParameters-2", h.parcelId);
+        assertEquals(212000, h.purchasePrice, 0.001);
+        assertEquals(Year.of(2022), h.sold);
+
+        assertEquals(1, houses.deleteAll());
+    }
+
+    /**
      * Query for distinct values of an attribute.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
@@ -52,6 +52,8 @@ public interface Houses {
     @OrderBy("area")
     DoubleStream findPurchasePriceByLotSizeGreaterThan(float minLotSize);
 
+    List<House> findWithGarageDoorDimensions(int garage_door_width, int garage_door_height);
+
     List<House> save(House... h);
 
     boolean updateByIdSetGarageAddAreaAddKitchenLengthSetNumBedrooms(String parcel, Garage updatedGarage, int addedArea, int addedKitchenLength, int newNumBedrooms);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
@@ -29,6 +29,8 @@ import jakarta.data.repository.Sort;
 public interface Houses {
     long deleteAll();
 
+    int deleteBasedOnGarage(Garage.Type garage_type, int garage_door_height);
+
     long deleteById(String parcel);
 
     long deleteByKitchenWidthGreaterThan(int widthAbove);
@@ -53,6 +55,10 @@ public interface Houses {
     DoubleStream findPurchasePriceByLotSizeGreaterThan(float minLotSize);
 
     List<House> findWithGarageDoorDimensions(int garage_door_width, int garage_door_height);
+
+    void insert(House h);
+
+    Optional<House> remove(String parcelId);
 
     List<House> save(House... h);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -46,9 +46,9 @@ public interface Packages extends PageableRepository<Package, Integer> {
 
     Package[] deleteByDescriptionEndsWith(String ending, Sort... sorts);
 
-    Optional<Integer> deleteFirst(Sort sort);
+    Optional<Integer> deleteFirstBy(Sort sort);
 
-    int[] deleteFirst2(Sort... sorts);
+    int[] deleteFirst2By(Sort... sorts);
 
     LinkedList<?> deleteFirst2ByHeightLessThan(float maxHeight, Sort... sorts);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -64,7 +64,7 @@ public interface Primes {
     @Asynchronous
     CompletableFuture<Short> countByIdBetweenAndEvenNot(long first, long last, boolean isOdd);
 
-    Integer countNumberIdBetween(long first, long last);
+    Integer countByNumberIdBetween(long first, long last);
 
     @Query("SELECT p.numberId FROM Prime p WHERE p.numberId >= ?1 AND p.numberId <= ?2")
     long findAsLongBetween(long min, long max);
@@ -175,7 +175,7 @@ public interface Primes {
     @OrderBy("name")
     Slice<Prime> findByRomanNumeralStartsWithAndIdLessThan(String prefix, long max, Pageable pagination);
 
-    Prime findFirst(Sort sort);
+    Prime findFirst(Sort sort, Limit limitOf1);
 
     Stream<Prime> findFirst2147483648ByIdGreaterThan(long min); // Exceeds Integer.MAX_VALUE by 1
 
@@ -184,7 +184,7 @@ public interface Primes {
 
     Prime findFirstByNameLikeOrderByNumberId(String namePattern);
 
-    List<Object[]> findIdAndName(Sort... sort);
+    List<Object[]> findIdAndNameBy(Sort... sort);
 
     @OrderBy(value = "id", descending = true)
     Set<Long> findIdByIdBetween(long min, long max);
@@ -194,7 +194,7 @@ public interface Primes {
 
     boolean existsByNumberId(long number);
 
-    Boolean existsIdBetween(Long first, Long last);
+    Boolean existsByIdBetween(Long first, Long last);
 
     @Count
     @Filter(by = "id", op = Compare.GreaterThanEqual)

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -66,6 +66,8 @@ public interface Primes {
 
     Integer countByNumberIdBetween(long first, long last);
 
+    Stream<Prime> find(boolean even, int sumOfBits, Limit limit, Sort... sorts);
+
     @Query("SELECT p.numberId FROM Prime p WHERE p.numberId >= ?1 AND p.numberId <= ?2")
     long findAsLongBetween(long min, long max);
 
@@ -183,6 +185,8 @@ public interface Primes {
     Prime[] findFirst5ByIdLessThanEqual(long maxNumber);
 
     Prime findFirstByNameLikeOrderByNumberId(String namePattern);
+
+    Optional<Prime> findHexadecimal(String hex);
 
     List<Object[]> findIdAndNameBy(Sort... sort);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -59,12 +59,16 @@ public interface Primes {
     @Filter(by = "numberId", op = Compare.LessThan, param = "max")
     boolean anyLessThanEndingWithBitPattern(@Param("max") long upperLimit, @Param("bits") String pattern);
 
+    int count(int sumOfBits, boolean even);
+
     long countByIdLessThan(long number);
 
     @Asynchronous
     CompletableFuture<Short> countByIdBetweenAndEvenNot(long first, long last, boolean isOdd);
 
     Integer countByNumberIdBetween(long first, long last);
+
+    boolean existsWith(long id, String hex);
 
     Stream<Prime> find(boolean even, int sumOfBits, Limit limit, Sort... sorts);
 


### PR DESCRIPTION
This pull includes some initial steps for query by parameters.
Some method names in tests are renamed to become consistent with either query-by-method name or query-by-parameters.
Basic updates are included to identify whether query-by-method vs query-by-parameters is wanted, with the query-by-parameters processing set up to the point of identifying if parameters are present and allowing some basic operations.