### PR TITLE
Reactive Messaging context service configuration

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging-3.0/io.openliberty.mpReactiveMessaging-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging-3.0/io.openliberty.mpReactiveMessaging-3.0.feature
@@ -16,7 +16,6 @@ Subsystem-Name: MicroProfile Reactive Messaging 3.0
   io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0,6.1", \
   io.openliberty.org.eclipse.microprofile.reactive.messaging-3.0, \
   io.openliberty.cdi-3.0; ibm.tolerates:="4.0",  \
-  io.openliberty.concurrent-2.0; ibm.tolerates:="3.0", \
   io.openliberty.org.eclipse.microprofile.metrics-4.0; ibm.tolerates:="5.0,5.1"
 -bundles=io.openliberty.io.smallrye.reactive.messaging-provider4, \
  io.openliberty.io.smallrye.reactive.converter-api3, \

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaConnectorConstants.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaConnectorConstants.java
@@ -41,13 +41,17 @@ public class KafkaConnectorConstants {
     //Whether to complete ack() call before the partition offset is actually committed
     public static final String FAST_ACK = "fast.ack";
 
+    //The name of the context service to use
+    public static final String CONTEXT_SERVICE = "context.service";
+
     //The set of properties which should NOT be passed through to the Kafka client
     public static final Set<String> NON_KAFKA_PROPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(new String[] { TOPIC,
                                                                                                                              ConnectorFactory.CONNECTOR_ATTRIBUTE,
                                                                                                                              ConnectorFactory.CHANNEL_NAME_ATTRIBUTE,
                                                                                                                              UNACKED_LIMIT,
                                                                                                                              CREATION_RETRY_SECONDS,
-                                                                                                                             FAST_ACK
+                                                                                                                             FAST_ACK,
+                                                                                                                             CONTEXT_SERVICE
     })));
 
 //=======================Kafka Properties===============================//

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,7 +26,6 @@ import java.util.stream.StreamSupport;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -46,40 +46,67 @@ import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterExce
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaConsumer;
 
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.QuiesceParticipant;
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.QuiesceRegister;
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMAsyncProvider;
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMAsyncProviderFactory;
+
 @Connector(KafkaConnectorConstants.CONNECTOR_NAME)
 @ApplicationScoped
