### PR TITLE
A warning message should be logged on restore when a config property is updated after checkpoint even if the property had no default value.

### DIFF
--- a/dev/io.openliberty.checkpoint_fat_mpconfig/fat/src/io/openliberty/checkpoint/fat/MPConfigTest.java
+++ b/dev/io.openliberty.checkpoint_fat_mpconfig/fat/src/io/openliberty/checkpoint/fat/MPConfigTest.java
@@ -185,6 +185,18 @@ public class MPConfigTest extends FATServletClient {
                 case applicationScopedValueTest:
                     updateVariableConfig(server, "early_access_app_scope_key", "serverValue");
                     break;
+                case appScopeEarlyAccessNoDefaultEnvValueTest:
+                    configureEnvVariable(server, singletonMap("early_access_optional_app_scope_key", "optionalEnvValue"));
+                    break;
+                case appScopeEarlyAccessNoDefaultServerValueTest:
+                    updateVariableConfig(server, "early_access_optional_app_scope_key", "optionalServerValue");
+                    break;
+                case appScopeEarlyAccessNoDefaultProviderEnvValueTest:
+                    configureEnvVariable(server, singletonMap("early_access_provider_optional_app_scope_key", "providerEnvValue"));
+                    break;
+                case appScopeEarlyAccessNoDefaultProviderServerValueTest:
+                    updateVariableConfig(server, "early_access_provider_optional_app_scope_key", "providerServerValue");
+                    break;
 
                 // Default tests in all beans
                 case defaultValueTest:
@@ -257,6 +269,17 @@ public class MPConfigTest extends FATServletClient {
                     assertNotNull("CWWKC0651W message expected in logs", server.waitForStringInLog("CWWKC0651W:.*early_access_app_scope_key*", 100));
                     expectedWarning = "CWWKC0651W";
                     break;
+                case appScopeEarlyAccessNoDefaultEnvValueTest:
+                case appScopeEarlyAccessNoDefaultServerValueTest:
+                    assertNotNull("CWWKC0651W message expected in logs", server.waitForStringInLog("CWWKC0651W:.*early_access_optional_app_scope_key*", 100));
+                    expectedWarning = "CWWKC0651W";
+                    break;
+
+                case appScopeEarlyAccessNoDefaultProviderEnvValueTest:
+                case appScopeEarlyAccessNoDefaultProviderServerValueTest:
+                    assertNotNull("CWWKC0651W message expected in logs", server.waitForStringInLog("CWWKC0651W:.*early_access_provider_optional_app_scope_key*", 100));
+                    expectedWarning = "CWWKC0651W";
+                    break;
 
                 // Default tests in all beans
                 case defaultValueTest:
@@ -305,6 +328,10 @@ public class MPConfigTest extends FATServletClient {
         appScopeNoDefaultServerValueTest,
         appScopeProviderEnvValueChangeTest,
         applicationScopedValueTest,
+        appScopeEarlyAccessNoDefaultEnvValueTest,
+        appScopeEarlyAccessNoDefaultServerValueTest,
+        appScopeEarlyAccessNoDefaultProviderEnvValueTest,
+        appScopeEarlyAccessNoDefaultProviderServerValueTest,
         configObjectAppScopeEnvValueTest,
         configObjectAppScopeEnvValueChangeTest,
         configObjectAppScopeServerValueTest,

--- a/dev/io.openliberty.checkpoint_fat_mpconfig/test-applications/mpapp1/src/mpapp1/ApplicationScopedOnCheckpointBean.java
+++ b/dev/io.openliberty.checkpoint_fat_mpconfig/test-applications/mpapp1/src/mpapp1/ApplicationScopedOnCheckpointBean.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,11 +13,16 @@
 package mpapp1;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Initialized;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
+import javax.inject.Provider;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -28,9 +33,17 @@ public class ApplicationScopedOnCheckpointBean {
     @ConfigProperty(name = "early_access_app_scope_key", defaultValue = "annoValue")
     String testKey;
 
+    @Inject
+    @ConfigProperty(name = "early_access_optional_app_scope_key")
+    Optional<String> earlyAccessOptionalTestKey;
+
+    @Inject
+    @ConfigProperty(name = "early_access_provider_optional_app_scope_key")
+    Provider<Optional<String>> earlyAccessProviderOptionalTestKey;
+
     public void applicationScopedValueTest() {
         // The value of test_key was not updated here because the property was accessed during the checkpoint.
-        // A warning CWWKC0651W is thrown to let the user know that the updated value of the property might not be used during restore.
+        // A warning CWWKC0651W is logged to let the user know that the updated value of the property might not be used during restore.
         check("defaultValue");
     }
 
@@ -38,9 +51,50 @@ public class ApplicationScopedOnCheckpointBean {
     public void observeInit(@Observes @Initialized(ApplicationScoped.class) Object event) {
         System.out.println(getClass() + ": " + "Initializing application context");
         check("defaultValue");
+        checkOptionalValue(false);
+        checkProviderOptionalValue(false);
+    }
+
+    public void appScopeEarlyAccessNoDefaultEnvValueTest() {
+        // The value of earlyAccessOptionalTestKey was not updated here because the property was accessed during the checkpoint.
+        // A warning CWWKC0651W is logged to let the user know that the updated value of the property might not be used during restore.
+        checkOptionalValue(false);
+    }
+
+    public void appScopeEarlyAccessNoDefaultServerValueTest() {
+        // The value of earlyAccessOptionalTestKey was not updated here because the property was accessed during the checkpoint.
+        // A warning CWWKC0651W is logged to let the user know that the updated value of the property might not be used during restore.
+        checkOptionalValue(false);
+    }
+
+    public void appScopeEarlyAccessNoDefaultProviderEnvValueTest() {
+        checkProviderOptionalValue(true, "providerEnvValue");
+    }
+
+    public void appScopeEarlyAccessNoDefaultProviderServerValueTest() {
+        checkProviderOptionalValue(true, "providerServerValue");
     }
 
     private void check(String expected) {
         assertEquals("Wrong value for test key.", expected, testKey);
+    }
+
+    private void checkOptionalValue(boolean present) {
+        if (present) {
+            assertTrue("Value of optional test key should be present.", earlyAccessOptionalTestKey.isPresent());
+        } else {
+            assertFalse("Value of optional test key should not be present.", earlyAccessOptionalTestKey.isPresent());
+        }
+    }
+
+    private void checkProviderOptionalValue(boolean present, String... expected) {
+        if (present) {
+            assertTrue("Value of provider optional test key should be present.", earlyAccessProviderOptionalTestKey.get().isPresent());
+            // Even though the provider value gets updated on restore, the warning message CWWKC0651W will be logged.
+            assertEquals("Wrong value of provider optional test key.", expected[0], earlyAccessProviderOptionalTestKey.get().get());
+        } else {
+            assertFalse("Value of provider optional test key should not be present.", earlyAccessProviderOptionalTestKey.get().isPresent());
+        }
+
     }
 }

--- a/dev/io.openliberty.checkpoint_fat_mpconfig/test-applications/mpapp1/src/mpapp1/MPConfigServlet.java
+++ b/dev/io.openliberty.checkpoint_fat_mpconfig/test-applications/mpapp1/src/mpapp1/MPConfigServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -173,5 +173,25 @@ public class MPConfigServlet extends FATServlet {
     @Test
     public void applicationScopedValueTest() {
         appScopeOnCheckpointBean.applicationScopedValueTest();
+    }
+
+    @Test
+    public void appScopeEarlyAccessNoDefaultEnvValueTest() {
+        appScopeOnCheckpointBean.appScopeEarlyAccessNoDefaultEnvValueTest();
+    }
+
+    @Test
+    public void appScopeEarlyAccessNoDefaultServerValueTest() {
+        appScopeOnCheckpointBean.appScopeEarlyAccessNoDefaultServerValueTest();
+    }
+
+    @Test
+    public void appScopeEarlyAccessNoDefaultProviderEnvValueTest() {
+        appScopeOnCheckpointBean.appScopeEarlyAccessNoDefaultProviderEnvValueTest();
+    }
+
+    @Test
+    public void appScopeEarlyAccessNoDefaultProviderServerValueTest() {
+        appScopeOnCheckpointBean.appScopeEarlyAccessNoDefaultProviderServerValueTest();
     }
 }


### PR DESCRIPTION
The scenario should occur only when the config property is accessed early during the checkpoint.

When config is injected as Optional<T>, the value doesn't get updated on restore.
But when the config is injected as Provider<T>, the value gets updated on restore.

In both the cases we would log the CWWKC0651W warning message.