### PR TITLE
Wait for config update in concurrent persistent FAT

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/fat/src/com/ibm/ws/concurrent/persistent/fat/compatibility/FatTestConcurrentCompatible.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/fat/src/com/ibm/ws/concurrent/persistent/fat/compatibility/FatTestConcurrentCompatible.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,6 +84,7 @@ public class FatTestConcurrentCompatible extends CommonUtils {
         } else {
             server.setMarkToEndOfLog();
             server.setServerConfigurationFile("/config/disableTaskExecuteServer.xml");
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(APP_NAME));
         }
 
         // set default props


### PR DESCRIPTION
Test is updating configuration to disable running of persistent tasks but is not waiting for the update to complete, so tasks are running too early. Added a wait for the update to complete and ensure app is started (in case it was restarted).
