### PR TITLE
Initialize single instance of repository just once

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -221,7 +221,8 @@ public class DataExtension implements Extension, PrivilegedAction<DataExtensionP
 
                 BeanAttributes<?> attrs = beanMgr.createBeanAttributes(repositoryType);
                 Bean<?> bean = beanMgr.createBean(attrs, repositoryInterface, new RepositoryProducer.Factory<>( //
-                                beanMgr, provider, this, entityDefiner, primaryEntityClassReturnValue[0], queriesPerEntityClass));
+                                repositoryInterface, beanMgr, provider, this, //
+                                entityDefiner, primaryEntityClassReturnValue[0], queriesPerEntityClass));
                 repositoryBeans.add(bean);
             }
         }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -63,6 +63,7 @@ import com.ibm.wsspi.resource.ResourceFactory;
 
 import io.openliberty.data.internal.persistence.EntityDefiner;
 import io.openliberty.data.internal.persistence.QueryInfo;
+import jakarta.annotation.Generated;
 import jakarta.data.exceptions.MappingException;
 import jakarta.data.model.StaticMetamodel;
 import jakarta.data.repository.DataRepository;
@@ -174,19 +175,24 @@ public class DataExtension implements Extension, PrivilegedAction<DataExtensionP
     public <T> void annotatedStaticMetamodel(@Observes @WithAnnotations(StaticMetamodel.class) ProcessAnnotatedType<T> event) {
         AnnotatedType<T> type = event.getAnnotatedType();
 
-        StaticMetamodel staticMetamodel = type.getAnnotation(StaticMetamodel.class);
+        if (type.isAnnotationPresent(Generated.class)) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, "annotatedStaticMetamodel ignoring generated " + type.getJavaClass().getName());
+        } else {
+            StaticMetamodel staticMetamodel = type.getAnnotation(StaticMetamodel.class);
 
-        Class<?> entityClass = staticMetamodel.value();
+            Class<?> entityClass = staticMetamodel.value();
 
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(this, tc, "annotatedStaticMetamodel for " + entityClass.getName(),
-                     type.getJavaClass().getName());
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, "annotatedStaticMetamodel for " + entityClass.getName(),
+                         type.getJavaClass().getName());
 
-        List<Class<?>> newList = new LinkedList<>();
-        newList.add(type.getJavaClass());
-        List<Class<?>> existingList = staticMetamodels.putIfAbsent(entityClass, newList);
-        if (existingList != null)
-            existingList.add(type.getJavaClass());
+            List<Class<?>> newList = new LinkedList<>();
+            newList.add(type.getJavaClass());
+            List<Class<?>> existingList = staticMetamodels.putIfAbsent(entityClass, newList);
+            if (existingList != null)
+                existingList.add(type.getJavaClass());
+        }
     }
 
     public void afterTypeDiscovery(@Observes AfterTypeDiscovery event, BeanManager beanMgr) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -53,23 +54,57 @@ public class RepositoryProducer<R, P> implements Producer<R> {
         private final BeanManager beanMgr;
         private final EntityDefiner entityDefiner;
         private final DataExtension extension;
+        private RepositoryImpl<?> handler;
+        private final ReentrantReadWriteLock handlerLock = new ReentrantReadWriteLock();
         private final Class<?> primaryEntityClass;
         private final DataExtensionProvider provider;
         private final Map<Class<?>, List<QueryInfo>> queriesPerEntityClass;
+        private final Class<?> repositoryInterface;
 
-        Factory(BeanManager beanMgr, DataExtensionProvider provider, DataExtension extension, EntityDefiner entityDefiner,
-                Class<?> primaryEntityClass, Map<Class<?>, List<QueryInfo>> queriesPerEntityClass) {
+        Factory(Class<?> repositoryInterface, BeanManager beanMgr, DataExtensionProvider provider, DataExtension extension,
+                EntityDefiner entityDefiner, Class<?> primaryEntityClass, Map<Class<?>, List<QueryInfo>> queriesPerEntityClass) {
             this.beanMgr = beanMgr;
             this.entityDefiner = entityDefiner;
             this.extension = extension;
             this.primaryEntityClass = primaryEntityClass;
             this.provider = provider;
             this.queriesPerEntityClass = queriesPerEntityClass;
+            this.repositoryInterface = repositoryInterface;
         }
 
         @Override
         public <R> Producer<R> createProducer(Bean<R> bean) {
             return new RepositoryProducer<>(bean, this);
+        }
+
+        /**
+         * Lazily initialize the repository implementation.
+         * TODO This could be moved to produce if we use CDI to guarantee only a single instance is produced.
+         *
+         * @return repository implementation.
+         */
+        private RepositoryImpl<?> getHandler() {
+            handlerLock.readLock().lock();
+            try {
+                if (handler == null)
+                    try {
+                        // Switch to write lock for lazy initialization
+                        handlerLock.readLock().unlock();
+                        handlerLock.writeLock().lock();
+
+                        if (handler == null)
+                            handler = new RepositoryImpl<>(provider, extension, entityDefiner, //
+                                            repositoryInterface, primaryEntityClass, queriesPerEntityClass);
+                    } finally {
+                        // Downgrade to read lock for rest of method
+                        handlerLock.readLock().lock();
+                        handlerLock.writeLock().unlock();
+                    }
+
+                return handler;
+            } finally {
+                handlerLock.readLock().unlock();
+            }
         }
     }
 
@@ -128,12 +163,9 @@ public class RepositoryProducer<R, P> implements Producer<R> {
                         Tr.debug(this, tc, "add " + anno + " for " + method.getAnnotated().getJavaMember());
                 }
 
-        RepositoryImpl<R> handler = new RepositoryImpl<>(factory.provider, factory.extension, factory.entityDefiner, //
-                        repositoryInterface, factory.primaryEntityClass, factory.queriesPerEntityClass);
-
         R instance = repositoryInterface.cast(Proxy.newProxyInstance(repositoryInterface.getClassLoader(),
                                                                      new Class<?>[] { repositoryInterface },
-                                                                     handler));
+                                                                     factory.getHandler()));
 
         if (intercept) {
             R r = interception.createInterceptedInstance(instance);


### PR DESCRIPTION
This pull includes a couple of minor changes, along with a fix to ensure we are using a single instance of the repository implementation which is initialized just once.  The other changes optimize to ignore the static metamodel initialization when `@Generated` is present, and to rearrange a section of code and remove obsolete handling.