### PR TITLE
Wssec cxf test config updates to use sha256 signature algorithm

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -41,6 +41,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.JavaInfo;
+import componenttest.topology.impl.JavaInfo.Vendor;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
@@ -126,10 +127,9 @@ public class CxfBspTests {
         String vendorName = System.getProperty("java.vendor");
         Log.info(thisClass, thisMethod, "JDK Vendor Name is: " + vendorName);
 
-        //RTC 290711
-        //RTC 291296 handles the case with java runtime OSX_12_MONTEREY_IBMJDK8 which is hybrid jdk where
-        //Security, ORB and XML components are IBM Java and JVM, JIT, most class libraries are Oracle Java
-        if ((JavaInfo.isSystemClassAvailable("com.ibm.security.auth.module.Krb5LoginModule")) & (vendorName.contains("IBM"))) {
+        //issue 30353
+        JavaInfo info = JavaInfo.forServer(server);
+        if ((info.majorVersion() == 8) && (vendorName.contains("IBM"))) {
             Log.info(thisClass, thisMethod, "Using an IBM JDK");
         } else {
             Log.info(thisClass, thisMethod, "Using NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition/OSX_12_MONTEREY_IBMJDK8 - this test should not run!");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -41,7 +41,6 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.JavaInfo;
-import componenttest.topology.impl.JavaInfo.Vendor;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
@@ -140,6 +139,9 @@ public class CxfBspTests {
         return;
     }
 
+    //issue 30353 - samples CxfBsp test cases required both client and provider EchoBsp.wsdl update, where
+    //service client wsdl at com.ibm.ws.wssecurity_fat.wsscxf.1\publish\servers\com.ibm.ws.wssecurity_fat.sample\apps\WSSampleSeiClient
+    //service provider wsdl at com.ibm.ws.wssecurity_fat.wsscxf.1\test-applications\WSSampleSei\resources\WEB-INF\wsdl
     @Test
     public void testEcho11Service() throws Exception {
         String thisMethod = "testEcho11Service";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -125,10 +125,10 @@ public class CxfInteropX509Tests {
         Log.info(thisClass, thisMethod, "JDK Vendor Name is: " + vendorName);
 
         ibmJDK = true;
-        //RTC 290711
-        //RTC 291296 handles the case with java runtime OSX_12_MONTEREY_IBMJDK8 which is hybrid jdk where
-        //Security, ORB and XML components are IBM Java and JVM, JIT, most class libraries are Oracle Java
-        if ((JavaInfo.isSystemClassAvailable("com.ibm.security.auth.module.Krb5LoginModule")) & (vendorName.contains("IBM"))) {
+        
+        //issue 30353
+        JavaInfo info = JavaInfo.forServer(server);
+        if ((info.majorVersion() == 8) && (vendorName.contains("IBM"))) {
             Log.info(thisClass, thisMethod, "Using an IBM JDK");
         } else {
             Log.info(thisClass, thisMethod, "Using NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition/OSX_12_MONTEREY_IBMJDK8 - this test should not run!");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -125,7 +125,7 @@ public class CxfInteropX509Tests {
         Log.info(thisClass, thisMethod, "JDK Vendor Name is: " + vendorName);
 
         ibmJDK = true;
-        
+
         //issue 30353
         JavaInfo info = JavaInfo.forServer(server);
         if ((info.majorVersion() == 8) && (vendorName.contains("IBM"))) {
@@ -139,6 +139,9 @@ public class CxfInteropX509Tests {
         return;
     }
 
+    //issue 30353 - samples CxfInteropX509 test cases required both client and provider EchoX509.wsdl update, where
+    //service client wsdl at com.ibm.ws.wssecurity_fat.wsscxf.1\publish\servers\com.ibm.ws.wssecurity_fat.sample\apps\WSSampleSeiClient
+    //service provider wsdl at com.ibm.ws.wssecurity_fat.wsscxf.1\test-applications\WSSampleSei\resources\WEB-INF\wsdl
     @Test
     public void testEcho21Service() throws Exception {
         String thisMethod = "testEcho21Service";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sample/apps/WSSampleSeiClient/EchoBsp.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sample/apps/WSSampleSeiClient/EchoBsp.wsdl
@@ -84,7 +84,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!--ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -138,7 +138,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!--ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -224,7 +224,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -280,7 +280,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -362,7 +362,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -416,7 +416,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -493,7 +493,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -546,7 +546,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sample/apps/WSSampleSeiClient/EchoX509.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sample/apps/WSSampleSeiClient/EchoX509.wsdl
@@ -74,7 +74,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -143,7 +143,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -236,7 +236,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -295,7 +295,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -378,7 +378,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -442,7 +442,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sample/server_bsp.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sample/server_bsp.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -98,9 +98,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
-        <!-- 2/2021 EE8 Callbackhandler -->
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="sampleapp"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"
@@ -116,9 +116,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
-	<!-- 2/2021 EE8 Callbackhandler -->
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="sampleapp"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sample/server_bsp_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sample/server_bsp_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -98,9 +98,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-        <!-- 2/2021 EE8 Callbackhandler -->
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="sampleapp"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"
@@ -116,9 +116,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	<!-- 2/2021 EE8 Callbackhandler -->
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="sampleapp"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sample/server_x509.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sample/server_x509.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -98,9 +98,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
-	<!-- 2/2021 EE8 Callbackhandler -->
-
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="sampleapp"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"
@@ -116,9 +116,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
-	<!-- 2/2021 EE8 Callbackhandler -->
-
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="sampleapp"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sample/server_x509_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.sample/server_x509_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -98,9 +98,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	<!-- 2/2021 EE8 Callbackhandler -->
-
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="sampleapp"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"
@@ -116,9 +116,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	<!-- 2/2021 EE8 Callbackhandler -->
-
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="sampleapp"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509caller/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509caller/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,7 +87,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256" 
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client3"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientThird"
@@ -104,8 +106,10 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
                 ws-security.return.security.error="true"
 	>
+                <!--issue 30353 -->
 		<callerToken name="X509Token" />
 		<signatureProperties
+                        signatureAlgorithm="sha256" 
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerDefault"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509caller/server_orig.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509caller/server_orig.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,7 +87,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256" 
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client3"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientThird"
@@ -104,7 +106,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
 		<callerToken name="X509Token" />
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256" 
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerDefault"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509caller/server_orig_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509caller/server_orig_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,9 +87,10 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	<!-- EE8 Callbackhandler -->
 	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client3"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientThird"
@@ -105,10 +106,11 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	<!-- EE8 Callbackhandler -->
 	
+	        <!--issue 30353 -->
 		<callerToken name="X509Token" />
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerDefault"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509caller/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509caller/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,9 +87,10 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	<!-- EE8 Callbackhandler -->
 	
+	       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client3"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientThird"
@@ -106,11 +107,11 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.return.security.error="true"
 	>
-	<!-- 3/2021 added ws-security.return.security.error -->
-	<!-- 2/2021 EE8 Callbackhandler -->
 	
+	        <!--issue 30353 -->
 		<callerToken name="X509Token" />
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerDefault"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509symcaller/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509symcaller/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -86,7 +86,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
+                 <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client3"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientThird"
@@ -102,8 +104,10 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
+                <!--issue 30353 -->
 		<callerToken name="X509Token" />
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server3"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientThirdCert"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509symcaller/server_orig.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509symcaller/server_orig.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,7 +87,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client3"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientThird"
@@ -103,8 +105,10 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
+                <!--issue 30353 -->
 		<callerToken name="X509Token" />
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server3"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientThirdCert"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509symcaller/server_orig_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509symcaller/server_orig_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,9 +87,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	<!--  EE8 Callbackhandler -->
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client3"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientThird"
@@ -105,10 +105,10 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	<!--  EE8 Callbackhandler -->
-	
+	        <!--issue 30353 -->
 		<callerToken name="X509Token" />
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server3"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientThirdCert"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509symcaller/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/servers/com.ibm.ws.wssecurity_fat.x509symcaller/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,9 +87,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	<!--  EE8 Callbackhandler -->
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client3"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientThird"
@@ -105,10 +105,10 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	<!--  EE8 Callbackhandler -->
-	
+	        <!--issue 30353 -->
 		<callerToken name="X509Token" />
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server3"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientThirdCert"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/WSSampleSei/resources/WEB-INF/wsdl/EchoBsp.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/WSSampleSei/resources/WEB-INF/wsdl/EchoBsp.wsdl
@@ -84,7 +84,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!--ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -138,7 +138,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!--ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -224,7 +224,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -280,7 +280,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -362,7 +362,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -416,7 +416,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -493,7 +493,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -546,7 +546,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic128Rsa15/>
+                  <ns1:Basic256Sha256Rsa15/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/WSSampleSei/resources/WEB-INF/wsdl/EchoX509.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/WSSampleSei/resources/WEB-INF/wsdl/EchoX509.wsdl
@@ -74,7 +74,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -143,7 +143,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -236,7 +236,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -295,7 +295,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -378,7 +378,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -442,7 +442,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/callertoken/resources/WEB-INF/callertoken.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/callertoken/resources/WEB-INF/callertoken.wsdl
@@ -53,7 +53,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -104,7 +104,7 @@
                         <!-- sp:IncludeTimestamp / -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -169,7 +169,7 @@
                         <!-- sp:IncludeTimestamp / -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -216,7 +216,7 @@
                   <sp:OnlySignEntireHeadersAndBody/>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Sha256/> 
+                        <sp:Basic256Sha256/> 
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                </wsp:Policy>
@@ -252,7 +252,7 @@
                         <sp:IncludeTimestamp/>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -295,7 +295,7 @@
                     </sp:ProtectionToken>
                     <sp:AlgorithmSuite>
                        <wsp:Policy>
-                          <sp:Basic128/>
+                          <sp:Basic256Sha256/>
                        </wsp:Policy>
                     </sp:AlgorithmSuite>
                     <sp:Layout>
@@ -354,7 +354,7 @@
                         <sp:IncludeTimestamp/>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -375,7 +375,7 @@
                     </sp:ProtectionToken>
                     <sp:AlgorithmSuite>
                        <wsp:Policy>
-                          <sp:Basic128/>
+                          <sp:Basic256Sha256/>
                        </wsp:Policy>
                     </sp:AlgorithmSuite>
                     <sp:Layout>
@@ -440,7 +440,7 @@
                     <sp:SignBeforeEncrypting/>
                     <sp:AlgorithmSuite>
                        <wsp:Policy>
-                          <sp:Basic128/>
+                          <sp:Basic256Sha256/>
                        </wsp:Policy>
                     </sp:AlgorithmSuite>
                  </wsp:Policy>
@@ -477,7 +477,7 @@
                         <sp:IncludeTimestamp/>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/sha2sig/CxfSha2SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/sha2sig/CxfSha2SigTests.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -293,7 +293,9 @@ public class CxfSha2SigTests extends CommonTests {
      *
      */
 
-    @Test
+    //issue 30353 - remove the test? for negative test, ws sec client didn't supply signatureAlgorithm="sha256" intentionally, but this
+    //will not work with FIPS 140-3
+    //@Test
     //issue 23060
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EmptyAction.ID, RepeatWithEE7cbh20.ID })
     public void testCxfSha1ToSha2SigAlgorithm() throws Exception {

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/sha2sig/CxfSha2SigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/sha2sig/CxfSha2SigTests.java
@@ -293,9 +293,7 @@ public class CxfSha2SigTests extends CommonTests {
      *
      */
 
-    //issue 30353 - remove the test? for negative test, ws sec client didn't supply signatureAlgorithm="sha256" intentionally, but this
-    //will not work with FIPS 140-3
-    //@Test
+    @Test
     //issue 23060
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EmptyAction.ID, RepeatWithEE7cbh20.ID })
     public void testCxfSha1ToSha2SigAlgorithm() throws Exception {

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigTests.java
@@ -1076,7 +1076,9 @@ public class CxfX509MigTests {
      *
      */
 
-    @Test
+    //issue 30353 - comment out the test for now while further investigation is needed
+    //why test still failed with wsdl update Basic256ha256
+    //@Test
     public void testCxfX509TransportEndrosingSP11MigServiceHttps() throws Exception {
         String thisMethod = "testCxfX509TransportEndorsingSP11MigService";
         methodFull = "testCxfX509TransportEndorsingSP11MigServiceHttps";
@@ -2360,7 +2362,9 @@ public class CxfX509MigTests {
      *
      */
 
-    @Test
+    //issue 30353 - comment out the test for now while further investigation is needed
+    //why test still failed with wsdl update Basic256ha256
+    //@Test
     public void testCxfX509AsymmetricSignatureSP11MigService() throws Exception {
         String thisMethod = "testCxfX509AsymmetricSignatureSP11MigService";
         methodFull = "testCxfX509AsymmetricSignatureSP11MigService";
@@ -2647,7 +2651,9 @@ public class CxfX509MigTests {
      *
      */
 
-    @Test
+    //issue 30353 - comment out the test for now while further investigation is needed
+    //why test still failed with wsdl update Basic256ha256
+    //@Test
     public void testWsComplexSP11Service() throws Exception {
         String thisMethod = "testWsComplexSP11Service";
         methodFull = "testWsComplexSP11Service";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigTests.java
@@ -1076,9 +1076,7 @@ public class CxfX509MigTests {
      *
      */
 
-    //issue 30353 - comment out the test for now while further investigation is needed
-    //why test still failed with wsdl update Basic256ha256
-    //@Test
+    @Test
     public void testCxfX509TransportEndrosingSP11MigServiceHttps() throws Exception {
         String thisMethod = "testCxfX509TransportEndorsingSP11MigService";
         methodFull = "testCxfX509TransportEndorsingSP11MigServiceHttps";
@@ -2362,9 +2360,7 @@ public class CxfX509MigTests {
      *
      */
 
-    //issue 30353 - comment out the test for now while further investigation is needed
-    //why test still failed with wsdl update Basic256ha256
-    //@Test
+    @Test
     public void testCxfX509AsymmetricSignatureSP11MigService() throws Exception {
         String thisMethod = "testCxfX509AsymmetricSignatureSP11MigService";
         methodFull = "testCxfX509AsymmetricSignatureSP11MigService";
@@ -2651,9 +2647,7 @@ public class CxfX509MigTests {
      *
      */
 
-    //issue 30353 - comment out the test for now while further investigation is needed
-    //why test still failed with wsdl update Basic256ha256
-    //@Test
+    @Test
     public void testWsComplexSP11Service() throws Exception {
         String thisMethod = "testWsComplexSP11Service";
         methodFull = "testWsComplexSP11Service";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/publish/servers/com.ibm.ws.wssecurity_fat.endsuptokens/server_asym.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/publish/servers/com.ibm.ws.wssecurity_fat.endsuptokens/server_asym.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -86,8 +86,9 @@
 		ws-security.password="{xor}LDo8Ki02KyY="
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="{xor}EzY9Oi0rJgdqb2YcMzY6MSs="
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -102,8 +103,9 @@
 	<wsSecurityProvider
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="{xor}EzY9Oi0rJgdqb2YMOi0pOi1t"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/publish/servers/com.ibm.ws.wssecurity_fat.endsuptokens/server_asym_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/publish/servers/com.ibm.ws.wssecurity_fat.endsuptokens/server_asym_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,8 +87,9 @@
 		security.username="user1"
 		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.wss4j.crypto.merlin.keystore.type="jks"
 			org.apache.wss4j.crypto.merlin.keystore.password="{xor}EzY9Oi0rJgdqb2YcMzY6MSs="
 			org.apache.wss4j.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -104,8 +105,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.wss4j.crypto.merlin.keystore.type="jks"
 			org.apache.wss4j.crypto.merlin.keystore.password="{xor}EzY9Oi0rJgdqb2YMOi0pOi1t"
 			org.apache.wss4j.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha2.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha2.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -70,15 +70,17 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soaprequester"
 	>       
+                <!-- issue 30353 -->
 		<signatureProperties
+		    signatureAlgorithm="sha512"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"
 			org.apache.ws.security.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
 
 	</wsSecurityClient>
-	<!-- 11/2022 signatureAlgorithm="sha256" is not included in client setting, 
-	which is for negative test to use default sha1 algorithm and fail -->
+	<!-- issue 30353 09/2023 signatureAlgorithm="sha512" in client setting, provider expects sha256
+	this configuration is for negative test. client and provider are using different signature algorithms -->
 	
 	<include location="imports/java2Permissions.xml" />
         

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha2.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha2.xml
@@ -69,7 +69,7 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soaprequester"
-	>
+	>       
 		<signatureProperties
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha2_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_sha2_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -68,15 +68,16 @@
 		security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		security.signature.username="soaprequester"
 	>
-	
+	        <!-- issue 30353 -->
 		<signatureProperties
+		signatureAlgorithm="sha512"
 			org.apache.wss4j.crypto.merlin.keystore.type="jks"
 			org.apache.wss4j.crypto.merlin.keystore.password="client"
 			org.apache.wss4j.crypto.merlin.keystore.alias="soaprequester"
 			org.apache.wss4j.crypto.merlin.file="${server.config.dir}/dsig-sender.ks" />
 	</wsSecurityClient>
-	<!-- 11/2022 signatureAlgorithm="sha256" is not included in client setting, 
-	which is for negative test to use default sha1 algorithm and fail -->
+	<!-- issue 30353 09/2023 signatureAlgorithm="sha512" in client setting, provider expects sha256
+	this configuration is for negative test. client and provider are using different signature algorithm -->
 	
     <include location="imports/java2Permissions.xml" />
     

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/test-applications/endsuptokens/resources/WEB-INF/EndSupTokens.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/test-applications/endsuptokens/resources/WEB-INF/EndSupTokens.wsdl
@@ -248,7 +248,7 @@
                   <sp:OnlySignEntireHeadersAndBody/>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Sha256/> 
+                        <sp:Basic256Sha256/> 
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                </wsp:Policy>
@@ -304,7 +304,7 @@
                   <sp:OnlySignEntireHeadersAndBody/>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Sha256/> 
+                        <sp:Basic256Sha256/> 
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                </wsp:Policy>
@@ -363,7 +363,7 @@
                   <sp:OnlySignEntireHeadersAndBody/>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Sha256/> 
+                        <sp:Basic256Sha256/> 
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                </wsp:Policy>
@@ -475,7 +475,7 @@
                   <sp:OnlySignEntireHeadersAndBody/>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Sha256/> 
+                        <sp:Basic256Sha256/> 
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                </wsp:Policy>
@@ -537,7 +537,7 @@
                   <sp:OnlySignEntireHeadersAndBody/>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Sha256/> 
+                        <sp:Basic256Sha256/> 
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                </wsp:Policy>
@@ -599,7 +599,7 @@
                   <sp:OnlySignEntireHeadersAndBody/>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Sha256/> 
+                        <sp:Basic256Sha256/> 
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                </wsp:Policy>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/test-applications/x509migtoken/resources/WEB-INF/x509migtoken.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/test-applications/x509migtoken/resources/WEB-INF/x509migtoken.wsdl
@@ -495,7 +495,7 @@
                         <sp:IncludeTimestamp/>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -1031,7 +1031,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/test-applications/x509migtoken/resources/WEB-INF/x509migtoken.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/test-applications/x509migtoken/resources/WEB-INF/x509migtoken.wsdl
@@ -455,7 +455,7 @@
                         <sp:IncludeTimestamp/>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -538,7 +538,7 @@
                         <sp:IncludeTimestamp/>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -578,7 +578,7 @@
                         <sp:IncludeTimestamp/>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -618,7 +618,7 @@
                         <sp:IncludeTimestamp/>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -701,7 +701,7 @@
                         <sp:IncludeTimestamp/>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -758,7 +758,7 @@
                   <sp:OnlySignEntireHeadersAndBody/>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                </wsp:Policy>
@@ -1507,7 +1507,7 @@
                        <sp:EncryptSignature/>
                        <sp:AlgorithmSuite>
                           <wsp:Policy>
-                             <sp:Basic128Sha256/> 
+                             <sp:Basic256Sha256/> 
                           </wsp:Policy>
                        </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -1705,7 +1705,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128Sha256/>
+                                 <sp:Basic128/>
                                  <sp:InclusiveC14N/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
@@ -1900,7 +1900,7 @@
                          </sp:SignatureToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128Sha256/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ObjectTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ObjectTests.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- *
+ * 
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -131,15 +132,14 @@ public class CxfX509ObjectTests {
      * This test invokes a simple jax-ws cxf web service.
      * And the service need the x509 to sign and encrypt the SOAPBody
      * Service client code uses cxf/wss4j apis to create Crypto objects to sign and encrypt the SOAP message.
-     * This test does not require default ws-sec configuration (specified in server.xml)for the service client.
+     * Service client (CxfX509SvcClient) sets the Crypto objects in requestContext
+     * This test does not require default ws-security client configuration (specified in server.xml)for the service client since all the configuration 
+     * is passed via requestContext. we do not include wsSecurityClient element in server.xml
+     * issue 30353
      */
 
-    //4/2021 this test expects to fail with EE8 "java.lang.ClassNotFoundException: org.apache.wss4j.common.crypto.CryptoFactory"
-    //Aruna is aware of the cause from feature definition API packages; waiting for the next stage of update to fix it
 
-    //issue 30353 - comment out the test for now while further investigation is needed
-    //why test still failed "Could not sign data" with wsdl update Basic256ha256 and wssec provider added with Sha256 signature algorithm
-    //@Test
+    @Test
     public void testCxfX509Service() throws Exception {
 
         String thisMethod = "testCxfX509Service";
@@ -160,15 +160,6 @@ public class CxfX509ObjectTests {
         return;
     }
 
-    /**
-     * TestDescription:
-     *
-     * This test invokes a jax-ws cxf web service.
-     * It needs to have X509 key set to sign and encrypt the SOAPBody
-     * The request is request in https.
-     * Though this test is not enforced it yet.
-     *
-     */
     protected void testRoutine(
                                String thisMethod,
                                String testMode, // Positive, positive-1, negative or negative-1... etc

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ObjectTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ObjectTests.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,7 +24,6 @@ import java.util.Set;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -138,7 +137,9 @@ public class CxfX509ObjectTests {
     //4/2021 this test expects to fail with EE8 "java.lang.ClassNotFoundException: org.apache.wss4j.common.crypto.CryptoFactory"
     //Aruna is aware of the cause from feature definition API packages; waiting for the next stage of update to fix it
 
-    @Test
+    //issue 30353 - comment out the test for now while further investigation is needed
+    //why test still failed "Could not sign data" with wsdl update Basic256ha256 and wssec provider added with Sha256 signature algorithm
+    //@Test
     public void testCxfX509Service() throws Exception {
 
         String thisMethod = "testCxfX509Service";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- *
+ * 
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -127,14 +127,13 @@ public class CxfX509OverRideTests {
     }
 
     //
-    // The server.xml in this server did not have the appropriate settings.
-    // This test asks the cxf service client to set the properties to
-    // overwrite them.
-    //
+    // The server.xml in this server DOES NOT have the appropriate settings to sign/encrypt the SOAP message
+    // But the Service client (CxfX509SvcClient) uses cxf/wss4j apis to create signature / encryption properties objects using CORRECT configuration and put them in requestConext
+    // The wsSecurityClient element's signatureProperties and encryptionProperties in the server.xml are ignored in this case since the same configuration (signatureProperties and encryptionProperties) is specified in the requestContext by the service client
+    // This is a positive test. The configuration specified in the requestContext by the service client provides appropriate settings to sign/encrypt and that match with the provider
+    // issue 30353
 
-    //issue 30353 - comment out the test for now while further investigation is needed
-    //why test still failed "Could not sign data" with wsdl update Basic256ha256 and server.xml added with Sha256 signature algorithm
-    //@Test
+    @Test
     public void testCxfX509Service() throws Exception {
         String thisMethod = "testCxfX509Service";
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -132,7 +132,9 @@ public class CxfX509OverRideTests {
     // overwrite them.
     //
 
-    @Test
+    //issue 30353 - comment out the test for now while further investigation is needed
+    //why test still failed "Could not sign data" with wsdl update Basic256ha256 and server.xml added with Sha256 signature algorithm
+    //@Test
     public void testCxfX509Service() throws Exception {
         String thisMethod = "testCxfX509Service";
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11enc/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11enc/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="bob"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"
@@ -69,8 +70,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="alice"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11enc/server_enchdr.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11enc/server_enchdr.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="bob"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"
@@ -69,8 +70,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="alice"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11enc/server_enchdr_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11enc/server_enchdr_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="bob"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"
@@ -71,8 +72,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="alice"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11enc/server_orig.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11enc/server_orig.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soapprovider"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -64,8 +65,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soaprequester"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11enc/server_orig_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11enc/server_orig_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soapprovider"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -66,8 +67,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soaprequester"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11enc/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11enc/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="bob"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"
@@ -71,8 +72,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="alice"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11sig/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11sig/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soapprovider"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -64,8 +65,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soaprequester"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11sig/server_enchdr.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11sig/server_enchdr.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="bob"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"
@@ -69,8 +70,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="alice"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11sig/server_enchdr_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11sig/server_enchdr_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="bob"
 	>
-          
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"
@@ -71,8 +72,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="alice"
 	>
-
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11sig/server_orig.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11sig/server_orig.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soapprovider"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -64,8 +65,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soaprequester"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11sig/server_orig_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11sig/server_orig_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soapprovider"
 	>
-         
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -66,8 +67,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soaprequester"
 	>
-       
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11sig/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.wss11sig/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soapprovider"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -65,8 +66,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soaprequester"
 	>
-
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -86,8 +86,9 @@
 		ws-security.password="security"
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -103,8 +104,9 @@
 	<wsSecurityProvider
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerDefault"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,8 +87,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	 
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -105,8 +106,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerDefault"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_1/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_1/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -86,8 +86,9 @@
 		ws-security.password="security"
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -106,8 +107,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
                 ws-security.return.security.error="true"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_1/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_1/server.xml
@@ -86,9 +86,8 @@
 		ws-security.password="security"
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>       <!--issue 30353 -->
+	>
 		<signatureProperties
-                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -107,9 +106,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
                 ws-security.return.security.error="true"
-	>       <!--issue 30353 -->
+                ws-security.asymmetric.signature.algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+	>       <!-- issue 30353 add ws-security.asymmetric.signature.algorithm -->
 		<signatureProperties
-                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_1/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_1/server_wss4j.xml
@@ -87,9 +87,8 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	        <!--issue 30353 -->
+	
 		<signatureProperties
-                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -108,10 +107,10 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.return.security.error="true"
-	>
-	        <!--issue 30353 -->
+		ws-security.asymmetric.signature.algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+	>       <!-- issue 30353 add ws-security.asymmetric.signature.algorithm -->
+	
 		<signatureProperties
-                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_1/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_1/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,8 +87,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -108,8 +109,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.return.security.error="true"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_2/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_2/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -86,8 +86,9 @@
 	<wsSecurityProvider
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerDefault"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_2/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_2/server.xml
@@ -86,9 +86,9 @@
 	<wsSecurityProvider
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>       <!--issue 30353 -->
+		ws-security.asymmetric.signature.algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+	>       <!-- issue 30353 add ws-security.asymmetric.signature.algorithm -->
 		<signatureProperties
-                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerDefault"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_2/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_2/server_wss4j.xml
@@ -86,10 +86,10 @@
 	<wsSecurityProvider
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-	>
-	        <!--issue 30353 -->
+		ws-security.asymmetric.signature.algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+	>       <!-- issue 30353 add ws-security.asymmetric.signature.algorithm -->
+	
 		<signatureProperties
-                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerDefault"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_2/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509_2/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,8 +87,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerDefault"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509async/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509async/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soapprovider"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256" 
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -64,8 +65,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soaprequester"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256" 
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509async/server_orig.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509async/server_orig.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soapprovider"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -64,8 +65,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soaprequester"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509async/server_orig_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509async/server_orig_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soapprovider"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -65,8 +66,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soaprequester"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509async/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509async/server_wss4j.xml
@@ -51,9 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soapprovider"
 	>
-	<!-- 2/2021 EE8 Callbackhandler -->
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -67,9 +67,10 @@
 		ws-security.signature.username="soaprequester"
 	>
 	<!-- ws-security.password="security"  -->
-	<!-- 2/2021 EE8 Callbackhandler -->
 	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509crl/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509crl/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="myx509certN"
 		ws-security.enableRevocation="true"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="myx509"
 			org.apache.ws.security.crypto.merlin.keystore.alias="myx509certN"
@@ -68,8 +69,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="myx509certN"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="myx509"
 			org.apache.ws.security.crypto.merlin.keystore.alias="myx509certN"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509crl/server_certn.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509crl/server_certn.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -52,8 +52,9 @@
 		ws-security.signature.username="myx509certN"
 		ws-security.enableRevocation="true"
                 ws-security.return.security.error="true"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="myx509"
 			org.apache.ws.security.crypto.merlin.keystore.alias="myx509certN"
@@ -69,8 +70,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="myx509certN"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="myx509"
 			org.apache.ws.security.crypto.merlin.keystore.alias="myx509certN"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509crl/server_certn_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509crl/server_certn_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -53,8 +53,9 @@
 		ws-security.enableRevocation="true"
 		ws-security.return.security.error="true"
 	>
-
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="myx509"
 			org.apache.ws.security.crypto.merlin.keystore.alias="myx509certN"
@@ -71,8 +72,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="myx509certN"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="myx509"
 			org.apache.ws.security.crypto.merlin.keystore.alias="myx509certN"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509crl/server_certp.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509crl/server_certp.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -52,8 +52,9 @@
 		ws-security.signature.username="myx509certp"
 		ws-security.enableRevocation="true"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="myx509"
 			org.apache.ws.security.crypto.merlin.keystore.alias="myx509certp"
@@ -69,8 +70,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="myx509certp"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="myx509"
 			org.apache.ws.security.crypto.merlin.keystore.alias="myx509certp"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509crl/server_certp_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509crl/server_certp_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -52,8 +52,9 @@
 		ws-security.signature.username="myx509certp"
 		ws-security.enableRevocation="true"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="myx509"
 			org.apache.ws.security.crypto.merlin.keystore.alias="myx509certp"
@@ -70,8 +71,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="myx509certp"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="myx509"
 			org.apache.ws.security.crypto.merlin.keystore.alias="myx509certp"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509crl/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509crl/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -52,8 +52,9 @@
 		ws-security.signature.username="myx509certN"
 		ws-security.enableRevocation="true"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="myx509"
 			org.apache.ws.security.crypto.merlin.keystore.alias="myx509certN"
@@ -70,8 +71,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="myx509certN"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="myx509"
 			org.apache.ws.security.crypto.merlin.keystore.alias="myx509certN"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509enc/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509enc/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="bob"
                 ws-security.return.security.error="true"
-	>
-		<signatureProperties
+	>       <!--issue 30353 -->
+                <signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"
@@ -70,8 +71,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="alice"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509enc/server_orig.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509enc/server_orig.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="bob"
                 ws-security.return.security.error="true"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"
@@ -70,8 +71,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="alice"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509enc/server_orig_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509enc/server_orig_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -52,8 +52,9 @@
 		ws-security.signature.username="bob"
 		ws-security.return.security.error="true"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"
@@ -72,8 +73,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="alice"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509enc/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509enc/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -52,8 +52,9 @@
 		ws-security.signature.username="bob"
 		ws-security.return.security.error="true"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"
@@ -72,8 +73,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="alice"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soapprovider"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -65,8 +66,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soaprequester"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_badclpwd.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_badclpwd.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -49,8 +49,9 @@
 	<wsSecurityProvider
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -63,8 +64,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soaprequester"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="BadClientPswd"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_badclpwd_ee9_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_badclpwd_ee9_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -65,8 +66,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soaprequester"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="BadClientPswd"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_badclpwd_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_badclpwd_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -65,8 +66,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soaprequester"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="BadClientPswd"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_badenc.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_badenc.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soapprovider"
                 ws-security.return.security.error="true"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -65,8 +66,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="alice"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_badenc_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_badenc_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -52,8 +52,9 @@
 		ws-security.signature.username="soapprovider"
 		ws-security.return.security.error="true"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -67,8 +68,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="alice"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_enc.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_enc.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="bob"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"
@@ -64,8 +65,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="alice"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_enc_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_enc_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="bob"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="bob"
@@ -66,8 +67,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="alice"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jceks"
 			org.apache.ws.security.crypto.merlin.keystore.password="storepass"
 			org.apache.ws.security.crypto.merlin.keystore.alias="alice"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_expcert.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_expcert.xml
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soapprovider"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -64,8 +65,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="wsfpexpreq"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="wsfpexpreq"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_expcert_ee9_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_expcert_ee9_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soapprovider"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -66,8 +67,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="wsfpexpreq"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="wsfpexpreq"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_expcert_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_expcert_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soapprovider"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -66,8 +67,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="wsfpexpreq"
 	>
-	
+	        <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="wsfpexpreq"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_orig.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_orig.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -50,8 +50,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soapprovider"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -64,8 +65,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 		ws-security.signature.username="soaprequester"
-	>
+	>       <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_orig_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_orig_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soapprovider"
 	>
-
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -65,9 +66,10 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soaprequester"
-	>
-
+	> 
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/publish/servers/com.ibm.ws.wssecurity_fat.x509sig/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -51,8 +51,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soapprovider"
 	>
-
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soapprovider"
@@ -66,8 +67,9 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.signature.username="soaprequester"
 	>
-
+                <!--issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="soaprequester"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/wss11enc/resources/WEB-INF/WSS11Encryption.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/wss11enc/resources/WEB-INF/WSS11Encryption.wsdl
@@ -38,7 +38,7 @@
                </sp:RecipientEncryptionToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -84,7 +84,7 @@
                </sp:RecipientEncryptionToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509aSync/resources/WEB-INF/X509Async.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509aSync/resources/WEB-INF/X509Async.wsdl
@@ -61,7 +61,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509client/src/com/ibm/ws/wssecurity/fat/x509client/CxfX509SvcClient.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509client/src/com/ibm/ws/wssecurity/fat/x509client/CxfX509SvcClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -251,6 +251,8 @@ public class CxfX509SvcClient extends HttpServlet {
         // Load the keystore
         //Crypto crypto = new Merlin();
         requestContext.put("ws-security.callback-handler", "com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback");
+        //issue 30353
+        requestContext.put("ws-security.asymmetric.signature.algorithm", "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
         String strServerDir = System.getProperty("server.config.dir").replace('\\', '/');
         String strX509JksSignLocation = strServerDir + "x509ClientDefaultS.properties";
 
@@ -292,6 +294,8 @@ public class CxfX509SvcClient extends HttpServlet {
         String strX509JksSignLocation = strServerDir + "/x509ClientDefaultS.properties";
         String strX509JksEncrLocation = strServerDir + "/x509ClientSecondE.properties"; // do the server.xml on purpose
         requestContext.put("ws-security.callback-handler", "com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"); // The callback
+        //issue 30353
+        requestContext.put("ws-security.asymmetric.signature.algorithm", "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
         requestContext.put("ws-security.signature.properties", getProperties(strX509JksSignLocation, strServerDir));
         requestContext.put("ws-security.encryption.properties", getProperties(strX509JksEncrLocation, strServerDir));
     }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509client/src/com/ibm/ws/wssecurity/fat/x509client/CxfX509SvcClientWss4j.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509client/src/com/ibm/ws/wssecurity/fat/x509client/CxfX509SvcClientWss4j.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -254,6 +254,8 @@ public class CxfX509SvcClientWss4j extends HttpServlet {
         // Load the keystore
         //Crypto crypto = new Merlin();
         requestContext.put("ws-security.callback-handler", "com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j");
+        //issue 30353
+        requestContext.put("ws-security.asymmetric.signature.algorithm", "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
         String strServerDir = System.getProperty("server.config.dir").replace('\\', '/');
         String strX509JksSignLocation = strServerDir + "x509ClientDefaultS.properties";
 
@@ -295,6 +297,8 @@ public class CxfX509SvcClientWss4j extends HttpServlet {
         String strX509JksSignLocation = strServerDir + "/x509ClientDefaultS.properties";
         String strX509JksEncrLocation = strServerDir + "/x509ClientSecondE.properties"; // do the server.xml on purpose
         requestContext.put("ws-security.callback-handler", "com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"); // The callback
+        //issue 30353
+        requestContext.put("ws-security.asymmetric.signature.algorithm", "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
         requestContext.put("ws-security.signature.properties", getProperties(strX509JksSignLocation, strServerDir));
         requestContext.put("ws-security.encryption.properties", getProperties(strX509JksEncrLocation, strServerDir));
     }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509crl/resources/WEB-INF/X509Crl.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509crl/resources/WEB-INF/X509Crl.wsdl
@@ -39,7 +39,7 @@
                </sp:RecipientToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509enc/resources/WEB-INF/X509XmlEnc.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509enc/resources/WEB-INF/X509XmlEnc.wsdl
@@ -48,7 +48,7 @@
              </sp:RecipientEncryptionToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128Rsa15/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>
@@ -105,7 +105,7 @@
              </sp:RecipientEncryptionToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128Rsa15/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>
@@ -158,7 +158,7 @@
              </sp:RecipientEncryptionToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128Rsa15/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>
@@ -323,7 +323,7 @@
                                                                                      
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>
@@ -382,7 +382,7 @@
                                                    
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509enc/resources/WEB-INF/X509XmlEnc.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509enc/resources/WEB-INF/X509XmlEnc.wsdl
@@ -48,7 +48,7 @@
              </sp:RecipientEncryptionToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic256Sha256/>
+                   <sp:Basic256Sha256Rsa15/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>
@@ -105,7 +105,7 @@
              </sp:RecipientEncryptionToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic256Sha256/>
+                   <sp:Basic256Sha256Rsa15/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>
@@ -158,7 +158,7 @@
              </sp:RecipientEncryptionToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic256Sha256/>
+                   <sp:Basic256Sha256Rsa15/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>
@@ -382,7 +382,7 @@
                                                    
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic256Sha256/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509sig/resources/WEB-INF/X509StrTypes.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509sig/resources/WEB-INF/X509StrTypes.wsdl
@@ -47,7 +47,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>
@@ -103,7 +103,7 @@
                   </sp:RecipientSignatureToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>
@@ -158,7 +158,7 @@
                   </sp:RecipientSignatureToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128/>
+                        <sp:Basic256Sha256/>
                         <sp:STRTransform10/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
@@ -221,7 +221,7 @@
                   </sp:RecipientSignatureToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>
@@ -276,7 +276,7 @@
                   </sp:RecipientSignatureToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509token/resources/WEB-INF/x509token1.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509token/resources/WEB-INF/x509token1.wsdl
@@ -45,7 +45,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.caller/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.caller/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,7 +87,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
+	        <!-- issue 30353 -->
 		<signatureProperties
+		        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -107,7 +109,9 @@
 	<!-- 11/2022 issue 23060 added ws-security.return.security.error -->
 	
 		<callerToken name="UsernameToken" />
+                <!-- issue 30353 -->
 		<signatureProperties
+		        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.caller/server_orig.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.caller/server_orig.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -88,7 +88,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
 	>
+	        <!-- issue 30353 -->
 		<signatureProperties
+		        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -109,7 +111,9 @@
 	   <!-- 11/2022 issue 23060 added ws-security.return.security.error -->
 	   
 		<callerToken name="UsernameToken" />
+                <!-- issue 30353 -->
 		<signatureProperties
+		        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.caller/server_orig_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.caller/server_orig_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,9 +87,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	<!-- 2/2021 EE8 Callbackhandler -->
-
+	        <!-- issue 30353 -->
 		<signatureProperties
+		        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -106,10 +106,11 @@
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 		ws-security.return.security.error="true"
 	>
-	<!-- 2/2021 EE8 Callbackhandler -->
-
+                
 		<callerToken name="UsernameToken" />
+                <!-- issue 30353 -->
 		<signatureProperties
+		        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.caller/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.caller/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -87,8 +87,9 @@
 		ws-security.username="user1"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-	<!-- 2/2021 EE8 Callbackhandler -->	
+	        <!-- issue 30353 -->
 		<signatureProperties
+		        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -106,10 +107,11 @@
 		ws-security.return.security.error="true"
 	>
 	<!-- 3/2021 added ws-security.return.security.error -->
-	<!-- 2/2021 EE8 Callbackhandler -->
 	
 		<callerToken name="UsernameToken" />
+                <!-- issue 30353 -->
 		<signatureProperties
+		        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplates/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplates/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -58,8 +58,9 @@
 		ws-security.username="user1"
 		ws-security.password="security"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>
+	>       <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -74,8 +75,9 @@
 	<wsSecurityProvider
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>
+	>       <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplates/server_sym.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplates/server_sym.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -63,7 +63,10 @@
 		<!-- **Do not need the private key password in Symmetric tests ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"> -->
 		<!-- **Do not need Signature properties in Symmetric. But put back for 
 			EndorsingSupportingToken -->
+
+               <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -82,7 +85,10 @@
 	>
 		<!-- **Do not need Signature properties in Symmetric. But put back for 
 			EndorsingSupportingToken -->
+
+                <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefaultCert"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplates/server_sym_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplates/server_sym_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -60,12 +60,14 @@
 		ws-security.password="security"
 		ws-security.username="user1"
 	>
-        <!-- EE8 Callbackhandler -->
 
 		<!-- **Do not need the private key password in Symmetric tests ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"> -->
 		<!-- **Do not need Signature properties in Symmetric. But put back for 
 			EndorsingSupportingToken -->
+ 
+                <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -82,11 +84,13 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-        <!-- EE8 Callbackhandler -->
-
+        
 		<!-- **Do not need Signature properties in Symmetric. But put back for 
 			EndorsingSupportingToken -->
+
+                <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefaultCert"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplates/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplates/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -58,10 +58,10 @@
 		ws-security.username="user1"
 		ws-security.password="security"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-	>
-        <!-- EE8 Callbackhandler -->
-
+	> 
+                <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -77,9 +77,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-        <!-- EE8 Callbackhandler -->
-
+                <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplateswithep/server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplateswithep/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -58,8 +58,9 @@
 		ws-security.username="user1"
 		ws-security.password="security"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>
+	>       <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -74,8 +75,9 @@
 	<wsSecurityProvider
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"
-	>
+	>       <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplateswithep/server_sym.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplateswithep/server_sym.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -63,7 +63,10 @@
 		<!-- **Do not need the private key password in Symmetric tests ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"> -->
 		<!-- **Do not need Signature properties in Symmetric. But put back for 
 			EndorsingSupportingToken -->
+
+                <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -82,7 +85,10 @@
 	>
 		<!-- **Do not need Signature properties in Symmetric. But put back for 
 			EndorsingSupportingToken -->
+
+                <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefaultCert"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplateswithep/server_sym_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplateswithep/server_sym_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -60,12 +60,14 @@
 		ws-security.password="security"
 		ws-security.username="user1"
 	>
-        <!-- 2/2021 EE8 Callbackhandler -->
 
 		<!-- **Do not need the private key password in Symmetric tests ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbh.CommonPasswordCallback"> -->
 		<!-- **Do not need Signature properties in Symmetric. But put back for 
 			EndorsingSupportingToken -->
+
+                 <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -82,11 +84,13 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-         <!-- 2/2021 EE8 Callbackhandler -->
 
 		<!-- **Do not need Signature properties in Symmetric. But put back for 
 			EndorsingSupportingToken -->
+
+                 <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefaultCert"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplateswithep/server_wss4j.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/publish/servers/com.ibm.ws.wssecurity_fat.wsstemplateswithep/server_wss4j.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -58,10 +58,10 @@
 		ws-security.username="user1"
 		ws-security.password="security"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
-	>
-         <!-- 2/2021 EE8 Callbackhandler -->
-
+	> 
+                 <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Client"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ClientDefault"
@@ -77,9 +77,9 @@
 		id="default"
 		ws-security.callback-handler="com.ibm.ws.wssecurity.example.cbhwss4j.CommonPasswordCallbackWss4j"
 	>
-         <!-- 2/2021 EE8 Callbackhandler -->
-
+                 <!-- issue 30353 -->
 		<signatureProperties
+                        signatureAlgorithm="sha256"
 			org.apache.ws.security.crypto.merlin.keystore.type="jks"
 			org.apache.ws.security.crypto.merlin.keystore.password="LibertyX509Server2"
 			org.apache.ws.security.crypto.merlin.keystore.alias="x509ServerSecond"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/test-applications/callertoken/resources/WEB-INF/callertoken.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/test-applications/callertoken/resources/WEB-INF/callertoken.wsdl
@@ -53,7 +53,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -169,7 +169,7 @@
                         <!-- sp:IncludeTimestamp / -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -216,7 +216,7 @@
                   <sp:OnlySignEntireHeadersAndBody/>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Sha256/> 
+                        <sp:Basic256Sha256/> 
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                </wsp:Policy>
@@ -252,7 +252,7 @@
                         <sp:IncludeTimestamp/>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -295,7 +295,7 @@
                     </sp:ProtectionToken>
                     <sp:AlgorithmSuite>
                        <wsp:Policy>
-                          <sp:Basic128/>
+                          <sp:Basic256Sha256/>
                        </wsp:Policy>
                     </sp:AlgorithmSuite>
                     <sp:Layout>
@@ -354,7 +354,7 @@
                         <sp:IncludeTimestamp/>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -375,7 +375,7 @@
                     </sp:ProtectionToken>
                     <sp:AlgorithmSuite>
                        <wsp:Policy>
-                          <sp:Basic128/>
+                          <sp:Basic256Sha256/>
                        </wsp:Policy>
                     </sp:AlgorithmSuite>
                     <sp:Layout>
@@ -440,7 +440,7 @@
                     <sp:SignBeforeEncrypting/>
                     <sp:AlgorithmSuite>
                        <wsp:Policy>
-                          <sp:Basic128/>
+                          <sp:Basic256Sha256/>
                        </wsp:Policy>
                     </sp:AlgorithmSuite>
                  </wsp:Policy>
@@ -477,7 +477,7 @@
                         <sp:IncludeTimestamp/>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/test-applications/wsstemplates/resources/WEB-INF/WSSTemplatesTest.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/test-applications/wsstemplates/resources/WEB-INF/WSSTemplatesTest.wsdl
@@ -191,7 +191,7 @@
 						<sp:EncryptSignature />
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 					</wsp:Policy>
@@ -234,7 +234,7 @@
 						</sp:ProtectionToken>
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 						<sp:Layout>


### PR DESCRIPTION
Cherry-picked from https://github.com/OpenLiberty/open-liberty/pull/26227 to create new branch for wssec cxf FAT update.
These changes are to address failures that we saw in ws-security fat projects when we run the tests with fips140-3 enabled
test configurations are updated to use sha256 signature algorithm