### PR TITLE
Enable sequential peer recovery

### DIFF
--- a/dev/com.ibm.tx.jta/src/com/ibm/tx/jta/impl/TransactionImpl.java
+++ b/dev/com.ibm.tx.jta/src/com/ibm/tx/jta/impl/TransactionImpl.java
@@ -3261,9 +3261,9 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
         boolean result = false;
         if (_inRecovery && auditRecovery && resource instanceof JTAXAResourceImpl) {
             if (outcome) {
-                Tr.audit(tc, "WTRN0137_REC_TXN_COMMIT", new Object[] { _localTID, printXID(resource), resource.describe() });
+                Tr.audit(tc, "WTRN0137_REC_TXN_COMMIT", new Object[] { String.valueOf(_localTID), printXID(resource), resource.describe() });
             } else {
-                Tr.audit(tc, "WTRN0138_REC_TXN_ROLLBACK", new Object[] { _localTID, printXID(resource), resource.describe() });
+                Tr.audit(tc, "WTRN0138_REC_TXN_ROLLBACK", new Object[] { String.valueOf(_localTID), printXID(resource), resource.describe() });
             }
             result = true;
         }
@@ -3280,18 +3280,20 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
         if (_inRecovery && auditRecovery && resource instanceof JTAXAResourceImpl) {
             if (outcome) {
                 if (code == XAResource.XA_OK) {
-                    Tr.audit(tc, "WTRN0140_REC_TXN_COMMITED", new Object[] { _localTID, printXID(resource), resource.describe() });
+                    Tr.audit(tc, "WTRN0140_REC_TXN_COMMITED", new Object[] { String.valueOf(_localTID), printXID(resource), resource.describe() });
 
                 } else // what about XAER_NOTA
                 {
-                    Tr.audit(tc, "WTRN0141_REC_TXN_COMMITERR", new Object[] { _localTID, printXID(resource), resource.describe(), XAReturnCodeHelper.convertXACode(code) });
+                    Tr.audit(tc, "WTRN0141_REC_TXN_COMMITERR",
+                             new Object[] { String.valueOf(_localTID), printXID(resource), resource.describe(), XAReturnCodeHelper.convertXACode(code) });
                 }
             } else {
                 if (code == XAResource.XA_OK) {
-                    Tr.audit(tc, "WTRN0142_REC_TXN_ROLLED", new Object[] { _localTID, printXID(resource), resource.describe() });
+                    Tr.audit(tc, "WTRN0142_REC_TXN_ROLLED", new Object[] { String.valueOf(_localTID), printXID(resource), resource.describe() });
                 } else // what about XAER_NOTA
                 {
-                    Tr.audit(tc, "WTRN0143_REC_TXN_ROLLEDERR", new Object[] { _localTID, printXID(resource), resource.describe(), XAReturnCodeHelper.convertXACode(code) });
+                    Tr.audit(tc, "WTRN0143_REC_TXN_ROLLEDERR",
+                             new Object[] { String.valueOf(_localTID), printXID(resource), resource.describe(), XAReturnCodeHelper.convertXACode(code) });
                 }
             }
         }
@@ -3306,7 +3308,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
 
         boolean result = false;
         if (_inRecovery && auditRecovery && resource instanceof JTAXAResourceImpl) {
-            Tr.audit(tc, "WTRN0139_REC_TXN_FORGET", new Object[] { _localTID, printXID(resource), resource.describe() });
+            Tr.audit(tc, "WTRN0139_REC_TXN_FORGET", new Object[] { String.valueOf(_localTID), printXID(resource), resource.describe() });
             result = true;
         }
 
@@ -3321,10 +3323,11 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
 
         if (_inRecovery && auditRecovery && resource instanceof JTAXAResourceImpl) {
             if (code == XAResource.XA_OK) {
-                Tr.audit(tc, "WTRN0144_REC_TXN_FORGOT", new Object[] { _localTID, printXID(resource), resource.describe() });
+                Tr.audit(tc, "WTRN0144_REC_TXN_FORGOT", new Object[] { String.valueOf(_localTID), printXID(resource), resource.describe() });
             } else // what about XAER_NOTA
             {
-                Tr.audit(tc, "WTRN0145_REC_TXN_FORGETERR", new Object[] { _localTID, resource.getXID(), resource.describe(), XAReturnCodeHelper.convertXACode(code) });
+                Tr.audit(tc, "WTRN0145_REC_TXN_FORGETERR",
+                         new Object[] { String.valueOf(_localTID), resource.getXID(), resource.describe(), XAReturnCodeHelper.convertXACode(code) });
             }
         }
 
