### PR TITLE
re-enable uber jar tests

### DIFF
--- a/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/utility/SpringBootUtilityThinTest.java
+++ b/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/utility/SpringBootUtilityThinTest.java
@@ -275,7 +275,7 @@ public class SpringBootUtilityThinTest extends CommonWebServerTests {
         super.testBasicSpringBootApplication();
     }
 
-    // disable test until uber jar creating works reliably @Test
+    @Test
     public void testLibertyUberJarThinning() throws Exception {
         String dropinsSpring = "dropins/" + SPRING_APP_TYPE + "/";
         new File(new File(server.getServerRoot()), dropinsSpring).mkdirs();
@@ -313,7 +313,7 @@ public class SpringBootUtilityThinTest extends CommonWebServerTests {
         super.testBasicSpringBootApplication();
     }
 
-    // disable test until uber jar creating works reliably @Test
+    @Test
     public void testDefaultHostWithAppPortRunLibertyUberJarWithSSL() throws Exception {
         String dropinsSpring = "dropins/" + SPRING_APP_TYPE + "/";
         new File(new File(server.getServerRoot()), dropinsSpring).mkdirs();
@@ -442,7 +442,7 @@ public class SpringBootUtilityThinTest extends CommonWebServerTests {
         return trustAllCerts;
     }
 
-    // disable test until uber jar creating works reliably @Test
+    @Test
     public void testInvalidLibertyUberJar() throws Exception {
         String dropinsSpring = "dropins/" + SPRING_APP_TYPE + "/";
         new File(new File(server.getServerRoot()), dropinsSpring).mkdirs();
@@ -480,7 +480,7 @@ public class SpringBootUtilityThinTest extends CommonWebServerTests {
         server.deleteDirectoryFromLibertyInstallRoot("usr/shared/resources/libraries/");
     }
 
-    // disable test until uber jar creating works reliably @Test
+    @Test
     public void testErrorOccursWhenAppNotConfiguredInLibertyUberJar() throws Exception {
         //Configure app in wrong location
         String dropinsSpring = "thin/";

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/utility/SpringBootUtilityThinTest.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/utility/SpringBootUtilityThinTest.java
@@ -277,8 +277,7 @@ public class SpringBootUtilityThinTest extends CommonWebServerTests {
         super.testBasicSpringBootApplication();
     }
 
-    // disable test until uber jar creating works reliably
-    // @Test
+    @Test
     public void testLibertyUberJarThinning() throws Exception {
         String dropinsSpring = "dropins/" + SPRING_APP_TYPE + "/";
         new File(new File(server.getServerRoot()), dropinsSpring).mkdirs();
@@ -316,8 +315,7 @@ public class SpringBootUtilityThinTest extends CommonWebServerTests {
         super.testBasicSpringBootApplication();
     }
 
-    // disable test until uber jar creating works reliably
-    // @Test
+    @Test
     public void testDefaultHostWithAppPortRunLibertyUberJarWithSSL() throws Exception {
         String dropinsSpring = "dropins/" + SPRING_APP_TYPE + "/";
         new File(new File(server.getServerRoot()), dropinsSpring).mkdirs();
@@ -446,8 +444,7 @@ public class SpringBootUtilityThinTest extends CommonWebServerTests {
         return trustAllCerts;
     }
 
-    // disable test until uber jar creating works reliably
-    // @Test
+    @Test
     public void testInvalidLibertyUberJar() throws Exception {
         String dropinsSpring = "dropins/" + SPRING_APP_TYPE + "/";
         new File(new File(server.getServerRoot()), dropinsSpring).mkdirs();
@@ -485,8 +482,7 @@ public class SpringBootUtilityThinTest extends CommonWebServerTests {
         server.deleteDirectoryFromLibertyInstallRoot("usr/shared/resources/libraries/");
     }
 
-    // disable test until uber jar creating works reliably
-    // @Test
+    @Test
     public void testErrorOccursWhenAppNotConfiguredInLibertyUberJar() throws Exception {
         //Configure app in wrong location
         String dropinsSpring = "thin/";


### PR DESCRIPTION
fixes #26444 

Re-enables the SpringBoot uber jar packaging liberty tests.