### PR TITLE
Lazily create instrumenter in Telemetry filter classes for InstantOn to avoid early reading of config properties on checkpoint

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/.classpath
+++ b/dev/io.openliberty.checkpoint_fat/.classpath
@@ -35,6 +35,7 @@
 	<classpathentry kind="src" path="test-applications/mapCache/src"/>
 	<classpathentry kind="src" path="test-applications/webCacheApp/src"/>
 	<classpathentry kind="src" path="test-applications/xmlBindings/src"/>
+	<classpathentry kind="src" path="test-applications/jaxrspropagation/src"/>
 	<classpathentry kind="src" path="test-bundles/test-mbeans/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -80,7 +80,8 @@ tested.features: \
 	sociallogin-1.0,\
 	mpMetrics-5.1,\
 	passwordUtilities-1.0,\
-	appSecurity-1.0
+	appSecurity-1.0,\
+	mpTelemetry-1.1
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -50,12 +50,7 @@ src: \
 	test-applications/webCacheApp/src,\
 	test-applications/xmlBindings/src,\
 	test-bundles/test-mbeans/src,\
-	test-applications/jaxrspropagation,\
-	test-applications/jaxrspropagation/common,\
-	test-applications/jaxrspropagation/methods,\
-	test-applications/jaxrspropagation/responses,\
-	test-applications/jaxrspropagation/spanexporter,\
-	test-applications/jaxrspropagation/transports
+	test-applications/jaxrspropagation/src
 
 fat.project: true
 
@@ -89,8 +84,9 @@ tested.features: \
 	appSecurity-1.0,\
 	mpTelemetry-1.1,\
 	mpConfig-3.1,\
-    restfulWS-3.1,\
-    servlet-6.0
+	restfulWS-3.1,\
+	servlet-5.0,\
+	servlet-6.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -49,7 +49,13 @@ src: \
 	test-applications/mapCache/src,\
 	test-applications/webCacheApp/src,\
 	test-applications/xmlBindings/src,\
-	test-bundles/test-mbeans/src
+	test-bundles/test-mbeans/src,\
+	test-applications/jaxrspropagation,\
+	test-applications/jaxrspropagation/common,\
+	test-applications/jaxrspropagation/methods,\
+	test-applications/jaxrspropagation/responses,\
+	test-applications/jaxrspropagation/spanexporter,\
+	test-applications/jaxrspropagation/transports
 
 fat.project: true
 
@@ -81,7 +87,10 @@ tested.features: \
 	mpMetrics-5.1,\
 	passwordUtilities-1.0,\
 	appSecurity-1.0,\
-	mpTelemetry-1.1
+	mpTelemetry-1.1,\
+	mpConfig-3.1,\
+    restfulWS-3.1,\
+    servlet-6.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
@@ -126,7 +135,6 @@ tested.features: \
 	com.ibm.ws.org.slf4j.simple;version=latest,\
 	com.ibm.ws.org.slf4j.api;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.0,\
-	com.ibm.websphere.org.eclipse.microprofile.rest.client.1.4,\
 	io.openliberty.jakarta.restfulWS.3.0,\
 	jakarta.ws.rs-api,\
 	io.openliberty.jakarta.cdi.3.0,\
@@ -178,6 +186,10 @@ tested.features: \
 	com.ibm.websphere.appserver.api.distributedMap;version=latest,\
 	org.testng,\
 	com.ibm.ws.jmx,\
-	com.ibm.ws.kernel.service
+	com.ibm.ws.kernel.service,\
+	io.opentelemetry:opentelemetry-opentracing-shim;version=1.19.0.alpha,\
+	io.opentracing:opentracing-api;version=0.33.0,\
+	com.ibm.ws.kernel.boot.core;version=latest,\
+	com.ibm.ws.kernel.boot.common;version=latest
 
 -sub: *.bnd

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
@@ -92,7 +92,8 @@ import componenttest.topology.impl.LibertyServer;
                 WebCacheTest.class,
                 XMLbindingsTest.class,
                 LocalConnectorTest.class,
