### PR TITLE
Fix ltpa validation keys directory monitoring

### DIFF
--- a/dev/com.ibm.websphere.security/src/com/ibm/ws/security/filemonitor/LTPAFileMonitor.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/ws/security/filemonitor/LTPAFileMonitor.java
@@ -32,6 +32,7 @@ public class LTPAFileMonitor extends SecurityFileMonitor {
     /** {@inheritDoc} */
     @Override
     public void onBaseline(Collection<File> baseline) {
+        actionable.performFileBasedAction(baseline);
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.websphere.security/src/com/ibm/ws/security/filemonitor/SecurityFileMonitor.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/ws/security/filemonitor/SecurityFileMonitor.java
@@ -67,7 +67,7 @@ public class SecurityFileMonitor implements FileMonitor {
             // Currently MONITOR_DIRECTORIES is only used for the LTPAFileMonitor
             // this is not used for other securityFileMonitors
             fileMonitorProps.put(FileMonitor.MONITOR_DIRECTORIES, dirs);
-            fileMonitorProps.put(FileMonitor.MONITOR_FILTER, "\\.keys");
+            fileMonitorProps.put(FileMonitor.MONITOR_FILTER, ".*\\.keys");
         }
         fileMonitorProps.put(FileMonitor.MONITOR_INTERVAL, monitorInterval);
 

--- a/dev/com.ibm.websphere.security/src/com/ibm/ws/security/filemonitor/SecurityFileMonitor.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/ws/security/filemonitor/SecurityFileMonitor.java
@@ -64,7 +64,10 @@ public class SecurityFileMonitor implements FileMonitor {
         final Hashtable<String, Object> fileMonitorProps = new Hashtable<String, Object>();
         fileMonitorProps.put(FileMonitor.MONITOR_FILES, paths);
         if (dirs != null && !dirs.isEmpty()) {
+            // Currently MONITOR_DIRECTORIES is only used for the LTPAFileMonitor
+            // this is not used for other securityFileMonitors
             fileMonitorProps.put(FileMonitor.MONITOR_DIRECTORIES, dirs);
+            fileMonitorProps.put(FileMonitor.MONITOR_FILTER, "\\.keys");
         }
         fileMonitorProps.put(FileMonitor.MONITOR_INTERVAL, monitorInterval);
 
@@ -112,8 +115,7 @@ public class SecurityFileMonitor implements FileMonitor {
 
     /** {@inheritDoc} */
     @Override
-    public void onBaseline(Collection<File> baseline) {
-    }
+    public void onBaseline(Collection<File> baseline) {}
 
     /** {@inheritDoc} */
     @Override

--- a/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImplTest.java
+++ b/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImplTest.java
@@ -85,11 +85,6 @@ public class LTPAConfigurationImplTest {
     private final ServiceReference<LTPAKeysChangeNotifier> ltpaKeysChangeNotifierRef = mock.mock(ServiceReference.class, "ltpaKeysChangeNotifierRef");
     private final LTPAKeysChangeNotifier ltpaKeysChangeNotifier = mock.mock(LTPAKeysChangeNotifier.class);
 
-    //private final LocalFileResource keysFileInServerConfig2 = mock.mock(LocalFileResource.class);
-    private final WsResource keysFileInServerConfig = mock.mock(WsResource.class, "keysFileInServerConfig");
-    private final WsResource parentResource = mock.mock(WsResource.class, "parentResource");
-    //keysFileInDirectory
-
     private LTPAConfigurationImplTestDouble ltpaConfig;
     private Map<String, Object> props;
 
@@ -101,7 +96,7 @@ public class LTPAConfigurationImplTest {
 
     @Before
     public void setUp() {
-        props = createProps(DEFAULT_CONFIG_LOCATION, PWD, 120L, 0L, DEFAULT_MONITOR_DIR_VALUE, 0L);
+        props = createProps(PATH_TO_FILE, PWD, 120L, 0L, DEFAULT_MONITOR_DIR_VALUE, 0L);
 
         mock.checking(new Expectations() {
             {
@@ -137,49 +132,8 @@ public class LTPAConfigurationImplTest {
     private void setupLocationServiceExpectations(final int numberOfInvocations) {
         mock.checking(new Expectations() {
             {
-                exactly(numberOfInvocations).of(locateService).resolveResource(DEFAULT_CONFIG_LOCATION);
-                will(returnValue(keysFileInServerConfig));
-
-                exactly(numberOfInvocations * 2).of(keysFileInServerConfig).getParent();
-                will(returnValue(parentResource));
-
-                exactly(numberOfInvocations).of(parentResource).toRepositoryPath();
-                will(returnValue(DEFAULT_CONFIG_LOCATION_DIR));
-
-                exactly(numberOfInvocations).of(locateService).resolveString(DEFAULT_CONFIG_LOCATION_DIR);
-                will(returnValue(RESOLVED_DEFAULT_CONFIG_LOCATION_DIR));
-
-                exactly(numberOfInvocations).of(keysFileInServerConfig).getName();
-                will(returnValue("ltpa.keys"));
-
-                //exactly(numberOfInvocations).of(locateService).resolveString(DEFAULT_OUTPUT_LOCATION);
-                //will(returnValue(RESOLVED_DEFAULT_OUTPUT_LOCATION));
-
-            }
-        });
-    }
-
-    private void setupLocationServiceExpectationsNew(final int numberOfInvocations) {
-        mock.checking(new Expectations() {
-            {
-                exactly(numberOfInvocations).of(locateService).resolveResource(DEFAULT_CONFIG_LOCATION);
-                will(returnValue(keysFileInServerConfig));
-
-                exactly(numberOfInvocations).of(keysFileInServerConfig).getParent();
-                will(returnValue(parentResource));
-
-                exactly(numberOfInvocations).of(parentResource).toRepositoryPath();
-                will(returnValue(DEFAULT_CONFIG_LOCATION_DIR));
-
-                exactly(numberOfInvocations).of(locateService).resolveString(DEFAULT_CONFIG_LOCATION_DIR);
-                will(returnValue(RESOLVED_DEFAULT_CONFIG_LOCATION_DIR));
-
-                exactly(numberOfInvocations).of(keysFileInServerConfig).getName();
-                will(returnValue("ltpa.keys"));
-
-                if (DEFAULT_MONITOR_DIR_VALUE)
-                    exactly(numberOfInvocations).of(locateService).resolveResource(RESOLVED_DEFAULT_CONFIG_LOCATION_DIR);
-                //wsLocationAdmin.resolveResource("testServerName/resources/security/")
+                exactly(numberOfInvocations).of(locateService).resolveString(DEFAULT_OUTPUT_LOCATION);
+                will(returnValue(RESOLVED_DEFAULT_OUTPUT_LOCATION));
             }
         });
     }
@@ -233,27 +187,6 @@ public class LTPAConfigurationImplTest {
         outputMgr.restoreStreams();
     }
 
-    protected void addPathToAnotherFileExpectations() {
-        mock.checking(new Expectations() {
-            {
-                one(locateService).resolveResource(PATH_TO_ANOTHER_FILE);
-                will(returnValue(keysFileInServerConfig));
-
-                exactly(2).of(keysFileInServerConfig).getParent();
-                will(returnValue(parentResource));
-
-                one(parentResource).toRepositoryPath();
-                will(returnValue(PATH_TO_ANOTHER_FILE));
-
-                one(locateService).resolveString(PATH_TO_ANOTHER_FILE);
-                will(returnValue(PATH_TO_ANOTHER_FILE));
-
-                one(keysFileInServerConfig).getName();
-                will(returnValue(""));
-            }
-        });
-    }
-
     @Test
     public void deactivateUnregister() {
         mock.checking(new Expectations() {
@@ -294,7 +227,7 @@ public class LTPAConfigurationImplTest {
     @Test
     public void getKeyFile() {
         assertEquals("Key file value was not the expected value",
-                     RESOLVED_DEFAULT_CONFIG_LOCATION, ltpaConfig.getPrimaryKeyFile());
+                     PATH_TO_FILE, ltpaConfig.getPrimaryKeyFile());
     }
 
     /**
@@ -351,9 +284,7 @@ public class LTPAConfigurationImplTest {
     @Test
     public void modified() {
         setupExecutorServiceExpectations(1);
-        //setupLocationServiceExpectations(1);
-
-        addPathToAnotherFileExpectations();
+        setupLocationServiceExpectations(1);
 
         props.put(LTPAConfiguration.CFG_KEY_IMPORT_FILE, PATH_TO_ANOTHER_FILE);
         ltpaConfig.modified(props);
@@ -372,13 +303,11 @@ public class LTPAConfigurationImplTest {
     @Test
     public void modified_monitorIntervalSame_fileChanged_unregistersListenerAndCreatesKeys() throws Exception {
         setupExecutorServiceExpectations(2);
-        setupLocationServiceExpectations(1);
+        setupLocationServiceExpectations(2);
         setupFileMonitorRegistrationsExpectations(2);
 
         props.put(LTPAConfiguration.CFG_KEY_MONITOR_INTERVAL, 5L);
         LTPAConfigurationImplTestDouble ltpaConfig = createActivatedLTPAConfigurationImpl();
-
-        addPathToAnotherFileExpectations();
 
         props.put(LTPAConfiguration.CFG_KEY_IMPORT_FILE, PATH_TO_ANOTHER_FILE);
         ltpaConfig.modified(props);
@@ -390,13 +319,11 @@ public class LTPAConfigurationImplTest {
     @Test
     public void modified_fileAndMonitorIntervalChanged_unregistersListenerAndCreatesKeys() throws Exception {
         setupExecutorServiceExpectations(2);
-        setupLocationServiceExpectations(1);
+        setupLocationServiceExpectations(2);
         setupFileMonitorRegistrationsExpectations(2);
 
         props.put(LTPAConfiguration.CFG_KEY_MONITOR_INTERVAL, 5L);
         LTPAConfigurationImplTestDouble ltpaConfig = createActivatedLTPAConfigurationImpl();
-
-        addPathToAnotherFileExpectations();
 
         props.put(LTPAConfiguration.CFG_KEY_IMPORT_FILE, PATH_TO_ANOTHER_FILE);
         props.put(LTPAConfiguration.CFG_KEY_MONITOR_INTERVAL, 10L);
@@ -409,13 +336,11 @@ public class LTPAConfigurationImplTest {
     @Test
     public void modified_fileChanged_monitorIntervalSetToZero_unregistersListenerAndCreatesKeys() throws Exception {
         setupExecutorServiceExpectations(2);
-        setupLocationServiceExpectations(1);
+        setupLocationServiceExpectations(2);
         setupFileMonitorRegistrationsExpectations(1);
 
         props.put(LTPAConfiguration.CFG_KEY_MONITOR_INTERVAL, 5L);
         LTPAConfigurationImplTestDouble ltpaConfig = createActivatedLTPAConfigurationImpl();
-
-        addPathToAnotherFileExpectations();
 
         props.put(LTPAConfiguration.CFG_KEY_IMPORT_FILE, PATH_TO_ANOTHER_FILE);
         props.put(LTPAConfiguration.CFG_KEY_MONITOR_INTERVAL, 0L);
@@ -473,22 +398,16 @@ public class LTPAConfigurationImplTest {
     @Test
     public void keyFileFromConfigDirWhenDefaultLocationNotOverridden() {
         setupExecutorServiceExpectations(1);
+        setupLocationServiceExpectations(1);
+        final WsResource keysFileInServerConfig = mock.mock(WsResource.class);
         mock.checking(new Expectations() {
             {
-                one(locateService).resolveResource(RESOLVED_DEFAULT_OUTPUT_LOCATION);
+                one(locateService).resolveResource(DEFAULT_CONFIG_LOCATION);
                 will(returnValue(keysFileInServerConfig));
-
-                exactly(2).of(keysFileInServerConfig).getParent();
-                will(returnValue(parentResource));
-
-                one(parentResource).toRepositoryPath();
-                will(returnValue(DEFAULT_CONFIG_LOCATION_DIR));
-
-                one(locateService).resolveString(DEFAULT_CONFIG_LOCATION_DIR);
-                will(returnValue(RESOLVED_DEFAULT_CONFIG_LOCATION_DIR));
-
-                one(keysFileInServerConfig).getName();
-                will(returnValue("ltpa.keys"));
+                one(locateService).resolveString(DEFAULT_CONFIG_LOCATION);
+                will(returnValue(RESOLVED_DEFAULT_CONFIG_LOCATION));
+                one(keysFileInServerConfig).exists();
+                will(returnValue(true));
             }
         });
 
@@ -496,28 +415,16 @@ public class LTPAConfigurationImplTest {
         LTPAConfigurationImplTestDouble ltpaConfig = createActivatedLTPAConfigurationImpl();
         assertEquals("Key file value was not the expected value",
                      RESOLVED_DEFAULT_CONFIG_LOCATION, ltpaConfig.getPrimaryKeyFile());
-        //Key file value was not the expected value expected:<[testServerName/resources/security/ltpa.keys]> but was:<[]>
     }
 
     @Test
     public void keyFileFromOutputDirWhenDefaultLocationNotOverriddenAndKeysFileNotInConfigDir() {
         setupExecutorServiceExpectations(1);
+        setupLocationServiceExpectations(1);
         mock.checking(new Expectations() {
             {
-                one(locateService).resolveResource(RESOLVED_DEFAULT_OUTPUT_LOCATION);
-                will(returnValue(keysFileInServerConfig));
-
-                exactly(2).of(keysFileInServerConfig).getParent();
-                will(returnValue(parentResource));
-
-                one(parentResource).toRepositoryPath();
-                will(returnValue(RESOLVED_DEFAULT_CONFIG_LOCATION_DIR));
-
-                one(locateService).resolveString(RESOLVED_DEFAULT_CONFIG_LOCATION_DIR);
-                will(returnValue(RESOLVED_DEFAULT_CONFIG_LOCATION_DIR));
-
-                one(keysFileInServerConfig).getName();
-                will(returnValue("ltpa.keys"));
+                one(locateService).resolveResource(DEFAULT_CONFIG_LOCATION);
+                will(returnValue(null));
             }
         });
 

--- a/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPAKeyCreateTaskTest.java
+++ b/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPAKeyCreateTaskTest.java
@@ -67,9 +67,6 @@ public class LTPAKeyCreateTaskTest {
     private final WsLocationAdmin locationService = mock.mock(WsLocationAdmin.class);
     private Map<String, Object> props;
 
-    private final WsResource keysFileInServerConfig = mock.mock(WsResource.class, "keysFileInServerConfig");
-    private final WsResource parentResource = mock.mock(WsResource.class, "parentResource");
-
     private class LTPAKeyCreatorDouble extends LTPAKeyCreateTask {
         LTPAKeyCreatorDouble(WsLocationAdmin locService, LTPAConfigurationImpl config) {
             super(locService, config);
@@ -109,20 +106,8 @@ public class LTPAKeyCreateTaskTest {
     private void setupLocationServiceExpecatations() {
         mock.checking(new Expectations() {
             {
-                one(locationService).resolveResource(TEST_FILE_NAME);
-                will(returnValue(keysFileInServerConfig));
-
-                exactly(2).of(keysFileInServerConfig).getParent();
-                will(returnValue(parentResource));
-
-                one(parentResource).toRepositoryPath();
-                will(returnValue(""));
-
-                one(locationService).resolveString("");
-                will(returnValue(""));
-
-                one(keysFileInServerConfig).getName();
-                will(returnValue(TEST_FILE_NAME));
+                one(locationService).resolveString(DEFAULT_OUTPUT_LOCATION);
+                will(returnValue(RESOLVED_DEFAULT_OUTPUT_LOCATION));
             }
         });
     }


### PR DESCRIPTION
1. fixes rtc 297282 - where key.p12 file is processed by the directory monitor when it should not be.

2. fixes the validation keys files processing logic to work when the monitored directory is outside of the wlp