### PR TITLE
Update to SmallRye Metrics 5.1.0-RC3 and disable optional test until …

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1069,7 +1069,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-metrics</artifactId>
-      <version>5.1.0-RC2</version>
+      <version>5.1.0-RC3</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -209,7 +209,7 @@ io.smallrye:smallrye-graphql-schema-builder:1.0.26
 io.smallrye:smallrye-graphql-schema-model:1.0.26
 io.smallrye:smallrye-graphql-servlet:1.0.26
 io.smallrye:smallrye-graphql:1.0.26
-io.smallrye:smallrye-metrics:5.1.0-RC2
+io.smallrye:smallrye-metrics:5.1.0-RC3
 io.smallrye:smallrye-open-api-core:3.1.1
 io.smallrye:smallrye-open-api-jaxrs:3.1.1
 io.zipkin.reporter2:zipkin-reporter:2.16.3

--- a/dev/io.openliberty.io.smallrye.metrics/bnd.bnd
+++ b/dev/io.openliberty.io.smallrye.metrics/bnd.bnd
@@ -33,6 +33,6 @@ WS-TraceGroup: METRICS
 publish.wlp.jar.suffix: lib
 
 -buildpath: \
-    io.smallrye:smallrye-metrics;version=5.1.0.RC2
+    io.smallrye:smallrye-metrics;version=5.1.0.RC3
 	
 instrument.disabled: true

--- a/dev/io.openliberty.microprofile.metrics.internal.5.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -183,6 +183,9 @@
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-api-tck</dependency>
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                             </dependenciesToScan>
+                            <excludes>
+                                <exclude>**/MPMetricBaseMetricsTest.java</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -220,6 +223,7 @@
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                             </dependenciesToScan>
                             <excludes>
+                                <exclude>**/MPMetricBaseMetricsTest.java</exclude>
                                 <exclude>**/TimerTest.java</exclude>
                                 <exclude>**/MeterTest.java</exclude>
                             </excludes>
@@ -260,6 +264,7 @@
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                             </dependenciesToScan>
                             <excludes>
+                                <exclude>**/MPMetricBaseMetricsTest.java</exclude>
                                 <exclude>**/TimerTest.java</exclude>
                                 <exclude>**/MeterTest.java</exclude>
                             </excludes>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -183,6 +183,9 @@
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-api-tck</dependency>
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                             </dependenciesToScan>
+                            <excludes>
+                                <exclude>**/MPMetricBaseMetricsTest.java</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -220,6 +223,7 @@
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                             </dependenciesToScan>
                             <excludes>
+                                <exclude>**/MPMetricBaseMetricsTest.java</exclude>
                                 <exclude>**/TimerTest.java</exclude>
                                 <exclude>**/MeterTest.java</exclude>
                             </excludes>
@@ -260,6 +264,7 @@
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                             </dependenciesToScan>
                             <excludes>
+                                <exclude>**/MPMetricBaseMetricsTest.java</exclude>
                                 <exclude>**/TimerTest.java</exclude>
                                 <exclude>**/MeterTest.java</exclude>
                             </excludes>


### PR DESCRIPTION
…MP Metrics 5.1.1

#build


RC3 pulls in a fix for `gc.time` to be a gauge instead of a counter. The TCK has a bug and expects it to be a counter. The optional test is disabled until the TCK can be fixed in `5.1.1`