### PR TITLE
Call RestClientBuilderListener for client beans on EE7/8

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/cdi/RestClientBean.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/cdi/RestClientBean.java
@@ -92,7 +92,7 @@ public class RestClientBean implements Bean<Object>, PassivationCapable {
     @Override
     public Object create(CreationalContext<Object> creationalContext) {
         //Liberty change start
-        RestClientBuilder builder = new CxfTypeSafeClientBuilder();
+        RestClientBuilder builder = RestClientBuilder.newBuilder();
         String baseUri = getBaseUri();
         builder = ((CxfTypeSafeClientBuilder)builder).baseUri(URI.create(baseUri));
         List<Class<?>> providers = getConfiguredProviders();

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/cdi/RestClientBean.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/cdi/RestClientBean.java
@@ -58,6 +58,7 @@ import org.apache.cxf.common.util.PropertyUtils;
 import org.apache.cxf.common.util.ReflectionUtil;
 import org.apache.cxf.microprofile.client.CxfTypeSafeClientBuilder;
 import org.apache.cxf.microprofile.client.config.ConfigFacade;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -114,7 +115,10 @@ public class RestClientBean implements Bean<Object>, PassivationCapable {
 
     @Override
     public Object create(CreationalContext<Object> creationalContext) {
-        CxfTypeSafeClientBuilder builder = new CxfTypeSafeClientBuilder();
+        //Liberty change start
+        CxfTypeSafeClientBuilder builder = (CxfTypeSafeClientBuilder) RestClientBuilder.newBuilder();
+        //Liberty change end
+
         String baseUri = getBaseUri();
         builder = (CxfTypeSafeClientBuilder) builder.baseUri(URI.create(baseUri));
         List<Class<?>> providers = getConfiguredProviders();

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureJaegerTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureJaegerTest.java
@@ -37,15 +37,14 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.annotation.Server;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.jaegertracing.api_v2.Model.Span;
+import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
-import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 
@@ -54,7 +53,6 @@ import io.opentelemetry.api.trace.SpanKind;
  * Spans are exported to Jaeger
  */
 @RunWith(FATRunner.class)
-// Broken on EE7 & 8, see https://github.com/OpenLiberty/open-liberty/issues/26856
 public class CrossFeatureJaegerTest {
 
     private static final String CROSS_FEATURE_TELEMETRY_SERVER = "crossFeatureTelemetryServer";
@@ -63,11 +61,7 @@ public class CrossFeatureJaegerTest {
     private static final AttributeKey<String> JAEGER_VERSION = AttributeKey.stringKey("jaeger.version");
 
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-    // Broken on EE7 & 8, see https://github.com/OpenLiberty/open-liberty/issues/26856
-    public static RepeatTests repeat = TelemetryActions.repeat(CROSS_FEATURE_TELEMETRY_SERVER,
-                                                               MicroProfileActions.MP61,
-                                                               TelemetryActions.MP50_MPTEL11,
-                                                               MicroProfileActions.MP60);
+    public static RepeatTests repeat = FATSuite.allMPRepeats(CROSS_FEATURE_TELEMETRY_SERVER);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureZipkinTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureZipkinTest.java
@@ -35,15 +35,14 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.annotation.Server;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
+import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinQueryClient;
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinSpan;
-import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.opentelemetry.api.trace.SpanKind;
 
 /**
@@ -58,11 +57,7 @@ public class CrossFeatureZipkinTest {
     private static final Class<?> c = CrossFeatureZipkinTest.class;
 
     public static ZipkinContainer zipkinContainer = new ZipkinContainer().withLogConsumer(new SimpleLogConsumer(ZipkinTest.class, "zipkin"));
-    // Broken on EE7 & 8, see https://github.com/OpenLiberty/open-liberty/issues/26856
-    public static RepeatTests repeat = TelemetryActions.repeat(CROSS_FEATURE_TELEMETRY_SERVER,
-                                                               MicroProfileActions.MP61,
-                                                               TelemetryActions.MP50_MPTEL11,
-                                                               MicroProfileActions.MP60);
+    public static RepeatTests repeat = FATSuite.allMPRepeats(CROSS_FEATURE_TELEMETRY_SERVER);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(zipkinContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/injected/InjectedClientTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/injected/InjectedClientTestServlet.java
@@ -20,11 +20,9 @@ import javax.servlet.annotation.WebServlet;
 
 import org.junit.Test;
 
-import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
-import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -46,9 +44,6 @@ public class InjectedClientTestServlet extends FATServlet {
     private InMemorySpanExporter exporter;
 
     @Test
-    // Not instrumented properly on EE7/8
-    // See https://github.com/OpenLiberty/open-liberty/issues/26856
-    @SkipForRepeat({ TelemetryActions.MP14_MPTEL11_ID, TelemetryActions.MP41_MPTEL11_ID })
     public void testInjectedClient() {
         Span span = testSpans.withTestSpan(() -> {
             assertThat(client.get(), equalTo("OK"));


### PR DESCRIPTION
Ensure we call the RestClientBuilderListener when building a rest client for injection using CDI.

For mpRestClient-1.x and 2.x

Fixes #26856
Fixes #26911