### PR TITLE
Update parallel classloader locking for Liberty classloaders

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoadingServiceImpl.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoadingServiceImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2022 IBM Corporation and others.
+ * Copyright (c) 2010, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -606,9 +606,9 @@ public class ClassLoadingServiceImpl implements LibertyClassLoadingService<Liber
         new WeakLibraryListener(libid, acl.getKey().getId(), acl, bundleContext) {
             @Override
             protected void update() {
-                Object cl = get();
-                if (cl instanceof AppClassLoader && aclStore != null)
-                    aclStore.remove((AppClassLoader) cl);
+                AppClassLoader cl = get();
+                if (cl != null && aclStore != null)
+                    aclStore.remove(cl);
                 deregister();
             }
         };

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/LibertyLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/LibertyLoader.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,10 +16,12 @@ import java.io.IOException;
 import java.net.URL;
 import java.security.SecureClassLoader;
 import java.util.Enumeration;
+import java.util.function.Supplier;
 
 import org.osgi.framework.Bundle;
 
 import com.ibm.ws.classloading.LibertyClassLoader;
+import com.ibm.ws.kernel.service.util.KeyBasedLockStore;
 
 public abstract class LibertyLoader extends SecureClassLoader implements NoClassNotFoundLoader, LibertyClassLoader, DeclaredApiAccess {
     static {
@@ -31,6 +33,25 @@ public abstract class LibertyLoader extends SecureClassLoader implements NoClass
     public LibertyLoader(ClassLoader parent) {
         super(parent);
         this.parent = parent;
+    }
+
+    private static final class NameBasedClassLoaderLock {};
+
+    private final KeyBasedLockStore<String, NameBasedClassLoaderLock> classNameLockStore = new KeyBasedLockStore<>(new Supplier<NameBasedClassLoaderLock>() {
+        @Override
+        public NameBasedClassLoaderLock get() {
+            return new NameBasedClassLoaderLock();
+        }
+    });
+
+    /**
+     * Override the default Java implementation for this method because on HotSpot based implementations the collection of locks
+     * is a hard reference and bloats memory and on J9 based implementations the collection is a Hashtable which doesn't allow for
+     * concurrency when getting the lock.  With this implementation both issues (memory and concurrency) are handled. 
+     */
+    @Override
+    protected final Object getClassLoadingLock(String className) {
+        return classNameLockStore.getLock(className);
     }
 
     @Override

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/providers/WeakLibraryListener.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/providers/WeakLibraryListener.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,6 +19,7 @@ import java.lang.ref.WeakReference;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
+import com.ibm.ws.classloading.internal.AppClassLoader;
 import com.ibm.ws.classloading.internal.util.RefQueue;
 import com.ibm.wsspi.library.LibraryChangeListener;
 
@@ -29,12 +30,12 @@ import com.ibm.wsspi.library.LibraryChangeListener;
  * It uses a weak reference and a reference queue to clean up any unowned
  * listeners.
  */
-public abstract class WeakLibraryListener extends WeakReference<Object> implements LibraryChangeListener {
+public abstract class WeakLibraryListener extends WeakReference<AppClassLoader> implements LibraryChangeListener {
 
-    private static final RefQueue<Object, WeakLibraryListener> QUEUE = new RefQueue<Object, WeakLibraryListener>();
+    private static final RefQueue<AppClassLoader, WeakLibraryListener> QUEUE = new RefQueue<AppClassLoader, WeakLibraryListener>();
     private volatile ServiceRegistration<LibraryChangeListener> listenerReg;
 
-    protected WeakLibraryListener(String libraryId, String ownerId, Object owner, BundleContext ctx) {
+    protected WeakLibraryListener(String libraryId, String ownerId, AppClassLoader owner, BundleContext ctx) {
         super(owner, QUEUE);
         // clean up any enqueued references
         removeStaleListeners();

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/KeyBasedLockStore.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/KeyBasedLockStore.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,7 +23,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 public final class KeyBasedLockStore<Key, Lock> {
 
     private final ReferenceQueue<Lock> refQueue = new ReferenceQueue<>();
-    private final ConcurrentHashMap<String, LockWeakRef> lockMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Key, LockWeakRef> lockMap = new ConcurrentHashMap<>();
     private final Supplier<Lock> lockCreator;
 
     public KeyBasedLockStore(Supplier<Lock> lockCreator) {
@@ -31,16 +31,16 @@ public final class KeyBasedLockStore<Key, Lock> {
     }
 
     private final class LockWeakRef extends WeakReference<Lock> {
-        final String key;
+        final Key key;
 
         @Trivial
-        public LockWeakRef(Lock referent, String keyValue) {
+        public LockWeakRef(Lock referent, Key keyValue) {
             super(referent, refQueue);
             key = keyValue;
         }
     }
 
-    public final Lock getLock(String key) {
+    public final Lock getLock(Key key) {
         poll();
         LockWeakRef lockRef = lockMap.get(key);
         Lock lock = lockRef != null ? lockRef.get() : null;


### PR DESCRIPTION
- Update to use our concurrent weak locking store for LibertyLoader locks instead of what Java provides.  Since our implementation is concurrent and weak we have better concurrency and use less memory
- Update the locking store so that it uses the generic type in the methods and data structures instead of assuming that the key is a String
- Update WeakLibraryListener to reference AppClassLoader instead of Object to avoid unnecessary instanceof checks and casting for no reason.
