### PR TITLE
Add fats test for Reactve Messaging 3.0 Emitters

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
@@ -83,7 +83,7 @@ kafka.create.outgoing.retry.CWMRX1010W.explanation=An error occurred when the Ka
 kafka.create.outgoing.retry.CWMRX1010W.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify whether the problem was transient and was resolved by retrying the connector setup.
 
 # {0} = kafka record data, {1} = exception details
-# 'nack' is the name of a method and should not be translated 
+# 'nack' is the name of a method and should not be translated
 kafka.input.message.nacked.CWMRX1011E=CWMRX1011E: The nack method was called on a message that was created from a Kafka record, indicating that it was not processed successfully. The reactive message stream will be shut down. The record was: {0}. The exception was: {1}.
 kafka.input.message.nacked.CWMRX1011E.explanation=A message from the Kafka connector caused a failure somewhere in the application, resulting in the message being negatively acknowledged. As the message has not been successfully processed, the committed offset has not be advanced for the partition that the message came from. No more messages can be processed from this partition.
 kafka.input.message.nacked.CWMRX1011E.useraction=Review the error message and the messages.log file on the server to identify the problem. To avoid message processing stopping on a failure, implement logic within your application that provides alternative handling of messages that are negatively-acknowledged.

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaReader.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaReader.java
@@ -28,6 +28,9 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
  * An interface for reading ConsumerRecords from a Kafka topic. The key and message types are dependent on the KafkaConsumer which is passed in.
  * <p>
  * This reader doesn't commit any offsets so each new reader will start reading from the start of the topic.
