### PR TITLE
Adding new LTPA Configuration Unit Tests

### DIFF
--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAConfiguration.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAConfiguration.java
@@ -127,19 +127,4 @@ public interface LTPAConfiguration {
      * @return validation Keys
      */
     List<Properties> getValidationKeys();
-
-    /**
-     * @return the first validation key's file name
-     */
-    String getFirstValidationKeyFileName();
-
-    /**
-     * @return the first validation key's file password
-     */
-    String getFirstValidationKeyPassword();
-
-    /**
-     * @return the first validation key's not use after date
-     */
-    String getFirstValidationKeyValidUntilDate();
 }

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAConfiguration.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAConfiguration.java
@@ -127,4 +127,5 @@ public interface LTPAConfiguration {
      * @return validation Keys
      */
     List<Properties> getValidationKeys();
+    
 }

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAConfiguration.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAConfiguration.java
@@ -128,4 +128,18 @@ public interface LTPAConfiguration {
      */
     List<Properties> getValidationKeys();
 
+    /**
+     * @return the first validation key's file name
+     */
+    String getFirstValidationKeyFileName();
+
+    /**
+     * @return the first validation key's file password
+     */
+    String getFirstValidationKeyPassword();
+
+    /**
+     * @return the first validation key's not use after date
+     */
+    String getFirstValidationKeyValidUntilDate();
 }

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
@@ -787,25 +787,48 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
         return ltpaKeysChangeNotifierService.getService();
     }
 
+    /** {@inheritDoc} */
     @Override
     public long getMonitorInterval() {
         return monitorInterval;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean getMonitorValidationKeysDir() {
         return monitorValidationKeysDir;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getUpdateTrigger() {
         return updateTrigger;
     }
 
+    /** {@inheritDoc} */
     @Sensitive
     @Override
     public List<Properties> getValidationKeys() {
         return validationKeys;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getFirstValidationKeyFileName() {
+        return validationKeys.get(0).getProperty(CFG_KEY_VALIDATION_FILE_NAME);
+    }
+
+    /** {@inheritDoc} */
+    @Sensitive
+    @Override
+    public String getFirstValidationKeyPassword() {
+        return validationKeys.get(0).getProperty(CFG_KEY_VALIDATION_PASSWORD);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getFirstValidationKeyValidUntilDate() {
+        return validationKeys.get(0).getProperty(CFG_KEY_VALIDATION_VALID_UNTIL_DATE);
     }
 
     /*

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
@@ -812,6 +812,10 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
         return validationKeys;
     }
 
+    protected List<Properties> testMaskKeysPasswords(List<Properties> originalList) {
+        return maskKeysPasswords(originalList);
+    }
+
     /*
      *
      */

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
@@ -812,25 +812,6 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
         return validationKeys;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public String getFirstValidationKeyFileName() {
-        return validationKeys.get(0).getProperty(CFG_KEY_VALIDATION_FILE_NAME);
-    }
-
-    /** {@inheritDoc} */
-    @Sensitive
-    @Override
-    public String getFirstValidationKeyPassword() {
-        return validationKeys.get(0).getProperty(CFG_KEY_VALIDATION_PASSWORD);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public String getFirstValidationKeyValidUntilDate() {
-        return validationKeys.get(0).getProperty(CFG_KEY_VALIDATION_VALID_UNTIL_DATE);
-    }
-
     /*
      *
      */

--- a/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImplTest.java
+++ b/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImplTest.java
@@ -196,6 +196,28 @@ public class LTPAConfigurationImplTest {
             super.setFileMonitorRegistration(ltpaFileMonitorRegistration);
             wasSetFileMonitorRegistrationCalled = true;
         }
+
+        /**
+         * @return the first validation key's file name
+         */
+        public String getFirstValidationKeyFileName() {
+            return getValidationKeys().get(0).getProperty(CFG_KEY_VALIDATION_FILE_NAME);
+        }
+
+
+        /**
+         * @return the first validation key's file password
+         */
+        public String getFirstValidationKeyPassword() {
+            return getValidationKeys().get(0).getProperty(CFG_KEY_VALIDATION_PASSWORD);
+        }
+
+        /**
+         * @return the first validation key's not use after date
+         */
+        public String getFirstValidationKeyValidUntilDate() {
+            return getValidationKeys().get(0).getProperty(CFG_KEY_VALIDATION_VALID_UNTIL_DATE);
+        }
     }
 
     @After
@@ -403,7 +425,7 @@ public class LTPAConfigurationImplTest {
 
     @Test
     public void modified_monitorIntervalSet_everythingElseTheSame_keysNotReloaded() {
-        setupExecutorServiceExpectations(0);
+        setupExecutorServiceExpectations(1);
         setupLocationServiceExpectations(1);
         setupFileMonitorRegistrationsExpectations(1);
 
@@ -413,7 +435,7 @@ public class LTPAConfigurationImplTest {
 
     @Test
     public void modified_monitorValidationKeysDirSet_everythingElseTheSame_keysReloaded() {
-        setupExecutorServiceExpectations(0);
+        setupExecutorServiceExpectations(1);
         setupLocationServiceExpectations(1);
         setupFileMonitorRegistrationsExpectations(1);
 
@@ -473,7 +495,7 @@ public class LTPAConfigurationImplTest {
 
     @Test
     public void modified_monitorIntervalSetToZero_everythingElseTheSame_unregistersListener() throws Exception {
-        setupExecutorServiceExpectations(1);
+        setupExecutorServiceExpectations(2);
         setupLocationServiceExpectations(2);
         setupFileMonitorRegistrationsExpectations(1);
 


### PR DESCRIPTION
Added the following unit tests to the LTPA project:

1. fileMonitorRegistration_monitorValidationKeysDir
2.  fileMonitorRegistration_updateTriggerMbean
3.  fileMonitorRegistration_updateTriggerDisabled
4.  getMonitorInterval
5.  getMonitorValidationKeysDir
6.  getUpdateTrigger
7.  getValidationKeys
8.  getFirstValidationKeyFileName
9.  getFirstValidationKeyPassword
10.  getFirstValidationKeyValidUntilDate
11.  modified_monitorValidationKeysDirSet_everythingElseTheSame_keysReloaded
12.  modified_monitorValidationKeysDirSame_fileChanged_unregistersListenerAndCreatesKeys
13.  modified_fileAndMonitorValidationKeysDirChanged_unregistersListenerAndCreatesKeys
14. maskKeysPasswords_replacesPasswordWithMask
