### PR TITLE
Explicit imports for CpuInfo

### DIFF
--- a/dev/com.ibm.tx.jta/bnd.bnd
+++ b/dev/com.ibm.tx.jta/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2023 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -27,16 +27,17 @@ Bundle-Vendor: IBM
 WS-TraceGroup: Transaction
 DynamicImport-Package: *
 Import-Package: \
- com.ibm.tx,\
- com.ibm.tx.config,\
- com.ibm.tx.util,\
- com.ibm.tx.util.alarm,\
- com.ibm.ws.recoverylog.spi,\
- javax.resource,\
- javax.resource.spi,\
- javax.resource.spi.work,\
- javax.transaction;version="1.1.0",\
- javax.transaction.xa;version="1.1.0"
+  com.ibm.tx,\
+  com.ibm.tx.config,\
+  com.ibm.tx.util,\
+  com.ibm.tx.util.alarm,\
+  com.ibm.ws.kernel.service.util,\
+  com.ibm.ws.recoverylog.spi,\
+  javax.resource,\
+  javax.resource.spi,\
+  javax.resource.spi.work,\
+  javax.transaction.xa;version="1.1.0",\
+  javax.transaction;version="1.1.0"
 
 Bundle-Activator: com.ibm.tx.jta.util.TxBundleTools
 
@@ -49,36 +50,36 @@ Service-Component: \
  # TODO can we scrap the test export?
 # all packages have packageinfo files (package-info.java with @version javadoc)
 Export-Package: \
- com.ibm.tx.jta,\
- com.ibm.tx.jta.config,\
- com.ibm.tx.jta.impl,\
- com.ibm.tx.jta.util,\
- com.ibm.tx.jta.util.alarm,\
- com.ibm.tx.ltc,\
- com.ibm.tx.ltc.impl,\
- com.ibm.ws.LocalTransaction.resources;version="2.0.0",\
- com.ibm.ws.LocalTransaction;version="2.0.0",\
- com.ibm.ws.Transaction,\
- com.ibm.ws.Transaction.JTA,\
- com.ibm.ws.Transaction.JTS,\
- com.ibm.ws.Transaction.resources;version="1.0.16",\
- com.ibm.ws.Transaction.test,\
- com.ibm.ws.uow;version="2.0.0",\
- com.ibm.wsspi.tx
+  com.ibm.tx.jta,\
+  com.ibm.tx.jta.config,\
+  com.ibm.tx.jta.impl,\
+  com.ibm.tx.jta.util,\
+  com.ibm.tx.jta.util.alarm,\
+  com.ibm.tx.ltc,\
+  com.ibm.tx.ltc.impl,\
+  com.ibm.ws.LocalTransaction.resources;version="2.0.0",\
+  com.ibm.ws.LocalTransaction;version="2.0.0",\
+  com.ibm.ws.Transaction,\
+  com.ibm.ws.Transaction.JTA,\
+  com.ibm.ws.Transaction.JTS,\
+  com.ibm.ws.Transaction.resources;version="1.0.16",\
+  com.ibm.ws.Transaction.test,\
+  com.ibm.ws.uow;version="2.0.0",\
+  com.ibm.wsspi.tx
 
 instrument.disabled: true
 
 -buildpath: \
- com.ibm.tx.util;version=latest,\
- com.ibm.websphere.javaee.connector.1.6;version=latest,\
- com.ibm.websphere.javaee.transaction.1.1;version=latest,\
- com.ibm.websphere.org.osgi.core;version=latest,\
- com.ibm.websphere.org.osgi.service.component;version=latest,\
- com.ibm.ws.classloading;version=latest,\
- com.ibm.ws.kernel.service;version=latest,\
- com.ibm.ws.logging.core,\
- com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
- com.ibm.ws.recoverylog;version=latest,\
- com.ibm.ws.resource;version=latest,\
- com.ibm.ws.kernel.boot.common;version=latest
- 
+  com.ibm.tx.util;version=latest,\
+  com.ibm.websphere.javaee.connector.1.6;version=latest,\
+  com.ibm.websphere.javaee.transaction.1.1;version=latest,\
+  com.ibm.websphere.org.osgi.core;version=latest,\
+  com.ibm.websphere.org.osgi.service.component;version=latest,\
+  com.ibm.ws.classloading;version=latest,\
+  com.ibm.ws.kernel.boot.common;version=latest,\
+  com.ibm.ws.kernel.service;version=latest,\
+  com.ibm.ws.logging.core,\
+  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+  com.ibm.ws.recoverylog;version=latest,\
+  com.ibm.ws.resource;version=latest
+

--- a/dev/com.ibm.tx.util/bnd.bnd
+++ b/dev/com.ibm.tx.util/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2022 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -27,22 +27,23 @@ WS-TraceGroup: Transaction
 
 # LIBERTY change - no import of com.ibm.ws.util.logging (we'll pick it
 # dynamically anyway)
-Import-Package: javax.transaction;version="1.1.0"
+Import-Package: \
+  com.ibm.ws.kernel.service.util,\
+  javax.transaction;version="1.1.0"
 
 # all packages have packageinfo files (package-info.java with @version javadoc)
 Export-Package: com.ibm.tx,\
