### PR TITLE
Publish a dist zip file per project to be extracted into the build.image project

### DIFF
--- a/dev/ant_build.js/bnd.bnd
+++ b/dev/ant_build.js/bnd.bnd
@@ -15,3 +15,5 @@
 -nobundles=true
 
 instrument.disabled: true
+
+publish.wlp.jar.disabled: true

--- a/dev/ant_build.js/public_imports/js_imports.xml
+++ b/dev/ant_build.js/public_imports/js_imports.xml
@@ -11,7 +11,6 @@
         IBM Corporation - initial API and implementation
  -->
 <project name="ui_imports" basedir="../../com.ibm.ws.ui">
-	<echo> importing libraries </echo>
 	<import file="internal_imports/closure.xml" />
 	<import file="internal_imports/dojo.xml" />
 	<import file="internal_imports/jshint.xml" />

--- a/dev/build.image/bnd.bnd
+++ b/dev/build.image/bnd.bnd
@@ -15,3 +15,5 @@
 -nobundles=true
 
 instrument.disabled: true
+
+publish.wlp.jar.disabled: true

--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -23,6 +23,28 @@ import java.nio.file.Paths
 
 apply plugin: 'maven-publish'
 
+configurations {
+    buildDists
+}
+
+dependencies {
+    rootProject.buildImageDists.each {
+        buildDists("$it:latest.integration@zip")
+    }
+}
+
+assemble {
+    dependsOn parent.subprojects.minus(cnf).publish
+    doLast {
+        configurations.buildDists.each {
+            copy {
+                from zipTree(it[0])
+                into file('build.image')
+            }
+        }
+    }
+}
+
 def releaseVersion = "${bnd.libertyRelease}-" + rootProject.userProps.getProperty("version.qualifier")
 
 def getBetaVersion() {
@@ -162,7 +184,6 @@ assemble {
     dependsOn copySwidFixpackTagToBuildImage
     dependsOn copyPublicKeyToBuildImage
 }
-
 
 def failOnError = false
 
@@ -391,6 +412,7 @@ def getFeaturePath(feature, suffix) {
     }
     file
 }
