### PR TITLE
Wait for FFDC in JDBC FAT

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -408,8 +408,10 @@ public class DataSourceTest extends FATServletClient {
 
     @Test
     @Mode(TestMode.FULL)
-    @AllowedFFDC({ "javax.resource.spi.ResourceAllocationException" })
+    @ExpectedFFDC({ "javax.resource.spi.ResourceAllocationException" })
     public void testInterruptedWaiters() throws Exception {
+        server.setMarkToEndOfLog();
         runTest();
+        server.waitForStringInLogUsingMark("FFDC1015I.*ResourceAllocationException");
     }
 }


### PR DESCRIPTION
- wait for expected FFDC that is logged on async thread so it does not interfere with subsequent tests
