### PR TITLE
Fix test failure caused by PR 26601

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletResponse.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletResponse.java
@@ -873,12 +873,14 @@ public class SRTServletResponse implements HttpServletResponse, IResponseOutput,
                 }
 
                 String convertedCharEncoding = EncodingUtils.getJvmConverter(charEncoding);
+                Charset charset;
                 if (convertedCharEncoding == null) {
-                    convertedCharEncoding = Charset.defaultCharset().name();
-                }
-                Charset charset = EncodingUtils.getCharsetForName(convertedCharEncoding);
-                if (charset == null) {
-                    throw new UnsupportedEncodingException(convertedCharEncoding + " is not found");
+                    charset = Charset.defaultCharset();
+                } else {
+                    charset = EncodingUtils.getCharsetForName(convertedCharEncoding);
+                    if (charset == null) {
+                        throw new UnsupportedEncodingException(convertedCharEncoding + " is not found");
+                    }
                 }
                 _outWriter = new OutputStreamWriter(_rawOut, charset);
                 _outWriterEncoding = charEncoding;

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/EncodingUtils.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/EncodingUtils.java
@@ -15,7 +15,7 @@ package com.ibm.wsspi.webcontainer.util;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -412,7 +412,7 @@ public class EncodingUtils {
         if (charset == null) {
             try {
                 charset = Charset.forName(name);
-            } catch (UnsupportedCharsetException e) {
+            } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
                 charset = NOT_FOUND;
             }
             supportedEncodingsCache.put(name, charset);

--- a/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/webapp/SRTServletRequestTest.java
+++ b/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/webapp/SRTServletRequestTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,7 +20,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.io.UnsupportedEncodingException;
 import java.security.Principal;
 import java.util.Hashtable;
 
@@ -88,6 +90,12 @@ public class SRTServletRequestTest {
         assertEquals("utf-8", srtReq.getCharacterEncoding());
         assertEquals("utf-8", srtReq.getCharacterEncoding());
         assertEquals("utf-8", srtReq.getCharacterEncoding());
+        try {
+            srtReq.setCharacterEncoding("UTF-8 ");
+            fail("Excepted an UnsupportedEncodingException");
+        } catch (UnsupportedEncodingException e) {
+            // expected exception
+        }
     }
 
     /**


### PR DESCRIPTION
- PR #26601 missed an exception scenario for an invalid charset name. This caused a test failure.  This fixes that scenario.
