### PR TITLE
query annotation using method parameter names

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3147,6 +3147,16 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Use a repository query with named parameters, where the parameters are obtained from
+     * the corresponding method parameters based on the method's parameter names.
+     */
+    @Test
+    public void testNamedParametersFromMethodParameterNames() {
+        assertArrayEquals(new long[] { 19, 29, 43, 47 },
+                          primes.matchAny(19, "XLVII", "2B", "twenty-nine"));
+    }
+
+    /**
      * Test NotBetween in a filter.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3157,6 +3157,33 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Use a repository query with both named parameters and positional parameters. Expect this to be rejected.
+     */
+    @Test
+    public void testNamedParametersMixedWithPositionalParameters() {
+        try {
+            Collection<Long> found = primes.matchAnyWithMixedUsageOfPositionalAndNamed("three", 23);
+            fail("Should not be able to mix positional and named parameters. Found: " + found);
+        } catch (MappingException x) {
+            // expected
+        }
+    }
+
+    /**
+     * Use a repository query with named parameters, where the parameters are
+     * sometimes obtained from the Param annotation and other times obtained from
+     * the corresponding method parameters based on the method's parameter names.
+     */
+    @Test
+    public void testNamedParametersMixingAnnotationAndParameterNames() {
+        assertEquals(List.of(5L, 13L, 29L, 31L),
+                     primes.matchAnyWithMixedUsageOfParamAnnotation(31, "thirteen", "V", "1D")
+                                     .stream()
+                                     .sorted()
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
      * Test NotBetween in a filter.
      */
     @Test
@@ -3330,6 +3357,18 @@ public class DataTestServlet extends FATServlet {
         assertEquals(2, shipments.removeCanceled());
 
         assertEquals(3, shipments.removeEverything());
+    }
+
+    /**
+     * Use a repository query with positional parameters and a literal value that looks like a named parameter, but isn't.
+     */
+    @Test
+    public void testPositionalParameterWithLiteralThatLooksLikeANamedParameter() {
+        assertEquals(List.of("thirty-seven", "forty-one"), // ordered by numeric value
+                     primes.matchAnyExceptLiteralValueThatLooksLikeANamedParameter(41, "thirty-seven"));
+
+        assertEquals(List.of("forty-one", "thirty-seven"), // ordered by name
+                     primes.matchAnyExceptLiteralValueThatLooksLikeANamedParameter("thirty-seven", 41));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -228,6 +228,10 @@ public interface Primes {
     Stream<Prime> lessThanWithSuffixOrBetweenWithSuffix(long numLessThan, String firstSuffix,
                                                         long lowerLimit, long upperLimit, String secondSuffix);
 
+    @OrderBy("id")
+    @Query("SELECT o.numberId FROM Prime o WHERE (o.name = :numberName OR :numeral=o.romanNumeral OR o.hex =:hex OR o.numberId=:num)")
+    long[] matchAny(long num, String numeral, String hex, String numberName);
+
     @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId), COUNT(o.numberId), AVG(o.numberId) FROM Prime o WHERE o.numberId < ?1")
     Deque<Double> minMaxSumCountAverageDeque(long numBelow);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.Iterator;
@@ -231,6 +232,23 @@ public interface Primes {
     @OrderBy("id")
     @Query("SELECT o.numberId FROM Prime o WHERE (o.name = :numberName OR :numeral=o.romanNumeral OR o.hex =:hex OR o.numberId=:num)")
     long[] matchAny(long num, String numeral, String hex, String numberName);
+
+    @OrderBy("id")
+    @Query("SELECT o.name FROM Prime o WHERE (o.name <> ':name' AND (o.numberId=?1 OR o.name=?2))")
+    List<String> matchAnyExceptLiteralValueThatLooksLikeANamedParameter(long num, String name);
+
+    @OrderBy("name")
+    @Query("SELECT o.name FROM Prime o WHERE ((o.name=?1 OR o.numberId=?2) AND o.name <> ':name')")
+    ArrayList<String> matchAnyExceptLiteralValueThatLooksLikeANamedParameter(String name, long num);
+
+    @Query("SELECT o.numberId FROM Prime o WHERE (o.name = :numName OR o.romanNumeral=:numeral OR o.hex =:hexadecimal OR o.numberId=:num)")
+    Streamable<Long> matchAnyWithMixedUsageOfParamAnnotation(long num,
+                                                             @Param("numName") String numberName,
+                                                             String numeral,
+                                                             @Param("hexadecimal") String hex);
+
+    @Query("SELECT o.numberId FROM Prime o WHERE (o.name = ?1 OR o.numberId=:num)")
+    Collection<Long> matchAnyWithMixedUsageOfPositionalAndNamed(String name, long num);
 
     @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId), COUNT(o.numberId), AVG(o.numberId) FROM Prime o WHERE o.numberId < ?1")
     Deque<Double> minMaxSumCountAverageDeque(long numBelow);

--- a/dev/io.openliberty.data.internal_fat/test-applications/ProviderTestApp/src/test/jakarta/data/inmemory/provider/CompositeBuildCompatibleExtension.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/ProviderTestApp/src/test/jakarta/data/inmemory/provider/CompositeBuildCompatibleExtension.java
@@ -54,7 +54,7 @@ public class CompositeBuildCompatibleExtension implements BuildCompatibleExtensi
         AnnotationMember providerMember = java.security.AccessController.doPrivileged((java.security.PrivilegedAction<AnnotationMember>) () -> //
         repositoryAnnotationInfo.member("provider"));
 
-        String provider = providerMember.toString();
+        String provider = providerMember.asString();
         boolean provideRepository = "Composites Mock Data Provider".equals(provider);
 
         // Otherwise, if the provider is not explicitly specified,


### PR DESCRIPTION
Allow method parameter names to be used in place of `@Param`.