### PR TITLE
Do not enable Java security when running FATs with Java greater than 17

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -94,7 +94,7 @@ public class LibertyClient {
     protected static final boolean FAT_TEST_LOCALRUN = Boolean.getBoolean("fat.test.localrun");
     protected static final String MAC_RUN = PrivHelper.getProperty("fat.on.mac");
     protected static final String GLOBAL_TRACE = PrivHelper.getProperty("global.trace.spec", "").trim();
-    protected static final boolean GLOBAL_JAVA2SECURITY = FAT_TEST_LOCALRUN //
+    protected static final boolean GLOBAL_JAVA2SECURITY = javaInfo.MAJOR > 17 ? false : FAT_TEST_LOCALRUN //
                     ? Boolean.parseBoolean(PrivHelper.getProperty("global.java2.sec", "true")) //
                     : Boolean.parseBoolean(PrivHelper.getProperty("global.java2.sec", "false"));
 
@@ -672,7 +672,8 @@ public class LibertyClient {
         // if we have FIPS 140-3 enabled, and the matched java/platform, add JVM arg
         if (isFIPS140_3EnabledAndSupported()) {
             Log.info(c, "startClientWithArgs", "The JDK version: " + javaInfo.majorVersion() + " and vendor: " + JavaInfo.Vendor.IBM);
-            Log.info(c, "startClientWithArgs", "FIPS 140-3 global build properties is set for Client " + getClientName() + " with IBM Java 8, adding JVM arguments -Xenablefips140-3, ...,  to run with FIPS 140-3 enabled");
+            Log.info(c, "startClientWithArgs", "FIPS 140-3 global build properties is set for Client " + getClientName()
+                                               + " with IBM Java 8, adding JVM arguments -Xenablefips140-3, ...,  to run with FIPS 140-3 enabled");
 
             JVM_ARGS += " -Xenablefips140-3";
             JVM_ARGS += " -Dcom.ibm.jsse2.usefipsprovider=true";
@@ -3927,14 +3928,14 @@ public class LibertyClient {
     public boolean isFIPS140_3EnabledAndSupported() {
         String methodName = "isFIPS140_3EnabledAndSupported";
         boolean isIBMJVM8 = (javaInfo.majorVersion() == 8) && (javaInfo.VENDOR == Vendor.IBM);
-        if(GLOBAL_CLIENT_FIPS_140_3){
+        if (GLOBAL_CLIENT_FIPS_140_3) {
             Log.info(c, methodName, "Liberty client is running JDK version: " + javaInfo.majorVersion() + " and vendor: " + javaInfo.VENDOR);
-            if(isIBMJVM8) {
-                Log.info(c, methodName, "global build properties FIPS_140_3 is set for client " + getClientName() + 
-                                            " and IBM java 8 is available to run with FIPS 140-3 enabled.");
+            if (isIBMJVM8) {
+                Log.info(c, methodName, "global build properties FIPS_140_3 is set for client " + getClientName() +
+                                        " and IBM java 8 is available to run with FIPS 140-3 enabled.");
             } else {
                 Log.info(c, methodName, "The global build properties FIPS_140_3 is set for client " + getClientName() +
-                                            ",  but no IBM java 8 on liberty client to run with FIPS 140-3 enabled.");
+                                        ",  but no IBM java 8 on liberty client to run with FIPS 140-3 enabled.");
             }
         }
         return GLOBAL_CLIENT_FIPS_140_3 && isIBMJVM8;

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -227,8 +227,8 @@ public class LibertyServer implements LogMonitorClient {
     protected static final JavaInfo javaInfo = JavaInfo.forCurrentVM();
 
     protected static final boolean FAT_TEST_LOCALRUN = Boolean.getBoolean("fat.test.localrun");
-    protected static final boolean GLOBAL_JAVA2SECURITY = Boolean.parseBoolean(PrivHelper.getProperty("global.java2.sec", "false"));
-    protected static final boolean GLOBAL_DEBUG_JAVA2SECURITY = FAT_TEST_LOCALRUN //
+    protected static final boolean GLOBAL_JAVA2SECURITY = javaInfo.MAJOR > 17 ? false : Boolean.parseBoolean(PrivHelper.getProperty("global.java2.sec", "false"));
+    protected static final boolean GLOBAL_DEBUG_JAVA2SECURITY = javaInfo.MAJOR > 17 ? false : FAT_TEST_LOCALRUN //
                     ? Boolean.parseBoolean(PrivHelper.getProperty("global.debug.java2.sec", "true")) //
                     : Boolean.parseBoolean(PrivHelper.getProperty("global.debug.java2.sec", "false"));
 
@@ -1642,7 +1642,8 @@ public class LibertyServer implements LogMonitorClient {
         // if we have FIPS 140-3 enabled, and the matched java/platform,  add JVM Arg
         if (isFIPS140_3EnabledAndSupported()) {
             Log.info(c, "startServerWithArgs", "Liberty server is running JDK version: " + info.majorVersion() + " and vendor: " + info.VENDOR);
-            Log.info(c, "startServerWithArgs", "FIPS 140-3 global build properties is set for server " + getServerName() + " with IBM Java 8, adding JVM arguments -Xenablefips140-3, ...,  to run with FIPS 140-3 enabled");
+            Log.info(c, "startServerWithArgs", "FIPS 140-3 global build properties is set for server " + getServerName()
+                                               + " with IBM Java 8, adding JVM arguments -Xenablefips140-3, ...,  to run with FIPS 140-3 enabled");
 
             JVM_ARGS += " -Xenablefips140-3";
             JVM_ARGS += " -Dcom.ibm.jsse2.usefipsprovider=true";
@@ -3781,9 +3782,9 @@ public class LibertyServer implements LogMonitorClient {
     /**
      * Copies a file from the oldAbsolutePath to the newAbsolutePath in the Liberty server.
      *
-     * @param oldAbsolutePath The absolute path of the file to copy.
-     * @param newAbsolutePath The absolute path of the destination.
-     * @param fileName        The name of the file to copy. The file name will be unchanged from source to dest
+     * @param  oldAbsolutePath The absolute path of the file to copy.
+     * @param  newAbsolutePath The absolute path of the destination.
+     * @param  fileName        The name of the file to copy. The file name will be unchanged from source to dest
      *
      * @throws Exception
      */
@@ -3798,9 +3799,9 @@ public class LibertyServer implements LogMonitorClient {
     /**
      * Renames a file from the oldAbsolutePath to the newAbsolutePath in the Liberty server.
      *
-     * @param oldAbsolutePath The absolute path of the file to copy.
-     * @param newAbsolutePath The absolute path of the destination.
-     * @param fileName        The name of the file to rename. The file name will be unchanged from source to dest
+     * @param  oldAbsolutePath The absolute path of the file to copy.
+     * @param  newAbsolutePath The absolute path of the destination.
+     * @param  fileName        The name of the file to rename. The file name will be unchanged from source to dest
      *
      * @throws Exception
      */
@@ -7159,14 +7160,14 @@ public class LibertyServer implements LogMonitorClient {
         String methodName = "isFIPS140_3EnabledAndSupported";
         JavaInfo serverJavaInfo = JavaInfo.forServer(this);
         boolean isIBMJVM8 = (serverJavaInfo.majorVersion() == 8) && (serverJavaInfo.VENDOR == Vendor.IBM);
-        if(GLOBAL_FIPS_140_3){
+        if (GLOBAL_FIPS_140_3) {
             Log.info(c, methodName, "Liberty server is running JDK version: " + serverJavaInfo.majorVersion() + " and vendor: " + serverJavaInfo.VENDOR);
-            if(isIBMJVM8) {
-                Log.info(c, methodName, "global build properties FIPS_140_3 is set for server " + getServerName() + 
-                                            " and IBM java 8 is available to run with FIPS 140-3 enabled.");
+            if (isIBMJVM8) {
+                Log.info(c, methodName, "global build properties FIPS_140_3 is set for server " + getServerName() +
+                                        " and IBM java 8 is available to run with FIPS 140-3 enabled.");
             } else {
                 Log.info(c, methodName, "The global build properties FIPS_140_3 is set for server " + getServerName() +
-                                            ",  but no IBM java 8 on liberty server to run with FIPS 140-3 enabled.");
+                                        ",  but no IBM java 8 on liberty server to run with FIPS 140-3 enabled.");
             }
         }
         return GLOBAL_FIPS_140_3 && isIBMJVM8;


### PR DESCRIPTION
- Liberty does not support Java security with Java releases greater than 17.  Update the FAT Java security function to set to false when using Java 18 or higher since it will just fail the test with an error in the server messages.log saying you shouldn't have Java security enabled since you are using a Java greater than 17.
