### PR TITLE
PR for Issue 26225: Fix OIDC social client emitting raw NLS message key instead of message text

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/RedirectionProcessor.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/RedirectionProcessor.java
@@ -32,6 +32,7 @@ public class RedirectionProcessor {
     private final HttpServletRequest request;
     private final HttpServletResponse response;
     private final TraceComponent tc;
+    private final TraceComponent tcLocal = Tr.register(UserInfoHelper.class, TraceConstants.TRACE_GROUP, TraceConstantsCommonMessages.MESSAGE_BUNDLE);
 
     public RedirectionProcessor(HttpServletRequest request, HttpServletResponse response, TraceComponent tc) {
         this.request = request;
@@ -115,7 +116,7 @@ public class RedirectionProcessor {
         String requestUrl = getOriginalRequestUrl(state);
 
         if (requestUrl == null || requestUrl.isEmpty()) {
-            String errorMsg = Tr.formatMessage(tc, "OIDC_CLIENT_BAD_REQUEST_NO_COOKIE", request.getRequestURL()); // CWWKS1750E
+            String errorMsg = Tr.formatMessage(tcLocal, "OIDC_CLIENT_BAD_REQUEST_NO_COOKIE", request.getRequestURL()); // CWWKS1750E
             Tr.error(tc, errorMsg);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return;


### PR DESCRIPTION
Updates the `RedirectionProcessor` class to have a local `Tr` variable that is tied to the NLS messages associated with its package. As the code was written, the `RedirectionProcessor` class accepted a `Tr` instance variable in its constructor and inadvertently used that object to look up an NLS message that wasn't in the associated message bundle. That caused the message to not be found, and the message key was emitted to the logs as-is. Now the local `Tr` variable will emit the correct error message.

Resolves #26225