### PR TITLE
Update Java specific FATs to handle JAR or WAR files

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -58,11 +58,11 @@ io.openliberty.yoko:yoko-rmi-impl:1.5.0.db1c134d1f
 io.openliberty.yoko:yoko-rmi-spec:1.5.0.db1c134d1f
 io.openliberty.yoko:yoko-spec-corba:1.5.0.db1c134d1f
 io.openliberty.yoko:yoko-util:1.5.0.db1c134d1f
-io.openliberty:java-apps:war:17.0.0
-io.openliberty:java-apps:war:18.0.0
-io.openliberty:java-apps:war:19.0.0
-io.openliberty:java-apps:war:20.0.0
-io.openliberty:java-apps:war:21.0.0
+io.openliberty:java-apps:17.0.0
+io.openliberty:java-apps:18.0.0
+io.openliberty:java-apps:19.0.0
+io.openliberty:java-apps:20.0.0
+io.openliberty:java-apps:21.0.0
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0

--- a/dev/io.openliberty.java.internal_fat/build.gradle
+++ b/dev/io.openliberty.java.internal_fat/build.gradle
@@ -36,43 +36,43 @@ task copyKernelService(type: Copy) {
 task copyApp17A(type: Copy) {
   from configurations.app17
   into new File(autoFvtDir, 'publish/servers/java17-cdi-server/apps/')
-  rename 'java-apps-*.*.*.jar', 'io.openliberty.java.internal_fat_17.war'
+  rename 'java-apps-*.*.*.*', 'io.openliberty.java.internal_fat_17.war'
 }
 
 task copyApp17B(type: Copy) {
   from configurations.app17
   into new File(autoFvtDir, 'publish/servers/java17-server/apps/')
-  rename 'java-apps-*.*.*.jar', 'io.openliberty.java.internal_fat_17.war'
+  rename 'java-apps-*.*.*.*', 'io.openliberty.java.internal_fat_17.war'
 }
 
 task copyApp18A(type: Copy) {
   from configurations.app18
   into new File(autoFvtDir, 'publish/servers/java18-cdi-server/apps/')
-  rename 'java-apps-*.*.*.jar', 'io.openliberty.java.internal_fat_18.war'
+  rename 'java-apps-*.*.*.*', 'io.openliberty.java.internal_fat_18.war'
 }
 
 task copyApp18B(type: Copy) {
   from configurations.app18
   into new File(autoFvtDir, 'publish/servers/java18-server/apps/')
-  rename 'java-apps-*.*.*.jar', 'io.openliberty.java.internal_fat_18.war'
+  rename 'java-apps-*.*.*.*', 'io.openliberty.java.internal_fat_18.war'
 }
 
 task copyApp19(type: Copy) {
   from configurations.app19
   into new File(autoFvtDir, 'publish/servers/java19-server/apps/')
-  rename 'java-apps-*.*.*.jar', 'io.openliberty.java.internal_fat_19.war'
+  rename 'java-apps-*.*.*.*', 'io.openliberty.java.internal_fat_19.war'
 }
 
 task copyApp20(type: Copy) {
   from configurations.app20
   into new File(autoFvtDir, 'publish/servers/java20-server/apps/')
-  rename 'java-apps-*.*.*.jar', 'io.openliberty.java.internal_fat_20.war'
+  rename 'java-apps-*.*.*.*', 'io.openliberty.java.internal_fat_20.war'
 }
 
 task copyApp21(type: Copy) {
   from configurations.app21
   into new File(autoFvtDir, 'publish/servers/java21-server/apps/')
-  rename 'java-apps-*.*.*.jar', 'io.openliberty.java.internal_fat_21.war'
+  rename 'java-apps-*.*.*.*', 'io.openliberty.java.internal_fat_21.war'
 }
 
 addRequiredLibraries.dependsOn copyKernelService


### PR DESCRIPTION
Switching from Java 21 EA to GA, Jared reminded me that we need to recompile the WAR file that the Java 21 specific FAT uses with the GA version of Java 21.

In doing so, we discovered that the file extensions in DHE were `*.war` and artifactory were `*.jar`.  The build systems worked fine, but local testing of this FAT will fail if it pulls down the file with a `*.war` extension since the gradle rename in the `build.gradle` file is explicitly looking for a file that ends in `*.jar`.

This PR handles modifying the `build.gradle` file to handle any file extension.