@@ -3337,7 +3340,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
             Tr.entry(tc, "auditTransaction", this);
 
         if (_inRecovery && auditRecovery) {
-            Tr.audit(tc, "WTRN0136_RECOVERING_TRAN", new Object[] { getTranName(), _localTID, Util.printStatus(getStatus()) });
+            Tr.audit(tc, "WTRN0136_RECOVERING_TRAN", new Object[] { getTranName(), String.valueOf(_localTID), Util.printStatus(getStatus()) });
         }
 
         if (tc.isEntryEnabled())

--- a/dev/com.ibm.tx.jta/src/com/ibm/tx/jta/util/TranLogConfiguration.java
+++ b/dev/com.ibm.tx.jta/src/com/ibm/tx/jta/util/TranLogConfiguration.java
@@ -1,12 +1,12 @@
 package com.ibm.tx.jta.util;
 
 /*******************************************************************************
- * Copyright (c) 2002, 2021 IBM Corporation and others.
+ * Copyright (c) 2002, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -86,49 +86,49 @@ public final class TranLogConfiguration {
 
     public int type() {
         if (tc.isDebugEnabled())
-            Tr.debug(tc, "type", _type);
+            Tr.debug(tc, "type: {0}", _type);
         return _type;
     }
 
     public String streamName() {
         if (tc.isDebugEnabled())
-            Tr.debug(tc, "streamName", _streamName);
+            Tr.debug(tc, "streamName: {0}", _streamName);
         return _streamName;
     }
 
     public String originalLogDirectory() {
         if (tc.isDebugEnabled())
-            Tr.debug(tc, "originalLogDirectory", _originalLogDirectory);
+            Tr.debug(tc, "originalLogDirectory: {0}", _originalLogDirectory);
         return _originalLogDirectory;
     }
 
     public String expandedLogDirectory() {
         if (tc.isDebugEnabled())
-            Tr.debug(tc, "expandedLogDirectory", _expandedLogDirectory);
+            Tr.debug(tc, "expandedLogDirectory: {0}", _expandedLogDirectory);
         return _expandedLogDirectory;
     }
 
     public int logFileSize() {
         if (tc.isDebugEnabled())
-            Tr.debug(tc, "logFileSize", _logFileSize);
+            Tr.debug(tc, "logFileSize: {0}", _logFileSize);
         return _logFileSize;
     }
 
     public boolean enabled() {
         if (tc.isDebugEnabled())
-            Tr.debug(tc, "enabled", _enabled);
+            Tr.debug(tc, "enabled: {0}", _enabled);
         return _enabled;
     }
 
     public String customId() {
         if (tc.isDebugEnabled())
-            Tr.debug(tc, "customId", _customId);
+            Tr.debug(tc, "customId: {0}", _customId);
         return _customId;
     }
 
     public Properties customProperties() {
         if (tc.isDebugEnabled())
-            Tr.debug(tc, "customProperties", _customProps);
+            Tr.debug(tc, "customProperties: {0}", _customProps);
         return _customProps;
     }
 }

--- a/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/FileSharedServerLeaseLog.java
+++ b/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/FileSharedServerLeaseLog.java
@@ -836,15 +836,19 @@ public class FileSharedServerLeaseLog extends LeaseLogImpl implements SharedServ
                 if (tc.isEntryEnabled())
                     Tr.exit(tc, "getBackendURL", ret);
                 return ret;
-            } catch (Exception e) {
+            } catch (FileNotFoundException e) {
                 if (tc.isDebugEnabled())
-                    Tr.debug(tc, "getBackendURL: Lease was probably being renewed. Wait 500ms and try one more time", e);
+                    Tr.debug(tc, "getBackendURL: Lease file not found. Recovery is probably done.");
+                break;
+            } catch (IOException e) {
+                if (tc.isDebugEnabled())
+                    Tr.debug(tc, "getBackendURL: Lease was probably being renewed. Wait 500ms and try again.", e);
             }
 
-            // Just the one retry
-            if (retries++ > 0) {
+            // Retry for 30s
+            if (retries++ > 60) {
                 if (tc.isDebugEnabled())
-                    Tr.debug(tc, "getBackendURL: Couldn't access lease file even on a retry.");
+                    Tr.debug(tc, "getBackendURL: Couldn't access lease file even after retrying.");
                 break;
             }
 

--- a/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/MultiScopeRecoveryLog.java
+++ b/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/MultiScopeRecoveryLog.java
@@ -2457,6 +2457,7 @@ public class MultiScopeRecoveryLog implements LogCursorCallback, MultiScopeLog {
             if (_logHandle != null) {
                 try {
                     _logHandle.delete();
+                    _logHandle = null;
                 } catch (Exception e) {
                     FFDCFilter.processException(e, "com.ibm.ws.recoverylog.spi.MultiScopeRecoveryLog.delete", "2445", this);
                     if (tc.isEntryEnabled())

--- a/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/PeerLeaseData.java
+++ b/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/PeerLeaseData.java
@@ -40,8 +40,6 @@ public class PeerLeaseData {
 
     @Trivial
     public String getRecoveryIdentity() {
-        if (tc.isDebugEnabled())
-            Tr.debug(tc, "getRecoveryIdentity", _recoveryIdentity);
         return _recoveryIdentity;
     }
 
@@ -50,8 +48,6 @@ public class PeerLeaseData {
      */
     @Trivial
     public long getLeaseTime() {
-        if (tc.isDebugEnabled())
-            Tr.debug(tc, "getLeaseTime", Utils.traceTime(_leaseTime));
         return _leaseTime;
     }
 
