### PR TITLE
Fixed the computed REST Elapsed Time metric calculation

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.5.0.monitor.internal/src/io/openliberty/microprofile/metrics/internal/monitor/computed/internal/ComputedMonitorMetricsHandler.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.monitor.internal/src/io/openliberty/microprofile/metrics/internal/monitor/computed/internal/ComputedMonitorMetricsHandler.java
@@ -546,8 +546,18 @@ public class ComputedMonitorMetricsHandler {
             if (cmm.getComputationType().equals(Constants.DURATION)) {
                 Duration currentDur = currentTimer.getElapsedTime();
                 if (currentDur != null)  {
-                    metricNum = currentDur.getNano();
-                    currentValue = (metricNum.doubleValue()) * Constants.NANOSECONDCONVERSION; // to seconds.
+                    // In the Duration API, the length of the duration is stored using two fields - seconds and nanoseconds. 
+                    // The nanoseconds part is a value from 0 to 999,999,999 that is an adjustment to the length in seconds. 
+                    // To retrieve the REST elaspedTime, we need to get the seconds and the nanoseconds and add them.
+                    double tempSecs = (double) currentDur.getSeconds();
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "REST Timer ElapsedTime Duration in seconds = " + tempSecs);
+                    }
+                    double tempNanos = (double) currentDur.getNano();
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "REST Timer ElapsedTime Duration in nanoseconds = " + tempNanos);
+                    }
+                    currentValue = tempSecs + (tempNanos * Constants.NANOSECONDCONVERSION); // convert to secs
                 }
             } else {
                 // Get Total Counter Value for Timer

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/computed/ComputedMonitorMetricsHandler.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/computed/ComputedMonitorMetricsHandler.java
@@ -501,8 +501,18 @@ public class ComputedMonitorMetricsHandler {
             if (cmm.getComputationType().equals(DURATION)) {
                 Duration currentDur = currentTimer.getElapsedTime();
                 if (currentDur != null)  {
-                    metricNum = currentDur.getNano();
-                    currentValue = (metricNum.doubleValue()) * NANOSECOND_CONVERSION; // to seconds.
+                    // In the Duration API, the length of the duration is stored using two fields - seconds and nanoseconds. 
+                    // The nanoseconds part is a value from 0 to 999,999,999 that is an adjustment to the length in seconds. 
+                    // To retrieve the REST elaspedTime, we need to get the seconds and the nanoseconds and add them.
+                    double tempSecs = (double) currentDur.getSeconds();
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "REST Timer ElapsedTime Duration in seconds = " + tempSecs);
+                    }
+                    double tempNanos = (double) currentDur.getNano();
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "REST Timer ElapsedTime Duration in nanoseconds = " + tempNanos);
+                    }
+                    currentValue = tempSecs + (tempNanos * NANOSECOND_CONVERSION); // convert to secs
                 }
             } else {
                 // Get Total Counter Value for Timer


### PR DESCRIPTION
fixes #26648
- Fixed how the `REST_request_elapsedTime_per_request` computed metric is calculated. When retrieving the Timer.getElapsedTime value, it returns a Duration. To get the total elapsedTime, we must add up the Nanoseconds and seconds values from the Duration, to get the final value.