### PR TITLE
transition from method name prefix to annotation based

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -782,13 +782,13 @@ public class QueryInfo {
      * @param count   The Count annotation if present, otherwise null.
      * @param exists  The Exists annotation if present, otherwise null.
      * @param select  The Select annotation if present, otherwise null.
-     * @return true if the method has a Count, Delete, Exists, Insert, Query, Save, or Update annotation. Otherwise false.
+     * @return Count, Delete, Exists, Insert, Query, Save, or Update annotation if present. Otherwise null.
      * @throws UnsupportedOperationException if the combination of annotations is not valid.
      */
     @Trivial
-    boolean validateAnnotationCombinations(Delete delete, Insert insert, Update update, Save save,
-                                           jakarta.data.repository.Query query, OrderBy[] orderBy,
-                                           Filter[] filters, Count count, Exists exists, Select select) {
+    Annotation validateAnnotationCombinations(Delete delete, Insert insert, Update update, Save save,
+                                              jakarta.data.repository.Query query, OrderBy[] orderBy,
+                                              Filter[] filters, Count count, Exists exists, Select select) {
         int f = filters.length == 0 ? 0 : 1;
         int o = orderBy.length == 0 ? 0 : 1;
         int q = query == null ? 0 : 1;
@@ -827,7 +827,11 @@ public class QueryInfo {
                                                     annoClassNames); // TODO NLS
         }
 
-        return iusdce + q > 0;
+        return ius == 1 //
+                        ? (insert != null ? insert : update != null ? update : save) //
+                        : iusdce == 1 //
+                                        ? (delete != null ? delete : count != null ? count : exists) //
+                                        : (q == 1 ? query : null);
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -574,14 +574,14 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Count method that uses the query-by-parameters pattern.
+     * Parameter-based query with the Count annotation to indicate that it performs a count rather than a find operation.
      */
     @Test
-    public void testCountQueryByParameters() {
-        assertEquals(1, primes.count(1, true));
-        assertEquals(0, primes.count(1, false));
-        assertEquals(0, primes.count(2, true));
-        assertEquals(3, primes.count(2, false));
+    public void testCountAnnoParameterBasedQuery() {
+        assertEquals(1, primes.numEvenWithSumOfBits(1, true));
+        assertEquals(0, primes.numEvenWithSumOfBits(1, false));
+        assertEquals(0, primes.numEvenWithSumOfBits(2, true));
+        assertEquals(3, primes.numEvenWithSumOfBits(2, false));
     }
 
     /**
@@ -1223,13 +1223,13 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Exists method that uses the query-by-parameters pattern.
+     * Parameter-based query with the Exists annotation.
      */
     @Test
-    public void testExistsQueryByParameters() {
-        assertEquals(true, primes.existsWith(47, "2F"));
-        assertEquals(false, primes.existsWith(41, "2F")); // 2F is not hex for 41 decimal
-        assertEquals(false, primes.existsWith(15, "F")); // not prime
+    public void testExistsAnnotationWithParameterBasedQuery() {
+        assertEquals(true, primes.isFoundWith(47, "2F"));
+        assertEquals(false, primes.isFoundWith(41, "2F")); // 2F is not hex for 41 decimal
+        assertEquals(false, primes.isFoundWith(15, "F")); // not prime
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -61,16 +61,12 @@ public interface Primes {
     @Filter(by = "numberId", op = Compare.LessThan, param = "max")
     boolean anyLessThanEndingWithBitPattern(@Param("max") long upperLimit, @Param("bits") String pattern);
 
-    int count(int sumOfBits, boolean even);
-
     long countByIdLessThan(long number);
 
     @Asynchronous
     CompletableFuture<Short> countByIdBetweenAndEvenNot(long first, long last, boolean isOdd);
 
     Integer countByNumberIdBetween(long first, long last);
-
-    boolean existsWith(long id, String hex);
 
     Stream<Prime> find(boolean even, int sumOfBits, Limit limit, Sort... sorts);
 
@@ -222,6 +218,9 @@ public interface Primes {
     @OrderBy(value = "id", descending = true)
     List<Long> inRangeHavingVNumeralAndSubstringOfName(long min, long max, String nameSuffix);
 
+    @Exists
+    boolean isFoundWith(long id, String hex);
+
     @Filter(by = "id", op = Compare.LessThan)
     @Filter(by = "name", op = Compare.EndsWith)
     @Filter(as = Filter.Type.Or, by = "id", op = Compare.Between)
@@ -290,6 +289,9 @@ public interface Primes {
     @Filter(by = "id", op = Compare.LessThan)
     @OrderBy("id")
     List<Long> notWithinButBelow(int rangeMin, int rangeMax, int below);
+
+    @Count
+    int numEvenWithSumOfBits(int sumOfBits, boolean even);
 
     @Insert
     void persist(Prime... primes);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -21,6 +21,7 @@ import jakarta.data.Streamable;
 import jakarta.data.page.KeysetAwarePage;
 import jakarta.data.page.KeysetAwareSlice;
 import jakarta.data.page.Pageable;
+import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
@@ -39,8 +40,7 @@ import io.openliberty.data.repository.update.Assign;
 @Repository
 public interface Cities {
     @Exists
-    @Filter(by = "stateName")
-    boolean areFoundIn(String state);
+    boolean areFoundIn(@By("stateName") String state);
 
     long countByStateNameAndIdNotOrIdNotAndName(String state, CityId exceptForInState, CityId exceptForCity, String city);
 


### PR DESCRIPTION
The use of name prefixes on repository methods such as count and exists are now outside of the Jakarta Data specification, and should be replaced with the annotative approach that aligns better with parameter-based queries.