+
 def removeFeature(feature) {
     def file = getFeaturePath(feature)
     def bakfile = new File(file.getPath()+".bak")
@@ -623,7 +645,6 @@ task zipOpenLibertyDev(type: Zip) {
 publish.dependsOn zipOpenLibertyDev
 
 if (isAutomatedBuild && !isIFIXBuild) {
-
     // NOSHIP: Includes all features except excluded features.
     task zipOpenLibertyAll(type: Zip) {
         dependsOn packageOpenLibertyAll

--- a/dev/build.pii.package/bnd.bnd
+++ b/dev/build.pii.package/bnd.bnd
@@ -15,3 +15,5 @@
 -nobundles=true
 
 instrument.disabled: true
+
+publish.wlp.jar.disabled: true

--- a/dev/build.sharedResources/bnd.bnd
+++ b/dev/build.sharedResources/bnd.bnd
@@ -16,3 +16,4 @@
 
 instrument.disabled: true
 
+publish.wlp.jar.disabled: true

--- a/dev/cnf/bnd.bnd
+++ b/dev/cnf/bnd.bnd
@@ -15,3 +15,5 @@
 -nobundles=true
 
 instrument.disabled: true
+
+publish.wlp.jar.disabled: true

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -483,6 +483,9 @@ publishing {
 
 afterEvaluate {
   publishLibertyVersionsPublicationToMavenRepository.dependsOn libertyReleaseVersions
+  if (isUsingArtifactory && isArtifactoryPublishing) {
+    publishLibertyVersionsPublicationToMaven2Repository.dependsOn libertyReleaseVersions
+  }
 }
 
 task printProjectDependencies() {

--- a/dev/com.ibm.websphere.appserver.features/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.features/bnd.bnd
@@ -37,3 +37,5 @@ feature.project: true
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	biz.aQute.bnd:biz.aQute.bnd;version=6.3.0;packages=**,\
 	org.apache.aries:org.apache.aries.util;version=1.1.3
+
+publish.wlp.jar.disabled: true

--- a/dev/com.ibm.ws.org.apache.commons.daemon/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.commons.daemon/bnd.bnd
@@ -13,3 +13,5 @@
 -include= ~../cnf/resources/bnd/liberty-release.props
 
 -nobundles=true
+
+publish.wlp.jar.disabled: true

--- a/dev/com.ibm.ws.security.fat.common.SSO.clientTests/build.gradle
+++ b/dev/com.ibm.ws.security.fat.common.SSO.clientTests/build.gradle
@@ -80,7 +80,6 @@ task tokenEndpoint(type: War, dependsOn: classes) {
   destinationDirectory = file("${appBuildDir}")
   archiveFileName = "${appName}.war"
 
- println "In tokenEndpoint"
   from("test-applications/${appName}/resources") {
     include "**/*"
   }

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/build.gradle
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/build.gradle
@@ -437,7 +437,6 @@ assemble {
    * so that we don't need to keep adding them in each external
    * project.
    */
-  println "in assemble"
   copy { 
     from configurations.collectedDeps
     into "${buildDir}/collectedJars"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/build.gradle
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/build.gradle
@@ -282,8 +282,6 @@ task updateIdp_4_0_x_WAR(type: Zip, dependsOn: copy_40x_IDP) {
 }
 
 task updateIdp_4_1_x_WAR(type: Zip, dependsOn: copy_41x_IDP) {
-
-  println "In updateIdp_4_1_x_WAR"
   
   def originalWar = new File(downloadDir, 'idp-war-4.1.0.war')
   

--- a/dev/com.ibm.ws.ui.shared/bnd.bnd
+++ b/dev/com.ibm.ws.ui.shared/bnd.bnd
@@ -15,3 +15,5 @@
 -nobundles=true
 
 instrument.disabled: true
+
+publish.wlp.jar.disabled: true

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/build.gradle
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/build.gradle
@@ -52,8 +52,6 @@ addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 task addHazelcastToSharedDir(type: Copy) {
-  println configurations.hazelcast.resolve()
-
   from configurations.hazelcast
   into new File(autoFvtDir, 'publish/shared/resources/hazelcast')
   rename "hazelcast-${hazelcastVersion}.jar", 'hazelcast.jar'

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/build.gradle
@@ -19,7 +19,6 @@ task testmarker(type: War, dependsOn: classes) {
   destinationDirectory = file("${appBuildDir}")
   archiveFileName = "${appName}.war"
 
- println "In testmarker"
   from("test-applications/${appName}/resources") {
     include "**/*"
   }
@@ -34,7 +33,6 @@ task tokenEndpoint(type: War, dependsOn: classes) {
   destinationDirectory = file("${appBuildDir}")
   archiveFileName = "${appName}.war"
 
- println "In tokenEndpoint"
   from("test-applications/${appName}/resources") {
     include "**/*"
   }
@@ -44,8 +42,6 @@ task tokenEndpoint(type: War, dependsOn: classes) {
   }
 }
 assemble {
-
-   println "In assemble"
   dependsOn \
     testmarker,\
     tokenEndpoint

--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -144,6 +144,17 @@ pluginManagement {
           }
       }
       maven {
+          credentials {
+              username gradle.userProps.getProperty("artifactory.download.user")
+              password gradle.userProps.getProperty("artifactory.download.token")
+          }
+          url ("https://" + gradle.userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-open-liberty-release-maven-local")
+          metadataSources {
+            mavenPom()
+            artifact()
+          }
+      }
+      maven {
         url uri(bnd_repourl)
         metadataSources {
           mavenPom()

--- a/dev/wlp-gradle/propertiesSettings.gradle
+++ b/dev/wlp-gradle/propertiesSettings.gradle
@@ -51,6 +51,7 @@ def setProperties = { props ->
     boolean isContinuousBuild   = props.getProperty('is.continuous.build') == null      ? false : 'true'.equalsIgnoreCase(props.getProperty('is.continuous.build'))
     boolean isRelease           = props.getProperty('is.release') == null               ? false : 'true'.equalsIgnoreCase(props.getProperty('is.release'))
     boolean isPublicPublishing  = props.getProperty('is.public.publishing') == null     ? false : 'true'.equalsIgnoreCase(props.getProperty('is.public.publishing'))
+    boolean isArtifactoryPublishing = props.getProperty('is.artifactory.publishing') == null ? false : 'true'.equalsIgnoreCase(props.getProperty('is.artifactory.publishing'))
     boolean isUnittestsDisabled = props.getProperty('disable.run.runUnitTests') == null ? false : 'true'.equalsIgnoreCase(props.getProperty('disable.run.runUnitTests'))
     boolean isIFIXBuild         = props.getProperty('ghe.build.type') == null           ? false : props.getProperty('ghe.build.type').toLowerCase().contains("ifix")
 
@@ -73,6 +74,7 @@ def setProperties = { props ->
         rootProject.ext.isIFIXBuild         = isIFIXBuild
         rootProject.ext.isRelease           = isRelease
         rootProject.ext.isPublicPublishing  = isPublicPublishing
+        rootProject.ext.isArtifactoryPublishing = isArtifactoryPublishing
         rootProject.ext.isUnittestsDisabled = isUnittestsDisabled
         rootProject.ext.isBuildOsNativePackages = isBuildOsNativePackages
         rootProject.ext.betaVersionOverride = betaVersionOverride

--- a/dev/wlp-gradle/subprojects/assemble.gradle
+++ b/dev/wlp-gradle/subprojects/assemble.gradle
@@ -17,11 +17,16 @@ def fatProject = parseBoolean(bnd.get('fat.project', 'false'))
 
 def publishWlpJarDefault = testProject ? 'true' : 'false'
 
+// Publish a zip file to be extracted in the build.image project if one or more of the conditions below are met.
+boolean publishBuildImageDist = false
+def tmpBuildImage = new File(project.buildDir, 'tmp/buildImage')
+
 if (bnd.get('publish.tool.jar', '').empty && !parseBoolean(bnd.get('publish.wlp.jar.disabled', publishWlpJarDefault))) {
+    publishBuildImageDist = true
     task publishWLPJars(type: Copy) {
         dependsOn jar
         from project.buildDir
-        into buildImage.file('wlp/' + bnd.get('publish.wlp.jar.suffix', 'lib'))
+        into new File(tmpBuildImage, 'wlp/' + bnd.get('publish.wlp.jar.suffix', 'lib'))
         include bnd.get('publish.wlp.jar.include', '*.jar')
         def hasIFIXHeaders = [:]
         def fullVersions = [:]
@@ -107,6 +112,7 @@ if (bnd.get('publish.tool.jar', '').empty && !parseBoolean(bnd.get('publish.wlp.
 }
 
 if (bnd.get('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd.get('publish.wlp.jar.suffix', 'lib').contains('spi/ibm')) {
+    publishBuildImageDist = true
     task publishJavadoc(type: Copy) {
         dependsOn zipJavadoc
         from new File(project.buildDir, 'distributions')
@@ -118,11 +124,12 @@ if (bnd.get('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd.get('pub
 }
 
 if (!bnd.get('publish.tool.jar', '').empty) {
+    publishBuildImageDist = true
     task publishToolScripts(type: Copy) {
         enabled !bnd.get('publish.tool.script', '').empty
         dependsOn jar
         from cnf.file('resources/bin')
-        into buildImage.file('wlp/bin/' + bnd.get('publish.tool.script.subdir', ''))
+        into new File(tmpBuildImage, 'wlp/bin/' + bnd.get('publish.tool.script.subdir', ''))
         fileMode 0755
         rename 'tool(.*)', bnd.get('publish.tool.script') + '$1'
         filter(org.apache.tools.ant.filters.ReplaceTokens,
@@ -136,26 +143,28 @@ if (!bnd.get('publish.tool.jar', '').empty) {
         dependsOn jar
         dependsOn publishToolScripts
         from project.buildDir
-        into buildImage.file('wlp/bin/' + bnd.get('publish.tool.script.subdir', '') + 'tools')
+        into new File(tmpBuildImage, 'wlp/bin/' + bnd.get('publish.tool.script.subdir', '') + 'tools')
         include bnd.get('publish.tool.jar', '')
     }
     assemble.dependsOn publishToolJars
 }
 
 if (project.file('resources/schemas').exists()) {
+    publishBuildImageDist = true
     task publishSchemaResources(type: Copy) {
         dependsOn jar
         from project.file('resources/schemas')
-        into buildImage.file('wlp/dev/api/ibm/schema')
+        into new File(tmpBuildImage, 'wlp/dev/api/ibm/schema')
     }
     assemble.dependsOn publishSchemaResources
 }
 
 if (project.file('publish/platform').exists()) {
+    publishBuildImageDist = true
     task publishPlatformManifests(type: Copy) {
         dependsOn jar
         from project.file('publish/platform')
-        into buildImage.file('wlp/lib/platform')
+        into new File(tmpBuildImage, 'wlp/lib/platform')
         include '*.mf'
         filter(org.apache.tools.ant.filters.ConcatFilter,
                 append: file(cnf.file('resources/IBM-ProductID.txt')))
@@ -165,45 +174,72 @@ if (project.file('publish/platform').exists()) {
     task publishPlatformFiles(type: Copy) {
         dependsOn publishPlatformManifests
         from project.file('publish/platform')
-        into buildImage.file('wlp/lib/platform')
+        into new File(tmpBuildImage, 'wlp/lib/platform')
         exclude '*.mf'
     }
     assemble.dependsOn publishPlatformFiles
 }
 
 if (project.file('publish/templates').exists()) {
+    publishBuildImageDist = true
     task publishTemplates(type: Copy) {
         dependsOn jar
         from project.file('publish/templates')
-        into buildImage.file('wlp/templates')
+        into new File(tmpBuildImage, 'wlp/templates')
     }
     assemble.dependsOn publishTemplates
 }
 
 if (project.file('publish/bin').exists()) {
+    publishBuildImageDist = true
     task publishBinScripts(type: Copy) {
         dependsOn jar
         from project.file('publish/bin')
-        into buildImage.file('wlp/bin')
+        into new File(tmpBuildImage, 'wlp/bin')
         fileMode 0755
     }
     assemble.dependsOn publishBinScripts
 }
 
 if (parseBoolean(bnd.get('publish.wlp.clients', 'false'))) {
+    publishBuildImageDist = true
     task publishClientScripts(type: Copy) {
         dependsOn jar
         from project.file('publish/clients')
-        into buildImage.file('wlp/clients')
+        into new File(tmpBuildImage, 'wlp/clients')
     }
     assemble.dependsOn publishClientScripts
 }
 
 if (project.file('lib/native').exists()) {
+    publishBuildImageDist = true
     task publishLibNative(type: Copy) {
         dependsOn jar
         from project.file('lib/native')
-        into buildImage.file('wlp/lib/native')
+        into new File(tmpBuildImage, 'wlp/lib/native')
     }
     assemble.dependsOn publishLibNative
+}
+
+if (publishBuildImageDist) {
+    if (!rootProject.ext.has('buildImageDists')) {
+        rootProject.ext.buildImageDists = new ArrayList<String>()
+    }
+    rootProject.buildImageDists.add(project.group+':'+project.name)
+    task zipBuildImageDist(type: Zip) {
+        dependsOn assemble
+        from tmpBuildImage
+        into new File(project.buildDir, 'distributions')
+    }
+    publish.dependsOn zipBuildImageDist
+
+    publishing {
+        publications {
+            buildImageDist(MavenPublication) {
+                artifactId project.name
+                version project.version
+                artifact zipBuildImageDist
+            }
+        }
+    }
 }

--- a/dev/wlp-gradle/subprojects/publish.gradle
+++ b/dev/wlp-gradle/subprojects/publish.gradle
@@ -22,5 +22,18 @@ publishing {
         maven {
             url uri(cnf.file("release"))
         }
+        if (isUsingArtifactory && isArtifactoryPublishing) {
+            maven {
+                credentials {
+                    username gradle.userProps.getProperty("artifactory.download.user")
+                    password gradle.userProps.getProperty("artifactory.download.token")
+                }
+                url ("https://" + gradle.userProps.getProperty("artifactory.upload.server") + "/artifactory/wasliberty-open-liberty-release-maven-local")
+                metadataSources {
+                    mavenPom()
+                    artifact()
+                }
+            }
+        }
     }
 }

--- a/dev/wlp-gradle/subprojects/repos.gradle
+++ b/dev/wlp-gradle/subprojects/repos.gradle
@@ -19,6 +19,9 @@
  * Do not fall back to Maven Central and IBM DHE when there are Artifactory outages.
  */
 repositories {
+    maven {
+        url uri(cnf.file("release"))
+    }
     if (isUsingArtifactory) {
         maven {
             credentials {

--- a/dev/wlp-jakartaee-transform/bnd.bnd
+++ b/dev/wlp-jakartaee-transform/bnd.bnd
@@ -16,3 +16,5 @@
 tool.project: true
 
 generate.replacement: true
+
+publish.wlp.jar.disabled: true


### PR DESCRIPTION
- Currently, the building of open-liberty's image is coupled to compiling all 1000+ projects in the workspace. That causes very slow builds... up to 5 hours on EBC machines.
- Creating an image zip could be faster when only few projects have differences. We could package an image independently of having projects built in the workspace if the continuous builds uploaded what projects normally output into build.image.
- This PR generates a distribution zip file for each project that would copy files into build.image. Then instead of copying files from projects into build.image, the build for the build.image project will loop over all projects that do generate a distribution, and will extract that zip into build.image.
- This enables us to generate an image from distribution zips that could be located locally (when they are built on the machine) or on Artifactory (when they're pulled from a recent green continuous build).