### PR TITLE
Update to use ReentrantLock instead of synchronized

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -22,6 +22,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -117,7 +119,9 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
     private volatile UsePrivateHeaders usePrivateHeaders = UsePrivateHeaders.unknown;
     private volatile int configUpdate = 0;
 
-    private final Object WebConnCanCloseSync = new Object();
+    // Using Lock instead of Object with synchronized (WebConnCanCloseSync) to allow
+    // for unmounting when using virtual threads
+    private final Lock WebConnCanCloseSync = new ReentrantLock();
     private boolean WebConnCanClose = true;
     private final String h2InitError = "com.ibm.ws.transport.http.http2InitError";
 
@@ -241,7 +245,8 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
                 String toClose = (String) (vc.getStateMap().get(TransportConstants.UPGRADED_WEB_CONNECTION_NEEDS_CLOSE));
                 if ((toClose != null) && (toClose.compareToIgnoreCase("true") == 0)) {
                     // want to close down at least once, and only once, for this type of upgraded connection
-                    synchronized (WebConnCanCloseSync) {
+                    WebConnCanCloseSync.lock();
+                    try {
                         if (WebConnCanClose) {
                             // fall through to close logic after setting flag to only fall through once
                             // want to call close outside of the sync to avoid deadlocks.
@@ -255,6 +260,8 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
                             }
                             return;
                         }
+                    } finally {
+                        WebConnCanCloseSync.unlock();
                     }
                 }
             }
