### PR TITLE
Added permission to the server.xml for the JPAConfigServer.

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/publish/servers/JPAConfigServer/server.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/publish/servers/JPAConfigServer/server.xml
@@ -36,6 +36,8 @@
 
     <!-- Permission needed for Oracle driver -->
     <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers" />
+    <javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+    
 
     <!-- File read write permissions -->
     <javaPermission className="java.util.PropertyPermission" name="user.dir" actions="read"/>


### PR DESCRIPTION
Added permission to the server.xml for the JPAConfigServer.

For the following error:
```
java.security.AccessControlException: Access denied ("java.lang.reflect.ReflectPermission" "suppressAccessChecks")
    at java.base/java.security.AccessController.throwACE(AccessController.java:177)
    at java.base/java.security.AccessController.checkPermissionHelper(AccessController.java:239)
    at java.base/java.security.AccessController.checkPermission(AccessController.java:386)
    at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:416)
    at java.base/java.lang.reflect.AccessibleObject.checkPermission(AccessibleObject.java:91)
    at java.base/java.lang.reflect.Field.setAccessible(Field.java:171)
    at com.ibm.ws.testtooling.vehicle.JEEExecutionContextHelper$1.run(JEEExecutionContextHelper.java:237)
    at java.base/java.security.AccessController.doPrivileged(AccessController.java:692)
    at com.ibm.ws.testtooling.vehicle.JEEExecutionContextHelper.processJPAPersistenceContextInfo(JEEExecutionContextHelper.java:215)
```

fixes #24978