### PR TITLE
Start server at the top of the minute

### DIFF
--- a/dev/com.ibm.ws.logging_2_fat/fat/src/com/ibm/ws/logging/fat/TimeBasedLogRolloverTest.java
+++ b/dev/com.ibm.ws.logging_2_fat/fat/src/com/ibm/ws/logging/fat/TimeBasedLogRolloverTest.java
@@ -349,7 +349,7 @@ public class TimeBasedLogRolloverTest {
     public void testInvalidRolloverStartTime() throws Exception {
 
         //wait to do a server config update at the start of the minute
-	//this allows enough time for timedexit check
+        //this allows enough time for timedexit check
         if (Calendar.getInstance().get(Calendar.SECOND) != 0) {
             Thread.sleep((60000 - Calendar.getInstance().get(Calendar.SECOND)*1000));
             Thread.sleep(2000); //padding
@@ -364,7 +364,7 @@ public class TimeBasedLogRolloverTest {
         }
         setServerConfiguration(true, false, false, "24:00", "", 0);
         List<String> lines = serverInUse.findStringsInLogs("TRAS3015W");
-        LOG.logp(Level.INFO, CLASS_NAME, "testInvalidRolloverInterval", "Found warning: "+lines.toString());
+        LOG.logp(Level.INFO, CLASS_NAME, "testInvalidRolloverStartTime", "Found warning: "+lines.toString());
         assertTrue("No TRAS3015W warning was found indicating that 24:00 is an invalid rolloverStartTime", lines.size() > 0);
     }
 
@@ -374,6 +374,11 @@ public class TimeBasedLogRolloverTest {
      */
     @Test
     public void testInvalidRolloverInterval() throws Exception {
+        //wait to do a server startup at the start of the minute so that it has sufficient time for timedexit check
+        if (Calendar.getInstance().get(Calendar.SECOND) != 0) {
+            Thread.sleep((60000 - Calendar.getInstance().get(Calendar.SECOND)*1000));
+            Thread.sleep(2000); //padding
+        }
         setUp(server_xml, "testInvalidRolloverInterval");
 
         //wait to do a server config update at the start of the minute


### PR DESCRIPTION
fixes #26869 

Start server at the top of the minute to allow sufficient time for timedexit check before log rollover.