### PR TITLE
Wait for schedule in concurrent persistent JCA FAT

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/fat/src/fat/concurrent/persistent/jca/PersistRATest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/fat/src/fat/concurrent/persistent/jca/PersistRATest.java
@@ -106,9 +106,11 @@ public class PersistRATest {
         assertNotNull("Server should report it has started",
                       server.waitForStringInLog("CWWKF0011I"));
 
-        // Starting the RAR will asynchronously schedule a persistent task, initializing Derby. 
-        // Wait for the Derby start messages to avoid a test trying to concurrently start Derby.
-        server.waitForStringInLog("DSRA8206I"); // connected to Derby
+        // Starting the RAR will asynchronously schedule a persistent task, initializing Derby 
+        // and inserting a row; which may result in https://issues.apache.org/jira/browse/DERBY-6934
+        // Avoid this by waiting for the insert to complete before continuing with
+        // any test that may attempt to concurrently insert a row (schedule a task).
+        server.waitForStringInLog("PSETestResourceAdapter start task scheduled.");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/PSETestResourceAdapter.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/PSETestResourceAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -89,6 +89,8 @@ public class PSETestResourceAdapter implements ResourceAdapter {
                 @Override
                 public TaskStatus<?> call() throws Exception {
                     TaskStatus<?> taskStatus = scheduler.schedule(new RASerializableTask(), new RATrigger());
+                    
+                    System.out.println("PSETestResourceAdapter start task scheduled.");
 
                     for (long start = System.nanoTime(); !taskStatus.hasResult() && System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(POLL_INTERVAL))
                         taskStatus = scheduler.getStatus(taskStatus.getTaskId());


### PR DESCRIPTION
Update FAT to wait for the RAR start to schedule a task before running any test that also may schedule a task to avoid a know issue with Derby