### PR TITLE
Add test repeats to the mpJwt FATs to use mpConfig-3.1

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.mp.jwt/fat/src/com/ibm/ws/security/fat/common/mp/jwt/sharedTests/MPJwtMPConfigTests.java
+++ b/dev/com.ibm.ws.security.fat.common.mp.jwt/fat/src/com/ibm/ws/security/fat/common/mp/jwt/sharedTests/MPJwtMPConfigTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -60,6 +60,7 @@ public class MPJwtMPConfigTests extends CommonMpJwtFat {
     public static final String KeyMismatch = "KeyMismatch";
     protected final static MPJwtAppSetupUtils baseSetupUtils = new MPJwtAppSetupUtils();
     private static ServerFileUtils fatUtils = new ServerFileUtils();
+    protected static String mpConfigExtension = "mpConfig-3.1";
 
     public static enum MPConfigLocation {
         IN_APP, SYSTEM_PROP, ENV_VAR
@@ -116,7 +117,13 @@ public class MPJwtMPConfigTests extends CommonMpJwtFat {
     }
 
     protected static void startRSServerForMPTests(LibertyServer server, String configFile) throws Exception {
-        fatUtils.updateFeatureFiles(server, setActionInstance(RepeatTestFilter.getRepeatActionsAsString()), "mpConfigFeatures", "rsFeatures");
+
+        String extension = "";
+        if (RepeatTestFilter.getRepeatActionsAsString().contains(mpConfigExtension)) {
+            extension = "_" + mpConfigExtension;
+        }
+        fatUtils.updateFeatureFiles(server, setActionInstance(RepeatTestFilter.getRepeatActionsAsString()) + extension, "mpConfigFeatures");
+        fatUtils.updateFeatureFiles(server, setActionInstance(RepeatTestFilter.getRepeatActionsAsString()), "rsFeatures");
 
         serverTracker.addServer(server);
         transformApps(server);

--- a/dev/com.ibm.ws.security.fat.common.mp.jwt/publish/shared/config/mpConfigFeatures_mpJwt21_mpConfig-3.1.xml
+++ b/dev/com.ibm.ws.security.fat.common.mp.jwt/publish/shared/config/mpConfigFeatures_mpJwt21_mpConfig-3.1.xml
@@ -1,0 +1,26 @@
+<!--
+    Copyright (c) 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+ <server>
+
+	<featureManager>  		
+        <feature>jwt-1.0</feature>
+        <feature>restfulWS-3.0</feature>
+        <feature>ssl-1.0</feature>
+        <feature>mpJwt-2.1</feature>
+        <feature>pages-3.0</feature>
+        <feature>mpConfig-3.1</feature>
+        <feature>timedexit-1.0</feature>
+	</featureManager>
+
+</server>
+    

--- a/dev/com.ibm.ws.security.mp.jwt.2.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt21/fat/sharedTests/GenericEnvVarsAndSystemPropertiesTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.2.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt21/fat/sharedTests/GenericEnvVarsAndSystemPropertiesTests.java
@@ -12,14 +12,19 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt21.fat.sharedTests;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
+import com.ibm.ws.security.fat.common.actions.SecurityTestRepeatAction;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.mp.jwt.MPJwt21FatConstants;
+import com.ibm.ws.security.fat.common.mp.jwt.MPJwtFatConstants;
 import com.ibm.ws.security.fat.common.mp.jwt.sharedTests.MPJwt21MPConfigTests;
 import com.ibm.ws.security.fat.common.mp.jwt.utils.MP21ConfigSettings;
 
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -33,11 +38,24 @@ import componenttest.topology.impl.LibertyServer;
 @RunWith(FATRunner.class)
 public class GenericEnvVarsAndSystemPropertiesTests extends MPJwt21MPConfigTests {
 
+    @ClassRule
+    public static RepeatTests rr = createRepeats();
+
     public static LibertyServer resourceServer;
 
     protected static int tokenAge = 0;
     protected static int clockSkew = 300;
     protected static String keyManagementKeyAlias = "";
+
+    public static RepeatTests createRepeats() {
+
+        if (RepeatTestFilter.getRepeatActionsAsString().contains(MPJwtFatConstants.MP_JWT_21)) {
+            return RepeatTests.withoutModification().andWith(new SecurityTestRepeatAction(mpConfigExtension));
+        } else {
+            return RepeatTests.withoutModification();
+        }
+
+    }
 
     public static void commonMpJwt21Setup(LibertyServer requestedServer, String config, int inTokenAge, int inClockSkew, String inKeyMgmtKeyAlias, MPConfigLocation where) throws Exception {
 

--- a/dev/com.ibm.ws.security.mp.jwt.2.1_fat.mpJwt-2.1/bnd.bnd
+++ b/dev/com.ibm.ws.security.mp.jwt.2.1_fat.mpJwt-2.1/bnd.bnd
@@ -13,7 +13,7 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-tested.features: expressionlanguage-5.0, appsecurity-5.0, pages-3.1, servlet-6.0, restfulwsclient-3.1, restfulws-3.1
+tested.features: expressionlanguage-5.0, appsecurity-5.0, pages-3.1, servlet-6.0, restfulwsclient-3.1, restfulws-3.1, mpConfig-3.1
 
 src: \
     fat/src    


### PR DESCRIPTION
Adding repeats to the com.ibm.ws.security.mp.jwt.2.1_fat.mpJwt-2.1 FAT project to ensure that all function behaves properly when either mpConfig-3.0 or mpConfig-3.1 features are used.

 #26411