### PR TITLE
Move open tracing SPI to the IBM-SPI-Package header in feature files

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
@@ -1256,8 +1256,7 @@ public class VisibilityTest {
             if (APIs != null) {
                 for (ExternalPackageInfo packageInfo : APIs) {
                     String type = packageInfo.getType();
-                    // for now until we figure something out going to leave mpOpenTracing and openTracing feature wrong.
-                    if (!validAPITypes.contains(type) && !entry.getKey().toLowerCase().contains("opentracing")) {
+                    if (!validAPITypes.contains(type)) {
                         errorMessage.append(packageInfo.getPackageName()).append(" in feature ").append(entry.getKey()).append(" has an invalid type ").append(type).append('\n');
                     }
                 }

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-3.0/io.openliberty.mpOpenTracing-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-3.0/io.openliberty.mpOpenTracing-3.0.feature
@@ -10,8 +10,9 @@ IBM-API-Package: \
     org.eclipse.microprofile.opentracing; type="stable", \
     io.opentracing;  type="third-party", \
     io.opentracing.tag;  type="third-party", \
-    io.opentracing.propagation;  type="third-party", \
-    io.openliberty.opentracing.spi.tracer; type="ibm-spi"
+    io.opentracing.propagation;  type="third-party"
+IBM-SPI-Package: \
+    io.openliberty.opentracing.spi.tracer
 -features= \
     io.openliberty.mpConfig-3.0, \
     io.openliberty.restfulWS-3.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.0/com.ibm.websphere.appserver.opentracing-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.0/com.ibm.websphere.appserver.opentracing-1.0.feature
@@ -9,8 +9,8 @@ IBM-ShortName: opentracing-1.0
 Subsystem-Name: Opentracing 1.0
 IBM-API-Package: io.opentracing;  type="third-party",\
                  io.opentracing.tag;  type="third-party",\
-                 io.opentracing.propagation;  type="third-party", \
-                 com.ibm.ws.opentracing.tracer; type="ibm-spi"
+                 io.opentracing.propagation;  type="third-party"
+IBM-SPI-Package: com.ibm.ws.opentracing.tracer
 -features=com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1", \
   com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"
 -bundles=com.ibm.ws.jaxrs.defaultexceptionmapper, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.1/com.ibm.websphere.appserver.opentracing-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.1/com.ibm.websphere.appserver.opentracing-1.1.feature
@@ -9,8 +9,8 @@ IBM-ShortName: opentracing-1.1
 Subsystem-Name: Opentracing 1.1
 IBM-API-Package: io.opentracing;  type="third-party",\
                  io.opentracing.tag;  type="third-party",\
-                 io.opentracing.propagation;  type="third-party", \
-                 com.ibm.ws.opentracing.tracer; type="ibm-spi"
+                 io.opentracing.propagation;  type="third-party"
+IBM-SPI-Package: com.ibm.ws.opentracing.tracer
 -features=com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1", \
   com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"
 -bundles=com.ibm.ws.jaxrs.defaultexceptionmapper, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.2/com.ibm.websphere.appserver.opentracing-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.2/com.ibm.websphere.appserver.opentracing-1.2.feature
@@ -9,8 +9,8 @@ IBM-ShortName: opentracing-1.2
 Subsystem-Name: Opentracing 1.2
 IBM-API-Package: io.opentracing;  type="third-party",\
                  io.opentracing.tag;  type="third-party",\
-                 io.opentracing.propagation;  type="third-party", \
-                 com.ibm.ws.opentracing.tracer; type="ibm-spi"
+                 io.opentracing.propagation;  type="third-party"
+IBM-SPI-Package: com.ibm.ws.opentracing.tracer
 -features=com.ibm.websphere.appserver.mpConfig-1.3; ibm.tolerates:="1.4", \
   com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1", \
   com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.3/com.ibm.websphere.appserver.opentracing-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.3/com.ibm.websphere.appserver.opentracing-1.3.feature
@@ -9,8 +9,8 @@ IBM-ShortName: opentracing-1.3
 Subsystem-Name: Opentracing 1.3
 IBM-API-Package: io.opentracing;  type="third-party",\
                  io.opentracing.tag;  type="third-party",\
-                 io.opentracing.propagation;  type="third-party", \
-                 com.ibm.ws.opentracing.tracer; type="ibm-spi"
+                 io.opentracing.propagation;  type="third-party"
+IBM-SPI-Package: com.ibm.ws.opentracing.tracer
 -features=com.ibm.websphere.appserver.mpConfig-1.3; ibm.tolerates:="1.4", \
   com.ibm.websphere.appserver.jaxrs-2.1, \
   com.ibm.websphere.appserver.cdi-2.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-2.0/com.ibm.websphere.appserver.opentracing-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-2.0/com.ibm.websphere.appserver.opentracing-2.0.feature
@@ -8,8 +8,8 @@ IBM-ShortName: opentracing-2.0
 Subsystem-Name: Opentracing 2.0
 IBM-API-Package: io.opentracing;  type="third-party",\
                  io.opentracing.tag;  type="third-party",\
-                 io.opentracing.propagation;  type="third-party", \
-                 io.openliberty.opentracing.spi.tracer; type="ibm-spi"
+                 io.opentracing.propagation;  type="third-party"
+IBM-SPI-Package: io.openliberty.opentracing.spi.tracer
 -features=com.ibm.websphere.appserver.mpConfig-2.0, \
   com.ibm.websphere.appserver.jaxrs-2.1, \
   com.ibm.websphere.appserver.cdi-2.0


### PR DESCRIPTION
- com.ibm.ws.opentracing.tracer and io.openliberty.opentracing.spi.tracer were incorrectly in the IBM-API-Package header with a type of ibm-spi.  Now those packages are in the correctly header name so that they are recognized as SPIs instead of APIs.

For #25612