@@ -60,23 +56,18 @@ public class PeerLeaseData {
      */
     @Trivial
     public boolean isExpired() {
-        boolean expired = false;
         long curTime = System.currentTimeMillis();
 
         if (curTime - _leaseTime > _leaseTimeout * 1000) {
             if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Lease has EXPIRED for " + _recoveryIdentity + ", currenttime: " + Utils.traceTime(curTime) + ", storedTime: " + Utils.traceTime(_leaseTime) + " ("
-                             + (curTime - _leaseTime) / 1000 + "s)");
+                Tr.debug(tc, "Lease for " + _recoveryIdentity + " expired at " + Utils.traceTime(_leaseTime + _leaseTimeout));
             }
-            expired = true;
+            return true;
         } else {
             if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Lease has not expired for " + _recoveryIdentity + ", currenttime: " + Utils.traceTime(curTime) + ", storedTime: " + Utils.traceTime(_leaseTime) + " ("
-                             + (curTime - _leaseTime) / 1000 + "s)");
+                Tr.debug(tc, "Lease for " + _recoveryIdentity + " has not expired. " + (curTime + _leaseTimeout - _leaseTime) / 1000 + " seconds left.");
             }
+            return false;
         }
-
-        return expired;
     }
-
 }

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/CloudFATServletClient.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/CloudFATServletClient.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package tests;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.ibm.tx.jta.ut.util.XAResourceImpl;
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.transaction.fat.util.FATUtils;
+import com.ibm.ws.transaction.fat.util.SetupRunner;
+
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+public abstract class CloudFATServletClient extends FATServletClient {
+
+    private static boolean _isDerby;
+
+    public static LibertyServer server1;
+    public static LibertyServer server2;
+
+    public static String APP_NAME;
+    public static String SERVLET_NAME;
+
+    private static SetupRunner _runner;
+
+    protected static void initialize(LibertyServer s1, LibertyServer s2, String appName, String servletName) {
+        initialize(s1, s2, appName, servletName, null);
+    }
+
+    protected static void initialize(LibertyServer s1, LibertyServer s2, String appName, String servletName, SetupRunner runner) {
+        server1 = s1;
+        server2 = s2;
+
+        APP_NAME = appName;
+        SERVLET_NAME = appName + servletName;
+
+        _runner = runner;
+    }
+
+    /**
+     * The purpose of this test is to verify that simple peer transaction recovery works multiple times.
+     *
+     * The FSCloud001 server is started and halted by a servlet that leaves an indoubt transaction.
+     * FSCloud002, a peer server as it belongs to the same recovery group is started and recovery the
+     * transaction that belongs to FSCloud001. Twice.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDoubleRecoveryTakeover() throws Exception {
+        final String method = "testDoubleRecoveryTakeover";
+        StringBuilder sb = null;
+        String id = "Core";
+
+        if (_isDerby) {
+            return;
+        }
+
+        // Start Server1
+        FATUtils.startServers(_runner, server1);
+
+        try {
+            // We expect this to fail since it is gonna crash the server
+            sb = runTestWithResponse(server1, SERVLET_NAME, "setupRec" + id);
+        } catch (IOException e) {
+        }
+        Log.info(this.getClass(), method, "setupRec" + id + " returned: " + sb);
+
+        assertNotNull(server1.getServerName() + " did not crash properly", server1.waitForStringInTraceUsingMark(XAResourceImpl.DUMP_STATE));
+
+        // At this point server1's recovery log should (absolutely!) be present
+        checkLogPresence();
+
+        String server1RecoveryId = server1.getServerConfiguration().getTransaction().getRecoveryIdentity().replaceAll("\\W", "");
+
+        // Now start server2
+        FATUtils.startServers(_runner, server2);
+        server2.resetLogMarks();
+        assertNotNull(server2.getServerName() + " did not recover for " + server1RecoveryId,
+                      server2.waitForStringInTraceUsingMark("Performed recovery for " + server1RecoveryId,
+                                                            FATUtils.LOG_SEARCH_TIMEOUT));
+
+        // Check to see that the peer recovery log has been deleted
+        checkLogAbsence();
+
+        server2.setTraceMarkToEndOfDefaultTrace();
+
+        // Start Server1
+        FATUtils.startServers(_runner, server1);
+
+        try {
+            // We expect this to fail since it is gonna crash the server
+            sb = runTestWithResponse(server1, SERVLET_NAME, "setupRec" + id);
+        } catch (IOException e) {
+        }
+        Log.info(this.getClass(), method, "setupRec" + id + " returned: " + sb);
+
+        assertNotNull(server1.getServerName() + " did not crash properly", server1.waitForStringInTraceUsingMark(XAResourceImpl.DUMP_STATE));
+
+        try {
+            assertNotNull(server2.getServerName() + " did not recover for " + server1RecoveryId,
+                          server2.waitForStringInTraceUsingMark("Performed recovery for " + server1RecoveryId,
+                                                                FATUtils.LOG_SEARCH_TIMEOUT));
+
+            // Check to see that the peer recovery log files have been deleted
+            checkLogAbsence();
+        } finally {
+            FATUtils.stopServers(server2);
+        }
+    }
+
+    public static void setDerby() {
+        _isDerby = true;
+    }
+
+    public static boolean isDerby() {
+        return _isDerby;
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected abstract void checkLogPresence() throws Exception;
+
+    /**
+     * @throws Exception
+     */
+    protected abstract void checkLogAbsence() throws Exception;
+}

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DBRotationTest.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DBRotationTest.java
@@ -41,24 +41,21 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.database.container.DatabaseContainerType;
 import componenttest.topology.database.container.DatabaseContainerUtil;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
 @AllowedFFDC(value = { "javax.resource.spi.ResourceAllocationException" })
