### PR TITLE
Update test to not include mpTelemetry-1.1 when testing Java 8

### DIFF
--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
@@ -70,6 +70,7 @@ public class JakartaEE9Test extends FATServletClient {
         if (JavaInfo.JAVA_VERSION < 11) {
             compatFeatures.remove("mpReactiveStreams-3.0");
             compatFeatures.remove("mpReactiveMessaging-3.0");
+            compatFeatures.remove("mpTelemetry-1.1");
         }
 
         // remove logAnalysis-1.0.  It depends on hpel being configured


### PR DESCRIPTION
- mpTelemetry-1.1 requires Java 11.  EE 9 support has a minimum level of Java 8, so the test needs to exclude mpTelemetry-1.1 when testing using Java 8.
