### PR TITLE
Added GcTime per Cycle computed metrics to MpMetrics5x

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.5.0.monitor.internal/src/io/openliberty/microprofile/metrics/internal/monitor/computed/internal/ComputedMappingTable.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.monitor.internal/src/io/openliberty/microprofile/metrics/internal/monitor/computed/internal/ComputedMappingTable.java
@@ -54,15 +54,15 @@ public class ComputedMappingTable {
                 MetricUnits.PERCENT, "base", "memory.usedHeap", "memory.maxHeap"}};
         mappingTable.put("memoryStats", memoryTable);
 
-        // String[][] gcTable = new String[][] { { "gc.time.per.cycle",
-        // "gc.time.per.cycle.description",
-        // Constants.GAUGE, MetricUnits.SECONDS, "base", "gc.time", "gc.total" } };
-        // mappingTable.put("gcStats", gcTable);
+        String[][] gcTable = new String[][] { 
+            { "gc.time.per.cycle", "gc.time.per.cycle.description", Constants.GAUGE, MetricUnits.SECONDS, 
+                "base", "gc.time", "gc.total" } };
+        mappingTable.put("gcStats", gcTable);
 
         // Vendor Metrics
         String[][] servletTable = new String[][]{
             {"servlet.request.elapsedTime.per.request", "servlet.request.elapsedTime.per.request.description",
-                   Constants.GAUGE, MetricUnits.SECONDS, "vendor", "servlet.responseTime.total", "servlet.request.total"}};
+                Constants.GAUGE, MetricUnits.SECONDS, "vendor", "servlet.responseTime.total", "servlet.request.total"}};
         mappingTable.put("ServletStats", servletTable);
 
         String[][] connectionPoolTable = new String[][]{


### PR DESCRIPTION
fixes #26412
fixes #26425
- Added the new GcTime per Cycle computed metric for MpMetrics-5.x, using the GarbageCollectionMXBean API to retrieve the required GcTime and GcTotal values, needed for computation.
- Added additional null checks to handle timing issues, with the server/app stopping and calculating the metrics.
- Fixed a test failure that the LTPA messages should only be checked for the first server start, not the subsequent ones.
- Added @AllowedFFDC in FAT Runner class for cases when an FFDC is created when the MBean is not found, when the calculation is done during server shut down.