### PR TITLE
insert and update on Crud Repository

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -96,6 +96,7 @@ import jakarta.data.page.Page;
 import jakarta.data.page.Pageable;
 import jakarta.data.page.Slice;
 import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
@@ -1297,6 +1298,11 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     queryInfo.entityParamType = paramTypes[0];
                     q = generateDeleteEntity(queryInfo);
                 }
+            } else if (CrudRepository.class.equals(queryInfo.method.getDeclaringClass())) {
+                if ("update".equals(methodName) || "updateAll".equals(methodName)) {
+                    queryInfo.entityParamType = paramTypes[0];
+                    q = generateUpdateEntity(queryInfo);
+                }
             } else if (paramTypes[0].isArray()) {
                 if (defaultEntityClass.equals(paramTypes[0].getComponentType()))
                     queryInfo.entityParamType = paramTypes[0];
@@ -1310,6 +1316,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     }
                 }
             }
+
             if (queryInfo.type == null && queryInfo.entityParamType != null)
                 if (methodName.startsWith("delete") || methodName.startsWith("remove"))
                     q = generateDeleteEntity(queryInfo);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3439,7 +3439,7 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Tests all BasicRepository methods with a record as the entity.
+     * Tests all CrudRepository methods (apart from those inherited from BasicRepository) with a record as the entity.
      */
     @Test
     public void testRecordCrudRepositoryMethods() {

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
@@ -15,7 +15,7 @@ package test.jakarta.data.web;
 import java.util.Collection;
 import java.util.Optional;
 
-import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Repository;
 
 import io.openliberty.data.repository.Delete;
@@ -25,7 +25,7 @@ import io.openliberty.data.repository.Filter;
  * Repository interface for the Receipt entity which is a record
  */
 @Repository
-public interface Receipts extends BasicRepository<Receipt, Long> {
+public interface Receipts extends CrudRepository<Receipt, Long> {
     Optional<Receipt> deleteByPurchaseId(long purchaseId);
 
     @Delete

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
@@ -13,8 +13,11 @@
 package test.jakarta.data.jpa.web;
 
 import java.util.List;
+import java.util.Optional;
 
-import jakarta.data.repository.BasicRepository;
+import jakarta.data.Sort;
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
@@ -23,12 +26,15 @@ import jakarta.data.repository.Repository;
  * Experiments with auto-generated keys.
  */
 @Repository
-public interface Orders extends BasicRepository<Order, Long> {
+public interface Orders extends CrudRepository<Order, Long> {
 
     @Query("UPDATE Orders o SET o.total = o.total * :rate + :shipping WHERE o.id = :id")
     boolean addTaxAndShipping(@Param("id") long orderId,
                               @Param("rate") float taxRate,
                               @Param("shipping") float shippingCost);
 
-    List<Float> findTotalByPurchasedByIn(Iterable<String> purchasers);
+    @OrderBy("id")
+    Optional<Order> findFirstByPurchasedBy(String purchaser);
+
+    List<Float> findTotalByPurchasedByIn(Iterable<String> purchasers, Sort... sorts);
 }

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/CrudRepository.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/CrudRepository.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.repository;
+
+/**
+ * Interface methods copied from Jakarta Data.
+ */
+public interface CrudRepository<T, K> extends BasicRepository<T, K> {
+    void insert(T entity);
+
+    void insertAll(Iterable<T> entities);
+
+    boolean update(T entity);
+
+    int updateAll(Iterable<T> entities);
+}


### PR DESCRIPTION
CrudRepository was brought back into Jakarta Data, now inheriting from BasicRepository, with the insert, insertAll, update, and updateAll methods moved to there.  This pull gets us in sync with that and adds some tests.