### PR TITLE
26737: Relax ConnectionPoolStats abortConnections Test Timing

### DIFF
--- a/dev/com.ibm.ws.jca_fat_mbean/test-applications/fvtweb/src/web/ConnectionPoolStatsServlet.java
+++ b/dev/com.ibm.ws.jca_fat_mbean/test-applications/fvtweb/src/web/ConnectionPoolStatsServlet.java
@@ -742,7 +742,7 @@ public class ConnectionPoolStatsServlet extends HttpServlet {
             checkStats(test, dsStatobjName, dsObjectName, expectNumFreePoolConns, expectedNumConnectionHandles, expectedNumManagedConns);
         }
 
-        Thread.sleep(40); // simulate in use time running a query.
+        Thread.sleep(60); // simulate in use time running a query.
 
         long creatingConnectionStartSecondSet = System.currentTimeMillis();
 
@@ -779,11 +779,11 @@ public class ConnectionPoolStatsServlet extends HttpServlet {
             expectedNumManagedConns = 40;
             checkStats(test, dsStatobjName, dsObjectName, expectNumFreePoolConns, expectedNumConnectionHandles, expectedNumManagedConns);
 
-            Thread.sleep(40); // simulate in use time running a query.
+            Thread.sleep(20); // simulate in use time running a query.
 
             int destroyCountBeforeAbort = getMonitorData(dsStatobjName, "DestroyCount");
 
-            long testvalue = System.currentTimeMillis() - creatingConnectionStartSecondSet + 20;
+            long testvalue = System.currentTimeMillis() - creatingConnectionStartSecondSet + 40;
             String abortInfo = (String) mbeanServer.invoke(dsObjectName.getObjectName(), "abortConnections", new Object[] { "inuse", testvalue }, null);
             String expectedString1 = "20 in use connections added to the in use abort list";
             String expectedString2 = "10 free connections not added to the in use abort list";
@@ -849,7 +849,7 @@ public class ConnectionPoolStatsServlet extends HttpServlet {
             checkStats(test, dsStatobjName, dsObjectName, expectNumFreePoolConns, expectedNumConnectionHandles, expectedNumManagedConns);
         }
 
-        Thread.sleep(40); // simulate in use time running a query.
+        Thread.sleep(60); // simulate in use time running a query.
 
         long creatingConnectionStartSecondSet = System.currentTimeMillis();
 
@@ -894,11 +894,11 @@ public class ConnectionPoolStatsServlet extends HttpServlet {
             expectedNumManagedConns = 40;
             checkStats(test, dsStatobjName, dsObjectName, expectNumFreePoolConns, expectedNumConnectionHandles, expectedNumManagedConns);
 
-            Thread.sleep(40); // simulate in use time running a query.
+            Thread.sleep(20); // simulate in use time running a query.
 
             int destroyCountBeforeAbort = getMonitorData(dsStatobjName, "DestroyCount");
 
-            long testvalue = System.currentTimeMillis() - creatingConnectionStartSecondSet + 20;
+            long testvalue = System.currentTimeMillis() - creatingConnectionStartSecondSet + 40;
             String abortInfo = (String) mbeanServer.invoke(dsObjectName.getObjectName(), "abortConnections", new Object[] { "inuse", testvalue }, null);
             String expectedString1 = "20 in use connections added to the in use abort list";
             String expectedString2 = "10 free connections not added to the in use abort list";
@@ -964,7 +964,7 @@ public class ConnectionPoolStatsServlet extends HttpServlet {
             checkStats(test, dsStatobjName, dsObjectName, expectNumFreePoolConns, expectedNumConnectionHandles, expectedNumManagedConns);
         }
 
-        Thread.sleep(40); // simulate in use time running a query.
+        Thread.sleep(60); // simulate in use time running a query.
 
         long creatingConnectionStartSecondSet = System.currentTimeMillis();
 
@@ -1001,11 +1001,11 @@ public class ConnectionPoolStatsServlet extends HttpServlet {
             expectedNumManagedConns = 40;
             checkStats(test, dsStatobjName, dsObjectName, expectNumFreePoolConns, expectedNumConnectionHandles, expectedNumManagedConns);
 
-            Thread.sleep(40); // simulate in use time running a query.
+            Thread.sleep(20); // simulate in use time running a query.
 
             int destroyCountBeforeAbort = getMonitorData(dsStatobjName, "DestroyCount");
 
-            long testvalue = System.currentTimeMillis() - creatingConnectionStartSecondSet + 20;
+            long testvalue = System.currentTimeMillis() - creatingConnectionStartSecondSet + 40;
             String abortInfo = (String) mbeanServer.invoke(dsObjectName.getObjectName(), "abortConnections", new Object[] { "inuse", testvalue }, null);
             String expectedString1 = "10 in use connections added to the in use abort list";
             String expectedString2 = "10 free connections not added to the in use abort list";


### PR DESCRIPTION
Updating all 3 of the similarly structured tests to help make the sets of connections more distinct and to put the threshold used in the test more firmly in between the two sets. With the current setup, in local testing, I often see the last connection from set 1 and/or the first connection from set 2 end up dangerously close to the threshold. I've seen more wiggle room after making the proposed change locally.