### PR TITLE
UtilsChainListener waitOnChains does not wait

### DIFF
--- a/dev/com.ibm.ws.channelfw/src/com/ibm/websphere/channelfw/ChannelUtils.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/websphere/channelfw/ChannelUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2026 IBM Corporation and others.
+ * Copyright (c) 2009, 2014 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -926,8 +926,8 @@ public final class ChannelUtils extends ChannelUtilsBase {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "Quick check to see if chains stopped immediately");
         }
-        // Quick check (1 second) to see if chains stopped immediately
-        listener.checkChainsQuickly(quiesceTimeout);
+        // Remove stopped chains.
+        listener.cleanUpChains(quiesceTimeout);
     }
 
     /**

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/websphere/channelfw/ChannelUtils.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/websphere/channelfw/ChannelUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corporation and others.
+ * Copyright (c) 2009, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/websphere/channelfw/ChannelUtils.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/websphere/channelfw/ChannelUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corporation and others.
+ * Copyright (c) 2009, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -909,10 +909,10 @@ public final class ChannelUtils extends ChannelUtilsBase {
                 Runnable runner = new Runnable() {
                     @Override
                     public void run() {
-                        // wait for the quiesce time to expire
-                        listener.waitOnChains(quiesceTimeout);
-
-                        // call the runnable to finish cleanup activity.
+                        // Wait for chains to actually stop (or timeout)
+                        listener.waitForChainsToStop(quiesceTimeout);
+                        
+                        // Chains are now stopped (or timeout expired), run cleanup
                         runOnStop.run();
                     }
                 };
@@ -924,10 +924,10 @@ public final class ChannelUtils extends ChannelUtilsBase {
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "Waiting for chains to stop");
+            Tr.debug(tc, "Quick check to see if chains stopped immediately");
         }
-        // wait for the quiesce time to expire
-        listener.waitOnChains(quiesceTimeout);
+        // Quick check (1 second) to see if chains stopped immediately
+        listener.checkChainsQuickly(quiesceTimeout);
     }
 
     /**

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corporation and others.
+ * Copyright (c) 2009, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -56,7 +56,7 @@ public class UtilsChainListener {
 
         ChannelFramework cf = ChannelFrameworkFactory.getChannelFramework();
         int elapsedTime = 0;
-        if (waitingChainNames.size() > 0 && elapsedTime < quiesceTimeout) {
+        while (waitingChainNames.size() > 0 && elapsedTime < quiesceTimeout) {
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
                 Tr.event(this, tc, "Waiting on " + waitingChainNames.size() + " chain(s) to stop");
@@ -75,7 +75,5 @@ public class UtilsChainListener {
             elapsedTime += 1000;
 
         }
-
     }
-
 }

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
@@ -78,16 +78,16 @@ public class UtilsChainListener {
             return;
         }
         
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(this, tc, "Quick check: " + waitingChainNames.size() + " chain(s) may still be quiescing");
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(this, tc, "Quick check: " + waitingChainNames.size() + " chain(s) may still be quiescing");
         }
         
         // Remove any chains that already stopped
         removeStoppedChains();
         
         if (waitingChainNames.isEmpty()) {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(this, tc, "All chains already stopped");
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "All chains already stopped");
             }
             return;
         }
@@ -101,8 +101,8 @@ public class UtilsChainListener {
             final long pollInterval = 100;   // Poll every 100ms
             long elapsedTime = 0;
             
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(this, tc, "Polling for up to " + maxWaitTime + "ms for chains to stop");
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "Polling for up to " + maxWaitTime + "ms for chains to stop");
             }
             
             while (elapsedTime < maxWaitTime && !waitingChainNames.isEmpty()) {
@@ -118,8 +118,8 @@ public class UtilsChainListener {
             }
         }
         
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(this, tc, "After quick check: " + waitingChainNames.size() + " chain(s) still quiescing");
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(this, tc, "After quick check: " + waitingChainNames.size() + " chain(s) still quiescing");
         }
     }
 
@@ -152,8 +152,8 @@ public class UtilsChainListener {
             return;
         }
         
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(this, tc, "Waiting for " + waitingChainNames.size() + " chain(s) to stop");
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(this, tc, "Waiting for " + waitingChainNames.size() + " chain(s) to stop");
         }
 
         long startTime = System.nanoTime();
@@ -178,11 +178,11 @@ public class UtilsChainListener {
             
         } while (true);        
         
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             if (waitingChainNames.isEmpty()) {
-                Tr.event(this, tc, "All chains stopped after " + elapsedTime + " ns");
+                Tr.debug(this, tc, "All chains stopped after " + elapsedTime + " ns");
             } else {
-                Tr.event(this, tc, "Timeout expired, " + waitingChainNames.size() + " chain(s) still running");
+                Tr.debug(this, tc, "Timeout expired, " + waitingChainNames.size() + " chain(s) still running");
             }
         }
     }

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
@@ -49,16 +49,18 @@ public class UtilsChainListener {
 
     /**
      * Perform a quick check (up to 1 second) to see if any chains stopped immediately.
+     * Remove any chains found to be stopped.
      * This does not wait for the full chainQuiesceTimeout.
      * Chains that are still quiescing will be forcefully stopped by StopChainTask
      * when the chainQuiesceTimeout expires.
      *
-     * @param chainQuiesceTimeout If <= 1000ms, skips the check (not worth waiting).
-     *                            If > 1000ms, waits 1 second to see if chains stop quickly.
+     * @param chainQuiesceTimeout Determines if we should pause for a second.
+     *                            If 1 second or less, just do a quick check with no delay.
+     *
      */
