### PR TITLE
runtime update to support specifying signatureAlgorithm config option with older schema

### DIFF
--- a/dev/com.ibm.ws.wssecurity.3.4.1/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/bnd.bnd
@@ -136,18 +136,26 @@ instrument.classesExcludes: com/ibm/ws/wssecurity/resources/*.class
 	io.openliberty.wssecurity;version=latest
 	
 -testpath: \
-	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
-	com.ibm.ws.junit.extensions;version=latest,\
-	org.jmock:jmock-legacy;version='2.5.0',\
-	org.jmock:jmock-junit4;strategy=exact;version='2.5.1',\
-	org.jmock:jmock;strategy=exact;version='2.5.1',\
-	com.ibm.ws.org.objenesis:objenesis;version='1.0',\
-	cglib:cglib;version='3.3.0',\
-	com.ibm.ws.org.objectweb.asm;version=latest,\
-	org.hamcrest:hamcrest-all;version='1.3',\
-	com.ibm.ws.kernel.boot;version=latest, \
-	com.ibm.ws.componenttest.2.0,\
-	com.ibm.ws.junit.extensions,\
-	com.ibm.ws.componenttest.2.0
+    ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
+    com.ibm.ws.junit.extensions;version=latest, \
+    org.jmock:jmock-legacy;version=2.5.0, \
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest, \
+    org.hamcrest:hamcrest-all;version=1.3, \
+    org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
+    org.jmock:jmock;strategy=exact;version=2.5.1, \
+    com.ibm.ws.org.objenesis:objenesis;version=1.0, \
+    com.ibm.ws.kernel.boot;version=latest, \
+	com.ibm.ws.org.apache.cxf.rt.security.3.4.1;version=latest,\
+	com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1;version=latest,\
+	com.ibm.ws.org.apache.neethi.3.1.1;version=latest,\
+	com.ibm.ws.org.apache.santuario.xmlsec.2.2.0;version=latest,\
+	com.ibm.ws.org.apache.wss4j.ws.security.common;version=latest,\
+	com.ibm.ws.org.apache.wss4j.ws.security.dom;version=latest,\
+	com.ibm.ws.org.apache.wss4j.policy;version=latest,\
+	com.ibm.ws.org.apache.wss4j.bindings;version=latest,\
+	com.ibm.ws.org.apache.wss4j.ws.security.policy.stax;version=latest,\
+	com.ibm.ws.org.apache.wss4j.ws.security.stax;version=latest,\
+	com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2;version=latest 
 
 

--- a/dev/com.ibm.ws.wssecurity.3.4.1/build.gradle
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/build.gradle
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.lang=ALL-UNNAMED",
+              "--add-opens", "java.base/java.io=ALL-UNNAMED",
+              "--add-opens", "java.base/java.security.cert=ALL-UNNAMED",
+              "--add-opens", "java.base/java.net=ALL-UNNAMED",
+              "--add-opens", "java.base/java.util=ALL-UNNAMED"]
+}

--- a/dev/com.ibm.ws.wssecurity.3.4.1/test/com/ibm/ws/wssecurity/signature/SignatureAlgorithmsTest.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/test/com/ibm/ws/wssecurity/signature/SignatureAlgorithmsTest.java
@@ -1,0 +1,331 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.wssecurity.signature;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Collection;
+
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.ws.policy.AssertionInfo;
+import org.apache.cxf.ws.policy.AssertionInfoMap;
+import org.apache.wss4j.policy.SP12Constants;
+import org.apache.wss4j.policy.SP11Constants;
+import org.apache.wss4j.policy.SPConstants;
+import org.apache.wss4j.policy.model.AlgorithmSuite;
+import org.apache.wss4j.policy.model.AlgorithmSuite.AlgorithmSuiteType;
+import org.apache.wss4j.policy.model.AbstractBinding;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+
+import test.common.SharedOutputManager;
+
+
+/**
+*
+*/
+public class SignatureAlgorithmsTest {
+
+   private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.wssecurity.*=all");
+   @Rule
+   public TestRule managerRule = outputMgr;
+
+   private static final Mockery mockery = new JUnit4Mockery() {
+       {
+           setImposteriser(ClassImposteriser.INSTANCE);
+       }
+   };
+
+   private static SignatureAlgorithms AlgorithmSuite;
+
+   private static final AssertionInfoMap aim = mockery.mock(AssertionInfoMap.class, "aim");
+   private static final SoapMessage message = mockery.mock(SoapMessage.class, "message");
+   private static final AlgorithmSuite algorithm = mockery.mock(AlgorithmSuite.class, "algorithm");
+   //private static final AlgorithmSuiteType algorithmsuitetype = mockery.mock(AlgorithmSuiteType.class, "algorithmsuitetype");
+
+   @SuppressWarnings("unchecked")
+   private static final Collection<AssertionInfo> ais = mockery.mock(Collection.class, "ais");
+   private static final AssertionInfo ai = mockery.mock(AssertionInfo.class, "ai");
+   private static final AbstractBinding transport = mockery.mock(AbstractBinding.class, "transport");
+   private static final String method = "sha1";
+
+   @Rule
+   public final TestName testName = new TestName();
+   
+   @BeforeClass
+   public static void setUpBeforeClass() throws Exception {
+       outputMgr.captureStreams();
+       
+   }
+
+   @AfterClass
+   public static void tearDownAfterClass() throws Exception {
+       outputMgr.dumpStreams();
+       outputMgr.restoreStreams();
+   }
+   
+
+   @Before
+   public void before() {
+       System.out.println("Entering test: " + testName.getMethodName());
+       AlgorithmSuite = new SignatureAlgorithms();
+   }
+
+   @After
+   public void tearDown() throws Exception {
+       System.out.println("Exiting test: " + testName.getMethodName());
+       outputMgr.resetStreams();
+
+       mockery.assertIsSatisfied();
+   }
+
+   @SuppressWarnings("static-access")
+   @Test
+   public void setAlgorithmTest() {
+
+       final AlgorithmSuiteType type = new AlgorithmSuiteType(
+                                                              "Basic256",
+                                                              SPConstants.SHA1,
+                                                              SPConstants.AES256,
+                                                              SPConstants.KW_AES256,
+                                                              SPConstants.KW_RSA_OAEP,
+                                                              SPConstants.P_SHA1_L256,
+                                                              SPConstants.P_SHA1_L192,
+                                                              256, 192, 256,
+                                                              256, 1024, 4096);
+       mockery.checking(new Expectations() {
+           {
+               one(message).get(AssertionInfoMap.class);
+               will(returnValue(aim));
+               one(aim).get(SP12Constants.TRANSPORT_BINDING);
+               will(returnValue(ais));
+               one(ais).iterator();
+               will(returnIterator(ai));
+               one(ai).getAssertion();
+               will(returnValue(transport));
+               one(transport).getAlgorithmSuite();
+               will(returnValue(algorithm));
+               atMost(2).of(algorithm).getAlgorithmSuiteType();
+               will(returnValue(type));
+               //one(algorithmsuitetype).setAsymmetricSignature(method);
+
+           }
+       });
+
+       try {
+           AlgorithmSuite.setAlgorithm(message, method);
+       } catch (Exception e) {
+           e.printStackTrace();
+           fail("Unexpected exception was thrown: " + e.getMessage());
+       }
+   }
+
+   @SuppressWarnings("static-access")
+   @Test
+   public void getAlgorithmSuiteTest_UsingSP12TransportBinding() {
+
+       mockery.checking(new Expectations() {
+           {
+               one(aim).get(SP12Constants.TRANSPORT_BINDING);
+               will(returnValue(ais));
+               one(ais).iterator();
+               will(returnIterator(ai));
+               one(ai).getAssertion();
+               will(returnValue(transport));
+               one(transport).getAlgorithmSuite();
+               will(returnValue(algorithm));
+           }
+       });
+       try {
+
+           AlgorithmSuite alg = AlgorithmSuite.getAlgorithmSuite(aim);
+           assertEquals(alg, algorithm);
+       } catch (Exception e) {
+           e.printStackTrace();
+           fail("Unexpected exception was thrown: " + e.getMessage());
+       }
+   }
+   
+   @SuppressWarnings("static-access")
+   @Test
+   public void getAlgorithmSuiteTest_UsingSP11TransportBinding() {
+
+       mockery.checking(new Expectations() {
+           {
+               one(aim).get(SP12Constants.TRANSPORT_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP11Constants.TRANSPORT_BINDING);
+               will(returnValue(ais));
+               one(ais).iterator();
+               will(returnIterator(ai));
+               one(ai).getAssertion();
+               will(returnValue(transport));
+               one(transport).getAlgorithmSuite();
+               will(returnValue(algorithm));
+           }
+       });
+       try {
+
+           AlgorithmSuite alg = AlgorithmSuite.getAlgorithmSuite(aim);
+           assertEquals(alg, algorithm);
+       } catch (Exception e) {
+           e.printStackTrace();
+           fail("Unexpected exception was thrown: " + e.getMessage());
+       }
+   }
+   
+   @SuppressWarnings("static-access")
+   @Test
+   public void getAlgorithmSuiteTest_UsingSP12AsymmetricBinding() {
+
+       mockery.checking(new Expectations() {
+           {
+               one(aim).get(SP12Constants.TRANSPORT_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP11Constants.TRANSPORT_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP12Constants.ASYMMETRIC_BINDING);
+               will(returnValue(ais));
+               one(ais).iterator();
+               will(returnIterator(ai));
+               one(ai).getAssertion();
+               will(returnValue(transport));
+               one(transport).getAlgorithmSuite();
+               will(returnValue(algorithm));
+           }
+       });
+       try {
+
+           AlgorithmSuite alg = AlgorithmSuite.getAlgorithmSuite(aim);
+           assertEquals(alg, algorithm);
+       } catch (Exception e) {
+           e.printStackTrace();
+           fail("Unexpected exception was thrown: " + e.getMessage());
+       }
+   }
+   
+   @SuppressWarnings("static-access")
+   @Test
+   public void getAlgorithmSuiteTest_UsingSP11AsymmetricBinding() {
+
+       mockery.checking(new Expectations() {
+           {
+               one(aim).get(SP12Constants.TRANSPORT_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP11Constants.TRANSPORT_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP12Constants.ASYMMETRIC_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP11Constants.ASYMMETRIC_BINDING);
+               will(returnValue(ais));
+               one(ais).iterator();
+               will(returnIterator(ai));
+               one(ai).getAssertion();
+               will(returnValue(transport));
+               one(transport).getAlgorithmSuite();
+               will(returnValue(algorithm));
+           }
+       });
+       try {
+
+           AlgorithmSuite alg = AlgorithmSuite.getAlgorithmSuite(aim);
+           assertEquals(alg, algorithm);
+       } catch (Exception e) {
+           e.printStackTrace();
+           fail("Unexpected exception was thrown: " + e.getMessage());
+       }
+   }
+
+   @SuppressWarnings("static-access")
+   @Test
+   public void getAlgorithmSuiteTest_UsingSP12SymmetricBinding() {
+
+       mockery.checking(new Expectations() {
+           {
+
+               one(aim).get(SP12Constants.TRANSPORT_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP11Constants.TRANSPORT_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP12Constants.ASYMMETRIC_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP11Constants.ASYMMETRIC_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP12Constants.SYMMETRIC_BINDING);
+               will(returnValue(ais));
+               one(ais).iterator();
+               will(returnIterator(ai));
+               one(ai).getAssertion();
+               will(returnValue(transport));
+               one(transport).getAlgorithmSuite();
+               will(returnValue(algorithm));
+           }
+       });
+       try {
+
+           AlgorithmSuite alg = AlgorithmSuite.getAlgorithmSuite(aim);
+           assertEquals(alg, algorithm);
+       } catch (Exception e) {
+           e.printStackTrace();
+           fail("Unexpected exception was thrown: " + e.getMessage());
+       }
+   }
+   
+   @SuppressWarnings("static-access")
+   @Test
+   public void getAlgorithmSuiteTest_UsingSP11SymmetricBinding() {
+
+       mockery.checking(new Expectations() {
+           {
+
+               one(aim).get(SP12Constants.TRANSPORT_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP11Constants.TRANSPORT_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP12Constants.ASYMMETRIC_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP11Constants.ASYMMETRIC_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP12Constants.SYMMETRIC_BINDING);
+               will(returnValue(null));
+               one(aim).get(SP11Constants.SYMMETRIC_BINDING);
+               will(returnValue(ais));
+               one(ais).iterator();
+               will(returnIterator(ai));
+               one(ai).getAssertion();
+               will(returnValue(transport));
+               one(transport).getAlgorithmSuite();
+               will(returnValue(algorithm));
+           }
+       });
+       try {
+
+           AlgorithmSuite alg = AlgorithmSuite.getAlgorithmSuite(aim);
+           assertEquals(alg, algorithm);
+       } catch (Exception e) {
+           e.printStackTrace();
+           fail("Unexpected exception was thrown: " + e.getMessage());
+       }
+   }
+}
+
+
+


