### PR TITLE
JAX-WS: bootstrap.properties replacement is refactored

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFPositivePropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFPositivePropertiesTest.java
@@ -18,6 +18,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.ws.jaxws.fat.util.ExplodedShrinkHelper;
 import com.ibm.ws.jaxws.fat.util.TestUtils;
 import com.ibm.ws.properties.test.servlet.LibertyCXFPositivePropertiesTestServlet;
@@ -82,9 +83,11 @@ public class LibertyCXFPositivePropertiesTest {
 
         // For EE10, we test all the properties tested in the other repeats plus the additional Woodstox configuration property
         if (JakartaEEAction.isEE10OrLaterActive()) {
-            TestUtils.publishFileToServer(server,
-                                          "LibertyCXFPropertiesTest", "woodstox-true-bootstrap.properties",
-                                          "", "bootstrap.properties");
+            server.getServerBootstrapPropertiesFile().delete(); // In the next line we are forcing overwrite, however, we are deleting here to be sure.
+            server.getServerBootstrapPropertiesFile().copyFromSource(new RemoteFile(server.getMachine(), server.pathToAutoFVTTestFiles
+                                                                                                         + "/LibertyCXFPropertiesTest/woodstox-true-bootstrap.properties"),
+                                                                     false,
+                                                                     true);
         }
 
         server.startServer("LibertyCXFPropertiesTest.log");


### PR DESCRIPTION
Fixes #26507