-    public void checkChainsQuickly(long chainQuiesceTimeout) {
-        // If timeout is <= 1 second, don't bother.
-        if (chainQuiesceTimeout <= 1000 || waitingChainNames.isEmpty()) {
+    public void cleanUpChains(long chainQuiesceTimeout) {
+
+        if (waitingChainNames.isEmpty()) {
             return;
         }
         
@@ -66,15 +68,30 @@ public class UtilsChainListener {
             Tr.event(this, tc, "Quick check: " + waitingChainNames.size() + " chain(s) may still be quiescing");
         }
         
-        // Give chains 1 second to stop quickly
+        // Remove any chains that already stopped
+        removeStoppedChains();
+        
+        if (waitingChainNames.isEmpty() || chainQuiesceTimeout <= 1000) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                if (waitingChainNames.isEmpty()) {
+                    Tr.event(this, tc, "All chains already stopped");
+                } else {
+                    Tr.event(this, tc, "Skipping 1-second wait (timeout too short)");
+                }
+            }
+            return;
+        }
+
+        
+        // Give chains 1 second to stop
         try {
             Thread.sleep(1000);
         } catch (InterruptedException ie) {
             // ignore
         }
         
-        // Check which chains stopped during the 1 second wait
-        allChainsStopped();  // This updates the internal list
+        // Remove chains that stopped during the wait
+        removeStoppedChains();
         
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(this, tc, "After quick check: " + waitingChainNames.size() + " chain(s) still quiescing");
@@ -82,54 +99,63 @@ public class UtilsChainListener {
     }
 
     /**
-     * Check if all watched chains have stopped.
-     *
-     * @return true if all chains are no longer running, false otherwise
+     * Remove stopped chains from the watch list.
      */
-    public boolean allChainsStopped() {
+    private void removeStoppedChains() {
         if (waitingChainNames.isEmpty()) {
-            return true;
+            return;
         }
         
         ChannelFramework cf = ChannelFrameworkFactory.getChannelFramework();
-        for (String chainName : waitingChainNames) {
-            if (cf.isChainRunning(chainName)) {
-                return false;  // At least one chain still running
+        Iterator<String> iter = waitingChainNames.iterator();
+        while (iter.hasNext()) {
+            if (!cf.isChainRunning(iter.next())) {
+                iter.remove();
             }
         }
-        return true;  // All chains stopped
     }
 
     /**
      * Wait for all watched chains to stop, polling periodically.
      * This method blocks until either all chains have stopped or the timeout expires.
+     * Stopped chains are removed from the list.
      *
      * @param chainQuiesceTimeout Maximum time to wait in milliseconds
      */
     public void waitForChainsToStop(long chainQuiesceTimeout) {
-        if (chainQuiesceTimeout <= 0 || waitingChainNames.isEmpty()) {
+        if (waitingChainNames.isEmpty()) {
             return;
         }
-        
-        long startNanos = System.nanoTime();
-        long timeoutNanos = chainQuiesceTimeout * 1_000_000L;  // Convert ms to ns
         
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(this, tc, "Waiting for " + waitingChainNames.size() + " chain(s) to stop");
         }
-        
-        // Keep checking if all chains have stopped
-        while ((System.nanoTime() - startNanos) < timeoutNanos && !allChainsStopped()) {
+
+        long startTime = System.nanoTime();
+        long expireTime = chainQuiesceTimeout * 1_000_000L;  // Convert ms to ns
+        long elapsedTime = System.nanoTime() - startTime;
+               
+        // Always cleanup at least once, then keep checking until timeout or all chains stopped
+        do {
+            removeStoppedChains();  // Remove chains that have stopped
+            
+            if (waitingChainNames.isEmpty() || (elapsedTime >= expireTime)) {
+                break;  // All chains stopped, or timeout expired
+            }
+            
             try {
                 Thread.sleep(100);  // Poll every 100ms
             } catch (InterruptedException ie) {
                 break;
             }
-        }
+            elapsedTime = System.nanoTime() - startTime;
+        } while (true);
+        
+        elapsedTime = System.nanoTime() - startTime;
         
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            if (allChainsStopped()) {
-                Tr.event(this, tc, "All chains stopped");
+            if (waitingChainNames.isEmpty()) {
+                Tr.event(this, tc, "All chains stopped after " + elapsedTime + " ns");
             } else {
                 Tr.event(this, tc, "Timeout expired, " + waitingChainNames.size() + " chain(s) still running");
             }

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
@@ -147,12 +147,11 @@ public class UtilsChainListener {
             try {
                 Thread.sleep(100);  // Poll every 100ms
             } catch (InterruptedException ie) {
+                elapsedTime = System.nanoTime() - startTime;  // Update for trace.
                 break;
             }
             
-        } while (true);
-        
-        elapsedTime = System.nanoTime() - startTime;
+        } while (true);        
         
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             if (waitingChainNames.isEmpty()) {

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
@@ -49,16 +49,16 @@ public class UtilsChainListener {
 
     /**
      * Perform a quick check (up to 1 second) to see if any chains stopped immediately.
-     * This is a courtesy check only - does not wait for the full chainQuiesceTimeout.
+     * This does not wait for the full chainQuiesceTimeout.
      * Chains that are still quiescing will be forcefully stopped by StopChainTask
      * when the chainQuiesceTimeout expires.
      *
-     * @param chainQuiesceTimeout If 0, skips the check entirely (immediate stop requested).
-     *                            If > 0, waits 1 second to see if chains stop quickly.
+     * @param chainQuiesceTimeout If <= 1000ms, skips the check (not worth waiting).
+     *                            If > 1000ms, waits 1 second to see if chains stop quickly.
      */
     public void checkChainsQuickly(long chainQuiesceTimeout) {
-        // If timeout is 0, immediate stop was requested - don't wait at all
-        if (chainQuiesceTimeout <= 0 || waitingChainNames.isEmpty()) {
+        // If timeout is <= 1 second, don't bother.
+        if (chainQuiesceTimeout <= 1000 || waitingChainNames.isEmpty()) {
             return;
         }
         
@@ -66,21 +66,15 @@ public class UtilsChainListener {
             Tr.event(this, tc, "Quick check: " + waitingChainNames.size() + " chain(s) may still be quiescing");
         }
         
-        // Give chains 1 second to stop quickly (but only if quiesce timeout > 0)
+        // Give chains 1 second to stop quickly
         try {
             Thread.sleep(1000);
         } catch (InterruptedException ie) {
             // ignore
         }
         
-        // Remove any chains that stopped during the 1 second wait
-        ChannelFramework cf = ChannelFrameworkFactory.getChannelFramework();
-        Iterator<String> iter = waitingChainNames.iterator();
-        while (iter.hasNext()) {
-            if (!cf.isChainRunning(iter.next())) {
-                iter.remove();
-            }
-        }
+        // Check which chains stopped during the 1 second wait
+        allChainsStopped();  // This updates the internal list
         
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(this, tc, "After quick check: " + waitingChainNames.size() + " chain(s) still quiescing");

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
@@ -48,14 +48,28 @@ public class UtilsChainListener {
     }
 
     /**
-     * Perform a quick check (up to 1 second) to see if any chains stopped immediately.
+     * Perform a quick check (up to 1 second) to see if chains stopped.
      * Remove any chains found to be stopped.
      * This does not wait for the full chainQuiesceTimeout.
      * Chains that are still quiescing will be forcefully stopped by StopChainTask
      * when the chainQuiesceTimeout expires.
+     * <p>
+     * Previously this code had a 1-second sleep AFTER attempting to remove stopped chains.
+     * It only attempted to remove chains once. The updated code still uses the arbitrary
+     * 1-second maximum wait, but adds polling and retries, which allows it to finish early,
+     * and has a better chance of returning with all stopped chains removed.
+     * <p>
+     * It seems that it would be better for the caller to call method waitForChainsToStop()
+     * but that causes test cases to fail which didn't fail before. That needs to be investigated,
+     * but the updated code below shouldn't cause any issues.
+     * <p>
+     * Why use a maxWaitTime of 1 second, rather than just use the timeout? There is a test case,
+     * which is probably unrealistic. It sets the chainQuiesceTimeout to 250ms. That window is
+     * too small for the chains to be removed consistently within the time frame. In practice, it
+     * probably doesn't make sense to set the chainQuiesceTimeout less than the server quiesceTimeout.
      *
-     * @param chainQuiesceTimeout Determines if we should pause for a second.
-     *                            If 1 second or less, just do a quick check with no delay.
+     * @param chainQuiesceTimeout Determines if we should wait for chains to stop.
+     *                            If 0 or less, just do an immediate check with no delay.
      *
      */
     public void cleanUpChains(long chainQuiesceTimeout) {
@@ -71,27 +85,38 @@ public class UtilsChainListener {
         // Remove any chains that already stopped
         removeStoppedChains();
         
-        if (waitingChainNames.isEmpty() || chainQuiesceTimeout <= 1000) {
+        if (waitingChainNames.isEmpty()) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                if (waitingChainNames.isEmpty()) {
-                    Tr.event(this, tc, "All chains already stopped");
-                } else {
-                    Tr.event(this, tc, "Skipping 1-second wait (timeout too short)");
-                }
+                Tr.event(this, tc, "All chains already stopped");
             }
             return;
         }
 
-        
-        // Give chains 1 second to stop
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException ie) {
-            // ignore
+        //
+        // Poll for chains to stop, up to a maximum of 1 second 
+        // Note: This wait time is independent of chainQuiesceTimeout, which controls
+        // when StopChainTask forcefully stops chains
+        if (chainQuiesceTimeout > 0) {
+            final long maxWaitTime = 1000;  // Maximum time to wait in milliseconds
+            final long pollInterval = 100;   // Poll every 100ms
+            long elapsedTime = 0;
+            
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                Tr.event(this, tc, "Polling for up to " + maxWaitTime + "ms for chains to stop");
+            }
+            
+            while (elapsedTime < maxWaitTime && !waitingChainNames.isEmpty()) {
+                try {
+                    Thread.sleep(pollInterval);
+                    elapsedTime += pollInterval;
+                } catch (InterruptedException ie) {
+                    break;
+                }
+                
+                // Remove chains that stopped during this poll interval
+                removeStoppedChains();
+            }
         }
-        
-        // Remove chains that stopped during the wait
-        removeStoppedChains();
         
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(this, tc, "After quick check: " + waitingChainNames.size() + " chain(s) still quiescing");

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
@@ -133,12 +133,13 @@ public class UtilsChainListener {
 
         long startTime = System.nanoTime();
         long expireTime = chainQuiesceTimeout * 1_000_000L;  // Convert ms to ns
-        long elapsedTime = System.nanoTime() - startTime;
+        long elapsedTime;
                
         // Always cleanup at least once, then keep checking until timeout or all chains stopped
         do {
             removeStoppedChains();  // Remove chains that have stopped
             
+            elapsedTime = System.nanoTime() - startTime;
             if (waitingChainNames.isEmpty() || (elapsedTime >= expireTime)) {
                 break;  // All chains stopped, or timeout expired
             }
@@ -148,7 +149,7 @@ public class UtilsChainListener {
             } catch (InterruptedException ie) {
                 break;
             }
-            elapsedTime = System.nanoTime() - startTime;
+            
         } while (true);
         
         elapsedTime = System.nanoTime() - startTime;

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
@@ -102,7 +102,7 @@ public class UtilsChainListener {
             long elapsedTime = 0;
             
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(this, tc, "Polling for up to " + maxWaitTime + "ms for chains to stop");
+                Tr.event(this, tc, "Waiting on " + waitingChainNames.size() + " chain(s) to stop");
             }
             
             while (elapsedTime < maxWaitTime && !waitingChainNames.isEmpty()) {

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2023 IBM Corporation and others.
+ * Copyright (c) 2009, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- *
+ * 
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -48,32 +48,98 @@ public class UtilsChainListener {
     }
 
     /**
-     * Poll the list of chains until they're stopped or the quiesce timeout is hit
+     * Perform a quick check (up to 1 second) to see if any chains stopped immediately.
+     * This is a courtesy check only - does not wait for the full chainQuiesceTimeout.
+     * Chains that are still quiescing will be forcefully stopped by StopChainTask
+     * when the chainQuiesceTimeout expires.
      *
-     * @param quiesceTimeout
+     * @param chainQuiesceTimeout If 0, skips the check entirely (immediate stop requested).
+     *                            If > 0, waits 1 second to see if chains stop quickly.
      */
-    public void waitOnChains(long quiesceTimeout) {
-
+    public void checkChainsQuickly(long chainQuiesceTimeout) {
+        // If timeout is 0, immediate stop was requested - don't wait at all
+        if (chainQuiesceTimeout <= 0 || waitingChainNames.isEmpty()) {
+            return;
+        }
+        
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+            Tr.event(this, tc, "Quick check: " + waitingChainNames.size() + " chain(s) may still be quiescing");
+        }
+        
+        // Give chains 1 second to stop quickly (but only if quiesce timeout > 0)
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ie) {
+            // ignore
+        }
+        
+        // Remove any chains that stopped during the 1 second wait
         ChannelFramework cf = ChannelFrameworkFactory.getChannelFramework();
-        int elapsedTime = 0;
-        while (waitingChainNames.size() > 0 && elapsedTime < quiesceTimeout) {
-
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(this, tc, "Waiting on " + waitingChainNames.size() + " chain(s) to stop");
+        Iterator<String> iter = waitingChainNames.iterator();
+        while (iter.hasNext()) {
+            if (!cf.isChainRunning(iter.next())) {
+                iter.remove();
             }
-
-            Iterator<String> iter = waitingChainNames.iterator();
-            while (iter.hasNext()) {
-                if (!cf.isChainRunning(iter.next()))
-                    iter.remove();
-            }
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException ie) {
-                // ignore
-            }
-            elapsedTime += 1000;
-
+        }
+        
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+            Tr.event(this, tc, "After quick check: " + waitingChainNames.size() + " chain(s) still quiescing");
         }
     }
+
+    /**
+     * Check if all watched chains have stopped.
+     *
+     * @return true if all chains are no longer running, false otherwise
+     */
+    public boolean allChainsStopped() {
+        if (waitingChainNames.isEmpty()) {
+            return true;
+        }
+        
+        ChannelFramework cf = ChannelFrameworkFactory.getChannelFramework();
+        for (String chainName : waitingChainNames) {
+            if (cf.isChainRunning(chainName)) {
+                return false;  // At least one chain still running
+            }
+        }
+        return true;  // All chains stopped
+    }
+
+    /**
+     * Wait for all watched chains to stop, polling periodically.
+     * This method blocks until either all chains have stopped or the timeout expires.
+     *
+     * @param chainQuiesceTimeout Maximum time to wait in milliseconds
+     */
+    public void waitForChainsToStop(long chainQuiesceTimeout) {
+        if (chainQuiesceTimeout <= 0 || waitingChainNames.isEmpty()) {
+            return;
+        }
+        
+        long startNanos = System.nanoTime();
+        long timeoutNanos = chainQuiesceTimeout * 1_000_000L;  // Convert ms to ns
+        
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+            Tr.event(this, tc, "Waiting for " + waitingChainNames.size() + " chain(s) to stop");
+        }
+        
+        // Keep checking if all chains have stopped
+        while ((System.nanoTime() - startNanos) < timeoutNanos && !allChainsStopped()) {
+            try {
+                Thread.sleep(100);  // Poll every 100ms
+            } catch (InterruptedException ie) {
+                break;
+            }
+        }
+        
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+            if (allChainsStopped()) {
+                Tr.event(this, tc, "All chains stopped");
+            } else {
+                Tr.event(this, tc, "Timeout expired, " + waitingChainNames.size() + " chain(s) still running");
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] "Fixes #26387"   It's not clear if the bug caused any noticeable problem.  So I haven't marked it as a release bug.
- [x] Not an externally known issue

### What's different

The main effect of this change is that the intended cleanup, which was supposed to occur after the chains have stopped, now actually happens. Prior to this change, the code was not actually waiting for the chains to stop.