### PR TITLE
Update EclipseLink ASM to 9.6

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2939,7 +2939,7 @@
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>org.eclipse.persistence.asm</artifactId>
-      <version>9.5.0</version>
+      <version>9.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -583,7 +583,7 @@ org.eclipse.microprofile.rest.client:microprofile-rest-client-api:2.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:3.0.1
 org.eclipse.parsson:parsson:1.1.4
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.13
-org.eclipse.persistence:org.eclipse.persistence.asm:9.5.0
+org.eclipse.persistence:org.eclipse.persistence.asm:9.6.0
 org.eclipse.persistence:org.eclipse.persistence.core:2.7.13
 org.eclipse.persistence:org.eclipse.persistence.core:3.0.3
 org.eclipse.persistence:org.eclipse.persistence.core:4.0.2

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
@@ -18,7 +18,7 @@ eclVersion=2.7.13
 eclHash=7ffb888
 eclFullVersion=${eclVersion}
 eclPackageVersion=2.0.16
-asmFullVersion=9.5.0
+asmFullVersion=9.6.0
 
 Bundle-SymbolicName: com.ibm.websphere.appserver.thirdparty.eclipselink.2.7
 Bundle-Description: EclipseLink JPA

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
@@ -18,7 +18,7 @@ eclVersion=2.6.10.WAS
 eclHash=f193aac
 eclFullVersion=${eclVersion}-${eclHash}
 eclPackageVersion=1.0.16
-asmFullVersion=9.5.0
+asmFullVersion=9.6.0
 
 Bundle-SymbolicName: com.ibm.websphere.appserver.thirdparty.eclipselink
 Bundle-Description: EclipseLink JPA

--- a/dev/io.openliberty.persistence.3.0.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.persistence.3.0.thirdparty/bnd.bnd
@@ -17,7 +17,7 @@ bVersion=1.0
 eclVersion=3.0.3
 eclFullVersion=${eclVersion}
 eclPackageVersion=3.0.3
-asmFullVersion=9.5.0
+asmFullVersion=9.6.0
 
 Bundle-SymbolicName: io.openliberty.persistence.3.0.thirdparty
 Bundle-Description: EclipseLink JPA

--- a/dev/io.openliberty.persistence.3.1.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/bnd.bnd
@@ -17,7 +17,7 @@ bVersion=1.0
 eclVersion=4.0.2
 eclFullVersion=${eclVersion}
 eclPackageVersion=4.0.2
-asmFullVersion=9.5.0
+asmFullVersion=9.6.0
 
 Bundle-SymbolicName: io.openliberty.persistence.3.1.thirdparty
 Bundle-Description: EclipseLink JPA


### PR DESCRIPTION
Update EclipseLink ASM to 9.6 for Java 22 support.

for #26461