### PR TITLE
update StaticMetamodel to latest from spec

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/io.openliberty.data-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/io.openliberty.data-1.0.feature
@@ -7,6 +7,7 @@ IBM-API-Package: \
   io.openliberty.data.repository; type="ibm-api",\
   jakarta.data; type="spec",\
   jakarta.data.exceptions; type="spec",\
+  jakarta.data.model; type="spec",\
   jakarta.data.page; type="spec",\
   jakarta.data.repository; type="spec"
 Subsystem-Name: Jakarta Data 1.0

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/AttributeInfoImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/AttributeInfoImpl.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.data.internal.persistence;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+import jakarta.data.Sort;
+import jakarta.data.model.AttributeInfo;
+
+/**
+ * Attribute information for the static metamodel.
+ */
+@Trivial
+record AttributeInfoImpl(
+                String name,
+                Sort asc,
+                Sort ascIgnoreCase,
+                Sort desc,
+                Sort descIgnoreCase)
+                implements AttributeInfo {
+
+    static AttributeInfoImpl create(String name) {
+        return new AttributeInfoImpl(name, //
+                        Sort.asc(name), //
+                        Sort.ascIgnoreCase(name), //
+                        Sort.desc(name), //
+                        Sort.descIgnoreCase(name));
+    }
+}

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityDefiner.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityDefiner.java
@@ -343,23 +343,27 @@ public class EntityDefiner implements Runnable {
                 for (Class<?> metamodelClass : metamodelClasses)
                     for (Field field : metamodelClass.getFields()) {
                         int mod = field.getModifiers();
-                        if (String.class.equals(field.getType())
+                        if (jakarta.data.model.Attribute.class.equals(field.getType())
                             && Modifier.isPublic(mod)
                             && Modifier.isStatic(mod)
-                            && !Modifier.isFinal(mod)
-                            && Modifier.isVolatile(mod)) {
+                            && Modifier.isFinal(mod)) {
 
                             String fieldName = field.getName();
-                            String value = entityInfo.attributeNames.get(fieldName.toLowerCase());
-                            if (value != null)
+                            String attrName = entityInfo.attributeNames.get(fieldName.toLowerCase());
+                            jakarta.data.model.Attribute attribute = null;
+                            if (attrName != null)
                                 try {
-                                    if (trace && tc.isDebugEnabled())
-                                        Tr.debug(this, tc, "set " + metamodelClass.getSimpleName() + '.' + fieldName + " = " + value);
-                                    field.set(null, value);
+                                    attribute = (jakarta.data.model.Attribute) field.get(null);
                                 } catch (IllegalAccessException | IllegalArgumentException x) {
-                                    System.out.println("Unable to set the value of the " + field + " field to " + value);
+                                    System.out.println("Unable to initialize the " + fieldName + " field of the " +
+                                                       metamodelClass.getName() + " StaticMetamodel class.");
                                     // TODO NLS
                                 }
+                            if (trace && tc.isDebugEnabled())
+                                Tr.debug(this, tc, "initialize " + metamodelClass.getSimpleName() + '.' + fieldName + " (" + attrName + "): " + attribute);
+
+                            if (attribute != null)
+                                attribute.init(AttributeInfoImpl.create(fieldName));
                         }
                     }
             }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -51,8 +51,8 @@ import com.ibm.wsspi.persistence.DatabaseStore;
 import com.ibm.wsspi.resource.ResourceFactory;
 
 import io.openliberty.data.internal.persistence.EntityDefiner;
-import jakarta.data.StaticMetamodel;
 import jakarta.data.exceptions.MappingException;
+import jakarta.data.model.StaticMetamodel;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
 import jakarta.enterprise.event.Observes;

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/BeanDefiningAnnotationMetadata.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/BeanDefiningAnnotationMetadata.java
@@ -19,7 +19,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import io.openliberty.cdi.spi.CDIExtensionMetadata;
-import jakarta.data.StaticMetamodel;
+import jakarta.data.model.StaticMetamodel;
 import jakarta.data.repository.Repository;
 
 /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1064,8 +1064,8 @@ public class DataTestServlet extends FATServlet {
                              "TestEmbeddable-104-2288-60",
                              "TestEmbeddable-304-3655-30"),
                      houses.findByAreaGreaterThan(1500,
-                                                  Sort.desc(House_.numBedrooms),
-                                                  Sort.asc(House_.LotSize))
+                                                  Sort.desc(House_.numBedrooms.name()),
+                                                  Sort.asc(House_.LotSize.name()))
                                      .map(house -> house.parcelId)
                                      .collect(Collectors.toList()));
 
