### PR TITLE
Start using Concurrency 3.1.0-M1

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1162,6 +1162,11 @@
       <version>3.0.3</version>
     </dependency>
     <dependency>
+      <groupId>jakarta.enterprise.concurrent</groupId>
+      <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+      <version>3.1.0-M1</version>
+    </dependency>
+    <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
       <version>3.0.1</version>
@@ -2144,7 +2149,7 @@
     <dependency>
       <groupId>org.apache.santuario</groupId>
       <artifactId>xmlsec</artifactId>
-      <version>2.3.0</version>
+      <version>2.3.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sshd</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -228,6 +228,7 @@ jakarta.batch:jakarta.batch-api:2.1.1
 jakarta.ejb:jakarta.ejb-api:4.0.1
 jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:2.0.0
 jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.3
+jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.1.0-M1
 jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.1
 jakarta.enterprise:jakarta.enterprise.cdi-api:4.0.1
 jakarta.enterprise:jakarta.enterprise.lang-model:4.0.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-3.1.feature
@@ -4,7 +4,7 @@ visibility=private
 singleton=true
 -features=com.ibm.websphere.appserver.eeCompatible-11.0, \
   io.openliberty.noShip-1.0
--bundles=io.openliberty.jakarta.concurrency.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.2"
+-bundles=io.openliberty.jakarta.concurrency.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.1.0-M1"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/bnd.bnd
@@ -23,9 +23,4 @@ src: \
 
 fat.project: true
 
