### PR TITLE
JPA entity with attribute converter

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1166,6 +1166,7 @@ public class DataJPATestServlet extends FATServlet {
         o2 = orders.findById(o2.id).get();
 
         assertEquals(168.89f, o2.total, 0.01f);
+        assertEquals(o2.purchasedOn, OffsetDateTime.of(2022, 6, 1, 14, 0, 0, 0, MDT));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/OffsetDateTimeToStringConverter.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/OffsetDateTimeToStringConverter.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.time.OffsetDateTime;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * A converter between OffsetDateTime and String.
+ */
+@Converter
+public class OffsetDateTimeToStringConverter implements AttributeConverter<OffsetDateTime, String> {
+
+    @Override
+    public String convertToDatabaseColumn(OffsetDateTime d) {
+        return d.toString();
+    }
+
+    @Override
+    public OffsetDateTime convertToEntityAttribute(String s) {
+        return OffsetDateTime.parse(s);
+    }
+
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Order.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Order.java
@@ -14,6 +14,7 @@ package test.jakarta.data.jpa.web;
 
 import java.time.OffsetDateTime;
 
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -32,6 +33,7 @@ public class Order {
 
     public String purchasedBy;
 
+    @Convert(converter = OffsetDateTimeToStringConverter.class)
     public OffsetDateTime purchasedOn;
 
     public float total;

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Creatures.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Creatures.java
@@ -12,10 +12,15 @@
  *******************************************************************************/
 package test.jakarta.data.validation.web;
 
+import java.util.List;
+
 import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Repository;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 
 /**
  * Repository for a Jakarta Persistence entity with bean validation annotations.
@@ -24,6 +29,12 @@ import jakarta.validation.constraints.Positive;
 public interface Creatures extends BasicRepository<@Valid Creature, @Positive Long> {
 
     int countById(Long id);
+
+    @OrderBy("id")
+    @Size(min = 0, max = 3)
+    List<Creature> findByScientificNameStartsWithAndWeightBetween(@NotBlank String genus,
+                                                                  @Positive float minWeight,
+                                                                  @Positive float maxWeight);
 
     boolean updateByIdSetWeight(long id, float newWeight);
 }

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
@@ -71,6 +71,65 @@ public class DataValidationTestServlet extends FATServlet {
     }
 
     /**
+     * Use a repository method with constraints on the different method parameters and the return type.
+     * Verify that these methods raise ConstraintViolationException when the constraints are violated, but otherwise run successfully.
+     */
+    @Test
+    public void testConstraintsOnRepositoryMethod() {
+        Creature c1 = new Creature(1001l, "Mink", "Neogale vison", //
+                        BigDecimal.valueOf(44037855L, 6), BigDecimal.valueOf(-92508962L, 6), //
+                        ZonedDateTime.now(ZoneId.of("America/Chicago")).minusMinutes(10).toOffsetDateTime(), //
+                        1.9f);
+        Creature c2 = new Creature(1002l, "Mink", "Neogale vison", //
+                        BigDecimal.valueOf(44036829L, 6), BigDecimal.valueOf(-92507138L, 6), //
+                        ZonedDateTime.now(ZoneId.of("America/Chicago")).minusMinutes(20).toOffsetDateTime(), //
+                        2.2f);
+        Creature c3 = new Creature(1003l, "Double-crested Cormorant", "Nannopterum auritum", //
+                        BigDecimal.valueOf(44028468L, 6), BigDecimal.valueOf(-92506186L, 6), //
+                        ZonedDateTime.now(ZoneId.of("America/Chicago")).minusMinutes(30).toOffsetDateTime(), //
+                        2.3f);
+        Creature c4 = new Creature(1004l, "Mink", "Neogale vison", //
+                        BigDecimal.valueOf(44036987L, 6), BigDecimal.valueOf(-92503694L, 6), //
+                        ZonedDateTime.now(ZoneId.of("America/Chicago")).minusMinutes(40).toOffsetDateTime(), //
+                        1.4f);
+        creatures.saveAll(List.of(c1, c2, c3, c4));
+
+        List<Creature> found;
+
+        // no constraints violated:
+        found = creatures.findByScientificNameStartsWithAndWeightBetween("Neogale ", 1.0f, 2.0f);
+        assertEquals(2, found.size());
+
+        try {
+            found = creatures.findByScientificNameStartsWithAndWeightBetween(" ", 1.0f, 2.0f);
+            fail("Did not detect violation of constraint on first parameter to be non-blank.");
+        } catch (ConstraintViolationException x) {
+            // expected
+        }
+
+        try {
+            found = creatures.findByScientificNameStartsWithAndWeightBetween("Neogale ", -1.0f, 2.5f);
+            fail("Did not detect violation of constraint on second parameter to be positive.");
+        } catch (ConstraintViolationException x) {
+            // expected
+        }
+
+        try {
+            found = creatures.findByScientificNameStartsWithAndWeightBetween("Neogale ", 2.0f, -3.0f);
+            fail("Did not detect violation of constraint on third parameter to be positive.");
+        } catch (ConstraintViolationException x) {
+            // expected
+        }
+
+        try {
+            found = creatures.findByScientificNameStartsWithAndWeightBetween("N%", 1.0f, 3.0f);
+            fail("Did not detect violation on constraint on return value to have a maximum size of 3.");
+        } catch (ConstraintViolationException x) {
+            // expected
+        }
+    }
+
+    /**
      * Verify that a constraint placed on the parameterized type variable for the Id type
      * enforces validation on that type when methods from the repository are used.
      */


### PR DESCRIPTION
Write a Jakarta Data test case that has an entity attribute annotated with Convert to supply a custom converter.
This required working around a problem where JPA/EclipseLink doesn't detect the converter class even though it clearly sees the Convert annotation.  To work around this, I added detection of the Convert annotation and explicitly added a converter element for it in the generated orm.xml

Also, this adds a test case to the validation/data bucket where constraints are placed on both the parameters and return type of a method rather than on the entity.