### PR TITLE
Start server at the top of the minute

### DIFF
--- a/dev/com.ibm.ws.logging_2_fat/fat/src/com/ibm/ws/logging/fat/TimeBasedLogRolloverTest.java
+++ b/dev/com.ibm.ws.logging_2_fat/fat/src/com/ibm/ws/logging/fat/TimeBasedLogRolloverTest.java
@@ -347,6 +347,14 @@ public class TimeBasedLogRolloverTest {
      */
     @Test
     public void testInvalidRolloverStartTime() throws Exception {
+
+        //wait to do a server config update at the start of the minute
+	//this allows enough time for timedexit check
+        if (Calendar.getInstance().get(Calendar.SECOND) != 0) {
+            Thread.sleep((60000 - Calendar.getInstance().get(Calendar.SECOND)*1000));
+            Thread.sleep(2000); //padding
+        }
+
         setUp(server_xml, "testInvalidRolloverStartTime");
         
         //wait to do a server config update at the start of the minute

--- a/dev/com.ibm.ws.logging_2_fat/publish/servers/com.ibm.ws.logging.timedrolloverxml/server.xml
+++ b/dev/com.ibm.ws.logging_2_fat/publish/servers/com.ibm.ws.logging.timedrolloverxml/server.xml
@@ -15,9 +15,9 @@
     <include location="../fatTestPorts.xml"/>
     
     <featureManager>
-	   <feature>jsp-2.2</feature>
-       <feature>timedexit-1.0</feature>
+        <feature>jsp-2.2</feature>
+        <feature>timedexit-1.0</feature>
     </featureManager>
 
-    <logging rolloverStartTime="00:00" rolloverInterval="1m" maxFiles="5"/>
+    <logging rolloverStartTime="00:00" rolloverInterval="1m" maxFiles="10"/>
 </server>


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/open-liberty/issues/26807

Start the server at the top of the minute to allow timed exit check before the log rolling over.