### PR TITLE
Introduce unit test for DatabaseContainerFactory

### DIFF
--- a/dev/com.ibm.ws.transaction.db_fat/fat/src/com/ibm/ws/transaction/test/SSLRecoveryTest.java
+++ b/dev/com.ibm.ws.transaction.db_fat/fat/src/com/ibm/ws/transaction/test/SSLRecoveryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -63,7 +63,7 @@ public class SSLRecoveryTest extends FATServletClient {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        testContainer.withStartupTimeout(FATUtils.TESTCONTAINER_STARTUP_TIMEOUT).waitingFor(Wait.forLogMessage(".*database system is ready.*", 2)).start();
+        testContainer.waitingFor(Wait.forLogMessage(".*database system is ready.*", 2).withStartupTimeout(FATUtils.TESTCONTAINER_STARTUP_TIMEOUT)).start();
 
         setUp();
 

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
@@ -119,7 +119,7 @@ public class DatabaseContainerFactory {
                     acceptDB2License.invoke(cont);
                     //Add startup timeout since DB2 tends to take longer than the default 3 minutes on build machines.
                     Method withStartupTimeoutDB2 = cont.getClass().getMethod("withStartupTimeout", Duration.class);
-                    withStartupTimeoutDB2.invoke(cont, Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN && !FATRunner.ARM_ARCHITECTURE ? 5 : 15));
+                    withStartupTimeoutDB2.invoke(cont, getContainerTimeout(5, 15));
                     break;
                 case Derby:
                     break;
@@ -131,7 +131,7 @@ public class DatabaseContainerFactory {
                     usingSid.invoke(cont);
                     //Add startup timeout since Oracle tends to take longer than the default 3 minutes on build machines.
                     Method withStartupTimeoutOracle = cont.getClass().getMethod("withStartupTimeout", Duration.class);
-                    withStartupTimeoutOracle.invoke(cont, Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN ? 3 : 25));
+                    withStartupTimeoutOracle.invoke(cont, getContainerTimeout(3, 25));
                     break;
                 case Postgres:
                     //This allows postgres by default to participate in XA transactions (2PC).
@@ -185,6 +185,23 @@ public class DatabaseContainerFactory {
             Log.warning(c, "MISSING: " + type + " JDBC driver not in location: " + temp.getAbsolutePath());
         }
 
+        return result;
+    }
+
+    /**
+     * Creates a container timeout duration (in minutes) based on where the test is being run.
+     *
+     * @param  low  - For fast systems: typically your local system
+     * @param  high - For slow systems: typically our build systems
+     *
+     * @return      The timeout duration
+     */
+    private static Duration getContainerTimeout(int low, int high) {
+        boolean isFast = FATRunner.FAT_TEST_LOCALRUN && !FATRunner.ARM_ARCHITECTURE;
+        Duration result = Duration.ofMinutes(isFast ? low : high);
+        Log.info(c, "getContainerTimeout", "Returning container timeout of " + result.toMinutes() + " minutes, because"
+                                           + " FAT_TEST_LOCALRUN = " + FATRunner.FAT_TEST_LOCALRUN + " and"
+                                           + " ARM_ARCHITECTURE = " + FATRunner.ARM_ARCHITECTURE);
         return result;
     }
 }

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
@@ -191,14 +191,14 @@ public class DatabaseContainerFactory {
     /**
      * Creates a container timeout duration (in minutes) based on where the test is being run.
      *
-     * @param  low  - For fast systems: typically your local system
-     * @param  high - For slow systems: typically our build systems
+     * @param  fastTimeout - For fast systems: typically your local system
+     * @param  slowTimeout - For slow systems: typically our build systems
      *
-     * @return      The timeout duration
+     * @return             The timeout duration
      */
-    private static Duration getContainerTimeout(int low, int high) {
+    private static Duration getContainerTimeout(int fastTimeout, int slowTimeout) {
         boolean isFast = FATRunner.FAT_TEST_LOCALRUN && !FATRunner.ARM_ARCHITECTURE;
-        Duration result = Duration.ofMinutes(isFast ? low : high);
+        Duration result = Duration.ofMinutes(isFast ? fastTimeout : slowTimeout);
         Log.info(c, "getContainerTimeout", "Returning container timeout of " + result.toMinutes() + " minutes, because"
                                            + " FAT_TEST_LOCALRUN = " + FATRunner.FAT_TEST_LOCALRUN + " and"
                                            + " ARM_ARCHITECTURE = " + FATRunner.ARM_ARCHITECTURE);

--- a/dev/fattest.simplicity/test/componenttest/topology/database/container/DatabaseContainerFactoryTest.java
+++ b/dev/fattest.simplicity/test/componenttest/topology/database/container/DatabaseContainerFactoryTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package componenttest.topology.database.container;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.Test;
+import org.testcontainers.containers.Db2Container;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+
+import componenttest.custom.junit.runner.FATRunner;
+
+public class DatabaseContainerFactoryTest {
+
+    @Test
+    public void testDB2ContainerCreation() throws Exception {
+        JdbcDatabaseContainer<?> db2 = DatabaseContainerFactory.createType(DatabaseContainerType.DB2);
+        assertTrue(db2.getClass().isAssignableFrom(Db2Container.class));
+        Db2Container _db2 = (Db2Container) db2;
+
+        Map<String, String> env = getField(Db2Container.class, _db2, "env", Map.class);
+        assertTrue(env.containsKey("LICENSE"));
+        assertEquals("accept", env.get("LICENSE"));
+
+        WaitStrategy waitStrategy = getField(Db2Container.class, _db2, "waitStrategy", WaitStrategy.class);
+        assertTrue(waitStrategy.getClass().isAssignableFrom(LogMessageWaitStrategy.class));
+        LogMessageWaitStrategy _waitStrategy = (LogMessageWaitStrategy) waitStrategy;
+
+        Duration startupTimeout = getField(LogMessageWaitStrategy.class, _waitStrategy, "startupTimeout", Duration.class);
+        if (startupTimeout.toMinutes() == 5) {
+            assertTrue(FATRunner.FAT_TEST_LOCALRUN && !FATRunner.ARM_ARCHITECTURE);
+        } else if (startupTimeout.toMinutes() == 15) {
+            assertFalse(FATRunner.FAT_TEST_LOCALRUN && !FATRunner.ARM_ARCHITECTURE);
+        } else {
+            fail("Unexpected startupTimeout " + startupTimeout.toMinutes() + " should have been either 5 or 15 minutes");
+        }
+
+    }
+
+    @Test
+    public void testDerbyContainerCreation() throws Exception {
+        JdbcDatabaseContainer<?> derby = DatabaseContainerFactory.createType(DatabaseContainerType.Derby);
+        assertTrue(derby.getClass().isAssignableFrom(DerbyNoopContainer.class));
+    }
+
+    @Test
+    public void testDerbyClientContainerCreation() throws Exception {
+        JdbcDatabaseContainer<?> derbyClient = DatabaseContainerFactory.createType(DatabaseContainerType.DerbyClient);
+        assertTrue(derbyClient.getClass().isAssignableFrom(DerbyClientContainer.class));
+    }
+
+    @Test
+    public void testOracleContainerCreation() throws Exception {
+        JdbcDatabaseContainer<?> oracle = DatabaseContainerFactory.createType(DatabaseContainerType.Oracle);
+        assertTrue(oracle.getClass().isAssignableFrom(OracleContainer.class));
+        OracleContainer _oracle = (OracleContainer) oracle;
+
+        boolean usingSid = getField(OracleContainer.class, _oracle, "usingSid", boolean.class);
+        assertTrue(usingSid);
+
+        WaitStrategy waitStrategy = getField(Db2Container.class, _oracle, "waitStrategy", WaitStrategy.class);
+        assertTrue(waitStrategy.getClass().isAssignableFrom(LogMessageWaitStrategy.class));
+        LogMessageWaitStrategy _waitStrategy = (LogMessageWaitStrategy) waitStrategy;
+
+        Duration startupTimeout = getField(LogMessageWaitStrategy.class, _waitStrategy, "startupTimeout", Duration.class);
+        if (startupTimeout.toMinutes() == 3) {
+            assertTrue(FATRunner.FAT_TEST_LOCALRUN && !FATRunner.ARM_ARCHITECTURE);
+        } else if (startupTimeout.toMinutes() == 25) {
+            assertFalse(FATRunner.FAT_TEST_LOCALRUN && !FATRunner.ARM_ARCHITECTURE);
+        } else {
+            fail("Unexpected startupTimeout " + startupTimeout.toMinutes() + " should have been either 3 or 25 minutes");
+        }
+    }
+
+    @Test
+    public void testPostgreSQLContainerCreation() throws Exception {
+        JdbcDatabaseContainer<?> postgresql = DatabaseContainerFactory.createType(DatabaseContainerType.Postgres);
+        assertTrue(postgresql.getClass().isAssignableFrom(PostgreSQLContainer.class));
+        PostgreSQLContainer _postgresql = (PostgreSQLContainer) postgresql;
+
+        String[] cmdParts = _postgresql.getCommandParts();
+        assertEquals(3, cmdParts.length);
+        assertEquals("postgres", cmdParts[0]);
+        assertEquals("-c", cmdParts[1]);
+        assertEquals("max_prepared_transactions=5", cmdParts[2]);
+    }
+
+    @Test
+    public void testSQLServerContainerCreation() throws Exception {
+        JdbcDatabaseContainer<?> sqlserver = DatabaseContainerFactory.createType(DatabaseContainerType.SQLServer);
+        assertTrue(sqlserver.getClass().isAssignableFrom(MSSQLServerContainer.class));
+        MSSQLServerContainer _sqlserver = (MSSQLServerContainer) sqlserver;
+
+        Map<String, String> env = getField(MSSQLServerContainer.class, _sqlserver, "env", Map.class);
+        assertTrue(env.containsKey("ACCEPT_EULA"));
+        assertEquals("Y", env.get("ACCEPT_EULA"));
+    }
+
+    private static <T> T getField(Class<?> clazz, Object obj, String name, Class<T> type) throws Exception {
+        Field f = null;
+        Class<?> tempClazz = clazz;
+
+        while (tempClazz.getSuperclass() != null) {
+            try {
+                f = tempClazz.getDeclaredField(name);
+                break;
+            } catch (NoSuchFieldException e) {
+                tempClazz = tempClazz.getSuperclass();
+            }
+        }
+
+        if (f == null) {
+            throw new RuntimeException("Could not find field with name: " + name);
+        }
+
+        assertTrue(f.getType().isAssignableFrom(type));
+        f.setAccessible(true);
+        return (T) f.get(obj);
+    }
+
+}

--- a/dev/fattest.simplicity/test/componenttest/topology/database/container/DatabaseContainerFactoryTest.java
+++ b/dev/fattest.simplicity/test/componenttest/topology/database/container/DatabaseContainerFactoryTest.java
@@ -76,7 +76,7 @@ public class DatabaseContainerFactoryTest {
         boolean usingSid = getField(OracleContainer.class, _oracle, "usingSid", boolean.class);
         assertTrue(usingSid);
 
-        WaitStrategy waitStrategy = getField(Db2Container.class, _oracle, "waitStrategy", WaitStrategy.class);
+        WaitStrategy waitStrategy = getField(OracleContainer.class, _oracle, "waitStrategy", WaitStrategy.class);
         assertTrue(waitStrategy.getClass().isAssignableFrom(LogMessageWaitStrategy.class));
         LogMessageWaitStrategy _waitStrategy = (LogMessageWaitStrategy) waitStrategy;
 


### PR DESCRIPTION
Ensures that configuration of containers created via DatabaseContainerFactory are done correctly.
This will also ensure that future updates to TestContainers does not break any of our functionality.

