### PR TITLE
Test Kafka with post-process subscriber method

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
@@ -37,9 +37,6 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
-/**
- *
- */
 @RunWith(FATRunner.class)
 public class KafkaAcknowledgementTest {
 
@@ -52,7 +49,11 @@ public class KafkaAcknowledgementTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME,
+                                                                  ReactiveMessagingActions.MP61_RM30,
+                                                                  ReactiveMessagingActions.MP20_RM10,
+                                                                  ReactiveMessagingActions.MP50_RM30,
+                                                                  ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -60,7 +61,9 @@ public class KafkaAcknowledgementTest {
                         .addProperty(AbstractKafkaTestServlet.KAFKA_BOOTSTRAP_PROPERTY, PlaintextTests.kafkaContainer.getBootstrapServers())
                         .include(ConnectorProperties.simpleIncomingChannel(PlaintextTests.connectionProperties(), KafkaReceptionBean.CHANNEL_NAME,
                                                                            KafkaAcknowledgementTestServlet.APP_GROUPID))
-                        .include(ConnectorProperties.simpleOutgoingChannel(PlaintextTests.connectionProperties(), KafkaDeliveryBean.CHANNEL_NAME));
+                        .include(ConnectorProperties.simpleOutgoingChannel(PlaintextTests.connectionProperties(), KafkaDeliveryBean.CHANNEL_NAME))
+                        .include(ConnectorProperties.simpleIncomingChannel(PlaintextTests.connectionProperties(), KafkaPostProcessReceptionBean.POST_PROCESS_CHANNEL,
+                                                                           KafkaAcknowledgementTestServlet.APP_GROUPID));
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addAsLibraries(kafkaClientLibs())

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -118,5 +118,21 @@ public class KafkaAcknowledgementTestServlet extends AbstractKafkaTestServlet {
 
         // Assert that partition offset gets committed to 3
         kafkaTestClient.assertTopicOffsetAdvancesTo(offset + 3, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT, KafkaReceptionBean.CHANNEL_NAME, APP_GROUPID);
+    }
+
+    @Test
+    public void testPostProcessSubscriber() throws InterruptedException {
+        long offset = kafkaTestClient.getTopicOffset(KafkaPostProcessReceptionBean.POST_PROCESS_CHANNEL, APP_GROUPID);
+
+        KafkaWriter<String, String> writer = kafkaTestClient.writerFor(KafkaPostProcessReceptionBean.POST_PROCESS_CHANNEL);
+        writer.sendMessage("test1");
+        writer.sendMessage("test2");
+        writer.sendMessage("test3");
+        writer.sendMessage("test4");
+        writer.sendMessage("test5");
+
+        // All messages should be received and acked immediately
+        // Assert that partition offset gets committed to 5
+        kafkaTestClient.assertTopicOffsetAdvancesTo(offset + 5, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT, KafkaPostProcessReceptionBean.POST_PROCESS_CHANNEL, APP_GROUPID);
     }
 }


### PR DESCRIPTION
Test receiving messages from Kafka using the connector and sending them on to a simple subscriber method which does post-process acknowledgements.