### PR TITLE
Telemetry 1.1: Register TelemetryContainerFilter when using EE7/8

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryContainerFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryContainerFilter.java
@@ -71,7 +71,7 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
     private static final RestRouteCache ROUTE_CACHE = new RestRouteCache();
 
     private Instrumenter<ContainerRequestContext, ContainerResponseContext> instrumenter;
-    
+
     private volatile boolean lazyCreate = false;
     private final AtomicReference<Instrumenter<ContainerRequestContext, ContainerResponseContext>> lazyInstrumenter = new AtomicReference<>();
 
@@ -85,14 +85,14 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
             instrumenter = createInstrumenter();
         }
     }
-    
+
     private Instrumenter<ContainerRequestContext, ContainerResponseContext> getInstrumenter() {
         if (instrumenter != null) {
             return instrumenter;
         }
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
-                if (i == null) {                   
+                if (i == null) {
                     return createInstrumenter();
                 } else {
                     return i;
@@ -103,7 +103,6 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
         return instrumenter;
     }
 
-    
     private Instrumenter<ContainerRequestContext, ContainerResponseContext> createInstrumenter() {
         try {
             OpenTelemetryInfo openTelemetry = OpenTelemetryAccessor.getOpenTelemetryInfo();
@@ -206,6 +205,14 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
         } catch (Exception e) {
             Tr.error(tc, Tr.formatMessage(tc, "CWMOT5002.telemetry.error", e));
         }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        if (!CheckpointPhase.getPhase().restored()) {
+            return true;
+        }
+        return getInstrumenter() != null;
     }
 
     private static class ContainerRequestContextTextMapGetter implements TextMapGetter<ContainerRequestContext> {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
@@ -34,10 +34,9 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -49,6 +48,8 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.methods.JaxRsMethodTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.responses.JaxRsResponseCodeTestEndpoints;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.responses.JaxRsResponseCodeTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.route.JaxRsRouteTestEndpoints;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.route.JaxRsRouteTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.B3MultiPropagationTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.B3PropagationTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.JaegerPropagationTestServlet;
@@ -82,10 +83,11 @@ public class JaxRsIntegration extends FATServletClient {
                     //@TestServlet(contextRoot = ASYNC_SERVER_APP_NAME, servlet = JaxRsServerAsyncTestServlet.class),
                     @TestServlet(contextRoot = METHODS_APP_NAME, servlet = JaxRsMethodTestServlet.class),
                     @TestServlet(contextRoot = METHODS_APP_NAME, servlet = JaxRsResponseCodeTestServlet.class),
+                    @TestServlet(contextRoot = METHODS_APP_NAME, servlet = JaxRsRouteTestServlet.class),
     })
     @Server(SERVER_NAME)
     public static LibertyServer server;
-    
+
     @ClassRule
     public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
 
@@ -170,6 +172,7 @@ public class JaxRsIntegration extends FATServletClient {
         WebArchive methodsApp = ShrinkWrap.create(WebArchive.class, METHODS_APP_NAME + ".war")
                         .addPackage(JaxRsMethodTestEndpoints.class.getPackage())
                         .addPackage(JaxRsResponseCodeTestEndpoints.class.getPackage())
+                        .addPackage(JaxRsRouteTestEndpoints.class.getPackage())
                         .addPackage(InMemorySpanExporter.class.getPackage())
                         .addPackage(TestSpans.class.getPackage())
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
@@ -193,8 +196,7 @@ public class JaxRsIntegration extends FATServletClient {
         if (RepeatTestFilter.isRepeatActionActive(MicroProfileActions.MP60_ID)) {
             HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspans/" + traceId);
             assertEquals(TEST_PASSED, readspans.run(String.class));
-        }
-        else{
+        } else {
             HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspansmptel11/" + traceId);
             assertEquals(TEST_PASSED, readspans.run(String.class));
         }
@@ -208,8 +210,7 @@ public class JaxRsIntegration extends FATServletClient {
         if (RepeatTestFilter.isRepeatActionActive(MicroProfileActions.MP60_ID)) {
             HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspans/" + traceId);
             assertEquals(TEST_PASSED, readspans.run(String.class));
-        }
-        else{
+        } else {
             HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspansmptel11/" + traceId);
             assertEquals(TEST_PASSED, readspans.run(String.class));
         }
@@ -223,8 +224,7 @@ public class JaxRsIntegration extends FATServletClient {
         if (RepeatTestFilter.isRepeatActionActive(MicroProfileActions.MP60_ID)) {
             HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspans/" + traceId);
             assertEquals(TEST_PASSED, readspans.run(String.class));
-        }
-        else{
+        } else {
             HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspansmptel11/" + traceId);
             assertEquals(TEST_PASSED, readspans.run(String.class));
         }
@@ -238,8 +238,7 @@ public class JaxRsIntegration extends FATServletClient {
         if (RepeatTestFilter.isRepeatActionActive(MicroProfileActions.MP60_ID)) {
             HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspans/" + traceId);
             assertEquals(TEST_PASSED, readspans.run(String.class));
-        }
-        else{
+        } else {
             HttpRequest readspans = new HttpRequest(server, "/" + APP_NAME + "/endpoints/readspansmptel11/" + traceId);
             assertEquals(TEST_PASSED, readspans.run(String.class));
         }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegrationWithConcurrency.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegrationWithConcurrency.java
@@ -47,6 +47,8 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.methods.JaxRsMethodTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.responses.JaxRsResponseCodeTestEndpoints;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.responses.JaxRsResponseCodeTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.route.JaxRsRouteTestEndpoints;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.route.JaxRsRouteTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.B3MultiPropagationTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.B3PropagationTestServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.transports.JaegerPropagationTestServlet;
@@ -79,6 +81,7 @@ public class JaxRsIntegrationWithConcurrency extends FATServletClient {
                     @TestServlet(contextRoot = ASYNC_SERVER_APP_NAME, servlet = JaxRsServerAsyncTestServlet.class),
                     @TestServlet(contextRoot = METHODS_APP_NAME, servlet = JaxRsMethodTestServlet.class),
                     @TestServlet(contextRoot = METHODS_APP_NAME, servlet = JaxRsResponseCodeTestServlet.class),
+                    @TestServlet(contextRoot = METHODS_APP_NAME, servlet = JaxRsRouteTestServlet.class),
     })
     @Server(SERVER_NAME)
     public static LibertyServer server;
@@ -164,6 +167,7 @@ public class JaxRsIntegrationWithConcurrency extends FATServletClient {
         WebArchive methodsApp = ShrinkWrap.create(WebArchive.class, METHODS_APP_NAME + ".war")
                         .addPackage(JaxRsMethodTestEndpoints.class.getPackage())
                         .addPackage(JaxRsResponseCodeTestEndpoints.class.getPackage())
+                        .addPackage(JaxRsRouteTestEndpoints.class.getPackage())
                         .addPackage(InMemorySpanExporter.class.getPackage())
                         .addPackage(TestSpans.class.getPackage())
                         .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/route/JaxRsRouteTestEndpoints.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/route/JaxRsRouteTestEndpoints.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.route;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+@Path("routeTestEndpoints")
+public class JaxRsRouteTestEndpoints {
+
+    @Path("/getWithId/{id}")
+    @GET
+    public String getWithId(@PathParam("id") String id) {
+        return id;
+    }
+
+    @Path("/getWithQueryParam")
+    @GET
+    public String getWithQueryParam(@QueryParam("id") String id) {
+        return id;
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/route/JaxRsRouteTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/route/JaxRsRouteTestServlet.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.route;
+
+import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.isSpan;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
+import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
+/**
+ * Test that the HTTP_ROUTE attribute is set correctly for a method with placeholders
+ */
+@SuppressWarnings("serial")
+@WebServlet("/testJaxRsRoute")
+public class JaxRsRouteTestServlet extends FATServlet {
+
+    @Inject
+    private InMemorySpanExporter exporter;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private TestSpans utils;
+
+    @Test
+    public void testRouteWithId() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient().target(testUri).path("getWithId/myIdForTesting").request()
+                            .build("GET").invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("myIdForTesting"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString() + "/getWithId/myIdForTesting"));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_ROUTE, getPath() + "/getWithId/{id}"));
+    }
+
+    @Test
+    public void testRouteWithQueryParam() {
+        URI testUri = getUri();
+        Span span = utils.withTestSpan(() -> {
+            Response response = ClientBuilder.newClient()
+                            .target(testUri)
+                            .path("getWithQueryParam")
+                            .queryParam("id", "myIdForTesting")
+                            .request()
+                            .build("GET").invoke();
+            assertThat(response.getStatus(), equalTo(200));
+            assertThat(response.readEntity(String.class), equalTo("myIdForTesting"));
+        });
+
+        List<SpanData> spans = exporter.getFinishedSpanItems(3, span.getSpanContext().getTraceId());
+        TestSpans.assertLinearParentage(spans);
+
+        SpanData clientSpan = spans.get(1);
+        SpanData serverSpan = spans.get(2);
+
+        assertThat(clientSpan, isSpan()
+                        .withKind(SpanKind.CLIENT)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_URL, testUri.toString() + "/getWithQueryParam?id=myIdForTesting"));
+
+        assertThat(serverSpan, isSpan()
+                        .withKind(SpanKind.SERVER)
+                        .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
+                        .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
+                        .withAttribute(SemanticAttributes.HTTP_ROUTE, getPath() + "/getWithQueryParam"));
+    }
+
+    private URI getUri() {
+        try {
+            String path = getPath();
+            URI originalUri = new URI(request.getRequestURL().toString());
+            URI result = new URI(originalUri.getScheme(), originalUri.getAuthority(), path, null, null);
+            return result;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getPath() {
+        return request.getContextPath() + "/routeTestEndpoints";
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryContainerFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/TelemetryContainerFilter.java
@@ -68,7 +68,7 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
 
     @javax.ws.rs.core.Context
     private ResourceInfo resourceInfo;
-    
+
     public TelemetryContainerFilter() {
         if (!CheckpointPhase.getPhase().restored()) {
             lazyCreate = true;
@@ -76,14 +76,14 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
             instrumenter = createInstrumenter();
         }
     }
-    
+
     private Instrumenter<ContainerRequestContext, ContainerResponseContext> getInstrumenter() {
         if (instrumenter != null) {
             return instrumenter;
         }
         if (lazyCreate) {
             instrumenter = lazyInstrumenter.updateAndGet((i) -> {
-                if (i == null) {                    
+                if (i == null) {
                     return createInstrumenter();
                 } else {
                     return i;
@@ -111,6 +111,14 @@ public class TelemetryContainerFilter extends AbstractTelemetryContainerFilter i
         } else {
             return null;
         }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        if (!CheckpointPhase.getPhase().restored()) {
+            return true;
+        }
+        return getInstrumenter() != null;
     }
 
     @Override

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/javax/TelemetryJaxRsProviderRegister.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/javax/TelemetryJaxRsProviderRegister.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,19 +13,20 @@
 
 package io.openliberty.microprofile.telemetry11.internal.rest.javax;
 
+import static org.osgi.service.component.annotations.ConfigurationPolicy.IGNORE;
+
 import java.util.List;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jaxrs20.providers.api.JaxRsProviderRegister;
 
-import static org.osgi.service.component.annotations.ConfigurationPolicy.IGNORE;
 import io.openliberty.microprofile.telemetry11.internal.rest.TelemetryClientFilter;
+import io.openliberty.microprofile.telemetry11.internal.rest.TelemetryContainerFilter;
 
 @Component(configurationPolicy = IGNORE)
 public class TelemetryJaxRsProviderRegister implements JaxRsProviderRegister {
@@ -39,6 +40,11 @@ public class TelemetryJaxRsProviderRegister implements JaxRsProviderRegister {
             if (clientSide) {
                 TelemetryClientFilter currentFilter = new TelemetryClientFilter();
                 if (currentFilter != null && currentFilter.isEnabled()) {
+                    providers.add(currentFilter);
+                }
+            } else {
+                TelemetryContainerFilter currentFilter = new TelemetryContainerFilter();
+                if (currentFilter != null) {
                     providers.add(currentFilter);
                 }
             }

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/javax/TelemetryJaxRsProviderRegister.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/javax/TelemetryJaxRsProviderRegister.java
@@ -44,7 +44,7 @@ public class TelemetryJaxRsProviderRegister implements JaxRsProviderRegister {
                 }
             } else {
                 TelemetryContainerFilter currentFilter = new TelemetryContainerFilter();
-                if (currentFilter != null) {
+                if (currentFilter != null && currentFilter.isEnabled()) {
                     providers.add(currentFilter);
                 }
             }

--- a/dev/io.openliberty.microprofile.telemetry.internal.common/src/io/openliberty/microprofile/telemetry/internal/common/rest/AbstractTelemetryContainerFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.common/src/io/openliberty/microprofile/telemetry/internal/common/rest/AbstractTelemetryContainerFilter.java
@@ -10,8 +10,12 @@
 package io.openliberty.microprofile.telemetry.internal.common.rest;
 
 public abstract class AbstractTelemetryContainerFilter {
-	
-	//This is here to prevent a build time dependency from the common package to the versioned packages.
-    protected static final String SPAN_SCOPE = "otel.span.server.scope";  
 
+    //This is here to prevent a build time dependency from the common package to the versioned packages.
+    protected static final String SPAN_SCOPE = "otel.span.server.scope";
+
+    /**
+     * @return whether telemetry is enabled (i.e. whether the filter will actually do anything)
+     */
+    public abstract boolean isEnabled();
 }


### PR DESCRIPTION
The container filter wasn't being registered when running on EE7/8, resulting in the route information not being provided correctly.

This wasn't immediately obvious from the tests failures, so add some tests specifically for this.

Update the SpanMatcher to output more useful failure messages.

Builds on top of #26797, rebase once that PR is merged.

Fixes #26826