-public class DBRotationTest extends FATServletClient {
+public class DBRotationTest extends CloudFATServletClient {
     private static final Class<?> c = DBRotationTest.class;
 
     private static final int LOG_SEARCH_TIMEOUT = 300000;
-    public static final String APP_NAME = "transaction";
-    public static final String SERVLET_NAME = APP_NAME + "/Simple2PCCloudServlet";
     private static final String APP_PATH = "../com.ibm.ws.transaction.cloud_fat.base/";
     protected static final int cloud2ServerPort = 9992;
 
     @Server("com.ibm.ws.transaction_ANYDBCLOUD001")
-    public static LibertyServer server1;
+    public static LibertyServer s1;
 
     @Server("com.ibm.ws.transaction_ANYDBCLOUD002")
-    public static LibertyServer server2;
+    public static LibertyServer s2;
 
     @Server("com.ibm.ws.transaction_ANYDBCLOUD002.nopeerlocking")
     public static LibertyServer server2nopeerlocking;
@@ -94,6 +91,8 @@ public class DBRotationTest extends FATServletClient {
     @BeforeClass
     public static void init() throws Exception {
         Log.info(c, "init", "BeforeClass");
+
+        initialize(s1, s2, "transaction", "/Simple2PCCloudServlet", runner);
 
         final WebArchive app = ShrinkHelper.buildDefaultAppFromPath(APP_NAME, APP_PATH, "servlets.*");
         final DeployOptions[] dO = new DeployOptions[0];
@@ -407,7 +406,6 @@ public class DBRotationTest extends FATServletClient {
     public void testBackwardCompatibility() throws Exception {
         final String method = "testBackwardCompatibility";
 
-
         serversToCleanup = new LibertyServer[] { server1 };
 
         FATUtils.startServers(runner, server1);
@@ -435,5 +433,15 @@ public class DBRotationTest extends FATServletClient {
         final String msg = "Status of " + server.getServerName() + " is " + status;
         Log.info(c, "checkDead", msg);
         throw new Exception(msg);
+    }
+
+    @Override
+    protected void checkLogAbsence() throws Exception {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    protected void checkLogPresence() throws Exception {
+        // TODO Auto-generated method stub
     }
 }

--- a/dev/com.ibm.ws.transaction.cloud_fat.derby.0/fat/src/suite/FATSuite.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.derby.0/fat/src/suite/FATSuite.java
@@ -34,6 +34,7 @@ import tests.DBRotationTest;
 public class FATSuite extends TxTestContainerSuite {
 
 	static {
+		DBRotationTest.setDerby();
 		beforeSuite(DatabaseContainerType.Derby);
 	}
 

--- a/dev/com.ibm.ws.transaction.cloud_fat.simpleFS/fat/src/suite/FATSuite.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.simpleFS/fat/src/suite/FATSuite.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package suite;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -24,7 +25,7 @@ import componenttest.rules.repeater.RepeatTests;
                 SimpleFS2PCCloudTest.class,
 })
 public class FATSuite {
-//    @ClassRule
+    @ClassRule
     public static RepeatTests r = RepeatTests.withoutModificationInFullMode()
                     .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers(SimpleFS2PCCloudTest.serverNames))
                     .andWith(FeatureReplacementAction.EE9_FEATURES()

--- a/dev/com.ibm.ws.transaction/src/com/ibm/ws/transaction/services/JTMConfigurationProvider.java
+++ b/dev/com.ibm.ws.transaction/src/com/ibm/ws/transaction/services/JTMConfigurationProvider.java
@@ -358,6 +358,7 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
      * Use Tr configuration for 'transaction' group.
      */
     @Override
+    @Trivial
     public Level getTraceLevel() {
         return tc.getLoggerLevel();
     }
@@ -375,6 +376,7 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
     }
 
     @Override
+    @Trivial
     public String getLeaseCheckStrategy() {
         return (String) _props.get("leaseCheckStrategy");
     }
@@ -386,18 +388,21 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
     }
 
     @Override
+    @Trivial
     public int getLeaseCheckInterval() {
         Number num = (Number) _props.get("leaseCheckInterval");
         return num.intValue();
     }
 
     @Override
+    @Trivial
     public int getLeaseLength() {
         Number num = (Number) _props.get("leaseLength");
         return num.intValue();
     }
 
     @Override
+    @Trivial
     public int getLeaseRenewalThreshold() {
         Number num = (Number) _props.get("leaseRenewalThreshold");
         return num.intValue();

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -7026,7 +7026,10 @@ public class LibertyServer implements LogMonitorClient {
      */
     public String waitForStringInTraceUsingMark(String regexp, long timeout) {
         try {
-            return waitForStringInLogUsingMark(regexp, timeout, getMostRecentTraceFile());
+            RemoteFile f = getMostRecentTraceFile();
+
+            Log.info(c, "waitForStringInTrace", "Waiting for \"" + regexp + "\" to be found in " + f);
+            return waitForStringInLogUsingMark(regexp, timeout, f);
         } catch (Exception e) {
             Log.warning(c, "Could not find string in trace log file due to exception " + e);
             return null;


### PR DESCRIPTION
#build #spawn.fullfat.buckets=com.ibm.ws.jta_fat,com.ibm.ws.transaction.cloud_fat.base,com.ibm.ws.transaction.cloud_fat.db2.0,com.ibm.ws.transaction.cloud_fat.db2.1,com.ibm.ws.transaction.cloud_fat.db2.2,com.ibm.ws.transaction.cloud_fat.derby.0,com.ibm.ws.transaction.cloud_fat.derby.1,com.ibm.ws.transaction.cloud_fat.derby.2,com.ibm.ws.transaction.cloud_fat.dualFS,com.ibm.ws.transaction.cloud_fat.oracle.0,com.ibm.ws.transaction.cloud_fat.oracle.1,com.ibm.ws.transaction.cloud_fat.oracle.2,com.ibm.ws.transaction.cloud_fat.peerlocking.1,com.ibm.ws.transaction.cloud_fat.peerlocking.2,com.ibm.ws.transaction.cloud_fat.postgresql.0,com.ibm.ws.transaction.cloud_fat.postgresql.1,com.ibm.ws.transaction.cloud_fat.postgresql.2,com.ibm.ws.transaction.cloud_fat.simpleFS,com.ibm.ws.transaction.cloud_fat.sqlserver.0,com.ibm.ws.transaction.cloud_fat.sqlserver.1,com.ibm.ws.transaction.cloud_fat.sqlserver.2,com.ibm.ws.transaction.core_fat.base,com.ibm.ws.transaction.core_fat.baseDB,com.ibm.ws.transaction.core_fat.cdi,com.ibm.ws.transaction.core_fat.commitPriority,com.ibm.ws.transaction.core_fat.heuristics,com.ibm.ws.transaction.core_fat.heuristicsDB,com.ibm.ws.transaction.core_fat.misc,com.ibm.ws.transaction.core_fat.startMultiEJB,com.ibm.ws.transaction.core_fat.startup,com.ibm.ws.transaction.core_fat.xa,com.ibm.ws.transaction.core_fat.xaDB,com.ibm.ws.transaction.db_fat,com.ibm.ws.transaction.hadb_fat.db2.1,com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.db2.retriablecodes,com.ibm.ws.transaction.hadb_fat.derby.1,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.derby.retriablecodes,com.ibm.ws.transaction.hadb_fat.oracle.1,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.oracle.retriablecodes,com.ibm.ws.transaction.hadb_fat.postgresql.1,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.postgresql.retriablecodes,com.ibm.ws.transaction.hadb_fat.sqlserver.1,com.ibm.ws.transaction.hadb_fat.sqlserver.2,com.ibm.ws.transaction.hadb_fat.sqlserver.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes,com.ibm.ws.transaction.recovery_fat.1,com.ibm.ws.transaction.recovery_fat.2,com.ibm.ws.transaction.recovery_fat.3,com.ibm.ws.tx.jta_fat,com.ibm.ws.tx.jta_fat_hibernate,com.ibm.ws.wsat.common_fat,com.ibm.ws.wsat.concurrent_fat,com.ibm.ws.wsat.migration_fat.1,com.ibm.ws.wsat.migration_fat.2,com.ibm.ws.wsat.migration_fat.3,com.ibm.ws.wsat.migration_fat.4,com.ibm.ws.wsat.migration_fat.5,com.ibm.ws.wsat.recovery_fat.lps,com.ibm.ws.wsat.recovery_fat.multi.1,com.ibm.ws.wsat.recovery_fat.multi.2,com.ibm.ws.wsat.recovery_fat.multi.3,com.ibm.ws.wsat.recovery_fat.multi.4,com.ibm.ws.wsat.recovery_fat.single.1,com.ibm.ws.wsat.recovery_fat.single.2,com.ibm.ws.wsat_fat.assertion,com.ibm.ws.wsat_fat.db,com.ibm.ws.wsat_fat.db_optional,com.ibm.ws.wsat_fat.dbs,com.ibm.ws.wsat_fat.dbs_optional,com.ibm.ws.wsat_fat.multi,com.ibm.ws.wsat_fat.ssl,io.openliberty.checkpoint_fat_transaction