### PR TITLE
Update ConcurrentCDITest to use minimum java level 21

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -29,7 +29,7 @@ import componenttest.topology.utils.FATServletClient;
 import concurrent.cdi4.web.ConcurrentCDI4Servlet;
 
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 17)
+@MinimumJavaLevel(javaLevel = 21)
 public class ConcurrentCDITest extends FATServletClient {
 
     public static final String APP_NAME = "concurrentCDIApp";


### PR DESCRIPTION
Ensure Jakarta EE 11 tests are run on Java 21+