### PR TITLE
Issue #26574: Improve CNTR0047E

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/MessageDrivenBeanO.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/MessageDrivenBeanO.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corporation and others.
+ * Copyright (c) 2001, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -856,8 +856,8 @@ public class MessageDrivenBeanO extends ManagedBeanOBase implements MessageDrive
     {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getEJBHome");
-        Tr.error(tc, "METHOD_NOT_ALLOWED_CNTR0047E", "MessageDrivenBeanO.getEJBHome()");
-        throw new IllegalStateException("Method Not Allowed Exception: See Message-drive Bean Component Contract section of the applicable EJB Specification.");
+        Tr.error(tc, "METHOD_NOT_ALLOWED_CNTR0047E", "EJBContext.getEJBHome()");
+        throw new IllegalStateException("Method Not Allowed Exception: See Message-driven Bean Component Contract section of the applicable EJB Specification.");
     } // getEJBHome
 
     /**
@@ -871,8 +871,8 @@ public class MessageDrivenBeanO extends ManagedBeanOBase implements MessageDrive
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getEJBLocalHome");
         Tr.error(tc, "METHOD_NOT_ALLOWED_CNTR0047E",
-                 "MessageDrivenBeanO.getEJBLocalHome()");
-        throw new IllegalStateException("Method Not Allowed Exception: See Message-drive Bean Component Contract section of the applicable EJB Specification.");
+                 "EJBContext.getEJBLocalHome()");
+        throw new IllegalStateException("Method Not Allowed Exception: See Message-driven Bean Component Contract section of the applicable EJB Specification.");
     } // getEJBLocalHome
 
     /**

--- a/dev/com.ibm.ws.ejbcontainer.mdb.core/src/com/ibm/ws/ejbcontainer/mdb/BMMessageDrivenBeanO.java
+++ b/dev/com.ibm.ws.ejbcontainer.mdb.core/src/com/ibm/ws/ejbcontainer/mdb/BMMessageDrivenBeanO.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corporation and others.
+ * Copyright (c) 2001, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -50,8 +50,8 @@ public class BMMessageDrivenBeanO
 
         //do not allow getRollbackOnly for bean-managed MDB's
         Tr.error(tc, "METHOD_NOT_ALLOWED_CNTR0047E",
-                 "BMMessageDrivenBeanO.getRollbackOnly()");
-        throw new IllegalStateException("Method Not Allowed Exception: See Message-drive Bean Component Contract section of the applicable EJB Specification.");
+                 "EJBContext.getRollbackOnly()");
+        throw new IllegalStateException("Method Not Allowed Exception: See Message-driven Bean Component Contract section of the applicable EJB Specification.");
     }
 
     @Override
@@ -59,8 +59,8 @@ public class BMMessageDrivenBeanO
 
         //do not allow setRollbackOnly for bean-managed MDB's
         Tr.error(tc, "METHOD_NOT_ALLOWED_CNTR0047E",
-                 "BMMessageDrivenBeanO.setRollbackOnly()");
-        throw new IllegalStateException("Method Not Allowed Exception: See Message-drive Bean Component Contract section of the applicable EJB Specification.");
+                 "EJBContext.setRollbackOnly()");
+        throw new IllegalStateException("Method Not Allowed Exception: See Message-driven Bean Component Contract section of the applicable EJB Specification.");
     }
 
 }

--- a/dev/com.ibm.ws.ejbcontainer.mdb.core/src/com/ibm/ws/ejbcontainer/mdb/CMMessageDrivenBeanO.java
+++ b/dev/com.ibm.ws.ejbcontainer.mdb.core/src/com/ibm/ws/ejbcontainer/mdb/CMMessageDrivenBeanO.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corporation and others.
+ * Copyright (c) 2001, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -54,8 +54,8 @@ public class CMMessageDrivenBeanO
     public synchronized UserTransaction getUserTransaction() //d116376
     {
         Tr.error(tc, "METHOD_NOT_ALLOWED_CNTR0047E",
-                 "CMMessageDrivenBeanO.getUserTransaction()");
-        throw new IllegalStateException("Method Not Allowed Exception: See Message-drive Bean Component " +
+                 "EJBContext.getUserTransaction()");
+        throw new IllegalStateException("Method Not Allowed Exception: See Message-driven Bean Component " +
                                         "Contract section of the applicable EJB Specification.");
     }
 


### PR DESCRIPTION
Update the replacement text to indicate which EJB specification API method usage is in error, rather than the Liberty internal class.

fixes #26574 