### PR TITLE
Handle trace rollover in multi server peer recovery reroute tests

### DIFF
--- a/dev/com.ibm.ws.wsat.recovery_fat.multi.7/fat/src/tests/ReroutePeerRecoveryTest.java
+++ b/dev/com.ibm.ws.wsat.recovery_fat.multi.7/fat/src/tests/ReroutePeerRecoveryTest.java
@@ -88,6 +88,8 @@ public class ReroutePeerRecoveryTest extends MultiRecoveryTest {
 	@Before
 	public void beforeTest() throws Exception {
 		WSATTest.callClearResourcesServlet(recoveryServer, server3, server5);
+		server3.setTraceMarkToEndOfDefaultTrace();
+		server5.setTraceMarkToEndOfDefaultTrace();
 	}
 	
 	private static final String[] allowedMsgs = new String[] {"WTRN0048W"};


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.wsat.recovery_fat.lps,com.ibm.ws.wsat.recovery_fat.multi.1,com.ibm.ws.wsat.recovery_fat.multi.2,com.ibm.ws.wsat.recovery_fat.multi.3,com.ibm.ws.wsat.recovery_fat.multi.4,com.ibm.ws.wsat.recovery_fat.multi.5,com.ibm.ws.wsat.recovery_fat.multi.6,com.ibm.ws.wsat.recovery_fat.multi.7