### PR TITLE
mixed JPA entities on a repository

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
@@ -15,12 +15,14 @@ package test.jakarta.data.jpa.web;
 import java.util.List;
 import java.util.stream.Stream;
 
+import jakarta.data.Streamable;
 import jakarta.data.page.KeysetAwareSlice;
 import jakarta.data.page.Pageable;
 import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
 
 import io.openliberty.data.repository.Compare;
 import io.openliberty.data.repository.Filter;
@@ -72,6 +74,10 @@ public interface Businesses extends BasicRepository<Business, Integer> {
     @OrderBy("name") // Business.name, not Business.Location.Address.Street.name
     @Select("name")
     List<String> onSouthSide();
+
+    // Save with a different entity type does not conflict with the primary entity type from BasicRepository
+    @Save
+    Streamable<Employee> save(Employee... e);
 
     boolean update(Business b);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -117,6 +117,9 @@ public class DataJPATestServlet extends FATServlet {
     Employees employees;
 
     @Inject
+    MixedRepository mixed;
+
+    @Inject
     Orders orders;
 
     @Inject
@@ -1618,10 +1621,10 @@ public class DataJPATestServlet extends FATServlet {
         // Clear out data before test
         employees.deleteByLastName("TestIdOnEmbeddable");
 
-        Streamable<Employee> added = employees.save(new Employee("Irene", "TestIdOnEmbeddable", (short) 2636, 'A'),
-                                                    new Employee("Isabella", "TestIdOnEmbeddable", (short) 8171, 'B'),
-                                                    new Employee("Ivan", "TestIdOnEmbeddable", (short) 4948, 'A'),
-                                                    new Employee("Isaac", "TestIdOnEmbeddable", (short) 5310, 'C'));
+        Streamable<Employee> added = businesses.save(new Employee("Irene", "TestIdOnEmbeddable", (short) 2636, 'A'),
+                                                     new Employee("Isabella", "TestIdOnEmbeddable", (short) 8171, 'B'),
+                                                     new Employee("Ivan", "TestIdOnEmbeddable", (short) 4948, 'A'),
+                                                     new Employee("Isaac", "TestIdOnEmbeddable", (short) 5310, 'C'));
 
         assertEquals(List.of("Irene", "Isabella", "Ivan", "Isaac"),
                      added.stream().map(e -> e.firstName).collect(Collectors.toList()));
@@ -2055,6 +2058,28 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals(t8.leviedAgainst, list.get(7).leviedAgainst);
 
         assertEquals(8, tariffs.deleteByLeviedBy("USA"));
+    }
+
+    /**
+     * Use a repository that has no primary entity class, and no lifecyle methods, but allows find operations
+     * for a mixture of different entity classes.
+     */
+    @Test
+    public void testMixedRepository() {
+
+        Business[] found = mixed.findByLocationAddressCity("Stewartville");
+        assertEquals(List.of("Geotek", "HALCON"),
+                     Stream.of(found)
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        LinkedList<Unpopulated> nothing = mixed.findBySomethingStartsWith("TestMixedRepository");
+        assertEquals(0, nothing.size());
+
+        assertEquals(List.of("Minnesota", "New York"),
+                     mixed.findByName("Rochester")
+                                     .map(c -> c.stateName)
+                                     .collect(Collectors.toList()));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
@@ -13,13 +13,14 @@ package test.jakarta.data.jpa.web;
 import java.util.List;
 import java.util.stream.Stream;
 
-import jakarta.data.Streamable;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 
 /**
- *
+ * Repository that infers its primary entity type from the entity result class of find operations.
+ * Do not add add a superinterface for this class, and do not add any lifecycle methods.
+ * (A save method for Employee can be found on the Businesses repository)
  */
 @Repository
 public interface Employees {
@@ -37,8 +38,6 @@ public interface Employees {
 
     @OrderBy("badge")
     Stream<Badge> findByLastName(String lastName);
-
-    Streamable<Employee> save(Employee... e);
 
     // "IN" is not supported for embeddables, but EclipseLink generates SQL that leads to an SQLDataException rather than rejecting outright
     @Query("SELECT e FROM Employee e WHERE e.badge IN ?1")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.LinkedList;
+import java.util.stream.Stream;
+
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository that has no primary entity type and allows queries for different entity classes.
+ * Do not add any lifecycle methods.
+ */
+@Repository
+public interface MixedRepository { // Do not inherit from a supertype
+
+    @OrderBy("name")
+    Business[] findByLocationAddressCity(String cityName);
+
+    @OrderBy("stateName")
+    Stream<City> findByName(String name);
+
+    LinkedList<Unpopulated> findBySomethingStartsWith(String prefix);
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Unpopulated.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Unpopulated.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Entity without any values in the database.
+ * This is used for a test that references the entity only as
+ * the result of a single finder method. Do not add other usage.
+ */
+@Entity
+public class Unpopulated {
+
+    @Id
+    @Column(nullable = false)
+    private Integer id;
+
+    @Column(nullable = false)
+    private String something;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getSomething() {
+        return something;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public void setName(String something) {
+        this.something = something;
+    }
+}


### PR DESCRIPTION
Add coverage for scenarios where:
 - a repository has no primary entity type and only has find methods that return various different entity classes
 - a repository that has lifecycle methods to save entities with different entity classes
 - a repository method that infers its primary entity type from the return type of find methods, which is possible because the find methods only return a single type of entity class.