### PR TITLE
spec updates to use Optional for Cursor on Pageable

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/KeysetAwarePageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/KeysetAwarePageImpl.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.RandomAccess;
 import java.util.stream.Stream;
 
@@ -56,7 +57,7 @@ public class KeysetAwarePageImpl<T> implements KeysetAwarePage<T> {
         this.queryInfo = queryInfo;
         this.pagination = pagination == null ? Pageable.ofSize(100) : pagination;
         this.isForward = this.pagination.mode() != Pageable.Mode.CURSOR_PREVIOUS;
-        Pageable.Cursor keysetCursor = this.pagination.cursor();
+        Optional<Pageable.Cursor> keysetCursor = this.pagination.cursor();
 
         int maxPageSize = this.pagination.size();
         int firstResult = this.pagination.mode() == Pageable.Mode.OFFSET //
@@ -65,7 +66,7 @@ public class KeysetAwarePageImpl<T> implements KeysetAwarePage<T> {
 
         EntityManager em = queryInfo.entityInfo.persister.createEntityManager();
         try {
-            String jpql = keysetCursor == null ? queryInfo.jpql : //
+            String jpql = keysetCursor.isEmpty() ? queryInfo.jpql : //
                             isForward ? queryInfo.jpqlAfterKeyset : //
                                             queryInfo.jpqlBeforeKeyset;
 
@@ -73,8 +74,8 @@ public class KeysetAwarePageImpl<T> implements KeysetAwarePage<T> {
             TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql, queryInfo.entityInfo.entityClass);
             queryInfo.setParameters(query, args);
 
-            if (keysetCursor != null)
-                queryInfo.setKeysetParameters(query, keysetCursor);
+            if (keysetCursor.isPresent())
+                queryInfo.setKeysetParameters(query, keysetCursor.get());
 
             query.setFirstResult(firstResult);
             query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1)); // extra position is for knowing whether to expect another page

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Pageable.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Pageable.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,6 +14,7 @@ package jakarta.data.page;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.data.Sort;
 
@@ -47,7 +48,7 @@ public interface Pageable {
 
     public Pageable beforeKeysetCursor(Pageable.Cursor cursor);
 
-    public Cursor cursor();
+    public Optional<Cursor> cursor();
 
     public Mode mode();
 

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Pagination.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Pagination.java
@@ -14,6 +14,7 @@ package jakarta.data.page;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -28,7 +29,7 @@ record Pagination(long page,
                 int size,
                 List<Sort> sorts,
                 Mode mode,
-                Cursor cursor)
+                Cursor type)
                 implements Pageable {
 
     Pagination {
@@ -36,7 +37,7 @@ record Pagination(long page,
             throw new IllegalArgumentException("pageNumber: " + page);
         if (size < 1)
             throw new IllegalArgumentException("maxPageSize: " + size);
-        if (mode != Mode.OFFSET && (cursor == null || cursor.size() == 0))
+        if (mode != Mode.OFFSET && (type == null || type.size() == 0))
             throw new IllegalArgumentException("No keyset values were provided.");
     }
 
@@ -61,6 +62,11 @@ record Pagination(long page,
     }
 
     @Override
+    public Optional<Cursor> cursor() {
+        return type == null ? Optional.empty() : Optional.of(type);
+    }
+
+    @Override
     public Pagination next() {
         if (mode == Mode.OFFSET)
             return new Pagination(page + 1, size, sorts, mode, null);
@@ -78,12 +84,12 @@ record Pagination(long page,
 
     @Override
     public Pagination page(long pageNumber) {
-        return new Pagination(pageNumber, size, sorts, mode, cursor);
+        return new Pagination(pageNumber, size, sorts, mode, type);
     }
 
     @Override
     public Pagination size(int maxPageSize) {
-        return new Pagination(page, maxPageSize, sorts, mode, cursor);
+        return new Pagination(page, maxPageSize, sorts, mode, type);
     }
 
     @Override
@@ -94,7 +100,7 @@ record Pagination(long page,
         else
             order = StreamSupport.stream(sorts.spliterator(), false).collect(Collectors.toUnmodifiableList());
 
-        return new Pagination(page, size, order, mode, cursor);
+        return new Pagination(page, size, order, mode, type);
     }
 
     @Override
@@ -102,15 +108,15 @@ record Pagination(long page,
         @SuppressWarnings("unchecked")
         List<Sort> order = sorts == null ? Collections.EMPTY_LIST : List.of(sorts);
 
-        return new Pagination(page, size, order, mode, cursor);
+        return new Pagination(page, size, order, mode, type);
     }
 
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder("Pageable{page=").append(page).append(", size=").append(size);
 
-        if (cursor != null)
-            b.append(", mode=").append(mode).append(", ").append(cursor.size()).append(" keys");
+        if (type != null)
+            b.append(", mode=").append(mode).append(", ").append(type.size()).append(" keys");
 
         for (Sort o : sorts) {
             b.append(", ").append(o.property()).append(o.ignoreCase() ? " IGNORE CASE" : "").append(o.isDescending() ? " DESC" : " ASC");


### PR DESCRIPTION
Align with updates that were recently made to the spec changing the return type of pageable.cursor() to `Optional<Cursor>`