### PR TITLE
javaMail-1.x: Export Activation APIs as specification APIs

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/javaMail-1.5/com.ibm.websphere.appserver.javaMail-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/javaMail-1.5/com.ibm.websphere.appserver.javaMail-1.5.feature
@@ -3,7 +3,8 @@ symbolicName=com.ibm.websphere.appserver.javaMail-1.5
 WLP-DisableAllFeatures-OnConflict: false
 visibility=public
 singleton=true
-IBM-API-Package: javax.mail;  type="spec", \
+IBM-API-Package: javax.activation; type="spec"; require-java:="9", \
+ javax.mail;  type="spec", \
  javax.mail.internet;  type="spec", \
  javax.mail.util;  type="spec", \
  javax.mail.search;  type="spec", \
@@ -25,7 +26,7 @@ Subsystem-Name: JavaMail 1.5
   com.ibm.websphere.appserver.injection-1.0, \
   com.ibm.websphere.appserver.javax.mail-1.5
 -bundles=\
-  com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false, \
+  com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/", \
   com.ibm.ws.javamail,\
   com.ibm.ws.javamail.config
 -jars=com.ibm.websphere.javaee.mail.1.5; location:=dev/api/spec/; mavenCoordinates="javax.mail:javax.mail-api:1.5.6", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/javaMail-1.6/com.ibm.websphere.appserver.javaMail-1.6.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/javaMail-1.6/com.ibm.websphere.appserver.javaMail-1.6.feature
@@ -6,7 +6,7 @@ singleton=true
 IBM-ShortName: javaMail-1.6
 Subsystem-Version: 1.6
 Subsystem-Name: JavaMail 1.6
-IBM-API-Package: \
+IBM-API-Package: javax.activation; type="spec"; require-java:="9", \
  javax.mail; type="spec", \
  javax.mail.internet; type="spec", \
  javax.mail.util; type="spec", \
@@ -27,7 +27,7 @@ IBM-API-Package: \
   com.ibm.websphere.appserver.eeCompatible-8.0, \
   com.ibm.websphere.appserver.javax.mail-1.6
 -bundles=\
-  com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false, \
+  com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/", \
   com.ibm.ws.javamail.1.6,\
   com.ibm.ws.javamail.config
 -jars=com.ibm.websphere.javaee.mail.1.6; location:=dev/api/spec/; mavenCoordinates="javax.mail:javax.mail-api:1.6.2", \


### PR DESCRIPTION
Because Java 9 dropped the `javax.activation` APIs, and we don't offer the Activation APIs within a seperate feature, we should export the `javax.activation` as `type="spec"` in the `IBM-API-Header`. Doing so will make it so the `javaMail-1.5` and `javaMail-1.6` features can load the MailCommandMap files that depend on Activation, when running on Java 9+, and prevent failures like this:

```
Caused by: java.lang.ClassNotFoundException: CWWKL0084W: The javax.activation.FileTypeMap class could not be loaded. Try enabling the jaxb-2.2 feature or a newer version of the feature in the server.xml file.
```