### PR TITLE
Enable H2 SSL tests

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2SecureTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2SecureTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -74,12 +74,12 @@ public class Http2SecureTests extends FATServletClient {
     /**
      * Test Coverage: Client requests a servlet that will generate a push request
      * Test Outcome: Server pushes a resource to the client
-     * Note: JDK9+ required here for ALPN
+     * Note: JDK9+ was required here for ALPN originally but ALPN support has been
+     * backported to Java 8 for all major JDKs
      *
      * @throws Exception
      */
     @Test
-    @MinimumJavaLevel(javaLevel = 9)
     public void testSimplePushSecure() throws Exception {
         String[] requestUris = new String[] { "/H2TestModule/SimplePushServlet" };
         int port = server.getHttpSecondarySecurePort();
@@ -91,12 +91,12 @@ public class Http2SecureTests extends FATServletClient {
     /**
      * Test Coverage: Client makes multiple requests to a servlet that will generate a push request
      * Test Outcome: Server pushes multiple resources to the client
-     * Note: JDK9+ required here for ALPN
+     * Note: JDK9+ was required here for ALPN originally but ALPN support has been
+     * backported to Java 8 for all major JDKs
      *
      * @throws Exception
      */
     @Test
-    @MinimumJavaLevel(javaLevel = 9)
     public void testMultiplePushesSecure() throws Exception {
         String[] requestUris = new String[] { "/H2TestModule/SimplePushServlet",
                                               "/H2TestModule/SimplePushServlet",
@@ -110,12 +110,12 @@ public class Http2SecureTests extends FATServletClient {
     /**
      * Test Coverage: Client makes a request to a servlet with a simple body
      * Test Outcome: Server responds with the servlet body
-     * Note: JDK9+ required here for ALPN
+     * Note: JDK9+ was required here for ALPN originally but ALPN support has been
+     * backported to Java 8 for all major JDKs
      *
      * @throws Exception
      */
     @Test
-    @MinimumJavaLevel(javaLevel = 9)
     public void testSimpleRequestSecure() throws Exception {
         String[] requestUris = new String[] { "/H2TestModule/H2HeadersAndBody" };
         int port = server.getHttpSecondarySecurePort();
@@ -127,12 +127,12 @@ public class Http2SecureTests extends FATServletClient {
     /**
      * Test Coverage: Client makes multiple requests to a servlet with a simple body
      * Test Outcome: Server responds multiple times
-     * Note: JDK9+ required here for ALPN
+     * Note: JDK9+ was required here for ALPN originally but ALPN support has been
+     * backported to Java 8 for all major JDKs
      *
      * @throws Exception
      */
     @Test
-    @MinimumJavaLevel(javaLevel = 9)
     public void testMultipleRequestsSecure() throws Exception {
         String[] requestUris = new String[] { "/H2TestModule/H2HeadersAndBody",
                                               "/H2TestModule/H2HeadersAndBody",


### PR DESCRIPTION
Originally, ALPN support needed for H2 SSL was added in major JDKs in Java 9. After some time, this ALPN support has been backported to Java 8 in all major JDKs.
- OpenJDK seems to have backported ALPN to Java 8 https://groups.google.com/g/netty/c/ehSjsBxnyNY  , https://bugs.openjdk.org/browse/JDK-8230977 
- Oracle JDK seems to have ALPN support also https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/alpn.html 
- IBM JDK also seems to have ALPN support https://www.ibm.com/support/pages/apar/IJ24011  (looked in the jars and seeing the methods as well)

Because of this, it should be okay to enable these SSL tests for Java 8

