### PR TITLE
Update the processing of TraceOptions annotation on the class

### DIFF
--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/anno/service/internal/AnnotationServiceImpl_Logging.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/anno/service/internal/AnnotationServiceImpl_Logging.java
@@ -18,7 +18,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.TraceOptions;
 import com.ibm.wsspi.anno.service.AnnotationService_Logging;
 
-@TraceOptions(traceGroup = AnnotationService_Logging.ANNO_LOGGER_STATE)
+@TraceOptions(traceGroup = AnnotationService_Logging.ANNO_LOGGER_STATE, messageBundle = "com.ibm.ws.anno.resources.internal.AnnoMessages")
 public class AnnotationServiceImpl_Logging implements AnnotationService_Logging {
 
     /**

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyTracePreprocessInstrumentation.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyTracePreprocessInstrumentation.java
@@ -92,6 +92,7 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
     public class ClassTraceInfo {
         ClassNode classNode;
         public PackageInfo packageInfo;
+        private TraceOptionsData classTraceOptions;
 
         // Explicitly declared Liberty TraceComponent
         FieldNode libertyTraceComponentFieldNode;
@@ -112,9 +113,15 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
         List<String> warnings = new ArrayList<String>();
         boolean failInstrumentation;
 		public TraceOptionsData getTraceOptionsData() {
+		    if (classTraceOptions != null) {
+		        return classTraceOptions;
+		    }
 			if (packageInfo != null)
 				return packageInfo.getTraceOptionsData();
 			return null;
+		}
+		public void setClassTraceOptionsData(TraceOptionsData traceOptions) {
+		    classTraceOptions = traceOptions;
 		}
     }
 
@@ -229,12 +236,11 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
     }
 
     /**
-     * Locate and merge the metadata from the {@code TraceOptions} annotations
-     * specified on the class and the package. This is used to determine the
+     * Locate the metadata from the {@code TraceOptions} annotations
+     * specified on the class. This is used to determine the
      * resource bundle name, trace group names, and other miscellaneous info.
      * <p>
-     * The class annotation is intended to override package information when
-     * appropriate.
+     * The class annotation is intended to override package information.
      * 
      * @param info the collected class information
      */
@@ -244,42 +250,7 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
         if (traceOptionsAnnotation != null) {
             TraceOptionsAnnotationVisitor optionsVisitor = new TraceOptionsAnnotationVisitor();
             traceOptionsAnnotation.accept(optionsVisitor);
-            TraceOptionsData traceOptions = optionsVisitor.getTraceOptionsData();
-
-            // Merge with package annotation's defaults
-            TraceOptionsData packageData = info.packageInfo != null ? info.packageInfo.getTraceOptionsData() : null;
-            if (packageData != null) {
-                // Remove the current annotation if present
-                if (traceOptionsAnnotation != null) {
-                    info.classNode.visibleAnnotations.remove(traceOptionsAnnotation);
-                }
-
-                // If the class trace options differ from the package trace
-                // options, merge them and add a class annotation.
-                if (!traceOptions.equals(packageData)) {
-                    if (traceOptions.getMessageBundle() == null && packageData.getMessageBundle() != null) {
-                        traceOptions.setMessageBundle(packageData.getMessageBundle());
-                    }
-                    if (traceOptions.getTraceGroups().isEmpty() && !packageData.getTraceGroups().isEmpty()) {
-                        for (String group : packageData.getTraceGroups()) {
-                            traceOptions.addTraceGroup(group);
-                        }
-                    }
-
-                    traceOptionsAnnotation = (AnnotationNode) info.classNode.visitAnnotation(TRACE_OPTIONS_TYPE.getDescriptor(), true);
-                    AnnotationVisitor groupsVisitor = traceOptionsAnnotation.visitArray("traceGroups");
-                    for (String group : traceOptions.getTraceGroups()) {
-                        groupsVisitor.visit(null, group);
-                    }
-                    groupsVisitor.visitEnd();
-
-                    traceOptionsAnnotation.visit("traceGroup", "");
-                    traceOptionsAnnotation.visit("messageBundle", traceOptions.getMessageBundle() == null ? "" : traceOptions.getMessageBundle());
-                    traceOptionsAnnotation.visit("traceExceptionThrow", Boolean.valueOf(traceOptions.isTraceExceptionThrow()));
-                    traceOptionsAnnotation.visit("traceExceptionHandling", Boolean.valueOf(traceOptions.isTraceExceptionHandling()));
-                    traceOptionsAnnotation.visitEnd();
-                }
-            }
+            info.setClassTraceOptionsData(optionsVisitor.getTraceOptionsData());
         }
     }
 


### PR DESCRIPTION
- The instrumentation during the build was not correctly processing the TraceOptions annotation when it was specified on the class.  It would cause the group and the message bundle to be null if package-info did not have the annotation also specified.

This problem was exposed by the changes done in #7524 to instrument the class to include the TraceOptions information on the Tr.register.  The processing that would have happened during startup would have done it right.  I even tried the StaticTraceInstrumentation and it did it right.  So it appears to be limited to the build instrumentation logic.

Fixes #26943