### PR TITLE
Fix defect 293864

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundServiceContextImpl.java
@@ -458,6 +458,9 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      */
     protected HttpRequestMessageImpl getRequestImpl() {
         if (null == getMyRequest()) {
+            if (getObjectFactory() == null) {
+                return null;
+            }
             setMyRequest(getObjectFactory().getRequest(this));
             getMyRequest().setHeaderChangeLimit(getHttpConfig().getHeaderChangeLimit());
         }
@@ -864,13 +867,20 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
     protected void logFinalResponse(long numBytesWritten) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             HttpChannelConfig c = getHttpConfig();
-            Tr.debug(tc, "logFinal", c, c.getAccessLog(), c.getAccessLog().isStarted(), numBytesWritten);
+            Tr.debug(tc, "logFinalResponse", c, c.getAccessLog(), c.getAccessLog().isStarted(), numBytesWritten);
         }
 
         // exit if access logging is disabled
         if (!getHttpConfig().getAccessLog().isStarted()) {
             return;
         }
+        if(getRequest() == null) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "logFinalResponse", "getRequest() is null. HTTPAccess log entry is skipped." );
+            }
+            return; 
+        }
+
         if (MethodValues.UNDEF.equals(getRequest().getMethodValue())) {
             // don't log anything if there wasn't a real request
             return;

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -1257,6 +1257,15 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
                         ic.sendResponse(StatusCodes.INTERNAL_ERROR, new Exception("Dispatch error", t), true);
                     }
                 }
+
+                if (ic.decrementNeeded.compareAndSet(true, false)) {
+                        //  ^ set back to false in case close is called more than once after destroy is called (highly unlikely)
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "decrementNeeded is true: decrement active connection");
+                    }
+                    ic.myChannel.decrementActiveConns();
+                }
+
             } finally {
                 if (this.classifiedExecutor != null) {
                     DecoratedExecutorThread.removeExecutor();


### PR DESCRIPTION
Scenario where the web-socket connection is opened and immediately closed.  First thread (which handles the upgrade connection) does not complete properly since the close connection thread interrupts and calls destroy.  This results in the getObjectFactory returning null.

Only issue is that the HTTPAccess entry is skipped (wsoc upgrade call - see below) in this scenario since getRequest() throws an NPE due to getObjectFactory returning null (destroy occurs before the close). I've opted to check for null within getRequestImpl(), and return null instead. 

Example of the upgrade within the access log: 
```127.0.0.1 - [02/Nov/2023:14:53:44 -0400] "GET /basic/codedText HTTP/1.1" 101 -```

If the request is null within logFinalResponse then we log an entry within the trace. 