### PR TITLE
add wc trace to DeliveryDelayClient in com.ibm.ws.messaging.open_jms20deliverydelay_fat

### DIFF
--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/publish/servers/DeliveryDelayClient/bootstrap.properties
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/publish/servers/DeliveryDelayClient/bootstrap.properties
@@ -1,2 +1,2 @@
-com.ibm.ws.logging.trace.specification=*=info=enabled:SIBMessageTrace=all:test=all:SIBOSGi=all
+com.ibm.ws.logging.trace.specification=*=info=enabled:SIBMessageTrace=all:test=all:SIBOSGi=all:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HTTPChannel=all:GenericBNF=all
 bootstrap.include=../testports.properties


### PR DESCRIPTION
In order to better diagnose an intermittent FNF exception in com.ibm.ws.messaging.open_jms20deliverydelay_fat, server DeliveryDelayClient, web container trace is being added.