@@ -1074,9 +1074,9 @@ public class DataTestServlet extends FATServlet {
                              "TestEmbeddable-104-2288-60",
                              "TestEmbeddable-204-2992-20"),
                      houses.findByAreaGreaterThan(1400,
-                                                  Sort.desc(House_.garage_door_height),
-                                                  Sort.asc(House_.kitchen_width),
-                                                  Sort.asc(House_.AREA))
+                                                  House_.garage_door_height.desc(),
+                                                  House_.kitchen_width.asc(),
+                                                  House_.AREA.asc())
                                      .map(house -> house.parcelId)
                                      .collect(Collectors.toList()));
 
@@ -1085,7 +1085,7 @@ public class DataTestServlet extends FATServlet {
                              "TestEmbeddable-204-2992-20",
                              "TestEmbeddable-104-2288-60"),
                      houses.findByAreaGreaterThan(1300,
-                                                  Sort.desc(House_.parcelid))
+                                                  House_.parcelid.descIgnoreCase())
                                      .map(house -> house.parcelId)
                                      .collect(Collectors.toList()));
 
@@ -1094,7 +1094,7 @@ public class DataTestServlet extends FATServlet {
                              "TestEmbeddable-304-3655-30",
                              "TestEmbeddable-404-4418-40"),
                      houses.findByAreaGreaterThan(1200,
-                                                  Sort.asc(House_.id))
+                                                  House_.id.ascIgnoreCase())
                                      .map(house -> house.parcelId)
                                      .collect(Collectors.toList()));
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/House_.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/House_.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
-import jakarta.data.StaticMetamodel;
+import jakarta.data.model.StaticMetamodel;
 
 /**
  * Metamodel for the House entity.

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/House_.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/House_.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import jakarta.data.model.Attribute;
 import jakarta.data.model.StaticMetamodel;
 
 /**
@@ -19,29 +20,29 @@ import jakarta.data.model.StaticMetamodel;
  */
 @StaticMetamodel(House.class)
 public class House_ {
-    public static volatile String AREA;
+    public static final Attribute AREA = Attribute.get();
 
-    public static volatile String garage;
+    public static final Attribute garage = Attribute.get();
 
-    public static volatile String GARAGE_AREA;
+    public static final Attribute GARAGE_AREA = Attribute.get();
 
-    public static volatile String garage_door_height;
+    public static final Attribute garage_door_height = Attribute.get();
 
-    public static volatile String Garage_Door_Width;
+    public static final Attribute Garage_Door_Width = Attribute.get();
 
-    public static volatile String garage_type;
+    public static final Attribute garage_type = Attribute.get();
 
-    public static volatile String kitchen;
+    public static final Attribute kitchen = Attribute.get();
 
-    public static volatile String kitchen_length;
+    public static final Attribute kitchen_length = Attribute.get();
 
-    public static volatile String kitchen_width;
+    public static final Attribute kitchen_width = Attribute.get();
 
-    public static volatile String id;
+    public static final Attribute id = Attribute.get();
 
-    public static volatile String LotSize;
+    public static final Attribute LotSize = Attribute.get();
 
-    public static volatile String numBedrooms;
+    public static final Attribute numBedrooms = Attribute.get();
 
-    public static volatile String parcelid;
+    public static final Attribute parcelid = Attribute.get();
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CityAttrNames1.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CityAttrNames1.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import jakarta.data.model.Attribute;
 import jakarta.data.model.StaticMetamodel;
 
 /**
@@ -17,7 +18,7 @@ import jakarta.data.model.StaticMetamodel;
  */
 @StaticMetamodel(City.class)
 public class CityAttrNames1 {
-    public static volatile String name = "replace-this-with-the-field-name";
-    public static volatile String stateName;
-    public static volatile String population;
+    public static final Attribute name = Attribute.get();
+    public static final Attribute stateName = Attribute.get();
+    public static final Attribute population = Attribute.get();
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CityAttrNames1.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CityAttrNames1.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
-import jakarta.data.StaticMetamodel;
+import jakarta.data.model.StaticMetamodel;
 
 /**
  * Static metamodel for the City entity.

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CityAttrNames2.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CityAttrNames2.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
-import jakarta.data.StaticMetamodel;
+import jakarta.data.model.StaticMetamodel;
 
 /**
  * Static metamodel for the City entity.

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CityAttrNames2.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CityAttrNames2.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import jakarta.data.model.Attribute;
 import jakarta.data.model.StaticMetamodel;
 
 /**
@@ -17,10 +18,10 @@ import jakarta.data.model.StaticMetamodel;
  */
 @StaticMetamodel(City.class)
 public class CityAttrNames2 {
-    public static volatile String areaCodes;
-    public static volatile String changeCount;
-    public static volatile String id;
-    public static volatile String ignore = "do-not-replace";
+    public static final Attribute areaCodes = Attribute.get();
+    public static final Attribute changeCount = Attribute.get();
+    public static final Attribute id = Attribute.get();
+    public static final Attribute ignore = Attribute.get();
     public static volatile long population; // ignored due to data type
-    public static final String name = "do-not-replace-final";
+    public static final Attribute name = null;
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2117,16 +2117,28 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testStaticMetamodel() {
-        assertEquals("name", CityAttrNames1.name);
-        assertEquals("population", CityAttrNames1.population);
-        assertEquals("stateName", CityAttrNames1.stateName);
+        assertEquals("name", CityAttrNames1.name.name());
+        assertEquals(Sort.asc("population"), CityAttrNames1.population.asc());
+        assertEquals(Sort.ascIgnoreCase("stateName"), CityAttrNames1.stateName.ascIgnoreCase());
 
-        assertEquals("areaCodes", CityAttrNames2.areaCodes);
-        assertEquals("changeCount", CityAttrNames2.changeCount);
-        assertEquals(null, CityAttrNames2.id);
-        assertEquals("do-not-replace", CityAttrNames2.ignore);
+        assertEquals("areaCodes", CityAttrNames2.areaCodes.name());
+        assertEquals(Sort.desc("changeCount"), CityAttrNames2.changeCount.desc());
         assertEquals(0L, CityAttrNames2.population);
-        assertEquals("do-not-replace-final", CityAttrNames2.name);
+        assertEquals(null, CityAttrNames2.name);
+
+        try {
+            String name = CityAttrNames2.id.name();
+            fail("Metamodel should not initialize an id field when the entity has a compound unique identifier (IdClass): " + name);
+        } catch (MappingException x) {
+            // expected
+        }
+
+        try {
+            Sort sort = CityAttrNames2.ignore.asc();
+            fail("Metamodel should not initialize fields that do not correspond to entity attributes: " + sort);
+        } catch (MappingException x) {
+            // expected
+        }
     }
 
     /**
@@ -2134,9 +2146,21 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testStaticMetamodelIgnoresNonJPAEntity() {
-        assertEquals(null, EntityModelUnknown_.days);
-        assertEquals(null, EntityModelUnknown_.months);
-        assertEquals("do-not-replace-this", EntityModelUnknown_.years);
+        try {
+            Sort sort = EntityModelUnknown_.days.desc();
+            fail("Metamodel should not initialize fields for a non-entity or unrecognized entity: " + sort);
+        } catch (MappingException x) {
+            // expected
+        }
+
+        try {
+            String name = EntityModelUnknown_.months.name();
+            fail("Metamodel should not initialize fields for a non-entity or unrecognized entity: " + name);
+        } catch (MappingException x) {
+            // expected
+        }
+
+        assertEquals(null, EntityModelUnknown_.years);
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/EntityModelUnknown_.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/EntityModelUnknown_.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import jakarta.data.model.Attribute;
 import jakarta.data.model.StaticMetamodel;
 
 /**
@@ -17,7 +18,7 @@ import jakarta.data.model.StaticMetamodel;
  */
 @StaticMetamodel(java.time.Period.class)
 public class EntityModelUnknown_ {
-    public static volatile String days;
-    public static volatile String months;
-    public static volatile String years = "do-not-replace-this";
+    public static final Attribute days = Attribute.get();
+    public static final Attribute months = Attribute.get();
+    public static final Attribute years = null;
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/EntityModelUnknown_.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/EntityModelUnknown_.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
-import jakarta.data.StaticMetamodel;
+import jakarta.data.model.StaticMetamodel;
 
 /**
  * Static metamodel for an non-JPA entity type to ignore.

--- a/dev/io.openliberty.jakarta.data.1.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.data.1.0/bnd.bnd
@@ -25,6 +25,7 @@ Bundle-Description: Copied Jakarta Data API classes and some proposed or experim
 Export-Package: \
   jakarta.data;version="1.0.0",\
   jakarta.data.exceptions;version="1.0.0",\
+  jakarta.data.model;version="1.0.0",\
   jakarta.data.page;version="1.0.0",\
   jakarta.data.repository;version="1.0.0"
 

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/model/Attribute.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/model/Attribute.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.model;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.data.Sort;
+import jakarta.data.exceptions.MappingException;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+public class Attribute {
+    private final AtomicReference<AttributeInfo> info = new AtomicReference<AttributeInfo>();
+
+    private Attribute() {
+    }
+
+    private final AttributeInfo attrInfo() {
+        AttributeInfo attrInfo = info.get();
+        if (attrInfo == null)
+            throw new MappingException("Not found");
+        return attrInfo;
+
+    }
+
+    public final Sort asc() {
+        return attrInfo().asc();
+    }
+
+    public final Sort ascIgnoreCase() {
+        return attrInfo().ascIgnoreCase();
+    }
+
+    public static final Attribute create() {
+        return new Attribute();
+    }
+
+    public final Sort desc() {
+        return attrInfo().desc();
+    }
+
+    public final Sort descIgnoreCase() {
+        return attrInfo().descIgnoreCase();
+    }
+
+    public static final Attribute get() {
+        return new Attribute();
+    }
+
+    public final boolean init(AttributeInfo attrInfo) {
+        return info.compareAndSet(null, attrInfo);
+    }
+
+    public final String name() {
+        return attrInfo().name();
+    }
+}

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/model/AttributeInfo.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/model/AttributeInfo.java
@@ -10,25 +10,21 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data;
+package jakarta.data.model;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import jakarta.data.Sort;
 
 /**
- * To propose in Jakarta Data.
+ * Method signatures are copied from Jakarta Data.
  */
-@Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
-public @interface StaticMetamodel {
-    /**
-     * An entity class.
-     *
-     * @return the entity class.
-     */
-    Class<?> value();
+public interface AttributeInfo {
+    Sort asc();
+
+    Sort ascIgnoreCase();
+
+    Sort desc();
+
+    Sort descIgnoreCase();
+
+    String name();
 }

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/model/StaticMetamodel.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/model/StaticMetamodel.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.model;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// TODO create story to have Liberty tools team generate metamodel classes based on the entities used
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface StaticMetamodel {
+    /**
+     * An entity class.
+     *
+     * @return the entity class.
+     */
+    Class<?> value();
+}


### PR DESCRIPTION
Update our copy of spec classes to include recent updates to the static metamodel.
Then update our code and tests to implement/expect the pattern of defining Attribute fields.