### PR TITLE
Fixed computed metrics when mp_app tag is used in MpMetrics-5.0

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.5.0.monitor.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.5.0.monitor.internal/bnd.bnd
@@ -46,6 +46,7 @@ WS-TraceGroup: METRICS
 
 -buildpath: \
 	com.ibm.ws.logging;version=latest,\
+	io.openliberty.org.eclipse.microprofile.config.3.0;version=latest,\
 	com.ibm.ws.monitor;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
 	io.openliberty.microprofile.metrics.5.0.internal;version=latest,\

--- a/dev/io.openliberty.microprofile.metrics.5.0.monitor.internal/src/io/openliberty/microprofile/metrics/internal/monitor/MonitorMetricsHandler.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.monitor.internal/src/io/openliberty/microprofile/metrics/internal/monitor/MonitorMetricsHandler.java
@@ -245,7 +245,8 @@ public class MonitorMetricsHandler {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "Unregistering computed metric for " + metricIDSet);
             }
-            cmmh.unregister(metricIDSet);
+            String mpAppName = monMetrics.getMpAppName();
+            cmmh.unregister(metricIDSet, mpAppName);
         }
     }
 

--- a/dev/io.openliberty.microprofile.metrics.5.0.monitor.internal/src/io/openliberty/microprofile/metrics/internal/monitor/computed/internal/ComputedMonitorMetrics.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.monitor.internal/src/io/openliberty/microprofile/metrics/internal/monitor/computed/internal/ComputedMonitorMetrics.java
@@ -21,12 +21,18 @@ public class ComputedMonitorMetrics {
     private double prevValue;
     private String monitorMetricScope;
     private String appName;
+    private String mpAppNameConfigValue;
+    
+    public ComputedMonitorMetrics(String metricScope, MetricID metricID, String computationType) {
+       this(metricScope, metricID, computationType, null, null);
+    }
 
-    public ComputedMonitorMetrics(String metricScope, MetricID metricID, String computationType, String appName) {
+    public ComputedMonitorMetrics(String metricScope, MetricID metricID, String computationType, String appName, String mpAppNameConfigValue) {
         this.monitorMetricScope = metricScope;
         this.monitorMetricID = metricID;
         this.computationType = computationType;
         this.appName = appName;
+        this.mpAppNameConfigValue = mpAppNameConfigValue;
         this.prevValue = (double) 0.0;
     }
 
@@ -52,6 +58,10 @@ public class ComputedMonitorMetrics {
 
     public String getAppName() {
         return this.appName;
+    }
+    
+    public String getMpAppNameConfigValue() {
+        return this.mpAppNameConfigValue;
     }
 
     public Double getDifference(double current) {

--- a/dev/io.openliberty.microprofile.metrics.5.0.monitor.internal/src/io/openliberty/microprofile/metrics/internal/monitor/computed/internal/ComputedMonitorMetricsHandler.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.monitor.internal/src/io/openliberty/microprofile/metrics/internal/monitor/computed/internal/ComputedMonitorMetricsHandler.java
@@ -15,6 +15,9 @@ package io.openliberty.microprofile.metrics.internal.monitor.computed.internal;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -114,8 +117,7 @@ public class ComputedMonitorMetricsHandler {
         SortedSet<MetricID> baseMetricsIDSet = metricRegistry.getMetricIDs();
 
         // Get the Base scoped metrics needed to create the computed base metrics.
-        List<String> baseMetricGroupList = mappingTable
-                .getMetricGroupsList("base");
+        List<String> baseMetricGroupList = mappingTable.getMetricGroupsList("base");
 
         // Iterate over the list of Base metric groups needed for computation.
         for (String baseMetricGroup : baseMetricGroupList) {
@@ -137,18 +139,16 @@ public class ComputedMonitorMetricsHandler {
                     // Check if the base metric name from the registry equals the base metric name duration needed for computation.
                     String baseMetricName = mid.getName();
                     if (baseMetricName.equals(metricDurationName)) {
-                        metricTagNames = mid.getTagsAsArray();
+                        metricTagNames = getComputedMetricsTags(mid);
 
                         // Add the duration metrics to the computation set, no appName for base metrics.
-                        cmm = new ComputedMonitorMetrics(
-                                MetricRegistry.BASE_SCOPE, mid, Constants.DURATION, null);
+                        MetricID durationMetricID = new MetricID(metricDurationName, metricTagNames);
+                        cmm = new ComputedMonitorMetrics(MetricRegistry.BASE_SCOPE, durationMetricID, Constants.DURATION);
                         computedMonitorMetricsSet.add(cmm);
 
                         // Add the total count metric to the computation set, no appName for base metrics.
-                        MetricID totalCountMetricID = new MetricID(
-                                metricTotalCountName, metricTagNames);
-                        cmm = new ComputedMonitorMetrics(
-                                MetricRegistry.BASE_SCOPE, totalCountMetricID, Constants.TOTAL, null);
+                        MetricID totalCountMetricID = new MetricID(metricTotalCountName, metricTagNames);
+                        cmm = new ComputedMonitorMetrics(MetricRegistry.BASE_SCOPE, totalCountMetricID, Constants.TOTAL);
                         computedMonitorMetricsSet.add(cmm);
 
                         // Once the existing metrics needed for calculation are cached, register new computed metric in the Metric Registry.
@@ -159,11 +159,8 @@ public class ComputedMonitorMetricsHandler {
                         computationMetricsMap.put(computedMetricID,
                                 computedMonitorMetricsSet);
 
-                        if (TraceComponent.isAnyTracingEnabled()
-                                && tc.isDebugEnabled()) {
-                            Tr.debug(tc,
-                                    "Created computed metric for base computation : "
-                                            + computedMetricID.toString());
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Created computed metric for base computation : " + computedMetricID.toString());
                         }
                     }
                 }
@@ -187,14 +184,11 @@ public class ComputedMonitorMetricsHandler {
 
                 if (metricDurationName.equals(metricName)) {
                     // cache the metrics tag for the new computed metric name.
-                    computedMetricTagNames = mID.getTagsAsArray();
-                    cmm = new ComputedMonitorMetrics(
-                            MetricRegistry.VENDOR_SCOPE, mID,
-                            Constants.DURATION, null); // no appName
+                    computedMetricTagNames = getComputedMetricsTags(mID);
+                    cmm = new ComputedMonitorMetrics(MetricRegistry.VENDOR_SCOPE, mID, Constants.DURATION);
 
                 } else if (metricTotalCountName.equals(metricName)) {
-                    cmm = new ComputedMonitorMetrics(
-                            MetricRegistry.VENDOR_SCOPE, mID, Constants.TOTAL, null); // no appName
+                    cmm = new ComputedMonitorMetrics(MetricRegistry.VENDOR_SCOPE, mID, Constants.TOTAL);
                 }
 
                 if (cmm != null) {
@@ -203,12 +197,10 @@ public class ComputedMonitorMetricsHandler {
             }
 
             // Once the existing metrics needed for calculation are cached, register new computed metric.
-            MetricID computedMetricID = registerNewComputedMetricWithExistingMetricTag(
-                    metricData, computedMetricTagNames);
+            MetricID computedMetricID = registerNewComputedMetricWithExistingMetricTag(metricData, computedMetricTagNames);
 
             // Populating map with newly registered computed metric and corresponding metrics set needed for computation.
-            computationMetricsMap.put(computedMetricID,
-                    computedMonitorMetricsSet);
+            computationMetricsMap.put(computedMetricID, computedMonitorMetricsSet);
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc,
@@ -218,7 +210,7 @@ public class ComputedMonitorMetricsHandler {
         }
     }
 
-    public void createRESTComputedMetrics(String objectName, MetricID restMetricID, String appName) {
+    public void createRESTComputedMetrics(String objectName, MetricID restMetricID, String appName, String mpAppNameConfigValue) {
         String[][] data = mappingTable.getData(objectName);
 
         // Loop through each base REST metric data.
@@ -229,23 +221,20 @@ public class ComputedMonitorMetricsHandler {
             // Create a new set for every new computed metric.
             Set<ComputedMonitorMetrics> computedMonitorMetricsSet = new HashSet<ComputedMonitorMetrics>();
 
-            metricTagNames = restMetricID.getTagsAsArray();
+            metricTagNames = getComputedMetricsTags(restMetricID);
 
             // Add the duration metrics to the computation set.
-            cmm = new ComputedMonitorMetrics(MetricRegistry.BASE_SCOPE,
-                    restMetricID, Constants.DURATION, appName);
+            cmm = new ComputedMonitorMetrics(MetricRegistry.BASE_SCOPE, restMetricID, Constants.DURATION, appName, mpAppNameConfigValue);
             computedMonitorMetricsSet.add(cmm);
 
             // Add the total count metric to the computation set, using the previous MetricID, 
             // since REST is a Timer, it has the same metricID.
-            cmm = new ComputedMonitorMetrics(MetricRegistry.BASE_SCOPE,
-                    restMetricID, Constants.TOTAL, appName);
+            cmm = new ComputedMonitorMetrics(MetricRegistry.BASE_SCOPE, restMetricID, Constants.TOTAL, appName, mpAppNameConfigValue);
             computedMonitorMetricsSet.add(cmm);
 
             // Once the existing metrics needed for calculation are cached, register new
             // computed metric in the Metric Registry.
-            MetricID computedMetricID = registerNewComputedMetricWithExistingMetricTag(
-                    metricData, metricTagNames);
+            MetricID computedMetricID = registerNewComputedMetricWithExistingMetricTag(metricData, metricTagNames);
 
             // Populating map with newly registered computed metric and corresponding
             // metrics set needed for computation
@@ -256,6 +245,30 @@ public class ComputedMonitorMetricsHandler {
                         "Created computed metric for base REST computation : " + computedMetricID.toString());
             }
         }
+    }
+    
+    private Tag[] getComputedMetricsTags(MetricID metricId) {
+        Map<String, String> metricTagMap = metricId.getTags();
+        Tag[] metricsTagsArr = null;
+        
+        // The mp_app tag is a reserved tag in mpMetrics, we cannot register or retrieve a metric with
+        // a metricID that contains the mp_app tag. Need to remove it from the metricID 
+        // before registering or retrieving a metric.
+        if (metricTagMap.containsKey("mp_app")) {
+            Map<String, String> tempTagMaps = new HashMap<>(metricTagMap);
+            tempTagMaps.remove("mp_app");
+            
+            List<Tag> metricsTagList = new ArrayList<>();
+            for (Map.Entry<String, String> entry : tempTagMaps.entrySet()) {
+                metricsTagList.add(new Tag(entry.getKey(), entry.getValue()));
+            }
+            metricsTagsArr = metricsTagList.toArray(new Tag[metricsTagList.size()]);
+        }
+        else {
+            // If no mp_app tag is present in the metricID, just return tags as-is.
+            metricsTagsArr = metricId.getTagsAsArray();
+        }
+        return metricsTagsArr;
     }
 
     public MetricID registerNewComputedMetricWithExistingMetricTag(String[] metricData, Tag[] existingMetricTags) {
@@ -302,18 +315,18 @@ public class ComputedMonitorMetricsHandler {
             }
         }
 
-        // Clear all the computed base metric maps
+        // Clear all the computed metric maps
         computationMetricsMap.clear();
         finalComputedMetricsMap.clear();
     }
 
-    public void unregister(Set<MetricID> monitorMetricsIDSet) {
+    public void unregister(Set<MetricID> monitorMetricsIDSet, String mpAppName) {
         MetricID computedMetricID = null;
         for (MetricID mID : monitorMetricsIDSet) {
             computedMetricID = getComputedMetricIDToRemove(mID);
             if (computedMetricID != null) {
                 // Remove the corresponding computed metricID.
-                removeComputedMetrics(computedMetricID);
+                removeComputedMetrics(computedMetricID, mpAppName);
             }
         }
     }
@@ -323,9 +336,10 @@ public class ComputedMonitorMetricsHandler {
             MetricID computedMetricID = entry.getKey();
             for (ComputedMonitorMetrics cmm : entry.getValue()) {
                 String restAppName = cmm.getAppName();
+                String mpAppNameConfigValue = cmm.getMpAppNameConfigValue();
                 if (restAppName != null) {
                     if (restAppName.equals(appName)) {
-                        removeComputedMetrics(computedMetricID);
+                        removeComputedMetrics(computedMetricID, mpAppNameConfigValue);
                         break; // Removed the computed REST metric for the corresponding app, no need to continue the loop.
                     }
                 }
@@ -333,10 +347,15 @@ public class ComputedMonitorMetricsHandler {
         }
     }
 
-    public void removeComputedMetrics(MetricID computedMetricID) {
+    public void removeComputedMetrics(MetricID computedMetricID, String mpAppName) {
         // Remove the corresponding computed metricID.
         computationMetricsMap.remove(computedMetricID);
         finalComputedMetricsMap.remove(computedMetricID);
+        
+        // Check if the mpAppName is set via MpConfig.
+        if (mpAppName != null && !mpAppName.isEmpty()) {
+            computedMetricID = mergeMPAppTag(computedMetricID, mpAppName);
+        }
 
         MetricRegistry vendorRegistry = getMetricRegistry(MetricRegistry.VENDOR_SCOPE);
         boolean rc = vendorRegistry.remove(computedMetricID);
@@ -346,7 +365,7 @@ public class ComputedMonitorMetricsHandler {
         }
     }
 
-    public MetricID getComputedMetricIDToRemove(MetricID monitorMetricID) {
+    private MetricID getComputedMetricIDToRemove(MetricID monitorMetricID) {
         for (Map.Entry<MetricID, Set<ComputedMonitorMetrics>> entry : computationMetricsMap.entrySet()) {
             MetricID computedMetricID = entry.getKey();
             Set<ComputedMonitorMetrics> monitorMetricSet = entry.getValue();
@@ -358,6 +377,15 @@ public class ComputedMonitorMetricsHandler {
             }
         }
         return null;
+    }
+    
+    private MetricID mergeMPAppTag(MetricID mid, String appNameValue) {
+        Tag appTag = new Tag("mp_app", appNameValue);
+        
+        Tag[] tempArr = Arrays.copyOf(mid.getTagsAsArray(), mid.getTagsAsArray().length + 1);
+        tempArr[tempArr.length - 1] = appTag;
+        
+        return new MetricID(mid.getName(), tempArr);
     }
 
     public Double getComputedValue(MetricID metricId) {
@@ -433,7 +461,7 @@ public class ComputedMonitorMetricsHandler {
         }
     }
     
-    private void calculateEWMAValueForGC(MetricID computedMetricID, Set<ComputedMonitorMetrics> monitorMetrics) {
+    public void calculateEWMAValueForGC(MetricID computedMetricID, Set<ComputedMonitorMetrics> monitorMetrics) {
         double currValue = 0.0, diffDuration = 0.0, diffTotalCount = 0.0;
         
         // Get the collection of Garbage Collection MXBeans
@@ -542,38 +570,48 @@ public class ComputedMonitorMetricsHandler {
 
     public void calculateEWMAValue(MetricID computedMetricID, double duration, double totalCount) {
         double computedVal = 0.0;
-
-        // Calculate the new computed metric.
-        // If the duration or the totalCount is a negative value, set the computedValue to be -1.0
-        // Should only happen when calculating the gc.time.per.cycle.
-        computedVal = ((duration < 0.0) || (totalCount < 0.0)) ? -1.0 : (duration / totalCount);
-
+        
         // Only the computed metricIDs that require EWMA will be passed into this method.
         EWMA ewmaObj = (EWMA) finalComputedMetricsMap.get(computedMetricID);
 
-        if (ewmaObj == null) {
-            // Initialization of the EWMA object, for the first time.
-            double alpha = calculateAlpha(EWMA_MOVING_WINDOW_INTERVAL); // 5 min moving window
-            ewmaObj = new EWMA(alpha);
-
-            // EWMA[0] will be equal directly to the initially calculated value.
-            double initialValue = (duration == 0.0 || totalCount == 0.0) ? 0.0 : computedVal;
-            ewmaObj.updateNewValue(initialValue);
-        } else {
-            if ((duration == 0.0 || totalCount == 0.0)) {
-                // If nothing changed during the current sampling period, get the previously calculated EWMA value and feed it into it again.
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Idling - There were no new data in the sampling period, getting the previously calculated EWMA value to feed into it again.");
-                }
-                ewmaObj.updateNewValue(ewmaObj.getAveragedValue());
-            } else {
-                ewmaObj.updateNewValue(computedVal);
-            }
+        // Calculate the new computed metric.
+        // If the duration or the totalCount is a negative value, set the computedValue to be -1.0
+        // Should only happen when calculating the gc.time.per.cycle, if the gc.time is unknown to
+        // the JVM. The rest of the metrics needed for computation are monotonically increasing,
+        // and will never result in a negative value.
+        computedVal = ((duration < 0.0) || (totalCount < 0.0)) ? -1.0 : (duration / totalCount);
+        
+        if (computedVal == -1.0) {
+            finalComputedMetricsMap.put(computedMetricID, computedVal);
         }
-        finalComputedMetricsMap.put(computedMetricID, ewmaObj);
+        else {
+            if (ewmaObj == null) {
+                // Initialization of the EWMA object, for the first time.
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "First initialization of the computed metric, creating EWMA object.");
+                }
+                double alpha = calculateAlpha(EWMA_MOVING_WINDOW_INTERVAL); // 5 min moving window
+                ewmaObj = new EWMA(alpha);
+
+                // EWMA[0] will be equal directly to the initially calculated value.
+                double initialValue = (duration == 0.0 || totalCount == 0.0) ? 0.0 : computedVal;
+                ewmaObj.updateNewValue(initialValue);
+            } else {
+                if ((duration == 0.0 || totalCount == 0.0)) {
+                    // If nothing changed during the current sampling period, get the previously calculated EWMA value and feed it into it again.
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Idling - There were no new data in the sampling period, getting the previously calculated EWMA value to feed into it again.");
+                    }
+                    ewmaObj.updateNewValue(ewmaObj.getAveragedValue());
+                } else {
+                    ewmaObj.updateNewValue(computedVal);
+                }
+            }
+            finalComputedMetricsMap.put(computedMetricID, ewmaObj); 
+        }
     }
 
-    public double calculateAlpha(double movingWindowInMins) {
+    private double calculateAlpha(double movingWindowInMins) {
         double alpha, movingWindowInSecs, numOfDataSamplesInMovingWindow;
 
         // Get the moving window duration in seconds.

--- a/dev/io.openliberty.restfulWS.mpMetrics.filter/bnd.bnd
+++ b/dev/io.openliberty.restfulWS.mpMetrics.filter/bnd.bnd
@@ -64,6 +64,7 @@ DynamicImport-Package: com.ibm.websphere.monitor.meters;version="1.0.0", \
 
 -buildpath: \
 	com.ibm.ws.classloading,\
+	io.openliberty.org.eclipse.microprofile.config.3.0;version=latest,\
 	io.openliberty.jakarta.annotation.2.1;version=latest,\
 	com.ibm.ws.monitor,\
 	io.openliberty.jakarta.servlet.6.0;version=latest,\


### PR DESCRIPTION
fixes #26457
fixes #26505

- Fixed the issue when the MP Config property `mp.metrics.appName` or `mp.metrics.defaultAppName` is set, the computed metrics can not be created or required metrics can not be retrieved using the MetricID, that contains the `mp_app` tag.
- Added test cases for the above scenario.
- Fixed a test failure, where the computed gc metric could not be found, due to gc name mismatch for different Java versions.