### PR TITLE
Add brief descriptions to JSTL/Tag bundles

### DIFF
--- a/dev/com.ibm.websphere.javaee.jsp.tld.2.2/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.jsp.tld.2.2/bnd.bnd
@@ -6,14 +6,13 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.2
 -nouses=true
 
+# Contains JSTL Implementation for Tooling
+# Contained within dev/api/spec
 Bundle-SymbolicName: com.ibm.websphere.javaee.jsp.tld.2.2
 
 Export-Package: \

--- a/dev/com.ibm.websphere.javaee.jstl.1.2/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.jstl.1.2/bnd.bnd
@@ -6,13 +6,11 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+# Contains JSTL 1.2 API
 Bundle-SymbolicName: com.ibm.websphere.javaee.jstl.1.2; singleton:=true
 
 Export-Package: \

--- a/dev/com.ibm.ws.org.apache.taglibs.standard/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.taglibs.standard/bnd.bnd
@@ -6,13 +6,11 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+# Contains JSTL 1.2 implementation
 Bundle-SymbolicName: com.ibm.ws.org.apache.taglibs.standard
 Bundle-Description: JSTL Impl Version 1.2
 

--- a/dev/io.openliberty.jakarta.jstl.2.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.jstl.2.0/bnd.bnd
@@ -6,13 +6,11 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+# Contains Tags 2.0 API
 Bundle-SymbolicName: io.openliberty.jakarta.jstl.2.0; singleton:=true
 Bundle-Description: Jakarta Standard Tag Library, version 2.0
 

--- a/dev/io.openliberty.jakarta.pages.tld.3.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.pages.tld.3.0/bnd.bnd
@@ -6,14 +6,12 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 -nouses=true
 
+# Contains Tags Implementation for Tooling
 Bundle-SymbolicName: io.openliberty.jakarta.pages.tld.3.0
 Bundle-Description: Jakarta Standard Tag Library, version 2.0
 

--- a/dev/io.openliberty.jakarta.pages.tld.3.1/bnd.bnd
+++ b/dev/io.openliberty.jakarta.pages.tld.3.1/bnd.bnd
@@ -6,14 +6,12 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 -nouses=true
 
+# Contains Tags Implementation for Tooling
 Bundle-SymbolicName: io.openliberty.jakarta.pages.tld.3.1
 Bundle-Description: Jakarta Standard Tag Library, version 3.0
 

--- a/dev/io.openliberty.jakarta.servlet.jsp.jstl.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.jakarta.servlet.jsp.jstl.2.0.internal/bnd.bnd
@@ -6,13 +6,12 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+# Contains 2.0 TLD files only (No Implementation)
+# Packaged within the com.ibm.ws.jsp bundle to be used as a global tag library
 Bundle-SymbolicName: io.openliberty.jakarta.servlet.jsp.jstl.2.0.internal
 Bundle-Description: TLDs for the Jakarta Standard Tag Library; Version 2.0.0
 

--- a/dev/io.openliberty.jakarta.servlet.jsp.tags.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.jakarta.servlet.jsp.tags.3.0.internal/bnd.bnd
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -18,6 +15,8 @@ javac.target: 11
 
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 
+# Contains 3.0 TLD files only (No Implementation)
+# Packaged within the com.ibm.ws.jsp bundle to be used as a global tag library
 Bundle-SymbolicName: io.openliberty.jakarta.servlet.jsp.tags.3.0.internal
 Bundle-Description: TLDs for the Jakarta Standard Tag Library; Version 3.0.1
 

--- a/dev/io.openliberty.org.apache.taglibs.standard.3.0/bnd.bnd
+++ b/dev/io.openliberty.org.apache.taglibs.standard.3.0/bnd.bnd
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -18,6 +15,7 @@ javac.target: 11
 
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 
+# Contains Tags 3.0 implementation
 Bundle-SymbolicName: io.openliberty.org.apache.taglibs.standard.3.0
 Bundle-Description: Jakarta Standard Tag Library Implementation, version 3.0
 

--- a/dev/io.openliberty.org.apache.taglibs.standard/bnd.bnd
+++ b/dev/io.openliberty.org.apache.taglibs.standard/bnd.bnd
@@ -6,13 +6,11 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+# Contains Tags 2.0 implementation
 Bundle-SymbolicName: io.openliberty.org.apache.taglibs.standard
 Bundle-Description: Jakarta Standard Tag Library Implementation, version 2.0
 


### PR DESCRIPTION
fixes #24719

Potential follow up:

We should upload these jars to artifactory to avoid having these projects: 
- io.openliberty.jakarta.servlet.jsp.jstl.2.0.internal
- io.openliberty.jakarta.servlet.jsp.tags.3.0.internal

Similar as with the 1.2 TLD jar:

https://github.com/OpenLiberty/open-liberty/blob/b759077a53b48e299df2d696e121312d5f01cb79/dev/com.ibm.ws.jsp/bnd.bnd#L118

Downside is if we need to change them, then we might need re upload them rather than pull them from the API