### PR TITLE
Retrieve gc.time from MP Metrics, instead of GC MXBean for computed m…

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/computed/ComputedMonitorMetricsHandler.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/computed/ComputedMonitorMetricsHandler.java
@@ -501,18 +501,12 @@ public class ComputedMonitorMetricsHandler {
             if (cmm.getComputationType().equals(DURATION)) {
                 Duration currentDur = currentTimer.getElapsedTime();
                 if (currentDur != null)  {
-                    // In the Duration API, the length of the duration is stored using two fields - seconds and nanoseconds. 
-                    // The nanoseconds part is a value from 0 to 999,999,999 that is an adjustment to the length in seconds. 
-                    // To retrieve the REST elaspedTime, we need to get the seconds and the nanoseconds and add them.
-                    double tempSecs = (double) currentDur.getSeconds();
+                    // Get total elapsed time in nanoseconds from Duration API.
+                    double tempDurNanos = (double) currentDur.toNanos();
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, "REST Timer ElapsedTime Duration in seconds = " + tempSecs);
+                        Tr.debug(tc, "REST Timer ElapsedTime Duration in nanoseconds = " + tempDurNanos);
                     }
-                    double tempNanos = (double) currentDur.getNano();
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, "REST Timer ElapsedTime Duration in nanoseconds = " + tempNanos);
-                    }
-                    currentValue = tempSecs + (tempNanos * NANOSECOND_CONVERSION); // convert to secs
+                    currentValue = tempDurNanos * NANOSECOND_CONVERSION; // convert to secs
                 }
             } else {
                 // Get Total Counter Value for Timer


### PR DESCRIPTION
fixes #26835 
- For consistency with the other computed metrics, updated the code to retrieve the `gc.time` and `gc.count` from MP Metrics 5.x registry, instead of explicitly getting it from the GC MXBean.
- Replaced the extra step of retrieving and summing the Total Seconds and Total nanoseconds for the total REST elapsed time, with directly getting the total elapsed time in Nanoseconds and converted that into seconds.