-public class KafkaIncomingConnector implements IncomingConnectorFactory {
+public class KafkaIncomingConnector implements IncomingConnectorFactory, QuiesceParticipant {
 
     private static final TraceComponent tc = Tr.register(KafkaIncomingConnector.class);
 
-    ManagedScheduledExecutorService executor;
-
     @Inject
-    KafkaAdapterFactory kafkaAdapterFactory;
+    private KafkaAdapterFactory kafkaAdapterFactory;
 
+    private RMAsyncProviderFactory asyncProviderFactory;
     private final List<KafkaInput<?, ?>> kafkaInputs = Collections.synchronizedList(new ArrayList<>());
+    private QuiesceRegister quiesceRegister;
 
     @PostConstruct
     private void postConstruct() {
         Bundle b = FrameworkUtil.getBundle(KafkaIncomingConnector.class);
-        ServiceReference<ManagedScheduledExecutorService> mgdSchedExecSvcRef = b.getBundleContext().getServiceReference(ManagedScheduledExecutorService.class);
-        this.executor = b.getBundleContext().getService(mgdSchedExecSvcRef);
+        ServiceReference<RMAsyncProviderFactory> asyncProviderSvcRef = b.getBundleContext().getServiceReference(RMAsyncProviderFactory.class);
+        this.asyncProviderFactory = b.getBundleContext().getService(asyncProviderSvcRef);
 
-        if (this.executor == null) {
-            String msg = Tr.formatMessage(tc, "internal.kafka.connector.error.CWMRX1000E", "The Managed Scheduled Executor Service could not be found.");
+        if (this.asyncProviderFactory == null) {
+            String msg = Tr.formatMessage(tc, "internal.kafka.connector.error.CWMRX1000E", "The Async Provider service could not be found.");
             throw new IllegalStateException(msg);
+        }
+
+        // Register ourselves with the quiesce listener
+        ServiceReference<QuiesceRegister> quiesceRegisterSvc = b.getBundleContext().getServiceReference(QuiesceRegister.class);
+        quiesceRegister = b.getBundleContext().getService(quiesceRegisterSvc);
+        if (quiesceRegister != null) {
+            quiesceRegister.register(this);
         }
     }
 
+    @Override
+    public void quiesce() {
+        shutdown();
+    }
+
     @PreDestroy
+    private void preDestroy() {
+        if (quiesceRegister != null) {
+            quiesceRegister.remove(this);
+        }
+        shutdown();
+    }
+
     private void shutdown() {
         synchronized (kafkaInputs) {
-            for (KafkaInput<?, ?> kafkaInput : kafkaInputs) {
+            Iterator<KafkaInput<?, ?>> i = kafkaInputs.iterator();
+            while (i.hasNext()) {
                 try {
-                    kafkaInput.shutdown();
+                    i.next().shutdown();
                 } catch (Exception e) {
                     // Ensures we attempt to shutdown all inputs
                     // and also that we get an FFDC for any errors
+                } finally {
+                    i.remove();
                 }
             }
         }
@@ -103,6 +130,7 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory {
             int unackedLimit = config.getOptionalValue(KafkaConnectorConstants.UNACKED_LIMIT, Integer.class).orElse(maxPollRecords);
             int retrySeconds = config.getOptionalValue(KafkaConnectorConstants.CREATION_RETRY_SECONDS, Integer.class).orElse(0);
             boolean fastAck = config.getOptionalValue(KafkaConnectorConstants.FAST_ACK, Boolean.class).orElse(false);
+            String contextServiceRef = config.getOptionalValue(KafkaConnectorConstants.CONTEXT_SERVICE, String.class).orElse(null);
 
             // Configure our defaults
             Map<String, Object> consumerConfig = new HashMap<>();
@@ -122,8 +150,10 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory {
             // Create the kafkaConsumer
             KafkaConsumer<String, Object> kafkaConsumer = getKafkaConsumerWithRetry(consumerConfig, retrySeconds, channelName);
 
+            RMAsyncProvider asyncProvider = asyncProviderFactory.getAsyncProvider(contextServiceRef);
+
             PartitionTrackerFactory partitionTrackerFactory = new PartitionTrackerFactory();
-            partitionTrackerFactory.setExecutor(executor);
+            partitionTrackerFactory.setAsyncProvider(asyncProvider);
             partitionTrackerFactory.setAdapterFactory(kafkaAdapterFactory);
             partitionTrackerFactory.setAutoCommitEnabled(enableAutoCommit);
 
@@ -132,7 +162,7 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory {
             }
 
             // Create our connector around the kafkaConsumer
-            KafkaInput<String, Object> kafkaInput = new KafkaInput<>(this.kafkaAdapterFactory, partitionTrackerFactory, kafkaConsumer, this.executor,
+            KafkaInput<String, Object> kafkaInput = new KafkaInput<>(this.kafkaAdapterFactory, partitionTrackerFactory, kafkaConsumer, asyncProvider,
                                                                      topic, unackedLimit, fastAck);
             kafkaInputs.add(kafkaInput);
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/PartitionTracker.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/PartitionTracker.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,6 +20,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.TopicPartition;
+
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMContext;
 
 /**
  * Tracks a particular assignment of a partition to this consumer
@@ -72,9 +74,10 @@ public class PartitionTracker {
      *
      * @param offset the record offset
      * @param leaderEpoch the record leaderEpoch
+     * @param context the context to apply around the completion of the result, if the completion stage is completed asynchronously
      * @return a CompletionStage which completes when any associated processing has been completed (e.g. when the message offset has been committed)
      */
-    public CompletionStage<Void> recordDone(long offset, Optional<Integer> leaderEpoch) {
+    public CompletionStage<Void> recordDone(long offset, Optional<Integer> leaderEpoch, RMContext context) {
         return CompletableFuture.completedFuture(null);
     }
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/PartitionTrackerFactory.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/PartitionTrackerFactory.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,10 +13,11 @@
 package com.ibm.ws.microprofile.reactive.messaging.kafka;
 
 import java.time.Duration;
-import java.util.concurrent.ScheduledExecutorService;
 
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.TopicPartition;
+
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMAsyncProvider;
 
 /**
  *
@@ -24,17 +25,17 @@ import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.TopicPartition;
 public class PartitionTrackerFactory {
 
     private KafkaAdapterFactory adapterFactory = null;
-    private ScheduledExecutorService executor = null;
     private int commitBatchMaxElements = 500;
     private Duration commitBatchMaxInterval = Duration.ofMillis(500);
     private boolean autoCommitEnabled = false;
+    private RMAsyncProvider asyncProvider = null;
 
     public void setAdapterFactory(KafkaAdapterFactory adapterFactory) {
         this.adapterFactory = adapterFactory;
     }
 
-    public void setExecutor(ScheduledExecutorService executor) {
-        this.executor = executor;
+    public void setAsyncProvider(RMAsyncProvider asyncProvider) {
+        this.asyncProvider = asyncProvider;
     }
 
     public void setCommitBatchMaxElements(int commitBatchMaxElements) {
@@ -59,7 +60,7 @@ public class PartitionTrackerFactory {
         if (autoCommitEnabled) {
             return new PartitionTracker(partition);
         } else {
-            return new CommittingPartitionTracker(partition, adapterFactory, kafkaInput, initialCommittedOffset, executor, commitBatchMaxElements, commitBatchMaxInterval);
+            return new CommittingPartitionTracker(partition, adapterFactory, kafkaInput, initialCommittedOffset, asyncProvider, commitBatchMaxElements, commitBatchMaxInterval);
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/bnd.bnd
@@ -41,6 +41,8 @@ fat.project: true
 
 fat.test.container.images: confluentinc/cp-kafka:7.1.1
 
+Import-Package: *
+
 -buildpath: \
 	io.openliberty.microprofile.reactive.messaging.internal_fat.common;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.reactive.messaging.1.0;version=latest,\
@@ -58,6 +60,7 @@ fat.test.container.images: confluentinc/cp-kafka:7.1.1
 	com.ibm.ws.io.smallrye.reactive.streams-operators;version=latest,\
 	com.ibm.ws.microprofile.reactive.messaging.kafka;version=latest,\
 	com.ibm.ws.microprofile.reactive.messaging.kafka.adapter;version=latest,\
+	io.openliberty.microprofile.reactive.messaging.internal;version=latest,\
 	com.ibm.ws.crypto.passwordutil;version=latest
 
 -dependson.1: \

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbTest.java
@@ -37,7 +37,7 @@ import componenttest.topology.utils.FATServletClient;
 public class JsonbTest extends FATServletClient {
 
     public static final String APP_NAME = "jsob-messaging";
-    public static final String SERVER_NAME = "SimpleRxMessagingServer";
+    public static final String SERVER_NAME = "JsonbRxMessagingServer";
 
     @ClassRule
     public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME, ReactiveMessagingActions.MP61_RM30, ReactiveMessagingActions.MP20_RM10);

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/KafkaDefaultContextTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/KafkaDefaultContextTest.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties.simpleIncomingChannel;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties.simpleOutgoingChannel;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * Test that thread context is propagated correctly when receiving messages from Kafka without the concurrent feature enabled in server.xml.
+ * <p>
+ * Note that RM 1.0 depends on concurrent, so concurrent will be active for that repeat
+ */
+@RunWith(FATRunner.class)
+public class KafkaDefaultContextTest extends FATServletClient {
+
+    public static final String APP_NAME = "KafkaDefaultContext";
+    public static final String SERVER_NAME = "ContextRxMessagingServer";
+
+    public static final String INPUT_TOPIC = "KafkaDefaultContextTest-in";
+    public static final String OUTPUT_TOPIC = "KafkaDefaultContextTest-out";
+
+    @TestServlet(servlet = KafkaDefaultContextTestServlet.class, contextRoot = APP_NAME)
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME,
+                                                                  ReactiveMessagingActions.MP61_RM30,
+                                                                  ReactiveMessagingActions.MP50_RM30,
+                                                                  ReactiveMessagingActions.MP20_RM10);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ConnectorProperties inputConfig = simpleIncomingChannel(PlaintextTests.connectionProperties(),
+                                                                KafkaDefaultContextTestMessageBean.INPUT_CHANNEL,
+                                                                APP_NAME);
+
+        ConnectorProperties outputConfig = simpleOutgoingChannel(PlaintextTests.connectionProperties(),
+                                                                 KafkaDefaultContextTestMessageBean.OUTPUT_CHANNEL);
+
+        PropertiesAsset config = new PropertiesAsset()
+                        .include(inputConfig)
+                        .include(outputConfig);
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addPackage(KafkaDefaultContextTest.class.getPackage())
+                        .addAsResource(config, "META-INF/microprofile-config.properties");
+
+        KafkaUtils.addKafkaTestFramework(war, PlaintextTests.connectionProperties());
+
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        try {
+            server.stopServer();
+        } finally {
+            KafkaUtils.deleteKafkaTopics(PlaintextTests.getAdminClient());
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/KafkaDefaultContextTestMessageBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/KafkaDefaultContextTestMessageBean.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context;
+
+import javax.annotation.Resource;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+/**
+ * Test bean that appends the app name to a string message
+ */
+@ApplicationScoped
+public class KafkaDefaultContextTestMessageBean {
+
+    public static final String INPUT_CHANNEL = "context-test-in";
+    public static final String OUTPUT_CHANNEL = "context-test-out";
+
+    @Resource(lookup = "java:app/AppName")
+    private String appName;
+
+    @Incoming(INPUT_CHANNEL)
+    @Outgoing(OUTPUT_CHANNEL)
+    public String addAppName(String input) {
+        return input + "-" + appName;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/KafkaDefaultContextTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/KafkaDefaultContextTestServlet.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestConstants;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaReader;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClient;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaWriter;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/ContextTestServlet")
+public class KafkaDefaultContextTestServlet extends FATServlet {
+
+    @Inject
+    private KafkaTestClient client;
+
+    @Resource(lookup = "java:app/AppName")
+    private String appName;
+
+    @Test
+    public void testContextPropagation() throws Exception {
+        try (KafkaWriter<String, String> testWriter = client.writerFor(KafkaDefaultContextTestMessageBean.INPUT_CHANNEL);
+                        KafkaReader<String, String> testReader = client.readerFor(KafkaDefaultContextTestMessageBean.OUTPUT_CHANNEL)) {
+
+            // Check our injection of the app name has worked
+            assertThat(appName, not(isEmptyOrNullString()));
+
+            // Send two messages
+            testWriter.sendMessage("abc");
+            testWriter.sendMessage("def");
+
+            // If application context is propagated correctly, each message should have the app name appended
+            List<String> received = testReader.assertReadMessages(2, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
+            assertThat(received, contains("abc-" + appName,
+                                          "def-" + appName));
+
+            // Send two more messages
+            // Kafka connector should need to poll in the background between these two sets of messages
+            // which would start another async task
+            testWriter.sendMessage("xyz");
+            testWriter.sendMessage("uvw");
+
+            received = testReader.assertReadMessages(2, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
+            assertThat(received, contains("xyz-" + appName,
+                                          "uvw-" + appName));
+        }
+    }
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/KafkaCustomContextTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/KafkaCustomContextTest.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context.custom;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties.simpleIncomingChannel;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties.simpleOutgoingChannel;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.KafkaConnectorConstants;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * Test context propagation with concurrent enabled and custom context services defined
+ */
+@RunWith(FATRunner.class)
+public class KafkaCustomContextTest extends FATServletClient {
+    public static final String APP_NAME = "KafkaDefaultContext";
+    public static final String SERVER_NAME = "CustomContextRxMessagingServer";
+
+    @TestServlet(servlet = KafkaCustomContextTestServlet.class, contextRoot = APP_NAME)
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME,
+                                                                  ReactiveMessagingActions.MP61_RM30,
+                                                                  ReactiveMessagingActions.MP50_RM30,
+                                                                  ReactiveMessagingActions.MP20_RM10);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ConnectorProperties configuredDefaultInput = simpleIncomingChannel(PlaintextTests.connectionProperties(),
+                                                                           KakfaCustomContextTestBean.DEFAULT_IN,
+                                                                           APP_NAME);
+
+        ConnectorProperties configuredDefaultOutput = simpleOutgoingChannel(PlaintextTests.connectionProperties(),
+                                                                            KakfaCustomContextTestBean.DEFAULT_OUT);
+
+        ConnectorProperties propagateAllInput = simpleIncomingChannel(PlaintextTests.connectionProperties(),
+                                                                      KakfaCustomContextTestBean.PROPAGATE_ALL_IN,
+                                                                      APP_NAME)
+                        .addProperty(KafkaConnectorConstants.CONTEXT_SERVICE, "propagateAll");
+
+        ConnectorProperties propagateAllOutput = simpleOutgoingChannel(PlaintextTests.connectionProperties(),
+                                                                       KakfaCustomContextTestBean.PROPAGATE_ALL_OUT);
+
+        ConnectorProperties propagateNoneInput = simpleIncomingChannel(PlaintextTests.connectionProperties(),
+                                                                       KakfaCustomContextTestBean.PROPAGATE_NONE_IN,
+                                                                       APP_NAME)
+                        .addProperty(KafkaConnectorConstants.CONTEXT_SERVICE, "propagateNone");
+
+        ConnectorProperties propagateNoneOutput = simpleOutgoingChannel(PlaintextTests.connectionProperties(),
+                                                                        KakfaCustomContextTestBean.PROPAGATE_NONE_OUT);
+
+        ConnectorProperties propagateAppInput = simpleIncomingChannel(PlaintextTests.connectionProperties(),
+                                                                      KakfaCustomContextTestBean.PROPAGATE_APP_IN,
+                                                                      APP_NAME);
+
+        ConnectorProperties propagateAppOutput = simpleOutgoingChannel(PlaintextTests.connectionProperties(),
+                                                                       KakfaCustomContextTestBean.PROPAGATE_APP_OUT);
+
+        PropertiesAsset config = new PropertiesAsset()
+                        .include(configuredDefaultInput)
+                        .include(configuredDefaultOutput)
+                        .include(propagateAllInput)
+                        .include(propagateAllOutput)
+                        .include(propagateNoneInput)
+                        .include(propagateNoneOutput)
+                        .include(propagateAppInput)
+                        .include(propagateAppOutput);
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addPackage(KafkaCustomContextTestServlet.class.getPackage())
+                        .addAsResource(config, "META-INF/microprofile-config.properties");
+
+        KafkaUtils.addKafkaTestFramework(war, PlaintextTests.connectionProperties());
+
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        try {
+            server.stopServer();
+        } finally {
+            KafkaUtils.deleteKafkaTopics(PlaintextTests.getAdminClient());
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/KafkaCustomContextTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/KafkaCustomContextTestServlet.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context.custom;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestConstants;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaReader;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClient;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaWriter;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/KafkaCustomContextTest")
+public class KafkaCustomContextTestServlet extends FATServlet {
+
+    @Inject
+    private KafkaTestClient client;
+
+    @Resource(lookup = "java:app/AppName")
+    private String appName;
+
+    @Test
+    public void testDefaultContextService() throws Exception {
+        try (KafkaWriter<String, String> testWriter = client.writerFor(KakfaCustomContextTestBean.DEFAULT_IN);
+                        KafkaReader<String, String> testReader = client.readerFor(KakfaCustomContextTestBean.DEFAULT_OUT)) {
+
+            // Check our injection of the app name has worked
+            assertThat(appName, not(isEmptyOrNullString()));
+
+            // Send two messages
+            testWriter.sendMessage("abc");
+            testWriter.sendMessage("def");
+
+            // Check correct context was propagated
+            List<String> received = testReader.assertReadMessages(2, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
+            assertThat(received, contains("abc-" + appName + "-true",
+                                          "def-" + appName + "-true"));
+        }
+    }
+
+    @Test
+    public void testPropagateAll() throws Exception {
+        try (KafkaWriter<String, String> testWriter = client.writerFor(KakfaCustomContextTestBean.PROPAGATE_ALL_IN);
+                        KafkaReader<String, String> testReader = client.readerFor(KakfaCustomContextTestBean.PROPAGATE_ALL_OUT)) {
+
+            // Check our injection of the app name has worked
+            assertThat(appName, not(isEmptyOrNullString()));
+
+            // Check our injection of the app name has worked
+            assertThat(appName, not(isEmptyOrNullString()));
+
+            // Send two messages
+            testWriter.sendMessage("abc");
+            testWriter.sendMessage("def");
+
+            // Check correct context was propagated
+            List<String> received = testReader.assertReadMessages(2, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
+            assertThat(received, contains("abc-" + appName + "-true",
+                                          "def-" + appName + "-true"));
+        }
+    }
+
+    @Test
+    public void testPropagateNone() throws Exception {
+        try (KafkaWriter<String, String> testWriter = client.writerFor(KakfaCustomContextTestBean.PROPAGATE_NONE_IN);
+                        KafkaReader<String, String> testReader = client.readerFor(KakfaCustomContextTestBean.PROPAGATE_NONE_OUT)) {
+
+            // Check our injection of the app name has worked
+            assertThat(appName, not(isEmptyOrNullString()));
+
+            // Send two messages
+            testWriter.sendMessage("abc");
+            testWriter.sendMessage("def");
+
+            // Check correct context was propagated
+            List<String> received = testReader.assertReadMessages(2, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
+            assertThat(received, contains("abc-noapp-false",
+                                          "def-noapp-false"));
+        }
+    }
+
+    @Test
+    public void testPropagateAppMetadataOnly() throws Exception {
+        try (KafkaWriter<String, String> testWriter = client.writerFor(KakfaCustomContextTestBean.PROPAGATE_NONE_IN);
+                        KafkaReader<String, String> testReader = client.readerFor(KakfaCustomContextTestBean.PROPAGATE_NONE_OUT)) {
+
+            // Check our injection of the app name has worked
+            assertThat(appName, not(isEmptyOrNullString()));
+
+            // Send two messages
+            testWriter.sendMessage("abc");
+            testWriter.sendMessage("def");
+
+            // Check correct context was propagated
+            List<String> received = testReader.assertReadMessages(2, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
+            assertThat(received, contains("abc-noapp-false",
+                                          "def-noapp-false"));
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/KakfaCustomContextTestBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/KakfaCustomContextTestBean.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context.custom;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+@ApplicationScoped
+public class KakfaCustomContextTestBean {
+
+    public static final String DEFAULT_IN = "default-context-service-in";
+    public static final String DEFAULT_OUT = "default-contest-service-out";
+
+    public static final String PROPAGATE_ALL_IN = "propagate-all-in";
+    public static final String PROPAGATE_ALL_OUT = "propagate-all-out";
+
+    public static final String PROPAGATE_NONE_IN = "propagate-none-in";
+    public static final String PROPAGATE_NONE_OUT = "propagate-none-out";
+
+    public static final String PROPAGATE_APP_IN = "propagate-app-in";
+    public static final String PROPAGATE_APP_OUT = "propagate-app-out";
+
+    @Incoming(DEFAULT_IN)
+    @Outgoing(DEFAULT_OUT)
+    public String configuredDefaultStream(String input) {
+        return processMessage(input);
+    }
+
+    @Incoming(PROPAGATE_ALL_IN)
+    @Outgoing(PROPAGATE_ALL_OUT)
+    public String propagateAllStream(String input) {
+        return processMessage(input);
+    }
+
+    @Incoming(PROPAGATE_NONE_IN)
+    @Outgoing(PROPAGATE_NONE_OUT)
+    public String propagateNoneStream(String input) {
+        return processMessage(input);
+    }
+
+    @Incoming(PROPAGATE_APP_IN)
+    @Outgoing(PROPAGATE_APP_OUT)
+    public String propagateAppOnlyStream(String input) {
+        return processMessage(input);
+    }
+
+    private String processMessage(String input) {
+        try {
+            return input + "-" + getAppName() + "-" + isTcclSet();
+        } catch (Exception e) {
+            return e.toString();
+        }
+    }
+
+    private String getAppName() {
+        try {
+            return (String) new InitialContext().lookup("java:app/AppName");
+        } catch (NamingException e) {
+            return "noapp";
+        }
+    }
+
+    private boolean isTcclSet() {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        // Check if Liberty's special classloader is the TCCL
+        // Unfortunately, when the TCCL is not set, we get a context classloader which delegates based on the classes on the stack so this is the easiest way to determine whether we have a regular TCCL or not
+        if (tccl.getClass().getName().endsWith("ThreadContextClassLoader")) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
@@ -55,7 +55,7 @@ public class KafkaPartitionTest {
 
     private static final String APP_NAME = "KafkaPartitionTest";
 
-    public static final String SERVER_NAME = "SimpleRxMessagingServer";
+    public static final String SERVER_NAME = "ConcurrentRxMessagingServer";
 
     @Server(SERVER_NAME)
     @TestServlets({

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/MockAsyncProvider.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/MockAsyncProvider.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.tck;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMAsyncProvider;
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMContext;
+
+/**
+ * Mock implementation of {@link RMAsyncProvider} for running tests outside of liberty
+ * <p>
+ * It does no context propagation and uses a fixed size thread pool for concurrency.
+ */
+public class MockAsyncProvider implements RMAsyncProvider, AutoCloseable {
+
+    public ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
+
+    @Override
+    public RMContext captureContext() {
+        return RMContext.NOOP;
+    }
+
+    @Override
+    public ExecutorService getExecutorService() {
+        return executor;
+    }
+
+    @Override
+    public ScheduledExecutorService getScheduledExecutorService() {
+        return executor;
+    }
+
+    @Override
+    public void close() {
+        executor.shutdown();
+        try {
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            // Stop waiting and shutdown now
+        }
+        executor.shutdownNow();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
@@ -25,6 +25,8 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.ack.auto.KafkaAutoAckTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.containers.ExtendedKafkaContainer;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context.KafkaDefaultContextTest;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context.custom.KafkaCustomContextTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.delivery.KafkaAcknowledgementTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.flatmap.KafkaFlatMapTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.message.ConsumerRecordTest;
@@ -50,8 +52,10 @@ import componenttest.containers.TestContainerSuite;
                 KafkaMessagingTest.class,
                 KafkaAcknowledgementTest.class,
                 KafkaAutoAckTest.class,
+                KafkaCustomContextTest.class,
                 KafkaCustomSerializerTest.class,
                 KafkaCustomKeySerializerTest.class,
+                KafkaDefaultContextTest.class,
                 KafkaFlatMapTest.class,
                 KafkaPartitionTest.class,
                 KafkaSharedLibTest.class,
@@ -72,7 +76,7 @@ public class PlaintextTests extends TestContainerSuite {
         return Collections.singletonMap(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
     }
 
-    public static AdminClient getAdminClient(){
+    public static AdminClient getAdminClient() {
         Map<String, Object> adminClientProps = connectionProperties();
         return AdminClient.create(adminClientProps);
     }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/ConcurrentRxMessagingServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/ConcurrentRxMessagingServer/bootstrap.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2017, 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=5471
+com.ibm.ws.logging.trace.specification = *=info:logservice=detail:REACTIVEMESSAGE=all:com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl.*=FINEST:org.apache.kafka.*=all

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/ConcurrentRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/ConcurrentRxMessagingServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -14,11 +14,13 @@
 
     <include location="../fatTestPorts.xml" />
 
+    <!-- This server has the concurrent feature added for tests which need a managed executor -->
     <featureManager>
         <feature>componenttest-1.0</feature>
         <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
         <feature>servlet-4.0</feature>
+        <feature>concurrent-1.0</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/ContextRxMessagingServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/ContextRxMessagingServer/bootstrap.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2017, 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=5471
+com.ibm.ws.logging.trace.specification = *=info:logservice=detail:REACTIVEMESSAGE=all:com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl.*=FINEST:org.apache.kafka.*=all

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/ContextRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/ContextRxMessagingServer/server.xml
@@ -1,0 +1,26 @@
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <include location="../fatTestPorts.xml" />
+
+    <!-- This server has jndi-1.0 added so we can easily check the application context -->
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>osgiconsole-1.0</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>mpReactiveMessaging-1.0</feature>
+        <feature>servlet-4.0</feature>
+        <feature>jndi-1.0</feature>
+    </featureManager>
+</server>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/CustomContextRxMessagingServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/CustomContextRxMessagingServer/bootstrap.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2017, 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=5471
+com.ibm.ws.logging.trace.specification = *=info:logservice=detail:REACTIVEMESSAGE=all:com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl.*=FINEST:org.apache.kafka.*=all

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/CustomContextRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/CustomContextRxMessagingServer/server.xml
@@ -1,0 +1,36 @@
+<!--
+    Copyright (c) 2023 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <include location="../fatTestPorts.xml" />
+
+    <!-- This server has concurrent-1.0 enabled and custom context services configured -->
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>osgiconsole-1.0</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>mpReactiveMessaging-1.0</feature>
+        <feature>servlet-4.0</feature>
+        <feature>jndi-1.0</feature>
+        <feature>concurrent-1.0</feature>
+    </featureManager>
+    
+    <contextService id="propagateAll">
+        <classloaderContext/>
+        <jeeMetadataContext/>
+        <securityContext/>
+    </contextService>
+    
+    <contextService id="propagateNone">
+    </contextService>
+</server>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/JsonbRxMessagingServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/JsonbRxMessagingServer/bootstrap.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2017, 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=5471
+com.ibm.ws.logging.trace.specification = *=info:logservice=detail:REACTIVEMESSAGE=all:com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl.*=FINEST:org.apache.kafka.*=all

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/JsonbRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/JsonbRxMessagingServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -14,11 +14,14 @@
 
     <include location="../fatTestPorts.xml" />
 
+    <!-- This server has jsonb and concurrent added -->
     <featureManager>
         <feature>componenttest-1.0</feature>
         <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
         <feature>servlet-4.0</feature>
+        <feature>jsonb-1.0</feature>
+        <feature>concurrent-1.0</feature>
     </featureManager>
 </server>

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/bnd.bnd
@@ -21,20 +21,27 @@ Bundle-Description: MicroProfile Reactive Messaging common components
 WS-TraceGroup: REACTIVEMESSAGE
 
 -dsannotations: \
-  io.openliberty.microprofile.reactive.messaging.internal.interfaces.MessageAccessProvider
+  io.openliberty.microprofile.reactive.messaging.internal.interfaces.MessageAccessProvider,\
+  io.openliberty.microprofile.reactive.messaging.internal.RMAsyncProviderFactoryImpl,\
+  io.openliberty.microprofile.reactive.messaging.internal.QuiesceRegisterImpl
 
 Export-Package: \
   io.openliberty.microprofile.reactive.messaging.internal.interfaces
+
+Private-Package: \
+  io.openliberty.microprofile.reactive.messaging.internal
 
 Import-Package: \
   org.eclipse.microprofile.reactive.messaging;version="[1.0, 3)",\
   *
 
 -buildpath: \
+  com.ibm.ws.context;version=latest,\
   com.ibm.ws.logging;version=latest,\
   com.ibm.ws.logging.core;version=latest,\
   org.eclipse.osgi;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.websphere.org.osgi.service.component;version=latest,\
   com.ibm.websphere.org.eclipse.microprofile.reactive.messaging.1.0;version=latest,\
-  com.ibm.wsspi.org.osgi.service.component.annotations;version=latest
+  com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+  com.ibm.ws.kernel.service;version=latest

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/QuiesceRegisterImpl.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/QuiesceRegisterImpl.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.internal;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+import com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener;
+
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.QuiesceParticipant;
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.QuiesceRegister;
+
+/**
+ *
+ */
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE)
+public class QuiesceRegisterImpl implements ServerQuiesceListener, QuiesceRegister {
+
+    private final Set<QuiesceParticipant> participants = new HashSet<>();
+
+    @Override
+    public void serverStopping() {
+        for (QuiesceParticipant participant : participants) {
+            participant.quiesce();
+        }
+    }
+
+    @Override
+    public void register(QuiesceParticipant participant) {
+        participants.add(participant);
+    }
+
+    @Override
+    public void remove(QuiesceParticipant participant) {
+        participants.remove(participant);
+    }
+
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/RMAsyncProviderFactoryImpl.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/RMAsyncProviderFactoryImpl.java
@@ -11,12 +11,13 @@ package io.openliberty.microprofile.reactive.messaging.internal;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
@@ -32,7 +33,7 @@ import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMAsyn
 import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMAsyncProviderFactory;
 import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMContext;
 
-@Component
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE)
 public class RMAsyncProviderFactoryImpl implements RMAsyncProviderFactory {
 
     private static final TraceComponent tc = Tr.register(RMAsyncProviderFactoryImpl.class);
@@ -59,7 +60,14 @@ public class RMAsyncProviderFactoryImpl implements RMAsyncProviderFactory {
     @Reference(target = "(id=DefaultContextService)", cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
     private volatile WSContextService defaultContextService;
 
-    private final Map<String, WSContextService> namedContextServices = Collections.synchronizedMap(new HashMap<>());
+    /**
+     * A map of named context services configured in the server.xml
+     * <p>
+     * Maps from the context service ID to the context service.
+     * <p>
+     * Updated dynamically if context services are added or removed while the server is running.
+     */
+    private final Map<String, WSContextService> namedContextServices = new ConcurrentHashMap<>();
 
     /**
      * The liberty global thread pool executor
@@ -73,6 +81,9 @@ public class RMAsyncProviderFactoryImpl implements RMAsyncProviderFactory {
     @Reference(target = "(deferrable=false)", policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
     private volatile ScheduledExecutorService scheduledExecutor;
 
+    /**
+     * Updates {@link #namedContextServices} when a new service is added
+     */
     @Reference(service = WSContextService.class, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.MULTIPLE)
     protected void addContextService(WSContextService contextService, Map<String, Object> properties) {
         String name = getContextServiceName(properties);
@@ -81,21 +92,35 @@ public class RMAsyncProviderFactoryImpl implements RMAsyncProviderFactory {
         }
     }
 
+    /**
+     * Updates {@link #namedContextServices} when the properties of a context service are updated
+     * <p>
+     * Not sure if this actually happens, but since the properties includes the name, that could in theory change.
+     */
     protected void updatedContextService(WSContextService contextService, Map<String, Object> properties) {
         String name = getContextServiceName(properties);
         if (name == null) {
-            namedContextServices.entrySet().removeIf(e -> e.getValue() == contextService);
-        } else if (namedContextServices.get(name) != contextService) {
+            namedContextServices.values().remove(contextService);
+        } else if (!contextService.equals(namedContextServices.get(name))) {
             // If name has changed, remove and re-add
-            namedContextServices.entrySet().removeIf(e -> e.getValue() == contextService);
+            namedContextServices.values().remove(contextService);
             namedContextServices.put(name, contextService);
         }
     }
 
+    /**
+     * Updates {@link #namedContextServices} when a context service is removed
+     */
     protected void removeContextService(WSContextService contextService) {
-        namedContextServices.entrySet().removeIf(e -> e.getValue() == contextService);
+        namedContextServices.values().remove(contextService);
     }
 
+    /**
+     * Extract the name of a context service from its OSGi service properties
+     *
+     * @param properties the OSGi service properties
+     * @return the name, or {@code null} if the context service doesn't have a name (e.g. because it's an internal one)
+     */
     private String getContextServiceName(Map<String, Object> properties) {
         Object name = properties.get("id");
         if (name instanceof String) {
@@ -110,11 +135,18 @@ public class RMAsyncProviderFactoryImpl implements RMAsyncProviderFactory {
         return new NamedAsyncProvider(contextServiceRef);
     }
 
+    /**
+     * Look up the context service with the given name and use it to capture the thread context
+     *
+     * @param contextServiceName the context service to use, or {@code null} to use the default context service
+     * @return the captured thread context
+     */
     @SuppressWarnings("unchecked")
     private RMContext captureContext(String contextServiceName) {
         WSContextService namedContextService = null;
         if (contextServiceName != null) {
             namedContextService = namedContextServices.get(contextServiceName);
+            // TODO: confirm behavior if named context service not found
         }
 
         if (namedContextService != null) {
@@ -135,10 +167,20 @@ public class RMAsyncProviderFactoryImpl implements RMAsyncProviderFactory {
         }
     }
 
+    /**
+     * An RMAsyncProvider which uses a named context service to capture thread context.
+     * <p>
+     * {@code null} can be provided as the name to use the default context service.
+     */
     private class NamedAsyncProvider implements RMAsyncProvider {
 
         private final String name;
 
+        /**
+         * Create a new AsyncProvider
+         *
+         * @param name the name of the context service to use for capturing thread context, or {@code null} to use the default
+         */
         public NamedAsyncProvider(String name) {
             this.name = name;
         }
@@ -163,6 +205,9 @@ public class RMAsyncProviderFactoryImpl implements RMAsyncProviderFactory {
 
         private final ThreadContextDescriptor context;
 
+        /**
+         * @param context the thread context captured with {@link WSContextService#captureThreadContext(Map, Map...)}
+         */
         public RMContextImpl(ThreadContextDescriptor context) {
             this.context = context;
         }

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/RMAsyncProviderFactoryImpl.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/RMAsyncProviderFactoryImpl.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.wsspi.threadcontext.ThreadContext;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
+import com.ibm.wsspi.threadcontext.WSContextService;
+
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMAsyncProvider;
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMAsyncProviderFactory;
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMContext;
+
+@Component
+public class RMAsyncProviderFactoryImpl implements RMAsyncProviderFactory {
+
+    private static final TraceComponent tc = Tr.register(RMAsyncProviderFactoryImpl.class);
+
+    @SuppressWarnings("unchecked")
+    private static final Map<String, ?>[] DEFAULT_CONTEXT_PROVIDERS = new Map[] {
+                                                                                  Collections.singletonMap(WSContextService.THREAD_CONTEXT_PROVIDER,
+                                                                                                           "com.ibm.ws.classloader.context.provider"),
+                                                                                  Collections.singletonMap(WSContextService.THREAD_CONTEXT_PROVIDER,
+                                                                                                           "com.ibm.ws.javaee.metadata.context.provider"),
+                                                                                  Collections.singletonMap(WSContextService.THREAD_CONTEXT_PROVIDER,
+                                                                                                           "com.ibm.ws.security.context.provider"),
+    };
+
+    /**
+     * The built-in context service
+     */
+    @Reference(target = "(service.pid=com.ibm.ws.context.manager)", policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    private volatile WSContextService builtInContextService;
+
+    /**
+     * The default context service provided by the concurrent feature
+     */
+    @Reference(target = "(id=DefaultContextService)", cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    private volatile WSContextService defaultContextService;
+
+    private final Map<String, WSContextService> namedContextServices = Collections.synchronizedMap(new HashMap<>());
+
+    /**
+     * The liberty global thread pool executor
+     */
+    @Reference(target = "(component.name=com.ibm.ws.threading)", policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    private volatile ExecutorService globalExecutor;
+
+    /**
+     * A scheduled executor which delegates to the global thread pool
+     */
+    @Reference(target = "(deferrable=false)", policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    private volatile ScheduledExecutorService scheduledExecutor;
+
+    @Reference(service = WSContextService.class, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.MULTIPLE)
+    protected void addContextService(WSContextService contextService, Map<String, Object> properties) {
+        String name = getContextServiceName(properties);
+        if (name != null) {
+            namedContextServices.put(name, contextService);
+        }
+    }
+
+    protected void updatedContextService(WSContextService contextService, Map<String, Object> properties) {
+        String name = getContextServiceName(properties);
+        if (name == null) {
+            namedContextServices.entrySet().removeIf(e -> e.getValue() == contextService);
+        } else if (namedContextServices.get(name) != contextService) {
+            // If name has changed, remove and re-add
+            namedContextServices.entrySet().removeIf(e -> e.getValue() == contextService);
+            namedContextServices.put(name, contextService);
+        }
+    }
+
+    protected void removeContextService(WSContextService contextService) {
+        namedContextServices.entrySet().removeIf(e -> e.getValue() == contextService);
+    }
+
+    private String getContextServiceName(Map<String, Object> properties) {
+        Object name = properties.get("id");
+        if (name instanceof String) {
+            return (String) name;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public RMAsyncProvider getAsyncProvider(String contextServiceRef) {
+        return new NamedAsyncProvider(contextServiceRef);
+    }
+
+    @SuppressWarnings("unchecked")
+    private RMContext captureContext(String contextServiceName) {
+        WSContextService namedContextService = null;
+        if (contextServiceName != null) {
+            namedContextService = namedContextServices.get(contextServiceName);
+        }
+
+        if (namedContextService != null) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "Capturing context with named context service", contextServiceName, namedContextService);
+            }
+            return new RMContextImpl(namedContextService.captureThreadContext(null));
+        } else if (defaultContextService != null) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "Capturing context with default context service");
+            }
+            return new RMContextImpl(defaultContextService.captureThreadContext(null));
+        } else {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "Capturing context with build-in context service");
+            }
+            return new RMContextImpl(builtInContextService.captureThreadContext(null, DEFAULT_CONTEXT_PROVIDERS));
+        }
+    }
+
+    private class NamedAsyncProvider implements RMAsyncProvider {
+
+        private final String name;
+
+        public NamedAsyncProvider(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public RMContext captureContext() {
+            return RMAsyncProviderFactoryImpl.this.captureContext(name);
+        }
+
+        @Override
+        public ExecutorService getExecutorService() {
+            return globalExecutor;
+        }
+
+        @Override
+        public ScheduledExecutorService getScheduledExecutorService() {
+            return scheduledExecutor;
+        }
+    }
+
+    private static class RMContextImpl implements RMContext {
+
+        private final ThreadContextDescriptor context;
+
+        public RMContextImpl(ThreadContextDescriptor context) {
+            this.context = context;
+        }
+
+        @Override
+        public void execute(Runnable runnable) {
+            ArrayList<ThreadContext> contextApplied = context.taskStarting();
+            try {
+                runnable.run();
+            } finally {
+                context.taskStopping(contextApplied);
+            }
+        }
+    }
+
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/RMAsyncProviderFactoryImpl.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/RMAsyncProviderFactoryImpl.java
@@ -87,7 +87,7 @@ public class RMAsyncProviderFactoryImpl implements RMAsyncProviderFactory {
     @Reference(service = WSContextService.class, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.MULTIPLE)
     protected void addContextService(WSContextService contextService, Map<String, Object> properties) {
         String name = getContextServiceName(properties);
-        if (name != null) {
+        if ((name != null) && !isApplicationDefinedContextService(properties)) {
             namedContextServices.put(name, contextService);
         }
     }
@@ -99,7 +99,7 @@ public class RMAsyncProviderFactoryImpl implements RMAsyncProviderFactory {
      */
     protected void updatedContextService(WSContextService contextService, Map<String, Object> properties) {
         String name = getContextServiceName(properties);
-        if (name == null) {
+        if ((name == null) || isApplicationDefinedContextService(properties)) {
             namedContextServices.values().remove(contextService);
         } else if (!contextService.equals(namedContextServices.get(name))) {
             // If name has changed, remove and re-add
@@ -128,6 +128,16 @@ public class RMAsyncProviderFactoryImpl implements RMAsyncProviderFactory {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Returns whether a context service is one defined within an application using {@code @ContextServiceDefinition}.
+     *
+     * @param properties the service properties of the {@code WSContextService} service to check
+     * @return {@code true} if the service properties are for an application-defined context service, otherwise {@code false}
+     */
+    private boolean isApplicationDefinedContextService(Map<String, Object> properties) {
+        return !"file".equals(properties.get("config.source"));
     }
 
     @Override

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/QuiesceParticipant.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/QuiesceParticipant.java
@@ -9,10 +9,19 @@
  *******************************************************************************/
 package io.openliberty.microprofile.reactive.messaging.internal.interfaces;
 
+import com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener;
+
 /**
- *
+ * An object which can be notified when the server quiesces.
+ * <p>
+ * Must be manually registered with {@link QuiesceRegister}.
+ * <p>
+ * Used by components in Reactive Messaging which aren't OSGi components and so can't easily register themselves as a {@link ServerQuiesceListener}
  */
 public interface QuiesceParticipant {
 
+    /**
+     * Called when the server is stopping
+     */
     void quiesce();
 }

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/QuiesceParticipant.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/QuiesceParticipant.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.internal.interfaces;
+
+/**
+ *
+ */
+public interface QuiesceParticipant {
+
+    void quiesce();
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/QuiesceRegister.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/QuiesceRegister.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.internal.interfaces;
+
+public interface QuiesceRegister {
+
+    void register(QuiesceParticipant participant);
+
+    void remove(QuiesceParticipant participant);
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/QuiesceRegister.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/QuiesceRegister.java
@@ -9,9 +9,26 @@
  *******************************************************************************/
 package io.openliberty.microprofile.reactive.messaging.internal.interfaces;
 
+/**
+ * Allows {@link QuiesceParticipant}s to register and unregister themselves.
+ * <p>
+ * An instance of this interface should be obtained by looking up the singleton service from OSGi.
+ */
 public interface QuiesceRegister {
 
+    /**
+     * Register an object to be notified about the server quiescing
+     * <p>
+     * All objects passed to this method must later be passed to {@link #remove(QuiesceParticipant)} to avoid a memory leak.
+     *
+     * @param participant the object to register
+     */
     void register(QuiesceParticipant participant);
 
+    /**
+     * Deregister an object for notifications about the server quiescing
+     *
+     * @param participant the object to deregister
+     */
     void remove(QuiesceParticipant participant);
 }

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMAsyncProvider.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMAsyncProvider.java
@@ -14,6 +14,8 @@ import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Provides the services needed for Reactive Messaging components to do asynchronous tasks
+ * <p>
+ * Instances must be created via {@link RMAsyncProviderFactory}
  */
 public interface RMAsyncProvider {
 

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMAsyncProvider.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMAsyncProvider.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.internal.interfaces;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Provides the services needed for Reactive Messaging components to do asynchronous tasks
+ */
+public interface RMAsyncProvider {
+
+    /**
+     * Captures the context from the current thread
+     * <p>
+     * The returned object can be used to apply this context to another thread
+     *
+     * @return the context object
+     * @throws IllegalArgumentException if a named context service is requested but could not be found
+     */
+    RMContext captureContext();
+
+    /**
+     * Gets the executor service to use
+     *
+     * @return the executor service
+     */
+    ExecutorService getExecutorService();
+
+    /**
+     * Gets the scheduled executor service to use
+     *
+     * @return the scheduled executor service
+     */
+    ScheduledExecutorService getScheduledExecutorService();
+
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMAsyncProviderFactory.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMAsyncProviderFactory.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.internal.interfaces;
+
+/**
+ *
+ */
+public interface RMAsyncProviderFactory {
+
+    RMAsyncProvider getAsyncProvider(String contextServiceRef);
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMAsyncProviderFactory.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMAsyncProviderFactory.java
@@ -10,9 +10,17 @@
 package io.openliberty.microprofile.reactive.messaging.internal.interfaces;
 
 /**
- *
+ * Creates {@link RMAsyncProvider} instances.
+ * <p>
+ * An instance of this interface should be obtained by looking up the singleton service in OSGi.
  */
 public interface RMAsyncProviderFactory {
 
-    RMAsyncProvider getAsyncProvider(String contextServiceRef);
+    /**
+     * Creates an {@code RMAsyncProvider} which uses the named context service to capture thread context
+     *
+     * @param contextServiceName the context service name, or {@code null} to use the default context service
+     * @return the async provider
+     */
+    RMAsyncProvider getAsyncProvider(String contextServiceName);
 }

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMContext.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMContext.java
@@ -11,6 +11,8 @@ package io.openliberty.microprofile.reactive.messaging.internal.interfaces;
 
 /**
  * Represents a context which can be applied to a thread
+ * <p>
+ * Instances can be created via {@link RMAsyncProvider#captureContext()}
  */
 public interface RMContext {
 

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMContext.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMContext.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.internal.interfaces;
+
+/**
+ * Represents a context which can be applied to a thread
+ */
+public interface RMContext {
+
+    /**
+     * An RM context object which applies no context
+     */
+    RMContext NOOP = Runnable::run;
+
+    /**
+     * Runs a runnable using the context captured by this object
+     *
+     * @param runnable the runnable to run
+     */
+    void execute(Runnable runnable);
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/package-info.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/package-info.java
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+@TraceOptions(traceGroup = "REACTIVEMESSAGE")
+package io.openliberty.microprofile.reactive.messaging.internal;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;


### PR DESCRIPTION
Several changes here:

- Remove the RM 3.0 dependency on concurrent
  - Use global thread pool and internal `WSContextService` instead of  `ManagedExecutorService` and `ManagedScheduledExecutorService`
- Add explicit tests for context propagation with RM
- Add new config option to select a custom context service

With this change, users who are using the `concurrent-x.x` feature, can define a context service in server.xml:

```xml
    <contextService id="myContextService">
        <classloaderContext/>
        <jeeMetadataContext/>
    </contextService>
```

They can then configure the kafka connector to use it by setting MP Config properties. It can be set globally:
```properties
mp.messaging.connector.liberty-kafka.context.service=myContextService
```

It can also be set for a specific channel:
```properties
mp.messaging.incoming.myChannel.context.service=myContextService
```

If this property is not set, it will use the default context service if `concurrent-x.x` is enabled, or the built-in context service otherwise.

Fixes #26678