### PR TITLE
26419 - avoid tracing CacheControlHeaderProvider

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -159,7 +159,8 @@ Include-Resource: \
 
 instrument.ffdc: false
 instrument.classesExcludes: com/ibm/ws/jaxrs20/internal/resources/*.class, \
-	org/apache/cxf/common/util/UrlUtils.class
+	org/apache/cxf/common/util/UrlUtils.class, \
+	org/apache/cxf/jaxrs/impl/CacheControlHeaderProvider.class
 
 -buildpath: \
 	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\


### PR DESCRIPTION
Don't trace `org.apache.cxf.jaxrs.impl.CacheControlHeaderProvider` in `jaxrs-2.0`

Fixes https://github.com/OpenLiberty/open-liberty/issues/26419