### PR TITLE
Update SPI in JSP to override URIs in TLD Files

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
@@ -52,6 +52,6 @@ Subsystem-Name: JavaServer Pages 2.2
  com.ibm.ws.org.apache.taglibs.standard
 -jars=com.ibm.websphere.appserver.spi.jsp; location:=dev/spi/ibm/, \
  com.ibm.websphere.javaee.jsp.tld.2.2; location:=dev/api/spec/
--files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.0-javadoc.zip
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.1-javadoc.zip
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.3/com.ibm.websphere.appserver.jsp-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.3/com.ibm.websphere.appserver.jsp-2.3.feature
@@ -49,7 +49,7 @@ Subsystem-Name: JavaServer Pages 2.3
  com.ibm.ws.org.apache.taglibs.standard
 -jars=com.ibm.websphere.appserver.spi.jsp; location:=dev/spi/ibm/, \
  com.ibm.websphere.javaee.jsp.tld.2.2; location:=dev/api/spec/
--files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.0-javadoc.zip
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.1-javadoc.zip
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.0/io.openliberty.pages-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.0/io.openliberty.pages-3.0.feature
@@ -49,7 +49,7 @@ Subsystem-Name: Jakarta Server Pages 3.0
  io.openliberty.org.apache.taglibs.standard
 -jars=com.ibm.websphere.appserver.spi.jsp; location:=dev/spi/ibm/, \
  io.openliberty.jakarta.pages.tld.3.0; location:=dev/api/spec/
--files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.0-javadoc.zip
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.1-javadoc.zip
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.1/io.openliberty.pages-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/pages-3.1/io.openliberty.pages-3.1.feature
@@ -47,7 +47,7 @@ Subsystem-Name: Jakarta Server Pages 3.1
  io.openliberty.org.apache.taglibs.standard.3.0
 -jars=com.ibm.websphere.appserver.spi.jsp; location:=dev/spi/ibm/, \
  io.openliberty.jakarta.pages.tld.3.1; location:=dev/api/spec/
--files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.0-javadoc.zip
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.1-javadoc.zip
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/pages-4.0/io.openliberty.pages-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/pages-4.0/io.openliberty.pages-4.0.feature
@@ -45,7 +45,7 @@ Subsystem-Name: Jakarta Server Pages 4.0
  io.openliberty.org.apache.taglibs.standard.3.0
 -jars=com.ibm.websphere.appserver.spi.jsp; location:=dev/spi/ibm/, \
  io.openliberty.jakarta.pages.tld.3.1; location:=dev/api/spec/
--files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.0-javadoc.zip
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.1-javadoc.zip
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.spi.jsp/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.jsp/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion: 1.0
+bVersion: 1.1
 
 Bundle-Name: WebSphere JSP SPI
 Bundle-Description: WebSphere JSP SPI, version ${bVersion}

--- a/dev/com.ibm.ws.jsp.2.3_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsp.2.3_fat/bnd.bnd
@@ -14,9 +14,12 @@ src: \
     fat/src,\
     test-applications/TestInjection.war/src,\
     test-applications/TestEL.war/src,\
-    test-applications/TestPreDestroy.war/src
+    test-applications/TestPreDestroy.war/src,\
+    test-bundle/src
 
 fat.project: true
+
+-sub: *.bnd
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, jsp-2.2 is added programmatically at runtime.
@@ -49,4 +52,5 @@ tested.features:\
     httpunit:httpunit;version=1.5.4,\
     com.ibm.websphere.javaee.interceptor.1.1;version=latest,\
     org.apache.httpcomponents:httpclient;version=4.1.2,\
-    org.apache.httpcomponents:httpcore;version=4.1.2
+    org.apache.httpcomponents:httpcore;version=4.1.2,\
+    com.ibm.websphere.appserver.spi.jsp

