### PR TITLE
Clean up endpointSessionMap and httpSessionMap during http session expiration

### DIFF
--- a/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/WebSocketServletContainerInitializer.java
+++ b/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/WebSocketServletContainerInitializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -67,6 +67,10 @@ public class WebSocketServletContainerInitializer implements ServletContainerIni
             WsocHttpSessionListener listener = new WsocHttpSessionListener();
             listener.initialize(serverContainer.getEndpointManager());
             servletContext.addListener(listener);
+
+            WsocHttpSessionIdListener sessionIdListener = new WsocHttpSessionIdListener();
+            sessionIdListener.initialize(serverContainer.getEndpointManager());
+            servletContext.addListener(sessionIdListener);
 
             if (clazzes != null) {
                 String endPointContext = servletContext.getContextPath();

--- a/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/WsocHttpSessionIdListener.java
+++ b/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/WsocHttpSessionIdListener.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.wsoc;
+
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionIdListener;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * Session listener to notify the EndpointManager's httpSessionMap sessionId key should be changed
+ */
+public class WsocHttpSessionIdListener implements HttpSessionIdListener {
+
+    private static final TraceComponent tc = Tr.register(WsocHttpSessionIdListener.class);
+
+    EndpointManager endpointManager = null;
+
+    public void initialize(final EndpointManager em) {
+        endpointManager = em;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see javax.servlet.http.HttpSessionListener#sessionIdChanged(javax.servlet.http.HttpSessionEvent, java.lang.String)
+     */
+    @Override
+    public void  sessionIdChanged(final HttpSessionEvent event, final String oldSessionId) {
+
+        final String newSessionId = event.getSession().getId();
+
+        // change the sessions
+        if (endpointManager != null) {
+            endpointManager.httpSessionIdChanged(newSessionId, oldSessionId);
+        }
+
+    }
+}


### PR DESCRIPTION
fixes #26771

There are two leaks fixed in this PR. For the descriptions below, keep in mind there are two sessions -- the HTTP Session and the WebSocket session. 

**httpSessionMap**
- This main leak reported by the customer.
- This leak is caused by a http session id change.  The fix is to create the WsocHttpSessionIdListener and update the http session id key when id changes.
- This is used to track the http sessions to websocket sessions for when the former expire. Once expired, we'll close websocket session (see note below about the follow up)

**endpointSessionMap** 
- This is used to track the wsoc sessions to endpoints. 
- javax.websocket.Session#getOpenSessions basically forces to track the sessions for a particular endpoint. This means we need this object.

I don't like having two ArrayLists for the websocket sessions (see endpointSessionMap & httpSessionMap); however, I don't see a way around it.  We could merge the two, but code would be more complex and I prefer a simpler implementation here.

Follow up: The websocket close message is not sent once the session expired. Maybe only on secure connections per the code? Work / Investigation can be completed via https://github.com/OpenLiberty/open-liberty/issues/28021 


FAT:
- Our websocket FAT is not designed for this type of scenario, so I'd rather opt of of adding a FAT test (especially with other work prioritized). 
- Extra logging has been added to debug this further, if necessary (unlikely).  
- Test app 
  - Use a shorter session timeout (i.e ` <httpSession cookieHttpOnly="false" cookieName="JSESSIONID" invalidationTimeout="15s"/>`)
  [websocket-demo.war.zip](https://github.com/OpenLiberty/open-liberty/files/14764561/websocket-demo.war.zip)
  - the change session id is invoked is via the iframe refresh
  - clicking the websocket button creates a new websocket session which echos hello and a count. 
  - NOTE: use two browsers so that cookie aren't shared / use different urls (localhost / 127.0.0.1 ) to ensure cookies aren't shared
