### PR TITLE
Telemetry agent test fix

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/apps/agent/AgentTestResource.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/apps/agent/AgentTestResource.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Context;
@@ -145,6 +146,12 @@ public class AgentTestResource extends Application {
         Span span = Span.current();
         withSpanNonBeanMethod();
         return span.getSpanContext().getTraceId();
+    }
+    
+    @GET
+    @Path("/pathparameter/{parameter}")
+    public String callPathParameter(@PathParam("parameter") String parameter) {
+        return Span.current().getSpanContext().getTraceId();
     }
 
     @GET

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentTest.java
@@ -175,6 +175,27 @@ public class AgentTest {
         assertThat(services, contains(SERVICE_NAME));
     }
 
+    @Test
+    public void testPathParameter() throws Exception {
+        HttpRequest request = new HttpRequest(server, "/agentTest/pathparameter/param");
+        String traceId = request.run(String.class);
+        traceIdsUsed.add(traceId);
+        Log.info(c, "testBasic", "TraceId is " + traceId);
+
+        List<Span> spans = client.waitForSpansForTraceId(traceId, hasSize(1));
+        Log.info(c, "testBasic", "Spans returned: " + spans);
+
+        Span span = spans.get(0);
+
+        assertThat(span, JaegerSpanMatcher.isSpan().withTraceId(traceId)
+                                    .withAttribute(SemanticAttributes.HTTP_ROUTE, "/agentTest/pathparameter/{parameter}")
+                                    .withAttribute(SemanticAttributes.HTTP_METHOD, "GET"));
+        
+        // We shouldn't have any additional spans
+        List<String> services = client.getServices();
+        assertThat(services, contains(SERVICE_NAME));
+    }
+
     /**
      * Test we can manually create spans
      */


### PR DESCRIPTION
For issue #26882

-Accepts the values that the agent produces for http.route

- Extend the tests to exercise the http.route calculation with the use of path parameters