--- a/dev/com.ibm.ws.jsp.2.3_fat/build.gradle
+++ b/dev/com.ibm.ws.jsp.2.3_fat/build.gradle
@@ -11,10 +11,23 @@ dependencies {
     requiredLibs project(':io.openliberty.org.apache.commons.codec'),
       project(':io.openliberty.org.apache.commons.codec'),
       project(':io.openliberty.org.apache.commons.logging'),
+      project(':com.ibm.ws.jsp.2.3_fat'),
       'net.sf.jtidy:jtidy:9.3.8',
       'org.apache.httpcomponents:httpclient:4.1.2',
       'org.apache.httpcomponents:httpcore:4.1.2',
       'httpunit:httpunit:1.5.4'
     }
-    
+
+
+task copyFeatureBundle(type: Copy) {
+  dependsOn jar
+  from buildDir
+  into new File(autoFvtDir, 'lib/LibertyFATTestFiles/bundles')
+  include 'io.openliberty.test.tld.jar'
+}
+
+autoFVT {
+  dependsOn copyFeatureBundle
+}
+
 addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/FATSuite.java
@@ -9,6 +9,9 @@
  *******************************************************************************/
 package com.ibm.ws.jsp23.fat;
 
+
+import static org.junit.Assert.assertTrue;
+
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -22,6 +25,7 @@ import com.ibm.ws.jsp23.fat.tests.JSPExceptionTests;
 import com.ibm.ws.jsp23.fat.tests.JSPJava11Test;
 import com.ibm.ws.jsp23.fat.tests.JSPJava17Test;
 import com.ibm.ws.jsp23.fat.tests.JSPJava21Test;
+import com.ibm.ws.jsp23.fat.tests.JSPGlobalTLDTest;
 import com.ibm.ws.jsp23.fat.tests.JSPJava8Test;
 import com.ibm.ws.jsp23.fat.tests.JSPPrepareJSPThreadCountDefaultValueTests;
 import com.ibm.ws.jsp23.fat.tests.JSPPrepareJSPThreadCountNonDefaultValueTests;
@@ -32,6 +36,9 @@ import com.ibm.ws.jsp23.fat.tests.JSTLTests;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.JavaInfo;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
 
 /**
  * JSP 2.3 Tests
@@ -51,7 +58,8 @@ import componenttest.rules.repeater.RepeatTests;
                 JSP23JSP22ServerTest.class,
                 JSPPrepareJSPThreadCountNonDefaultValueTests.class,
                 JSPPrepareJSPThreadCountDefaultValueTests.class,
-                JSTLTests.class
+                JSTLTests.class,
+                JSPGlobalTLDTest.class
 })
 public class FATSuite {
 
@@ -69,11 +77,32 @@ public class FATSuite {
                     .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
                     .andWith(FeatureReplacementAction.EE11_FEATURES());
 
+    //Server used for setup
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("globalTLDServer");
+    
+    public static final String USER_FEATURE_PATH = "usr/extension/lib/features/";
+    public static final String USER_BUNDLE_PATH = "usr/extension/lib/";
+    public static final String USER_FEATURE_MF_FAT_PATH = "features/globaltld-1.0.mf";
+    public static final String USER_FEATURE_NAME = "globaltld-1.0.mf";
+    public static final String USER_BUNDLE_JAR_FAT_PATH = "bundles/io.openliberty.test.tld.jar";
+    public static final String USER_BUNDLE_JAR_NAME = "io.openliberty.test.tld.jar";
+
     /**
      * @see {@link FatLogHandler#generateHelpFile()}
      */
     @BeforeClass
