### PR TITLE
Update to prefer jdbc-4.3 and tolerate jdbc-4.2 with EE 11.

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.batch2.1.internal.ee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.batch2.1.internal.ee-11.0.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.batch2.1.internal.ee-11.0
 singleton=true
 -features=com.ibm.websphere.appserver.eeCompatible-11.0, \
   com.ibm.websphere.appserver.servlet-6.1, \
-  com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
+  com.ibm.websphere.appserver.jdbc-4.3; ibm.tolerates:="4.2", \
   com.ibm.websphere.appserver.transaction-2.0, \
   io.openliberty.persistence-3.2
 kind=noship

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-11.0/io.openliberty.jakartaee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-11.0/io.openliberty.jakartaee-11.0.feature
@@ -10,7 +10,7 @@ Subsystem-Name: Jakarta EE Platform 11.0
   io.openliberty.mail-2.1, \
   io.openliberty.messagingClient-3.0, \
   io.openliberty.connectors-2.1, \
-  com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
+  com.ibm.websphere.appserver.jdbc-4.3; ibm.tolerates:="4.2", \
   io.openliberty.batch-2.1, \
   io.openliberty.cdi-4.1, \
   io.openliberty.webProfile-11.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-11.0/io.openliberty.jakartaeeClient-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-11.0/io.openliberty.jakartaeeClient-11.0.feature
@@ -99,7 +99,7 @@ Subsystem-Name: Jakarta EE 11.0 Application Client
   io.openliberty.messagingClient-3.0, \
   io.openliberty.jakarta.jndiClient-2.0, \
   io.openliberty.jsonb-3.0, \
-  com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
+  com.ibm.websphere.appserver.jdbc-4.3; ibm.tolerates:="4.2", \
   io.openliberty.persistence-3.2, \
   io.openliberty.beanValidation-3.1, \
   com.ibm.websphere.appserver.eeCompatible-11.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.0/com.ibm.websphere.appserver.jdbc-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.0/com.ibm.websphere.appserver.jdbc-4.0.feature
@@ -8,6 +8,7 @@ IBM-API-Package: com.ibm.wsspi.zos.tx; type="internal", \
 IBM-ShortName: jdbc-4.0
 Subsystem-Name: Java Database Connectivity 4.0
 -features=com.ibm.websphere.appserver.appLifecycle-1.0, \
+  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0,9.0,10.0", \
   com.ibm.websphere.appserver.connectionManagement-1.0, \
   com.ibm.websphere.appserver.requestProbes-1.0, \
   com.ibm.websphere.appserver.jndi-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.1/com.ibm.websphere.appserver.jdbc-4.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.1/com.ibm.websphere.appserver.jdbc-4.1.feature
@@ -8,6 +8,7 @@ IBM-API-Package: com.ibm.wsspi.zos.tx; type="internal", \
 IBM-ShortName: jdbc-4.1
 Subsystem-Name: Java Database Connectivity 4.1
 -features=com.ibm.websphere.appserver.appLifecycle-1.0, \
+  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0,9.0,10.0", \
   com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:="1.1,2.0", \
   com.ibm.websphere.appserver.connectionManagement-1.0, \
   com.ibm.websphere.appserver.requestProbes-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.2/com.ibm.websphere.appserver.jdbc-4.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.2/com.ibm.websphere.appserver.jdbc-4.2.feature
@@ -8,6 +8,7 @@ IBM-API-Package: com.ibm.wsspi.zos.tx; type="internal", \
 IBM-ShortName: jdbc-4.2
 Subsystem-Name: Java Database Connectivity 4.2
 -features=com.ibm.websphere.appserver.appLifecycle-1.0, \
+  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0,9.0,10.0,11.0", \
   com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:="1.1,2.0", \
   com.ibm.websphere.appserver.connectionManagement-1.0, \
   io.openliberty.jdbc4.2.internal.ee-6.0; ibm.tolerates:="9.0", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.3/com.ibm.websphere.appserver.jdbc-4.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.3/com.ibm.websphere.appserver.jdbc-4.3.feature
