### PR TITLE
Update OpenAPI UI to newer Axios version

### DIFF
--- a/dev/com.ibm.ws.openapi.ui/swagger-ui/package-lock.json
+++ b/dev/com.ibm.ws.openapi.ui/swagger-ui/package-lock.json
@@ -3444,9 +3444,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -12873,7 +12873,7 @@
         "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.69.0",
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.0",
         "@types/ramda": "=0.28.23",
-        "axios": "=1.3.4",
+        "axios": "^1.6.0",
         "minimatch": "=7.3.0",
         "process": "=0.11.10",
         "ramda": "=0.28.0",
@@ -13538,9 +13538,9 @@
       }
     },
     "axios": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/dev/com.ibm.ws.openapi.ui/swagger-ui/package.json
+++ b/dev/com.ibm.ws.openapi.ui/swagger-ui/package.json
@@ -38,6 +38,9 @@
     "stream-browserify": "^3.0.0",
     "swagger-ui": "^4.18.1"
   },
+  "overrides": {
+    "axios": "^1.6.0"
+  },
   "browserslist": [
     "defaults",
     "firefox >= 38",


### PR DESCRIPTION
Override Axios version used by apidom-reference 

Webpack of js to bundled versions after update remained the same