@@ -1092,17 +1099,23 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
             if (webconn != null && webconn.equalsIgnoreCase("CLOSED_NON_UPGRADED_STREAMS")) {
                 vc.getStateMap().put(TransportConstants.CLOSE_NON_UPGRADED_STREAMS, "null");
             } else {
-                synchronized (WebConnCanCloseSync) {
+                WebConnCanCloseSync.lock();
+                try {
                     if (WebConnCanClose) {
                         error = closeStreams();
                     }
+                } finally {
+                    WebConnCanCloseSync.unlock();
                 }
             }
         } else {
-            synchronized (WebConnCanCloseSync) {
+            WebConnCanCloseSync.lock();
+            try {
                 if (WebConnCanClose) {
                     error = closeStreams();
                 }
+            } finally {
+                WebConnCanCloseSync.unlock();
             }
         }
 

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.java
@@ -1,0 +1,431 @@
+package org.jboss.resteasy.core.interception.jaxrs;
+
+import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.core.ServerResponseWriter.RunnableWithIOException;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.core.ResteasyContext.CloseableContext;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
+import org.jboss.resteasy.specimpl.BuiltResponse;
+import org.jboss.resteasy.spi.ApplicationException;
+import org.jboss.resteasy.spi.Dispatcher;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.ResteasyAsynchronousResponse;
+import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
+
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.EntityTag;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class ContainerResponseContextImpl implements SuspendableContainerResponseContext
+{
+   protected final HttpRequest request;
+   protected final HttpResponse httpResponse;
+   protected final BuiltResponse jaxrsResponse;
+   private ResponseContainerRequestContext requestContext;
+   private ContainerResponseFilter[] responseFilters;
+   private RunnableWithIOException continuation;
+   private int currentFilter;
+   private boolean suspended;
+   private boolean filterReturnIsMeaningful = true;
+   private Map<Class<?>, Object> contextDataMap;
+   private boolean inFilter;
+   private Throwable throwable;
+   private Consumer<Throwable> onComplete;
+   private boolean weSuspended;
+
+   @Deprecated
+   public ContainerResponseContextImpl(final HttpRequest request, final HttpResponse httpResponse, final BuiltResponse serverResponse)
+   {
+      this(request, httpResponse, serverResponse, null, new ContainerResponseFilter[]{}, t -> {}, null);
+   }
+
+   public ContainerResponseContextImpl(final HttpRequest request, final HttpResponse httpResponse, final BuiltResponse serverResponse,
+                                       final ResponseContainerRequestContext requestContext, final ContainerResponseFilter[] responseFilters,
+                                       final Consumer<Throwable> onComplete, final RunnableWithIOException continuation)
+   {
+      this.request = request;
+      this.httpResponse = httpResponse;
+      this.jaxrsResponse = serverResponse;
+      this.requestContext = requestContext;
+      this.responseFilters = responseFilters;
+      this.continuation = continuation;
+      this.onComplete = onComplete;
+      contextDataMap = ResteasyContext.getContextDataMap();
+   }
+
+   public BuiltResponse getJaxrsResponse()
+   {
+      return jaxrsResponse;
+   }
+
+   public HttpResponse getHttpResponse()
+   {
+      return httpResponse;
+   }
+
+   @Override
+   public int getStatus()
+   {
+      return jaxrsResponse.getStatus();
+   }
+
+   @Override
+   public void setStatus(int code)
+   {
+      httpResponse.setStatus(code);
+      jaxrsResponse.setStatus(code);
+   }
+
+   @Override
+   public Response.StatusType getStatusInfo()
+   {
+      return jaxrsResponse.getStatusInfo();
+   }
+
+   @Override
+   public void setStatusInfo(Response.StatusType statusInfo)
+   {
+      httpResponse.setStatus(statusInfo.getStatusCode());
+      jaxrsResponse.setStatus(statusInfo.getStatusCode());
+   }
+
+   @Override
+   public Class<?> getEntityClass()
+   {
+      return jaxrsResponse.getEntityClass();
+   }
+
+   @Override
+   public Type getEntityType()
+   {
+      return jaxrsResponse.getGenericType();
+   }
+
+   @Override
+   public void setEntity(Object entity)
+   {
+      //if (entity != null) logger.info("*** setEntity(Object) " + entity.toString());
+      if (entity != null && jaxrsResponse.getEntity() == null && jaxrsResponse.getStatusInfo().equals(Response.Status.NO_CONTENT)){
+         LogMessages.LOGGER.statusNotSet(Response.Status.NO_CONTENT.getStatusCode(), Response.Status.NO_CONTENT.getReasonPhrase());
+      }
+      jaxrsResponse.setEntity(entity);
+      // todo TCK does weird things in its testing of get length
+      // it resets the entity in a response filter which results
+      // in a bad content-length being sent back to the client
+      // so, we'll remove any content-length setting
+      getHeaders().remove(HttpHeaders.CONTENT_LENGTH);
+   }
+
+   @Override
+   public void setEntity(Object entity, Annotation[] annotations, MediaType mediaType)
+   {
+      //if (entity != null) logger.info("*** setEntity(Object, Annotation[], MediaType) " + entity.toString() + ", " + mediaType);
+      if (entity != null && jaxrsResponse.getEntity() == null && jaxrsResponse.getStatusInfo().equals(Response.Status.NO_CONTENT)){
+         LogMessages.LOGGER.statusNotSet(Response.Status.NO_CONTENT.getStatusCode(), Response.Status.NO_CONTENT.getReasonPhrase());
+      }
+      jaxrsResponse.setEntity(entity);
+      jaxrsResponse.setAnnotations(annotations);
+      jaxrsResponse.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, mediaType);
+      // todo TCK does weird things in its testing of get length
+      // it resets the entity in a response filter which results
+      // in a bad content-length being sent back to the client
+      // so, we'll remove any content-length setting
+      getHeaders().remove(HttpHeaders.CONTENT_LENGTH);
+   }
+
+   @Override
+   public MultivaluedMap<String, Object> getHeaders()
+   {
+      return jaxrsResponse.getMetadata();
+   }
+
+   @Override
+   public Set<String> getAllowedMethods()
+   {
+      return jaxrsResponse.getAllowedMethods();
+   }
+
+   @Override
+   public Date getDate()
+   {
+      return jaxrsResponse.getDate();
+   }
+
+   @Override
+   public Locale getLanguage()
+   {
+      return jaxrsResponse.getLanguage();
+   }
+
+   @Override
+   public int getLength()
+   {
+      return jaxrsResponse.getLength();
+   }
+
+   @Override
+   public MediaType getMediaType()
+   {
+      return jaxrsResponse.getMediaType();
+   }
+
+   @Override
+   public Map<String, NewCookie> getCookies()
+   {
+      return jaxrsResponse.getCookies();
+   }
+
+   @Override
+   public EntityTag getEntityTag()
+   {
+      return jaxrsResponse.getEntityTag();
+   }
+
+   @Override
+   public Date getLastModified()
+   {
+      return jaxrsResponse.getLastModified();
+   }
+
+   @Override
+   public URI getLocation()
+   {
+      return jaxrsResponse.getLocation();
+   }
+
+   @Override
+   public Set<Link> getLinks()
+   {
+      return jaxrsResponse.getLinks();
+   }
+
+   @Override
+   public boolean hasLink(String relation)
+   {
+      return jaxrsResponse.hasLink(relation);
+   }
+
+   @Override
+   public Link getLink(String relation)
+   {
+      return jaxrsResponse.getLink(relation);
+   }
+
+   @Override
+   public Link.Builder getLinkBuilder(String relation)
+   {
+      return jaxrsResponse.getLinkBuilder(relation);
+   }
+
+   @Override
+   public boolean hasEntity()
+   {
+      return !jaxrsResponse.isClosed() && jaxrsResponse.hasEntity();
+   }
+
+   @Override
+   public Object getEntity()
+   {
+      return !jaxrsResponse.isClosed() ? jaxrsResponse.getEntity() : null;
+   }
+
+   @Override
+   public OutputStream getEntityStream()
+   {
+      try
+      {
+         return httpResponse.getOutputStream();
+      }
+      catch (IOException e)
+      {
+         throw new RuntimeException(e);
+      }
+   }
+
+   @Override
+   public void setEntityStream(OutputStream entityStream)
+   {
+      httpResponse.setOutputStream(entityStream);
+   }
+
+   @Override
+   public Annotation[] getEntityAnnotations()
+   {
+      return jaxrsResponse.getAnnotations();
+   }
+
+   @Override
+   public MultivaluedMap<String, String> getStringHeaders()
+   {
+      return jaxrsResponse.getStringHeaders();
+   }
+
+   @Override
+   public String getHeaderString(String name)
+   {
+      return jaxrsResponse.getHeaderString(name);
+   }
+
+
+   @Override
+   public synchronized void suspend() {
+      if(continuation == null)
+         throw new RuntimeException("Suspend not supported yet");
+      suspended = true;
+   }
+
+   @Override
+   public synchronized void resume() {
+      if(!suspended)
+         throw new RuntimeException("Cannot resume: not suspended");
+      if(inFilter)
+      {
+         // suspend/resume within filter, same thread: just ignore and move on
+         suspended = false;
+         return;
+      }
+
+      // go on, but with proper exception handling
+      try(CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)){
+         filter();
+      }catch(Throwable t) {
+         // don't throw to client
+         writeException(t);
+      }
+   }
+
+   @Override
+   public synchronized void resume(Throwable t) {
+      if(!suspended)
+         throw new RuntimeException("Cannot resume: not suspended");
+      if(inFilter)
+      {
+         // not suspended, or suspend/abortWith within filter, same thread: collect and move on
+         throwable = t;
+         suspended = false;
+      }
+      else
+      {
+         try(CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)){
+            writeException(t);
+         }
+      }
+   }
+
+   private void writeException(Throwable t)
+   {
+      /*
+       * Here we cannot call AsyncResponse.resume(t) because that would invoke the response filters
+       * and we should not invoke them because we're already in them.
+       */
+      HttpResponse httpResponse = (HttpResponse) contextDataMap.get(HttpResponse.class);
+      SynchronousDispatcher dispatcher = (SynchronousDispatcher) contextDataMap.get(Dispatcher.class);
+      ResteasyAsynchronousResponse asyncResponse = request.getAsyncContext().getAsyncResponse();
+
+      RESTEasyTracingLogger tracingLogger = RESTEasyTracingLogger.getInstance(request);
+      tracingLogger.flush(httpResponse.getOutputHeaders());
+
+      dispatcher.unhandledAsynchronousException(httpResponse, t);
+      onComplete.accept(t);
+      asyncResponse.complete();
+      asyncResponse.completionCallbacks(t);
+   }
+
+   public synchronized void filter() throws IOException
+   {
+      RESTEasyTracingLogger logger = RESTEasyTracingLogger.getInstance(request);
+
+      while(currentFilter < responseFilters.length)
+      {
+         ContainerResponseFilter filter = responseFilters[currentFilter++];
+         try
+         {
+            suspended = false;
+            throwable = null;
+            inFilter = true;
+            final long timestamp = logger.timestamp("RESPONSE_FILTER");
+            filter.filter(requestContext, this);
+            logger.logDuration("RESPONSE_FILTER", timestamp, filter);
+         }
+         catch (IOException e)
+         {
+            throw new ApplicationException(e);
+         }
+         finally
+         {
+            inFilter = false;
+         }
+         if(suspended) {
+            if(!request.getAsyncContext().isSuspended())
+            {
+               request.getAsyncContext().suspend();
+               weSuspended = true;
+            }
+            // ignore any abort request until we are resumed
+            filterReturnIsMeaningful = false;
+            return;
+         }
+         if (throwable != null)
+         {
+            // handle the case where we've been suspended by a previous filter
+            if(filterReturnIsMeaningful)
+               SynchronousDispatcher.rethrow(throwable);
+            else
+            {
+               writeException(throwable);
+               return;
+            }
+         }
+      }
+      // here it means we reached the last filter
+
+      // some frameworks don't support async request filters, in which case suspend() is forbidden
+      // so if we get here we're still synchronous and don't have a continuation, which must be in
+      // the caller
+      if(continuation == null)
+         return;
+
+      // if we've never been suspended, the caller is valid so let it handle any exception
+      if(filterReturnIsMeaningful) {
+         continuation.run(onComplete);
+         return;
+      }
+      // if we've been suspended then the caller is a filter and have to invoke our continuation
+      // FIXME: we don't really know if we're already trying to send an exception, so we can't just blindly
+      // try to write it out
+      try
+      {
+         continuation.run((t) -> {
+            onComplete.accept(t);
+            if(weSuspended)
+            {
+               // if we're the ones who turned the request async, nobody will call complete() for us, so we have to
+               request.getAsyncContext().complete();
+            }
+         });
+      } catch (IOException e)
+      {
+         LogMessages.LOGGER.unknownException(request.getHttpMethod(), request.getUri().getPath(), e);
+      }
+   }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/interception/jaxrs/PreMatchContainerRequestContext.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/interception/jaxrs/PreMatchContainerRequestContext.java
@@ -1,0 +1,393 @@
+package org.jboss.resteasy.core.interception.jaxrs;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.core.PostResourceMethodInvoker;
+import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.core.ResteasyContext.CloseableContext;
+import org.jboss.resteasy.specimpl.BuiltResponse;
+import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
+import org.jboss.resteasy.spi.ApplicationException;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
+import org.jboss.resteasy.core.PostResourceMethodInvokers;
+
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Request;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class PreMatchContainerRequestContext implements SuspendableContainerRequestContext
+{
+   private static final Logger LOG = Logger.getLogger(PreMatchContainerRequestContext.class);
+
+   protected final HttpRequest httpRequest;
+   protected Response response;
+   private ContainerRequestFilter[] requestFilters;
+   private int currentFilter;
+   private boolean suspended;
+   private boolean filterReturnIsMeaningful = true;
+   private Supplier<BuiltResponse> continuation;
+   private Map<Class<?>, Object> contextDataMap;
+   private boolean inFilter;
+   private Throwable throwable;
+   private boolean startedContinuation;
+
+   @Deprecated
+   public PreMatchContainerRequestContext(final HttpRequest request)
+   {
+      this(request, new ContainerRequestFilter[]{}, null);
+   }
+
+   public PreMatchContainerRequestContext(final HttpRequest request,
+                                          final ContainerRequestFilter[] requestFilters, final Supplier<BuiltResponse> continuation)
+   {
+      this.httpRequest = request;
+      this.requestFilters = requestFilters;
+      this.continuation = continuation;
+      contextDataMap = ResteasyContext.getContextDataMap();
+   }
+
+   public HttpRequest getHttpRequest()
+   {
+      return httpRequest;
+   }
+
+   public Response getResponseAbortedWith()
+   {
+      return response;
+   }
+
+   @Override
+   public Object getProperty(String name)
+   {
+      return httpRequest.getAttribute(name);
+   }
+
+   @Override
+   public Collection<String> getPropertyNames()
+   {
+      ArrayList<String> names = new ArrayList<String>();
+      Enumeration<String> enames = httpRequest.getAttributeNames();
+      while (enames.hasMoreElements())
+      {
+         names.add(enames.nextElement());
+      }
+      return names;
+   }
+
+   @Override
+   public void setProperty(String name, Object object)
+   {
+      httpRequest.setAttribute(name, object);
+   }
+
+   @Override
+   public void removeProperty(String name)
+   {
+      httpRequest.removeAttribute(name);
+   }
+
+   @Override
+   public UriInfo getUriInfo()
+   {
+      return httpRequest.getUri();
+   }
+
+   @Override
+   public void setRequestUri(URI requestUri) throws IllegalStateException
+   {
+      httpRequest.setRequestUri(requestUri);
+   }
+
+   @Override
+   public void setRequestUri(URI baseUri, URI requestUri) throws IllegalStateException
+   {
+      httpRequest.setRequestUri(baseUri, requestUri);
+   }
+
+   @Override
+   public String getMethod()
+   {
+      return httpRequest.getHttpMethod();
+   }
+
+   @Override
+   public void setMethod(String method)
+   {
+      httpRequest.setHttpMethod(method);
+   }
+
+   @Override
+   public MultivaluedMap<String, String> getHeaders()
+   {
+      return ((ResteasyHttpHeaders) httpRequest.getHttpHeaders()).getMutableHeaders();
+   }
+
+   @Override
+   public Date getDate()
+   {
+      return httpRequest.getHttpHeaders().getDate();
+   }
+
+   @Override
+   public Locale getLanguage()
+   {
+      return httpRequest.getHttpHeaders().getLanguage();
+   }
+
+   @Override
+   public int getLength()
+   {
+      return httpRequest.getHttpHeaders().getLength();
+   }
+
+   @Override
+   public MediaType getMediaType()
+   {
+      return httpRequest.getHttpHeaders().getMediaType();
+   }
+
+   @Override
+   public List<MediaType> getAcceptableMediaTypes()
+   {
+      return httpRequest.getHttpHeaders().getAcceptableMediaTypes();
+   }
+
+   @Override
+   public List<Locale> getAcceptableLanguages()
+   {
+      return httpRequest.getHttpHeaders().getAcceptableLanguages();
+   }
+
+   @Override
+   public Map<String, Cookie> getCookies()
+   {
+      return httpRequest.getHttpHeaders().getCookies();
+   }
+
+   @Override
+   public boolean hasEntity()
+   {
+      return getMediaType() != null;
+   }
+
+   @Override
+   public InputStream getEntityStream()
+   {
+      return httpRequest.getInputStream();
+   }
+
+   @Override
+   public void setEntityStream(InputStream entityStream)
+   {
+      httpRequest.setInputStream(entityStream);
+   }
+
+   @Override
+   public SecurityContext getSecurityContext()
+   {
+      return ResteasyContext.getContextData(SecurityContext.class);
+   }
+
+   @Override
+   public void setSecurityContext(SecurityContext context)
+   {
+      ResteasyContext.pushContext(SecurityContext.class, context);
+   }
+
+   @Override
+   public Request getRequest()
+   {
+      return ResteasyContext.getContextData(Request.class);
+   }
+
+   @Override
+   public String getHeaderString(String name)
+   {
+      return httpRequest.getHttpHeaders().getHeaderString(name);
+   }
+
+   @Override
+   public synchronized void suspend() {
+      if(continuation == null)
+         throw new RuntimeException("Suspend not supported yet");
+      suspended = true;
+   }
+
+   @Override
+   public synchronized void abortWith(Response response)
+   {
+      if(suspended && !inFilter)
+      {
+         try(CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)){
+            httpRequest.getAsyncContext().getAsyncResponse().resume(response);
+         }
+      }
+      else
+      {
+         // not suspended, or suspend/abortWith within filter, same thread: collect and move on
+         this.response = response;
+         suspended = false;
+      }
+   }
+
+   @Override
+   public synchronized void resume() {
+      if(!suspended)
+         throw new RuntimeException("Cannot resume: not suspended");
+      if(inFilter)
+      {
+         // suspend/resume within filter, same thread: just ignore and move on
+         suspended = false;
+         return;
+      }
+
+      // go on, but with proper exception handling
+      try(CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)){
+         filter();
+      }catch(Throwable t) {
+         // don't throw to client
+         writeException(t);
+      }
+   }
+
+   @Override
+   public synchronized void resume(Throwable t) {
+      if(!suspended)
+         throw new RuntimeException("Cannot resume: not suspended");
+      if(inFilter)
+      {
+         // not suspended, or suspend/abortWith within filter, same thread: collect and move on
+         throwable = t;
+         suspended = false;
+      }
+      else
+      {
+         try(CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)){
+            writeException(t);
+         }
+      }
+   }
+
+   private void writeException(Throwable t)
+   {
+      /*
+       * Here, contrary to ContainerResponseContextImpl.writeException, we can use the async response
+       * to write the exception, because it calls the right response filters, complete() and callbacks
+       */
+      httpRequest.getAsyncContext().getAsyncResponse().resume(t);
+   }
+
+   public synchronized BuiltResponse filter()
+   {
+      RESTEasyTracingLogger tracingLogger = RESTEasyTracingLogger.getInstance(httpRequest);
+
+      final long totalTimestamp = tracingLogger.timestamp("REQUEST_FILTER_SUMMARY");
+
+      while(requestFilters != null && currentFilter < requestFilters.length)
+      {
+         ContainerRequestFilter filter = requestFilters[currentFilter++];
+         try
+         {
+            suspended = false;
+            response = null;
+            throwable = null;
+            inFilter = true;
+            final long timestamp = tracingLogger.timestamp("REQUEST_FILTER");
+            filter.filter(this);
+            tracingLogger.logDuration("REQUEST_FILTER", timestamp, filter);
+         }
+         catch (IOException e)
+         {
+            cleanupPostResourceMethodInvokers();
+            throw new ApplicationException(e);
+         }
+         finally
+         {
+            inFilter = false;
+         }
+         if(suspended) {
+            if(!httpRequest.getAsyncContext().isSuspended())
+               httpRequest.getAsyncContext().suspend();
+            // ignore any abort request until we are resumed
+            filterReturnIsMeaningful = false;
+            response = null;
+            return null;
+         }
+         BuiltResponse serverResponse = (BuiltResponse)getResponseAbortedWith();
+         if (serverResponse != null)
+         {
+            // handle the case where we've been suspended by a previous filter
+            if(filterReturnIsMeaningful)
+               return serverResponse;
+            else
+            {
+               httpRequest.getAsyncContext().getAsyncResponse().resume(serverResponse);
+               return null;
+            }
+         }
+         if (throwable != null)
+         {
+            // handle the case where we've been suspended by a previous filter
+            if(filterReturnIsMeaningful)
+               SynchronousDispatcher.rethrow(throwable);
+            else
+            {
+               writeException(throwable);
+               return null;
+            }
+         }
+      }
+      tracingLogger.logDuration("REQUEST_FILTER_SUMMARY", totalTimestamp, requestFilters == null ? 0 : requestFilters.length);
+      // here it means we reached the last filter
+      // some frameworks don't support async request filters, in which case suspend() is forbidden
+      // so if we get here we're still synchronous and don't have a continuation, which must be in
+      // the caller
+      startedContinuation = true;
+      if(continuation == null)
+         return null;
+      // in any case, return the continuation: sync will use it, and async will ignore it
+      return continuation.get();
+   }
+
+   public boolean startedContinuation()
+   {
+      return startedContinuation;
+   }
+
+   private void cleanupPostResourceMethodInvokers() {
+      PostResourceMethodInvokers postResourceMethodInvokers =
+              ResteasyContext.getContextData(PostResourceMethodInvokers.class);
+      // close PostResourceMethodInvokers and clear array list
+      if (postResourceMethodInvokers != null) {
+         for(PostResourceMethodInvoker p : postResourceMethodInvokers.getInvokers()) {
+            try {
+               p.close();
+            } catch (Exception e) {
+               LOG.warn(e.getMessage());
+            }
+         }
+         postResourceMethodInvokers.clear();
+      }
+   }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/interception/jaxrs/PreMatchContainerRequestContext.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/interception/jaxrs/PreMatchContainerRequestContext.java
@@ -1,3 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021, 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jboss.resteasy.core.interception.jaxrs;
 
 import org.jboss.logging.Logger;