@@ -8,6 +8,7 @@ IBM-API-Package: com.ibm.wsspi.zos.tx; type="internal", \
 IBM-ShortName: jdbc-4.3
 Subsystem-Name: Java Database Connectivity 4.3
 -features=com.ibm.websphere.appserver.appLifecycle-1.0, \
+  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0,9.0,10.0,11.0", \
   com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:="1.1,2.0", \
   com.ibm.websphere.appserver.connectionManagement-1.0, \
   com.ibm.websphere.appserver.requestProbes-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/persistence-3.2/io.openliberty.persistence-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/persistence-3.2/io.openliberty.persistence-3.2.feature
@@ -223,7 +223,7 @@ IBM-API-Package: org.eclipse.persistence.descriptors.changetracking; type="inter
 IBM-ShortName: persistence-3.2
 WLP-AlsoKnownAs: jpa-3.2
 Subsystem-Name: Jakarta Persistence 3.2
--features=com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
+-features=com.ibm.websphere.appserver.jdbc-4.3; ibm.tolerates:="4.2", \
   io.openliberty.persistenceContainer-3.2, \
   com.ibm.websphere.appserver.eeCompatible-11.0, \
   io.openliberty.jsonp-2.1, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.2/io.openliberty.persistenceContainer-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.2/io.openliberty.persistenceContainer-3.2.feature
@@ -13,7 +13,7 @@ IBM-API-Package: jakarta.persistence; type="spec", \
  jakarta.persistence.metamodel; type="spec"
 IBM-App-ForceRestart: uninstall, \
  install
--features=com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
+-features=com.ibm.websphere.appserver.jdbc-4.3, \
   io.openliberty.xmlBinding.internal-4.0, \
   io.openliberty.jakarta.annotation-3.0; apiJar=false, \
   com.ibm.websphere.appserver.eeCompatible-11.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-11.0/io.openliberty.webProfile-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-11.0/io.openliberty.webProfile-11.0.feature
@@ -13,7 +13,7 @@ Subsystem-Name: Jakarta EE Web Profile 11.0
   io.openliberty.jsonb-3.0, \
   io.openliberty.enterpriseBeansLite-4.0, \
   io.openliberty.websocket-2.2, \
-  com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
+  com.ibm.websphere.appserver.jdbc-4.3; ibm.tolerates:="4.2", \
   io.openliberty.persistence-3.2, \
   io.openliberty.beanValidation-3.1, \
   io.openliberty.restfulWS-4.0, \

--- a/dev/com.ibm.ws.jdbc_fat_krb5/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/bnd.bnd
@@ -28,8 +28,11 @@ fat.test.container.images: kyleaure/db2-krb5:2.0, kyleaure/krb5-server:1.0, kyle
 
 tested.features: \
   connectors-2.0, \
+  connectors-2.1, \
   servlet-5.0, \
