### PR TITLE
should not try to send bcl requests if no bcl uri is setup

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelper.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelper.java
@@ -28,10 +28,14 @@ import org.apache.http.util.EntityUtils;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.JwtContext;
 
+import com.ibm.oauth.core.api.error.OidcServerException;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.productinfo.ProductInfo;
+import com.ibm.ws.security.oauth20.ProvidersService;
+import com.ibm.ws.security.oauth20.api.OAuth20Provider;
+import com.ibm.ws.security.oauth20.api.OidcOAuth20ClientProvider;
 import com.ibm.ws.security.oauth20.plugins.OidcBaseClient;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
 
@@ -89,7 +93,44 @@ public class BackchannelLogoutRequestHelper {
             }
             return false;
         }
+        if (!hasClientWithBackchannelLogoutUri()) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "No client has a back-channel logout uri set up, so back-channel logout will not be performed.");
+            }
+            return false;
+        }
         return true;
+    }
+
+    boolean hasClientWithBackchannelLogoutUri() {
+        String oauthProviderName = oidcServerConfig.getOauthProviderName();
+        OAuth20Provider provider = ProvidersService.getOAuth20Provider(oauthProviderName);
+        if (provider == null) {
+            return false;
+        }
+        return hasClientWithBackchannelLogoutUri(provider);
+    }
+
+    @FFDCIgnore(OidcServerException.class)
+    boolean hasClientWithBackchannelLogoutUri(OAuth20Provider provider) {
+        OidcOAuth20ClientProvider clientProvider = provider.getClientProvider();
+        if (clientProvider == null) {
+            return false;
+        }
+        try {
+            for (OidcBaseClient client : clientProvider.getAll()) {
+                String backchannelLogoutUri = client.getBackchannelLogoutUri();
+                if (backchannelLogoutUri != null && !backchannelLogoutUri.isEmpty()) {
+                    return true;
+                }
+            }
+        } catch (OidcServerException e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "There was an issue getting all the OIDC OAuth20 clients.");
+            }
+            return false;
+        }
+        return false;
     }
 
     void sendBackchannelLogoutRequestsToClients(Map<OidcBaseClient, Set<String>> clientsAndLogoutTokens) {

--- a/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelperTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequestHelperTest.java
@@ -9,13 +9,25 @@
  *******************************************************************************/
 package io.openliberty.security.openidconnect.backchannellogout;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
 import javax.servlet.http.HttpServletRequest;
 
+import org.jmock.Expectations;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
+import com.ibm.oauth.core.api.error.OidcServerException;
+import com.ibm.ws.security.oauth20.api.OAuth20Provider;
+import com.ibm.ws.security.oauth20.api.OidcOAuth20ClientProvider;
+import com.ibm.ws.security.oauth20.plugins.OidcBaseClient;
 import com.ibm.ws.security.test.common.CommonTestClass;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
 
@@ -27,6 +39,8 @@ public class BackchannelLogoutRequestHelperTest extends CommonTestClass {
 
     private final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
     private final OidcServerConfig oidcServerConfig = mockery.mock(OidcServerConfig.class);
+    private final OAuth20Provider provider = mockery.mock(OAuth20Provider.class);
+    private final OidcOAuth20ClientProvider clientProvider = mockery.mock(OidcOAuth20ClientProvider.class);
 
     private BackchannelLogoutRequestHelper helper;
 
@@ -51,6 +65,138 @@ public class BackchannelLogoutRequestHelperTest extends CommonTestClass {
     public static void tearDownAfterClass() throws Exception {
         outputMgr.dumpStreams();
         outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void hasClientWithBackchannelLogoutUri_nullClientProvider() {
+        mockery.checking(new Expectations() {
+            {
+                one(provider).getClientProvider();
+                will(returnValue(null));
+            }
+        });
+        boolean result = helper.hasClientWithBackchannelLogoutUri(provider);
+        assertFalse("Expected false because there is no client provider, so the clients cannot be checked.", result);
+    }
+
+    @Test
+    public void hasClientWithBackchannelLogoutUri_errorGettingClients() throws OidcServerException {
+        OidcServerException oidcServerException = new OidcServerException("some description", "some code", 500);
+        mockery.checking(new Expectations() {
+            {
+                one(provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(throwException(oidcServerException));
+            }
+        });
+        boolean result = helper.hasClientWithBackchannelLogoutUri(provider);
+        assertFalse("Expected false because there was an error getting the clients, so the clients cannot be checked.", result);
+    }
+
+    @Test
+    public void hasClientWithBackchannelLogoutUri_noClients() throws OidcServerException {
+        Collection<OidcBaseClient> clients = new ArrayList<>();
+        mockery.checking(new Expectations() {
+            {
+                one(provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(clients));
+            }
+        });
+        boolean result = helper.hasClientWithBackchannelLogoutUri(provider);
+        assertFalse("Expected false because there are no clients.", result);
+    }
+
+    @Test
+    public void hasClientWithBackchannelLogoutUri_noClientsHaveBackchannelLogoutUri_null() throws OidcServerException {
+        Collection<OidcBaseClient> clients = new ArrayList<>();
+        OidcBaseClient client1 = mockery.mock(OidcBaseClient.class, "oidcBaseClient1");
+        clients.add(client1);
+        OidcBaseClient client2 = mockery.mock(OidcBaseClient.class, "oidcBaseClient2");
+        clients.add(client2);
+        mockery.checking(new Expectations() {
+            {
+                one(provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(clients));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue(null));
+                one(client2).getBackchannelLogoutUri();
+                will(returnValue(null));
+            }
+        });
+        boolean result = helper.hasClientWithBackchannelLogoutUri(provider);
+        assertFalse("Expected false because the clients' back-channel logout uri's were null.", result);
+    }
+
+    @Test
+    public void hasClientWithBackchannelLogoutUri_noClientsHaveBackchannelLogoutUri_empty() throws OidcServerException {
+        Collection<OidcBaseClient> clients = new ArrayList<>();
+        OidcBaseClient client1 = mockery.mock(OidcBaseClient.class, "oidcBaseClient1");
+        clients.add(client1);
+        OidcBaseClient client2 = mockery.mock(OidcBaseClient.class, "oidcBaseClient2");
+        clients.add(client2);
+        mockery.checking(new Expectations() {
+            {
+                one(provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(clients));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue(""));
+                one(client2).getBackchannelLogoutUri();
+                will(returnValue(""));
+            }
+        });
+        boolean result = helper.hasClientWithBackchannelLogoutUri(provider);
+        assertFalse("Expected false because the clients' back-channel logout uri's were empty.", result);
+    }
+
+    @Test
+    public void hasClientWithBackchannelLogoutUri_atLeastOneClientHasBackchannelLogoutUri_first() throws OidcServerException {
+        Collection<OidcBaseClient> clients = new ArrayList<>();
+        OidcBaseClient client1 = mockery.mock(OidcBaseClient.class, "oidcBaseClient1");
+        clients.add(client1);
+        OidcBaseClient client2 = mockery.mock(OidcBaseClient.class, "oidcBaseClient2");
+        clients.add(client2);
+        mockery.checking(new Expectations() {
+            {
+                one(provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(clients));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue("http://localhost:8941/oidcclient/backchannel_logout/client01"));
+            }
+        });
+        boolean result = helper.hasClientWithBackchannelLogoutUri(provider);
+        assertTrue("Expected true because at least one client had a back-channel logout uri configured.", result);
+    }
+
+    @Test
+    public void hasClientWithBackchannelLogoutUri_atLeastOneClientHasBackchannelLogoutUri_second() throws OidcServerException {
+        Collection<OidcBaseClient> clients = new ArrayList<>();
+        OidcBaseClient client1 = mockery.mock(OidcBaseClient.class, "oidcBaseClient1");
+        clients.add(client1);
+        OidcBaseClient client2 = mockery.mock(OidcBaseClient.class, "oidcBaseClient2");
+        clients.add(client2);
+        mockery.checking(new Expectations() {
+            {
+                one(provider).getClientProvider();
+                will(returnValue(clientProvider));
+                one(clientProvider).getAll();
+                will(returnValue(clients));
+                one(client1).getBackchannelLogoutUri();
+                will(returnValue(null));
+                one(client2).getBackchannelLogoutUri();
+                will(returnValue("http://localhost:8941/oidcclient/backchannel_logout/client02"));
+            }
+        });
+        boolean result = helper.hasClientWithBackchannelLogoutUri(provider);
+        assertTrue("Expected true because at least one client had a back-channel logout uri configured.", result);
     }
 
 }


### PR DESCRIPTION
for #26459 

add an additional check to ensure that there is at least one client setup on the OP with a back-channel logout uri before proceeding to creating the logout tokens. this fixes a problem where an error is thrown when we'd try to process the id token in the id_token_hint for back-channel logout even though it is not set up.