- com.ibm.tx.config,\
- com.ibm.tx.util,\
- com.ibm.tx.util.alarm
+  com.ibm.tx.config,\
+  com.ibm.tx.util,\
+  com.ibm.tx.util.alarm
 
 instrument.disabled: true
 
 -buildpath: \
-	com.ibm.ws.resource;version=latest,\
+  com.ibm.websphere.javaee.transaction.1.1;version=latest,\
+  com.ibm.websphere.org.osgi.core;version=latest,\
+  com.ibm.websphere.org.osgi.service.component;version=latest,\
+  com.ibm.ws.kernel.service;version=latest,\
   com.ibm.ws.logging.core,\
-	com.ibm.websphere.javaee.transaction.1.1;version=latest, \
-	com.ibm.websphere.org.osgi.core;version=latest, \
-	com.ibm.websphere.org.osgi.service.component;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
-	com.ibm.ws.kernel.service;version=latest
-	
+  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+  com.ibm.ws.resource;version=latest


### PR DESCRIPTION
#build #spawn.fullfat.buckets=com.ibm.ws.jta_fat,com.ibm.ws.transaction.cloud_fat.base,com.ibm.ws.transaction.cloud_fat.db2.0,com.ibm.ws.transaction.cloud_fat.db2.1,com.ibm.ws.transaction.cloud_fat.db2.2,com.ibm.ws.transaction.cloud_fat.derby.0,com.ibm.ws.transaction.cloud_fat.derby.1,com.ibm.ws.transaction.cloud_fat.derby.2,com.ibm.ws.transaction.cloud_fat.dualFS,com.ibm.ws.transaction.cloud_fat.oracle.0,com.ibm.ws.transaction.cloud_fat.oracle.1,com.ibm.ws.transaction.cloud_fat.oracle.2,com.ibm.ws.transaction.cloud_fat.peerlocking.1,com.ibm.ws.transaction.cloud_fat.peerlocking.2,com.ibm.ws.transaction.cloud_fat.postgresql.0,com.ibm.ws.transaction.cloud_fat.postgresql.1,com.ibm.ws.transaction.cloud_fat.postgresql.2,com.ibm.ws.transaction.cloud_fat.simpleFS,com.ibm.ws.transaction.cloud_fat.sqlserver.0,com.ibm.ws.transaction.cloud_fat.sqlserver.1,com.ibm.ws.transaction.cloud_fat.sqlserver.2,com.ibm.ws.transaction.core_fat.base,com.ibm.ws.transaction.core_fat.baseDB,com.ibm.ws.transaction.core_fat.cdi,com.ibm.ws.transaction.core_fat.commitPriority,com.ibm.ws.transaction.core_fat.heuristics,com.ibm.ws.transaction.core_fat.heuristicsDB,com.ibm.ws.transaction.core_fat.misc,com.ibm.ws.transaction.core_fat.startMultiEJB,com.ibm.ws.transaction.core_fat.startup,com.ibm.ws.transaction.core_fat.xa,com.ibm.ws.transaction.core_fat.xaDB,com.ibm.ws.transaction.db_fat,com.ibm.ws.transaction.hadb_fat.db2.1,com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.db2.retriablecodes,com.ibm.ws.transaction.hadb_fat.derby.1,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.derby.retriablecodes,com.ibm.ws.transaction.hadb_fat.oracle.1,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.oracle.retriablecodes,com.ibm.ws.transaction.hadb_fat.postgresql.1,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.postgresql.retriablecodes,com.ibm.ws.transaction.hadb_fat.sqlserver.1,com.ibm.ws.transaction.hadb_fat.sqlserver.2,com.ibm.ws.transaction.hadb_fat.sqlserver.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes,com.ibm.ws.transaction.recovery_fat.1,com.ibm.ws.transaction.recovery_fat.2,com.ibm.ws.transaction.recovery_fat.3,com.ibm.ws.tx.jta_fat,com.ibm.ws.tx.jta_fat_hibernate,com.ibm.ws.wsat.common_fat,com.ibm.ws.wsat.concurrent_fat,com.ibm.ws.wsat.migration_fat.1,com.ibm.ws.wsat.migration_fat.2,com.ibm.ws.wsat.migration_fat.3,com.ibm.ws.wsat.migration_fat.4,com.ibm.ws.wsat.migration_fat.5,com.ibm.ws.wsat.recovery_fat.lps,com.ibm.ws.wsat.recovery_fat.multi.1,com.ibm.ws.wsat.recovery_fat.multi.2,com.ibm.ws.wsat.recovery_fat.multi.3,com.ibm.ws.wsat.recovery_fat.multi.4,com.ibm.ws.wsat.recovery_fat.single.1,com.ibm.ws.wsat.recovery_fat.single.2,com.ibm.ws.wsat_fat.assertion,com.ibm.ws.wsat_fat.db,com.ibm.ws.wsat_fat.db_optional,com.ibm.ws.wsat_fat.dbs,com.ibm.ws.wsat_fat.dbs_optional,com.ibm.ws.wsat_fat.multi,com.ibm.ws.wsat_fat.ssl,io.openliberty.checkpoint_fat_transaction