### PR TITLE
xmlWS-4.0: Fix xmlWS-4.0 tools to work without xmlWS-3.0 installed

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWS-4.0/io.openliberty.xmlWS-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWS-4.0/io.openliberty.xmlWS-4.0.feature
@@ -48,6 +48,15 @@ IBM-SPI-Package: \
  com.ibm.ws.jaxws.web.jakarta, \
  com.ibm.ws.jaxws.wsat, \
  com.ibm.ws.webservices.javaee.common.jakarta
+# These jars are used for the xmlWS scripts below.
+-jars=\
+ io.openliberty.com.sun.xml.messaging.saaj.2.0, \
+ io.openliberty.jakarta.xmlBinding.3.0; location:="dev/api/spec/", \
+ io.openliberty.jakarta.activation.2.0; location:="dev/api/spec/", \
+ io.openliberty.jakarta.jws.3.0; location:="dev/api/spec/", \
+ io.openliberty.jakarta.soap.2.0; location:="dev/api/spec/", \
+ io.openliberty.jakarta.xmlWS.3.0; location:="dev/api/spec/", \
+ io.openliberty.xmlWS.3.0.internal.tools
 -files=\
  bin/xmlWS/wsgen; ibm.executable:=true; ibm.file.encoding:=ebcdic, \
  bin/xmlWS/wsimport; ibm.executable:=true; ibm.file.encoding:=ebcdic, \

--- a/dev/io.openliberty.ws.jaxws.tools_fat/bnd.bnd
+++ b/dev/io.openliberty.ws.jaxws.tools_fat/bnd.bnd
@@ -23,7 +23,10 @@ fat.project: true
 tested.features:\
 	servlet-5.0,\
 	servlet-4.0,\
-	xmlws-3.0
+	xmlws-3.0, \
+	xmlws-4.0, \
+	xmlbinding-4.0, \
+	servlet-6.0
 	
 -buildpath:\
     com.ibm.websphere.javaee.jws.1.0;version=latest,\

--- a/dev/io.openliberty.ws.jaxws.tools_fat/fat/src/com/ibm/ws/jaxws/tools/FATSuite.java
+++ b/dev/io.openliberty.ws.jaxws.tools_fat/fat/src/com/ibm/ws/jaxws/tools/FATSuite.java
@@ -33,5 +33,5 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModificationInFullMode().andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly()).andWith(FeatureReplacementAction.EE9_FEATURES());
+    public static RepeatTests r = RepeatTests.withoutModificationInFullMode().andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly()).andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11)).andWith(FeatureReplacementAction.EE10_FEATURES());
 }

--- a/dev/io.openliberty.ws.jaxws.tools_fat/fat/src/com/ibm/ws/jaxws/tools/test/FATTest.java
+++ b/dev/io.openliberty.ws.jaxws.tools_fat/fat/src/com/ibm/ws/jaxws/tools/test/FATTest.java
@@ -379,7 +379,7 @@ public class FATTest {
 
     // Not required for xmlWS-3.0
     @Test
-    @SkipForRepeat(JakartaEEAction.EE9_ACTION_ID)
+    @SkipForRepeat({JakartaEEAction.EE9_ACTION_ID, JakartaEEAction.EE10_ACTION_ID})
     public void testWsImportToolWithoutTarget() throws Exception {
 
         server.waitForStringInLog("CWWKZ0001I.*PeopleService");


### PR DESCRIPTION
This PR does the following:

- Adds the jars header, and tooling jars to both `xmlWS` features
- Repeats the `io.openliberty.jaxws.tools_fat` bucket for the EE10 features. 