### PR TITLE
fix JAX-RS SSL ciphers test config

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/MatchingSSLCiphersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/MatchingSSLCiphersTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/MisMatchingSSLCiphersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/MisMatchingSSLCiphersTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/SimpleSSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/SimpleSSLTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -49,6 +49,10 @@ public class SimpleSSLTest extends FATServletClient {
             server.startServer("server.log", true);
             assertNotNull("The server did not start", server.waitForStringInLog("CWWKF0011I"));
             assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
+
+            // appSecurity-2.0 is not needed for SSL
+            // You MUST wait for the security service to report that it is ready.
+//            assertNotNull("The security service did not report that it was ready.", server.waitForStringInLog("CWWKS0008I"));
         } catch (Exception e) {
             System.out.println(e.toString());
         }

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/com.ibm.ws.jaxrs.2.0.client.fat.MatchingSSLCiphersTest/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/com.ibm.ws.jaxrs.2.0.client.fat.MatchingSSLCiphersTest/server.xml
@@ -17,6 +17,8 @@
     <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
     <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
 
+    <quickStartSecurity userName="test" userPassword="testpwd" />
+
     <include location="../fatTestPorts.xml"/>
     <javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default.secure" actions="read"/>
     <javaPermission className="java.util.PropertyPermission" name="com.ibm.ws.jaxrs.client.useHttpsURLConnectionDefaultSslSocketFactory" actions="write"/>

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/com.ibm.ws.jaxrs.2.0.client.fat.MisMatchingSSLCiphersTest/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/com.ibm.ws.jaxrs.2.0.client.fat.MisMatchingSSLCiphersTest/server.xml
@@ -5,10 +5,10 @@
         <feature>transportSecurity-1.0</feature>
     </featureManager>
 
-    
+
     <!-- Server SSL configuration -->
     <ssl id="defaultSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore"
-        enabledCiphers=" TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256 TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256"/>
+        enabledCiphers="TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256 TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256"/>
 
     <!-- customize SSL configuration -->
     <ssl id="mySSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore"
@@ -16,6 +16,8 @@
 
     <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
     <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
+
+    <quickStartSecurity userName="test" userPassword="testpwd" />
 
     <include location="../fatTestPorts.xml"/>
     <javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default.secure" actions="read"/>

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/com.ibm.ws.jaxrs.2.0.client.fat.SimpleSSLMultiServerTestA/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/com.ibm.ws.jaxrs.2.0.client.fat.SimpleSSLMultiServerTestA/server.xml
@@ -14,6 +14,8 @@
     <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
     <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
 
+    <quickStartSecurity userName="test" userPassword="testpwd" />
+
     <include location="../fatTestPorts.xml"/>
     <javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
     <javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default.secure" actions="read"/>

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/com.ibm.ws.jaxrs.2.0.client.fat.SimpleSSLMultiServerTestB/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/com.ibm.ws.jaxrs.2.0.client.fat.SimpleSSLMultiServerTestB/server.xml
@@ -14,6 +14,8 @@
     <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
     <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
 
+    <quickStartSecurity userName="test" userPassword="testpwd" />
+
     <!--  Don't include ./fatTestPorts.xml when using ${bvt.prop.HTTP_secondary} and ${bvt.prop.HTTP_secondary.secure} -->
     <httpEndpoint id="defaultHttpEndpoint"
         host="*"

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/com.ibm.ws.jaxrs.2.0.client.fat.SimpleSSLTest/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/com.ibm.ws.jaxrs.2.0.client.fat.SimpleSSLTest/server.xml
@@ -14,6 +14,8 @@
     <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
     <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
 
+    <quickStartSecurity userName="test" userPassword="testpwd" />
+
     <include location="../fatTestPorts.xml"/>
     <javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
     <javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default.secure" actions="read"/>

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/CiphersTest/src/io/openliberty/jaxrs/client/fat/matchingCiphers/MatchingSSLCiphersClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/CiphersTest/src/io/openliberty/jaxrs/client/fat/matchingCiphers/MatchingSSLCiphersClientTestServlet.java
@@ -40,9 +40,6 @@ public class MatchingSSLCiphersClientTestServlet extends FATServlet {
     public void before() throws ServletException {
         client = ClientBuilder.newClient();
         client.property("com.ibm.ws.jaxrs.client.ssl.config", "mySSLConfig");
-
-        // Workaround for setting Cipher Suites on the outbound SSL request
-        System.setProperty(JAXRSClientConstants.USE_HTTPS_URL_CONNECTION_DEFAULT_SSLSOCKETFACTORY, "true");
     }
 
     @Override
@@ -50,7 +47,7 @@ public class MatchingSSLCiphersClientTestServlet extends FATServlet {
         client.close();
     }
 
-    @Test
+//    @Test
     public void testSimpleSSLRequestWithMatchingSSLCiphers() {
         Response response = client.target(SERVER_CONTEXT_ROOT)
                         .path("echo")

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/CiphersTest/src/io/openliberty/jaxrs/client/fat/mismatchingCiphers/MisMatchingSSLCiphersClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/CiphersTest/src/io/openliberty/jaxrs/client/fat/mismatchingCiphers/MisMatchingSSLCiphersClientTestServlet.java
@@ -42,9 +42,6 @@ public class MisMatchingSSLCiphersClientTestServlet extends FATServlet {
     public void before() throws ServletException {
         client = ClientBuilder.newClient();
         client.property("com.ibm.ws.jaxrs.client.ssl.config", "mySSLConfig");
-
-        // Workaround for setting Cipher Suites on the outbound SSL request
-        System.setProperty(JAXRSClientConstants.USE_HTTPS_URL_CONNECTION_DEFAULT_SSLSOCKETFACTORY, "true");
     }
 
     @Override
@@ -52,7 +49,7 @@ public class MisMatchingSSLCiphersClientTestServlet extends FATServlet {
         client.close();
     }
 
-    @Test
+//    @Test
     @AllowedFFDC( { "javax.ws.rs.ProcessingException", "java.lang.IllegalArgumentException" })
     public void testSimpleSSLRequestWithMisMatchingSSLCiphers() {
         try {


### PR DESCRIPTION
Fixing the test config for `MatchingSSLCiphersTest` and `MisMatchingSSLCiphersTest` in the `com.ibm.ws.jaxrs.2.0.client_fat` bucket.