### PR TITLE
Revert "Remove beta fencing for HTTP request tracing"

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
@@ -49,8 +49,6 @@ import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.MicroProfileActions;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.jaegertracing.api_v2.Model.Span;
@@ -59,6 +57,9 @@ import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.TestUtils;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
+
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 
 /**
  * Test all the ways the agent can be configured
@@ -75,10 +76,10 @@ public class AgentConfigTest {
 
     @ClassRule
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-
+    
     @ClassRule
     public static RepeatTests r = MicroProfileActions.repeat("spanTestServer", MicroProfileActions.MP61, MicroProfileActions.MP60);
-
+    
     public static JaegerQueryClient client;
 
     @BeforeClass
@@ -226,7 +227,7 @@ public class AgentConfigTest {
 
         List<Span> spans = client.waitForSpansForTraceId(traceId, hasSize(1));
 
-        assertThat(spans.get(0), hasName("/agentTest"));
+        assertThat(spans.get(0), hasName("/agentTest/"));
 
         // We should still be able to manually create spans with the API
         String traceId2 = new HttpRequest(server, "/agentTest/manualSpans").run(String.class);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/TelemetryAgent/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/TelemetryAgent/jvm.options
@@ -1,2 +1,4 @@
 -javaagent:opentelemetry-javaagent.jar
 #-Dotel.javaagent.debug=true
+# beta fence for HTTP tracing
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/crossFeatureOpenTracingServer/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/crossFeatureOpenTracingServer/jvm.options
@@ -1,0 +1,2 @@
+# beta fence for HTTP tracing
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/crossFeatureOpenTracingZipkinServer/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/crossFeatureOpenTracingZipkinServer/jvm.options
@@ -1,0 +1,2 @@
+# beta fence for HTTP tracing
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/crossFeatureTelemetryServer/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/crossFeatureTelemetryServer/jvm.options
@@ -1,0 +1,2 @@
+# beta fence for HTTP tracing
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/spanTestServer/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/spanTestServer/jvm.options
@@ -1,0 +1,2 @@
+# beta fence for HTTP tracing
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Jax/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Jax/jvm.options
@@ -1,1 +1,3 @@
 -Dio.opentelemetry.context.enableStrictContext=true
+# beta fence for HTTP tracing as this server has tests that require it
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithConcurrency/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithConcurrency/bootstrap.properties
@@ -1,1 +1,3 @@
 bootstrap.include=../testports.properties
+# beta fence for HTTP tracing as this has tests that expect output from the servlet filter
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithConcurrency/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithConcurrency/jvm.options
@@ -1,1 +1,3 @@
 -Dio.opentelemetry.context.enableStrictContext=true
+# beta fence for HTTP tracing as this server has tests that require it
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10MisConfig/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10MisConfig/jvm.options
@@ -1,1 +1,3 @@
 -Dio.opentelemetry.context.enableStrictContext=true
+# beta fence for HTTP tracing as this runs tests that require the servlet filter
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Servlet/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Servlet/jvm.options
@@ -1,1 +1,3 @@
 -Dio.opentelemetry.context.enableStrictContext=true
+# beta fence for HTTP tracing as this runs tests that require the servlet filter
+-Dcom.ibm.ws.beta.edition=true


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#26584 due to conflict with InstantOn.