### PR TITLE
Set OpenAPI update workflow permissions

### DIFF
--- a/.github/workflows/update-openapi-ui.yml
+++ b/.github/workflows/update-openapi-ui.yml
@@ -4,8 +4,13 @@ name: Update OpenAPI UI dependencies
 
 on: workflow_dispatch
 
+permissions: {}
+
 jobs:
   update-openapi-ui:
+    permissions:
+      contents: write
+      pull-requests: write
     name: Update OpenAPI UI Dependencies
     runs-on: ubuntu-latest
     defaults:
@@ -13,7 +18,7 @@ jobs:
         working-directory: ./dev/com.ibm.ws.openapi.ui/swagger-ui
     steps:
     - name: Checkout Open Liberty
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Use Node.js v16
       uses: actions/setup-node@v3
       with:
@@ -51,7 +56,7 @@ jobs:
         git commit -m "Update Swagger UI to $SWAGGER_UI_VERSION [auto]"
         git push
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 #3.14.0
+      uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 #5.0.2
       id: create-pr
       if: ${{ env.GITHUB_REF_NAME == 'integration' }}
       with:


### PR DESCRIPTION
Currently, the OpenAPI workflow does not define its permissions, therefore it inherits whatever token it uses has, which is more then it needs.

Add deny-all permissions to the workflow and add `contents` and `pull-request permissions` to the openapi job so if any new jobs are added they need to add their own permissions. As the job creates new branches and PRs it requires write access to both

Update checkout and pull-request actions to latest to resolve new deprecations 

Fixes [#27137](https://github.com/OpenLiberty/open-liberty/issues/27137)

