### PR TITLE
Do not run javascript on Liberty splash page

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/commonTests/CommonLogoutAndRefreshTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/commonTests/CommonLogoutAndRefreshTests.java
@@ -223,6 +223,7 @@ public class CommonLogoutAndRefreshTests extends CommonAnnotatedSecurityTests {
         // now logged in - wait for token to expire
         actions.testLogAndSleep(sleepTimeInSeconds);
         String url = rpHttpsBase + "/" + appName + "/" + baseAppName;
+        webClient.getOptions().setJavaScriptEnabled(false);
         invokeAppGetToSplashPage(webClient, url);
 
     }


### PR DESCRIPTION
The Open Liberty Splash page contains javascript that is not running when a remote server is down:
`BasicLogoutTests_badRedirectUri_NotifyProviderFalse_jwt:java.lang.Exception: 2023-07-10-04:31:17:527 An error occurred invoking the URL [https://localhost:8940/BadRedirectNotifyProviderFalseLogoutServlet/BasicLogoutServlet]: com.ibm.ws.security.fat.common.exceptions.TestActionException: An error occurred while submitting a request to [https://localhost:8940/BadRedirectNotifyProviderFalseLogoutServlet/BasicLogoutServlet]. net.sourceforge.htmlunit.corejs.javascript.EcmaError: ReferenceError: "latestReleasedVersion" is not defined. (script in https://localhost:8920/ from (526, 32) to (576, 10)#542`
We don't really care about what's on the page - we just need "a" page to go to. 
I'm disabling javascript in htmlunit before making this call - this should resolve the issue.

