### PR TITLE
Fix expected name in AgentConfigTest

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.jaeger_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
@@ -226,7 +226,7 @@ public class AgentConfigTest {
 
         List<Span> spans = client.waitForSpansForTraceId(traceId, hasSize(1));
 
-        assertThat(spans.get(0), hasName("/agentTest"));
+        assertThat(spans.get(0), hasName("/agentTest/"));
 
         // We should still be able to manually create spans with the API
         String traceId2 = new HttpRequest(server, "/agentTest/manualSpans").run(String.class);


### PR DESCRIPTION
With the agent disabled, we get the name set by the feature.

The name set by the feature changed in #26861 because we have the JAX-RS filter update the name when it runs after the servlet filter. The update to this test was missed because it doesn't run on Java 21 and so didn't run in the personal build.