-  servlet-6.0
+  servlet-6.0, \
+  servlet-6.1, \
+  jdbc-4.3
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/PostgresKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/PostgresKerberosTest.java
@@ -30,8 +30,7 @@ import com.ibm.ws.jdbc.fat.krb5.containers.PostgresKerberosContainer;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -52,10 +51,13 @@ public class PostgresKerberosTest extends FATServletClient {
 
     @ClassRule
     public static RepeatTests repeat = RepeatTests.withoutModification()
-                    .andWith(new JakartaEE9Action()
+                    .andWith(FeatureReplacementAction.EE9_FEATURES()
                                     .forServers("com.ibm.ws.jdbc.fat.krb5.postgresql")
                                     .fullFATOnly())
-                    .andWith(new JakartaEE10Action()
+                    .andWith(FeatureReplacementAction.EE10_FEATURES()
+                                    .forServers("com.ibm.ws.jdbc.fat.krb5.postgresql")
+                                    .fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE11_FEATURES()
                                     .forServers("com.ibm.ws.jdbc.fat.krb5.postgresql")
                                     .fullFATOnly());
 

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/bnd.bnd
@@ -25,7 +25,8 @@ src: \
 fat.project: true
 
 tested.features: connectors-2.0, enterprisebeanslite-4.0, servlet-5.0, xmlbinding-3.0,\
-	appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, connectors-2.1, servlet-6.0, appsecurity-5.0
+	appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, connectors-2.1, servlet-6.0, appsecurity-5.0,\
+	servlet-6.1, appsecurity-6.0, jdbc-4.3
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -32,8 +32,7 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -49,8 +48,9 @@ public class JDBCLoadFromAppTest extends FATServletClient {
     @ClassRule
     public static RepeatTests r = RepeatTests
                     .withoutModification()
-                    .andWith(new JakartaEE9Action())
-                    .andWith(new JakartaEE10Action());
+                    .andWith(FeatureReplacementAction.EE9_FEATURES())
+                    .andWith(FeatureReplacementAction.EE10_FEATURES())
+                    .andWith(FeatureReplacementAction.EE11_FEATURES());
 
     @Server("com.ibm.ws.jdbc.fat.loadfromapp")
     @TestServlets(value = {

--- a/dev/com.ibm.ws.jdbc_fat_v43/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_v43/bnd.bnd
@@ -32,4 +32,4 @@ fat.project: true
 	com.ibm.tx.jta;version=latest,\
 	org.apache.derby:derby;version=10.11.1.1
 
-tested.features: servlet-5.0
+tested.features: servlet-5.0, servlet-6.1

--- a/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018,2020 IBM Corporation and others.
+ * Copyright (c) 2018,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -35,7 +35,7 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -49,7 +49,8 @@ public class JDBC43Test extends FATServletClient {
     @ClassRule
     public static RepeatTests r = RepeatTests
                     .withoutModification()
-                    .andWith(new JakartaEE9Action());
+                    .andWith(FeatureReplacementAction.EE9_FEATURES())
+                    .andWith(FeatureReplacementAction.EE11_FEATURES());
 
     @Server("com.ibm.ws.jdbc.fat.v43")
     @TestServlets({

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE11Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE11Action.java
@@ -123,6 +123,7 @@ public class JakartaEE11Action extends JakartaEEAction {
                                                                          "servlet-6.1",
                                                                          "websocket-2.2"
     };
+    private static final Set<String> NON_PREFERRED_EE11_JDBC_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("jdbc-4.0", "jdbc-4.1", "jdbc-4.2")));
 
     public static final Set<String> EE11_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE11_FEATURES_ARRAY)));
     public static final Set<String> EE11_ONLY_FEATURE_SET_LOWERCASE = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE11_ONLY_FEATURES_ARRAY_LOWERCASE)));
@@ -139,6 +140,9 @@ public class JakartaEE11Action extends JakartaEEAction {
         removeFeatures(EE8FeatureReplacementAction.EE8_FEATURE_SET);
         removeFeatures(JakartaEE9Action.EE9_FEATURE_SET);
         removeFeatures(JakartaEE10Action.EE10_FEATURE_SET);
+        // Update any previous jdbc versions to jdbc-4.3
+        addFeature("jdbc-4.3");
+        removeFeatures(NON_PREFERRED_EE11_JDBC_FEATURES);
         forceAddFeatures(false);
         withMinJavaLevel(SEVersion.JAVA17);
         withID(EE11_ACTION_ID);


### PR DESCRIPTION
- Update jdbc-4.0 and 4.1 features to not start with EE 11 features
- Update EE 11 features to prefer jdbc version of 4.3 and tolerate 4.2
- Update JakartaEE11Action to remove jdbc versions that are not 4.3 or 4.2 and replace with 4.3.
- Update appropriate jdbc FATs to have an EE 11 repeat
