### PR TITLE
Fix RM FAT repeats not loading in mpConfig-3.1 for MP 6.1 repeat

### DIFF
--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/publish/servers/SimpleRxMessagingServer/server.xml
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/publish/servers/SimpleRxMessagingServer/server.xml
@@ -20,5 +20,6 @@
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-3.0</feature>
         <feature>servlet-5.0</feature>
+        <feature>mpConfig-3.1</feature>
     </featureManager>
 </server>


### PR DESCRIPTION
As mpConfig was not present in the server.xml for the FAT server, `mpConfig-3.0` was used even for MP 6.1 repeats where it should have been `mpConfig-3.1`. 

Fixes #26822