### PR TITLE
com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/proxy/StatefullP…

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/proxy/StatefullProxy.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/proxy/StatefullProxy.java
@@ -1418,7 +1418,8 @@ public class StatefullProxy	extends BranchManager
 	 * Notification about timeout according to the m_director.getProxyTimeout()
 	 * 
 	 */
-	public synchronized void proxyTimeout() {
+	//remove sychronized as it caused a deadlock, see OL issue 25962
+	public void proxyTimeout() {
 
 		if (c_logger.isTraceDebugEnabled()) {
 			c_logger.traceDebug(this, "proxyTimeout", getMyInfo());


### PR DESCRIPTION
Deadlock reported under high load when running as a proxy. 