-                WebProfileJSPtest.class
+                WebProfileJSPtest.class,
+                MPTelemetryJaxRsIntegrationTest.class
 })
 
 public class FATSuite {

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPTelemetryJaxRsIntegrationTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPTelemetryJaxRsIntegrationTest.java
@@ -1,0 +1,292 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.checkpoint.fat;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static io.openliberty.checkpoint.fat.FATSuite.getTestMethod;
+import static io.openliberty.checkpoint.fat.FATSuite.configureEnvVariable;
+import static jaxrspropagation.JaxRsEndpoints.TEST_PASSED;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfCheckpointNotSupported;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureSet;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpRequest;
+import jaxrspropagation.JaxRsEndpoints;
+import jaxrspropagation.common.PropagationHeaderEndpoint;
+import jaxrspropagation.methods.JaxRsMethodTestEndpoints;
+import jaxrspropagation.methods.JaxRsMethodTestServlet;
+import jaxrspropagation.responses.JaxRsResponseCodeTestEndpoints;
+import jaxrspropagation.responses.JaxRsResponseCodeTestServlet;
+import jaxrspropagation.transports.B3MultiPropagationTestServlet;
+import jaxrspropagation.transports.B3PropagationTestServlet;
+import jaxrspropagation.transports.JaegerPropagationTestServlet;
+import jaxrspropagation.transports.W3CTraceBaggagePropagationTestServlet;
+import jaxrspropagation.transports.W3CTracePropagationTestServlet;
+import jaxrspropagation.spanexporter.TestSpans;
+import jaxrspropagation.spanexporter.InMemorySpanExporter;
+import jaxrspropagation.spanexporter.InMemorySpanExporterProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.openliberty.checkpoint.fat.MPTelemetryTest.TestMethod;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
+@RunWith(FATRunner.class)
+@SkipIfCheckpointNotSupported
+public class MPTelemetryJaxRsIntegrationTest extends FATServletClient {
+
+    public static final String SERVER_NAME = "Telemetry10Jax";
+    public static final String APP_NAME = "JaxPropagation";
+    public static final String W3C_TRACE_APP_NAME = "w3cTrace";
+    public static final String W3C_TRACE_BAGGAGE_APP_NAME = "w3cTraceBaggage";
+    public static final String B3_APP_NAME = "b3";
+    public static final String B3_MULTI_APP_NAME = "b3multi";
+    public static final String JAEGER_APP_NAME = "jaeger";
+    public static final String METHODS_APP_NAME = "jaxrsMethods";
+    public static final String MP50_MPTEL11_ID = MicroProfileActions.MP50_ID + "_MPTEL11";
+    public static final FeatureSet MP50_MPTEL11 = MicroProfileActions.MP50
+                    .addFeature("mpTelemetry-1.1")
+                    .build(MP50_MPTEL11_ID);
+
+    @TestServlets({
+                    @TestServlet(contextRoot = W3C_TRACE_APP_NAME, servlet = W3CTracePropagationTestServlet.class),
+                    @TestServlet(contextRoot = W3C_TRACE_BAGGAGE_APP_NAME, servlet = W3CTraceBaggagePropagationTestServlet.class),
+                    @TestServlet(contextRoot = B3_APP_NAME, servlet = B3PropagationTestServlet.class),
+                    @TestServlet(contextRoot = B3_MULTI_APP_NAME, servlet = B3MultiPropagationTestServlet.class),
+                    @TestServlet(contextRoot = JAEGER_APP_NAME, servlet = JaegerPropagationTestServlet.class),
+                    @TestServlet(contextRoot = METHODS_APP_NAME, servlet = JaxRsMethodTestServlet.class),
+                    @TestServlet(contextRoot = METHODS_APP_NAME, servlet = JaxRsResponseCodeTestServlet.class),
+    })
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+    
+    @ClassRule
+    public static RepeatTests repeatTest = MicroProfileActions.repeat(SERVER_NAME,
+                                                                      MicroProfileActions.MP60, // first test in LITE mode
+                                                                      MicroProfileActions.MP61, // rest are FULL mode
+                                                                      MP50_MPTEL11); 
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        PropertiesAsset appConfig = new PropertiesAsset()
+                        .addProperty("otel.sdk.disabled", "true")
+                        .addProperty("otel.traces.exporter", "oltp")
+                        .addProperty("otel.bsp.schedule.delay", "100");
+        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addPackage(JaxRsEndpoints.class.getPackage())
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(TestSpans.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        PropertiesAsset w3cTraceAppConfig = new PropertiesAsset()
+                        .include(appConfig)
+                        .addProperty("otel.propagators", "tracecontext");
+        WebArchive w3cTraceApp = ShrinkWrap.create(WebArchive.class, W3C_TRACE_APP_NAME + ".war")
+                        .addClass(W3CTracePropagationTestServlet.class)
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(TestSpans.class.getPackage())
+                        .addPackage(PropagationHeaderEndpoint.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(w3cTraceAppConfig, "META-INF/microprofile-config.properties");
+
+        PropertiesAsset w3cTraceBaggageAppConfig = new PropertiesAsset()
+                        .include(appConfig)
+                        .addProperty("otel.propagators", "tracecontext, baggage");
+        WebArchive w3cTraceBaggageApp = ShrinkWrap.create(WebArchive.class, W3C_TRACE_BAGGAGE_APP_NAME + ".war")
+                        .addClass(W3CTraceBaggagePropagationTestServlet.class)
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(TestSpans.class.getPackage())
+                        .addPackage(PropagationHeaderEndpoint.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(w3cTraceBaggageAppConfig, "META-INF/microprofile-config.properties");
+
+        PropertiesAsset b3AppConfig = new PropertiesAsset()
+                        .include(appConfig)
+                        .addProperty("otel.propagators", "b3");
+        WebArchive b3App = ShrinkWrap.create(WebArchive.class, B3_APP_NAME + ".war")
+                        .addClass(B3PropagationTestServlet.class)
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(TestSpans.class.getPackage())
+                        .addPackage(PropagationHeaderEndpoint.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(b3AppConfig, "META-INF/microprofile-config.properties");
+
+        PropertiesAsset b3MultiAppConfig = new PropertiesAsset()
+                        .include(appConfig)
+                        .addProperty("otel.propagators", "b3multi");
+        WebArchive b3MultiApp = ShrinkWrap.create(WebArchive.class, B3_MULTI_APP_NAME + ".war")
+                        .addClass(B3MultiPropagationTestServlet.class)
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(TestSpans.class.getPackage())
+                        .addPackage(PropagationHeaderEndpoint.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(b3MultiAppConfig, "META-INF/microprofile-config.properties");
+
+        PropertiesAsset jaegerAppConfig = new PropertiesAsset()
+                        .include(appConfig)
+                        .addProperty("otel.propagators", "jaeger");
+        WebArchive jaegerApp = ShrinkWrap.create(WebArchive.class, JAEGER_APP_NAME + ".war")
+                        .addClass(JaegerPropagationTestServlet.class)
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(TestSpans.class.getPackage())
+                        .addPackage(PropagationHeaderEndpoint.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(jaegerAppConfig, "META-INF/microprofile-config.properties");
+
+        WebArchive methodsApp = ShrinkWrap.create(WebArchive.class, METHODS_APP_NAME + ".war")
+                        .addPackage(JaxRsMethodTestEndpoints.class.getPackage())
+                        .addPackage(JaxRsResponseCodeTestEndpoints.class.getPackage())
+                        .addPackage(InMemorySpanExporter.class.getPackage())
+                        .addPackage(TestSpans.class.getPackage())
+                        .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                        .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, w3cTraceApp, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, w3cTraceBaggageApp, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, b3App, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, b3MultiApp, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, jaegerApp, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, methodsApp, SERVER_ONLY);
+        server.setCheckpoint(CheckpointPhase.AFTER_APP_START, true,
+                             server -> {
+                                 assertNotNull("'SRVE0169I: Loading Web Module: " + APP_NAME + "' message not found in log before rerstore",
+                                               server.waitForStringInLogUsingMark("SRVE0169I: .*" + APP_NAME, 0));
+                                 assertNotNull("'CWWKZ0001I: Application " + APP_NAME + " started' message not found in log.",
+                                               server.waitForStringInLogUsingMark("CWWKZ0001I: .*" + APP_NAME, 0));
+                                 configureBeforeRestore();
+                             });
+         
+        server.startServer("JaxRsIntegrationTest.log");
+    }
+    
+    private static void configureBeforeRestore() {
+        try {
+            server.saveServerConfiguration();
+            Map<String, String> config = new HashMap<>();
+            config.put("OTEL_SDK_DISABLED", "false");
+            config.put("OTEL_TRACES_EXPORTER", "in-memory");
+            configureEnvVariable(server, config);
+        } catch (Exception e) {
+            throw new AssertionError("Unexpected error configuring test.", e);
+        }
+    }
+    
+    @Test
+    public void testIntegrationWithJaxRsClient() throws Exception {
+        HttpRequest pokeJax = new HttpRequest(server, "/" + APP_NAME + "/endpoints/jaxrsclient");
+        String traceId = readTraceId(pokeJax);
+        
+        if (RepeatTestFilter.isRepeatActionActive(MicroProfileActions.MP60_ID)) {
+            HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspans/" + traceId);
+            assertEquals(TEST_PASSED, readspans.run(String.class));           
+        } else {
+            HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspansmptel11/" + traceId);
+            assertEquals(TEST_PASSED, readspans.run(String.class));
+        }           
+    }
+
+    @Test
+    public void testIntegrationWithJaxRsClientAsync() throws Exception {
+        HttpRequest pokeJax = new HttpRequest(server, "/" + APP_NAME + "/endpoints/jaxrsclientasync");
+        String traceId = readTraceId(pokeJax);
+
+        if (RepeatTestFilter.isRepeatActionActive(MicroProfileActions.MP60_ID)) {
+            HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspans/" + traceId);
+            assertEquals(TEST_PASSED, readspans.run(String.class));
+        } else {
+            HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspansmptel11/" + traceId);
+            assertEquals(TEST_PASSED, readspans.run(String.class));
+        } 
+    }
+
+    @Test
+    public void testIntegrationWithMpClient() throws Exception {
+        HttpRequest pokeMp = new HttpRequest(server, "/" + APP_NAME + "/endpoints/mpclient");
+        String traceId = readTraceId(pokeMp);
+
+        if (RepeatTestFilter.isRepeatActionActive(MicroProfileActions.MP60_ID)) {
+            HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspans/" + traceId);
+            assertEquals(TEST_PASSED, readspans.run(String.class));
+        } else {
+            HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspansmptel11/" + traceId);
+            assertEquals(TEST_PASSED, readspans.run(String.class));
+        } 
+    }
+
+    @Test
+    public void testIntegrationWithMpClientAsync() throws Exception {
+        HttpRequest pokeMp = new HttpRequest(server, "/" + APP_NAME + "/endpoints/mpclientasync");
+        String traceId = readTraceId(pokeMp);
+
+        if (RepeatTestFilter.isRepeatActionActive(MicroProfileActions.MP60_ID)) {
+            HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspans/" + traceId);
+            assertEquals(TEST_PASSED, readspans.run(String.class));
+        } else {
+            HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspansmptel11/" + traceId);
+            assertEquals(TEST_PASSED, readspans.run(String.class));
+        } 
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        try {
+            server.stopServer();
+        } finally {
+            server.restoreServerConfiguration();
+            configureEnvVariable(server, emptyMap());
+        }
+    }
+
+    private static final Pattern TRACE_ID_PATTERN = Pattern.compile("[0-9a-f]{32}");
+
+    private String readTraceId(HttpRequest httpRequest) throws Exception {
+        String response = httpRequest.run(String.class);
+        if (!TRACE_ID_PATTERN.matcher(response).matches()) {
+            Assert.fail("Request failed, response: " + response);
+        }
+        return response;
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPTelemetryTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPTelemetryTest.java
@@ -27,6 +27,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -36,6 +37,8 @@ import componenttest.annotation.Server;
 import componenttest.annotation.SkipIfCheckpointNotSupported;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.checkpoint.spi.CheckpointPhase;
@@ -47,11 +50,18 @@ public class MPTelemetryTest extends FATServletClient {
 
     public static final String APP_NAME = "mpTelemetry";
 
-    @Server("checkpointMPTelemetry")
+    public static final String SERVER_NAME = "checkpointMPTelemetry";
+
+    @Server(SERVER_NAME)
     @TestServlet(servlet = MpTelemetryServlet.class, contextRoot = APP_NAME)
     public static LibertyServer server;
 
     public TestMethod testMethod;
+
+    @ClassRule
+    public static RepeatTests repeatTest = MicroProfileActions.repeat(SERVER_NAME,
+                                                                      MicroProfileActions.MP60, // first test in LITE mode
+                                                                      MicroProfileActions.MP61); // rest are FULL mode
 
     @BeforeClass
     public static void deployApp() throws Exception {

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/Telemetry10Jax/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/Telemetry10Jax/bootstrap.properties
@@ -1,0 +1,4 @@
+bootstrap.include=../testports.properties
+websphere.java.security.exempt=true
+com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
+io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/Telemetry10Jax/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/Telemetry10Jax/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/Telemetry10Jax/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/Telemetry10Jax/server.xml
@@ -1,0 +1,45 @@
+<server description="Server for testing Telemetry10">
+
+    <include location="../fatTestPorts.xml" />
+
+    <featureManager>
+        <feature>servlet-6.0</feature>
+        <feature>mpTelemetry-1.0</feature>
+        <feature>componentTest-2.0</feature>
+        <feature>restfulWS-3.1</feature>
+        <feature>mpRestClient-3.0</feature>
+    </featureManager>
+
+    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+
+    <application id="JaxPropagation" name="JaxPropagation" type="war" location="JaxPropagation.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
+    <application type="war" location="w3cTrace.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
+    <application type="war" location="w3cTraceBaggage.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
+    <application type="war" location="b3.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
+    <application type="war" location="b3multi.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
+    <application type="war" location="jaeger.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
+    <application type="war" location="jaxrsMethods.war">
+        <classloader apiTypeVisibility="+third-party"/>
+    </application>
+
+    <!--logging traceSpecification="TELEMETRY=all:RESTfulWS=all"/-->
+
+</server>

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/JaxRsEndpoints.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/JaxRsEndpoints.java
@@ -1,0 +1,396 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrspropagation;
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
+import static io.opentelemetry.api.trace.SpanKind.SERVER;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_SCHEME;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_URL;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_NAME;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_PORT;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_PEER_NAME;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_PEER_PORT;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
+import java.util.logging.Logger;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jaxrspropagation.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+/**
+ * Tests MP Telemetry integration with restfulWS and mpRestClient.
+ * <p>
+ * Whenever a request is made or received by one of these features, MP Telemetry should create a span.
+ * Trace ID information should be sent via the HTTP headers so that the traces from both the client and server can be joined up.
+ * Baggage information should also be sent via the HTTP headers so that contextual information from the first service can be included in trace messages in the second service.
+ * <p>
+ * This class covers:
+ * <p>
+ * Creation of Spans in
+ * <ul>
+ * <li>JAX-RS Client {1}
+ * <li>JAX-RS Server {2}
+ * <li>MP Rest Client {3}
+ * </ul>
+ * <p>
+ * Propagation of Spans from
+ * <ul>
+ * <li>JAX-RS Server to JAX-RS Client {4}
+ * <li>JAX-RS Server to MP Client {5}
+ * <li>JAX-RS Server to JAX-RS Client Async {6}
+ * <li>JAX-RS Server to MP Client Async {7}
+ * </ul>
+ * <p>
+ * Baggage is correctly Propagated:
+ * <ul>
+ * <li>from JAX-RS Client to JAX-RS Server {8}
+ * <li>from MP Client to JAX-RS Server {9}
+ * <li>from JAX-RS Client async to JAX-RS Server {10}
+ * <li>from MP Client async to JAX-RS Server {11}
+ * </ul>
+ * <p>
+ * Correct application of Semantic convention attributes:
+ * <ul>
+ * <li>TCK RestClientSpanTest only checks HTTP_STATUS, HTTP_METHOD, HTTP_SCHEME, HTTP_TARGET, HTTP_URL, see if there are any others which should be present
+ * <li>There are constants defined for each of the attributes in the spec
+ * </ul>
+ * <p>
+ * <strong>NOTE</strong>: Some of the tests in this class could be re-written more simply using {@code FATServlet} and {@code TestSpans}.
+ * However, we've sometimes seen slightly different behaviour for JAX-RS client and MP Rest client depending on whether or not they're called via a JAX-RS resource method.
+ * Therefore we're leaving these tests as they are so that we have some test coverage of calling JAX-RS client via a JAX-RS resource method.
+ */
+@ApplicationPath("")
+@Path("endpoints")
+public class JaxRsEndpoints extends Application {
+
+    private static final Logger LOGGER = Logger.getLogger(JaxRsEndpoints.class.getName());
+
+    public static final String TEST_PASSED = "Test Passed";
+
+    @Inject
+    private InMemorySpanExporter spanExporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    private Client client;
+
+    @PostConstruct
+    private void openClient() {
+        LOGGER.info("Creating JAX-RS client");
+        client = ClientBuilder.newClient();
+    }
+
+    @PreDestroy
+    private void closeClient() {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+    }
+
+    //Gets a list of spans created by open telemetry when a test was running and confirms the spans are what we expected and IDs are propagated correctly
+    //spanExporter.reset() should be called at the start of each new test.
+    @GET
+    @Path("/readspans/{traceId}")
+    public Response readSpans(@Context UriInfo uriInfo, @PathParam("traceId") String traceId) {
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, traceId);
+
+        SpanData firstURL = spanData.get(0);
+        SpanData httpGet = spanData.get(1);
+        SpanData secondURL = spanData.get(2);
+
+        assertEquals(SERVER, firstURL.getKind());
+        assertEquals(CLIENT, httpGet.getKind());
+        assertEquals(SERVER, secondURL.getKind());
+
+        assertEquals(firstURL.getSpanId(), httpGet.getParentSpanId());
+        assertEquals(httpGet.getSpanId(), secondURL.getParentSpanId());
+
+        assertEquals(HTTP_OK, firstURL.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        assertEquals(HttpMethod.GET, firstURL.getAttributes().get(HTTP_METHOD));
+        assertEquals("http", firstURL.getAttributes().get(HTTP_SCHEME));
+        assertThat(httpGet.getAttributes().get(HTTP_URL), containsString("endpoints")); //There are many different URLs that will end up here. But all should contain "endpoints"
+
+        // The request used to call /readspans should have the same hostname and port as the test request
+        URI requestUri = uriInfo.getRequestUri();
+        assertEquals(requestUri.getHost(), firstURL.getAttributes().get(NET_HOST_NAME));
+        assertEquals(Long.valueOf(requestUri.getPort()), firstURL.getAttributes().get(NET_HOST_PORT));
+
+        assertEquals(CLIENT, httpGet.getKind());
+        assertEquals("HTTP GET", httpGet.getName());
+        assertEquals(HTTP_OK, httpGet.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        assertEquals(HttpMethod.GET, httpGet.getAttributes().get(HTTP_METHOD));
+        assertEquals(requestUri.getHost(), httpGet.getAttributes().get(NET_PEER_NAME));
+        assertEquals(Long.valueOf(requestUri.getPort()), httpGet.getAttributes().get(NET_PEER_PORT));
+        assertThat(httpGet.getAttributes().get(HTTP_URL), containsString("endpoints"));
+
+        return Response.ok(TEST_PASSED).build();
+    }
+    
+    @GET
+    @Path("/readspansmptel11/{traceId}")
+    public Response readSpansMpTel11(@Context UriInfo uriInfo, @PathParam("traceId") String traceId) {
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, traceId);
+
+        SpanData firstURL = spanData.get(0);
+        SpanData httpGet = spanData.get(1);
+        SpanData secondURL = spanData.get(2);
+
+        assertEquals(SERVER, firstURL.getKind());
+        assertEquals(CLIENT, httpGet.getKind());
+        assertEquals(SERVER, secondURL.getKind());
+
+        assertEquals(firstURL.getSpanId(), httpGet.getParentSpanId());
+        assertEquals(httpGet.getSpanId(), secondURL.getParentSpanId());
+
+        assertEquals(HTTP_OK, firstURL.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        assertEquals(HttpMethod.GET, firstURL.getAttributes().get(HTTP_METHOD));
+        assertEquals("http", firstURL.getAttributes().get(HTTP_SCHEME));
+        assertThat(httpGet.getAttributes().get(HTTP_URL), containsString("endpoints")); //There are many different URLs that will end up here. But all should contain "endpoints"
+
+        // The request used to call /readspans should have the same hostname and port as the test request
+        URI requestUri = uriInfo.getRequestUri();
+        assertEquals(requestUri.getHost(), firstURL.getAttributes().get(NET_HOST_NAME));
+        assertEquals(Long.valueOf(requestUri.getPort()), firstURL.getAttributes().get(NET_HOST_PORT));
+
+        assertEquals(CLIENT, httpGet.getKind());
+        assertEquals("GET", httpGet.getName());
+        assertEquals(HTTP_OK, httpGet.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        assertEquals(HttpMethod.GET, httpGet.getAttributes().get(HTTP_METHOD));
+        assertEquals(requestUri.getHost(), httpGet.getAttributes().get(NET_PEER_NAME));
+        assertEquals(Long.valueOf(requestUri.getPort()), httpGet.getAttributes().get(NET_PEER_PORT));
+        assertThat(httpGet.getAttributes().get(HTTP_URL), containsString("endpoints"));
+
+        return Response.ok(TEST_PASSED).build();
+    }
+
+    //This URL is called by the test framework to trigger testing both JAX-RS server and JAX-RS client
+    //Tests {2} automatically as this method triggers span creation.
+    @GET
+    @Path("/jaxrsclient")
+    public Response getJax(@Context UriInfo uriInfo) {
+        LOGGER.info(">>> getJax");
+        assertNotNull(Span.current());
+
+        try (Scope s = Baggage.builder().put("foo", "bar").build().makeCurrent()) {
+            Baggage baggage = Baggage.current();
+            assertEquals("bar", baggage.getEntryValue("foo"));
+
+            String url = new String(uriInfo.getAbsolutePath().toString());
+            url = url.replace("jaxrsclient", "jaxrstwo"); //The jaxrsclient will use the URL as given so it needs the final part to be provided.
+
+            Client client = ClientBuilder.newClient();           
+            try {
+                String result = client.target(url)
+                                .request(MediaType.TEXT_PLAIN)
+                                .get(String.class);
+                assertEquals(TEST_PASSED, result);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                client.close();
+            }
+        } finally {
+            LOGGER.info("<<< getJax");
+        }
+        return Response.ok(Span.current().getSpanContext().getTraceId()).build();
+    }
+
+    //This URL is called by the test framework to trigger testing for calling JAX-RS client in Asnyc.
+    //Tests {2} automatically as this method triggers span creation.
+    @GET
+    @Path("/jaxrsclientasync")
+    public Response getJaxAsync(@Context UriInfo uriInfo) {
+        LOGGER.info(">>> getJaxAsync");
+        assertNotNull(Span.current());
+
+        try (Scope s = Baggage.builder().put("foo", "bar").build().makeCurrent()) {
+            Baggage baggage = Baggage.current();
+            assertEquals("bar", baggage.getEntryValue("foo"));
+
+            String url = new String(uriInfo.getAbsolutePath().toString());
+            url = url.replace("jaxrsclientasync", "jaxrstwo"); //The jaxrsclient will use the URL as given so it needs the final part to be provided.
+
+            Client client = ClientBuilder.newClient();
+            Future<String> result = client.target(url)
+                            .request(MediaType.TEXT_PLAIN)
+                            .async()
+                            .get(String.class);
+
+            try {
+                String resultValue = result.get(10, SECONDS);
+                assertEquals(TEST_PASSED, resultValue);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                client.close();
+            }
+
+        } finally {
+            LOGGER.info("<<< getJax");
+        }
+        return Response.ok(Span.current().getSpanContext().getTraceId()).build();
+    }
+
+    //A method to be called by JAX Clients
+    //Tests {1} Automatically as this method triggers span creation. Tests {4} and {6} (depending on which method called by the framework calls this one) as span propagation is automatic.
+    @GET
+    @Path("/jaxrstwo")
+    public Response getJaxRsTwo() {
+        LOGGER.info(">>> getJaxRsTwo");
+        assertNotNull(Span.current());
+        Baggage baggage = Baggage.current();
+        LOGGER.info(">>> BAGGAGE= " + baggage);
+        assertEquals("bar", baggage.getEntryValue("foo")); //Assert that Baggage is propagated from Jax Server to Jax Client. Tests {8} and {10} (depending on which entry method calls this one)
+        LOGGER.info("<<< getJaxRsTwo");
+        return Response.ok(TEST_PASSED).build();
+    }
+
+    ////// MP code below //////
+
+    //This URL is called by the test framework to trigger testing mpclient
+    //Tests {1} automatically as this method triggers span creation.
+    @GET
+    @Path("/mpclient")
+    public Response getMP(@Context UriInfo uriInfo) {
+        LOGGER.info(">>> getMP");
+        assertNotNull(Span.current());
+
+        try (Scope s = Baggage.builder().put("foo", "bar").build().makeCurrent()) {
+            Baggage baggage = Baggage.current();
+            assertEquals("bar", baggage.getEntryValue("foo"));
+
+            String baseUrl = uriInfo.getAbsolutePath().toString().replace("/mpclient", ""); //The mpclient will add the final part of the URL for you, so we remove the final part.
+            URI baseUri = null;
+            try {
+                baseUri = new URI(baseUrl);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            assertNotNull(Span.current());
+            MPTwo two = RestClientBuilder.newBuilder()
+                            .baseUri(baseUri)
+                            .build(MPTwo.class);
+
+            String result = two.getMPTwo();
+            assertEquals(TEST_PASSED, result);
+        } finally {
+            LOGGER.info("<<< getMP");
+        }
+        return Response.ok(Span.current().getSpanContext().getTraceId()).build();
+        
+    }
+
+    //This method is called via mpClient from the entry methods.
+    //Tests {3} automatically as this method triggers span creation. Tests {5} and {7} (depending on which method called by the framework calls this one) as span propagation is automatic.
+    @GET
+    @Path("/mptwo")
+    public Response getMPTwo() {
+        LOGGER.info(">>> getMPTwo");
+
+        assertNotNull(Span.current());
+        Baggage baggage = Baggage.current();
+        assertEquals("bar", baggage.getEntryValue("foo")); //Assert that Baggage is propagated from Jax Server to MPClient. Tests {9} or {11} depending on which method called by the framework calls this one
+
+        LOGGER.info("<<< getMPTwo");
+        return Response.ok(TEST_PASSED).build();
+    }
+
+    @RegisterRestClient
+    public interface MPTwo {
+
+        @GET
+        @Path("/mptwo")
+        public String getMPTwo();
+
+    }
+
+    //This URL is called by the test framework to trigger testing mpclient with async
+    //Tests {1} automatically as this method triggers span creation.
+    @GET
+    @Path("/mpclientasync")
+    public Response getMPAsync(@Context UriInfo uriInfo) {
+        LOGGER.info(">>> getMPAsync");
+        assertNotNull(Span.current());
+
+        try (Scope s = Baggage.builder().put("foo", "bar").build().makeCurrent()) {
+
+            Baggage baggage = Baggage.current();
+            assertEquals("bar", baggage.getEntryValue("foo"));
+
+            String baseUrl = uriInfo.getAbsolutePath().toString().replace("/mpclientasync", ""); //The mpclient will add the final part of the URL for you, so we remove the final part.
+            URI baseUri = null;
+            try {
+                baseUri = new URI(baseUrl);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            assertNotNull(Span.current());
+            MPTwoAsync two = RestClientBuilder.newBuilder()
+                            .baseUri(baseUri)
+                            .build(MPTwoAsync.class);
+
+            String result = two.getMPTwo().toCompletableFuture().join();
+            assertEquals(TEST_PASSED, result);
+
+            LOGGER.info("<<< getMPAsync");
+        }
+        return Response.ok(Span.current().getSpanContext().getTraceId()).build();
+    }
+
+    @RegisterRestClient
+    public interface MPTwoAsync {
+
+        @GET
+        @Path("/mptwo")
+        public CompletionStage<String> getMPTwo();
+
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/JaxRsEndpoints.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/JaxRsEndpoints.java
@@ -223,17 +223,10 @@ public class JaxRsEndpoints extends Application {
             String url = new String(uriInfo.getAbsolutePath().toString());
             url = url.replace("jaxrsclient", "jaxrstwo"); //The jaxrsclient will use the URL as given so it needs the final part to be provided.
 
-            Client client = ClientBuilder.newClient();           
-            try {
-                String result = client.target(url)
-                                .request(MediaType.TEXT_PLAIN)
-                                .get(String.class);
-                assertEquals(TEST_PASSED, result);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            } finally {
-                client.close();
-            }
+            String result = client.target(url)
+                            .request(MediaType.TEXT_PLAIN)
+                            .get(String.class);
+            assertEquals(TEST_PASSED, result);
         } finally {
             LOGGER.info("<<< getJax");
         }

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/TestExceptionMapper.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/TestExceptionMapper.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * Maps an exception to an error response in a similar manner to FATServlet
+ */
+@Provider
+public class TestExceptionMapper implements ExceptionMapper<Throwable> {
+
+    @Context
+    private UriInfo uriInfo;
+
+    /** {@inheritDoc} */
+    @Override
+    public Response toResponse(Throwable t) {
+        StringWriter sw = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            System.out.println("ERROR: " + t);
+            pw.println("ERROR: Caught exception attempting to call " + uriInfo.getRequestUri().toString());
+            t.printStackTrace(pw);
+        }
+        return Response.ok(sw.toString()).build();
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/common/PropagationHeaderClient.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/common/PropagationHeaderClient.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.common;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/propagationHeaderEndpoint")
+public interface PropagationHeaderClient {
+
+    @GET
+    public String get();
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/common/PropagationHeaderEndpoint.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/common/PropagationHeaderEndpoint.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.common;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jaxrspropagation.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+
+/**
+ * This endpoint is used to test propagation.
+ *
+ * It does the following:
+ * <ul>
+ * <li>Creates a span
+ * <li>Collects the names of all known propagation headers which are present in the HTTP request and sets that as a span attribute with key {@link #PROPAGATION_HEADERS_ATTR}
+ * <li>Reads the baggage entry with key {@link #BAGGAGE_KEY} and if present sets
+ * <ul><li>span attribute {@link #BAGGAGE_VALUE_ATTR} to the entry value
+ * <li>span attribute {@link #BAGGAGE_METADATA_ATTR} to the entry metadata value
+ * </ul></ul>
+ *
+ * Tests using this endpoint should generally do the following:
+ * <ul>
+ * <li>Start a span
+ * <li>Set the baggage entry {@link #BAGGAGE_KEY} to a known test value
+ * <li>Request this endpoint
+ * <li>End their span
+ * <li>Retrieve the created spans (e.g. via {@link InMemorySpanExporter})
+ * <li>Verify that their span has a child CLIENT span which has a child SERVER span (which will be the span created by this endpoint) (if traceIds should be propagated)
+ * <li>Verify the value of the {@link #BAGGAGE_VALUE_ATTR} attribute in the SERVER span is value of the test baggage entry (if baggage should be propagated)
+ * <li>Verify the value of the {@link #BAGGAGE_METADATA_ATTR} attribute in the SERVER span (if baggage metadata should be propagated)
+ * <li>Verify the value of the {@link #PROPAGATION_HEADERS_ATTR} attribute in the SERVER span is the list of headers expected to be used for propagation
+ * </ul>
+ */
+@ApplicationPath("/")
+@Path("/propagationHeaderEndpoint")
+public class PropagationHeaderEndpoint extends Application {
+
+    public static final String BAGGAGE_KEY = "test.baggage.key";
+    public static final AttributeKey<String> BAGGAGE_METADATA_ATTR = AttributeKey.stringKey("test.baggage.metadata");
+    public static final AttributeKey<String> BAGGAGE_VALUE_ATTR = AttributeKey.stringKey("test.baggage");
+    public static final AttributeKey<List<String>> PROPAGATION_HEADERS_ATTR = AttributeKey.stringArrayKey("test.propagation.headers");
+
+    private static final List<String> PROPAGATION_HEADER_NAMES = Arrays.asList("baggage", "traceparent",
+                                                                               "b3",
+                                                                               "X-B3-TraceId", "X-B3-SpanId", "X-B3-ParentSpanId", "X-B3-Sampled",
+                                                                               "uber-trace-id");
+
+    @GET
+    public String get(@Context HttpHeaders headers) {
+        Span span = Span.current();
+
+        // Extract the propagation headers and store in the span
+        List<String> propagationHeaders = headers.getRequestHeaders().keySet().stream()
+                        .filter(PropagationHeaderEndpoint::isPropagationHeader)
+                        .collect(Collectors.toList());
+        span.setAttribute(PropagationHeaderEndpoint.PROPAGATION_HEADERS_ATTR, propagationHeaders);
+
+        // Extract the test baggage value (if present) and store in the span
+        BaggageEntry baggageEntry = Baggage.current().asMap().get(BAGGAGE_KEY);
+        if (baggageEntry != null) {
+            span.setAttribute(BAGGAGE_VALUE_ATTR, baggageEntry.getValue());
+            span.setAttribute(BAGGAGE_METADATA_ATTR, baggageEntry.getMetadata().getValue());
+        }
+
+        return "OK";
+    }
+
+    public static boolean isPropagationHeader(String header) {
+        return PROPAGATION_HEADER_NAMES.contains(header)
+               || header.startsWith("uberctx-"); // Jaeger baggage headers use keys as part of the header but have a common prefix
+    }
+
+    public static URI getBaseUri(HttpServletRequest request) {
+        try {
+            URI originalUri = URI.create(request.getRequestURL().toString());
+            URI targetUri = new URI(originalUri.getScheme(), originalUri.getAuthority(), request.getContextPath(), null, null);
+            System.out.println("Using URI: " + targetUri);
+            return targetUri;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/methods/JaxRsMethodTestEndpoints.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/methods/JaxRsMethodTestEndpoints.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.methods;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
+import jakarta.ws.rs.OPTIONS;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+
+@Path("methodTestEndpoints")
+public class JaxRsMethodTestEndpoints {
+
+    @GET
+    public String get() {
+        new Exception("Test stack").printStackTrace();
+        return "get";
+    }
+
+    @HEAD
+    public void head() {
+    }
+
+    @POST
+    public String post(String string) {
+        return "post";
+    }
+
+    @PUT
+    public String put(String string) {
+        return "put";
+    }
+
+    @DELETE
+    public String delete() {
+        return "delete";
+    }
+
+    @PATCH
+    public String patch(String string) {
+        return "patch";
+    }
+
+    @OPTIONS
+    public Response options() {
+        return Response.ok("options")
+                        .header(HttpHeaders.ALLOW, "GET")
+                        .header(HttpHeaders.ALLOW, "HEAD")
+                        .header(HttpHeaders.ALLOW, "POST")
+                        .header(HttpHeaders.ALLOW, "PUT")
+                        .header(HttpHeaders.ALLOW, "DELETE")
+                        .header(HttpHeaders.ALLOW, "PATCH")
+                        .header(HttpHeaders.ALLOW, "OPTIONS")
+                        .build();
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/methods/JaxRsMethodTestServlet.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/methods/JaxRsMethodTestServlet.java
@@ -1,0 +1,270 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.methods;
+
+import static jaxrspropagation.spanexporter.SpanDataMatcher.isSpan;
+import static jakarta.ws.rs.client.Entity.text;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jaxrspropagation.spanexporter.TestSpans;
+import jaxrspropagation.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Test tracing requests of each JAX-RS method type
+ */
+@SuppressWarnings("serial")
+@WebServlet("/testJaxRsMethod")
+public class JaxRsMethodTestServlet extends FATServlet {
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private TestSpans utils;
+
+    @Test
+    public void testGet() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .build("GET").invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("get"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+    }
+
+    @Test
+    public void testPost() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .buildPost(text("test"))
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("post"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "POST")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "POST")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+    }
+
+    @Test
+    public void testPut() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .buildPut(text("test"))
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("put"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "PUT")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "PUT")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+    }
+
+    @Test
+    public void testHead() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .build("HEAD")
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(204));
+            assertThat(response.hasEntity(), is(false));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "HEAD")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 204L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "HEAD")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 204L));
+
+    }
+
+    @Test
+    public void testDelete() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .build("DELETE")
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("delete"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "DELETE")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "DELETE")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+    }
+
+    @Test
+    public void testPatch() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .build("PATCH", text("test"))
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("patch"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "PATCH")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "PATCH")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+    }
+
+    @Test
+    public void testOptions() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .build("OPTIONS")
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("options"));
+            assertThat(response.getStringHeaders().get(HttpHeaders.ALLOW), containsInAnyOrder("GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "OPTIONS")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "OPTIONS")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L));
+    }
+
+    private URI getUri() {
+        try {
+            String path = request.getContextPath() + "/methodTestEndpoints";
+            URI originalUri = new URI(request.getRequestURL().toString());
+            URI result = new URI(originalUri.getScheme(), originalUri.getAuthority(), path, null, null);
+            return result;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/responses/JaxRsResponseCodeTestClient.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/responses/JaxRsResponseCodeTestClient.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.responses;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("responseCodeEndpoints")
+public interface JaxRsResponseCodeTestClient {
+
+    @Path("307")
+    @GET
+    public Response get307();
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/responses/JaxRsResponseCodeTestEndpoints.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/responses/JaxRsResponseCodeTestEndpoints.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.responses;
+
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+
+import java.net.URI;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.UriInfo;
+
+/**
+ *
+ */
+@ApplicationPath("/")
+@Path("responseCodeEndpoints")
+public class JaxRsResponseCodeTestEndpoints extends Application {
+
+    @Path("200")
+    @GET
+    public Response get200() {
+        return Response.ok("get200").build();
+    }
+
+    @Path("202")
+    @GET
+    public Response get202() {
+        return Response.accepted("get202").build();
+    }
+
+    @Path("400")
+    @GET
+    public Response get400() {
+        return Response.status(BAD_REQUEST)
+                        .entity("get400")
+                        .build();
+    }
+
+    @Path("404")
+    @GET
+    public Response get404() {
+        return Response.status(Status.NOT_FOUND)
+                        .entity("get404")
+                        .build();
+    }
+
+    @Path("500")
+    @GET
+    public Response get500() {
+        return Response.status(Status.INTERNAL_SERVER_ERROR)
+                        .entity("get500")
+                        .build();
+    }
+
+    @Path("307")
+    @GET
+    public Response get307(@Context UriInfo uriInfo) {
+        URI targetUri = uriInfo.getBaseUriBuilder()
+                        .path(JaxRsResponseCodeTestEndpoints.class)
+                        .path(JaxRsResponseCodeTestEndpoints.class, "redirectTarget")
+                        .build();
+        return Response.temporaryRedirect(targetUri).entity("get307").build();
+    }
+
+    @Path("redirectTarget")
+    @GET
+    public Response redirectTarget() {
+        return Response.ok("redirectTarget").build();
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/responses/JaxRsResponseCodeTestServlet.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/responses/JaxRsResponseCodeTestServlet.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.responses;
+
+import static jaxrspropagation.spanexporter.SpanDataMatcher.isSpan;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jaxrspropagation.spanexporter.TestSpans;
+import jaxrspropagation.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+
+/**
+ *
+ */
+@SuppressWarnings("serial")
+@WebServlet("/testJaxRsResponseCode")
+public class JaxRsResponseCodeTestServlet extends FATServlet {
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private TestSpans spans;
+
+    @Test
+    public void test200() {
+        doTestForStatusCode(200);
+    }
+
+    @Test
+    public void test202() {
+        doTestForStatusCode(202);
+    }
+
+    @Test
+    public void test400() {
+        doTestForStatusCode(400);
+    }
+
+    @Test
+    public void test404() {
+        doTestForStatusCode(404);
+    }
+
+    @Test
+    public void test500() {
+        doTestForStatusCode(500);
+    }
+
+    @Test
+    public void testRedirect() {
+        doTestForStatusCode(307);
+    }
+
+    @Test
+    public void testInvalidJaxRsPath() {
+        URI testUri = UriBuilder.fromUri(getBaseUri())
+                        .path("responseCodeEndpoints")
+                        .path("invalid")
+                        .build();
+        Span span = spans.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient()
+                            .target(testUri)
+                            .request()
+                            .build("GET")
+                            .invoke();
+            assertThat(response.getStatus(), equalTo(404));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 404L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        // Assert the span created by HTTP tracing
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 404L)
+                        .withAttribute(SemanticAttributes.HTTP_TARGET, testUri.getPath()));
+    }
+
+    private void doTestForStatusCode(int statusCode) {
+        URI testUri = getTargetUri(statusCode);
+        Span span = spans.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).request()
+                            .build("GET").invoke();
+            assertThat(response.getStatus(), equalTo(statusCode));
+            assertThat(response.readEntity(String.class), equalTo("get" + statusCode));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, (long) statusCode)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString()));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, (long) statusCode));
+
+    }
+
+    private URI getTargetUri(int statusCode) {
+        try {
+            String path = request.getContextPath() + "/responseCodeEndpoints/" + statusCode;
+            URI originalUri = new URI(request.getRequestURL().toString());
+            URI result = new URI(originalUri.getScheme(), originalUri.getAuthority(), path, null, null);
+            return result;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private URI getBaseUri() {
+        try {
+            String path = request.getContextPath();
+            URI originalUri = new URI(request.getRequestURL().toString());
+            URI result = new URI(originalUri.getScheme(), originalUri.getAuthority(), path, null, null);
+            return result;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/spanexporter/AbstractSpanMatcher.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/spanexporter/AbstractSpanMatcher.java
@@ -1,0 +1,384 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.spanexporter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+
+/**
+ * Matcher for some object which represents span data
+ * <p>
+ * This holds the common code for matching a span returned from Jaeger, Zipkin or the InMemorySpanExporter
+ *
+ * @param <SPAN> the span datatype
+ * @param <SELF> the matcher type
+ */
+public abstract class AbstractSpanMatcher<SPAN, SELF extends AbstractSpanMatcher<SPAN, SELF>> extends TypeSafeDiagnosingMatcher<SPAN> {
+
+    private final List<AttributeData<?>> expectedAttributes = new ArrayList<>();
+    private final List<String> expectedEvents = new ArrayList<>();
+    private final List<Class<?>> expectedExceptions = new ArrayList<>();
+    private SpanKind expectedKind = null;
+    private StatusCode expectedStatusCode = null;
+    private String expectedTraceId = null;
+    private String expectedParentSpanId = null;
+    private Boolean expectHasParent = null;
+    private String expectedName = null;
+    private String expectedServiceName = null;
+    private final List<AttributeData<?>> expectedResourceAttributes = new ArrayList<>();
+
+    /**
+     * Explicit constructor.
+     * <p>
+     * It's necessary to manually pass in the span class to avoid hamcrest doing reflection and triggering an AccessControlException
+     *
+     * @param spanClass the span class
+     */
+    protected AbstractSpanMatcher(Class<SPAN> spanClass) {
+        super(spanClass);
+    }
+
+    protected static class AttributeData<T> {
+        public final AttributeKey<T> key;
+        public final T value;
+
+        /**
+         * @param key
+         * @param value
+         */
+        public AttributeData(AttributeKey<T> key, T value) {
+            super();
+            this.key = key;
+            this.value = value;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String toString() {
+            return key + " = " + value;
+        }
+    }
+
+    /*
+     * Describes what we're looking for
+     */
+    @Override
+    public void describeTo(Description desc) {
+        desc.appendText("Span");
+
+        if (expectedName != null) {
+            desc.appendText("\n  with name: ");
+            desc.appendText(expectedName);
+        }
+
+        if (expectedTraceId != null) {
+            desc.appendText("\n  with traceId: ");
+            desc.appendText(expectedTraceId.toString());
+        }
+
+        if (expectedParentSpanId != null) {
+            desc.appendText("\n  with parent: ");
+            desc.appendText(expectedParentSpanId.toString());
+        }
+
+        if (expectHasParent != null) {
+            if (expectHasParent) {
+                desc.appendText("\n with a parent");
+            } else {
+                desc.appendText("\n with no parent");
+            }
+        }
+
+        if (expectedKind != null) {
+            desc.appendText("\n  with kind: ");
+            desc.appendValue(expectedKind);
+        }
+
+        if (expectedStatusCode != null) {
+            desc.appendText("\n  with status code: ");
+            desc.appendValue(expectedStatusCode);
+        }
+
+        if (!expectedAttributes.isEmpty()) {
+            desc.appendText("\n  with attributes: ");
+            desc.appendValue(expectedAttributes);
+        }
+
+        if (!expectedEvents.isEmpty()) {
+            desc.appendText("\n  with event logs: ");
+            desc.appendValue(expectedEvents);
+        }
+
+        if (!expectedExceptions.isEmpty()) {
+            desc.appendText("\n  with exception logs: ");
+            desc.appendValue(expectedExceptions);
+        }
+
+        if (expectedServiceName != null) {
+            desc.appendText("\n  with service name: ");
+            desc.appendText(expectedServiceName);
+        }
+
+        if (!expectedResourceAttributes.isEmpty()) {
+            desc.appendText("\n  with resource attributes: ");
+            desc.appendValue(expectedResourceAttributes);
+        }
+    }
+
+    /*
+     * Returns whether the span matches and adds a description of why it didn't match
+     */
+    @Override
+    protected boolean matchesSafely(SPAN span, Description desc) {
+        // For now, we just use the toString of the span as the description of why it didn't match
+        // We could list out or highlight the elements that didn't match, but usually it's obvious
+        // enough from the toString().
+        desc.appendValue(span);
+
+        if (expectedTraceId != null && !expectedTraceId.equals(getTraceId(span))) {
+            return false;
+        }
+
+        if (expectedName != null && !expectedName.equals(getName(span))) {
+            return false;
+        }
+
+        String parentSpanId = getParentSpanId(span);
+
+        if (expectedParentSpanId != null) {
+            if (!expectedParentSpanId.equals(parentSpanId)) {
+                return false;
+            }
+        }
+
+        if (expectHasParent != null) {
+            boolean hasParent = parentSpanId != null;
+            if (hasParent != expectHasParent) {
+                return false;
+            }
+        }
+
+        if (expectedKind != null) {
+            if (expectedKind != getKind(span)) {
+                return false;
+            }
+        }
+
+        if (expectedStatusCode != null) {
+            if (expectedStatusCode != getStatusCode(span)) {
+                return false;
+            }
+        }
+
+        for (AttributeData<?> attribute : expectedAttributes) {
+            if (!hasAttribute(span, attribute)) {
+                return false;
+            }
+        }
+
+        for (String eventName : expectedEvents) {
+            if (!hasEvent(span, eventName)) {
+                return false;
+            }
+        }
+
+        for (Class<?> exceptionClass : expectedExceptions) {
+            if (!hasException(span, exceptionClass)) {
+                return false;
+            }
+        }
+
+        if (expectedServiceName != null) {
+            if (!expectedServiceName.equals(getServiceName(span))) {
+                return false;
+            }
+        }
+
+        if (!expectedResourceAttributes.isEmpty()) {
+            for (AttributeData<?> attribute : expectedResourceAttributes) {
+                if (!hasResourceAttribute(span, attribute)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    // Abstract methods, to be implemented for each specific span data structure
+    // -------------------------------------------------------------------------
+
+    /**
+     * Gets the traceId of the span
+     *
+     * @param span the span
+     * @return the traceId
+     */
+    abstract protected String getTraceId(SPAN span);
+
+    /**
+     * Gets the name of the span
+     *
+     * @param span the span
+     * @return the span name
+     */
+    abstract protected String getName(SPAN span);
+
+    /**
+     * Gets the span ID of the parent span
+     *
+     * @param span the span
+     * @return the ID of the span's parent, or {@code null} if it has no parent
+     */
+    abstract protected String getParentSpanId(SPAN span);
+
+    /**
+     * Gets the span kind (CLIENT/SERVER/INTERNAL etc.)
+     *
+     * @param span the span
+     * @return the span kind
+     */
+    abstract protected SpanKind getKind(SPAN span);
+
+    /**
+     * Gets the status code (OK, ERROR, UNSET)
+     *
+     * @param span the span
+     * @return the status code
+     */
+    abstract protected StatusCode getStatusCode(SPAN span);
+
+    /**
+     * Returns whether the span has the given attribute with the expected value
+     *
+     * @param <T>   the attribute type
+     * @param span  the span
+     * @param key   the attribute key
+     * @param value the expected value
+     * @return {@code} true if {@code span} has the given attribute and it has the expected value, otherwise {@code false}
+     */
+    abstract protected <T> boolean hasAttribute(SPAN span, AttributeData<T> attributeData);
+
+    /**
+     * Returns whether the span has an event with the given name
+     *
+     * @param span  the span
+     * @param event the event name
+     * @return {@code true} if {@code span} has an event named {@code event}, otherwise {@code false}
+     */
+    abstract protected boolean hasEvent(SPAN span, String event);
+
+    /**
+     * Returns whehter the span has an exception event with the given name
+     *
+     * @param span           the span
+     * @param exceptionClass the expected exception class
+     * @return {@code true} if {@code span} has an event for an exception thrown of type {@code exceptionClass}, otherwise {@code false}
+     */
+    abstract protected boolean hasException(SPAN span, Class<?> exceptionClass);
+
+    /**
+     * Gets the {@link ResourceAttributes#SERVICE_NAME} from the span
+     *
+     * @param span the span
+     * @return the service name
+     */
+    abstract protected String getServiceName(SPAN span);
+
+    /**
+     * Returns whether the span has the given resource attribute with the expected value
+     *
+     * @param <T>   the resource attribute type
+     * @param span  the span
+     * @param key   the resource attribute key
+     * @param value the expected value
+     * @return {@code} true if {@code span} has the given resource attribute and it has the expected value, otherwise {@code false}
+     */
+    abstract protected <T> boolean hasResourceAttribute(SPAN span, AttributeData<T> attributeData);
+
+    /**
+     * Returns {@code this}. Needed for generics.
+     *
+     * @return {@code this}
+     */
+    abstract protected SELF self();
+
+    // Common configuration methods
+    // ----------------------------
+
+    public SELF withEventLog(String name) {
+        expectedEvents.add(name);
+        return self();
+    }
+
+    public SELF withExceptionLog(Class<?> exceptionClass) {
+        expectedExceptions.add(exceptionClass);
+        return self();
+    }
+
+    public SELF withTraceId(String traceId) {
+        expectedTraceId = traceId;
+        return self();
+    }
+
+    public SELF withName(String name) {
+        expectedName = name;
+        return self();
+    }
+
+    public SELF withNoParent() {
+        expectHasParent = false;
+        return self();
+    }
+
+    public SELF withParent() {
+        expectHasParent = true;
+        return self();
+    }
+
+    public SELF withParentSpanId(String spanId) {
+        expectedParentSpanId = spanId;
+        return self();
+    }
+
+    public SELF withKind(SpanKind kind) {
+        expectedKind = kind;
+        return self();
+    }
+
+    public <T> SELF withAttribute(AttributeKey<T> key, T value) {
+        expectedAttributes.add(new AttributeData<T>(key, value));
+        return self();
+    }
+
+    public SELF withStatus(StatusCode status) {
+        expectedStatusCode = status;
+        return self();
+    }
+
+    public SELF withServiceName(String serviceName) {
+        expectedServiceName = serviceName;
+        return self();
+    }
+
+    public <T> SELF withResourceAttribute(AttributeKey<T> key, T value) {
+        expectedResourceAttributes.add(new AttributeData<T>(key, value));
+        return self();
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/spanexporter/InMemorySpanExporter.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/spanexporter/InMemorySpanExporter.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2016-2023 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+// Original file source: https://github.com/eclipse/microprofile-telemetry/blob/main/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/exporter/InMemorySpanExporter.java
+
+package jaxrspropagation.spanexporter;
+
+import static java.util.Comparator.comparingLong;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.fail;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BooleanSupplier;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class InMemorySpanExporter implements SpanExporter {
+    private static final Logger LOGGER = Logger.getLogger(InMemorySpanExporter.class.getName());
+
+    private boolean isStopped = false;
+    // Static to allow multi-app testing
+    private static final List<SpanData> finishedSpanItems = new CopyOnWriteArrayList<>();
+    private static final Set<String> failedTestTraceIds = Collections.synchronizedSet(new HashSet<>());
+
+    /**
+     * Retrieve a list of finished span items with the same traceId as {@code span}
+     * <p>
+     * Asserts that the expected number of spans are received within the timeout
+     *
+     * @param spanCount the number of traces to wait for before returning
+     * @param span      the span with the traceId to look for
+     * @return the list of spans
+     */
+    public List<SpanData> getFinishedSpanItems(int spanCount, Span span) {
+        return getFinishedSpanItems(spanCount, span.getSpanContext().getTraceId());
+    }
+
+    /**
+     * Retrieve a list of finished span items for a given traceId
+     * <p>
+     * Asserts that the expected number of spans are received within the timeout
+     *
+     * @param spanCount the number of traces to wait for before returning
+     * @param traceId   the traceId to look for
+     * @return the list of spans
+     */
+    public List<SpanData> getFinishedSpanItems(int spanCount, String traceId) {
+        // Wait for the right number of spans to arrive
+        waitFor(Duration.ofSeconds(12), () -> getSpansForTraceId(traceId).size() >= spanCount);
+
+        // Actually get the spans and check there are the right number
+        List<SpanData> spans = getSpansForTraceId(traceId);
+        LOGGER.info("Retrieved traces for " + traceId + ", expected: " + spanCount + " found: " + spans.size());
+
+        // If we do not have the right number, report the traceId as belonging to a failed test and
+        // create a good failure message
+        if (spans.size() != spanCount) {
+            addFailedTestTraceId(traceId);
+            String foundSpans = spans.stream().map(Object::toString).collect(Collectors.joining("\n"));
+            fail("Expected " + spanCount + " traces but found " + spans.size() + "\n" + foundSpans);
+        }
+
+        // Remove the found spans from the list of finished spans so that we can log any unclaimed spans at shutdown
+        finishedSpanItems.removeAll(spans);
+
+        // Sort and return the spans
+        return sortByParentage(spans);
+    }
+
+    private List<SpanData> getSpansForTraceId(String traceId) {
+        return finishedSpanItems.stream()
+                        .filter(s -> s.getTraceId().equals(traceId))
+                        .collect(toList());
+    }
+
+    /**
+     * Wait up to {@code timeout} for {@code condition} to return {@code true}
+     * <p>
+     * This method will not throw an exception if {@code condition} never returns {@code true}. Callers should assert the condition after this method returns and create an
+     * appropriate error message.
+     *
+     * @param timeout   the timeout to wait
+     * @param condition the condition to check
+     */
+    private static void waitFor(Duration timeout, BooleanSupplier condition) {
+        long timeoutNanos = timeout.toNanos();
+        long startNanos = System.nanoTime();
+        while ((System.nanoTime() - startNanos) < timeoutNanos) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * Create a new list which contains the contents of {@code spans} sorted so that all spans appear before their children in the list
+     *
+     * @param spans a list of spans
+     * @return a new list of spans sorted by parentage
+     */
+    private List<SpanData> sortByParentage(List<SpanData> spans) {
+        Set<String> allSpanIds = spans.stream().map(SpanData::getSpanId).collect(toSet());
+
+        ArrayList<SpanData> result = new ArrayList<>();
+
+        // Start with all root spans and spans whose parents are not present in the list
+        // For each, add it to the list then recursively add its children
+        spans.stream().filter(s -> !s.getParentSpanContext().isValid() || !allSpanIds.contains(s.getParentSpanId()))
+                        .sorted((a, b) -> Long.compare(a.getStartEpochNanos(), b.getStartEpochNanos()))
+                        .forEach(s -> {
+                            result.add(s);
+                            addChildren(s, spans, result);
+                        });
+
+        return result;
+    }
+
+    private void addChildren(SpanData parent, List<SpanData> source, List<SpanData> destination) {
+        source.stream().filter(s -> parent.getSpanId().equals(s.getParentSpanId()))
+                        .sorted((a, b) -> Long.compare(a.getStartEpochNanos(), b.getStartEpochNanos()))
+                        .forEach(s -> {
+                            destination.add(s);
+                            addChildren(s, source, destination);
+                        });
+    }
+
+    /**
+     * Register that a traceId belongs to a test which has failed
+     * <p>
+     * If a test fails, we can expect that it may not claim all of its spans. When we check for remaining spans at shutdown, we will ignore any with this traceId since there's no
+     * point logging a failure twice.
+     *
+     * @param traceId the traceId associated with a failed test
+     */
+    public void addFailedTestTraceId(String traceId) {
+        failedTestTraceIds.add(traceId);
+    }
+
+    /**
+     * Careful when retrieving the list of finished spans. There is a chance when the response is already sent to the
+     * client and the server still writing the end of the spans. This means that a response is available to assert from
+     * the test side but not all spans may be available yet. For this reason, this method requires the number of
+     * expected spans.
+     *
+     * @deprecated Use {@link #getFinishedSpanItems(int, Span)} or {@link #getFinishedSpanItems(int, String)} instead.
+     *             They allow us to avoid mixing up spans from different tests without having to sleep between tests.
+     */
+    @Deprecated
+    public List<SpanData> getFinishedSpanItems(int spanCount) {
+        assertSpanCount(spanCount);
+        List<SpanData> results = finishedSpanItems.stream().sorted(comparingLong(SpanData::getStartEpochNanos))
+                        .collect(Collectors.toList());
+        finishedSpanItems.removeAll(results);
+        return results;
+    }
+
+    @Deprecated
+    public void assertSpanCount(int spanCount) {
+        int retries = 120;
+        while (retries > 0 && finishedSpanItems.size() != spanCount) {
+            try {
+                retries--;
+                Thread.sleep(100);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        Assert.assertEquals(spanCount, finishedSpanItems.size());
+    }
+
+    /**
+     * @deprecated No longer any need to reset. Any left over spans will now be ignored by {@code getFinishedSpanItems} and reported at app shutdown.
+     */
+    @Deprecated
+    public void reset() {
+        LOGGER.info("reset method called");
+        finishedSpanItems.clear();
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> spans) {
+        LOGGER.info("export method called, exporter = " + System.identityHashCode(this) + ", collection: " + System.identityHashCode(finishedSpanItems));
+        if (isStopped) {
+            return CompletableResultCode.ofFailure();
+        }
+
+        List<SpanData> lSpans = new ArrayList<SpanData>(spans);
+        Iterator<SpanData> iter = lSpans.listIterator();
+        while (iter.hasNext()) {
+            SpanData span = iter.next();
+            /*
+             * Remove readspans and FAT servlet spans.
+             *
+             * REGEX breakdown:
+             * Match start of line.
+             * Match 0 or 1 of the string "GET " (note whitespace) using a non-capturing group.
+             * Match a literal "/"
+             * Match anything
+             * Match a literal /
+             * match the string "test"
+             * Match anything until the end of the line.
+             */
+            if (span.getName().contains("readspans") || span.getName().matches("^(?:GET )?/.*/test.*$")) {
+                iter.remove();
+            }
+        }
+
+        if (!lSpans.isEmpty()) { //this will be empty after a call to readSpans
+            StringBuilder sb = new StringBuilder();
+            sb.append("----------------- list of spans (filtered but unordered, ordering will be based on parentage) ---------- ");
+            for (SpanData spanData : lSpans) {
+                sb.append(System.lineSeparator() + spanData.toString() + System.lineSeparator());
+            }
+            LOGGER.info(sb.toString());
+        }
+
+        finishedSpanItems.addAll(lSpans);
+        LOGGER.info("There are now " + finishedSpanItems.size() + " items");
+
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        LOGGER.info("shutdown method called");
+
+        // Sleep a while to allow any async work which may still be going on to export spans
+        try {
+            Thread.sleep(Duration.ofSeconds(3).toMillis());
+        } catch (InterruptedException e) {
+            // Ignore here, still want to do the check
+            LOGGER.severe("TEST9999E: Shutdown check for unclaimed spans interrupted");
+            e.printStackTrace();
+        }
+
+        // Search for and report any exported spans which were not retrieved by a test
+        List<SpanData> unclaimedSpans = finishedSpanItems.stream()
+                        .filter(s -> !failedTestTraceIds.contains(s.getTraceId()))
+                        .collect(Collectors.toList());
+
+        if (!unclaimedSpans.isEmpty()) {
+            String unclaimedNames = unclaimedSpans.stream()
+                            .map(SpanData::getName)
+                            .collect(Collectors.joining(", "));
+            LOGGER.severe("TEST9999E: Found unexpected spans at shutdown, full data in log: " + unclaimedNames);
+            for (SpanData span : unclaimedSpans) {
+                LOGGER.severe(span.toString());
+            }
+        }
+
+        isStopped = true;
+        return CompletableResultCode.ofSuccess();
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/spanexporter/InMemorySpanExporterProvider.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/spanexporter/InMemorySpanExporterProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016-2022 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package jaxrspropagation.spanexporter;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import jakarta.enterprise.inject.spi.CDI;
+
+public class InMemorySpanExporterProvider implements ConfigurableSpanExporterProvider {
+    @Override
+    public SpanExporter createExporter(final ConfigProperties config) {
+        return CDI.current().select(InMemorySpanExporter.class).get();
+    }
+
+    @Override
+    public String getName() {
+        return "in-memory";
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/spanexporter/SpanDataMatcher.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/spanexporter/SpanDataMatcher.java
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.spanexporter;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
+/**
+ * A hamcrest matcher for matching {@link SpanData} instances
+ * <p>
+ * Example usage:
+ *
+ * <pre>
+ * assertThat(span, isSpan().withName("foo").withKind(SERVER));
+ *
+ * assertThat(span, hasName("foo"));
+ * </pre>
+ */
+public class SpanDataMatcher extends AbstractSpanMatcher<SpanData, SpanDataMatcher> {
+
+    protected SpanDataMatcher() {
+        super(SpanData.class);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected String getTraceId(SpanData span) {
+        return span.getTraceId();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected String getName(SpanData span) {
+        return span.getName();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected String getParentSpanId(SpanData span) {
+        String spanId = span.getParentSpanId();
+        if (SpanId.isValid(spanId)) {
+            return spanId;
+        } else {
+            return null;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected SpanKind getKind(SpanData span) {
+        return span.getKind();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected StatusCode getStatusCode(SpanData span) {
+        return span.getStatus().getStatusCode();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected <T> boolean hasAttribute(SpanData span, AttributeData<T> attributeData) {
+        return attributeData.value.equals(span.getAttributes().get(attributeData.key));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected boolean hasEvent(SpanData span, String event) {
+        for (EventData eventData : span.getEvents()) {
+            if (event.equals(eventData.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected boolean hasException(SpanData span, Class<?> exceptionClass) {
+        String expectedClassName = exceptionClass.getCanonicalName();
+
+        for (EventData eventData : span.getEvents()) {
+            if (SemanticAttributes.EXCEPTION_EVENT_NAME.equals(eventData.getName())) {
+                String exceptionClassName = eventData.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE);
+                if (expectedClassName.equals(exceptionClassName)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected String getServiceName(SpanData span) {
+        return span.getResource().getAttribute(ResourceAttributes.SERVICE_NAME);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected <T> boolean hasResourceAttribute(SpanData span, AttributeData<T> attributeData) {
+        return attributeData.value.equals(span.getResource().getAttribute(attributeData.key));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected SpanDataMatcher self() {
+        return this;
+    }
+
+    // Static construction methods
+    // ---------------------------
+
+    public static SpanDataMatcher isSpan() {
+        return new SpanDataMatcher();
+    }
+
+    public static SpanDataMatcher hasEventLog(String name) {
+        return isSpan().withEventLog(name);
+    }
+
+    public static SpanDataMatcher hasExceptionLog(Class<?> exceptionClass) {
+        return isSpan().withExceptionLog(exceptionClass);
+    }
+
+    public static SpanDataMatcher hasTraceId(String traceId) {
+        return isSpan().withTraceId(traceId);
+    }
+
+    public static SpanDataMatcher hasName(String name) {
+        return isSpan().withName(name);
+    }
+
+    public static SpanDataMatcher hasNoParent() {
+        return isSpan().withNoParent();
+    }
+
+    public static SpanDataMatcher hasParent() {
+        return isSpan().withParent();
+    }
+
+    public static SpanDataMatcher hasParentSpanId(String spanId) {
+        return isSpan().withParentSpanId(spanId);
+    }
+
+    public static SpanDataMatcher hasKind(SpanKind kind) {
+        return isSpan().withKind(kind);
+    }
+
+    public static <T> SpanDataMatcher hasAttribute(AttributeKey<T> key, T value) {
+        return isSpan().withAttribute(key, value);
+    }
+
+    public static SpanDataMatcher hasStatus(StatusCode status) {
+        return isSpan().withStatus(status);
+    }
+
+    public static SpanDataMatcher hasServiceName(String serviceName) {
+        return isSpan().withServiceName(serviceName);
+    }
+
+    public static <T> SpanDataMatcher hasResourceAttribute(AttributeKey<T> key, T value) {
+        return isSpan().withResourceAttribute(key, value);
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/spanexporter/TestSpans.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/spanexporter/TestSpans.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.spanexporter;
+
+import static jaxrspropagation.spanexporter.SpanDataMatcher.hasNoParent;
+import static jaxrspropagation.spanexporter.SpanDataMatcher.hasParentSpanId;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import jaxrspropagation.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Utility methods for working with spans in tests
+ */
+@ApplicationScoped
+public class TestSpans {
+
+    private static final Logger LOGGER = Logger.getLogger(TestSpans.class.getName());
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private Tracer tracer;
+
+    /**
+     * Asserts that the first span in the list has no parent and that every other span is a child of the span preceding it in the list.
+     *
+     * @param spans the list of spans
+     */
+    public static void assertLinearParentage(List<SpanData> spans) {
+        if (spans.isEmpty()) {
+            return;
+        }
+
+        SpanData first = spans.get(0);
+        assertThat("Span 1", first, hasNoParent());
+
+        SpanData prev = first;
+        for (int i = 1; i < spans.size(); i++) {
+            SpanData current = spans.get(i);
+            assertThat("Span " + i, current, hasParentSpanId(prev.getSpanId()));
+            prev = current;
+        }
+    }
+
+    /**
+     * Creates a test span, makes it current, runs an action and ends the span
+     * <p>
+     * If {@code runnable} throws an exception or error, we assume that a test failure has occurred and instruct {@link InMemorySpanExporter} to ignore stray spans with the same
+     * traceId as the test span.
+     * <p>
+     * This method is intended to remove common boilerplate code in tests which use FATServlet
+     *
+     * @param runnable the action to run
+     * @return the test span
+     * @throws Exception if {@code runnable} throws an exception
+     */
+    public Span withTestSpan(ThrowingRunnable runnable) {
+        String spanName = "testSpan-" + request.getRequestURI();
+        Span span = tracer.spanBuilder(spanName)
+                        .setNoParent()
+                        .startSpan();
+
+        LOGGER.info("Created test span. SpanId: " + span.getSpanContext().getSpanId() + " TraceId: " + span.getSpanContext().getTraceId() + " Name: " + spanName);
+
+        try {
+            Context contextBefore = Context.current();
+            try (Scope scope = span.makeCurrent()) {
+                runnable.run();
+            } finally {
+                span.end();
+            }
+            assertEquals("Context Leak: initial context was not restored after test span", contextBefore, Context.current());
+        } catch (RuntimeException e) {
+            exporter.addFailedTestTraceId(span.getSpanContext().getTraceId());
+            throw e;
+        } catch (Exception e) {
+            // Wrap non-runtime exceptions
+            exporter.addFailedTestTraceId(span.getSpanContext().getTraceId());
+            throw new RuntimeException(e);
+        } catch (Throwable e) {
+            exporter.addFailedTestTraceId(span.getSpanContext().getTraceId());
+            throw e;
+        }
+
+        return span;
+    }
+
+    @FunctionalInterface
+    public static interface ThrowingRunnable {
+        public void run() throws Exception;
+    }
+
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/transports/B3MultiPropagationTestServlet.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/transports/B3MultiPropagationTestServlet.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.transports;
+
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_KEY;
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_METADATA_ATTR;
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_VALUE_ATTR;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jaxrspropagation.common.PropagationHeaderClient;
+import jaxrspropagation.common.PropagationHeaderEndpoint;
+import jaxrspropagation.spanexporter.TestSpans;
+import jaxrspropagation.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+
+@SuppressWarnings("serial")
+@WebServlet("/testB3MultiPropagation")
+public class B3MultiPropagationTestServlet extends FATServlet {
+
+    private static final String BAGGAGE_VALUE = "test.baggage.value";
+    private static final String BAGGAGE_METADATA = "test.baggage.metadata";
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter spanExporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private TestSpans testSpans;
+
+    @Test
+    public void testB3Propagation() throws URISyntaxException {
+        Span span = testSpans.withTestSpan(() -> {
+            Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+            try (Scope s = baggage.makeCurrent()) {
+                PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+                client.get();
+            }
+        });
+
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);
+
+        // Assert correct parent-child links
+        // Shows that propagation occurred
+        TestSpans.assertLinearParentage(spanData);
+
+        SpanData serverSpan = spanData.get(2);
+
+        // B3 does not support baggage, so baggage should not be propagated
+        assertNull("baggage value propagated", serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        assertNull("baggage metadata propagated", serverSpan.getAttributes().get(BAGGAGE_METADATA_ATTR));
+
+        // Assert that the expected headers were used
+        assertThat(serverSpan.getAttributes().get(PropagationHeaderEndpoint.PROPAGATION_HEADERS_ATTR),
+                   containsInAnyOrder("X-B3-TraceId", "X-B3-SpanId", "X-B3-Sampled"));
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/transports/B3PropagationTestServlet.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/transports/B3PropagationTestServlet.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.transports;
+
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_KEY;
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_METADATA_ATTR;
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_VALUE_ATTR;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jaxrspropagation.common.PropagationHeaderClient;
+import jaxrspropagation.common.PropagationHeaderEndpoint;
+import jaxrspropagation.spanexporter.TestSpans;
+import jaxrspropagation.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+
+@SuppressWarnings("serial")
+@WebServlet("/testB3Propagation")
+public class B3PropagationTestServlet extends FATServlet {
+
+    private static final String BAGGAGE_VALUE = "test.baggage.value";
+    private static final String BAGGAGE_METADATA = "test.baggage.metadata";
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter spanExporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private TestSpans testSpans;
+
+    @Test
+    public void testB3Propagation() throws URISyntaxException {
+        Span span = testSpans.withTestSpan(() -> {
+            Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+            try (Scope s = baggage.makeCurrent()) {
+                PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+                client.get();
+            }
+        });
+
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);
+
+        // Assert correct parent-child links
+        // Shows that propagation occurred
+        TestSpans.assertLinearParentage(spanData);
+
+        SpanData serverSpan = spanData.get(2);
+
+        // B3 does not support baggage, so baggage should not be propagated
+        assertNull("baggage value propagated", serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        assertNull("baggage metadata propagated", serverSpan.getAttributes().get(BAGGAGE_METADATA_ATTR));
+
+        // Assert that the expected headers were used
+        assertThat(serverSpan.getAttributes().get(PropagationHeaderEndpoint.PROPAGATION_HEADERS_ATTR), containsInAnyOrder("b3"));
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/transports/JaegerPropagationTestServlet.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/transports/JaegerPropagationTestServlet.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.transports;
+
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_KEY;
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_METADATA_ATTR;
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_VALUE_ATTR;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jaxrspropagation.common.PropagationHeaderClient;
+import jaxrspropagation.common.PropagationHeaderEndpoint;
+import jaxrspropagation.spanexporter.TestSpans;
+import jaxrspropagation.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+
+@SuppressWarnings("serial")
+@WebServlet("/testJaegerPropagation")
+public class JaegerPropagationTestServlet extends FATServlet {
+
+    private static final String BAGGAGE_VALUE = "test.baggage.value";
+    private static final String BAGGAGE_METADATA = "test.baggage.metadata";
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter spanExporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private TestSpans testSpans;
+
+    @Test
+    public void testJaegerPropagation() throws URISyntaxException {
+        Span span = testSpans.withTestSpan(() -> {
+            Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+            try (Scope s = baggage.makeCurrent()) {
+                PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+                client.get();
+            }
+        });
+
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);
+
+        // Assert correct parent-child links
+        // Shows that propagation occurred
+        TestSpans.assertLinearParentage(spanData);
+
+        SpanData serverSpan = spanData.get(2);
+
+        // Assert baggage is propagated
+        assertEquals("baggage value propagated", BAGGAGE_VALUE, serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        // Jaeger does not propagate baggage metadata, so we get back the result of BaggageEntryMetadata.empty().getValue() which is an empty string.
+        assertEquals("baggage metadata propagated", "", serverSpan.getAttributes().get(BAGGAGE_METADATA_ATTR));
+
+        // Assert that the expected headers were used
+        assertThat(serverSpan.getAttributes().get(PropagationHeaderEndpoint.PROPAGATION_HEADERS_ATTR), containsInAnyOrder("uber-trace-id", "uberctx-" + BAGGAGE_KEY));
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/transports/W3CTraceBaggagePropagationTestServlet.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/transports/W3CTraceBaggagePropagationTestServlet.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.transports;
+
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_KEY;
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_METADATA_ATTR;
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_VALUE_ATTR;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jaxrspropagation.common.PropagationHeaderClient;
+import jaxrspropagation.common.PropagationHeaderEndpoint;
+import jaxrspropagation.spanexporter.TestSpans;
+import jaxrspropagation.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+
+@SuppressWarnings("serial")
+@WebServlet("/testW3cTraceBaggagePropagation")
+public class W3CTraceBaggagePropagationTestServlet extends FATServlet {
+
+    private static final String BAGGAGE_VALUE = "test.baggage.value";
+    private static final String BAGGAGE_METADATA = "test.baggage.metadata";
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter spanExporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private TestSpans testSpans;
+
+    @Test
+    public void testW3cTraceBaggagePropagation() throws URISyntaxException {
+        Span span = testSpans.withTestSpan(() -> {
+            Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+            try (Scope s = baggage.makeCurrent()) {
+                PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+                client.get();
+            }
+        });
+
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);
+
+        // Assert correct parent-child links
+        // Shows that propagation occurred
+        TestSpans.assertLinearParentage(spanData);
+
+        SpanData serverSpan = spanData.get(2);
+
+        // Assert baggage is propagated
+        assertEquals("baggage value propagated", BAGGAGE_VALUE, serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        assertEquals("baggage metadata propagated", BAGGAGE_METADATA, serverSpan.getAttributes().get(BAGGAGE_METADATA_ATTR));
+
+        // Assert that the expected headers were used
+        assertThat(serverSpan.getAttributes().get(PropagationHeaderEndpoint.PROPAGATION_HEADERS_ATTR), containsInAnyOrder("traceparent", "baggage"));
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/transports/W3CTracePropagationTestServlet.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/jaxrspropagation/src/jaxrspropagation/transports/W3CTracePropagationTestServlet.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package jaxrspropagation.transports;
+
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_KEY;
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_METADATA_ATTR;
+import static jaxrspropagation.common.PropagationHeaderEndpoint.BAGGAGE_VALUE_ATTR;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jaxrspropagation.common.PropagationHeaderClient;
+import jaxrspropagation.common.PropagationHeaderEndpoint;
+import jaxrspropagation.spanexporter.TestSpans;
+import jaxrspropagation.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+
+@SuppressWarnings("serial")
+@WebServlet("/testW3cTracePropagation")
+public class W3CTracePropagationTestServlet extends FATServlet {
+
+    private static final String BAGGAGE_VALUE = "test.baggage.value";
+    private static final String BAGGAGE_METADATA = "test.baggage.metadata";
+
+    @Inject
+    private Tracer tracer;
+
+    @Inject
+    private InMemorySpanExporter spanExporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private TestSpans testSpans;
+
+    @Test
+    public void testW3cTracePropagation() throws URISyntaxException {
+        Span span = testSpans.withTestSpan(() -> {
+            Baggage baggage = Baggage.builder().put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+            try (Scope s = baggage.makeCurrent()) {
+                PropagationHeaderClient client = RestClientBuilder.newBuilder().baseUri(PropagationHeaderEndpoint.getBaseUri(request)).build(PropagationHeaderClient.class);
+                client.get();
+            }
+        });
+
+        List<SpanData> spanData = spanExporter.getFinishedSpanItems(3, span);
+
+        // Assert correct parent-child links
+        // Shows that propagation occurred
+        TestSpans.assertLinearParentage(spanData);
+
+        SpanData serverSpan = spanData.get(2);
+
+        // Baggage is not propagated if only tracecontext is enabled
+        assertNull("baggage value propagated", serverSpan.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        assertNull("baggage metadata propagated", serverSpan.getAttributes().get(BAGGAGE_METADATA_ATTR));
+
+        // Assert that the expected headers were used
+        assertThat(serverSpan.getAttributes().get(PropagationHeaderEndpoint.PROPAGATION_HEADERS_ATTR), containsInAnyOrder("traceparent"));
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
@@ -49,6 +49,8 @@ import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.jaegertracing.api_v2.Model.Span;
@@ -57,9 +59,6 @@ import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.TestUtils;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
-
-import componenttest.rules.repeater.MicroProfileActions;
-import componenttest.rules.repeater.RepeatTests;
 
 /**
  * Test all the ways the agent can be configured
@@ -76,10 +75,10 @@ public class AgentConfigTest {
 
     @ClassRule
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-    
+
     @ClassRule
     public static RepeatTests r = MicroProfileActions.repeat("spanTestServer", MicroProfileActions.MP61, MicroProfileActions.MP60);
-    
+
     public static JaegerQueryClient client;
 
     @BeforeClass
@@ -227,7 +226,7 @@ public class AgentConfigTest {
 
         List<Span> spans = client.waitForSpansForTraceId(traceId, hasSize(1));
 
-        assertThat(spans.get(0), hasName("/agentTest/"));
+        assertThat(spans.get(0), hasName("/agentTest"));
 
         // We should still be able to manually create spans with the API
         String traceId2 = new HttpRequest(server, "/agentTest/manualSpans").run(String.class);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/TelemetryAgent/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/TelemetryAgent/jvm.options
@@ -1,4 +1,2 @@
 -javaagent:opentelemetry-javaagent.jar
 #-Dotel.javaagent.debug=true
-# beta fence for HTTP tracing
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/crossFeatureOpenTracingServer/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/crossFeatureOpenTracingServer/jvm.options
@@ -1,2 +1,0 @@
-# beta fence for HTTP tracing
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/crossFeatureOpenTracingZipkinServer/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/crossFeatureOpenTracingZipkinServer/jvm.options
@@ -1,2 +1,0 @@
-# beta fence for HTTP tracing
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/crossFeatureTelemetryServer/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/crossFeatureTelemetryServer/jvm.options
@@ -1,2 +1,0 @@
-# beta fence for HTTP tracing
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/spanTestServer/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/publish/servers/spanTestServer/jvm.options
@@ -1,2 +1,0 @@
-# beta fence for HTTP tracing
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
@@ -82,7 +82,7 @@ Private-Package: io.openliberty.microprofile.telemetry10.internal.helper,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.kernel.boot.core;version=latest,\
-	io.openliberty.microprofile.telemetry.internal.common;version=latest
+	io.openliberty.microprofile.telemetry.internal.common;version=latest,\
 	com.ibm.ws.kernel.boot.common;version=latest
 
 WS-TraceGroup: TELEMETRY

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/bnd.bnd
@@ -83,5 +83,6 @@ Private-Package: io.openliberty.microprofile.telemetry10.internal.helper,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.kernel.boot.core;version=latest,\
 	io.openliberty.microprofile.telemetry.internal.common;version=latest
+	com.ibm.ws.kernel.boot.common;version=latest
 
 WS-TraceGroup: TELEMETRY

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryClientFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryClientFilter.java
@@ -18,10 +18,12 @@ import static java.util.Collections.singletonList;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 import io.openliberty.microprofile.telemetry.internal.common.AgentDetection;
 import io.openliberty.microprofile.telemetry.internal.common.info.OpenTelemetryInfo;
 import io.openliberty.microprofile.telemetry.internal.common.rest.AbstractTelemetryClientFilter;
@@ -49,7 +51,9 @@ public class TelemetryClientFilter extends AbstractTelemetryClientFilter impleme
 
     private static final TraceComponent tc = Tr.register(TelemetryClientFilter.class);
 
-    private final Instrumenter<ClientRequestContext, ClientResponseContext> instrumenter;
+    private Instrumenter<ClientRequestContext, ClientResponseContext> instrumenter;
+    private volatile boolean lazyCreate = false;
+    private final AtomicReference<Instrumenter<ClientRequestContext, ClientResponseContext>> lazyInstrumenter = new AtomicReference<>();
 
     private final String configString = "otel.span.client.";
 
@@ -57,40 +61,65 @@ public class TelemetryClientFilter extends AbstractTelemetryClientFilter impleme
     private static final HttpClientAttributesGetterImpl HTTP_CLIENT_ATTRIBUTES_GETTER = new HttpClientAttributesGetterImpl();
 
     TelemetryClientFilter() {
+        if (instrumenter == null) {
+            if (!CheckpointPhase.getPhase().restored()) {
+                lazyCreate = true;
+            } else {
+                instrumenter = createInstrumenter();
+            }
+        }
+    }
+    
+    private Instrumenter<ClientRequestContext, ClientResponseContext> getInstrumenter() {
+        if (instrumenter != null) {
+            return instrumenter;
+        }
+        if (lazyCreate) {
+            instrumenter = lazyInstrumenter.updateAndGet((i) -> {
+                if (i == null) {
+                    return createInstrumenter();
+                } else {
+                    return i;
+                }
+            });
+        }
+        return instrumenter;
+    }
+    
+    private Instrumenter<ClientRequestContext, ClientResponseContext> createInstrumenter() {
         OpenTelemetryInfo openTelemetryInfo = OpenTelemetryAccessor.getOpenTelemetryInfo();
-        Instrumenter<ClientRequestContext, ClientResponseContext> instrumenter = null;
         try {
             if (openTelemetryInfo.getEnabled() && !AgentDetection.isAgentActive()) {
                 InstrumenterBuilder<ClientRequestContext, ClientResponseContext> builder = Instrumenter.builder(openTelemetryInfo.getOpenTelemetry(),
                                                                                                                 "Client filter",
                                                                                                                 HttpSpanNameExtractor.create(HTTP_CLIENT_ATTRIBUTES_GETTER));
 
-                instrumenter = builder
+                Instrumenter<ClientRequestContext, ClientResponseContext> result = builder
                                 .setSpanStatusExtractor(HttpSpanStatusExtractor.create(HTTP_CLIENT_ATTRIBUTES_GETTER))
                                 .addAttributesExtractor(HttpClientAttributesExtractor.create(HTTP_CLIENT_ATTRIBUTES_GETTER))
                                 .addAttributesExtractor(NetClientAttributesExtractor.create(NET_CLIENT_ATTRIBUTES_GETTER))
                                 .buildClientInstrumenter(new ClientRequestContextTextMapSetter());
+                return result;
             } else {
-                instrumenter = null;
+                return null;
             }
         } catch (Exception e) {
-            instrumenter = null;
             Tr.error(tc, Tr.formatMessage(tc, "CWMOT5002.telemetry.error", e));
-        } finally {
-            this.instrumenter = instrumenter;
-        }
+            return null;
+        } 
     }
 
     @Override
     public void filter(final ClientRequestContext request) {
-        if (instrumenter != null) {
+        Instrumenter<ClientRequestContext, ClientResponseContext> currentInstrumenter = getInstrumenter();
+        if (currentInstrumenter != null) {
             AccessController.doPrivileged(new PrivilegedAction<Void>() {
                 @Override
                 public Void run() {
                     try {
                         Context parentContext = Context.current();
-                        if (instrumenter.shouldStart(parentContext, request)) {
-                            Context spanContext = instrumenter.start(parentContext, request);
+                        if (currentInstrumenter.shouldStart(parentContext, request)) {
+                            Context spanContext = currentInstrumenter.start(parentContext, request);
                             request.setProperty(configString + "context", spanContext);
                             request.setProperty(configString + "parentContext", parentContext);
                         }
@@ -105,7 +134,8 @@ public class TelemetryClientFilter extends AbstractTelemetryClientFilter impleme
 
     @Override
     public void filter(final ClientRequestContext request, final ClientResponseContext response) {
-        if (instrumenter != null) {
+        Instrumenter<ClientRequestContext, ClientResponseContext> currentInstrumenter = getInstrumenter();
+        if (currentInstrumenter != null) {
             AccessController.doPrivileged(new PrivilegedAction<Void>() {
                 @Override
                 public Void run() {
@@ -115,7 +145,7 @@ public class TelemetryClientFilter extends AbstractTelemetryClientFilter impleme
                             return null;
                         }
                         try {
-                            instrumenter.end(spanContext, request, response, null);
+                            currentInstrumenter.end(spanContext, request, response, null);
                         } finally {
                             request.removeProperty(configString + "context");
                             request.removeProperty(configString + "parentContext");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryClientFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryClientFilter.java
@@ -74,13 +74,13 @@ public class TelemetryClientFilter extends AbstractTelemetryClientFilter impleme
         }
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
-                if (i == null) {
-                    lazyCreate = false;
+                if (i == null) {                    
                     return createInstrumenter();
                 } else {
                     return i;
                 }
             });
+            lazyCreate = false;
         }
         return instrumenter;
     }
@@ -165,11 +165,10 @@ public class TelemetryClientFilter extends AbstractTelemetryClientFilter impleme
      */
     @Override
     public boolean isEnabled() {
-        if (instrumenter != null || !CheckpointPhase.getPhase().restored()) {
+        if (!CheckpointPhase.getPhase().restored()) {
             return true;
         }         
-        instrumenter = getInstrumenter();
-        return instrumenter != null;                   
+        return getInstrumenter() != null;                     
     }
 
     private static class ClientRequestContextTextMapSetter implements TextMapSetter<ClientRequestContext> {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryClientFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryClientFilter.java
@@ -61,12 +61,10 @@ public class TelemetryClientFilter extends AbstractTelemetryClientFilter impleme
     private static final HttpClientAttributesGetterImpl HTTP_CLIENT_ATTRIBUTES_GETTER = new HttpClientAttributesGetterImpl();
 
     TelemetryClientFilter() {
-        if (instrumenter == null) {
-            if (!CheckpointPhase.getPhase().restored()) {
-                lazyCreate = true;
-            } else {
-                instrumenter = createInstrumenter();
-            }
+        if (!CheckpointPhase.getPhase().restored()) {
+            lazyCreate = true;
+        } else {
+            instrumenter = createInstrumenter();
         }
     }
     

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryContainerFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryContainerFilter.java
@@ -79,12 +79,10 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
     private ResourceInfo resourceInfo;
 
     public TelemetryContainerFilter() {
-        if (instrumenter == null) {
-            if (!CheckpointPhase.getPhase().restored()) {
-                lazyCreate = true;
-            } else {
-                instrumenter = createInstrumenter();
-            }
+        if (!CheckpointPhase.getPhase().restored()) {
+            lazyCreate = true;
+        } else {
+            instrumenter = createInstrumenter();
         }
     }
     

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryContainerFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryContainerFilter.java
@@ -92,13 +92,13 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
         }
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
-                if (i == null) {
-                    lazyCreate = false;
+                if (i == null) {                   
                     return createInstrumenter();
                 } else {
                     return i;
                 }
             });
+            lazyCreate = false;
         }
         return instrumenter;
     }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryContainerFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryContainerFilter.java
@@ -95,6 +95,7 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
                 if (i == null) {
+                    lazyCreate = false;
                     return createInstrumenter();
                 } else {
                     return i;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryContainerFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryContainerFilter.java
@@ -18,10 +18,12 @@ import static java.util.Collections.singletonList;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 import io.openliberty.microprofile.telemetry.internal.common.AgentDetection;
 import io.openliberty.microprofile.telemetry.internal.common.info.OpenTelemetryInfo;
 import io.openliberty.microprofile.telemetry.internal.common.rest.AbstractTelemetryContainerFilter;
@@ -69,11 +71,41 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
     private static final RestRouteCache ROUTE_CACHE = new RestRouteCache();
 
     private Instrumenter<ContainerRequestContext, ContainerResponseContext> instrumenter;
+    
+    private volatile boolean lazyCreate = false;
+    private final AtomicReference<Instrumenter<ContainerRequestContext, ContainerResponseContext>> lazyInstrumenter = new AtomicReference<>();
 
     @jakarta.ws.rs.core.Context
     private ResourceInfo resourceInfo;
 
     public TelemetryContainerFilter() {
+        if (instrumenter == null) {
+            if (!CheckpointPhase.getPhase().restored()) {
+                lazyCreate = true;
+            } else {
+                instrumenter = createInstrumenter();
+            }
+        }
+    }
+    
+    private Instrumenter<ContainerRequestContext, ContainerResponseContext> getInstrumenter() {
+        if (instrumenter != null) {
+            return instrumenter;
+        }
+        if (lazyCreate) {
+            instrumenter = lazyInstrumenter.updateAndGet((i) -> {
+                if (i == null) {
+                    return createInstrumenter();
+                } else {
+                    return i;
+                }
+            });
+        }
+        return instrumenter;
+    }
+
+    
+    private Instrumenter<ContainerRequestContext, ContainerResponseContext> createInstrumenter() {
         try {
             OpenTelemetryInfo openTelemetry = OpenTelemetryAccessor.getOpenTelemetryInfo();
             if (openTelemetry.getEnabled() && !AgentDetection.isAgentActive()) {
@@ -82,34 +114,36 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
                                                                                                                       INSTRUMENTATION_NAME,
                                                                                                                       HttpSpanNameExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER));
 
-                this.instrumenter = builder
+                Instrumenter<ContainerRequestContext, ContainerResponseContext> result = builder
                                 .setSpanStatusExtractor(HttpSpanStatusExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER))
                                 .addAttributesExtractor(HttpServerAttributesExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER))
                                 .addAttributesExtractor(NetServerAttributesExtractor.create(NET_SERVER_ATTRIBUTES_GETTER))
                                 .buildServerInstrumenter(new ContainerRequestContextTextMapGetter());
+                return result;
 
             } else {
-                this.instrumenter = null;
+                return null;
             }
         } catch (Exception e) {
             Tr.error(tc, Tr.formatMessage(tc, "CWMOT5002.telemetry.error", e));
-            this.instrumenter = null;
+            return null;
         }
     }
 
     @Override
     public void filter(final ContainerRequestContext request) {
-        if (instrumenter == null) {
+        Instrumenter<ContainerRequestContext, ContainerResponseContext> currentInstrumenter = getInstrumenter();
+        if (currentInstrumenter == null) {
             return;
         }
 
         try {
             Context parentContext = Context.current();
-            if (instrumenter.shouldStart(parentContext, request)) {
+            if (currentInstrumenter.shouldStart(parentContext, request)) {
                 request.setProperty(REST_RESOURCE_CLASS, resourceInfo.getResourceClass());
                 request.setProperty(REST_RESOURCE_METHOD, resourceInfo.getResourceMethod());
 
-                Context spanContext = instrumenter.start(parentContext, request);
+                Context spanContext = currentInstrumenter.start(parentContext, request);
                 Scope scope = spanContext.makeCurrent();
                 request.setProperty(SPAN_CONTEXT, spanContext);
                 request.setProperty(SPAN_PARENT_CONTEXT, parentContext);
@@ -152,9 +186,9 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
     public void filter(final ContainerRequestContext request, final ContainerResponseContext response) {
         // Note: for async resource methods, this may not run on the same thread as the other filter method
         // Scope is ended in TelemetryServletRequestListener to ensure it does run on the original request thread
-
+        Instrumenter<ContainerRequestContext, ContainerResponseContext> currentInstrumenter = getInstrumenter();
         try {
-            if (instrumenter == null) {
+            if (currentInstrumenter == null) {
                 return;
             }
 
@@ -163,7 +197,7 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
                 return;
             }
             try {
-                instrumenter.end(spanContext, request, response, null);
+                currentInstrumenter.end(spanContext, request, response, null);
             } finally {
                 request.removeProperty(REST_RESOURCE_CLASS);
                 request.removeProperty(REST_RESOURCE_METHOD);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryServletContainerInitializer.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryServletContainerInitializer.java
@@ -17,7 +17,6 @@ import org.osgi.service.component.annotations.Component;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.kernel.productinfo.ProductInfo;
 
 import io.openliberty.microprofile.telemetry.internal.common.rest.TelemetryServletRequestListener;
 import jakarta.servlet.FilterRegistration;
@@ -38,21 +37,13 @@ public class TelemetryServletContainerInitializer implements ServletContainerIni
     public void onStartup(Set<Class<?>> c, ServletContext sc) throws ServletException {
         sc.addListener(TelemetryServletRequestListener.class);
 
-        // Beta fencing for HTTP tracing
-        if (ProductInfo.getBetaEdition()) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Running beta driver, enable TelemetryServletFilter");
-            }
-            FilterRegistration.Dynamic filterRegistration = sc.addFilter("io.openliberty.microprofile.telemetry10.internal.rest.TelemetryServletFilter",
-                                                                         TelemetryServletFilter.class);
-            filterRegistration.addMappingForUrlPatterns(null, true, "/*");
-            filterRegistration.setAsyncSupported(true);
-        } else {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Running product driver, disable TelemetryServletFilter");
-            }
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Enable TelemetryServletFilter");
         }
-
+        FilterRegistration.Dynamic filterRegistration = sc.addFilter("io.openliberty.microprofile.telemetry10.internal.rest.TelemetryServletFilter",
+                                                                     TelemetryServletFilter.class);
+        filterRegistration.addMappingForUrlPatterns(null, true, "/*");
+        filterRegistration.setAsyncSupported(true);
     }
 
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryServletFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryServletFilter.java
@@ -77,12 +77,10 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
 
     @Override
     public void init(FilterConfig config) {
-        if (instrumenter == null) {
-            if (!CheckpointPhase.getPhase().restored()) {
-                lazyCreate = true;
-            } else {
-                instrumenter = createInstrumenter();
-            }
+        if (!CheckpointPhase.getPhase().restored()) {
+            lazyCreate = true;
+        } else {
+            instrumenter = createInstrumenter();
         }
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryServletFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryServletFilter.java
@@ -91,12 +91,12 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
                 if (i == null) {
-                    lazyCreate = false;
                     return createInstrumenter();
                 } else {
                     return i;
                 }
             });
+            lazyCreate = false;
         }
         return instrumenter;
     }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryServletFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryServletFilter.java
@@ -93,6 +93,7 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
                 if (i == null) {
+                    lazyCreate = false;
                     return createInstrumenter();
                 } else {
                     return i;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryServletFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryServletFilter.java
@@ -16,6 +16,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -23,6 +25,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 import io.openliberty.microprofile.telemetry.internal.common.AgentDetection;
 import io.openliberty.microprofile.telemetry.internal.common.info.OpenTelemetryInfo;
 import io.openliberty.microprofile.telemetry.internal.common.rest.AbstractTelemetryServletFilter;
@@ -64,6 +67,8 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
     private static final NetServerAttributesGetterImpl NET_SERVER_ATTRIBUTES_GETTER = new NetServerAttributesGetterImpl();
 
     private Instrumenter<ServletRequest, ServletResponse> instrumenter;
+    private volatile boolean lazyCreate = false;
+    private final AtomicReference<Instrumenter<ServletRequest, ServletResponse>> lazyInstrumenter = new AtomicReference<>();
 
     private final Config config = ConfigProvider.getConfig();
 
@@ -73,44 +78,70 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
     @Override
     public void init(FilterConfig config) {
         if (instrumenter == null) {
-            OpenTelemetryInfo otelInfo = OpenTelemetryAccessor.getOpenTelemetryInfo();
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "otelInfo.getEnabled()=" + otelInfo.getEnabled());
-            }
-            if (otelInfo != null &&
-                otelInfo.getEnabled() &&
-                !AgentDetection.isAgentActive() &&
-                !checkDisabled(getTelemetryProperties())) {
-                InstrumenterBuilder<ServletRequest, ServletResponse> builder = Instrumenter.builder(
-                                                                                                    otelInfo.getOpenTelemetry(),
-                                                                                                    INSTRUMENTATION_NAME,
-                                                                                                    HttpSpanNameExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER));
-
-                instrumenter = builder.setSpanStatusExtractor(HttpSpanStatusExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER))
-                                .addAttributesExtractor(HttpServerAttributesExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER))
-                                .addAttributesExtractor(NetServerAttributesExtractor.create(NET_SERVER_ATTRIBUTES_GETTER))
-                                .buildServerInstrumenter(new ServletRequestContextTextMapGetter());
-                if (tc.isDebugEnabled()) {
-                    Tr.debug(tc, "instrumenter is initialized");
-                }
+            if (!CheckpointPhase.getPhase().restored()) {
+                lazyCreate = true;
             } else {
-                instrumenter = null;
-                if (tc.isDebugEnabled()) {
-                    Tr.debug(tc, "instrumenter is set to null");
-                }
+                instrumenter = createInstrumenter();
             }
-
         }
+    }
+
+    private Instrumenter<ServletRequest, ServletResponse> getInstrumenter() {
+        if (instrumenter != null) {
+            return instrumenter;
+        }
+        if (lazyCreate) {
+            instrumenter = lazyInstrumenter.updateAndGet((i) -> {
+                if (i == null) {
+                    return createInstrumenter();
+                } else {
+                    return i;
+                }
+            });
+        }
+        return instrumenter;
+    }
+
+    private Instrumenter<ServletRequest, ServletResponse> createInstrumenter() {
+        OpenTelemetryInfo otelInfo = OpenTelemetryAccessor.getOpenTelemetryInfo();
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "otelInfo.getEnabled()=" + otelInfo.getEnabled());
+        }
+        if (otelInfo != null &&
+            otelInfo.getEnabled() &&
+            !AgentDetection.isAgentActive() &&
+            !checkDisabled(getTelemetryProperties())) {
+            InstrumenterBuilder<ServletRequest, ServletResponse> builder = Instrumenter.builder(
+                                                                                                otelInfo.getOpenTelemetry(),
+                                                                                                INSTRUMENTATION_NAME,
+                                                                                                HttpSpanNameExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER));
+
+            Instrumenter<ServletRequest, ServletResponse> result = builder.setSpanStatusExtractor(HttpSpanStatusExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER))
+                            .addAttributesExtractor(HttpServerAttributesExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER))
+                            .addAttributesExtractor(NetServerAttributesExtractor.create(NET_SERVER_ATTRIBUTES_GETTER))
+                            .buildServerInstrumenter(new ServletRequestContextTextMapGetter());
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "instrumenter is initialized");
+            }
+            return result;
+        } else {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "instrumenter is set to null");
+            }
+            return null;
+        }
+
     }
 
     /** {@inheritDoc} */
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         Scope scope = null;
-        if (instrumenter != null) {
+        Instrumenter<ServletRequest, ServletResponse> current = getInstrumenter();
+        if (current != null) {
             Context parentContext = Context.current();
-            if (instrumenter.shouldStart(parentContext, request)) {
-                Context spanContext = instrumenter.start(parentContext, request);
+            if (current.shouldStart(parentContext, request)) {
+                Context spanContext = current.start(parentContext, request);
                 scope = spanContext.makeCurrent();
                 request.setAttribute(SPAN_CONTEXT, spanContext);
                 request.setAttribute(SPAN_PARENT_CONTEXT, parentContext);
@@ -134,17 +165,17 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
             asyncContext.addListener(new AsyncListener() {
                 @Override
                 public void onComplete(AsyncEvent event) throws IOException {
-                    endSpan(request, response, null);
+                    endSpan(request, response, null, current);
                 }
 
                 @Override
                 public void onTimeout(AsyncEvent event) throws IOException {
-                    endSpan(request, response, event.getThrowable());
+                    endSpan(request, response, event.getThrowable(), current);
                 }
 
                 @Override
                 public void onError(AsyncEvent event) throws IOException {
-                    endSpan(request, response, event.getThrowable());
+                    endSpan(request, response, event.getThrowable(), current);
                 }
 
                 @Override
@@ -152,7 +183,7 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
                 }
             });
         } else {
-            endSpan(request, response, null);
+            endSpan(request, response, null, current);
         }
 
         if (scope != null) {
@@ -162,23 +193,21 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
 
     }
 
-    private void endSpan(ServletRequest request, ServletResponse response, Throwable throwable) {
-        if (instrumenter != null) {
-            Context spanContext = (Context) request.getAttribute(SPAN_CONTEXT);
-            if (spanContext == null) {
-                return;
-            }
+    private void endSpan(ServletRequest request, ServletResponse response, Throwable throwable, Instrumenter<ServletRequest, ServletResponse> current) {
+        Context spanContext = (Context) request.getAttribute(SPAN_CONTEXT);
+        if (spanContext == null) {
+            return;
+        }
 
-            try {
-                if (tc.isDebugEnabled()) {
-                    Tr.debug(tc, "End span traceId=" + Span.fromContext(spanContext).getSpanContext().getTraceId() + " spanId="
-                                 + Span.fromContext(spanContext).getSpanContext().getSpanId());
-                }
-                instrumenter.end(spanContext, request, response, throwable);
-            } finally {
-                request.removeAttribute(SPAN_CONTEXT);
-                request.removeAttribute(SPAN_PARENT_CONTEXT);
+        try {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "End span traceId=" + Span.fromContext(spanContext).getSpanContext().getTraceId() + " spanId="
+                             + Span.fromContext(spanContext).getSpanContext().getSpanId());
             }
+            current.end(spanContext, request, response, throwable);
+        } finally {
+            request.removeAttribute(SPAN_CONTEXT);
+            request.removeAttribute(SPAN_PARENT_CONTEXT);
         }
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Jax/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Jax/jvm.options
@@ -1,3 +1,1 @@
 -Dio.opentelemetry.context.enableStrictContext=true
-# beta fence for HTTP tracing as this server has tests that require it
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithConcurrency/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithConcurrency/bootstrap.properties
@@ -1,3 +1,1 @@
 bootstrap.include=../testports.properties
-# beta fence for HTTP tracing as this has tests that expect output from the servlet filter
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithConcurrency/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10JaxWithConcurrency/jvm.options
@@ -1,3 +1,1 @@
 -Dio.opentelemetry.context.enableStrictContext=true
-# beta fence for HTTP tracing as this server has tests that require it
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10MisConfig/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10MisConfig/jvm.options
@@ -1,3 +1,1 @@
 -Dio.opentelemetry.context.enableStrictContext=true
-# beta fence for HTTP tracing as this runs tests that require the servlet filter
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Servlet/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Servlet/jvm.options
@@ -1,3 +1,1 @@
 -Dio.opentelemetry.context.enableStrictContext=true
-# beta fence for HTTP tracing as this runs tests that require the servlet filter
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/bnd.bnd
@@ -71,6 +71,7 @@ Import-Package: \
 	com.ibm.websphere.org.eclipse.microprofile.rest.client.1.1;version=latest,\
 	io.openliberty.org.jboss.resteasy.common;version=latest,\
 	io.openliberty.microprofile.telemetry.internal.common;version=latest,\
-	io.openliberty.io.opentelemetry.1.29;version=latest
+	io.openliberty.io.opentelemetry.1.29;version=latest,\
+	com.ibm.ws.kernel.boot.common;version=latest
 
 WS-TraceGroup: TELEMETRY

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryClientFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryClientFilter.java
@@ -69,6 +69,7 @@ public class TelemetryClientFilter extends AbstractTelemetryClientFilter impleme
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
                 if (i == null) {
+                    lazyCreate = false;
                     return createInstrumenter();
                 } else {
                     return i;
@@ -140,10 +141,15 @@ public class TelemetryClientFilter extends AbstractTelemetryClientFilter impleme
     /**
      * @return false if OpenTelemetry is disabled
      *         Indicated by instrumenter being set to null
+     * @return true when instrumenter is not null or if it is called during checkpoint
      */
     @Override
     public boolean isEnabled() {
-        return instrumenter != null;
+        if (instrumenter != null || !CheckpointPhase.getPhase().restored()) {
+            return true;
+        }         
+        instrumenter = getInstrumenter();
+        return instrumenter != null;    
     }
 
     private static class ClientRequestContextTextMapSetter implements TextMapSetter<ClientRequestContext> {

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryClientFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryClientFilter.java
@@ -66,13 +66,13 @@ public class TelemetryClientFilter extends AbstractTelemetryClientFilter impleme
         }
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
-                if (i == null) {
-                    lazyCreate = false;
+                if (i == null) {                    
                     return createInstrumenter();
                 } else {
                     return i;
                 }
             });
+            lazyCreate = false;
         }
         return instrumenter;
     }
@@ -143,11 +143,10 @@ public class TelemetryClientFilter extends AbstractTelemetryClientFilter impleme
      */
     @Override
     public boolean isEnabled() {
-        if (instrumenter != null || !CheckpointPhase.getPhase().restored()) {
+        if (!CheckpointPhase.getPhase().restored()) {
             return true;
         }         
-        instrumenter = getInstrumenter();
-        return instrumenter != null;    
+        return getInstrumenter() != null;  
     }
 
     private static class ClientRequestContextTextMapSetter implements TextMapSetter<ClientRequestContext> {

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryClientFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryClientFilter.java
@@ -53,12 +53,10 @@ public class TelemetryClientFilter extends AbstractTelemetryClientFilter impleme
     private static final HttpClientAttributesGetterImpl HTTP_CLIENT_ATTRIBUTES_GETTER = new HttpClientAttributesGetterImpl();
 
     public TelemetryClientFilter() {
-        if (instrumenter == null) {
-            if (!CheckpointPhase.getPhase().restored()) {
-                lazyCreate = true;
-            } else {
-                instrumenter = createInstrumenter();
-            }
+        if (!CheckpointPhase.getPhase().restored()) {
+            lazyCreate = true;
+        } else {
+            instrumenter = createInstrumenter();
         }
     }
     

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryContainerFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryContainerFilter.java
@@ -70,12 +70,10 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
     private ResourceInfo resourceInfo;
     
     public TelemetryContainerFilter() {
-        if (instrumenter == null) {
-            if (!CheckpointPhase.getPhase().restored()) {
-                lazyCreate = true;
-            } else {
-                instrumenter = createInstrumenter();
-            }
+        if (!CheckpointPhase.getPhase().restored()) {
+            lazyCreate = true;
+        } else {
+            instrumenter = createInstrumenter();
         }
     }
     

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryContainerFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryContainerFilter.java
@@ -83,13 +83,13 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
         }
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
-                if (i == null) {
-                    lazyCreate = false;
+                if (i == null) {                    
                     return createInstrumenter();
                 } else {
                     return i;
                 }
             });
+            lazyCreate = false;
         }
         return instrumenter;
     }

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryContainerFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryContainerFilter.java
@@ -86,6 +86,7 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
                 if (i == null) {
+                    lazyCreate = false;
                     return createInstrumenter();
                 } else {
                     return i;

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryServletFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryServletFilter.java
@@ -89,6 +89,7 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
                 if (i == null) {
+                    lazyCreate = false;
                     return createInstrumenter();
                 } else {
                     return i;

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryServletFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryServletFilter.java
@@ -16,6 +16,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import javax.servlet.AsyncContext;
 import javax.servlet.AsyncEvent;
@@ -36,6 +38,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 import io.openliberty.microprofile.telemetry.internal.common.AgentDetection;
 import io.openliberty.microprofile.telemetry.internal.common.info.OpenTelemetryInfo;
 import io.openliberty.microprofile.telemetry.internal.common.rest.AbstractTelemetryServletFilter;
@@ -60,6 +63,8 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
     private static final HttpServerAttributesGetterImpl HTTP_SERVER_ATTRIBUTES_GETTER = new HttpServerAttributesGetterImpl();
 
     private Instrumenter<ServletRequest, ServletResponse> instrumenter;
+    private volatile boolean lazyCreate = false;
+    private final AtomicReference<Instrumenter<ServletRequest, ServletResponse>> lazyInstrumenter = new AtomicReference<>();
 
     private final Config config = ConfigProvider.getConfig();
 
@@ -69,33 +74,58 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
     @Override
     public void init(FilterConfig config) {
         if (instrumenter == null) {
-            OpenTelemetryInfo otelInfo = OpenTelemetryAccessor.getOpenTelemetryInfo();
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "otelInfo.getEnabled()=" + otelInfo.getEnabled());
-            }
-            if (otelInfo != null &&
-                otelInfo.getEnabled() &&
-                !AgentDetection.isAgentActive() &&
-                !checkDisabled(getTelemetryProperties())) {
-                InstrumenterBuilder<ServletRequest, ServletResponse> builder = Instrumenter.builder(
-                                                                                                    otelInfo.getOpenTelemetry(),
-                                                                                                    INSTRUMENTATION_NAME,
-                                                                                                    HttpSpanNameExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER));
-
-                this.instrumenter = builder
-                                .setSpanStatusExtractor(HttpSpanStatusExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER))
-                                .addAttributesExtractor(HttpServerAttributesExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER))
-                                .buildServerInstrumenter(new ServletRequestContextTextMapGetter());
-                if (tc.isDebugEnabled()) {
-                    Tr.debug(tc, "instrumenter is initialized");
-                }
+            if (!CheckpointPhase.getPhase().restored()) {
+                lazyCreate = true;
             } else {
-                instrumenter = null;
-                if (tc.isDebugEnabled()) {
-                    Tr.debug(tc, "instrumenter is set to null");
-                }
+                instrumenter = createInstrumenter();
             }
+        }
+    }
 
+    private Instrumenter<ServletRequest, ServletResponse> getInstrumenter() {
+        if (instrumenter != null) {
+            return instrumenter;
+        }
+        if (lazyCreate) {
+            instrumenter = lazyInstrumenter.updateAndGet((i) -> {
+                if (i == null) {
+                    return createInstrumenter();
+                } else {
+                    return i;
+                }
+            });
+        }
+        return instrumenter;
+    }
+    
+    private Instrumenter<ServletRequest, ServletResponse> createInstrumenter() {
+        OpenTelemetryInfo otelInfo = OpenTelemetryAccessor.getOpenTelemetryInfo();
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "otelInfo.getEnabled()=" + otelInfo.getEnabled());
+        }
+        if (otelInfo != null &&
+            otelInfo.getEnabled() &&
+            !AgentDetection.isAgentActive() &&
+            !checkDisabled(getTelemetryProperties())) {
+            InstrumenterBuilder<ServletRequest, ServletResponse> builder = Instrumenter.builder(
+                                                                                                otelInfo.getOpenTelemetry(),
+                                                                                                INSTRUMENTATION_NAME,
+                                                                                                HttpSpanNameExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER));
+
+            Instrumenter<ServletRequest, ServletResponse> result = builder
+                            .setSpanStatusExtractor(HttpSpanStatusExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER))
+                            .addAttributesExtractor(HttpServerAttributesExtractor.create(HTTP_SERVER_ATTRIBUTES_GETTER))
+                            .buildServerInstrumenter(new ServletRequestContextTextMapGetter());
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "instrumenter is initialized");
+            }
+            return result;
+        } else {
+            instrumenter = null;
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "instrumenter is set to null");
+            }
+            return null;
         }
     }
 
@@ -103,10 +133,11 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         Scope scope = null;
-        if (instrumenter != null) {
+        Instrumenter<ServletRequest, ServletResponse> current = getInstrumenter();
+        if (current != null) {
             Context parentContext = Context.current();
-            if (instrumenter.shouldStart(parentContext, request)) {
-                Context spanContext = instrumenter.start(parentContext, request);
+            if (current.shouldStart(parentContext, request)) {
+                Context spanContext = current.start(parentContext, request);
                 scope = spanContext.makeCurrent();
                 request.setAttribute(SPAN_CONTEXT, spanContext);
                 request.setAttribute(SPAN_PARENT_CONTEXT, parentContext);
@@ -130,17 +161,17 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
             asyncContext.addListener(new AsyncListener() {
                 @Override
                 public void onComplete(AsyncEvent event) throws IOException {
-                    endSpan(request, response, null);
+                    endSpan(request, response, null, current);
                 }
 
                 @Override
                 public void onTimeout(AsyncEvent event) throws IOException {
-                    endSpan(request, response, event.getThrowable());
+                    endSpan(request, response, event.getThrowable(), current);
                 }
 
                 @Override
                 public void onError(AsyncEvent event) throws IOException {
-                    endSpan(request, response, event.getThrowable());
+                    endSpan(request, response, event.getThrowable(), current);
                 }
 
                 @Override
@@ -148,7 +179,7 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
                 }
             });
         } else {
-            endSpan(request, response, null);
+            endSpan(request, response, null, current);
         }
 
         if (scope != null) {
@@ -158,8 +189,8 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
 
     }
 
-    private void endSpan(ServletRequest request, ServletResponse response, Throwable throwable) {
-        if (instrumenter != null) {
+    private void endSpan(ServletRequest request, ServletResponse response, Throwable throwable, Instrumenter<ServletRequest, ServletResponse> current) {
+        if (current != null) {
             Context spanContext = (Context) request.getAttribute(SPAN_CONTEXT);
             if (spanContext == null) {
                 return;
@@ -170,7 +201,7 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
                     Tr.debug(tc, "End span traceId=" + Span.fromContext(spanContext).getSpanContext().getTraceId() + " spanId="
                                  + Span.fromContext(spanContext).getSpanContext().getSpanId());
                 }
-                instrumenter.end(spanContext, request, response, throwable);
+                current.end(spanContext, request, response, throwable);
             } finally {
                 request.removeAttribute(SPAN_CONTEXT);
                 request.removeAttribute(SPAN_PARENT_CONTEXT);

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryServletFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryServletFilter.java
@@ -86,13 +86,13 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
         }
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
-                if (i == null) {
-                    lazyCreate = false;
+                if (i == null) {                    
                     return createInstrumenter();
                 } else {
                     return i;
                 }
             });
+            lazyCreate = false;
         }
         return instrumenter;
     }

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryServletFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryServletFilter.java
@@ -73,12 +73,10 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
 
     @Override
     public void init(FilterConfig config) {
-        if (instrumenter == null) {
-            if (!CheckpointPhase.getPhase().restored()) {
-                lazyCreate = true;
-            } else {
-                instrumenter = createInstrumenter();
-            }
+        if (!CheckpointPhase.getPhase().restored()) {
+            lazyCreate = true;
+        } else {
+            instrumenter = createInstrumenter();
         }
     }
 


### PR DESCRIPTION
Add more MPTelemetry tests and repeat the tests for EE10.

fixes #26522
fixes #26744 