-# TODO update these to Jakarta EE 11 features
-tested.features: appsecurity-5.0, cdi-4.0, concurrent-3.0, pages-3.1
-
-# To define a global minimum java level for the FAT, use the following property.
-# If unspecified, the default value is ${javac.source}
-fat.minimum.java.level: 17
+tested.features: appsecurity-6.0, cdi-4.1, concurrent-3.1, pages-4.0

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherFull.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherFull.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -40,7 +40,7 @@ import componenttest.topology.utils.tck.TCKRunner;
  */
 @Mode(FULL)
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 17)
+@MinimumJavaLevel(javaLevel = 21)
 public class ConcurrentTckLauncherFull {
 
     final static Map<String, String> additionalProps = new HashMap<>();
@@ -50,7 +50,7 @@ public class ConcurrentTckLauncherFull {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        //TODO Remove once TCK is available from stagging repo
+        //Comment out to use snapshot version
         additionalProps.put("jakarta.concurrent.tck.groupid", "jakarta.enterprise.concurrent");
         additionalProps.put("jakarta.concurrent.tck.version", "3.1.0-M1");
 

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherFull.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherFull.java
@@ -51,8 +51,8 @@ public class ConcurrentTckLauncherFull {
     @BeforeClass
     public static void setUp() throws Exception {
         //TODO Remove once TCK is available from stagging repo
-        additionalProps.put("jakarta.concurrent.tck.groupid", "io.openliberty.jakarta.enterprise.concurrent");
-        additionalProps.put("jakarta.concurrent.tck.version", "3.1.0-20230802");
+        additionalProps.put("jakarta.concurrent.tck.groupid", "jakarta.enterprise.concurrent");
+        additionalProps.put("jakarta.concurrent.tck.version", "3.1.0-M1");
 
         //Jakarta TCK platform
         additionalProps.put("jakarta.tck.platform", "full");

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherWeb.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherWeb.java
@@ -36,7 +36,7 @@ import componenttest.topology.utils.tck.TCKRunner;
  * tests as if they were running as simplicity junit FAT tests in the standard location.
  */
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 17)
+@MinimumJavaLevel(javaLevel = 21)
 public class ConcurrentTckLauncherWeb {
 
     final static Map<String, String> additionalProps = new HashMap<>();
@@ -46,7 +46,7 @@ public class ConcurrentTckLauncherWeb {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        //TODO Remove once TCK is available from stagging repo
+        //Comment out to use snapshot version
         additionalProps.put("jakarta.concurrent.tck.groupid", "jakarta.enterprise.concurrent");
         additionalProps.put("jakarta.concurrent.tck.version", "3.1.0-M1");
 

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherWeb.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherWeb.java
@@ -47,8 +47,8 @@ public class ConcurrentTckLauncherWeb {
     @BeforeClass
     public static void setUp() throws Exception {
         //TODO Remove once TCK is available from stagging repo
-        additionalProps.put("jakarta.concurrent.tck.groupid", "io.openliberty.jakarta.enterprise.concurrent");
-        additionalProps.put("jakarta.concurrent.tck.version", "3.1.0-20230802");
+        additionalProps.put("jakarta.concurrent.tck.groupid", "jakarta.enterprise.concurrent");
+        additionalProps.put("jakarta.concurrent.tck.version", "3.1.0-M1");
 
         //Jakarta TCK platform
         additionalProps.put("jakarta.tck.platform", "web");

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/FATSuite.java
@@ -25,7 +25,7 @@ import componenttest.topology.impl.JavaInfo;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                AlwaysPassesTest.class, //Need to have a passing test for Java 8 and Java 11
+                AlwaysPassesTest.class, //Need to have a passing test for Java 8, 11, and 17
                 ConcurrentTckLauncherFull.class, //FULL MODE
                 ConcurrentTckLauncherWeb.class //LITE MODE
 })

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/servers/ConcurrentTCKFullServer/server.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/servers/ConcurrentTCKFullServer/server.xml
@@ -13,14 +13,13 @@
 <server>
     <featureManager>
         <!-- Features being tested -->
-        <!-- TODO update to Jakarta EE 11 feature -->
-        <feature>jakartaee-10.0</feature>
+        <feature>jakartaee-11.0</feature>
 		
         <!-- Minimum features required 
-        <feature>concurrent-3.0</feature>
+        <feature>concurrent-3.1</feature>
         <feature>enterpriseBeans-4.0</feature>
-        <feature>appSecurity-5.0</feature>
-        <feature>pages-3.1</feature>
+        <feature>appSecurity-6.0</feature>
+        <feature>pages-4.0</feature>
         -->
 		 
         <!-- Features needed for arquillan support -->

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/servers/ConcurrentTCKWebServer/server.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/servers/ConcurrentTCKWebServer/server.xml
@@ -13,15 +13,14 @@
 <server>
     <featureManager>
         <!-- Features being tested -->
-        <!-- TODO update to Jakarta EE 11 feature -->
-        <feature>webProfile-10.0</feature>
+        <feature>webProfile-11.0</feature>
         
         <!-- Minimum features required 
-        <feature>concurrent-3.0</feature>
+        <feature>concurrent-3.1</feature>
         <feature>enterpriseBeansLite-4.0</feature>
         <feature>jdbc-4.3</feature>
-        <feature>appSecurity-5.0</feature>
-        <feature>pages-3.1</feature>
+        <feature>appSecurity-6.0</feature>
+        <feature>pages-4.0</feature>
         -->
         
         <!-- Features needed for arquillan support -->

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -87,16 +87,15 @@
             <version>${jakarta.concurrent.tck.version}</version>
         </dependency>
         <!-- API Dependency -->
-        <!-- TODO update to Jakarta EE 11 feature -->
         <dependency>
             <groupId>jakarta.enterprise.concurrent</groupId>
             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
             <version>${jakarta.concurrent.version}</version>
             <scope>system</scope>
-            <systemPath>${io.openliberty.jakarta.concurrency.3.0}</systemPath>
+            <systemPath>${io.openliberty.jakarta.concurrency.3.1}</systemPath>
         </dependency>
         <!-- Other API Dependencies -->
-        <!-- TODO update to Jakarta EE 11 feature -->
+        <!-- TODO update to Jakarta EE 11 bundles -->
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>

--- a/dev/io.openliberty.jakarta/concurrency.3.1.bnd
+++ b/dev/io.openliberty.jakarta/concurrency.3.1.bnd
@@ -1,0 +1,47 @@
+#*******************************************************************************
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Bundle-SymbolicName: io.openliberty.jakarta.concurrency.3.1; singleton:=true
+
+javac.source: 21
+javac.target: 21
+
+Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=21))"
+
+Export-Package: \
+  jakarta.enterprise.concurrent;version="3.1.0",\
+  jakarta.enterprise.concurrent.spi;version="3.1.0"
+
+DynamicImport-Package: \
+  jakarta.enterprise.util,\
+  jakarta.interceptor
+
+Import-Package: \
+  !jakarta.enterprise.util,\
+  !jakarta.interceptor,\
+  *
+
+-includeresource: \
+  @${repo;jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api;3.1.0.M1;EXACT}!/!(META-INF/maven/*|module-info.class)
+
+instrument.disabled: true
+
+publish.wlp.jar.suffix: dev/api/spec
+
+-buildpath: \
+  jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api;version=3.1.0-M1;strategy=exact
+  
+-maven-dependencies: \
+   dep1;groupId=jakarta.enterprise.concurrent;artifactId=jakarta.enterprise.concurrent-api;version=3.1.0-M1;scope=runtime


### PR DESCRIPTION
- Create concurrency 3.1 API bundle
- Transition concurrency 3.1 TCK test suite to use new API and TCK artifacts