### PR DESCRIPTION
- allow specifying **signatureAlgorithm** configuration attribute with older ws-security policy (docs.oasis-open.org/ws-sx/ws-securitypolicy/200512)
- we already support this configuration attribute with  <html><body>
<!--StartFragment-->

  | http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702
-- | --


<!--EndFragment-->
</body>
</html>
and with
WS-Security policy 1.3
(so the runtime can use sha256 or higher levels of signature algorithms even though the  WS-Security Policy specification does not allow the use of these algorithms)

- `To configure WS-Security in Liberty to support the stronger signature algorithm, you use the signatureAlgorithm attribute to define the required algorithm within the <signatureProperties> element in the server.xml file. The valid values for the signatureAlgorithm attribute are sha256, sha384, and sha512. For example, if you specify sha512 as the value of the signatureAlgorithm attribute, the signature algorithm that is used in the signature with an asymmetric key is RSA-SHA-512, and the signature algorithm that is used in the signature with a symmetric key is HMAC-SHA-512.`

- CXF 3.x (https://cxf.apache.org/docs/ws-securitypolicy.html) also allows these following config attributes
<html><body>
<!--StartFragment-->

ws-security.asymmetric.signature.algorithm | This  configuration tag overrides the default Asymmetric Signature algorithm  (RSA-SHA1) for use in WS-SecurityPolicy, as the WS-SecurityPolicy  specification does not allow the use of other algorithms at present.
-- | --
ws-security.symmetric.signature.algorithm | This  configuration tag overrides the default Symmetric Signature algorithm  (HMAC-SHA1) for use in WS-SecurityPolicy, as the WS-SecurityPolicy  specification does not allow the use of other algorithms at present.

<!--EndFragment-->
</body>
</html>

the service client can either programmatically set this on request context 
`requestContext.put("ws-security.asymmetric.signature.algorithm", "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");`

or 

in liberty server configuration file , update `wsSecurityClient` and `wsSecurityProvider` elements

`	<wsSecurityClient
		id="default"
		ws-security.password=..........
		ws-security.username="user1"
		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
		ws-security.asymmetric.signature.algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
	>`
	
	
`	<wsSecurityProvider
		id="default"
		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
                ws-security.return.security.error="true"
                ws-security.asymmetric.signature.algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
	> `
