### PR TITLE
Skip LastExecutionTests and TriggerTests for Jakarta EE 10

### DIFF
--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -88,7 +88,6 @@ public class FATSuite {
          */
         if (TestModeFilter.FRAMEWORK_TEST_MODE != Mode.TestMode.FULL) {
             Log.info(ConcurrentTckLauncherFull.class, "createSuiteXML", "Modifying API and Spec packages to exclude specific tests for lite mode.");
-            apiExcludes.add("ee.jakarta.tck.concurrent.api.Trigger");
             specExcludes.addAll(Arrays.asList("ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi",
                                               "ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.inheritedapi_servlet"));
         }
@@ -115,6 +114,9 @@ public class FATSuite {
 
         // Skip LastExecutionTests due to bug in TCK: https://github.com/jakartaee/concurrency/issues/258
         apiExcludes.add("ee.jakarta.tck.concurrent.api.LastExecution");
+
+        // Skip TriggerTests due to bug in TCK: https://github.com/jakartaee/concurrency/issues/270
+        apiExcludes.add("ee.jakarta.tck.concurrent.api.Trigger");
 
         apiPackage.setExclude(new ArrayList<String>(apiExcludes));
         specPackage.setExclude(new ArrayList<String>(specExcludes));

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/FATSuite.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -112,6 +112,9 @@ public class FATSuite {
             Log.info(ConcurrentTckLauncherFull.class, "createSuiteXML", "Skipping Signature Tests on unsupported JDK");
             specExcludes.add("ee.jakarta.tck.concurrent.spec.signature");
         }
+
+        // Skip LastExecutionTests due to bug in TCK: https://github.com/jakartaee/concurrency/issues/258
+        apiExcludes.add("ee.jakarta.tck.concurrent.api.LastExecution");
 
         apiPackage.setExclude(new ArrayList<String>(apiExcludes));
         specPackage.setExclude(new ArrayList<String>(specExcludes));


### PR DESCRIPTION
Known bug in TCK causes failures: https://github.com/jakartaee/concurrency/issues/258
Fix will be delivered in Jakarta EE 11 and we will depend on that test for coverage.

Known bug in TCK causes failures: https://github.com/jakartaee/concurrency/issues/270
Fix has been delivered in Jakarta EE 11 and we will depend on that test for coverage.
