### PR TITLE
ASM cleanup

### DIFF
--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/bci/ThrowableClassAdapter.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/bci/ThrowableClassAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
+import io.openliberty.asm.ASMHelper;
+
 /**
  * Applies a transformation to the java.lang.Throwable class
  *
@@ -23,7 +25,7 @@ import org.objectweb.asm.Opcodes;
 public class ThrowableClassAdapter extends ClassVisitor implements Opcodes {
 
     public ThrowableClassAdapter(ClassVisitor cv) {
-        super(ASM8, cv);
+        super(ASMHelper.getCurrentASM(), cv);
     }
 
     @Override

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/bci/ThrowableMethodAdapter.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/bci/ThrowableMethodAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,8 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
+import io.openliberty.asm.ASMHelper;
+
 /**
  * Injects all Throwable.printStackTrace(PrintStream) calls with a decision to override
  * itself to squash stack traces into one line.
@@ -31,7 +33,7 @@ class ThrowableMethodAdapter extends MethodVisitor implements Opcodes {
     private final String signature;
 
     public ThrowableMethodAdapter(MethodVisitor mv, String name, String desc, String signature) {
-        super(ASM8, mv);
+        super(ASMHelper.getCurrentASM(), mv);
         this.name = name;
         this.desc = desc;
         this.signature = signature;

--- a/dev/com.ibm.ws.org.objectweb.asm/src/io/openliberty/asm/ASMHelper.java
+++ b/dev/com.ibm.ws.org.objectweb.asm/src/io/openliberty/asm/ASMHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,6 +20,7 @@ import org.objectweb.asm.Opcodes;
  */
 public class ASMHelper {
     private static final int CURRENT_ASM = Opcodes.ASM9; // Update this when an ASM update introduces a new constant
+    private static final int CURRENT_MAX_JAVA_LEVEL = Opcodes.V22; // Update this to show the maximum version of Java we can run with
 
     /**
      * Returns the constant representing the current version of ASM.
@@ -30,4 +31,12 @@ public class ASMHelper {
         return CURRENT_ASM;
     }
 
+    /**
+     * Returns the constant representing the maximum Java level at which we can run
+     *
+     * @return
+     */
+    public final static int getMaximumJavaLevel() {
+        return CURRENT_MAX_JAVA_LEVEL;
+    }
 }

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/CheckInstrumentableClassAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/CheckInstrumentableClassAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,8 @@ package com.ibm.ws.ras.instrument.internal.bci;
 
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
+
+import io.openliberty.asm.ASMHelper;
 
 /**
  * Simple adapter that exposes {@code isInstrumentableClass()} and {@code isInstrumentableMethod()}.
@@ -49,7 +51,7 @@ public class CheckInstrumentableClassAdapter extends ClassVisitor {
      *            the visitor to delegate to
      */
     public CheckInstrumentableClassAdapter(ClassVisitor visitor) {
-        super(Opcodes.ASM9, visitor);
+        super(ASMHelper.getCurrentASM(), visitor);
     }
 
     /**

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/DeferConstructorProcessingMethodAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/DeferConstructorProcessingMethodAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,8 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+
+import io.openliberty.asm.ASMHelper;
 
 /**
  * This whole pile of code is needed to keep track of the state of the stack
@@ -91,7 +93,7 @@ public class DeferConstructorProcessingMethodAdapter extends MethodVisitor {
      * Create an instance of a {@code ProbeMethodAdapter}.
      */
     DeferConstructorProcessingMethodAdapter(MethodVisitor visitor) {
-        super(Opcodes.ASM9, visitor);
+        super(ASMHelper.getCurrentASM(), visitor);
     }
 
     private void push(Object stackElement, int count) {

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/RasMethodAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/RasMethodAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007 IBM Corporation and others.
+ * Copyright (c) 2007,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
+import io.openliberty.asm.ASMHelper;
+
 /**
  * Interface that must be implemented by method adapters that wish to plug into
  * the trace instrumentation framework.
@@ -23,7 +25,7 @@ import org.objectweb.asm.Type;
 public abstract class RasMethodAdapter extends MethodVisitor {
 
     public RasMethodAdapter(MethodVisitor visitor) {
-        super(Opcodes.ASM9, visitor);
+        super(ASMHelper.getCurrentASM(), visitor);
     }
 
     /**

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/FFDCIgnoreAnnotationVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/FFDCIgnoreAnnotationVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,8 @@ import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
+import io.openliberty.asm.ASMHelper;
+
 public class FFDCIgnoreAnnotationVisitor extends AnnotationVisitor {
 
     public final static Type FFDC_IGNORE_TYPE = Type.getObjectType("com/ibm/ws/ffdc/annotation/FFDCIgnore");
@@ -27,7 +29,7 @@ public class FFDCIgnoreAnnotationVisitor extends AnnotationVisitor {
     private final Set<Type> ignoredExceptionTypes = new HashSet<Type>();
 
     public FFDCIgnoreAnnotationVisitor(AnnotationVisitor delegate) {
-        super(Opcodes.ASM9, delegate);
+        super(ASMHelper.getCurrentASM(), delegate);
     }
 
     @Override
@@ -48,7 +50,7 @@ class IgnoredExceptionVisitor extends AnnotationVisitor {
     Set<Type> ignoredExceptionTypes;
 
     IgnoredExceptionVisitor(AnnotationVisitor delegate, Set<Type> ignoredExceptionTypes) {
-        super(Opcodes.ASM9, delegate);
+        super(ASMHelper.getCurrentASM(), delegate);
         this.ignoredExceptionTypes = ignoredExceptionTypes;
     }
 

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/InjectedTraceAnnotationVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/InjectedTraceAnnotationVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,8 @@ import java.util.List;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Opcodes;
 
+import io.openliberty.asm.ASMHelper;
+
 import com.ibm.ws.ras.instrument.internal.bci.RasMethodAdapter;
 
 public class InjectedTraceAnnotationVisitor extends AnnotationVisitor {
@@ -28,15 +30,15 @@ public class InjectedTraceAnnotationVisitor extends AnnotationVisitor {
     private boolean visitedValueArray = false;
 
     public InjectedTraceAnnotationVisitor() {
-        super(Opcodes.ASM9);
+        super(ASMHelper.getCurrentASM());
     }
 
     public InjectedTraceAnnotationVisitor(AnnotationVisitor av) {
-        super(Opcodes.ASM9, av);
+        super(ASMHelper.getCurrentASM(), av);
     }
 
     public <T extends RasMethodAdapter> InjectedTraceAnnotationVisitor(AnnotationVisitor av, Class<T> currentMethodVisitor) {
-        super(Opcodes.ASM9, av);
+        super(ASMHelper.getCurrentASM(), av);
         this.currentMethodVisitor = currentMethodVisitor;
     }
 
@@ -56,7 +58,7 @@ public class InjectedTraceAnnotationVisitor extends AnnotationVisitor {
 
     private class ValueArrayVisitor extends AnnotationVisitor {
         private ValueArrayVisitor(AnnotationVisitor av) {
-            super(Opcodes.ASM9, av);
+            super(ASMHelper.getCurrentASM(), av);
         }
 
         @Override

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceConfigClassVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceConfigClassVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007 IBM Corporation and others.
+ * Copyright (c) 2007,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,8 @@ import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+
+import io.openliberty.asm.ASMHelper;
 
 import com.ibm.ws.ras.instrument.internal.model.ClassInfo;
 import com.ibm.ws.ras.instrument.internal.model.FieldInfo;
@@ -46,7 +48,7 @@ public class TraceConfigClassVisitor extends ClassVisitor {
     protected TraceObjectFieldAnnotationVisitor traceObjectFieldAnnotationVisitor;
 
     public TraceConfigClassVisitor(ClassVisitor cv) {
-        super(Opcodes.ASM9, cv);
+        super(ASMHelper.getCurrentASM(), cv);
     }
 
     @Override
@@ -94,7 +96,7 @@ public class TraceConfigClassVisitor extends ClassVisitor {
         private final MethodInfo methodInfo;
 
         private MethodInfoMethodVisitor(MethodVisitor mv, MethodInfo methodInfo) {
-            super(Opcodes.ASM9, mv);
+            super(ASMHelper.getCurrentASM(), mv);
             this.methodInfo = methodInfo;
         }
 
@@ -115,7 +117,7 @@ public class TraceConfigClassVisitor extends ClassVisitor {
             private final MethodInfo methodInfo;
 
             private FFDCIgnoreAnnotationVisitor(AnnotationVisitor av, MethodInfo methodInfo) {
-                super(Opcodes.ASM9, av);
+                super(ASMHelper.getCurrentASM(), av);
                 this.methodInfo = methodInfo;
             }
 
@@ -133,7 +135,7 @@ public class TraceConfigClassVisitor extends ClassVisitor {
             private final MethodInfo methodInfo;
 
             private FFDCIgnoreValueArrayVisitor(AnnotationVisitor av, MethodInfo methodInfo) {
-                super(Opcodes.ASM9, av);
+                super(ASMHelper.getCurrentASM(), av);
                 this.methodInfo = methodInfo;
             }
 

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceConfigPackageVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceConfigPackageVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007 IBM Corporation and others.
+ * Copyright (c) 2007,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,8 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
+import io.openliberty.asm.ASMHelper;
+
 import com.ibm.ws.ras.instrument.internal.model.PackageInfo;
 import com.ibm.ws.ras.instrument.internal.model.TraceOptionsData;
 
@@ -30,11 +32,11 @@ public class TraceConfigPackageVisitor extends ClassVisitor {
     protected TraceOptionsAnnotationVisitor traceOptionsAnnotationVisitor;
 
     public TraceConfigPackageVisitor() {
-        super(Opcodes.ASM9);
+        super(ASMHelper.getCurrentASM());
     }
 
     public TraceConfigPackageVisitor(ClassVisitor visitor) {
-        super(Opcodes.ASM9, visitor);
+        super(ASMHelper.getCurrentASM(), visitor);
     }
 
     @Override

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceObjectFieldAnnotationVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceObjectFieldAnnotationVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,17 +16,19 @@ package com.ibm.ws.ras.instrument.internal.introspect;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Opcodes;
 
+import io.openliberty.asm.ASMHelper;
+
 public class TraceObjectFieldAnnotationVisitor extends AnnotationVisitor {
 
     private String fieldName;
     private String fieldDescriptor;
 
     public TraceObjectFieldAnnotationVisitor() {
-        super(Opcodes.ASM9);
+        super(ASMHelper.getCurrentASM());
     }
 
     public TraceObjectFieldAnnotationVisitor(AnnotationVisitor av) {
-        super(Opcodes.ASM9, av);
+        super(ASMHelper.getCurrentASM(), av);
     }
 
     @Override

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceOptionsAnnotationVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceOptionsAnnotationVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007 IBM Corporation and others.
+ * Copyright (c) 2007,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,8 @@ import java.util.List;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Opcodes;
 
+import io.openliberty.asm.ASMHelper;
+
 import com.ibm.ws.ras.instrument.internal.model.TraceOptionsData;
 
 public class TraceOptionsAnnotationVisitor extends AnnotationVisitor {
@@ -29,15 +31,15 @@ public class TraceOptionsAnnotationVisitor extends AnnotationVisitor {
     private TraceOptionsData packageData;
 
     public TraceOptionsAnnotationVisitor() {
-        super(Opcodes.ASM9);
+        super(ASMHelper.getCurrentASM());
     }
 
     public TraceOptionsAnnotationVisitor(AnnotationVisitor av) {
-        super(Opcodes.ASM9, av);
+        super(ASMHelper.getCurrentASM(), av);
     }
 
     public TraceOptionsAnnotationVisitor(AnnotationVisitor av, TraceOptionsData od) {
-    	super(Opcodes.ASM9, av);
+    	super(ASMHelper.getCurrentASM(), av);
     	packageData = od;
 	}
 
@@ -70,7 +72,7 @@ public class TraceOptionsAnnotationVisitor extends AnnotationVisitor {
     private final class TraceGroupsValueArrayVisitor extends AnnotationVisitor {
 
         private TraceGroupsValueArrayVisitor(AnnotationVisitor av) {
-            super(Opcodes.ASM9, av);
+            super(ASMHelper.getCurrentASM(), av);
         }
 
         @Override

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyRuntimeTransformer.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyRuntimeTransformer.java
@@ -31,6 +31,8 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.util.CheckClassAdapter;
 import org.objectweb.asm.util.TraceClassVisitor;
 
+import io.openliberty.asm.ASMHelper;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.logging.internal.NLSConstants;
@@ -202,7 +204,7 @@ public class LibertyRuntimeTransformer implements ClassFileTransformer {
         if (isJDK8WithHotReplaceBug)
             return classFileVersion <= Opcodes.V1_7;
         else
-            return classFileVersion <= Opcodes.V22;
+            return classFileVersion <= ASMHelper.getMaximumJavaLevel();
     }
 
     /**

--- a/dev/wlp-rasInstrumentation/bnd.bnd
+++ b/dev/wlp-rasInstrumentation/bnd.bnd
@@ -26,7 +26,8 @@ Bundle-Description: Unshipped bundle that houses ras instrumentation for use dur
 Private-Package: \
     com.ibm.*.annotation.*,\
     com.ibm.*.instrument.*,\
-    org.objectweb.asm.*
+    org.objectweb.asm.*,\
+    io.openliberty.asm.*
 
 -plugin.build.bnd.plugins:
 -pluginpath:


### PR DESCRIPTION
Found a few old ASM8 references that needed to be updated as well as a few places where we might be able to use the `io.openliberty.asm.ASMHelper` class to replace hardcoded ASM versions with a call to a static method to get the latest version of ASM or Java.