### PR TITLE
PR for Issue 26453: Clarify jwtBuilder expiresInSeconds description

### DIFF
--- a/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/l10n/metatype.properties
@@ -1,14 +1,11 @@
 ###############################################################################
-# Copyright (c) 2016, 2022 IBM Corporation and others.
+# Copyright (c) 2016, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 #
 #NLS_ENCODING=UNICODE
@@ -34,7 +31,7 @@ valid=Token expiration time in hours
 valid.desc=Indicates the token expiration time in hours. ExpiresInSeconds takes precedence if present.
 
 expiresInSeconds=Token expiration time in seconds
-expiresInSeconds.desc=Indicates the token expiration time in seconds. Takes precedence over expiry.
+expiresInSeconds.desc=Indicates the token expiration time in seconds. Takes precedence over expiry. When this attribute is set to a negative number, the value of the expiry attribute is used.
 claims=Supported claims
 claims.desc=Specify a comma separated list of claims to include in the token. These claims must be existing user attributes that are defined for the subject of the JWT in the user registry.
 


### PR DESCRIPTION
Clarifies that when set to a negative number, the `expiresInSeconds` attribute defaults to the value of the `expiry` attribute.

For #26453