### PR TITLE
ConfigurableWABTests skip session context error

### DIFF
--- a/dev/com.ibm.ws.app.manager.wab.installer_fat/fat/src/com/ibm/ws/app/manager/wab/installer/fat/ConfigurableWABTests.java
+++ b/dev/com.ibm.ws.app.manager.wab.installer_fat/fat/src/com/ibm/ws/app/manager/wab/installer/fat/ConfigurableWABTests.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -68,7 +68,8 @@ public class ConfigurableWABTests extends AbstractWABTests {
         if (server != null && server.isStarted()) {
             // ignore conflict error from the conflict test
             // ignore warning about virtual host not found
-            server.stopServer("CWWKZ0208E", "SRVE9956W");
+            // ignore session context error
+            server.stopServer("CWWKZ0208E", "SRVE9956W", "SRVE8059E");
         }
     }
 


### PR DESCRIPTION
FAT test com.ibm.ws.app.manager.wab.installer.fat.ConfigurableWABTests intermittently gets:
SRVE8059E: An unexpected exception occurred when trying to retrieve the session context
This message is not causing tests to fail, but it does cause a build break. Fat will be updated to ignore this message since it isn't otherwise impacting test results. Likely the SRVE8059E is caused by intermittent slow performance of the cloud vms but the web container recovers and operates normally.

