### PR TITLE
Enable the Liberty scheduled executor to run tasks on virtual threads

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017,2021 IBM Corporation and others.
+ * Copyright (c) 2017,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -100,6 +101,15 @@ public interface PolicyExecutor extends ExecutorService {
      * @return the number of running or about-to-run tasks
      */
     int getRunningTaskCount();
+
+    /**
+     * If this policy executor is configured with virtual=true, this method returns an executor that
+     * runs tasks on new virtual threads. The tasks submitted to this executor are not subject to the
+     * constraints of the policy executor.
+     *
+     * @return an executor that runs tasks on new virtual threads if virtual=true. Otherwise null.
+     */
+    Executor getVirtualThreadExecutor();
 
     /**
      * Submits and invokes a group of tasks with a callback per task to be invoked at various points in the task's life cycle.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ScheduledCustomExecutorTask.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ScheduledCustomExecutorTask.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020,2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.threading;
+
+import java.util.concurrent.Executor;
+
+import com.ibm.ws.ffdc.FFDCFilter;
+
+/**
+ * When tasks implementing this interface are scheduled to the Liberty scheduled executor,
+ * it delegates the actual running of the task to the designated executor.
+ */
+// TODO replace ScheduledPolicyExecutorTask with this after code that use it is updated
+public interface ScheduledCustomExecutorTask {
+    /**
+     * Returns a custom executor upon which to run this task.
+     * You can supply an executor that runs tasks on virtual threads.
+     * Or you can supply a PolicyExecutor such that tasks will be subject its constraints,
+     * but do not supply a PolicyExecutor that enables runIfQueueFull, because inline execution
+     * of tasks would interfere with the scheduling thread.
+     * The default value of null indicates to run the task directly on the Liberty thread pool.
+     *
+     * @return the executor upon which to run this task.
+     */
+    default Executor getExecutor() {
+        return null;
+    }
+
+    /**
+     * Computes the next fixed-rate execution time after the specified execution time,
+     * given the specified period.
+     *
+     * @param expectedExecutionTime nanosecond timestamp at which the task was expected to start executing.
+     *                                  If delayed, the current time will be later than this expected target execution time.
+     * @param period                period in nanoseconds at which the fixed-rate task should execute.
+     * @return nanosecond timestamp of the next fixed-rate execution.
+     */
+    default long getNextFixedRateExecutionTime(long expectedExecutionTime, long period) {
+        return expectedExecutionTime + period;
+    }
+
+    /**
+     * Provides a callback to be invoked when the task fails to resubmit to
+     * the designated executor. Typically, this will be because a PolicyExecutor
+     * is used and has been shut down, suspended, or has reached its limit
+     * for maximum queue capacity.
+     *
+     * @param failure the error that is raised by the resubmit attempt.
+     * @return error to report for the failure.
+     */
+    default Exception resubmitFailed(Exception failure) {
+        FFDCFilter.processException(failure, getClass().getName(), "59");
+        return failure;
+    }
+}

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ScheduledPolicyExecutorTask.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ScheduledPolicyExecutorTask.java
@@ -1,18 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2020,2021 IBM Corporation and others.
+ * Copyright (c) 2020,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.threading;
-
-import com.ibm.ws.ffdc.FFDCFilter;
 
 /**
  * When tasks implementing this interface are scheduled to the Liberty scheduled executor,
@@ -22,38 +20,13 @@ import com.ibm.ws.ffdc.FFDCFilter;
  * combination with a policy executor that enables runIfQueueFull, because inline execution
  * of tasks would interfere with the scheduling thread.
  */
-public interface ScheduledPolicyExecutorTask {
+// TODO replace with ScheduledCustomExecutorTask once code that uses this class is updated
+public interface ScheduledPolicyExecutorTask extends ScheduledCustomExecutorTask {
     /**
      * Returns the policy executor upon which to run this task.
      *
      * @return the policy executor upon which to run this task.
      */
+    @Override
     PolicyExecutor getExecutor();
-
-    /**
-     * Computes the next fixed-rate execution time after the specified execution time,
-     * given the specified period.
-     *
-     * @param expectedExecutionTime nanosecond timestamp at which the task was expected to start executing.
-     *                                  If delayed, the current time will be later than this expected target execution time.
-     * @param period                period in nanoseconds at which the fixed-rate task should execute.
-     * @return nanosecond timestamp of the next fixed-rate execution.
-     */
-    default long getNextFixedRateExecutionTime(long expectedExecutionTime, long period) {
-        return expectedExecutionTime + period;
-    }
-
-    /**
-     * Provides a callback to be invoked when the task fails to resubmit to
-     * the designated policy executor. Typically, this will be because the
-     * policy executor has been shut down, suspended, or has reached its limit
-     * for maximum queue capacity.
-     *
-     * @param failure the error that is raised by the resubmit attempt.
-     * @return error to report for the failure.
-     */
-    default Exception resubmitFailed(Exception failure) {
-        FFDCFilter.processException(failure, getClass().getName(), "38");
-        return failure;
-    }
 }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/SchedulingRunnableFixedHelper.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/SchedulingRunnableFixedHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015,2021 IBM Corporation and others.
+ * Copyright (c) 2015,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,7 +22,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import com.ibm.ws.threading.ScheduledPolicyExecutorTask;
+import com.ibm.ws.threading.ScheduledCustomExecutorTask;
 
 /**
  * Wrapper for the ScheduledFuture returned on overridden scheduleWithFixedRate and scheduleWithFixedDelay methods.
@@ -299,8 +299,8 @@ class SchedulingRunnableFixedHelper<V> implements ScheduledFuture<Object>, Runna
         try {
             long scheduleTime = this.m_periodInterval;
             if (!this.m_scheduledWithDelay) {
-                if (m_runnable instanceof ScheduledPolicyExecutorTask) {
-                    this.m_myNextExecutionTime = ((ScheduledPolicyExecutorTask) m_runnable).getNextFixedRateExecutionTime(m_myNextExecutionTime, m_periodInterval);
+                if (m_runnable instanceof ScheduledCustomExecutorTask) {
+                    this.m_myNextExecutionTime = ((ScheduledCustomExecutorTask) m_runnable).getNextFixedRateExecutionTime(m_myNextExecutionTime, m_periodInterval);
                 } else {
                     this.m_myNextExecutionTime = this.m_myNextExecutionTime + this.m_periodInterval;
                 }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledBlockingQueueTask.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledBlockingQueueTask.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,7 +16,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.ibm.ws.threading.PolicyExecutor;
-import com.ibm.ws.threading.ScheduledPolicyExecutorTask;
+import com.ibm.ws.threading.ScheduledCustomExecutorTask;
 
 /**
  * A task that directs its execution to the specified PolicyExecutor
@@ -25,7 +25,7 @@ import com.ibm.ws.threading.ScheduledPolicyExecutorTask;
  * and then adds to a LinkedBlockingQueue that tests can
  * poll to identify how many executions have occurred.
  */
-public class ScheduledBlockingQueueTask extends LinkedBlockingQueue<Integer> implements Runnable, ScheduledPolicyExecutorTask {
+public class ScheduledBlockingQueueTask extends LinkedBlockingQueue<Integer> implements Runnable, ScheduledCustomExecutorTask {
     private static final long serialVersionUID = 1514933845687256072L;
 
     /**

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledCallableTask.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledCallableTask.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020,2021 IBM Corporation and others.
+ * Copyright (c) 2020,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,13 +15,13 @@ package web;
 import java.util.concurrent.CountDownLatch;
 
 import com.ibm.ws.threading.PolicyExecutor;
-import com.ibm.ws.threading.ScheduledPolicyExecutorTask;
+import com.ibm.ws.threading.ScheduledCustomExecutorTask;
 
 /**
  * A subclass of CountDownTask that directs its execution to the specified PolicyExecutor
  * when submitted to the Liberty scheduled executor.
  */
-public class ScheduledCallableTask extends CountDownTask implements ScheduledPolicyExecutorTask {
+public class ScheduledCallableTask extends CountDownTask implements ScheduledCustomExecutorTask {
     private final PolicyExecutor executor;
 
     public ScheduledCallableTask(PolicyExecutor executor, CountDownLatch beginLatch, CountDownLatch continueLatch) {

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledRunnableTask.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledRunnableTask.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020,2021 IBM Corporation and others.
+ * Copyright (c) 2020,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,13 +18,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.ibm.ws.threading.PolicyExecutor;
-import com.ibm.ws.threading.ScheduledPolicyExecutorTask;
+import com.ibm.ws.threading.ScheduledCustomExecutorTask;
 
 /**
  * A task that directs its execution to the specified PolicyExecutor
  * when submitted to the Liberty scheduled executor.
  */
-public class ScheduledRunnableTask implements Runnable, ScheduledPolicyExecutorTask {
+public class ScheduledRunnableTask implements Runnable, ScheduledCustomExecutorTask {
     private final CountDownLatch beginLatch;
     private final CountDownLatch continueLatch;
     private final PolicyExecutor executor;


### PR DESCRIPTION
Generalize the ScheduledPolicyExecutorTask to allow scheduled tasks to select a custom executor, which could be one that runs on virtual threads.  This will be done in 3 parts. First, introducing ScheduledCustomExecutorTask as a supertype of ScheduledPolicyExecutorTask. Second (a separate pull), updating other code to switch over to ScheduledCustomExecutorTask.  Third (another separate pull), removing ScheduledPolicyExecutorTask.
