### PR TITLE
jms connections may leak when connection error event is used during matchManagedConnection.

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionEventListener.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionEventListener.java
@@ -228,7 +228,7 @@ public final class ConnectionEventListener implements javax.resource.spi.Connect
         }
 
         String tempString = "state " + mcWrapper.getStateString() + " ";
-        if (mcWrapper.getState() == mcWrapper.STATE_ACTIVE_FREE) {
+        if (mcWrapper.getState() == mcWrapper.STATE_ACTIVE_FREE && mcWrapper.getPoolState() != 50) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 if (eve != null)
                     Tr.debug(this, tc, "A connection error occurred for a free mcw listener " +


### PR DESCRIPTION
The connection error event should be used when the connection is being used by the application.   But in some cases, resource adapter detect connections are bad during matchManagedConnection processing and issue the connection error event instead of throwing a resource exception.   Even though a resource exception is the best way to inform the connection management code of a failing connection, code has been added to tolerate this behavior that can cause multithreaded access to the same connection resulting in some unexpected exceptions.

This fix is for connections that remain in the pool after the connection error event was issues from matchManagedConnection.

If WAS.j2c trace is enabled, the common way to identify this problem is if this is found in the log files.

[REMOVING] MCWrapper id x Managed connection com.ibm.commerce.messaging.adapters.jcaemail.JCAEmailManagedConnection@x State:STATE_ACTIVE_FREE

and after a minute or two of logging, this entry is still occurring with the same MCWrapper id and Managed connection.

This problem will only occur with resource adapters that are calling connection error event during the call to the resource adapters matchManagedConnection method.   