-    public static void generateHelpFile() {
+    public static void setup() throws Exception {
+
+        // Install user feature 
+        // TODO: Transform the jar to work with EE9+ features or recreate this test in the other Pages FATs
+        // https://github.com/OpenLiberty/open-liberty/issues/27345
+        server.copyFileToLibertyInstallRoot(USER_FEATURE_PATH, USER_FEATURE_MF_FAT_PATH);
+        assertTrue("Product feature: " + USER_FEATURE_MF_FAT_PATH + " should have been copied to: " + USER_FEATURE_PATH,
+                   server.fileExistsInLibertyInstallRoot(USER_FEATURE_PATH + USER_FEATURE_NAME));
+        server.copyFileToLibertyInstallRoot(USER_BUNDLE_PATH, USER_BUNDLE_JAR_FAT_PATH);
+        assertTrue("Product bundle: " + USER_BUNDLE_JAR_FAT_PATH + " should have been copied to: " + USER_BUNDLE_PATH,
+                   server.fileExistsInLibertyInstallRoot(USER_BUNDLE_PATH + USER_BUNDLE_JAR_NAME));
+
         FatLogHandler.generateHelpFile();
     }
 

--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPGlobalTLDTest.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPGlobalTLDTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jsp23.fat.tests;
+
+import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE11_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.logging.Logger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jsp23.fat.JSPUtils;
+import com.meterware.httpunit.GetMethodWebRequest;
+import com.meterware.httpunit.WebConversation;
+import com.meterware.httpunit.WebRequest;
+import com.meterware.httpunit.WebResponse;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEEAction;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * 
+ * Verified the new JSP SPI methods work. Added in PR 26892.
+ * Test ensure the global tlds are picked up with the overriden URIs.
+ * 
+ * Test Bundle is not transformed, so we skipp EE9+ features
+ */
+@SkipForRepeat({"CDI-2.0",EE9_FEATURES,EE10_FEATURES,EE11_FEATURES})
+@RunWith(FATRunner.class)
+public class JSPGlobalTLDTest {
+    private static final Logger LOG = Logger.getLogger(JSPGlobalTLDTest.class.getName());
+
+    private static final String OLGH26891_APP_NAME = "OLGH26891";
+
+    @Server("globalTLDServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, OLGH26891_APP_NAME + ".war");
+
+        server.startServer(JSPGlobalTLDTest.class.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    @Test
+    public void testGlobalTLDs_new_constructor() throws Exception {
+        String url = JSPUtils.createHttpUrlString(server, OLGH26891_APP_NAME, "testGlobalTLDs-new-constructor.jsp");
+        LOG.info("url: " + url);
+
+        WebConversation wc = new WebConversation();
+        wc.setExceptionsThrownOnErrorStatus(false);
+
+        WebRequest request = new GetMethodWebRequest(url);
+        WebResponse response = wc.getResponse(request);
+        LOG.info("Response: " + response.getText()); 
+
+        String expected = "***/WEB-INF/tld/test1.tld used!***";
+
+        assertTrue("The response did not contain: " + expected, response.getText().contains(expected));
+
+    }
+
+    @Test
+    public void testGlobalTLDs_old_constructor() throws Exception {
+        String url = JSPUtils.createHttpUrlString(server, OLGH26891_APP_NAME, "testGlobalTLDs-old-constructor.jsp");
+        LOG.info("url: " + url);
+
+        WebConversation wc = new WebConversation();
+        wc.setExceptionsThrownOnErrorStatus(false);
+
+        WebRequest request = new GetMethodWebRequest(url);
+        WebResponse response = wc.getResponse(request);
+        LOG.info("Response: " + response.getText()); 
+
+        String expected = "***io.test.one.tld***";
+
+        assertTrue("The response did not contain: " + expected, response.getText().contains(expected));
+    }
+}

--- a/dev/com.ibm.ws.jsp.2.3_fat/global_tld.bnd
+++ b/dev/com.ibm.ws.jsp.2.3_fat/global_tld.bnd
@@ -1,0 +1,36 @@
+#*******************************************************************************
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+bSymbolicName=io.openliberty.test.tld
+
+Bundle-Name: TEST TLD
+Bundle-SymbolicName: io.openliberty.test.tld
+Bundle-Description:  TEST TLD
+
+Private-Package: \
+  io.openliberty.test.tld
+
+Export-Package: \
+  io.openliberty.test.tag;version=1.0;thread-context=true, \
+  com.example;version=1.0;thread-context=true
+
+Service-Component: \
+  io.openliberty.test.global.taglib; \
+    implementation:=io.openliberty.test.tld.TestGlobalConfig; \
+    provide:='com.ibm.wsspi.jsp.taglib.config.GlobalTagLibConfig'; \
+    properties:="service.vendor=IBM"
+
+Include-Resource: \
+    WEB-INF=test-bundle/resources/WEB-INF
+
+-buildpath: \
+  com.ibm.ws.jsp;version=latest,\
+  com.ibm.websphere.javaee.jsp.2.2;version=latest

--- a/dev/com.ibm.ws.jsp.2.3_fat/jsp_fat.bnd
+++ b/dev/com.ibm.ws.jsp.2.3_fat/jsp_fat.bnd
@@ -1,0 +1,14 @@
+#*******************************************************************************
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+# Define the bundle for this FAT
+Bundle-SymbolicName: ${basename;${basedir}}

--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/files/features/globaltld-1.0.mf
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/files/features/globaltld-1.0.mf
@@ -1,0 +1,7 @@
+Subsystem-ManifestVersion: 1.0
+Subsystem-SymbolicName: io.openliberty.jsp.globaltld-1.0; visibility:=public
+Subsystem-Version: 1.0.0.qualifier
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Content: io.openliberty.test.tld; version="[1,1.0.100)"
+IBM-Feature-Version: 2
+IBM-ShortName: globaltld-1.0

--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/globalTLDServer/.gitignore
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/globalTLDServer/.gitignore
@@ -1,0 +1,1 @@
+/dropins

--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/globalTLDServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/globalTLDServer/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2023, 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7777

--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/globalTLDServer/server.xml
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/globalTLDServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2023, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -7,16 +7,13 @@
     
     SPDX-License-Identifier: EPL-2.0
  -->
-<server description="Server for testing JavaServer Pages 2.3">
+<server description="Server for testing Global Tag Library SPI">
 
     <include location="../fatTestPorts.xml"/>
 
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>usr:globaltld-1.0</feature>
     </featureManager>
-
-    <javaPermission className="java.util.PropertyPermission" name="dtm.debug" actions="read"/>
-
-     <javaPermission className="java.util.PropertyPermission" name="user.dir" actions="read"/>
 
 </server>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/OLGH26891.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/OLGH26891.war/resources/WEB-INF/web.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<web-app
+    version="3.1"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+
+  <display-name>OLGH26891</display-name>
+
+</web-app>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/OLGH26891.war/resources/testGlobalTLDs-new-constructor.jsp
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/OLGH26891.war/resources/testGlobalTLDs-new-constructor.jsp
@@ -1,0 +1,27 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<%@ page language="java" contentType="text/html; charset=ISO-8859-1"
+    pageEncoding="ISO-8859-1"%>
+<%@ taglib prefix="original" uri="/WEB-INF/tld/test1.tld"%>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+        <title>Global TLD: Original</title>
+    </head>
+    <body>
+        <!--
+            Expected to work 
+            We are using the new constructor, so the URI argument should be honored 
+            "addtoTldPathList(new TldPathConfig("WEB-INF/tld/test1.tld", "/WEB-INF/tld/test1.tld", false));"
+        -->
+        <original:Sample>/WEB-INF/tld/test1.tld used!</original:Sample>
+    </body>
+</html>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/OLGH26891.war/resources/testGlobalTLDs-old-constructor.jsp
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/OLGH26891.war/resources/testGlobalTLDs-old-constructor.jsp
@@ -1,0 +1,27 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<%@ page language="java" contentType="text/html; charset=ISO-8859-1"
+    pageEncoding="ISO-8859-1"%>
+<%@ taglib prefix="test2" uri="io.test.one.tld"%>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+        <title>Global TLD: Test 2</title>
+    </head>
+    <body>
+        <!--
+            Expected to work 
+            We are using the old constructor, so the TLD file'S URI should be honored
+            "addtoTldPathList(new TldPathConfig("WEB-INF/tld/test2.tld", "/WEB-INF/tld/test1.tld", null));"
+        -->
+        <test2:Sample>io.test.one.tld</test2:Sample>
+    </body>
+</html>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-bundle/resources/WEB-INF/tld/test1.tld
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-bundle/resources/WEB-INF/tld/test1.tld
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<taglib>
+    <tlib-version>1.2</tlib-version>
+    <jsp-version>2.3</jsp-version>
+    <short-name>TEST TLD</short-name>
+    <uri>io.test.one.tld</uri>
+    <tag>
+       <name>Sample</name>
+       <tag-class>io.openliberty.test.tag.SampleTag</tag-class>
+       <body-content>scriptless</body-content>
+    </tag>
+</taglib>

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-bundle/src/io/openliberty/test/tag/SampleTag.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-bundle/src/io/openliberty/test/tag/SampleTag.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.test.tag;
+
+import java.io.IOException;
+import javax.servlet.jsp.JspTagException;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.Tag;
+
+
+public class SampleTag implements Tag {
+  private PageContext pageContext;
+  
+  private Tag parent;
+  
+  public void setPageContext(PageContext pageContext) {
+    this.pageContext = pageContext;
+  }
+  
+  public void setParent(Tag parent) {
+    this.parent = parent;
+  }
+  
+  public Tag getParent() {
+    return this.parent;
+  }
+  
+  public int doStartTag() throws JspTagException {
+    try {
+          this.pageContext.getOut().write("***");
+    } catch (Exception e) {
+      throw new JspTagException(e.getCause());
+    }
+    return 1;
+  }
+  
+  public int doEndTag() throws JspTagException {  
+    try {
+          this.pageContext.getOut().write("***");
+    } catch (Exception e) {
+      throw new JspTagException(e.getCause());
+    }
+    return 0;
+  }
+  
+  public void release() {}
+}

--- a/dev/com.ibm.ws.jsp.2.3_fat/test-bundle/src/io/openliberty/test/tld/TestGlobalConfig.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-bundle/src/io/openliberty/test/tld/TestGlobalConfig.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.test.tld;
+
+import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import com.ibm.wsspi.jsp.taglib.config.GlobalTagLibConfig;
+import com.ibm.wsspi.jsp.taglib.config.TldPathConfig;
+
+public class TestGlobalConfig extends GlobalTagLibConfig {
+    public TestGlobalConfig() {
+        super();
+
+        setJarName("test-tld.jar");
+
+        // NEW CONSTRUCTOR
+        addtoTldPathList(new TldPathConfig("WEB-INF/tld/test1.tld", "/WEB-INF/tld/test1.tld", false));
+
+        // OLD CONSTRUCTOR
+        addtoTldPathList(new TldPathConfig("WEB-INF/tld/test1.tld", "/WEB-INF/tld/test1.tld", null));
+
+        setClassloader(AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+            public ClassLoader run() {
+                return TestGlobalConfig.class.getClassLoader();
+            }
+        }));
+
+        setJarURL(AccessController.doPrivileged(new PrivilegedAction<URL>() {
+            public URL run() {
+                return getClassloader().getResource("WEB-INF/tld/test1.tld");
+            }
+        }));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void addtoTldPathList(TldPathConfig tldPathConfig) {
+        getTldPathList().add(tldPathConfig);
+    }
+}

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/taglib/GlobalTagLibraryCache.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/taglib/GlobalTagLibraryCache.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2023 IBM Corporation and others.
+ * Copyright (c) 1997, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsp.taglib;
 
@@ -43,15 +40,15 @@ import com.ibm.ws.jsp.configuration.JspXmlExtConfig;
 import com.ibm.ws.jsp.inputsource.JspInputSourceFactoryImpl;
 import com.ibm.ws.jsp.taglib.config.AvailabilityCondition;
 import com.ibm.ws.jsp.taglib.config.AvailabilityConditionType;
-import com.ibm.wsspi.adaptable.module.Container;
-import com.ibm.wsspi.jsp.taglib.config.GlobalTagLibConfig;
 import com.ibm.ws.jsp.taglib.config.ImplicitTagLibConfig;
 import com.ibm.ws.jsp.taglib.config.TagLibCacheConfigParser;
-import com.ibm.wsspi.jsp.taglib.config.TldPathConfig;
+import com.ibm.wsspi.adaptable.module.Container;
 import com.ibm.wsspi.jsp.context.JspClassloaderContext;
 import com.ibm.wsspi.jsp.context.JspCoreContext;
 import com.ibm.wsspi.jsp.resource.JspInputSource;
 import com.ibm.wsspi.jsp.resource.JspInputSourceFactory;
+import com.ibm.wsspi.jsp.taglib.config.GlobalTagLibConfig;
+import com.ibm.wsspi.jsp.taglib.config.TldPathConfig;
 import com.ibm.wsspi.webcontainer.servlet.IServletContext;
 
 public class GlobalTagLibraryCache extends Hashtable implements JspCoreContext, 
@@ -582,15 +579,31 @@ public class GlobalTagLibraryCache extends Hashtable implements JspCoreContext,
             try {
                 TagLibraryInfoImpl tli = tldParser.parseTLD(tldInputSource, is, globalTagLibConfig.getJarURL().toExternalForm());
                 if (tli.getReliableURN() != null) {
-                    if (containsKey(tli.getReliableURN()) == false) {
+                    
                         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
                             logger.logp(Level.FINE, CLASS_NAME, "loadTldFromClassloader", "Global jar tld loaded for {0}", tli.getReliableURN());
                         }
-                        tli.setURI(tli.getReliableURN());
-                        put(tli.getReliableURN(), tli);
-                        tldPathConfig.setUri(tli.getReliableURN());
+
+                        if(tldPathConfig.isTLDURIOverridden()){ // override the URI within the TLD - see OLGH 26891
+                            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+                                logger.logp(Level.FINE, CLASS_NAME, "loadTldFromClassloader", "overrideTLDURI is true");
+                            }
+                            if (containsKey(tldPathConfig.getUri()) == false) {
+                                tli.setURI(tldPathConfig.getUri());
+                                tli.setReliableURN(tldPathConfig.getUri());
+                                put(tldPathConfig.getUri(), tli);
+                            }
+                        } else { // continue as before (use the uri within the file)
+                            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+                                logger.logp(Level.FINE, CLASS_NAME, "loadTldFromClassloader", "overrideTLDURI is false");
+                            }
+                            if (containsKey(tli.getReliableURN()) == false) {
+                                tli.setURI(tli.getReliableURN());
+                                put(tli.getReliableURN(), tli);
+                                tldPathConfig.setUri(tli.getReliableURN());
+                            }
+                        }
                         eventListenerList.addAll(tldParser.getEventListenerList());
-                    }
                 } else {
                     if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.WARNING)) {
                         logger.logp(Level.WARNING, CLASS_NAME, "loadTldFromClassloader", "jsp warning failed to find a uri tag in [" + tldInputSource.getAbsoluteURL() + "]");

--- a/dev/com.ibm.ws.jsp/src/com/ibm/wsspi/jsp/taglib/config/TldPathConfig.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/wsspi/jsp/taglib/config/TldPathConfig.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2004 IBM Corporation and others.
+ * Copyright (c) 1997, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.wsspi.jsp.taglib.config;
 
@@ -24,7 +21,17 @@ public class TldPathConfig {
     private String uri = null;
     private boolean containsListenerDefs = false;
     private List availabilityConditionList = null;    
+    private boolean overrideTLDURI = false;
     
+
+    /**
+     * Use {@link #TldPathConfig(String tldPath, String uri, boolean strContainsListenerDefs)  TldPathConfig(String tldPath, String uri, boolean strContainsListenerDefs)} instead
+     * 
+     * @param tldPath - location of the TLD file.
+     * @param uri -This value is ignored in favor of the uri attribute within the TLD file. Use the other constructor if a custom URI is needed.
+     * @param strContainsListenerDefs - use "true" if any listeners are contained while any other value is considered false.
+     */
+    @Deprecated 
     public TldPathConfig(String tldPath, String uri, String strContainsListenerDefs) {
         this.tldPath = tldPath;
         this.uri = uri;
@@ -32,8 +39,23 @@ public class TldPathConfig {
             containsListenerDefs = true;    
         }
         availabilityConditionList = new ArrayList();
+        overrideTLDURI = false;
     }
-    
+    /**
+     * Note that strContainsListenerDefs is a boolean
+     * 
+     * @param tldPath - location of the TLD file.
+     * @param uri - overrides the uri attribute within the TLD file. (If overriding is not needed, set uri argument to match the uri-attribute in the TLD)
+     * @param strContainsListenerDefs - boolean value  if any listeners are contained within the TLD.
+     */
+    public TldPathConfig(String tldPath, String uri, boolean strContainsListenerDefs) {
+        this.tldPath = tldPath;
+        this.uri = uri;
+        this.containsListenerDefs = strContainsListenerDefs;  
+        availabilityConditionList = new ArrayList();
+        this.overrideTLDURI = true;
+    }
+
     /**
      * Gets the conditions as to when this tld is made available.
      * The condition can be the existence of a file within the web-inf directory or the existence of a servlet class.
@@ -60,8 +82,11 @@ public class TldPathConfig {
     }
 
     /**
+     *  The uri will only be picked up by the JSP Engine when {@link #TldPathConfig(String tldPath, String uri, boolean strContainsListenerDefs)} is used.
+     * 
      * Sets the uri for the tld
-     * param string String - the uri for the tld
+     * <p> The uri will only be picked up by the JSP Engine when {@link #TldPathConfig(String tldPath, String uri, boolean strContainsListenerDefs)} is used. </p>
+     * @param string String - the uri for the tld
      */
     public void setUri(String string) {
         uri = string;
@@ -74,4 +99,14 @@ public class TldPathConfig {
     public boolean containsListenerDefs() {
         return containsListenerDefs;
     }
+
+    /**
+     * Specifies if the uri argument should override the uri attribute in the TLD. 
+     * <p> Determined by which construtor is used. </p>
+     * @return boolean - true only if {@link #TldPathConfig(String tldPath, String uri, boolean strContainsListenerDefs) TldPathConfig(String tldPath, String uri, boolean strContainsListenerDefs)}  is used
+     */
+    public boolean isTLDURIOverridden() {
+        return this.overrideTLDURI;
+    }
+
 }

--- a/dev/com.ibm.ws.jsp/src/com/ibm/wsspi/jsp/taglib/config/package-info.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/wsspi/jsp/taglib/config/package-info.java
@@ -1,18 +1,15 @@
 
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 /**
- * @version 1.0.0
+ * @version 1.1.0
  */
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package com.ibm.wsspi.jsp.taglib.config;


### PR DESCRIPTION
fixes #26891 

Testing requires a new bundle, and I'm not sure if that worth the trouble for this one particular test? 

Customer tested the fix and was pleased with the new behavior. 
______


I've added two new methods to the TldPathConfig class: 


    public TldPathConfig forceCustomURI()

        Forces the URI specified in the second TldPathConfig argument.  Ignores the URI in the tld file. 

        There is a boolean (forceCustomURI) in the class which tells which URI to use (arguement vs file) 

    public TldPathConfig[] configureWithBothURIs()

         Note this this returns an array.   It returns two TldPathConfig objects  - one with forceCustomURI true and the other as false. 

         Your extension class will need another method (which accepts an array) to handle the array. See the example below. 


test.tld: 
```
  <description>Example TagLib</description>
  <display-name>test TLD</display-name>
  <tlib-version>1.0</tlib-version>
  <short-name>t</short-name>
  <uri>com.test.tld</uri>
```



`addtoTldPathList((new` TldPathConfig("WEB-INF/test.tld", "WEB-INF/test.tld", null)).configureWithBothURIs());

```
private void addtoTldPathList(TldPathConfig[] tldPathConfigList) {
    for (TldPathConfig tld : tldPathConfigList)
      getTldPathList().add(tld); 
  }

```

The tld path list would contain two entries one for "META-INF/test.tld" and another for "com.test.tld".


If you only wanted to use "WEB-INF/test.tld", then use forceCustomURI() instead:

`addtoTldPathList((new TldPathConfig("WEB-INF/test.tld", "WEB-INF/test.tld", null)).forceCustomURI());`