### PR TITLE
Flow.Subscriber proxy test and onError/onComplete testing

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ConcurrentReactiveServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ConcurrentReactiveServlet.java
@@ -72,16 +72,16 @@ public class ConcurrentReactiveServlet extends FATServlet {
         //Check for context in onComplete
         for (long currentTime = Instant.now().toEpochMilli(),
                         endTime = currentTime + TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS); currentTime < endTime; currentTime = Instant.now().toEpochMilli()) {
-            if (subscriber.completeException != null) {
-                if (subscriber.completeException instanceof NamingException) {
-                    throw (AssertionError) new AssertionError("Context was not available in Subscriber onComplete").initCause(subscriber.completeException);
+            if (subscriber.onCompleteResult != null) {
+                if (subscriber.onCompleteResult instanceof NamingException) {
+                    throw (AssertionError) new AssertionError("Context was not available in Subscriber onComplete").initCause((NamingException) subscriber.onCompleteResult);
                 } else {
                     break;
                 }
             }
         }
-        if (!(subscriber.completeException instanceof ThreadSubscriber.PassException))
-            throw new AssertionError("Timed out waiting for subscriber.completeException");
+        if (subscriber.onCompleteResult == null)
+            throw new AssertionError("Timed out waiting for subscriber.onCompleteResult");
 
         //Check for context in onError
         try (ThreadPublisher publisher = new ThreadPublisher(executor, handler)) {
@@ -90,16 +90,16 @@ public class ConcurrentReactiveServlet extends FATServlet {
         }
         for (long currentTime = Instant.now().toEpochMilli(),
                         endTime = currentTime + TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS); currentTime < endTime; currentTime = Instant.now().toEpochMilli()) {
-            if (subscriber.errorException != null) {
-                if (subscriber.errorException instanceof NamingException) {
-                    throw (AssertionError) new AssertionError("Context was not available in Subscriber onError").initCause(subscriber.errorException);
+            if (subscriber.onErrorResult != null) {
+                if (subscriber.onErrorResult instanceof NamingException) {
+                    throw (AssertionError) new AssertionError("Context was not available in Subscriber onError").initCause((NamingException) subscriber.onErrorResult);
                 } else {
                     break;
                 }
             }
         }
-        if (!(subscriber.errorException instanceof ThreadSubscriber.PassException))
-            throw new AssertionError("Timed out waiting for subscriber.errorException");
+        if (subscriber.onErrorResult == null)
+            throw new AssertionError("Timed out waiting for subscriber.onErrorResult");
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ConcurrentReactiveServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ConcurrentReactiveServlet.java
@@ -62,7 +62,6 @@ public class ConcurrentReactiveServlet extends FATServlet {
             publisher.offer(continueLatch, null);
 
             if (!continueLatch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS)) {
-                System.out.println("timeout");
                 if (publisher.getClosedException() != null)
                     throw (AssertionError) new AssertionError("Context was not available in Publisher").initCause(publisher.getClosedException());
                 else
@@ -85,7 +84,6 @@ public class ConcurrentReactiveServlet extends FATServlet {
             throw new AssertionError("Timed out waiting for subscriber.completeException");
 
         //Check for context in onError
-        System.out.println("onError");
         try (ThreadPublisher publisher = new ThreadPublisher(executor, handler)) {
             publisher.subscribe(subscriber);
             publisher.closeExceptionally(new Throwable("Ignored Exception"));
@@ -120,7 +118,6 @@ public class ConcurrentReactiveServlet extends FATServlet {
             publisher.offer(continueLatch, null);
 
             if (!continueLatch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS)) {
-                System.out.println("timeout");
                 if (publisher.getClosedException() != null)
                     throw (AssertionError) new AssertionError("Context was not available in Publisher").initCause(publisher.getClosedException());
                 else if (processor.getClosedException() != null)
@@ -150,7 +147,6 @@ public class ConcurrentReactiveServlet extends FATServlet {
             publisher.offer(contextualCDL, null);
 
             if (!contextualCDL.await(TIMEOUT_NS, TimeUnit.NANOSECONDS)) {
-                System.out.println("timeout");
                 if (publisher.getClosedException() != null)
                     throw (AssertionError) new AssertionError("Context was not available in Publisher").initCause(publisher.getClosedException());
                 else if (processor.getClosedException() != null)
@@ -164,7 +160,7 @@ public class ConcurrentReactiveServlet extends FATServlet {
     }
 
     /**
-     * Test that an contextualized ThreadSubscriber has access to Context.
+     * Test that a contextualized ThreadSubscriber has access to Context.
      * Publisher -> Subscriber
      */
     @Test
@@ -178,7 +174,6 @@ public class ConcurrentReactiveServlet extends FATServlet {
             publisher.offer(continueLatch, null);
 
             if (!continueLatch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS)) {
-                System.out.println("timeout");
                 if (publisher.getClosedException() != null)
                     throw (AssertionError) new AssertionError("Context was not available in Publisher").initCause(publisher.getClosedException());
                 else

--- a/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadProcessor.java
+++ b/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadProcessor.java
@@ -69,7 +69,6 @@ public class ThreadProcessor extends SubmissionPublisher<ContextCDL> implements 
     @Override
     public void onError(Throwable throwable) {
         closeExceptionally(throwable);
-        throwable.printStackTrace(System.out);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadProcessor.java
+++ b/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadProcessor.java
@@ -37,7 +37,6 @@ public class ThreadProcessor extends SubmissionPublisher<ContextCDL> implements 
 
     @Override
     public int offer(ContextCDL latch, BiPredicate<Subscriber<? super ContextCDL>, ? super ContextCDL> onDrop) {
-        System.out.println("processor offer");
         try {
             latch.checkContext();
             return super.offer(latch, onDrop);
@@ -56,7 +55,6 @@ public class ThreadProcessor extends SubmissionPublisher<ContextCDL> implements 
 
     @Override
     public void onNext(ContextCDL latch) {
-        System.out.println("processor onNext");
         try {
             latch.checkContext();
             latch.countDown();

--- a/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadProcessor.java
+++ b/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadProcessor.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.SubmissionPublisher;
+import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 
 import javax.naming.NamingException;
@@ -30,8 +31,8 @@ public class ThreadProcessor extends SubmissionPublisher<ContextCDL> implements 
     Flow.Subscription subscription = null;
 
     //Subscriber methods
-    public ThreadProcessor(Executor ex) {
-        super(ex, 3);
+    public ThreadProcessor(Executor ex, BiConsumer<? super Subscriber<? super ContextCDL>, ? super Throwable> handler) {
+        super(ex, 3, handler);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadPublisher.java
+++ b/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadPublisher.java
@@ -15,6 +15,7 @@ package reactiveapp.web;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.SubmissionPublisher;
+import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 
 import javax.naming.NamingException;
@@ -24,8 +25,8 @@ import javax.naming.NamingException;
  */
 public class ThreadPublisher extends SubmissionPublisher<ContextCDL> {
 
-    public ThreadPublisher(Executor ex) {
-        super(ex, 3);
+    public ThreadPublisher(Executor ex, BiConsumer<? super Subscriber<? super ContextCDL>, ? super Throwable> handler) {
+        super(ex, 3, handler);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadSubscriber.java
+++ b/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadSubscriber.java
@@ -33,21 +33,19 @@ public class ThreadSubscriber implements Flow.Subscriber<ContextCDL> {
 
     @Override
     public void onNext(ContextCDL latch) {
-        System.out.println("subscriber onNext");
 
         try {
             latch.checkContext();
             latch.countDown();
             subscription.request(1);
         } catch (NamingException e) {
-            closeExceptionally(e);
+            onError(e);
         }
     }
 
     @Override
     public void onError(Throwable throwable) {
         closeExceptionally(throwable);
-        throwable.printStackTrace(System.out);
     }
 
     @Override
@@ -55,6 +53,7 @@ public class ThreadSubscriber implements Flow.Subscriber<ContextCDL> {
     }
 
     public void closeExceptionally(Throwable t) {
+        System.out.println("closedExceptionally - sub");
         closedException = t;
     }
 

--- a/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadSubscriber.java
+++ b/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadSubscriber.java
@@ -15,6 +15,7 @@ package reactiveapp.web;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Subscription;
 
+import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
 /**
@@ -23,7 +24,13 @@ import javax.naming.NamingException;
 public class ThreadSubscriber implements Flow.Subscriber<ContextCDL> {
 
     private Flow.Subscription subscription = null;
-    private Throwable closedException = null;
+    public Throwable completeException = null;
+    public Throwable errorException = null;
+
+    @SuppressWarnings("serial")
+    public class PassException extends Throwable {
+
+    }
 
     @Override
     public void onSubscribe(Subscription subscription) {
@@ -45,10 +52,23 @@ public class ThreadSubscriber implements Flow.Subscriber<ContextCDL> {
 
     @Override
     public void onError(Throwable throwable) {
+        try {
+            new InitialContext().lookup("java:comp/env/entry1");
+            errorException = new PassException();
+        } catch (NamingException e) {
+            errorException = e;
+        }
     }
 
     @Override
     public void onComplete() {
+        try {
+            new InitialContext().lookup("java:comp/env/entry1");
+            completeException = new PassException();
+        } catch (NamingException e) {
+            completeException = e;
+        }
+
     }
 
 }

--- a/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadSubscriber.java
+++ b/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadSubscriber.java
@@ -39,31 +39,16 @@ public class ThreadSubscriber implements Flow.Subscriber<ContextCDL> {
             latch.countDown();
             subscription.request(1);
         } catch (NamingException e) {
-            onError(e);
+            throw new RuntimeException(e);
         }
     }
 
     @Override
     public void onError(Throwable throwable) {
-        closeExceptionally(throwable);
     }
 
     @Override
     public void onComplete() {
-    }
-
-    public void closeExceptionally(Throwable t) {
-        System.out.println("closedExceptionally - sub");
-        closedException = t;
-    }
-
-    /**
-     * Returns the exception associated with closeExceptionally, or null if not closed or if closed normally.
-     *
-     * @return the exception, or null if none
-     */
-    public Throwable getClosedException() {
-        return closedException;
     }
 
 }

--- a/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadSubscriber.java
+++ b/dev/com.ibm.ws.concurrent_fat_reactive/test-applications/reactiveapp/src/reactiveapp/web/ThreadSubscriber.java
@@ -24,13 +24,8 @@ import javax.naming.NamingException;
 public class ThreadSubscriber implements Flow.Subscriber<ContextCDL> {
 
     private Flow.Subscription subscription = null;
-    public Throwable completeException = null;
-    public Throwable errorException = null;
-
-    @SuppressWarnings("serial")
-    public class PassException extends Throwable {
-
-    }
+    public Object onCompleteResult = null;
+    public Object onErrorResult = null;
 
     @Override
     public void onSubscribe(Subscription subscription) {
@@ -53,20 +48,18 @@ public class ThreadSubscriber implements Flow.Subscriber<ContextCDL> {
     @Override
     public void onError(Throwable throwable) {
         try {
-            new InitialContext().lookup("java:comp/env/entry1");
-            errorException = new PassException();
+            onErrorResult = new InitialContext().lookup("java:comp/env/entry1");
         } catch (NamingException e) {
-            errorException = e;
+            onErrorResult = e;
         }
     }
 
     @Override
     public void onComplete() {
         try {
-            new InitialContext().lookup("java:comp/env/entry1");
-            completeException = new PassException();
+            onCompleteResult = new InitialContext().lookup("java:comp/env/entry1");
         } catch (NamingException e) {
-            completeException = e;
+            onCompleteResult = e;
         }
 
     }


### PR DESCRIPTION
Additional testing for Flow in EE Concurrency, including proxying a Flow.Subscriber, onError, and onComplete context testing. Uses more natural error handling, by allowing the Publisher to use a handler for errors in Subscriber.onNext.
