### PR TITLE
Use RESTResponse.setContentType(..) in `MetricRestHandler` (mpMetrics-5.x)

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/helper/Constants.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/helper/Constants.java
@@ -67,6 +67,9 @@ public class Constants {
     public final static String PERCENTILE_999TH = "p999";
 
     // Content Types
+    public final static String CONTENT_TYPE_HEADER = "Content-Type";
+    public final static String CHARSET = "charset";
+    public final static String UTF8 = "utf-8";
     public final static String TEXTCONTENTTYPE = "text/plain; charset=utf-8";
     public final static String JSONCONTENTTYPE = "application/json; charset=utf-8";
 

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/rest/MetricRESTHandler.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/rest/MetricRESTHandler.java
@@ -137,8 +137,22 @@ public class MetricRESTHandler implements RESTHandler {
                             int status = (int) args[0];
                             String message = (String) args[1];
                             Map<String, String> headers = (Map<String, String>) args[2];
-
-                            headers.forEach((key, value) -> response.addResponseHeader(key, value));
+                            headers.forEach((key, value) -> {
+                                /*
+                                 * For Content-type, avoid adding to header directly and use
+                                 * RestRsponse.setContentType();
+                                 */
+                                if (key.equalsIgnoreCase(Constants.CONTENT_TYPE_HEADER)) {
+                                    if (!value.contains(Constants.CHARSET)) {
+                                        value += (value.endsWith(";")) ? "" : ";";
+                                        value += " " + Constants.CHARSET + "=" + Constants.UTF8;
+                                    }
+                                    // This will automatically set the header for Content-Type
+                                    response.setContentType(value);
+                                } else {
+                                    response.addResponseHeader(key, value);
+                                }
+                            });
                             response.setStatus(status);
                             response.getWriter().write(message);
                         }


### PR DESCRIPTION
PR Modifiers the `Responder` functional interface implementation (used by SmallRye Metrics) to intercept the `Content-Type` header and append the utf-8 charset if no charset is detected. This is followed by invoking `RESTResponse.setContentType(...)` (which will also set the header).

fixes #27093 

#build