### PR TITLE
fix timing issue in rollover test

### DIFF
--- a/dev/com.ibm.ws.logging_2_fat/fat/src/com/ibm/ws/logging/fat/TimeBasedLogRolloverTest.java
+++ b/dev/com.ibm.ws.logging_2_fat/fat/src/com/ibm/ws/logging/fat/TimeBasedLogRolloverTest.java
@@ -139,6 +139,12 @@ public class TimeBasedLogRolloverTest {
      */
     @Test
     public void testTimedRolloverEnv() throws Exception {
+        //waits until start of minute before setting up server config
+        //due to the env setup, sometimes the messages log rolls before all the server startup code is validated
+        if (Calendar.getInstance().get(Calendar.SECOND) != 0) {
+            Thread.sleep((60000 - Calendar.getInstance().get(Calendar.SECOND)*1000));
+            Thread.sleep(2000); //padding
+        }
         setUp(server_env, "testTimedRolloverEnv");
         checkForRolledLogsAtTime(getNextRolloverTime(0,1));
     }


### PR DESCRIPTION
#build

fixes: #23444

Due to the env setup, sometimes the `messages.log` rolls before all the server startup code is validated, leading to an error in finding `TE9900A` in the `messages.log` related to validating that `timedExit-1.0` is enabled (ie. `TE9900A` will exist in `messages_YY.MM.DD_HH.MM.SS.MS.log`, since the log was rolled).

This fix waits until the start of the minute before setting up the server config, to avoid log rolling before the server has finished its startup validation.