### PR TITLE
Update Parsson and verify fixes

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2929,7 +2929,7 @@
     <dependency>
       <groupId>org.eclipse.parsson</groupId>
       <artifactId>parsson</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.4</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -581,7 +581,7 @@ org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.3.1
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.4.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:2.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:3.0.1
-org.eclipse.parsson:parsson:1.1.0
+org.eclipse.parsson:parsson:1.1.4
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.13
 org.eclipse.persistence:org.eclipse.persistence.asm:9.5.0
 org.eclipse.persistence:org.eclipse.persistence.core:2.7.13

--- a/dev/com.ibm.ws.jsonb_fat/build.gradle
+++ b/dev/com.ibm.ws.jsonb_fat/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     johnzonJakarta "${id.group}:${id.name}:${id.version}:jakarta"
   }
   
-  parsson 'org.eclipse.parsson:parsson:1.1.0'
+  parsson 'org.eclipse.parsson:parsson:1.1.4'
   //This is the latest implementation of yasson that uses javax packages
   yasson1 'org.eclipse:yasson:1.0.4'
   
@@ -63,7 +63,7 @@ task addJonhzonJakarta(type: Copy) {
 
 task addParrson(type: Copy) {
   from configurations.parsson
-  into "${buildDir}/autoFVT/publish/shared/resources/parsson/1.1.0/jakarta/"
+  into "${buildDir}/autoFVT/publish/shared/resources/parsson/1.1.4/jakarta/"
   rename "parsson-.*.jar", "parsson.jar"
 }
 

--- a/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/FATSuite.java
@@ -270,7 +270,7 @@ public class FATSuite {
      */
     private static void addFakeProvider(LibertyServer server) throws Exception {
         if (JakartaEEAction.isEE10OrLaterActive()) {
-            RemoteFile parsson = server.getFileFromLibertySharedDir("resources/parsson/1.1.0/jakarta/parsson.jar");
+            RemoteFile parsson = server.getFileFromLibertySharedDir("resources/parsson/1.1.4/jakarta/parsson.jar");
             Path fakeDestination = Paths.get(server.getServerSharedPath(), "resources", "fakeProvider", "1.0", "jakarta");
 
             JavaArchive fake_json_p = ShrinkWrap.create(ZipImporter.class, "fake-json-p.jar")

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -151,7 +151,7 @@
 		<dependency>
 			<groupId>org.eclipse.parsson</groupId>
 			<artifactId>parsson</artifactId>
-			<version>1.1.0</version>
+			<version>1.1.4</version>
 			<scope>system</scope>
 			<systemPath>${io.openliberty.org.eclipse.parsson.1.1}</systemPath>
 		</dependency>

--- a/dev/io.openliberty.org.eclipse.parsson.1.1/bnd.bnd
+++ b/dev/io.openliberty.org.eclipse.parsson.1.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -10,10 +10,10 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.eclipse.parsson:parsson;1.1.0;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;org.eclipse.parsson:parsson;1.1.4;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
 -includeresource: \
-   @${repo;org.eclipse.parsson:parsson;1.1.0;EXACT}!/org/eclipse/parsson/*
+   @${repo;org.eclipse.parsson:parsson;1.1.4;EXACT}!/org/eclipse/parsson/*
 
 -buildpath: \
-	org.eclipse.parsson:parsson;version=1.1.0
+	org.eclipse.parsson:parsson;version=1.1.4


### PR DESCRIPTION
Between Parsson 1.1.0 and 1.1.4 various fixes went in to ensure data integrity within the custom buffer pool implementation within Parsson.
These data integrity issues are most noticed within multi threaded environments using JsonGenerator from JSON-P, JsonParser from JSON-P, or JSON-B in general.


