### PR TITLE
Fix exporting the same API twice with different types

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
@@ -15,9 +15,11 @@ package com.ibm.ws.feature.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -52,8 +54,9 @@ public class FeatureInfo {
     private String visibility = "private";
     private String shortName;
 
-    private Set<ExternalPackageInfo> APIs;
-    private Set<ExternalPackageInfo> SPIs;
+    // Using a list in order to find duplicates.
+    private List<ExternalPackageInfo> APIs;
+    private List<ExternalPackageInfo> SPIs;
 
     public FeatureInfo(File feature) {
         this.feature = feature;
@@ -184,14 +187,14 @@ public class FeatureInfo {
         return this.shortName;
     }
 
-    public Set<ExternalPackageInfo> getAPIs() {
+    public List<ExternalPackageInfo> getAPIs() {
         if (!isInit)
             populateInfo();
 
         return this.APIs;
     }
 
-    public Set<ExternalPackageInfo> getSPIs() {
+    public List<ExternalPackageInfo> getSPIs() {
         if (!isInit)
             populateInfo();
 
@@ -300,13 +303,13 @@ public class FeatureInfo {
         }
     }
 
-    private Set<ExternalPackageInfo> parseExternalPackages(String packageList, String defaultType) {
+    private List<ExternalPackageInfo> parseExternalPackages(String packageList, String defaultType) {
         if (packageList == null) {
             return null;
         }
 
         String[] packageNames = packageList.split(",");
-        Set<ExternalPackageInfo> extPackageInfoSet = new LinkedHashSet<>();
+        List<ExternalPackageInfo> extPackageInfoSet = new ArrayList<>();
         for (String packageName : packageNames) {
             String[] packageParts = packageName.split(";");
             String externalPackage = packageParts[0].trim();
@@ -331,7 +334,7 @@ public class FeatureInfo {
             }
             extPackageInfoSet.add(new ExternalPackageInfo(externalPackage, type));
         }
-        return Collections.unmodifiableSet(extPackageInfoSet);
+        return Collections.unmodifiableList(extPackageInfoSet);
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/javaeeClient-7.0/com.ibm.websphere.appserver.javaeeClient-7.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/javaeeClient-7.0/com.ibm.websphere.appserver.javaeeClient-7.0.feature
@@ -4,7 +4,6 @@ WLP-DisableAllFeatures-OnConflict: false
 visibility=public
 singleton=true
 IBM-API-Package: com.ibm.ws.ejb.portable; type="internal", \
- javax.xml.ws; type="internal", \
  com.ibm.websphere.endpoint; type="ibm-api", \
  com.ibm.websphere.ejbcontainer; type="ibm-api", \
  javax.rmi; type="spec", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/javaeeClient-8.0/com.ibm.websphere.appserver.javaeeClient-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/javaeeClient-8.0/com.ibm.websphere.appserver.javaeeClient-8.0.feature
@@ -7,7 +7,6 @@ IBM-ShortName: javaeeClient-8.0
 Subsystem-Name: Java EE 8 Application Client
 IBM-API-Package: \
   com.ibm.ws.ejb.portable; type="internal", \
-  javax.xml.ws; type="internal", \
   com.ibm.websphere.endpoint; type="ibm-api", \
   com.ibm.websphere.ejbcontainer; type="ibm-api", \
   javax.rmi; type="spec", \


### PR DESCRIPTION
- javax.xml.ws was being exported both as internal and spec.  It should just be spec.
