### PR TITLE
Add fast.ack option to Kafka Reactive Messaging Connector

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaConnectorConstants.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaConnectorConstants.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -38,12 +38,16 @@ public class KafkaConnectorConstants {
     //The length of time to retry creation of the KafkaConsumer
     public static final String CREATION_RETRY_SECONDS = "creation.retry.seconds";
 
+    //Whether to complete ack() call before the partition offset is actually committed
+    public static final String FAST_ACK = "fast.ack";
+
     //The set of properties which should NOT be passed through to the Kafka client
     public static final Set<String> NON_KAFKA_PROPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(new String[] { TOPIC,
                                                                                                                              ConnectorFactory.CONNECTOR_ATTRIBUTE,
                                                                                                                              ConnectorFactory.CHANNEL_NAME_ATTRIBUTE,
                                                                                                                              UNACKED_LIMIT,
-                                                                                                                             CREATION_RETRY_SECONDS
+                                                                                                                             CREATION_RETRY_SECONDS,
+                                                                                                                             FAST_ACK
     })));
 
 //=======================Kafka Properties===============================//

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -102,6 +102,7 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory {
             int maxPollRecords = config.getOptionalValue(KafkaConnectorConstants.MAX_POLL_RECORDS, Integer.class).orElse(500);
             int unackedLimit = config.getOptionalValue(KafkaConnectorConstants.UNACKED_LIMIT, Integer.class).orElse(maxPollRecords);
             int retrySeconds = config.getOptionalValue(KafkaConnectorConstants.CREATION_RETRY_SECONDS, Integer.class).orElse(0);
+            boolean fastAck = config.getOptionalValue(KafkaConnectorConstants.FAST_ACK, Boolean.class).orElse(false);
 
             // Configure our defaults
             Map<String, Object> consumerConfig = new HashMap<>();
@@ -132,7 +133,7 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory {
 
             // Create our connector around the kafkaConsumer
             KafkaInput<String, Object> kafkaInput = new KafkaInput<>(this.kafkaAdapterFactory, partitionTrackerFactory, kafkaConsumer, this.executor,
-                                                                     topic, unackedLimit);
+                                                                     topic, unackedLimit, fastAck);
             kafkaInputs.add(kafkaInput);
 
             return kafkaInput.getPublisher();

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
@@ -37,9 +37,6 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
-/**
- *
- */
 @RunWith(FATRunner.class)
 public class KafkaAcknowledgementTest {
 
@@ -52,7 +49,11 @@ public class KafkaAcknowledgementTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10, ReactiveMessagingActions.MP50_RM30, ReactiveMessagingActions.MP60_RM30);
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME,
+                                                                  ReactiveMessagingActions.MP61_RM30,
+                                                                  ReactiveMessagingActions.MP20_RM10,
+                                                                  ReactiveMessagingActions.MP50_RM30,
+                                                                  ReactiveMessagingActions.MP60_RM30);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -60,7 +61,9 @@ public class KafkaAcknowledgementTest {
                         .addProperty(AbstractKafkaTestServlet.KAFKA_BOOTSTRAP_PROPERTY, PlaintextTests.kafkaContainer.getBootstrapServers())
                         .include(ConnectorProperties.simpleIncomingChannel(PlaintextTests.connectionProperties(), KafkaReceptionBean.CHANNEL_NAME,
                                                                            KafkaAcknowledgementTestServlet.APP_GROUPID))
-                        .include(ConnectorProperties.simpleOutgoingChannel(PlaintextTests.connectionProperties(), KafkaDeliveryBean.CHANNEL_NAME));
+                        .include(ConnectorProperties.simpleOutgoingChannel(PlaintextTests.connectionProperties(), KafkaDeliveryBean.CHANNEL_NAME))
+                        .include(ConnectorProperties.simpleIncomingChannel(PlaintextTests.connectionProperties(), KafkaPostProcessReceptionBean.POST_PROCESS_CHANNEL,
+                                                                           KafkaAcknowledgementTestServlet.APP_GROUPID));
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addAsLibraries(kafkaClientLibs())

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -118,5 +118,21 @@ public class KafkaAcknowledgementTestServlet extends AbstractKafkaTestServlet {
 
         // Assert that partition offset gets committed to 3
         kafkaTestClient.assertTopicOffsetAdvancesTo(offset + 3, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT, KafkaReceptionBean.CHANNEL_NAME, APP_GROUPID);
+    }
+
+    @Test
+    public void testPostProcessSubscriber() throws InterruptedException {
+        long offset = kafkaTestClient.getTopicOffset(KafkaPostProcessReceptionBean.POST_PROCESS_CHANNEL, APP_GROUPID);
+
+        KafkaWriter<String, String> writer = kafkaTestClient.writerFor(KafkaPostProcessReceptionBean.POST_PROCESS_CHANNEL);
+        writer.sendMessage("test1");
+        writer.sendMessage("test2");
+        writer.sendMessage("test3");
+        writer.sendMessage("test4");
+        writer.sendMessage("test5");
+
+        // All messages should be received and acked immediately
+        // Assert that partition offset gets committed to 5
+        kafkaTestClient.assertTopicOffsetAdvancesTo(offset + 5, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT, KafkaPostProcessReceptionBean.POST_PROCESS_CHANNEL, APP_GROUPID);
     }
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaPostProcessReceptionBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaPostProcessReceptionBean.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.delivery;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+public class KafkaPostProcessReceptionBean {
+
+    public static final String POST_PROCESS_CHANNEL = "kafka-ack-post-process";
+
+    @Incoming(POST_PROCESS_CHANNEL)
+    public void process(String message) {
+        System.out.println("Message received: " + message);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
@@ -72,6 +72,7 @@ public class KafkaPartitionTest {
     public static void setup() throws Exception {
         //Generate unique topic names for each repeat
         String livePartitionTopicName = LivePartitionTestBean.CHANNEL_IN + RepeatTestFilter.getRepeatActionsAsString();
+        String livePartitionSubscriberMethodTopicName = LivePartitionTestSubscriberMethodBean.CHANNEL_IN + RepeatTestFilter.getRepeatActionsAsString();
         String partitionTopicName = PartitionTestReceptionBean.CHANNEL_NAME + RepeatTestFilter.getRepeatActionsAsString();
 
         // Create a topic with two partitions
@@ -82,6 +83,7 @@ public class KafkaPartitionTest {
         List<NewTopic> newTopics = new ArrayList<>();
         newTopics.add(new NewTopic(partitionTopicName, 2, (short) 1));
         newTopics.add(new NewTopic(livePartitionTopicName, LivePartitionTestBean.PARTITION_COUNT, (short) 1));
+        newTopics.add(new NewTopic(livePartitionSubscriberMethodTopicName, LivePartitionTestSubscriberMethodBean.PARTITION_COUNT, (short) 1));
         adminClient.createTopics(newTopics).all().get(KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
         // Create and deploy the app
@@ -96,7 +98,16 @@ public class KafkaPartitionTest {
                                         .simpleIncomingChannel(PlaintextTests.connectionProperties(), ConnectorProperties.DEFAULT_CONNECTOR_ID, LivePartitionTestBean.CHANNEL_IN,
                                                                LivePartitionTestServlet.APP_GROUPID, livePartitionTopicName)
                                         .addProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "5")
-                                        .addProperty(KafkaConnectorConstants.UNACKED_LIMIT, "100")); // Want to simulate having lots of unacked messages
+                                        .addProperty(KafkaConnectorConstants.UNACKED_LIMIT, "100") // Want to simulate having lots of unacked messages
+                                        .addProperty(KafkaConnectorConstants.FAST_ACK, "false"))
+                        .include(ConnectorProperties
+                                        .simpleIncomingChannel(PlaintextTests.connectionProperties(),
+                                                               ConnectorProperties.DEFAULT_CONNECTOR_ID,
+                                                               LivePartitionTestSubscriberMethodBean.CHANNEL_IN,
+                                                               LivePartitionTestServlet.APP_GROUPID,
+                                                               livePartitionSubscriberMethodTopicName)
+                                        .addProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "5")
+                                        .addProperty(KafkaConnectorConstants.FAST_ACK, "true"));
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackage(KafkaTestClient.class.getPackage())

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/LivePartitionTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/LivePartitionTestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions;
 
-import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions.LivePartitionTestBean.PARTITION_COUNT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
@@ -60,6 +59,8 @@ public class LivePartitionTestServlet extends AbstractKafkaTestServlet {
     private static final long serialVersionUID = 1L;
 
     public static final String APP_GROUPID = "kafka-live-partition-test-group";
+    public static final int FINAL_MESSAGE_NUMBER = 9999;
+
     @Resource
     private ManagedExecutorService executor;
 
@@ -67,49 +68,31 @@ public class LivePartitionTestServlet extends AbstractKafkaTestServlet {
     private LivePartitionTestBean bean;
 
     @Inject
+    private LivePartitionTestSubscriberMethodBean subscriberMethodBean;
+
+    @Inject
     @ConfigProperty(name = "mp.messaging.incoming." + LivePartitionTestBean.CHANNEL_IN + ".topic")
     private String topic;
 
+    @Inject
+    @ConfigProperty(name = "mp.messaging.incoming." + LivePartitionTestSubscriberMethodBean.CHANNEL_IN + ".topic")
+    private String subscriberMethodTopic;
+
+    /**
+     * Test live partition assignment
+     * <p>
+     * This test assumes fast.ack=false so that we can see which messages are successfully committed
+     */
     @Test
     public void testLivePartitionAssignment() throws Exception {
 
-        List<String> sentMessages = new ArrayList<>();
-
-        Map<String, Object> producerConfig = new HashMap<>();
-        producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaBootstrap());
-        producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-
-        // Load messages into topic
-        try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerConfig)) {
-            for (int partition = 0; partition < PARTITION_COUNT; partition++) {
-                for (int message = 0; message < 100; message++) {
-                    String value = partition + "-" + message;
-                    ProducerRecord<String, String> record = new ProducerRecord<String, String>(topic, partition, null, value);
-                    producer.send(record);
-                    sentMessages.add(value);
-                }
-
-                // Add a sentinal message to the end of each partition
-                String value = partition + "-" + LivePartitionTestBean.FINAL_MESSAGE_NUMBER;
-                ProducerRecord<String, String> record = new ProducerRecord<String, String>(topic, partition, null, value);
-                producer.send(record);
-                sentMessages.add(value);
-            }
-        }
-
-        Map<String, Object> consumerConfig = new HashMap<>();
-        consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaBootstrap());
-        consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, APP_GROUPID);
-        consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        List<String> sentMessages = sendTestMessages(topic, LivePartitionTestBean.PARTITION_COUNT, 100);
 
         // Sleep
         Thread.sleep(700);
 
         // Start a second consumer
-        LivePartitionTestConsumer consumer1 = new LivePartitionTestConsumer(consumerConfig, topic);
+        LivePartitionTestConsumer consumer1 = new LivePartitionTestConsumer(getTestConsumerConfig(), topic);
         Future<?> future1 = executor.submit(consumer1);
 
         // Wait for it to finish and close
@@ -119,7 +102,7 @@ public class LivePartitionTestServlet extends AbstractKafkaTestServlet {
         Thread.sleep(700);
 
         // Start a third consumer
-        LivePartitionTestConsumer consumer2 = new LivePartitionTestConsumer(consumerConfig, topic);
+        LivePartitionTestConsumer consumer2 = new LivePartitionTestConsumer(getTestConsumerConfig(), topic);
         Future<?> future2 = executor.submit(consumer2);
 
         // Wait for it to finish and close
@@ -134,7 +117,7 @@ public class LivePartitionTestServlet extends AbstractKafkaTestServlet {
 
         // Check that successfully acknowledged messages are in ascending order for each partition
         Map<Integer, Integer> highestMessagePerPartition = new HashMap<>();
-        IntStream.range(0, PARTITION_COUNT)
+        IntStream.range(0, LivePartitionTestBean.PARTITION_COUNT)
                         .forEach(i -> highestMessagePerPartition.put(i, -1));
 
         for (ReceivedMessage message : bean.getMessages()) {
@@ -160,6 +143,92 @@ public class LivePartitionTestServlet extends AbstractKafkaTestServlet {
         Collections.sort(sentMessages);
         Collections.sort(receivedMessageList);
         assertEquals("Recived messages not the same as sent messages", sentMessages, receivedMessageList);
+    }
+
+    /**
+     * Test live partition assignment when the target is a subscriber method
+     * <p>
+     * This test relies on fast.ack=true because the subscriber methods with post-process acknowledgement will wait for the
+     * acknowledgement to complete before accepting the next message.
+     */
+    @Test
+    public void testLivePartitionSubscriberMethod() throws Exception {
+        List<String> sentMessages = sendTestMessages(subscriberMethodTopic, LivePartitionTestSubscriberMethodBean.PARTITION_COUNT, 100);
+
+        // Sleep
+        Thread.sleep(700);
+
+        // Start a second consumer
+        LivePartitionTestConsumer consumer1 = new LivePartitionTestConsumer(getTestConsumerConfig(), subscriberMethodTopic);
+        Future<?> future1 = executor.submit(consumer1);
+
+        // Wait for it to finish and close
+        future1.get();
+
+        // Start a third consumer
+        LivePartitionTestConsumer consumer2 = new LivePartitionTestConsumer(getTestConsumerConfig(), subscriberMethodTopic);
+        Future<?> future2 = executor.submit(consumer2);
+
+        // Wait for it to finish and close
+        future2.get();
+
+        // Wait for the bean to finish consuming messages
+        subscriberMethodBean.awaitFinish();
+
+        System.out.println("Message count: " + subscriberMethodBean.getMessages().size());
+
+        // Check that each sent message was received at least once
+        Stream<String> receivedMessages = subscriberMethodBean.getMessages().stream()
+                        .map(ReceivedMessage::toString);
+        receivedMessages = Stream.concat(receivedMessages, consumer1.getMessages().stream());
+        receivedMessages = Stream.concat(receivedMessages, consumer2.getMessages().stream());
+
+        List<String> recievedMessageList = receivedMessages.distinct().collect(Collectors.toList());
+
+        // Sort before comparing
+        Collections.sort(sentMessages);
+        Collections.sort(recievedMessageList);
+
+        assertEquals("Recieved messages not the same as sent messages", sentMessages, recievedMessageList);
+    }
+
+    private List<String> sendTestMessages(String topic, int partitionCount, int messageCount) {
+        List<String> sentMessages = new ArrayList<>();
+
+        Map<String, Object> producerConfig = new HashMap<>();
+        producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaBootstrap());
+        producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+        // Load messages into topic
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerConfig)) {
+            for (int partition = 0; partition < partitionCount; partition++) {
+                for (int message = 0; message < 100; message++) {
+                    String value = partition + "-" + message;
+                    ProducerRecord<String, String> record = new ProducerRecord<String, String>(topic, partition, null, value);
+                    producer.send(record);
+                    sentMessages.add(value);
+                }
+
+                // Add a sentinal message to the end of each partition
+                String value = partition + "-" + FINAL_MESSAGE_NUMBER;
+                ProducerRecord<String, String> record = new ProducerRecord<String, String>(topic, partition, null, value);
+                producer.send(record);
+                sentMessages.add(value);
+            }
+        }
+
+        return sentMessages;
+    }
+
+    private Map<String, Object> getTestConsumerConfig() {
+        Map<String, Object> testConsumerConfig = new HashMap<>();
+        testConsumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaBootstrap());
+        testConsumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        testConsumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        testConsumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, APP_GROUPID);
+        testConsumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return testConsumerConfig;
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/LivePartitionTestSubscriberMethodBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/LivePartitionTestSubscriberMethodBean.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions.LivePartitionTestBean.ReceivedMessage;
+
+@ApplicationScoped
+public class LivePartitionTestSubscriberMethodBean {
+
+    public static final String CHANNEL_IN = "live-partition-test-subscriber-method-in";
+    public static final int WORK_TIME = 50;
+    public static final int PARTITION_COUNT = 2;
+
+    private final ArrayList<ReceivedMessage> messages = new ArrayList<>();
+    private final CountDownLatch partitionsFinished = new CountDownLatch(PARTITION_COUNT);
+
+    @Incoming(CHANNEL_IN)
+    public void receive(String message) throws InterruptedException {
+        System.out.println("SubscriberMethodBean received message: " + message);
+        Thread.sleep(WORK_TIME);
+        ReceivedMessage status = new ReceivedMessage(message);
+        messages.add(status);
+        if (status.number == LivePartitionTestServlet.FINAL_MESSAGE_NUMBER) {
+            partitionsFinished.countDown();
+        }
+    }
+
+    public void awaitFinish() throws InterruptedException {
+        int timeout = 20 * PARTITION_COUNT;
+        assertTrue("Test bean did not process all messages within " + timeout + " seconds", partitionsFinished.await(timeout, TimeUnit.SECONDS));
+    }
+
+    public List<ReceivedMessage> getMessages() {
+        return messages;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/KafkaPublisherVerification.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/KafkaPublisherVerification.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -103,7 +103,7 @@ public class KafkaPublisherVerification extends PublisherVerification<Message<St
         PartitionTrackerFactory trackerFactory = new PartitionTrackerFactory();
         trackerFactory.setExecutor(executor);
         trackerFactory.setAutoCommitEnabled(false);
-        KafkaInput<String, String> kafkaInput = new KafkaInput<>(kafkaAdapterFactory, trackerFactory, kafkaConsumer, executor, topicName, 100);
+        KafkaInput<String, String> kafkaInput = new KafkaInput<>(kafkaAdapterFactory, trackerFactory, kafkaConsumer, executor, topicName, 100, false);
         kafkaInputs.add(kafkaInput);
         return kafkaInput.getPublisher().buildRs();
     }
@@ -139,7 +139,7 @@ public class KafkaPublisherVerification extends PublisherVerification<Message<St
         PartitionTrackerFactory trackerFactory = new PartitionTrackerFactory();
         trackerFactory.setExecutor(executor);
         trackerFactory.setAutoCommitEnabled(false);
-        KafkaInput<String, String> kafkaInput = new KafkaInput<>(kafkaAdapterFactory, trackerFactory, kafkaConsumer, executor, topicName, 100);
+        KafkaInput<String, String> kafkaInput = new KafkaInput<>(kafkaAdapterFactory, trackerFactory, kafkaConsumer, executor, topicName, 100, false);
         kafkaInputs.add(kafkaInput);
         return kafkaInput.getPublisher().buildRs();
     }

--- a/dev/io.openliberty.microprofile.reactive.messaging.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.reactive.messaging.3.0.internal/bnd.bnd
@@ -25,7 +25,15 @@ Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 
 WS-TraceGroup: REACTIVEMESSAGE
 
+Include-Resource: \
+  OSGI-INF/wlp=resources/OSGI-INF/wlp
+
 Import-Package: *
+
+Private-Package: \
+  io.openliberty.microprofile.reactive.messaging30.internal
+
+IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
 -dsannotations: \
     io.openliberty.microprofile.reactive.messaging30.internal.MessageAccess30

--- a/dev/io.openliberty.microprofile.reactive.messaging.3.0.internal/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/io.openliberty.microprofile.reactive.messaging.3.0.internal/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -1,0 +1,13 @@
+<!--
+  ~ Copyright (c) 2023 IBM Corporation and others.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License 2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<server>
+    <!-- Default to fast ack=true-->
+    <variable name="mp.messaging.connector.liberty-kafka.fast.ack" defaultValue="true"/>
+</server>


### PR DESCRIPTION
When `fast.ack` is set to `true`, the Kafka connector will report that an acknowledgement has been completed as soon as it has received the acknowledgement. This is the default for `mpReactiveMessaging-3.0`.

When `fast.ack` is set to `false`, the Kafka connector will not report that acknowledgement has been completed until the partition offset has been successfully committed to the Kafka broker. There will usually be a delay before this happens because the Kafka connector attempts to batch up commits. In addition, if the partition offset cannot be committed, it will report that the acknowledgement failed. This can occur when another instance of the service joins the consumer group and some partitions are moved from one service to the other. This is the default for `mpReactiveMessaging-1.0` to preserve the existing behaviour.

We're adding this config property and changing the default behaviour for RM 3.0 because it works better with the way the Reactive Messaging container behaves. In particular, a subscriber method like this:

```java
@Incoming("myChannel")
public void myMethod(String payload) {}
```

which uses the `POST_PROCESS` acknowledgement mode will wait for each message to be acknowledged before it starts processing the next one. Since the Kafka connector tries to batch up acknowledgements, this results in a delay between the processing of each message.

Fixes #26692