### PR TITLE
Enabled WebContainer trace

### DIFF
--- a/dev/com.ibm.ws.jndi.open_fat/publish/servers/jndi_entry_id_update/bootstrap.properties
+++ b/dev/com.ibm.ws.jndi.open_fat/publish/servers/jndi_entry_id_update/bootstrap.properties
@@ -1,4 +1,7 @@
 bootstrap.include=../testports.properties
 
-com.ibm.ws.logging.trace.specification=Naming=debug:*=info=enabled
+com.ibm.ws.logging.trace.specification=Naming=debug:*=info=enabled:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all
 com.ibm.ws.logging.trace.max.file.size=0
+
+
+


### PR DESCRIPTION
Enabling WebContainer trace to debug intermittent test failure