### PR TITLE
match the spec API for BasicRepository

### DIFF
--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/BasicRepository.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/BasicRepository.java
@@ -24,7 +24,6 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     @Delete
     void delete(T entity);
 
-    @Delete
     void deleteAll();
 
     @Delete


### PR DESCRIPTION
Remove the `@Delete` annotation for a method of BasicRepository that doesn't match up with the spec.