### PR TITLE
Updated Computed Metrics FAT to wait for server config and clean up

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/files/server_monitorFilter5.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/files/server_monitorFilter5.xml
@@ -1,12 +1,13 @@
 <server>
     <featureManager>
-        <feature>xmlWS-4.0</feature>
         <feature>servlet-6.0</feature>
         <feature>jdbc-4.2</feature>
+        <feature>restfulWS-3.1</feature>
         <feature>mpMetrics-5.0</feature>
+        <feature>localConnector-1.0</feature>
     </featureManager>
 
-    <monitor filter="Threadpool, Session"/>
+    <monitor filter="Threadpool,Session"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverJDBCConfig.xml"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/files/server_monitorFilter6.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/files/server_monitorFilter6.xml
@@ -1,9 +1,10 @@
 <server>
     <featureManager>
-        <feature>xmlWS-4.0</feature>
         <feature>servlet-6.0</feature>
         <feature>jdbc-4.2</feature>
+        <feature>restfulWS-3.1</feature>
         <feature>mpMetrics-5.0</feature>
+        <feature>localConnector-1.0</feature>
     </featureManager>
 
     <monitor filter="ConnectionPool,WebContainer"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/files/server_monitorFilter7.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/files/server_monitorFilter7.xml
@@ -1,9 +1,10 @@
 <server>
     <featureManager>
-        <feature>xmlWS-4.0</feature>
         <feature>servlet-6.0</feature>
         <feature>jdbc-4.2</feature>
+        <feature>restfulWS-3.1</feature>
         <feature>mpMetrics-5.0</feature>
+        <feature>localConnector-1.0</feature>
     </featureManager>
 
     <monitor filter="WebContainer"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/files/server_monitorFilter8.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/files/server_monitorFilter8.xml
@@ -1,9 +1,10 @@
 <server>
     <featureManager>
-        <feature>xmlWS-4.0</feature>
         <feature>servlet-6.0</feature>
         <feature>jdbc-4.2</feature>
+        <feature>restfulWS-3.1</feature>
         <feature>mpMetrics-5.0</feature>
+        <feature>localConnector-1.0</feature>
     </featureManager>
 
     <monitor filter="ConnectionPool"/>


### PR DESCRIPTION
fixes #26518
- Fixes a test failure, where the test case did not wait long enough for the server to finish configuration update.
- Added additional logs and clean up during server stop.
- Removed redundant features from the test server.xml files