+ *
+ * Once an instance of KafkaReader is no longer required. It must be closed by KafkaReader.close()
+ *
  */
 public class KafkaReader<K, V> implements AutoCloseable {
 

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaReader.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaReader.java
@@ -28,7 +28,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
  * An interface for reading ConsumerRecords from a Kafka topic. The key and message types are dependent on the KafkaConsumer which is passed in.
  * <p>
  * This reader doesn't commit any offsets so each new reader will start reading from the start of the topic.
- *
+ * <p>
  * Once an instance of KafkaReader is no longer required. It must be closed by KafkaReader.close()
  *
  */

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaTestClient.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaTestClient.java
@@ -71,8 +71,8 @@ public class KafkaTestClient {
      * Create a test client with the given set of connection properties
      * <p>
      * The connection properties are properties common to every consumer or producer connecting to this broker.
-     *
-     * Once and instance of KafkaReader is no longer needed. It must be closed either via KafkaTestClient.cleanup() or KafkaReader.close()
+     * <p>
+     * Once an instance of KafkaReader is no longer needed. It must be closed either via KafkaTestClient.cleanup() or KafkaReader.close()
      *
      * @param connectionProperties the connection properties
      */

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaTestClient.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaTestClient.java
@@ -72,6 +72,8 @@ public class KafkaTestClient {
      * <p>
      * The connection properties are properties common to every consumer or producer connecting to this broker.
      *
+     * Once and instance of KafkaReader is no longer needed. It must be closed either via KafkaTestClient.cleanup() or KafkaReader.close()
+     *
      * @param connectionProperties the connection properties
      */
     public KafkaTestClient(Map<? extends String, ?> connectionProperties) {
@@ -82,6 +84,8 @@ public class KafkaTestClient {
      * Obtain a KafkaReader for the given topic name
      * <p>
      * The returned reader expects String messages and uses the {@value #TEST_GROUPID} consumer group
+     *
+     * Once and instance of KafkaReader is no longer needed. It must be closed either via KafkaTestClient.cleanup() or KafkaReader.close()
      *
      * @param topicName the topic to read from
      * @return the reader
@@ -101,6 +105,8 @@ public class KafkaTestClient {
      * <li>{@value ConsumerConfig#GROUP_ID_CONFIG} = {@value #TEST_GROUPID}</li>
      * <li>{@value ConsumerConfig#AUTO_OFFSET_RESET_CONFIG} = earliest</li>
      * </ul>
+     *
+     * Once and instance of KafkaReader is no longer needed. It must be closed either via KafkaTestClient.cleanup() or KafkaReader.close()
      *
      * @param config    the consumer config
      * @param topicName the topic to subscribe to
@@ -129,6 +135,8 @@ public class KafkaTestClient {
      * <p>
      * The returned writer writes String messages.
      *
+     * Once and instance of KafkaWriter is no longer needed. It must be closed either via KafkaTestClient.cleanup() or KafkaWriter.close()
+     *
      * @param topicName the topic to write to
      * @return the writer
      */
@@ -145,6 +153,8 @@ public class KafkaTestClient {
      * <li>{@value ProducerConfig#KEY_SERIALIZER_CLASS_CONFIG} = StringSerializer</li>
      * <li>{@value ProducerConfig#VALUE_SERIALIZER_CLASS_CONFIG} = StringSerializer</li>
      * </ul>
+     *
+     * Once and instance of KafkaWriter is no longer needed. It must be closed either via KafkaTestClient.cleanup() or KafkaWriter.close()
      *
      * @param <T>       the type of the message written to Kafka. This must match the type serialized by the class configured with
      *                      {@value ProducerConfig#VALUE_SERIALIZER_CLASS_CONFIG}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaWriter.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaWriter.java
@@ -27,6 +27,9 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestCons
 
 /**
  * An interface for writing messages to a kafka topic. The key and message types are dependent on the KafkaProducer which is passed in.
+ *
+ * Once an instance of KafkaWriter is no longer needed it must be close by KafkaWriter.close()
+ *
  */
 public class KafkaWriter<K, V> implements AutoCloseable {
 

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaWriter.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaWriter.java
@@ -27,7 +27,7 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestCons
 
 /**
  * An interface for writing messages to a kafka topic. The key and message types are dependent on the KafkaProducer which is passed in.
- *
+ * <p>
  * Once an instance of KafkaWriter is no longer needed it must be close by KafkaWriter.close()
  *
  */

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/bnd.bnd
@@ -33,7 +33,7 @@ tested.features:\
   mpConfig-3.1,\
   restfulws-3.0,\
   mpTelemetry-1.1,\
-  mpmetrics-4.0,\
+  mpmetrics-5.0,\
   mpmetrics-5.1,\
   restfulwsclient-3.0, \
   restfulws-3.0, \

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/bnd.bnd
@@ -30,23 +30,27 @@ tested.features:\
   concurrent-3.0,\
   cdi-4.0,\
   servlet-6.0,\
+  mpConfig-3.1,\
   restfulws-3.0,\
   mpTelemetry-1.1,\
   mpmetrics-4.0,\
-  mpmetrics-5.1
+  mpmetrics-5.1,\
+  restfulwsclient-3.0, \
+  restfulws-3.0, \
+  jsonp-2.0
 
 -buildpath: \
-	io.openliberty.microprofile.reactive.messaging.internal_fat.common.jakarta;version=latest,\
-	io.openliberty.org.eclipse.microprofile.reactive.messaging.3.0;version=latest,\
-	io.openliberty.org.eclipse.microprofile.reactive.streams.operators.3.0;version=latest,\
-	com.ibm.websphere.org.reactivestreams.reactive-streams.1.0;version=latest,\
-	io.openliberty.org.eclipse.microprofile.config.3.0;version=latest,\
-	io.openliberty.jakarta.cdi.3.0;version=latest,\
-	io.openliberty.jakarta.servlet.5.0;version=latest,\
-	org.apache.kafka:kafka-clients;version=3.5.1,\
-	io.openliberty.org.testcontainers;version=latest,\
-	com.ibm.ws.componenttest.2.0;version=latest,\
-	io.openliberty.jakarta.restfulWS.3.1
+    io.openliberty.microprofile.reactive.messaging.internal_fat.common.jakarta;version=latest,\
+    io.openliberty.org.eclipse.microprofile.reactive.messaging.3.0;version=latest,\
+    io.openliberty.org.eclipse.microprofile.reactive.streams.operators.3.0;version=latest,\
+    com.ibm.websphere.org.reactivestreams.reactive-streams.1.0;version=latest,\
+    io.openliberty.org.eclipse.microprofile.config.3.0;version=latest,\
+    io.openliberty.jakarta.cdi.3.0;version=latest,\
+    io.openliberty.jakarta.servlet.5.0;version=latest,\
+    io.openliberty.jakarta.restfulWS.3.0;version=latest,\
+    org.apache.kafka:kafka-clients;version=3.5.1,\
+    io.openliberty.org.testcontainers;version=latest,\
+    com.ibm.ws.componenttest.2.0;version=latest
 
 -dependson.1: \
     com.ibm.ws.org.slf4j.jdk14

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/emitter/EmitterApplication.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/emitter/EmitterApplication.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+package io.openliberty.microprofile.reactive.messaging.fat.apps.emitter;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class EmitterApplication extends Application {
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/emitter/EmitterRestResource.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/emitter/EmitterRestResource.java
@@ -22,18 +22,18 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 @Path("/")
-public class EmitterRestResource<T> {
+public class EmitterRestResource {
 
     public static final String PAYLOAD_CHANNEL_NAME = "restful-emitter-payload";
     public static final String MESSAGE_CHANNEL_NAME = "restful-emitter-message";
 
     @Inject
     @Channel(PAYLOAD_CHANNEL_NAME)
-    Emitter<String> payloadEmitter;
+    private Emitter<String> payloadEmitter;
 
     @Inject
     @Channel(MESSAGE_CHANNEL_NAME)
-    Emitter<String> messageEmitter;
+    private Emitter<String> messageEmitter;
 
     @POST
     @Path("/payload")

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/emitter/EmitterRestResource.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/emitter/EmitterRestResource.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+package io.openliberty.microprofile.reactive.messaging.fat.apps.emitter;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+
+import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+@Path("/")
+public class EmitterRestResource<T> {
+
+    public static final String PAYLOAD_CHANNEL_NAME = "restful-emitter-payload";
+    public static final String MESSAGE_CHANNEL_NAME = "restful-emitter-message";
+
+    @Inject
+    @Channel(PAYLOAD_CHANNEL_NAME)
+    Emitter<String> payloadEmitter;
+
+    @Inject
+    @Channel(MESSAGE_CHANNEL_NAME)
+    Emitter<String> messageEmitter;
+
+    @POST
+    @Path("/payload")
+    public CompletionStage<Void> emitPayload(String payload){
+        CompletionStage<Void> cs = payloadEmitter.send(payload);
+        return cs;
+    }
+
+    @POST
+    @Path("/message")
+    public CompletionStage<Void> emitMessage(String payload) {
+        CompletableFuture<Void> ackCf = new CompletableFuture<>();
+        messageEmitter.send(Message.of(payload,
+                () -> {
+                    ackCf.complete(null);
+                    return CompletableFuture.completedFuture(null);
+                },
+                t -> {
+                    ackCf.completeExceptionally(t);
+                    return CompletableFuture.completedFuture(null);
+                }));
+        return ackCf;
+    }
+
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/emitter/basic/KafkaEmitterTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/emitter/basic/KafkaEmitterTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+package io.openliberty.microprofile.reactive.messaging.fat.kafka.emitter.basic;
+
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestConstants;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.microprofile.reactive.messaging.fat.suite.KafkaTests;
+import io.openliberty.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaClientLibs;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaPermissions;
+
+@RunWith(FATRunner.class)
+public class KafkaEmitterTest {
+
+    public static final String APP_NAME = "kafka-message-emitter";
+    public static final String SERVER_NAME = "SimpleRxMessagingServer";
+
+    @Server(SERVER_NAME)
+    @TestServlet(contextRoot = APP_NAME, servlet = KafkaEmitterTestServlet.class)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static final RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP50_RM30,ReactiveMessagingActions.MP60_RM30);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        PropertiesAsset appConfig = new PropertiesAsset()
+                .addProperty(AbstractKafkaTestServlet.KAFKA_BOOTSTRAP_PROPERTY, KafkaTests.kafkaContainer.getBootstrapServers())
+                .include(ConnectorProperties.simpleOutgoingChannel(KafkaTests.connectionProperties(), KafkaEmitterTestServlet.CHANNEL_NAME))
+                .include(ConnectorProperties.simpleOutgoingChannel(KafkaTests.connectionProperties(), KafkaEmitterTestServlet.CHANNEL_NAME2));
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                .addAsLibraries(kafkaClientLibs())
+                .addAsManifestResource(kafkaPermissions(), "permissions.xml")
+                .addPackage(KafkaEmitterTestServlet.class.getPackage())
+                .addPackage(KafkaTestConstants.class.getPackage())
+                .addPackage(AbstractKafkaTestServlet.class.getPackage())
+                .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        try {
+            server.stopServer();
+        } finally {
+            KafkaUtils.deleteKafkaTopics(KafkaTests.getAdminClient());
+        }
+    }
+
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/emitter/basic/KafkaEmitterTestServlet.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/emitter/basic/KafkaEmitterTestServlet.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+package io.openliberty.microprofile.reactive.messaging.fat.kafka.emitter.basic;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestConstants;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaReader;
+import componenttest.custom.junit.runner.Mode;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+@WebServlet("/KafkaEmitterMessageTestServlet")
+public class KafkaEmitterTestServlet extends AbstractKafkaTestServlet {
+
+    public static final String CHANNEL_NAME = "emitter-test-outgoing-message";
+    public static final String CHANNEL_NAME2 = "emitter-test-outgoing-payload";
+
+    @Inject
+    @Channel(CHANNEL_NAME)
+    public Emitter<String> emitter;
+
+    @Inject
+    @Channel(CHANNEL_NAME2)
+    public Emitter<String> emitter2;
+
+    @Test
+    public void testmitterMessage() {
+        for(int i=1;i<=5;i++) {
+            emitter.send(Message.of("message" + i));
+        }
+
+        KafkaReader<String, String> reader = kafkaTestClient.readerFor(CHANNEL_NAME);
+        List<String> messages = reader.assertReadMessages(5, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
+        assertThat(messages, contains("message1","message2", "message3", "message4","message5"));
+    }
+
+    @Test
+    public void testEmitterPayload() {
+        for(int i=1;i<=5;i++) {
+            emitter.send(Message.of("payload" + i));
+        }
+
+        KafkaReader<String, String> reader = kafkaTestClient.readerFor(CHANNEL_NAME);
+        List<String> messages = reader.assertReadMessages(5, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
+        assertThat(messages, contains("payload1","payload2", "payload3", "payload4","payload5"));
+    }
+
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/emitter/basic/KafkaEmitterTestServlet.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/emitter/basic/KafkaEmitterTestServlet.java
@@ -14,7 +14,6 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestCons
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
 
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaReader;
-import componenttest.custom.junit.runner.Mode;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
 import org.eclipse.microprofile.reactive.messaging.Channel;
@@ -35,32 +34,32 @@ public class KafkaEmitterTestServlet extends AbstractKafkaTestServlet {
 
     @Inject
     @Channel(CHANNEL_NAME)
-    public Emitter<String> emitter;
+    private Emitter<String> emitter;
 
     @Inject
     @Channel(CHANNEL_NAME2)
-    public Emitter<String> emitter2;
+    private Emitter<String> emitter2;
 
     @Test
-    public void testmitterMessage() {
-        for(int i=1;i<=5;i++) {
+    public void testEmitterMessage() {
+        for (int i = 1; i <= 5; i++) {
             emitter.send(Message.of("message" + i));
         }
 
         KafkaReader<String, String> reader = kafkaTestClient.readerFor(CHANNEL_NAME);
         List<String> messages = reader.assertReadMessages(5, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
-        assertThat(messages, contains("message1","message2", "message3", "message4","message5"));
+        assertThat(messages, contains("message1", "message2", "message3", "message4", "message5"));
     }
 
     @Test
     public void testEmitterPayload() {
-        for(int i=1;i<=5;i++) {
-            emitter.send(Message.of("payload" + i));
+        for (int i = 1; i <= 5; i++) {
+            emitter.send("payload" + i);
         }
 
         KafkaReader<String, String> reader = kafkaTestClient.readerFor(CHANNEL_NAME);
         List<String> messages = reader.assertReadMessages(5, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
-        assertThat(messages, contains("payload1","payload2", "payload3", "payload4","payload5"));
+        assertThat(messages, contains("payload1", "payload2", "payload3", "payload4", "payload5"));
     }
 
 }

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/emitter/nack/KafkaEmitterNackRestfulTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/emitter/nack/KafkaEmitterNackRestfulTest.java
@@ -88,40 +88,38 @@ public class KafkaEmitterNackRestfulTest {
     @Test
     public void testEmittingNackPayload() throws Exception {
         server.setMarkToEndOfLog();
-        int port = server.getHttpDefaultPort();
-        URL url = new URL("http://localhost:"+port+"/"+APP_NAME+"/payload");
+        URL url = HttpUtils.createURL(server, APP_NAME + "/payload");
         HttpURLConnection conn = HttpUtils.getHttpConnection(url, HttpUtils.DEFAULT_TIMEOUT, HttpUtils.HTTPRequestMethod.POST);
-        OutputStream os = conn.getOutputStream();
-        os.write(("test").getBytes());
-        os.flush();
-        assertThat(conn.getResponseCode(), is(500));
-        os.close();
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(("test").getBytes());
+            os.flush();
+            assertThat(conn.getResponseCode(), is(500));
+        }
         conn.disconnect();
         // check that we get error about the payload emitter channel
-        assertNotNull("Channel can ",server.waitForStringInLogUsingMark("CWMRX1003E.*restful-emitter-payload"));
+        assertNotNull("Channel fails to send the payload.",server.waitForStringInLogUsingMark("CWMRX1003E.*restful-emitter-payload"));
     }
 
     @Test
     public void testEmittingNackMessage() throws Exception {
         server.setMarkToEndOfLog();
-        int port = server.getHttpDefaultPort();
-        URL url = new URL("http://localhost:"+port+"/"+APP_NAME+"/message");
+        URL url = HttpUtils.createURL(server, APP_NAME + "/message");
         HttpURLConnection conn = HttpUtils.getHttpConnection(url, HttpUtils.DEFAULT_TIMEOUT, HttpUtils.HTTPRequestMethod.POST);
-        OutputStream os = conn.getOutputStream();
-        os.write(("test").getBytes());
-        os.flush();
-        assertThat(conn.getResponseCode(), is(500));
-        os.close();
+        try(OutputStream os = conn.getOutputStream()) {
+            os.write(("test").getBytes());
+            os.flush();
+            assertThat(conn.getResponseCode(), is(500));
+        }
         conn.disconnect();
         // check that we get error about the message emitter channel
-        assertNotNull("Channel can ",server.waitForStringInLogUsingMark("CWMRX1003E.*restful-emitter-message"));
+        assertNotNull("Channel fails to send the message.",server.waitForStringInLogUsingMark("CWMRX1003E.*restful-emitter-message"));
     }
 
     @AfterClass
     public static void teardown() throws Exception {
         try {
-        //We expect a kafka error and an error from RESTEASY relating to th failure when we respond to the request
-        server.stopServer("CWMRX1003E.*restful-emitter", "RESTEASY002020");
+            //We expect a kafka error and an error from RESTEASY relating to the failure when we respond to the request
+            server.stopServer("CWMRX1003E.*restful-emitter", "RESTEASY002020");
         } finally {
             KafkaUtils.deleteKafkaTopics(KafkaTests.getAdminClient());
         }

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/emitter/nack/KafkaEmitterNackRestfulTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/emitter/nack/KafkaEmitterNackRestfulTest.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+package io.openliberty.microprofile.reactive.messaging.fat.kafka.emitter.nack;
+
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestConstants;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+import io.openliberty.microprofile.reactive.messaging.fat.apps.emitter.EmitterApplication;
+import io.openliberty.microprofile.reactive.messaging.fat.apps.emitter.EmitterRestResource;
+import io.openliberty.microprofile.reactive.messaging.fat.suite.KafkaTests;
+import io.openliberty.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaClientLibs;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaPermissions;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class KafkaEmitterNackRestfulTest {
+
+    public static final String APP_NAME = "kafka-message-restful-emitter";
+    public static final String SERVER_NAME = "SimpleRxMessagingServer";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static final RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP50_RM30,ReactiveMessagingActions.MP60_RM30);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+
+        Map<String, Object> invalidKafkaConfig = Collections.singletonMap(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "PLAINTEXT://localhost:10000");
+
+        PropertiesAsset appConfig = new PropertiesAsset()
+                .addProperty(AbstractKafkaTestServlet.KAFKA_BOOTSTRAP_PROPERTY, KafkaTests.kafkaContainer.getBootstrapServers())
+                .include(ConnectorProperties.simpleOutgoingChannel(invalidKafkaConfig, EmitterRestResource.PAYLOAD_CHANNEL_NAME))
+                .include(ConnectorProperties.simpleOutgoingChannel(invalidKafkaConfig, EmitterRestResource.MESSAGE_CHANNEL_NAME));
+
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                .addAsLibraries(kafkaClientLibs())
+                .addAsManifestResource(kafkaPermissions(), "permissions.xml")
+                .addPackage(EmitterApplication.class.getPackage())
+                .addPackage(KafkaTestConstants.class.getPackage())
+                .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        server.startServer();
+    }
+
+    @Test
+    public void testEmittingNackPayload() throws Exception {
+        server.setMarkToEndOfLog();
+        int port = server.getHttpDefaultPort();
+        URL url = new URL("http://localhost:"+port+"/"+APP_NAME+"/payload");
+        HttpURLConnection conn = HttpUtils.getHttpConnection(url, HttpUtils.DEFAULT_TIMEOUT, HttpUtils.HTTPRequestMethod.POST);
+        OutputStream os = conn.getOutputStream();
+        os.write(("test").getBytes());
+        os.flush();
+        assertThat(conn.getResponseCode(), is(500));
+        os.close();
+        conn.disconnect();
+        // check that we get error about the payload emitter channel
+        assertNotNull("Channel can ",server.waitForStringInLogUsingMark("CWMRX1003E.*restful-emitter-payload"));
+    }
+
+    @Test
+    public void testEmittingNackMessage() throws Exception {
+        server.setMarkToEndOfLog();
+        int port = server.getHttpDefaultPort();
+        URL url = new URL("http://localhost:"+port+"/"+APP_NAME+"/message");
+        HttpURLConnection conn = HttpUtils.getHttpConnection(url, HttpUtils.DEFAULT_TIMEOUT, HttpUtils.HTTPRequestMethod.POST);
+        OutputStream os = conn.getOutputStream();
+        os.write(("test").getBytes());
+        os.flush();
+        assertThat(conn.getResponseCode(), is(500));
+        os.close();
+        conn.disconnect();
+        // check that we get error about the message emitter channel
+        assertNotNull("Channel can ",server.waitForStringInLogUsingMark("CWMRX1003E.*restful-emitter-message"));
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        try {
+        //We expect a kafka error and an error from RESTEASY relating to th failure when we respond to the request
+        server.stopServer("CWMRX1003E.*restful-emitter", "RESTEASY002020");
+        } finally {
+            KafkaUtils.deleteKafkaTopics(KafkaTests.getAdminClient());
+        }
+    }
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/emitter/restful/KafkaEmitterRestfulTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/emitter/restful/KafkaEmitterRestfulTest.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+package io.openliberty.microprofile.reactive.messaging.fat.kafka.emitter.restful;
+
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestConstants;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaReader;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClient;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+import io.openliberty.microprofile.reactive.messaging.fat.apps.emitter.EmitterApplication;
+import io.openliberty.microprofile.reactive.messaging.fat.apps.emitter.EmitterRestResource;
+import io.openliberty.microprofile.reactive.messaging.fat.suite.KafkaTests;
+import io.openliberty.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaClientLibs;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaPermissions;
+
+@RunWith(FATRunner.class)
+@Mode(Mode.TestMode.FULL)
+public class KafkaEmitterRestfulTest {
+
+    public static final String APP_NAME = "kafka-message-restful-emitter";
+    public static final String SERVER_NAME = "SimpleRxMessagingServer";
+    public static KafkaTestClient kafkaTestClient;
+
+    public static String payload_topic_name;
+    public static String message_topic_name;
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static final RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP50_RM30,ReactiveMessagingActions.MP60_RM30);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+
+        payload_topic_name = EmitterRestResource.PAYLOAD_CHANNEL_NAME + RepeatTestFilter.getRepeatActionsAsString();
+        message_topic_name = EmitterRestResource.MESSAGE_CHANNEL_NAME + RepeatTestFilter.getRepeatActionsAsString();
+
+        PropertiesAsset appConfig = new PropertiesAsset()
+            .addProperty(AbstractKafkaTestServlet.KAFKA_BOOTSTRAP_PROPERTY, KafkaTests.kafkaContainer.getBootstrapServers())
+            .include(ConnectorProperties.simpleOutgoingChannel(KafkaTests.connectionProperties(), ConnectorProperties.DEFAULT_CONNECTOR_ID, EmitterRestResource.PAYLOAD_CHANNEL_NAME, payload_topic_name))
+            .include(ConnectorProperties.simpleOutgoingChannel(KafkaTests.connectionProperties(), ConnectorProperties.DEFAULT_CONNECTOR_ID, EmitterRestResource.MESSAGE_CHANNEL_NAME, message_topic_name));
+
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                .addAsLibraries(kafkaClientLibs())
+                .addAsManifestResource(kafkaPermissions(), "permissions.xml")
+                .addPackage(EmitterApplication.class.getPackage())
+                .addPackage(KafkaTestConstants.class.getPackage())
+                .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        server.startServer();
+
+        kafkaTestClient = new KafkaTestClient(KafkaTests.connectionProperties());
+    }
+
+    @Test
+    public void testEmittingRestPayload() throws Exception {
+        sendRequest("payload");
+
+        try(KafkaReader<String, String> reader = kafkaTestClient.readerFor(payload_topic_name)) {
+            List<String> messages = reader.assertReadMessages(5, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
+            assertThat(messages, contains("payload1", "payload2", "payload3", "payload4", "payload5"));
+        }
+    }
+
+    @Test
+    public void testEmttingRestMessage() throws Exception {
+        sendRequest("message");
+
+        try(KafkaReader<String, String> reader = kafkaTestClient.readerFor(message_topic_name)) {
+            List<String> messages = reader.assertReadMessages(5, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
+            assertThat(messages, contains("message1", "message2", "message3", "message4", "message5"));
+        }
+    }
+
+
+    public void sendRequest(String path) throws IOException {
+        int port = server.getHttpDefaultPort();
+        URL url = new URL("http://localhost:"+port+"/"+APP_NAME+"/"+path);
+        // Send 5 messages to the server to make sure we do process multiple requests
+        for(int count = 1; count <6;count++) {
+            HttpURLConnection conn = HttpUtils.getHttpConnection(url, HttpUtils.DEFAULT_TIMEOUT, HttpUtils.HTTPRequestMethod.POST);
+            OutputStream os = conn.getOutputStream();
+            os.write((path + count).getBytes());
+            os.flush();
+            assertThat(conn.getResponseCode(), is(204));
+            conn.disconnect();
+        }
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        try {
+            server.stopServer();
+        } finally {
+            KafkaUtils.deleteKafkaTopics(KafkaTests.getAdminClient());
+        }
+    }
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/nack/KafkaNackReceptionBean.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/nack/KafkaNackReceptionBean.java
@@ -6,8 +6,8 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *******************************************************************************/
-package io.openliberty.microprofile.reactive.messaging.fat.apps.kafkanack;
+ ******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.fat.kafka.nack;
 
 import static org.eclipse.microprofile.reactive.messaging.Acknowledgment.Strategy.MANUAL;
 

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/nack/KafkaNackTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/nack/KafkaNackTest.java
@@ -6,8 +6,8 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *******************************************************************************/
-package io.openliberty.microprofile.reactive.messaging.fat.apps.kafkanack;
+ ******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.fat.kafka.nack;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaClientLibs;
@@ -18,6 +18,7 @@ import static java.util.Arrays.asList;
 import java.util.Collections;
 import java.util.Map;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -97,10 +98,11 @@ public class KafkaNackTest extends FATServletClient {
     public static void teardown() throws Exception {
         server.stopServer("CWMRX1003E.*nack-test-channel", // CWMRX1003E: An error occurred when sending a message to the Kafka broker. The error is: org.apache.kafka.common.errors.TimeoutException: Topic nack-test-channel not present in metadata after 5000 ms.
                           "CWMRX1011E.*KafkaNackTestException");
+        KafkaUtils.deleteKafkaTopics(KafkaTests.getAdminClient());
     }
 
     @Test
-    @ExpectedFFDC("io.openliberty.microprofile.reactive.messaging.fat.apps.kafkanack.KafkaNackTestException")
+    @ExpectedFFDC("io.openliberty.microprofile.reactive.messaging.fat.kafka.nack.KafkaNackTestException")
     public void testIncomingMessageCanBeNacked() throws Exception {
         server.setMarkToEndOfLog();
 

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/nack/KafkaNackTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/nack/KafkaNackTest.java
@@ -96,9 +96,12 @@ public class KafkaNackTest extends FATServletClient {
 
     @AfterClass
     public static void teardown() throws Exception {
-        server.stopServer("CWMRX1003E.*nack-test-channel", // CWMRX1003E: An error occurred when sending a message to the Kafka broker. The error is: org.apache.kafka.common.errors.TimeoutException: Topic nack-test-channel not present in metadata after 5000 ms.
-                          "CWMRX1011E.*KafkaNackTestException");
-        KafkaUtils.deleteKafkaTopics(KafkaTests.getAdminClient());
+        try {
+            server.stopServer("CWMRX1003E.*nack-test-channel", // CWMRX1003E: An error occurred when sending a message to the Kafka broker. The error is: org.apache.kafka.common.errors.TimeoutException: Topic nack-test-channel not present in metadata after 5000 ms.
+                    "CWMRX1011E.*KafkaNackTestException");
+        } finally {
+            KafkaUtils.deleteKafkaTopics(KafkaTests.getAdminClient());
+        }
     }
 
     @Test

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/nack/KafkaNackTestDeliveryBean.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/nack/KafkaNackTestDeliveryBean.java
@@ -6,8 +6,8 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *******************************************************************************/
-package io.openliberty.microprofile.reactive.messaging.fat.apps.kafkanack;
+ ******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.fat.kafka.nack;
 
 import java.util.concurrent.CompletionStage;
 

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/nack/KafkaNackTestException.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/nack/KafkaNackTestException.java
@@ -6,8 +6,8 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *******************************************************************************/
-package io.openliberty.microprofile.reactive.messaging.fat.apps.kafkanack;
+ ******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.fat.kafka.nack;
 
 @SuppressWarnings("serial")
 public class KafkaNackTestException extends Exception {

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/nack/KafkaNackTestServlet.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/nack/KafkaNackTestServlet.java
@@ -6,8 +6,8 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *******************************************************************************/
-package io.openliberty.microprofile.reactive.messaging.fat.apps.kafkanack;
+ ******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.fat.kafka.nack;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/suite/FATSuite.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/suite/FATSuite.java
@@ -18,8 +18,8 @@ import io.openliberty.microprofile.reactive.messaging.fat.validation.ValidationT
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-                      KafkaTests.class,
-                      ValidationTests.class
+    KafkaTests.class,
+    ValidationTests.class
 })
 public class FATSuite extends TestContainerSuite {
 }

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/suite/KafkaTests.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/suite/KafkaTests.java
@@ -32,12 +32,15 @@ import io.openliberty.microprofile.reactive.messaging.fat.telemetry.ReactiveMess
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                KafkaNackTest.class,
-                KafkaValidationTests.class,
-                MetricsTest.class,
-                MultiAppMetricsTest.class,
-                ReactiveMessagingTelemetryTest.class,
-                ReactiveMessagingTelemetryTestWithJAXRS.class
+        KafkaNackTest.class,
+        KafkaValidationTests.class,
+        MetricsTest.class,
+        MultiAppMetricsTest.class,
+        ReactiveMessagingTelemetryTest.class,
+        ReactiveMessagingTelemetryTestWithJAXRS.class
+        KafkaEmitterTest.class,
+        KafkaEmitterRestfulTest.class,
+        KafkaEmitterNackRestfulTest.class
 })
 public class KafkaTests {
 

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/suite/KafkaTests.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/suite/KafkaTests.java
@@ -23,9 +23,12 @@ import org.junit.runners.Suite.SuiteClasses;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.containers.ExtendedKafkaContainer;
 
 import componenttest.containers.SimpleLogConsumer;
-import io.openliberty.microprofile.reactive.messaging.fat.apps.kafkanack.KafkaNackTest;
+import io.openliberty.microprofile.reactive.messaging.fat.kafka.emitter.basic.KafkaEmitterTest;
+import io.openliberty.microprofile.reactive.messaging.fat.kafka.emitter.nack.KafkaEmitterNackRestfulTest;
+import io.openliberty.microprofile.reactive.messaging.fat.kafka.emitter.restful.KafkaEmitterRestfulTest;
 import io.openliberty.microprofile.reactive.messaging.fat.kafka.metrics.MetricsTest;
 import io.openliberty.microprofile.reactive.messaging.fat.kafka.metrics.MultiAppMetricsTest;
+import io.openliberty.microprofile.reactive.messaging.fat.kafka.nack.KafkaNackTest;
 import io.openliberty.microprofile.reactive.messaging.fat.kafka.validation.KafkaValidationTests;
 import io.openliberty.microprofile.reactive.messaging.fat.telemetry.ReactiveMessagingTelemetryTest;
 import io.openliberty.microprofile.reactive.messaging.fat.telemetry.ReactiveMessagingTelemetryTestWithJAXRS;
@@ -37,7 +40,7 @@ import io.openliberty.microprofile.reactive.messaging.fat.telemetry.ReactiveMess
         MetricsTest.class,
         MultiAppMetricsTest.class,
         ReactiveMessagingTelemetryTest.class,
-        ReactiveMessagingTelemetryTestWithJAXRS.class
+        ReactiveMessagingTelemetryTestWithJAXRS.class,
         KafkaEmitterTest.class,
         KafkaEmitterRestfulTest.class,
         KafkaEmitterNackRestfulTest.class

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/publish/servers/SimpleRxMessagingServer/server.xml
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/publish/servers/SimpleRxMessagingServer/server.xml
@@ -23,7 +23,6 @@
         <feature>restfulWS-3.1</feature>
         <feature>servlet-5.0</feature>
         <feature>mpConfig-3.1</feature>
-        <feature>mpMetrics-5.0</feature>
     </featureManager>
     <mpMetrics authentication="false"/>
 </server>

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/publish/servers/SimpleRxMessagingServer/server.xml
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/publish/servers/SimpleRxMessagingServer/server.xml
@@ -16,9 +16,11 @@
 
     <featureManager>
         <feature>componenttest-2.0</feature>
-        <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
+        <feature>mpMetrics-4.0</feature>
         <feature>mpReactiveMessaging-3.0</feature>
+        <feature>osgiconsole-1.0</feature>
+        <feature>restfulWS-3.1</feature>
         <feature>servlet-5.0</feature>
         <feature>mpConfig-3.1</feature>
         <feature>mpMetrics-5.0</feature>


### PR DESCRIPTION
Add some Lite mode tests for simple emitter checking with Kafka

Full Fat for Restful examples of using an emitter both positive and negative 

Fixes #25970 

