### PR TITLE
set useSeparateSessionInvalidatorThreadPool property to false in the metrics monitor FATS

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF1/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF1/serverConfig.xml
@@ -11,6 +11,8 @@
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
   
+  	<httpSession useSeparateSessionInvalidatorThreadPool = "false" />
+  
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>
 </server>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF10/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF10/serverConfig.xml
@@ -11,6 +11,8 @@
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
   
+  	<httpSession useSeparateSessionInvalidatorThreadPool = "false" />
+  
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>
 </server>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF11/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF11/serverConfig.xml
@@ -11,6 +11,8 @@
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
   
+  	<httpSession useSeparateSessionInvalidatorThreadPool = "false" />
+  
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>
 </server>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF12/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF12/serverConfig.xml
@@ -11,6 +11,8 @@
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
   
+  	<httpSession useSeparateSessionInvalidatorThreadPool = "false" />
+  
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>
 </server>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF2/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF2/serverConfig.xml
@@ -11,6 +11,8 @@
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
   
+  	<httpSession useSeparateSessionInvalidatorThreadPool = "false" />
+  
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>
 </server>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF3/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF3/serverConfig.xml
@@ -11,6 +11,8 @@
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
   
+  	<httpSession useSeparateSessionInvalidatorThreadPool = "false" />
+  
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>
 </server>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF4/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF4/serverConfig.xml
@@ -11,6 +11,8 @@
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
   
+  	<httpSession useSeparateSessionInvalidatorThreadPool = "false" />
+  
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>
 </server>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF5/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF5/serverConfig.xml
@@ -11,6 +11,8 @@
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
   
+  	<httpSession useSeparateSessionInvalidatorThreadPool = "false" />
+  
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>
 </server>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF6/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF6/serverConfig.xml
@@ -11,6 +11,8 @@
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
   
+  	<httpSession useSeparateSessionInvalidatorThreadPool = "false" />
+  
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>
 </server>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF8/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF8/serverConfig.xml
@@ -11,6 +11,8 @@
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
   
+  	<httpSession useSeparateSessionInvalidatorThreadPool = "false" />
+  
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>
 </server>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/MetricsMonitorServer/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/MetricsMonitorServer/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF1/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF1/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF10/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF10/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF11/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF11/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF12/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF12/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF2/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF2/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF3/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF3/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF4/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF4/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF5/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF5/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF6/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF6/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF8/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF8/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF9/serverConfig.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/servers/TestEDF9/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/ComputedMetricsServer/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/ComputedMetricsServer/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/MetricsMonitorServer/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/MetricsMonitorServer/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF10/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF10/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF11/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF11/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF2/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF2/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF3/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF3/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF4/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF4/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF5/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF5/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF6/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF6/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF8/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF8/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF9/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF9/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/ComputedMetricsServer/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/ComputedMetricsServer/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/MetricsMonitorServer/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/MetricsMonitorServer/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF10/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF10/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF11/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF11/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF2/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF2/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF3/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF3/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF4/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF4/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF5/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF5/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF6/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF6/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF8/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF8/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF9/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/publish/servers/TestEDF9/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/ComputedMetricsServer/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/ComputedMetricsServer/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/MetricsMonitorServer/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/MetricsMonitorServer/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF10/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF10/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF11/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF11/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF2/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF2/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF3/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF3/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF4/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF4/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF5/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF5/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF6/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF6/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF8/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF8/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF9/serverConfig.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/publish/servers/TestEDF9/serverConfig.xml
@@ -10,6 +10,8 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
     <applicationMonitor updateTrigger="mbean"/>
+
+    <httpSession useSeparateSessionInvalidatorThreadPool = "false" />
   
     <!-- Java2 security -->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*"/>


### PR DESCRIPTION
#build

Potential solution to  #24590.
With discussions with sessions team, it was identified that the intermittent failures with the Metric Monitor FATS where the session for the `/metrics` endpoint is being invalidated at it's first invocation may be a timing issue between the creation of the session and the background thread which cleans up timed out sessions.

During the creation process of a session during the first invocation of a servlet the time out attribute for the session is initially set at 0. Subsequently, the default of 30 minutes will be set for the session. It appears that the background process which cleans up expired sessions occured simultaneously as when the session was created. Therefore, the session, although it was in the process of being created, was identified as being expired and removed. The session was then considered invalidated.