### PR TITLE
Added a wait to Computed MPMetrics FAT to ensure ServletStats MBean are registered before calling /metrics

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
@@ -532,7 +532,12 @@ public class ComputedMetricsTest {
 
        Log.info(c, testName, "------- Hitting the testREST application endpoint to initialize the REST metrics ------");
        getHttpServlet("/testRESTApp/test/get", computedMetricsServer);
+       
+       Log.info(c, testName, "------- Wait for the Servlet MBean for the REST test app to get registered in MonitorMetrics, before hitting the /metrics endpoint ------");
+       String mbeanRegStr = computedMetricsServer.waitForStringInLogUsingMark("type=ServletStats,name=testRESTApp.io.openliberty.microprofile.metrics.internal.monitor_fat.rest.TestApplication is registered", 60000, computedMetricsServer.getMostRecentTraceFile());
 
+       Log.info(c, testName, "------- Found Servlet MBean for the REST test app successfully registered trace : " + mbeanRegStr);
+       
        Log.info(c, testName, "------- Make sure all the expected metrics have the \"_app=myserver\" tag ------");
        checkForExpectedStrings(getHttpsServlet("/metrics/vendor", computedMetricsServer), expectedMetrics);
        

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
@@ -533,6 +533,11 @@ public class ComputedMetricsTest {
        Log.info(c, testName, "------- Hitting the testREST application endpoint to initialize the REST metrics ------");
        getHttpServlet("/testRESTApp/test/get", computedMetricsServer);
 
+       Log.info(c, testName, "------- Wait for the Servlet MBean for the REST test app to get registered in MonitorMetrics, before hitting the /metrics endpoint ------");
+       String mbeanRegStr = computedMetricsServer.waitForStringInLogUsingMark("type=ServletStats,name=testRESTApp.io.openliberty.microprofile.metrics.internal.monitor_fat.rest.TestApplication is registered", 60000, computedMetricsServer.getMostRecentTraceFile());
+
+       Log.info(c, testName, "------- Found Servlet MBean for the REST test app successfully registered trace : " + mbeanRegStr);
+       
        Log.info(c, testName, "------- Make sure all the expected metrics have the \"_app=myserver\" tag ------");
        checkForExpectedStrings(getHttpsServlet("/metrics/vendor", computedMetricsServer), expectedMetrics);
        

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
@@ -582,6 +582,11 @@ public class ComputedMetricsTest {
        Log.info(c, testName, "------- Hitting the testREST application endpoint to initialize the REST metrics ------");
        getHttpServlet("/testRESTApp/test/get", computedMetricsServer);
 
+       Log.info(c, testName, "------- Wait for the Servlet MBean for the REST test app to get registered in MonitorMetrics, before hitting the /metrics endpoint ------");
+       String mbeanRegStr = computedMetricsServer.waitForStringInLogUsingMark("type=ServletStats,name=testRESTApp.io.openliberty.microprofile.metrics.internal.monitor_fat.rest.TestApplication is registered", 60000, computedMetricsServer.getMostRecentTraceFile());
+
+       Log.info(c, testName, "------- Found Servlet MBean for the REST test app successfully registered trace : " + mbeanRegStr);
+       
        Log.info(c, testName, "------- Make sure all the expected metrics have the \"mp_app=myserver\" tag ------");
        checkForExpectedStrings(getHttpsServlet("/metrics?scope=vendor", computedMetricsServer), expectedMetrics);
        


### PR DESCRIPTION
fixes #26998
- Added a wait to the `testDynamicApplicationStopWithMpConfigPropSet` test, to wait for the ServletStats MBean for the REST test app to get registered before calling the `/metrics` endpoint to verify the expected metrics output.