### PR TITLE
Switch mpTelemetry-1.1 feature tolerates order

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-1.1/io.openliberty.mpTelemetry-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-1.1/io.openliberty.mpTelemetry-1.1.feature
@@ -26,7 +26,7 @@ IBM-API-Package: \
   io.opentelemetry.sdk.resources;type="third-party",\
   io.opentelemetry.instrumentation.annotations;type="third-party"
 -features=\
-  io.openliberty.mpTelemetry1.1.ee-7.0; ibm.tolerates:= "7.0, 8.0, 9.0, 10.0"
+  io.openliberty.mpTelemetry1.1.ee-10.0; ibm.tolerates:= "9.0, 8.0, 7.0"
 -bundles=\
   io.openliberty.com.squareup.okhttp,\
   io.openliberty.com.squareup.okio-jvm,\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/bnd.bnd
@@ -31,13 +31,16 @@ grpcVersion=1.57.2
 
 tested.features:\
   cdi-2.0,\
+  cdi-1.2,\
   mpTelemetry-1.1,\
   mpTelemetry-1.0,\
   mpConfig-3.1,\
   mpConfig-2.0,\
+  mpConfig-1.3,\
   mpRestClient-2.0,\
   mpRestClient-1.1,\
   jaxrs-2.1,\
+  jaxrs-2.0,\
   jsonp-1.1,\
   jsonp-1.0,\
   restfulWS-3.1,\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
@@ -26,6 +26,7 @@ tested.features:\
   mprestclient-1.1,\
   mprestclient-2.0,\
   concurrent-1.0,\
+  jaxrs-2.0,\
   jaxrsclient-2.1,\
   jaxrs-2.1,\
   mpTelemetry-1.0,\
@@ -33,6 +34,7 @@ tested.features:\
   mpconfig-1.3,\
   mpconfig-2.0,\
   mpConfig-3.1,\
+  cdi-1.2,\
   cdi-2.0,\
   restfulWS-3.0,\
   restfulWS-3.1,\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
@@ -25,6 +25,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryAction
                 JaxRsIntegration.class,
                 JaxRsIntegrationWithConcurrency.class,
                 Telemetry10.class,
+                TelemetryAloneTest.class,
                 TelemetryBeanTest.class,
                 TelemetryMultiAppTest.class,
                 TelemetrySpiTest.class,

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryAloneTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryAloneTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat;
+
+import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Test which other features start if you start mpTelemetry on its own
+ */
+@Mode(FULL)
+@RunWith(FATRunner.class)
+public class TelemetryAloneTest {
+
+    @Server("Telemetry10Alone")
+    public static LibertyServer server;
+
+    @After
+    public void stopServer() throws Exception {
+        server.stopServer();
+    }
+
+    @Test
+    public void testMpTelemetry10Alone() throws Exception {
+        setFeature("mpTelemetry-1.0");
+        server.startServer();
+        String featureString = server.waitForStringInLog("CWWKF0012I"); // The server installed the following features:
+        assertThat(featureString, allOf(containsString("cdi-4.0"), containsString("restfulWS-3.1")));
+    }
+
+    @Test
+    public void testMpTelemetry11Alone() throws Exception {
+        setFeature("mpTelemetry-1.1");
+        server.startServer();
+        String featureString = server.waitForStringInLog("CWWKF0012I"); // The server installed the following features:
+        assertThat(featureString, allOf(containsString("cdi-4.0"), containsString("restfulWS-3.1")));
+    }
+
+    private static void setFeature(String feature) throws Exception {
+        ServerConfiguration config = server.getServerConfiguration();
+        Set<String> features = config.getFeatureManager().getFeatures();
+        features.clear();
+        features.add(feature);
+        server.updateServerConfiguration(config);
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Alone/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Alone/bootstrap.properties
@@ -1,0 +1,1 @@
+bootstrap.include=../testports.properties

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Alone/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Alone/server.xml
@@ -1,0 +1,9 @@
+<server description="Server for testing Telemetry10">
+
+    <include location="../fatTestPorts.xml" />
+
+    <featureManager>
+        <feature>mpTelemetry-1.0</feature>
+    </featureManager>
+
+</server>


### PR DESCRIPTION
If given the choice, mpTelemetry-1.1 should start with EE10 features for
preference and then prefer other EE versions in descending order.

This would only have an effect if there are no other EE or MP features
in the server.xml which force a particular EE version.

Fixes #26864