### PR TITLE
Fix server config processing in <include> directory to be case-insensitive

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/XMLConfigParser.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/XMLConfigParser.java
@@ -406,7 +406,8 @@ public class XMLConfigParser {
                     while (children.hasNext()) {
                         alphabeticalChildren.add(children.next());
                     }
-                    Collections.sort(alphabeticalChildren);
+                    // Match sort used for configDropins. Reference ServerXMLConfiguration.java:parseDirectoryFiles()
+                    Collections.sort(alphabeticalChildren, String.CASE_INSENSITIVE_ORDER);
                     for(String child : alphabeticalChildren){
                         parseIncludeDir(parser, docLocation, child, includes, configuration);
                     }


### PR DESCRIPTION
Fixes #26818

Change the behavior of processing server configs in `<include>` directory (case-sensitive) to match the behavior used for processing `configDropins` directories (case-insensitive).