### PR TITLE
JPA Postgres and Consul error message

### DIFF
--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseManager.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseManager.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -67,6 +67,8 @@ public class DatabaseManager {
          */
         _unicodeSupportPlatform.add(Pattern.compile("(?i)(.)*db2(.)*"));
         _unicodeSupportPlatform.add(Pattern.compile("(?i)(.)*derby(.)*"));
+        _unicodeSupportPlatform.add(Pattern.compile("(?i)(.)*PostgreSQL(.)*"));
+
 
         final String emName = EntityManagerFactory.class.getName();
         final boolean isJakarta = emName.startsWith("jakarta");

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/ExternalTestService.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/ExternalTestService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/ExternalTestService.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/ExternalTestService.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -64,16 +64,16 @@ public class ExternalTestService {
     private ExternalTestService(JsonObject data, Map<String, ServiceProperty> props) {
         JsonObject serviceData = data.getJsonObject("Service");
         JsonObject nodeData = data.getJsonObject("Node");
-        String networkLocationProp = getNetworkLocation()+"_address";
+        String networkLocationProp = getNetworkLocation() + "_address";
         String address;
 
         if (props.get(networkLocationProp) != null) {
             //The service has a private IP on the same network, so use that
-           try {
+            try {
                 address = props.get(networkLocationProp).getStringValue();
-           } catch(Exception ex) {
+            } catch (Exception ex) {
                 address = nodeData.getString("Address");
-           }
+            }
         } else if (!serviceData.getString("Address", "").isEmpty()) {
             //Use the service address
             address = serviceData.getString("Address");
@@ -333,7 +333,11 @@ public class ExternalTestService {
             throw new Exception("There are not enough healthy services available for " + serviceName + " that match the filter provided");
 
         }
-        throw finalError;
+
+        //Http requests above ended in exception
+        Exception e = new Exception("Exception attempting to connect to Consul servers");
+        e.initCause(finalError);
+        throw e;
 
     }
 


### PR DESCRIPTION
Adds Postgres as a platform that supports Unicode for JPA. This prevents an exception when unicode is used with Postgres.

This was manually tested in the https://github.com/o-s-expert/jakarta-data-2023 environment it was discovered in.

Also includes an improvement for the error message when Consul servers can't be reached