### PR TITLE
mpTelemetry-1.0 include query in http.target

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryServletFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal/src/io/openliberty/microprofile/telemetry10/internal/rest/TelemetryServletFilter.java
@@ -17,7 +17,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -285,7 +284,13 @@ public class TelemetryServletFilter extends AbstractTelemetryServletFilter imple
         public String target(final ServletRequest request) {
             if (request instanceof HttpServletRequest) {
                 HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-                return httpServletRequest.getRequestURI();
+                String path = httpServletRequest.getRequestURI();
+                String query = httpServletRequest.getQueryString();
+                if (path != null && query != null && !query.isEmpty()) {
+                    return path + "?" + query;
+                } else {
+                    return path;
+                }
             }
             return null;
         }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
@@ -55,4 +55,5 @@ tested.features:\
 	com.ibm.websphere.javaee.jaxrs.2.1,\
 	com.ibm.websphere.javaee.annotation.1.2,\
 	com.ibm.websphere.javaee.concurrent.1.0,\
-	io.openliberty.org.eclipse.microprofile.rest.client.2.0
+	io.openliberty.org.eclipse.microprofile.rest.client.2.0,\
+	com.ibm.websphere.org.eclipse.microprofile.config.1.3

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
@@ -14,6 +14,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.annotation.MinimumJavaLevel;
+import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
@@ -51,5 +52,13 @@ public class FATSuite {
         return TelemetryActions
                         .repeat(serverName, MicroProfileActions.MP61, TelemetryActions.MP14_MPTEL11, TelemetryActions.MP41_MPTEL11, TelemetryActions.MP50_MPTEL11,
                                 MicroProfileActions.MP60);
+    }
+
+    public static String getTelemetryVersionUnderTest() {
+        if (RepeatTestFilter.isRepeatActionActive(MicroProfileActions.MP60_ID)) {
+            return "1.0";
+        } else {
+            return "1.1";
+        }
     }
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
@@ -102,7 +102,8 @@ public class JaxRsIntegration extends FATServletClient {
         PropertiesAsset appConfig = new PropertiesAsset()
                         .addProperty("otel.sdk.disabled", "false")
                         .addProperty("otel.traces.exporter", "in-memory")
-                        .addProperty("otel.bsp.schedule.delay", "100");
+                        .addProperty("otel.bsp.schedule.delay", "100")
+                        .addProperty("feature.version", FATSuite.getTelemetryVersionUnderTest());
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackage(JaxRsEndpoints.class.getPackage())
                         .addPackage(InMemorySpanExporter.class.getPackage())

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegrationWithConcurrency.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegrationWithConcurrency.java
@@ -100,7 +100,8 @@ public class JaxRsIntegrationWithConcurrency extends FATServletClient {
         PropertiesAsset appConfig = new PropertiesAsset()
                         .addProperty("otel.sdk.disabled", "false")
                         .addProperty("otel.traces.exporter", "in-memory")
-                        .addProperty("otel.bsp.schedule.delay", "100");
+                        .addProperty("otel.bsp.schedule.delay", "100")
+                        .addProperty("feature.version", FATSuite.getTelemetryVersionUnderTest());
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackage(JaxRsEndpoints.class.getPackage())
                         .addPackage(InMemorySpanExporter.class.getPackage())

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/route/JaxRsRouteTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/jaxrspropagation/route/JaxRsRouteTestServlet.java
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.route;
 
+import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.hasName;
 import static io.openliberty.microprofile.telemetry.internal_fat.common.SpanDataMatcher.isSpan;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -23,6 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
@@ -48,6 +50,10 @@ public class JaxRsRouteTestServlet extends FATServlet {
 
     @Inject
     private TestSpans utils;
+
+    @Inject
+    @ConfigProperty(name = "feature.version")
+    private String featureVersion;
 
     @Test
     public void testRouteWithId() {
@@ -75,7 +81,14 @@ public class JaxRsRouteTestServlet extends FATServlet {
                         .withKind(SpanKind.SERVER)
                         .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
                         .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
-                        .withAttribute(SemanticAttributes.HTTP_ROUTE, getPath() + "/getWithId/{id}"));
+                        .withAttribute(SemanticAttributes.HTTP_ROUTE, getPath() + "/getWithId/{id}")
+                        .withAttribute(SemanticAttributes.HTTP_TARGET, getPath() + "/getWithId/myIdForTesting"));
+
+        if (featureVersion.equals("1.1")) {
+            assertThat(serverSpan, hasName("GET " + getPath() + "/getWithId/{id}"));
+        } else {
+            assertThat(serverSpan, hasName(getPath() + "/getWithId/{id}"));
+        }
     }
 
     @Test
@@ -108,7 +121,14 @@ public class JaxRsRouteTestServlet extends FATServlet {
                         .withKind(SpanKind.SERVER)
                         .withAttribute(SemanticAttributes.HTTP_METHOD, "GET")
                         .withAttribute(SemanticAttributes.HTTP_STATUS_CODE, 200L)
-                        .withAttribute(SemanticAttributes.HTTP_ROUTE, getPath() + "/getWithQueryParam"));
+                        .withAttribute(SemanticAttributes.HTTP_ROUTE, getPath() + "/getWithQueryParam")
+                        .withAttribute(SemanticAttributes.HTTP_TARGET, getPath() + "/getWithQueryParam?id=myIdForTesting"));
+
+        if (featureVersion.equals("1.1")) {
+            assertThat(serverSpan, hasName("GET " + getPath() + "/getWithQueryParam"));
+        } else {
+            assertThat(serverSpan, hasName(getPath() + "/getWithQueryParam"));
+        }
     }
 
     private URI getUri() {


### PR DESCRIPTION
Include query parameters in the http.target attribute for mpTelemetry-1.0 spans.

Fixes #26905 