### PR TITLE
send resource parameters with requests to oidc provider 

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequest.java
@@ -226,17 +226,13 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
             addPkceParameters(pkceCodeChallengeMethod, state, authzParameters);
         }
 
-        // LIBERTY-I-61: START
         if (isImplicit) {
             addImplicitParameters(authzParameters);
         }
         String resources = getResourcesParameter();
-        System.out.println("Resources: " + resources);
         if (resources != null) {
             authzParameters.addParameter("resource", resources);
-            System.out.println("Adding resouces parameter no matter it is implcit or not. (isImplicit=" + isImplicit + ")");
         }
-        // LIBERTY-I-61: END
 
         // look for custom params in the configuration to send to the authorization ep
         addCustomParams(authzParameters);
@@ -261,11 +257,6 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
 
     void addImplicitParameters(AuthorizationRequestParameters authzParameters) throws UnsupportedEncodingException {
         authzParameters.addParameter("response_mode", "form_post");
-        // add resource
-        //        String resources = getResourcesParameter();
-        //        if (resources != null) {
-        //            authzParameters.addParameter("resource", resources);
-        //        }
     }
 
     String getResourcesParameter() throws UnsupportedEncodingException {

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequest.java
@@ -226,9 +226,18 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
             addPkceParameters(pkceCodeChallengeMethod, state, authzParameters);
         }
 
+        // LIBERTY-I-61: START
         if (isImplicit) {
             addImplicitParameters(authzParameters);
         }
+        String resources = getResourcesParameter();
+        System.out.println("Resources: " + resources);
+        if (resources != null) {
+            authzParameters.addParameter("resource", resources);
+            System.out.println("Adding resouces parameter no matter it is implcit or not. (isImplicit=" + isImplicit + ")");
+        }
+        // LIBERTY-I-61: END
+
         // look for custom params in the configuration to send to the authorization ep
         addCustomParams(authzParameters);
 
@@ -253,10 +262,10 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
     void addImplicitParameters(AuthorizationRequestParameters authzParameters) throws UnsupportedEncodingException {
         authzParameters.addParameter("response_mode", "form_post");
         // add resource
-        String resources = getResourcesParameter();
-        if (resources != null) {
-            authzParameters.addParameter("resource", resources);
-        }
+        //        String resources = getResourcesParameter();
+        //        if (resources != null) {
+        //            authzParameters.addParameter("resource", resources);
+        //        }
     }
 
     String getResourcesParameter() throws UnsupportedEncodingException {

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequest.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.security.common.web.JavaScriptUtils;
 import com.ibm.ws.security.common.web.WebSSOUtils;
 import com.ibm.ws.security.openidconnect.pkce.ProofKeyForCodeExchangeHelper;
@@ -46,6 +47,8 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
 
     ConvergedClientConfig clientConfig;
     WebSSOUtils webSsoUtils = new WebSSOUtils();
+    
+    private static boolean issuedBetaMessage = false;
 
     public OidcAuthorizationRequest(HttpServletRequest request, HttpServletResponse response, ConvergedClientConfig clientConfig) {
         super(request, response, clientConfig.getClientId());
@@ -230,7 +233,7 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
             addImplicitParameters(authzParameters);
         }
         String resources = getResourcesParameter();
-        if (resources != null) {
+        if (resources != null && (isImplicit || isRunningBetaMode())) {          
             authzParameters.addParameter("resource", resources);
         }
 
@@ -239,6 +242,18 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
 
         // check and see if we have any additional params to forward from the request
         addForwardLoginParams(authzParameters);
+    }
+    
+    boolean isRunningBetaMode() {
+        if (!ProductInfo.getBetaEdition()) {
+            return false;
+        } else {
+            if (!issuedBetaMessage) {
+                Tr.info(tc, "BETA: A beta method has been invoked for the class " + this.getClass().getName() + " for the first time.");
+                issuedBetaMessage = !issuedBetaMessage;
+            }
+            return true;
+        }
     }
 
     private boolean isACRConfigured() {


### PR DESCRIPTION
- update oidc client runtime to include resource parameters with authorization requests in authorization grant flow (we already do this with implicit flow)

for #23126 
fixes #26887
