### PR TITLE
Reduce trace in EJB Checkpoint FAT

### DIFF
--- a/dev/io.openliberty.ejbcontainer.checkpoint_fat/publish/servers/EjbStartCheckpointMockServer/bootstrap.properties
+++ b/dev/io.openliberty.ejbcontainer.checkpoint_fat/publish/servers/EjbStartCheckpointMockServer/bootstrap.properties
@@ -1,4 +1,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
-com.ibm.ws.logging.trace.specification=*=info:EJBContainer=all:JITDeploy=all:Injection=all:checkpoint=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.metadata.ejb.*=all:JITDeploy=all:Injection=all:checkpoint=all
 io.openliberty.checkpoint.allowed.features=servlet-3.1


### PR DESCRIPTION
Trace of EJB BackgroundLRUEvictionStrategy was interfering with the Checkpoint stub, so reduced EJBContainer trace to just trace EJB metadata processing that is required by the FAT.