### PR TITLE
fix-ltpa-expiration

### DIFF
--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
@@ -220,7 +220,6 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
     private List<Properties> getNonConfiguredValidationKeys() {
         List<Properties> validationKeysInDirectory = new ArrayList<Properties>();
         Iterator<File> keysFiles = this.allKeysFiles.iterator();
-        Properties properties = new Properties();
 
         if (keysFiles != null) {
             while (keysFiles.hasNext()) {
@@ -230,10 +229,11 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
                 String fullFileName = primaryKeyImportDir.concat(fileName);
 
                 // skip the primary LTPA keys file or validationKeys file configured in the valicationKeys element
-                if (primaryKeyImportFile.equals(fileName) || isConfiguredValidationKeys(fullFileName)) {
+                if (primaryKeyImportFile.equals(fullFileName) || isConfiguredValidationKeys(fullFileName)) {
                     continue;
                 }
 
+                Properties properties = new Properties();
                 properties.setProperty(CFG_KEY_VALIDATION_FILE_NAME, fullFileName);
                 properties.setProperty(CFG_KEY_VALIDATION_PASSWORD, primaryKeyPassword);
 
@@ -253,11 +253,13 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
      * @return
      */
     private boolean isConfiguredValidationKeys(String fn) {
-        Iterator<Properties> configValidationKeysIterator = configValidationKeys.iterator();
-        while (configValidationKeysIterator.hasNext()) {
-            Properties vKeys = configValidationKeysIterator.next();
-            if (vKeys.getProperty(CFG_KEY_VALIDATION_FILE_NAME).equals(fn))
-                return true;
+        if (configValidationKeys != null) {
+            Iterator<Properties> configValidationKeysIterator = configValidationKeys.iterator();
+            while (configValidationKeysIterator.hasNext()) {
+                Properties vKeys = configValidationKeysIterator.next();
+                if (vKeys.getProperty(CFG_KEY_VALIDATION_FILE_NAME).equals(fn))
+                    return true;
+            }
         }
 
         return false;
@@ -341,9 +343,9 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
     public void performFileBasedAction(Collection<File> createdFiles, Collection<File> modifiedFiles, Collection<File> deletedFiles) {
         Collection<File> allFiles = getAllFiles(createdFiles, modifiedFiles, deletedFiles);
 
-        processAllKeysFiles(createdFiles, modifiedFiles, deletedFiles);
+        processAllKeysFiles(createdFiles, modifiedFiles, deletedFiles); // we've got validation3.keys
 
-        processValidationKeys();
+        processValidationKeys(); //
 
         if (noValidationKeys()) { // no validationKeys. Keep behavior the same as SecurityFileMonnitor
             if (deletedFiles.isEmpty() == false) {

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
@@ -128,12 +128,12 @@ public class LTPAToken2 implements Token, Serializable {
         this.cipher = AES_CBC_CIPHER;
         this.expirationDifferenceAllowed = expDiffAllowed;
         decrypt();
-        if (attributes != null && attributes.length > 0) {
+        isValid();
+        if (attributes != null) {
             //Reset signature, encryptedBytes and remove attributes
             this.signature = null;
             this.encryptedBytes = null;
             userData.removeAttributes(attributes);
-            isValid();
         }
     }
 

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2Factory.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2Factory.java
@@ -97,9 +97,14 @@ public class LTPAToken2Factory implements TokenFactory {
                     }
                     return validatedToken;
                 }
-
             } catch (Exception e) {
-                //TODO:
+                //If the token is expired then we do not want to continue processing validation keys below
+                if (e instanceof com.ibm.websphere.security.auth.TokenExpiredException) {
+                    if (tc.isEntryEnabled())
+                        Tr.exit(tc, "validateTokenBytes (expired)");
+                    throw (com.ibm.websphere.security.auth.TokenExpiredException) e;
+                }
+                //invalidToken exceptions should continue to check other keys below
             }
         }
 

--- a/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/LTPAKeyRotationTests.java
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/LTPAKeyRotationTests.java
@@ -1064,11 +1064,36 @@ public class LTPAKeyRotationTests {
         updateConfigDynamically(server, serverConfiguration);
     }
 
+    /**
+     * Verify the following:
+     * <OL>
+     * <LI>Set Expiry to 1m, MonitorDirectory to true, and MonitorInterval to 5.
+     * <LI>Attempt to access a simple servlet configured for form login1 with valid credentials.
+     * <LI>Retry access to the simple servlet configured for form login1 with ltpa cookie1.
+     * <LI>Wait for 70 seconds.
+     * <LI>Retry access to the simple servlet configured for form login1 with ltpa cookie1.
+     * <OL>
+     * <P>Expected Results:
+     * <OL>
+     * <LI>Expiry is set to 1m, MonitorDirectory is set to true, and MonitorInterval to 5.
+     * <LI>Successful authentication to simple servlet with ltpa cookie1 created.
+     * <LI>Successful authentication to simple servlet.
+     * <LI>Wait for 70 seconds.
+     * <LI>Failed authentication to simple servlet.
+     * </OL>
+     */
+    @Mode(TestMode.LITE)
     @Test
     @AllowedFFDC({ "java.lang.IllegalArgumentException" })
     public void testExpiredLtpaToken() throws Exception {
         // Configure the server
         configureServer("true", "5", true);
+
+        // Set the expiry to 1m
+        ServerConfiguration serverConfiguration = server.getServerConfiguration();
+        LTPA ltpa = serverConfiguration.getLTPA();
+        ltpa.expiration = "1m";
+        updateConfigDynamically(server, serverConfiguration);
 
         // Initial login to simple servlet for form login1
         String response1 = flClient1.accessProtectedServletWithAuthorizedCredentials(FormLoginClient.PROTECTED_SIMPLE, validUser, validPassword);
@@ -1144,6 +1169,15 @@ public class LTPAKeyRotationTests {
     public boolean setLTPAMonitorIntervalElement(LTPA ltpa, String value) {
         if (!ltpa.monitorInterval.equals(value)) {
             ltpa.monitorInterval = value;
+            return true; // Config update is needed
+        }
+        return false; // Config update is not needed;
+    }
+
+    // Function to configure the expiration time for the LTPA token to a specific value
+    public boolean setLTPAExpiryElement(LTPA ltpa, String value) {
+        if (!ltpa.expiration.equals(value)) {
+            ltpa.expiration = value;
             return true; // Config update is needed
         }
         return false; // Config update is not needed;

--- a/dev/com.ibm.ws.security.token.ltpa_fat/publish/servers/com.ibm.ws.security.token.ltpa.fat.ltpaKeyRotationTestServer/server.xml
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/publish/servers/com.ibm.ws.security.token.ltpa.fat.ltpaKeyRotationTestServer/server.xml
@@ -102,7 +102,7 @@
 
     <authentication id="Basic" cacheEnabled="false" />
 
-    <ltpa monitorInterval = "5" monitorDirectory="true" keysPassword="{xor}Lz4sLCgwLTs=">
+    <ltpa monitorInterval = "5" monitorDirectory="true" expiration="5m" keysPassword="{xor}Lz4sLCgwLTs=">
         <validationKeys fileName="validation1.keys" password="{xor}Lz4sLCgwLTs=" notUseAfterDate="2099-01-01T00:00:00Z"/>
     </ltpa>
 


### PR DESCRIPTION
Fix the logic behind the exception provided for expired validation keys and how we do not want to continue processing them. Adding in a null check to avoid NPE. Small file name change. Also, adding a FAT to ensure that the element works properly.

