### PR TITLE
Explicity drop test tables

### DIFF
--- a/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DualServerDynamicDBRotationTest1.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DualServerDynamicDBRotationTest1.java
@@ -17,8 +17,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
-import com.ibm.ws.transaction.fat.util.TxTestContainerSuite;
-
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -48,7 +46,7 @@ public class DualServerDynamicDBRotationTest1 extends DualServerDynamicCoreTest1
 
     @AfterClass
     public static void afterClass() throws Exception {
-        TxTestContainerSuite.afterSuite();
+        dropTables();
     }
 
     @After

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DualServerDynamicDBRotationTest2.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DualServerDynamicDBRotationTest2.java
@@ -18,8 +18,6 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
-import com.ibm.ws.transaction.fat.util.TxTestContainerSuite;
-
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -56,7 +54,7 @@ public class DualServerDynamicDBRotationTest2 extends DualServerDynamicCoreTest2
 
     @AfterClass
     public static void afterClass() throws Exception {
-        TxTestContainerSuite.afterSuite();
+        dropTables();
     }
 
     @After

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DualServerDynamicTestBase.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DualServerDynamicTestBase.java
@@ -13,6 +13,7 @@
 package tests;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -22,6 +23,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.tx.jta.ut.util.LastingXAResourceImpl;
 import com.ibm.tx.jta.ut.util.XAResourceImpl;
 import com.ibm.websphere.simplicity.RemoteFile;
+import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.transaction.fat.util.FATUtils;
 import com.ibm.ws.transaction.fat.util.SetupRunner;
 import com.ibm.ws.transaction.fat.util.TxShrinkHelper;
@@ -85,6 +87,7 @@ public class DualServerDynamicTestBase extends FATServletClient {
         try {
             // We expect this to fail since it is gonna crash the server
             runTest(server1, servletName, "setupRec" + id);
+            fail("setupRec" + id + " did not cause " + server1.getServerName() + " to crash");
         } catch (IOException e) {
         }
 
@@ -156,5 +159,11 @@ public class DualServerDynamicTestBase extends FATServletClient {
         server2.setServerStartTimeout(FATUtils.LOG_SEARCH_TIMEOUT);
 
         server2.setHttpDefaultPort(server2.getHttpSecondaryPort());
+    }
+
+    public static void dropTables() {
+        Log.info(DualServerDynamicTestBase.class, "dropTables", "WAS_PARTNER_LOGcloud0011, WAS_LEASES_LOG, WAS_TRAN_LOGcloud0011, WAS_PARTNER_LOGcloud0021, WAS_TRAN_LOGcloud0021");
+        TxTestContainerSuite.dropTables("WAS_PARTNER_LOGcloud0011", "WAS_LEASES_LOG", "WAS_TRAN_LOGcloud0011", "WAS_PARTNER_LOGcloud0021",
+                                        "WAS_TRAN_LOGcloud0021");
     }
 }


### PR DESCRIPTION
#build #spawn.fullfat.buckets=com.ibm.ws.transaction.cloud_fat.base,com.ibm.ws.transaction.cloud_fat.db2.0,com.ibm.ws.transaction.cloud_fat.db2.1,com.ibm.ws.transaction.cloud_fat.db2.2,com.ibm.ws.transaction.cloud_fat.derby.0,com.ibm.ws.transaction.cloud_fat.derby.1,com.ibm.ws.transaction.cloud_fat.derby.2,com.ibm.ws.transaction.cloud_fat.dualFS,com.ibm.ws.transaction.cloud_fat.oracle.0,com.ibm.ws.transaction.cloud_fat.oracle.1,com.ibm.ws.transaction.cloud_fat.oracle.2,com.ibm.ws.transaction.cloud_fat.peerlocking.1,com.ibm.ws.transaction.cloud_fat.peerlocking.2,com.ibm.ws.transaction.cloud_fat.postgresql.0,com.ibm.ws.transaction.cloud_fat.postgresql.1,com.ibm.ws.transaction.cloud_fat.postgresql.2,com.ibm.ws.transaction.cloud_fat.simpleFS,com.ibm.ws.transaction.cloud_fat.sqlserver.0,com.ibm.ws.transaction.cloud_fat.sqlserver.1,com.ibm.ws.transaction.cloud_fat.sqlserver.2