### PR TITLE
Servlet 6.1 create initial WebContainer classes

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebApp40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebApp40.java
@@ -73,7 +73,7 @@ public class WebApp40 extends com.ibm.ws.webcontainer31.osgi.webapp.WebApp31 imp
     @Override
     public int getMajorVersion() {
         int level = WebContainer.getServletContainerSpecLevel();
-        return level == WebContainer.SPEC_LEVEL_61 ? 6 : level == WebContainer.SPEC_LEVEL_60 ? 6 : level == WebContainer.SPEC_LEVEL_50 ? 5 : 4;
+        return level == WebContainer.SPEC_LEVEL_60 ? 6 : level == WebContainer.SPEC_LEVEL_50 ? 5 : 4;
     }
 
     /*
@@ -84,7 +84,7 @@ public class WebApp40 extends com.ibm.ws.webcontainer31.osgi.webapp.WebApp31 imp
      */
     @Override
     public int getMinorVersion() {
-        return WebContainer.getServletContainerSpecLevel() == WebContainer.SPEC_LEVEL_61 ? 1 : 0;
+        return 0;
     }
 
     /*

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal.factories/bnd.bnd
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal.factories/bnd.bnd
@@ -80,7 +80,6 @@ Import-Package: \
     io.openliberty.webcontainer60.session.impl, \
     io.openliberty.webcontainer60.osgi.request, \
     io.openliberty.webcontainer60.osgi.response, \
-    io.openliberty.webcontainer60.osgi.srt, \
     *
 
 -buildpath: \

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal.factories/src/io/openliberty/webcontainer/servlet/internal/osgi/srt/factory/SRTConnectionContextPool61Impl.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal.factories/src/io/openliberty/webcontainer/servlet/internal/osgi/srt/factory/SRTConnectionContextPool61Impl.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package io.openliberty.webcontainer.servlet.internal.osgi.srt.factory;
@@ -13,7 +13,7 @@ import org.osgi.service.component.annotations.Component;
 
 import com.ibm.ws.webcontainer.osgi.srt.SRTConnectionContextPool;
 
-import io.openliberty.webcontainer60.osgi.srt.SRTConnectionContext60;
+import io.openliberty.webcontainer61.osgi.srt.SRTConnectionContext61;
 
 @Component(property = { "service.vendor=IBM", "service.ranking:Integer=61", "servlet.version=6.1" })
 public class SRTConnectionContextPool61Impl implements SRTConnectionContextPool {
@@ -29,7 +29,7 @@ public class SRTConnectionContextPool61Impl implements SRTConnectionContextPool 
         }
 
         if (context == null) {
-            context = new SRTConnectionContext60();
+            context = new SRTConnectionContext61();
         }
 
         context.nextContext = null;

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal.factories/src/io/openliberty/webcontainer/servlet/internal/osgi/webapp/factory/WebAppFactory61Impl.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal.factories/src/io/openliberty/webcontainer/servlet/internal/osgi/webapp/factory/WebAppFactory61Impl.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package io.openliberty.webcontainer.servlet.internal.osgi.webapp.factory;
@@ -17,8 +17,9 @@ import com.ibm.ws.managedobject.ManagedObjectService;
 import com.ibm.ws.webcontainer.osgi.webapp.WebApp;
 import com.ibm.ws.webcontainer.osgi.webapp.WebAppConfiguration;
 import com.ibm.ws.webcontainer.osgi.webapp.WebAppFactory;
-import com.ibm.ws.webcontainer40.osgi.webapp.WebApp40;
 import com.ibm.wsspi.injectionengine.ReferenceContext;
+
+import io.openliberty.webcontainer61.osgi.webapp.WebApp61;
 
 /**
 *
@@ -35,6 +36,6 @@ public class WebAppFactory61Impl implements WebAppFactory {
     @Override
     public WebApp createWebApp(WebAppConfiguration webAppConfig, ClassLoader moduleLoader, ReferenceContext referenceContext, MetaDataService metaDataService,
                                J2EENameFactory j2eeNameFactory, ManagedObjectService managedObjectService) {
-        return new WebApp40(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
+        return new WebApp61(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
     }
 }

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal/bnd.bnd
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal/bnd.bnd
@@ -23,7 +23,12 @@ Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=21))"
 # file, and place an @version javadoc tag in package-level javadoc. 
 # Append ";provide:=true" if this bundle also provides an implementation
 # for the exported API.
-#Export-Package: \
+Export-Package: \
+    io.openliberty.webcontainer61.osgi.srt*;provide:=true,\
+    io.openliberty.webcontainer61.osgi.webapp*;provide:=true,\
+    io.openliberty.webcontainer61.srt*;provide:=true
+    
+    
 
 Import-Package: \
     com.ibm.websphere.security, \
@@ -53,5 +58,6 @@ instrument.disabled: true
 	com.ibm.ws.javaee.dd;version=latest,\
 	com.ibm.ws.kernel.boot.core;version=latest,\
 	com.ibm.websphere.security;version=latest,\
+	io.openliberty.webcontainer.servlet.6.0.internal,\
 	io.openliberty.jakarta.servlet.6.1;version=latest,\
 	io.openliberty.session.6.0.internal;version=latest

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/osgi/srt/SRTConnectionContext61.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/osgi/srt/SRTConnectionContext61.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.webcontainer61.osgi.srt;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.webcontainer.srt.SRTServletRequest;
+import com.ibm.ws.webcontainer.srt.SRTServletResponse;
+import com.ibm.ws.webcontainer40.osgi.webapp.WebAppDispatcherContext40;
+import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
+
+import io.openliberty.webcontainer60.osgi.srt.SRTConnectionContext60;
+import io.openliberty.webcontainer61.srt.SRTServletRequest61;
+import io.openliberty.webcontainer61.srt.SRTServletResponse61;
+
+public class SRTConnectionContext61 extends SRTConnectionContext60 {
+    protected static final Logger logger = LoggerFactory.getInstance().getLogger("io.openliberty.webcontainer61.osgi.srt");
+    private static final String CLASS_NAME = SRTConnectionContext61.class.getName();
+
+    /**
+     * Used for pooling the SRTConnectionContext objects.
+     */
+    public SRTConnectionContext61 nextContext;
+
+    @Override
+    protected void init() {
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "init", "this [" + this + "] , request [" + _request + "]");
+        }
+
+        //Reuse 4.0 until there is something new in servlet 6.1 dispatch context
+        this._dispatchContext = new WebAppDispatcherContext40(_request);
+        _request.setWebAppDispatcherContext(_dispatchContext);
+    }
+
+    @Override
+    protected SRTServletRequest newSRTServletRequest() {
+        return new SRTServletRequest61(this);
+    }
+
+    @Override
+    protected SRTServletResponse newSRTServletResponse() {
+        return new SRTServletResponse61(this);
+    }
+}

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/osgi/srt/package-info.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/osgi/srt/package-info.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package io.openliberty.webcontainer61.osgi.srt;

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/osgi/webapp/WebApp61.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/osgi/webapp/WebApp61.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.webcontainer61.osgi.webapp;
+
+import java.nio.charset.Charset;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.ibm.websphere.csi.J2EENameFactory;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.container.service.metadata.MetaDataService;
+import com.ibm.ws.managedobject.ManagedObjectService;
+import com.ibm.ws.webcontainer.osgi.webapp.WebAppConfiguration;
+import com.ibm.ws.webcontainer.webapp.WebAppDispatcherContext;
+import com.ibm.ws.webcontainer40.facade.ServletContextFacade40;
+import com.ibm.ws.webcontainer40.osgi.webapp.WebApp40;
+import com.ibm.wsspi.injectionengine.ReferenceContext;
+import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
+
+import jakarta.servlet.ServletContext;
+
+public class WebApp61 extends WebApp40 implements ServletContext {
+    protected static final Logger logger = LoggerFactory.getInstance().getLogger("io.openliberty.webcontainer61.osgi.webapp");
+    protected static final String CLASS_NAME = WebApp61.class.getName();
+
+    public WebApp61(WebAppConfiguration webAppConfig,
+                    ClassLoader moduleLoader,
+                    ReferenceContext referenceContext,
+                    MetaDataService metaDataService,
+                    J2EENameFactory j2eeNameFactory,
+                    ManagedObjectService managedObjectService) {
+        super(webAppConfig, moduleLoader, referenceContext, metaDataService, j2eeNameFactory, managedObjectService);
+
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "constructor", "this [" + this + "]");
+        }
+    }
+
+    @Override
+    public WebAppDispatcherContext createDispatchContext() {
+        return new com.ibm.ws.webcontainer40.osgi.webapp.WebAppDispatcherContext40(this);
+    }
+
+    @Override
+    public ServletContext getFacade() {
+        if (this.facade == null)
+            this.facade = new ServletContextFacade40(this);
+        return this.facade;
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 6;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 1;
+    }
+
+    /*
+     * @since Servlet 6.1
+     */
+    @Override
+    public void setRequestCharacterEncoding(Charset encoding) {
+        //to be implemented
+    }
+
+    /*
+     * @since Servlet 6.1
+     */
+    @Override
+    public void setResponseCharacterEncoding(Charset encoding) {
+        //to be implemented
+    }
+
+}

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/osgi/webapp/package-info.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/osgi/webapp/package-info.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package io.openliberty.webcontainer61.osgi.webapp;

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/srt/SRTServletRequest61.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/srt/SRTServletRequest61.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.webcontainer61.srt;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.servlet.request.IRequest;
+import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
+
+import io.openliberty.webcontainer60.srt.SRTServletRequest60;
+import io.openliberty.webcontainer61.osgi.srt.SRTConnectionContext61;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class SRTServletRequest61 extends SRTServletRequest60 implements HttpServletRequest {
+
+    protected static final Logger logger = LoggerFactory.getInstance().getLogger("io.openliberty.webcontainer61.srt");
+    private static final String CLASS_NAME = SRTServletRequest61.class.getName();
+
+    public SRTServletRequest61(SRTConnectionContext61 context) {
+        super(context);
+    }
+
+    @Override
+    public void initForNextRequest(IRequest req) {
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) { //306998.15
+            logger.logp(Level.FINE, CLASS_NAME, "initForNextRequest", "this->" + this + " : " + " req ->" + req);
+        }
+
+        super.initForNextRequest(req);
+    }
+}

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/srt/SRTServletResponse61.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/srt/SRTServletResponse61.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.webcontainer61.srt;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.servlet.response.IResponse;
+import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
+
+import io.openliberty.webcontainer60.srt.SRTServletResponse60;
+import io.openliberty.webcontainer61.osgi.srt.SRTConnectionContext61;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class SRTServletResponse61 extends SRTServletResponse60 implements HttpServletResponse {
+    protected static final Logger logger = LoggerFactory.getInstance().getLogger("io.openliberty.webcontainer61.srt");
+    private static final String CLASS_NAME = SRTServletResponse61.class.getName();
+
+    public SRTServletResponse61(SRTConnectionContext61 context) {
+        super(context);
+    }
+
+    @Override
+    public void initForNextResponse(IResponse resp) {
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "initForNextRequest", "this [" + this + "] , resp [" + resp + "]");
+        }
+
+        super.initForNextResponse(resp);
+    }
+
+    @Override
+    public void sendRedirect(String s, int status, boolean b) {
+        if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
+            logger.logp(Level.FINE, CLASS_NAME, "sendRedirect", "this [" + this + "] , to be implemented - sendRedirect(String, int, boolean");
+        }
+    }
+}

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/srt/package-info.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/srt/package-info.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package io.openliberty.webcontainer61.srt;


### PR DESCRIPTION
fixes https://github.com/OpenLiberty/open-liberty/issues/27090

Create the initial classes: request, response, webapp, connection context.
Add a simple FAT test.