### PR TITLE
Skip DB2 JCC precedence tests on IBMi

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.jdbc.fat.db2/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.jdbc.fat.db2/server.xml
@@ -86,9 +86,9 @@
     -->
     <dataSource id="driver-property-preferred" jndiName="jdbc/driver-property-preferred" type="java.sql.Driver">
       <jdbcDriver libraryRef="DB2Lib"/>
-      <containerAuthData user="${DB2_USER}" password="${DB2_PASS}"/>
       <properties.db2.jcc url="jdbc:db2://$INVALID:000/$INVALID" 
-      serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}" databaseName="${DB2_DBNAME}"/> 
+      serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}" databaseName="${DB2_DBNAME}"
+      user="${DB2_USER}" password="${DB2_PASS}"/> 
     </dataSource>
     
   <!-- 
@@ -97,9 +97,8 @@
   -->  
   <dataSource id="driver-no-override" jndiName="jdbc/driver-no-override" type="java.sql.Driver">
     <jdbcDriver libraryRef="DB2Lib"/>
-    <containerAuthData user="${DB2_USER}" password="${DB2_PASS}"/>
     <properties.db2.jcc url="jdbc:db2://${DB2_HOSTNAME}:${DB2_PORT}/${DB2_DBNAME}" 
-    					portNumber="${DB2_PORT}"/>
+    					portNumber="${DB2_PORT}" user="${DB2_USER}" password="${DB2_PASS}"/>
   </dataSource>
   
   <!-- 
@@ -107,8 +106,7 @@
   -->  
   <dataSource id="ds-no-url-defaults" jndiName="jdbc/ds-no-url-defaults" type="javax.sql.DataSource">
     <jdbcDriver libraryRef="DB2Lib"/>
-    <containerAuthData user="${DB2_USER}" password="${DB2_PASS}"/>
-    <properties.db2.jcc databaseName="${DB2_DBNAME}" portNumber="${DB2_PORT}" />
+    <properties.db2.jcc databaseName="${DB2_DBNAME}" portNumber="${DB2_PORT}" user="${DB2_USER}" password="${DB2_PASS}" />
   </dataSource>
 
   <javaPermission codebase="${shared.resource.dir}db2/*" className="java.security.AllPermission"/>

--- a/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
@@ -65,12 +65,6 @@ public class DB2TestServlet extends FATServlet {
     @Resource(name = "java:comp/jdbc/env/unsharable-ds-xa-tightly-coupled", shareable = false)
     private DataSource unsharable_ds_xa_tightly_coupled;
 
-    @Resource(lookup = "jdbc/driver-property-preferred")
-    private DataSource driver_property_perferred;
-
-    @Resource(lookup = "jdbc/driver-no-override")
-    private DataSource driver_no_override;
-
     @Resource(lookup = "jdbc/ds-no-url-defaults")
     private DataSource ds_no_url_defaults;
 
@@ -306,7 +300,9 @@ public class DB2TestServlet extends FATServlet {
     }
 
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Tests JCC driver behavior, not valid for DB2 on i driver
     public void testVerifyConnectionPrecedence() throws Throwable {
+        DataSource driver_property_perferred = InitialContext.doLookup("jdbc/driver-property-preferred");
         try (Connection con = driver_property_perferred.getConnection(); PreparedStatement stmt = con.prepareStatement("INSERT INTO MYTABLE VALUES (?, ?)");) {
             stmt.setInt(1, 33);
             stmt.setString(2, "thirty-three");
@@ -315,7 +311,9 @@ public class DB2TestServlet extends FATServlet {
     }
 
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Tests JCC driver behavior, not valid for DB2 on i driver
     public void testVerifyDefaultDoesNotOverride() throws Throwable {
+        DataSource driver_no_override = InitialContext.doLookup("jdbc/driver-no-override");
         try (Connection con = driver_no_override.getConnection(); PreparedStatement stmt = con.prepareStatement("INSERT INTO MYTABLE VALUES (?, ?)");) {
             stmt.setInt(1, 34);
             stmt.setString(2, "thirty-four");


### PR DESCRIPTION
These tests are not valid when running on IBMi