### PR TITLE
Fix ppc64le GLIBC_TUNABLES to allow only P8 hwcaps

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -980,9 +980,9 @@ readServerEnv()
 criuEnvDefaults() {
   if [ -z "$GLIBC_TUNABLES" ]
   then
-    GLIBC_TUNABLES=glibc.cpu.hwcaps=z14,arch_2_07,-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load:glibc.pthread.rseq=0
+    GLIBC_TUNABLES=glibc.cpu.hwcaps=z14,-arch_3_00,-arch_3_1,-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load:glibc.pthread.rseq=0
   else
-    GLIBC_TUNABLES=${GLIBC_TUNABLES}:glibc.cpu.hwcaps=z14,arch_2_07,-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load:glibc.pthread.rseq=0
+    GLIBC_TUNABLES=${GLIBC_TUNABLES}:glibc.cpu.hwcaps=z14,-arch_3_00,-arch_3_1,-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load:glibc.pthread.rseq=0
   fi
   export GLIBC_TUNABLES
   export LD_BIND_NOT=on


### PR DESCRIPTION
For Power (like x86) the hwcaps tunables specified via the environment are added to final set, they do not override the set. Therefore in order to prevent ISA 3.0 and 3.1 (Power 9, 10) features from being used we have to subtract arch_3_00 and arch_3_1 rather than setting arch_2_07.