### PR TITLE
Add CONSTRUCTOR target to InjectedTrace annotation

### DIFF
--- a/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/annotation/InjectedTrace.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/annotation/InjectedTrace.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2013 IBM Corporation and others.
+ * Copyright (c) 2010, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,7 @@
 
 package com.ibm.websphere.ras.annotation;
 
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -26,7 +27,7 @@ import java.lang.annotation.Target;
  * intended to be added manually.
  */
 @Retention(RUNTIME)
-@Target({ TYPE, METHOD })
+@Target({ TYPE, METHOD, CONSTRUCTOR })
 public @interface InjectedTrace {
     /**
      * The processing that has been performed. Each element should be a


### PR DESCRIPTION
- When InjectedTrace annotation is added to a constructor, the target type didn't match since we only included METHOD target and did not include CONSTRUCTOR.  When using another byte code injection tool, this was output as an error when reading the ras instrument transformed bytes.
