### PR TITLE
Allow expected FFDCs when querying metrics during server shutdown in …

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
@@ -13,7 +13,6 @@
 package io.openliberty.microprofile.metrics.internal.monitor_fat;
 
 import java.io.BufferedReader;
-
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -36,11 +35,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -53,6 +51,7 @@ import componenttest.topology.impl.LibertyServer;
  * @SkipForRepeat("MPM3X")
  */
 @RunWith(FATRunner.class)
+@AllowedFFDC("javax.management.InstanceNotFoundException")
 public class MetricsMonitorTest {
 
     private static Class<?> c = MetricsMonitorTest.class;

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -40,12 +40,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@AllowedFFDC("javax.management.InstanceNotFoundException")
 public class TestEnableDisableFeaturesTest {
 
     private static Class<?> c = TestEnableDisableFeaturesTest.class;

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
@@ -13,7 +13,6 @@
 package io.openliberty.microprofile.metrics.internal.monitor_fat;
 
 import java.io.BufferedReader;
-
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -36,11 +35,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -53,6 +51,7 @@ import componenttest.topology.impl.LibertyServer;
  * @SkipForRepeat("MPM3X")
  */
 @RunWith(FATRunner.class)
+@AllowedFFDC("javax.management.InstanceNotFoundException")
 public class MetricsMonitorTest {
 
     private static Class<?> c = MetricsMonitorTest.class;

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -40,12 +40,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@AllowedFFDC("javax.management.InstanceNotFoundException")
 public class TestEnableDisableFeaturesTest {
 
     private static Class<?> c = TestEnableDisableFeaturesTest.class;

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
@@ -13,7 +13,6 @@
 package io.openliberty.microprofile.metrics.internal.monitor_fat;
 
 import java.io.BufferedReader;
-
 import java.io.InputStreamReader;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
@@ -23,9 +22,6 @@ import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -40,16 +36,15 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.RemoteFile;
-import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@AllowedFFDC("javax.management.InstanceNotFoundException")
 public class MetricsMonitorTest {
 
     private static Class<?> c = MetricsMonitorTest.class;

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -40,12 +40,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@AllowedFFDC("javax.management.InstanceNotFoundException")
 public class TestEnableDisableFeaturesTest {
 
     private static Class<?> c = TestEnableDisableFeaturesTest.class;


### PR DESCRIPTION
fixes #26793
- Added `@AllowedFFDC` in FAT Runner class for cases when an FFDC is created when the MBean is not found, when the calculation is done during server shut down, for MpMetrics-3.0, MpMetrics-4.0, and MpMetrics-5.0.