### PR TITLE
Allow checkpoint when java 2 security manager configured on JVM18+

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
@@ -246,17 +246,17 @@ public class FrameworkManager {
             String j2secNoRethrow = config.get(BootstrapConstants.JAVA_2_SECURITY_NORETHROW);
 
             if (j2secManager) {
-                CheckpointPhase.getPhase().addMultiThreadedHook(new CheckpointHook() {
-                    @Override
-                    // fail a checkpoint if j2secManager was requested.
-                    public void prepare() {
-                        throw new IllegalStateException(Tr.formatMessage(tc, "error.checkpoint.securitymanager.not.supported"));
-                    }
-                });
                 // OLGH#20289 -- Java 2 Security Manager is no longer supported with Java 18+
                 if (javaVersion() >= 18) {
                     Tr.error(tc, "error.set.securitymanager.jdk18", javaVersion());
                 } else {
+                    CheckpointPhase.getPhase().addMultiThreadedHook(new CheckpointHook() {
+                        @Override
+                        // fail a checkpoint if j2secManager was requested.
+                        public void prepare() {
+                            throw new IllegalStateException(Tr.formatMessage(tc, "error.checkpoint.securitymanager.not.supported"));
+                        }
+                    });
                     // Initialize the VirtualMachineHelper here.  HotSpot Java's read the sun.jvmstat.monitor.local system property during class initialization
                     // on Java 17 when doing Java dump or attaching for the localConnector-1.0 feature.
                     // The permission cannot be set in security policy due to it being during class initialization.

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/CheckpointWithSecurityManager.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/CheckpointWithSecurityManager.java
@@ -14,6 +14,7 @@ package io.openliberty.checkpoint.fat;
 
 import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodNameOnly;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.After;
 import org.junit.Rule;
@@ -24,6 +25,8 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ProgramOutput;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
+import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipIfCheckpointNotSupported;
 import componenttest.custom.junit.runner.FATRunner;
@@ -42,16 +45,37 @@ public class CheckpointWithSecurityManager {
 
     @Test
     @ExpectedFFDC({ "java.lang.UnsupportedOperationException", "io.openliberty.checkpoint.internal.criu.CheckpointFailedException" })
-    public void testAtApplicationsMultRestore() throws Exception {
+    @MaximumJavaLevel(javaLevel = 17)
+    // Checkpoint does not support running with security manager. Verify checkpoint fails when security manager configured.
+    public void testCheckpointJava2SecurityMaxJava17() throws Exception {
         server.setCheckpoint(new CheckpointInfo(CheckpointPhase.AFTER_APP_START, false, true, true, null));
         ProgramOutput output = server.startServer(getTestMethodNameOnly(testName) + ".log");
-        int retureCode = output.getReturnCode();
-        assertEquals("Wrong return code for failed checkpoint.", 72, retureCode);
+        int returnCode = output.getReturnCode();
+        assertEquals("Wrong return code for failed checkpoint.", 72, returnCode);
+    }
+
+    @Test
+    @MinimumJavaLevel(javaLevel = 18)
+    //Test that checkpoint works when security manager is configured jvm>=18, since the framework does not
+    // honor config to enable security manager on those jvm levels, it is a valid configuration for checkpoint
+    public void testCheckpointJava2SecurityMinJava18() throws Exception {
+        server.setCheckpoint(new CheckpointInfo(CheckpointPhase.AFTER_APP_START, false, false, false, null));
+        //Allow logged error 'CWWKE0955E: The websphere.java.security property was set ... but Java version is 21.'
+        server.addCheckpointRegexIgnoreMessage(".*CWWKE0955E.*");
+        ProgramOutput output = server.startServer(getTestMethodNameOnly(testName) + ".log");
+        int returnCode = output.getReturnCode();
+        assertEquals("Wrong return code for successful checkpoint.", 0, returnCode);
+        assertNotNull(server.findStringsInLogsAndTrace("CWWKE0955E: The websphere.java.security property was set in the bootstrap.properties"));
     }
 
     @After
     public void tearDown() throws Exception {
-        server.stopServer();
+        if (testName.getMethodName().contains("MinJava18")) {
+            //Allow 'CWWKE0955E: The websphere.java.security property was set ... but Java version is 21.'
+            server.stopServer(".*CWWKE0955E.*");
+        } else {
+            server.stopServer();
+        }
     }
 
 }


### PR DESCRIPTION
There is a code guard disallowing checkpoint if a security manager is enabled. Liberty framework running on JVM 18 or greater will ignore the configuration for a security manager, so it's safe to relax the guard against checkpoint on those JVMs.