@@ -30,6 +49,10 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+// Liberty change start
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+// Liberty change end
 import java.util.function.Supplier;
 
 /**
@@ -51,6 +74,7 @@ public class PreMatchContainerRequestContext implements SuspendableContainerRequ
    private boolean inFilter;
    private Throwable throwable;
    private boolean startedContinuation;
+   private final Lock lock = new ReentrantLock(); // Liberty change 
 
    @Deprecated
    public PreMatchContainerRequestContext(final HttpRequest request)
@@ -228,65 +252,101 @@ public class PreMatchContainerRequestContext implements SuspendableContainerRequ
    }
 
    @Override
-   public synchronized void suspend() {
-      if(continuation == null)
-         throw new RuntimeException("Suspend not supported yet");
-      suspended = true;
+   // Liberty change start
+   public void suspend() {
+      lock.lock();
+      try {
+      // Liberty change end
+         if(continuation == null)
+            throw new RuntimeException("Suspend not supported yet");
+         suspended = true;
+      // Liberty change start
+      } finally {
+         lock.unlock();
+      }
+      // Liberty change end
    }
 
    @Override
-   public synchronized void abortWith(Response response)
+   // Liberty change start
+   public void abortWith(Response response)
    {
-      if(suspended && !inFilter)
-      {
-         try(CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)){
-            httpRequest.getAsyncContext().getAsyncResponse().resume(response);
+      lock.lock();
+      try {
+      // Liberty change start
+         if(suspended && !inFilter)
+         {
+            try(CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)){
+               httpRequest.getAsyncContext().getAsyncResponse().resume(response);
+            }
          }
+         else
+         {
+            // not suspended, or suspend/abortWith within filter, same thread: collect and move on
+            this.response = response;
+            suspended = false;
+         }
+      // Liberty change start
+      } finally {
+          lock.unlock();
       }
-      else
-      {
-         // not suspended, or suspend/abortWith within filter, same thread: collect and move on
-         this.response = response;
-         suspended = false;
-      }
+      // Liberty change end
    }
 
    @Override
-   public synchronized void resume() {
-      if(!suspended)
-         throw new RuntimeException("Cannot resume: not suspended");
-      if(inFilter)
-      {
-         // suspend/resume within filter, same thread: just ignore and move on
-         suspended = false;
-         return;
-      }
+   // Liberty change start
+   public void resume() {
+      lock.lock();
+      try {
+      // Liberty change end
+         if(!suspended)
+            throw new RuntimeException("Cannot resume: not suspended");
+         if(inFilter)
+         {
+            // suspend/resume within filter, same thread: just ignore and move on
+            suspended = false;
+            return;
+         }
 
-      // go on, but with proper exception handling
-      try(CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)){
-         filter();
-      }catch(Throwable t) {
-         // don't throw to client
-         writeException(t);
-      }
-   }
-
-   @Override
-   public synchronized void resume(Throwable t) {
-      if(!suspended)
-         throw new RuntimeException("Cannot resume: not suspended");
-      if(inFilter)
-      {
-         // not suspended, or suspend/abortWith within filter, same thread: collect and move on
-         throwable = t;
-         suspended = false;
-      }
-      else
-      {
+         // go on, but with proper exception handling
          try(CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)){
+            filter();
+         }catch(Throwable t) {
+            // don't throw to client
             writeException(t);
          }
+      // Liberty change start
+      } finally {
+          lock.unlock();
       }
+      // Liberty change end
+   }
+
+   @Override
+   // Liberty change start
+   public void resume(Throwable t) {
+      lock.lock();
+      try {
+      // Liberty change end
+         if(!suspended)
+            throw new RuntimeException("Cannot resume: not suspended");
+         if(inFilter)
+         {
+            // not suspended, or suspend/abortWith within filter, same thread: collect and move on
+            throwable = t;
+            suspended = false;
+         }
+         else
+         {
+            try(CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)){
+               writeException(t);
+            }
+         }
+      // Liberty change start
+      } finally {
+          lock.unlock();
+      }
+      // Liberty change end
    }
 
    private void writeException(Throwable t)
@@ -298,76 +358,85 @@ public class PreMatchContainerRequestContext implements SuspendableContainerRequ
       httpRequest.getAsyncContext().getAsyncResponse().resume(t);
    }
 
-   public synchronized BuiltResponse filter()
+   // Liberty change start
+   public BuiltResponse filter()
    {
-      RESTEasyTracingLogger tracingLogger = RESTEasyTracingLogger.getInstance(httpRequest);
+      lock.lock();
+      try {
+      // Liberty change end
+         RESTEasyTracingLogger tracingLogger = RESTEasyTracingLogger.getInstance(httpRequest);
 
-      final long totalTimestamp = tracingLogger.timestamp("REQUEST_FILTER_SUMMARY");
+         final long totalTimestamp = tracingLogger.timestamp("REQUEST_FILTER_SUMMARY");
 
-      while(requestFilters != null && currentFilter < requestFilters.length)
-      {
-         ContainerRequestFilter filter = requestFilters[currentFilter++];
-         try
+         while(requestFilters != null && currentFilter < requestFilters.length)
          {
-            suspended = false;
-            response = null;
-            throwable = null;
-            inFilter = true;
-            final long timestamp = tracingLogger.timestamp("REQUEST_FILTER");
-            filter.filter(this);
-            tracingLogger.logDuration("REQUEST_FILTER", timestamp, filter);
+            ContainerRequestFilter filter = requestFilters[currentFilter++];
+            try
+            {
+               suspended = false;
+               response = null;
+               throwable = null;
+               inFilter = true;
+               final long timestamp = tracingLogger.timestamp("REQUEST_FILTER");
+               filter.filter(this);
+               tracingLogger.logDuration("REQUEST_FILTER", timestamp, filter);
+            }
+            catch (IOException e)
+            {
+               cleanupPostResourceMethodInvokers();
+               throw new ApplicationException(e);
+            }
+            finally
+            {
+               inFilter = false;
+            }
+            if(suspended) {
+               if(!httpRequest.getAsyncContext().isSuspended())
+                  httpRequest.getAsyncContext().suspend();
+               // ignore any abort request until we are resumed
+               filterReturnIsMeaningful = false;
+               response = null;
+               return null;
+            }
+            BuiltResponse serverResponse = (BuiltResponse)getResponseAbortedWith();
+            if (serverResponse != null)
+            {
+               // handle the case where we've been suspended by a previous filter
+               if(filterReturnIsMeaningful)
+                  return serverResponse;
+               else
+               {
+                  httpRequest.getAsyncContext().getAsyncResponse().resume(serverResponse);
+                  return null;
+               }
+            }
+            if (throwable != null)
+            {
+               // handle the case where we've been suspended by a previous filter
+               if(filterReturnIsMeaningful)
+                  SynchronousDispatcher.rethrow(throwable);
+               else
+               {
+                  writeException(throwable);
+                  return null;
+               }
+            }
          }
-         catch (IOException e)
-         {
-            cleanupPostResourceMethodInvokers();
-            throw new ApplicationException(e);
-         }
-         finally
-         {
-            inFilter = false;
-         }
-         if(suspended) {
-            if(!httpRequest.getAsyncContext().isSuspended())
-               httpRequest.getAsyncContext().suspend();
-            // ignore any abort request until we are resumed
-            filterReturnIsMeaningful = false;
-            response = null;
+         tracingLogger.logDuration("REQUEST_FILTER_SUMMARY", totalTimestamp, requestFilters == null ? 0 : requestFilters.length);
+         // here it means we reached the last filter
+         // some frameworks don't support async request filters, in which case suspend() is forbidden
+         // so if we get here we're still synchronous and don't have a continuation, which must be in
+         // the caller
+         startedContinuation = true;
+         if(continuation == null)
             return null;
-         }
-         BuiltResponse serverResponse = (BuiltResponse)getResponseAbortedWith();
-         if (serverResponse != null)
-         {
-            // handle the case where we've been suspended by a previous filter
-            if(filterReturnIsMeaningful)
-               return serverResponse;
-            else
-            {
-               httpRequest.getAsyncContext().getAsyncResponse().resume(serverResponse);
-               return null;
-            }
-         }
-         if (throwable != null)
-         {
-            // handle the case where we've been suspended by a previous filter
-            if(filterReturnIsMeaningful)
-               SynchronousDispatcher.rethrow(throwable);
-            else
-            {
-               writeException(throwable);
-               return null;
-            }
-         }
+         // in any case, return the continuation: sync will use it, and async will ignore it
+         return continuation.get();
+      // Liberty change start
+      } finally {
+          lock.unlock();
       }
-      tracingLogger.logDuration("REQUEST_FILTER_SUMMARY", totalTimestamp, requestFilters == null ? 0 : requestFilters.length);
-      // here it means we reached the last filter
-      // some frameworks don't support async request filters, in which case suspend() is forbidden
-      // so if we get here we're still synchronous and don't have a continuation, which must be in
-      // the caller
-      startedContinuation = true;
-      if(continuation == null)
-         return null;
-      // in any case, return the continuation: sync will use it, and async will ignore it
-      return continuation.get();
+      // Liberty change end
    }
 
    public boolean startedContinuation()


### PR DESCRIPTION
- When running with virtual threads, thread cannot unmount if they are in a synchronized block.  In order to work with virtual threads, the stacks need to be updated to use ReentrantLock instead to allow for unmounting.  The changed classes are ones that were identified as needing to be updated due to threads not unmount when doing a Jakarta RESTful Web Services work load using Jakarta EE 10 features when using virtual threads.