### PR TITLE
Fix method isDefaultRecoveryLog

### DIFF
--- a/dev/com.ibm.ws.transaction/src/com/ibm/ws/transaction/services/JTMConfigurationProvider.java
+++ b/dev/com.ibm.ws.transaction/src/com/ibm/ws/transaction/services/JTMConfigurationProvider.java
@@ -42,7 +42,6 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.Transaction.JTA.Util;
 import com.ibm.ws.kernel.launch.service.ForcedServerStop;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
-import com.ibm.wsspi.kernel.service.location.WsLocationConstants;
 import com.ibm.wsspi.kernel.service.location.WsResource;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceSet;
@@ -485,29 +484,8 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
                     Tr.debug(tc, "Disable recoverOnStartup during restore until config updates complete");
                 return false;
             }
-        } else {
-            if (checkpoint() && isDefaultRecoveryLog()) {
-                // Optimize restore for default recovery log. Perform initial
-                // local recovery during checkpoint and preserve logs through restore.
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "Enable recoverOnStartup during checkpoint for default recovery log");
-                return true;
-            }
         }
         return isRoS;
-    }
-
-    /**
-     * @return true iff the configured transactionLogDirectory is the default path.
-     */
-    private boolean isDefaultRecoveryLog() {
-        String txLogDirProp = (String) _props.get("transactionLogDirectory");
-        try {
-            String defaultLogDir = locationService.resolveString(WsLocationConstants.SYMBOL_SERVER_OUTPUT_DIR) + "tranlog";
-            return defaultLogDir.equals(txLogDirProp);
-        } catch (Exception ex) {
-            return false;
-        }
     }
 
     @Override

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionServlet/server.xml
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionServlet/server.xml
@@ -29,8 +29,10 @@
              dir="${shared.resource.dir}derby"
              includes="derby.jar" />
 
-    <!-- Potential overrides to transaction config at restore -->
-    <variable name="TX_LOG_DIR" defaultValue="${server.output.dir}tranlog" />
+    <!-- Potential overrides to transaction config at restore.
+         The defaultValue's for these variables must be the default
+         values declared in the transaction metatype. -->
+    <variable name="TX_LOG_DIR" defaultValue="${server.output.dir}/tranlog/" />
     <variable name="TX_RETRY_INT" defaultValue="10" />
 
     <transaction


### PR DESCRIPTION
Remove the method and fix corresponding test server to use the exact default value specified in transaction metatype.

