### PR TITLE
Update deployment descriptors for Concurrency 3.1

### DIFF
--- a/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/PlatformVersion.java
+++ b/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/PlatformVersion.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,6 +22,7 @@ public interface PlatformVersion {
     // 8,   http://xmlns.jcp.org/xml/ns/javaee  // last javax
     // 9,   https://jakarta.ee/xml/ns/jakartaee // jakarta EE 9
     // 10,  https://jakarta.ee/xml/ns/jakartaee // jakarta EE 10
+    // 11,  https://jakarta.ee/xml/ns/jakartaee // jakarta EE 11
 
     String NAMESPACE_SUN_J2EE   = "http://java.sun.com/xml/ns/j2ee";
     String NAMESPACE_SUN_JAVAEE = "http://java.sun.com/xml/ns/javaee";
@@ -33,14 +34,16 @@ public interface PlatformVersion {
     String VERSION_1_4_STR  =  "1.4";
     String VERSION_5_0_STR  =  "5.0";
     String VERSION_6_0_STR  =  "6.0";
-    String VERSION_7_STR    =  "7";    
+    String VERSION_7_STR    =  "7";
     String VERSION_7_0_STR  =  "7.0";
     String VERSION_8_0_STR  =  "8.0";
     String VERSION_9_STR    =  "9";
     String VERSION_9_0_STR  =  "9.0";
     String VERSION_10_STR   = "10";
     String VERSION_10_0_STR = "10.0";
-    
+    String VERSION_11_STR   = "11";
+    String VERSION_11_0_STR = "11.0";
+
     int VERSION_1_2_INT  =  12;
     int VERSION_1_3_INT  =  13;
     int VERSION_1_4_INT  =  14;
@@ -50,68 +53,73 @@ public interface PlatformVersion {
     int VERSION_8_0_INT  =  80;
     int VERSION_9_0_INT  =  90;
     int VERSION_10_0_INT = 100;
+    int VERSION_11_0_INT = 110;
     
     //
     
     public static String getDottedVersionText(int version) {
         switch ( version ) {
-            case 0: return null;
-            case 9: return "0.9";
-            case 10: return "1.0";
-            case 11: return "1.1";
-            case 12: return "1.2";
-            case 13: return "1.3";
-            case 14: return "1.4";
-            case 15: return "1.5";
-            case 16: return "1.6";
-            case 17: return "1.7";
-            case 20: return "2.0";
-            case 21: return "2.1";
-            case 22: return "2.2";
-            case 23: return "2.3";
-            case 24: return "2.4";
-            case 25: return "2.5";
-            case 30: return "3.0";
-            case 31: return "3.1";
-            case 32: return "3.2";
-            case 40: return "4.0";
-            case 50: return "5.0";
-            case 60: return "6.0";
-            case 70: return "7.0";
-            case 80: return "8.0";
-            case 90: return "9.0";
+            case 0:   return null;
+            case 9:   return "0.9";
+            case 10:  return "1.0";
+            case 11:  return "1.1";
+            case 12:  return "1.2";
+            case 13:  return "1.3";
+            case 14:  return "1.4";
+            case 15:  return "1.5";
+            case 16:  return "1.6";
+            case 17:  return "1.7";
+            case 20:  return "2.0";
+            case 21:  return "2.1";
+            case 22:  return "2.2";
+            case 23:  return "2.3";
+            case 24:  return "2.4";
+            case 25:  return "2.5";
+            case 30:  return "3.0";
+            case 31:  return "3.1";
+            case 32:  return "3.2";
+            case 40:  return "4.0";
+            case 50:  return "5.0";
+            case 60:  return "6.0";
+            case 61:  return "6.1";
+            case 70:  return "7.0";
+            case 80:  return "8.0";
+            case 90:  return "9.0";
             case 100: return "10.0";
-            default: throw new IllegalArgumentException("Unknown schema version [ " + version + " ]");
+            case 110: return "11.0";
+            default:  throw new IllegalArgumentException("Unknown schema version [ " + version + " ]");
         }
     }
 
     public static String getVersionText(int version) {
         switch ( version ) {
-            case 0: return null;
-            case 11: return "1.1";
-            case 12: return "1.2";
-            case 13: return "1.3";
-            case 14: return "1.4";
-            case 15: return "1.5";
-            case 16: return "1.6";
-            case 17: return "1.7";
-            case 20: return "2.0";
-            case 21: return "2.1";
-            case 22: return "2.2";            
-            case 23: return "2.3";
-            case 24: return "2.4";
-            case 25: return "2.5";
-            case 30: return "3.0";
-            case 31: return "3.1";
-            case 32: return "3.2";
-            case 40: return "4";
-            case 50: return "5";
-            case 60: return "6";
-            case 70: return "7";
-            case 80: return "8";
-            case 90: return "9";
+            case 0:   return null;
+            case 11:  return "1.1";
+            case 12:  return "1.2";
+            case 13:  return "1.3";
+            case 14:  return "1.4";
+            case 15:  return "1.5";
+            case 16:  return "1.6";
+            case 17:  return "1.7";
+            case 20:  return "2.0";
+            case 21:  return "2.1";
+            case 22:  return "2.2";
+            case 23:  return "2.3";
+            case 24:  return "2.4";
+            case 25:  return "2.5";
+            case 30:  return "3.0";
+            case 31:  return "3.1";
+            case 32:  return "3.2";
+            case 40:  return "4";
+            case 50:  return "5";
+            case 60:  return "6";
+            case 61:  return "6.1";
+            case 70:  return "7";
+            case 80:  return "8";
+            case 90:  return "9";
             case 100: return "10";
-            default: throw new IllegalArgumentException("Unknown schema version [ " + version + " ]");
+            case 110: return "11";
+            default:  throw new IllegalArgumentException("Unknown schema version [ " + version + " ]");
         }
-    }    
+    }
 }

--- a/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ContextService.java
+++ b/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ContextService.java
@@ -36,7 +36,7 @@ public interface ContextService extends JNDIEnvironmentRef, Describable {
     /**
      * @return &lt;qualifier&gt; elements as a read-only list
      */
-    String[] getQualifier();
+    String[] getQualifiers();
 
     /**
      * @return &lt;property&gt; elements as a read-only list

--- a/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ContextService.java
+++ b/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ContextService.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -32,6 +32,11 @@ public interface ContextService extends JNDIEnvironmentRef, Describable {
      * @return &lt;unchanged&gt; elements as a read-only list
      */
     String[] getUnchanged();
+
+    /**
+     * @return &lt;qualifier&gt; elements as a read-only list
+     */
+    String[] getQualifier();
 
     /**
      * @return &lt;property&gt; elements as a read-only list

--- a/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ManagedExecutor.java
+++ b/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ManagedExecutor.java
@@ -62,7 +62,7 @@ public interface ManagedExecutor extends JNDIEnvironmentRef, Describable {
     /**
      * @return &lt;qualifier&gt; elements as a read-only list
      */
-    String[] getQualifier();
+    String[] getQualifiers();
 
     /**
      * @return &lt;property&gt; elements as a read-only list

--- a/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ManagedExecutor.java
+++ b/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ManagedExecutor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,7 +17,7 @@ import java.util.List;
 /**
  * Represents &lt;managed-executor&gt;.
  */
-public interface ManagedExecutor extends JNDIEnvironmentRef, Describable {   
+public interface ManagedExecutor extends JNDIEnvironmentRef, Describable {
     /**
      * @return &lt;context-service-ref&gt;, or null if unspecified
      */
@@ -48,7 +48,24 @@ public interface ManagedExecutor extends JNDIEnvironmentRef, Describable {
     boolean isSetMaxAsync();
 
     /**
+     * @return &lt;virtual&gt; if specified
+     * @see #isSetVirutal
+     */
+    boolean isVirtual();
+
+    /**
+     * @return true if &lt;virtual&gt; is specified
+     * @see #isVirtual
+     */
+    boolean isSetVirtual();
+
+    /**
+     * @return &lt;qualifier&gt; elements as a read-only list
+     */
+    String[] getQualifier();
+
+    /**
      * @return &lt;property&gt; elements as a read-only list
      */
-    List<Property> getProperties();    
+    List<Property> getProperties();
 }

--- a/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ManagedScheduledExecutor.java
+++ b/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ManagedScheduledExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -62,7 +62,7 @@ public interface ManagedScheduledExecutor extends JNDIEnvironmentRef, Describabl
     /**
      * @return &lt;qualifier&gt; elements as a read-only list
      */
-    String[] getQualifier();
+    String[] getQualifiers();
 
     /**
      * @return &lt;property&gt; elements as a read-only list

--- a/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ManagedScheduledExecutor.java
+++ b/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ManagedScheduledExecutor.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -46,7 +46,24 @@ public interface ManagedScheduledExecutor extends JNDIEnvironmentRef, Describabl
      * @see #getMaxAsync
      */
     boolean isSetMaxAsync();
-    
+
+    /**
+     * @return &lt;virtual&gt; if specified
+     * @see #isSetVirutal
+     */
+    boolean isVirtual();
+
+    /**
+     * @return true if &lt;virtual&gt; is specified
+     * @see #isVirtual
+     */
+    boolean isSetVirtual();
+
+    /**
+     * @return &lt;qualifier&gt; elements as a read-only list
+     */
+    String[] getQualifier();
+
     /**
      * @return &lt;property&gt; elements as a read-only list
      */

--- a/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ManagedThreadFactory.java
+++ b/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ManagedThreadFactory.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -34,7 +34,24 @@ public interface ManagedThreadFactory extends JNDIEnvironmentRef, Describable {
      * @see #getPriority
      */
     boolean isSetPriority();
-    
+
+    /**
+     * @return &lt;virtual&gt; if specified
+     * @see #isSetVirutal
+     */
+    boolean isVirtual();
+
+    /**
+     * @return true if &lt;virtual&gt; is specified
+     * @see #isVirtual
+     */
+    boolean isSetVirtual();
+
+    /**
+     * @return &lt;qualifier&gt; elements as a read-only list
+     */
+    String[] getQualifier();
+
     /**
      * @return &lt;property&gt; elements as a read-only list
      */

--- a/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ManagedThreadFactory.java
+++ b/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/common/ManagedThreadFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -50,7 +50,7 @@ public interface ManagedThreadFactory extends JNDIEnvironmentRef, Describable {
     /**
      * @return &lt;qualifier&gt; elements as a read-only list
      */
-    String[] getQualifier();
+    String[] getQualifiers();
 
     /**
      * @return &lt;property&gt; elements as a read-only list

--- a/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/app/Application.java
+++ b/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/app/Application.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -33,20 +33,22 @@ public interface Application extends DeploymentDescriptor, DescriptionGroup, JND
     int VERSION_8 = 80;
     int VERSION_9 = 90;
     int VERSION_10 = 100;
+    int VERSION_11 = 110;
 
-    int [] VERSIONS = {
-            VERSION_1_2, VERSION_1_3, // dtd
-            VERSION_1_4,              // sun j2ee
-            VERSION_5, VERSION_6,     // sun javaee
-            VERSION_7, VERSION_8,     // jcp java
-            VERSION_9, VERSION_10     // Jakarta
-    };    
-    
+    int[] VERSIONS = {
+                       VERSION_1_2, VERSION_1_3, // dtd
+                       VERSION_1_4, // sun j2ee
+                       VERSION_5, VERSION_6, // sun javaee
+                       VERSION_7, VERSION_8, // jcp java
+                       VERSION_9, VERSION_10, VERSION_11 // Jakarta
+    };
+
     String getVersion();
 
     String getApplicationName();
 
     boolean isSetInitializeInOrder();
+
     boolean isInitializeInOrder();
 
     List<Module> getModules();

--- a/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/web/WebApp.java
+++ b/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/web/WebApp.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,24 +24,27 @@ public interface WebApp extends ModuleDeploymentDescriptor, DeploymentDescriptor
     int VERSION_2_2 = 22;
     int VERSION_2_3 = 23;
     int VERSION_2_4 = 24;
-    int VERSION_2_5 = 25;    
+    int VERSION_2_5 = 25;
     int VERSION_3_0 = 30;
     int VERSION_3_1 = 31;
     int VERSION_4_0 = 40; // JavaEE
     int VERSION_5_0 = 50; // Jakarta EE 9
     int VERSION_6_0 = 60; // Jakarta EE 10
+    int VERSION_6_1 = 61; // Jakarta EE 11
 
-    int[] VERSIONS = { 
-        VERSION_2_2, VERSION_2_3,
-        VERSION_2_4,
-        VERSION_2_5, VERSION_3_0,
-        VERSION_3_1, VERSION_4_0,
-        VERSION_5_0, VERSION_6_0
+    int[] VERSIONS = {
+                       VERSION_2_2, VERSION_2_3,
+                       VERSION_2_4,
+                       VERSION_2_5, VERSION_3_0,
+                       VERSION_3_1, VERSION_4_0,
+                       VERSION_5_0, VERSION_6_0,
+                       VERSION_6_1
     };
 
     String getVersion();
 
     boolean isSetMetadataComplete();
+
     boolean isMetadataComplete();
 
     @Override

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/app/ApplicationDDParser.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/app/ApplicationDDParser.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -34,15 +34,16 @@ public class ApplicationDDParser extends DDParserSpec {
         new VersionData("8",   null, NAMESPACE_JCP_JAVAEE, Application.VERSION_8, VERSION_8_0_INT),                            
         
         new VersionData("9", null, NAMESPACE_JAKARTA, Application.VERSION_9, VERSION_9_0_INT),
-        new VersionData("10", null, NAMESPACE_JAKARTA, Application.VERSION_10, VERSION_10_0_INT)
+        new VersionData("10", null, NAMESPACE_JAKARTA, Application.VERSION_10, VERSION_10_0_INT),
+        new VersionData("11", null, NAMESPACE_JAKARTA, Application.VERSION_11, VERSION_11_0_INT)
     };
 
     public static int getMaxTolerated() {
-        return Application.VERSION_10;
+        return Application.VERSION_11;
     }
     
     public static int getMaxImplemented() {
-        return Application.VERSION_9;
+        return Application.VERSION_9; //TODO should this be updated to 10?
     }
     
     @Override

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/app/ApplicationDDParser.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/app/ApplicationDDParser.java
@@ -43,7 +43,7 @@ public class ApplicationDDParser extends DDParserSpec {
     }
     
     public static int getMaxImplemented() {
-        return Application.VERSION_9; //TODO should this be updated to 10?
+        return Application.VERSION_10;
     }
     
     @Override

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ContextServiceType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ContextServiceType.java
@@ -92,9 +92,9 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
     }
 
     @Override
-    public String[] getQualifier() {
-        if (qualifier != null) {
-            return qualifier.getArray();
+    public String[] getQualifiers() {
+        if (qualifiers != null) {
+            return qualifiers.getArray();
         } else {
             return XSDTokenType.ListType.getEmptyArray();
         }
@@ -115,7 +115,7 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
     private StringType.ListType cleared;
     private StringType.ListType propagated;
     private StringType.ListType unchanged;
-    private XSDTokenType.ListType qualifier;
+    private XSDTokenType.ListType qualifiers;
     private PropertyType.ListType properties;
 
     public ContextServiceType() {
@@ -168,10 +168,10 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
         if ("qualifier".equals(localName)) {
             XSDTokenType unchanged_element = new XSDTokenType();
             parser.parse(unchanged_element);
-            if (qualifier == null) {
-                qualifier = new XSDTokenType.ListType();
+            if (qualifiers == null) {
+                qualifiers = new XSDTokenType.ListType();
             }
-            qualifier.add(unchanged_element);
+            qualifiers.add(unchanged_element);
             return true;
         }
 
@@ -204,7 +204,7 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
         diag.describeIfSet("cleared", cleared);
         diag.describeIfSet("propagated", propagated);
         diag.describeIfSet("unchanged", unchanged);
-        diag.describeIfSet("qualifier", qualifier);
+        diag.describeIfSet("qualifier", qualifiers);
     }
 
     @Override

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ContextServiceType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ContextServiceType.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,9 +20,9 @@ import com.ibm.ws.javaee.dd.common.ContextService;
 import com.ibm.ws.javaee.dd.common.Description;
 import com.ibm.ws.javaee.dd.common.Property;
 import com.ibm.ws.javaee.ddmodel.DDParser;
-import com.ibm.ws.javaee.ddmodel.StringType;
 import com.ibm.ws.javaee.ddmodel.DDParser.ParsableListImplements;
 import com.ibm.ws.javaee.ddmodel.DDParser.ParseException;
+import com.ibm.ws.javaee.ddmodel.StringType;
 
 // <xsd:complexType name="context-serviceType">
 // <xsd:sequence>
@@ -31,6 +31,7 @@ import com.ibm.ws.javaee.ddmodel.DDParser.ParseException;
 //   <xsd:element name="cleared" type="jakartaee:string" minOccurs="0" maxOccurs="unbounded"/>
 //   <xsd:element name="propagated" type="jakartaee:string" minOccurs="0" maxOccurs="unbounded"/>
 //   <xsd:element name="unchanged" type="jakartaee:string" minOccurs="0" maxOccurs="unbounded"/>
+//   <xsd:element name="qualifier" type="jakartaee:fully-qualified-classType" minOccurs="0" maxOccurs="unbounded"/>
 //   <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded"/>
 // </xsd:sequence>
 // <xsd:attribute name="id" type="xsd:ID"/>
@@ -53,7 +54,7 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
     @SuppressWarnings("unchecked")
     @Override
     public List<Description> getDescriptions() {
-        if ( descriptions != null ) {
+        if (descriptions != null) {
             return (List<Description>) descriptions;
         } else {
             return Collections.emptyList();
@@ -62,7 +63,7 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
 
     @Override
     public String[] getCleared() {
-        if ( cleared == null ) {
+        if (cleared == null) {
             // Per the xsd documentation, "Absent other configuration, cleared context defaults to Transaction."
             // However, we cannot default it here because we need to represent the state of unspecified
             // so that merging with annotations can be performed correctly.
@@ -74,7 +75,7 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
 
     @Override
     public String[] getPropagated() {
-        if ( propagated != null ) {
+        if (propagated != null) {
             return propagated.getArray();
         } else {
             return StringType.ListType.getEmptyArray();
@@ -83,13 +84,22 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
 
     @Override
     public String[] getUnchanged() {
-        if ( unchanged != null ) {
+        if (unchanged != null) {
             return unchanged.getArray();
         } else {
             return StringType.ListType.getEmptyArray();
         }
     }
-    
+
+    @Override
+    public String[] getQualifier() {
+        if (qualifier != null) {
+            return qualifier.getArray();
+        } else {
+            return XSDTokenType.ListType.getEmptyArray();
+        }
+    }
+
     @Override
     public List<Property> getProperties() {
         if (properties != null) {
@@ -105,6 +115,7 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
     private StringType.ListType cleared;
     private StringType.ListType propagated;
     private StringType.ListType unchanged;
+    private XSDTokenType.ListType qualifier;
     private PropertyType.ListType properties;
 
     public ContextServiceType() {
@@ -133,7 +144,7 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
             cleared.add(cleared_element);
             return true;
         }
-        
+
         if ("propagated".equals(localName)) {
             StringType propagated_element = new StringType();
             parser.parse(propagated_element);
@@ -152,7 +163,17 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
             }
             unchanged.add(unchanged_element);
             return true;
-        }        
+        }
+
+        if ("qualifier".equals(localName)) {
+            XSDTokenType unchanged_element = new XSDTokenType();
+            parser.parse(unchanged_element);
+            if (qualifier == null) {
+                qualifier = new XSDTokenType.ListType();
+            }
+            qualifier.add(unchanged_element);
+            return true;
+        }
 
         if ("property".equals(localName)) {
             PropertyType property = new PropertyType();
@@ -171,23 +192,25 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
 
     @Override
     public void describeHead(DDParser.Diagnostics diag) {
-        if ( descriptions != null ) {
-            diag.describe( "description", (DescriptionType) (descriptions.get(0)) );
+        if (descriptions != null) {
+            diag.describe("description", (DescriptionType) (descriptions.get(0)));
         }
         super.describeHead(diag);
     }
-    
+
     @Override
     public void describeBody(DDParser.Diagnostics diag) {
         super.describeBody(diag);
         diag.describeIfSet("cleared", cleared);
         diag.describeIfSet("propagated", propagated);
         diag.describeIfSet("unchanged", unchanged);
+        diag.describeIfSet("qualifier", qualifier);
     }
-    
+
     @Override
     public void describeTail(DDParser.Diagnostics diag) {
         super.describeTail(diag);
         diag.describeIfSet("property", properties);
     }
+
 }

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ContextServiceType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ContextServiceType.java
@@ -96,7 +96,7 @@ public class ContextServiceType extends JNDIEnvironmentRefType implements Contex
         if (qualifiers != null) {
             return qualifiers.getArray();
         } else {
-            return XSDTokenType.ListType.getEmptyArray();
+            return XSDTokenType.ListType.EMPTY_ARRAY;
         }
     }
 

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedExecutorType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedExecutorType.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -31,6 +31,8 @@ import com.ibm.ws.javaee.ddmodel.DDParser.ParseException;
 //   <xsd:element name="context-service-ref" type="jakartaee:jndi-nameType" minOccurs="0" maxOccurs="1"/>
 //   <xsd:element name="max-async" type="jakartaee:xsdPositiveIntegerType" minOccurs="0" maxOccurs="1"/>
 //   <xsd:element name="hung-task-threshold" type="jakartaee:xsdPositiveIntegerType" minOccurs="0" maxOccurs="1"/>
+//   <xsd:element name="virtual" type="jakartaee:true-falseType" minOccurs="0" maxOccurs="1"/>
+//   <xsd:element name="qualifier" type="jakartaee:fully-qualified-classType" minOccurs="0" maxOccurs="unbounded"/>
 //   <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded"/>
 // </xsd:sequence>
 // <xsd:attribute name="id" type="xsd:ID"/>
@@ -47,13 +49,13 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
     @SuppressWarnings("unchecked")
     @Override
     public List<Description> getDescriptions() {
-        if ( descriptions != null ) {
+        if (descriptions != null) {
             return (List<Description>) descriptions;
         } else {
             return Collections.emptyList();
         }
     }
-    
+
     @Override
     public String getContextServiceRef() {
         return contextServiceRef == null ? null : contextServiceRef.getValue();
@@ -87,14 +89,35 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
     public long getHungTaskThreshold() {
         return hungTaskThreshold != null ? hungTaskThreshold.getIntValue() : 0;
     }
-    
+
+    @Override
+    public boolean isSetVirtual() {
+        return AnySimpleType.isSet(virtual);
+    }
+
+    @Override
+    public boolean isVirtual() {
+        return virtual != null ? virtual.getBooleanValue() : false;
+    }
+
+    @Override
+    public String[] getQualifier() {
+        if (qualifier != null) {
+            return qualifier.getArray();
+        } else {
+            return XSDTokenType.ListType.getEmptyArray();
+        }
+    }
+
     //
 
     private List<? extends Description> descriptions;
     private JNDINameType contextServiceRef;
     private XSDIntegerType maxAsync;
     private XSDIntegerType hungTaskThreshold;
-    private PropertyType.ListType properties;    
+    private XSDBooleanType virtual;
+    private XSDTokenType.ListType qualifier;
+    private PropertyType.ListType properties;
 
     public ManagedExecutorType() {
         super("name");
@@ -105,7 +128,7 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
     public boolean isIdAllowed() {
         return true;
     }
-    
+
     @Override
     public boolean handleChild(DDParser parser, String localName) throws ParseException {
         if (super.handleChild(parser, localName)) {
@@ -126,7 +149,7 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
             parser.parse(contextServiceRef);
             return true;
         }
-        
+
         if ("hung-task-threshold".equals(localName)) {
             XSDIntegerType hungTaskThreshold = new XSDIntegerType();
             parser.parse(hungTaskThreshold);
@@ -141,6 +164,23 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
             return true;
         }
 
+        if ("virtual".equals(localName)) {
+            XSDBooleanType virtual = new XSDBooleanType();
+            parser.parse(virtual);
+            this.virtual = virtual;
+            return true;
+        }
+
+        if ("qualifier".equals(localName)) {
+            XSDTokenType unchanged_element = new XSDTokenType();
+            parser.parse(unchanged_element);
+            if (qualifier == null) {
+                qualifier = new XSDTokenType.ListType();
+            }
+            qualifier.add(unchanged_element);
+            return true;
+        }
+
         if ("property".equals(localName)) {
             PropertyType property = new PropertyType();
             parser.parse(property);
@@ -150,7 +190,7 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
             properties.add(property);
             return true;
         }
-        
+
         return false;
     }
 
@@ -158,8 +198,8 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
 
     @Override
     public void describeHead(DDParser.Diagnostics diag) {
-        if ( descriptions != null ) {
-            diag.describe( "description", (DescriptionType) (descriptions.get(0)) );
+        if (descriptions != null) {
+            diag.describe("description", (DescriptionType) (descriptions.get(0)));
         }
         super.describeHead(diag);
     }
@@ -167,14 +207,17 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
     @Override
     public void describeBody(DDParser.Diagnostics diag) {
         super.describeBody(diag);
-        diag.describe("context-service-ref", contextServiceRef);        
-        diag.describeIfSet("hung-task-threshold", hungTaskThreshold);        
+        diag.describe("context-service-ref", contextServiceRef);
+        diag.describeIfSet("hung-task-threshold", hungTaskThreshold);
         diag.describeIfSet("max-async", maxAsync);
+        diag.describeIfSet("virtual", virtual);
+        diag.describeIfSet("qualifier", qualifier);
     }
-    
+
     @Override
     public void describeTail(DDParser.Diagnostics diag) {
         super.describeTail(diag);
         diag.describeIfSet("property", properties);
-    }    
+    }
+
 }

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedExecutorType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedExecutorType.java
@@ -105,7 +105,7 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
         if (qualifiers != null) {
             return qualifiers.getArray();
         } else {
-            return XSDTokenType.ListType.getEmptyArray();
+            return XSDTokenType.ListType.EMPTY_ARRAY;
         }
     }
 

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedExecutorType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedExecutorType.java
@@ -101,9 +101,9 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
     }
 
     @Override
-    public String[] getQualifier() {
-        if (qualifier != null) {
-            return qualifier.getArray();
+    public String[] getQualifiers() {
+        if (qualifiers != null) {
+            return qualifiers.getArray();
         } else {
             return XSDTokenType.ListType.getEmptyArray();
         }
@@ -116,7 +116,7 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
     private XSDIntegerType maxAsync;
     private XSDIntegerType hungTaskThreshold;
     private XSDBooleanType virtual;
-    private XSDTokenType.ListType qualifier;
+    private XSDTokenType.ListType qualifiers;
     private PropertyType.ListType properties;
 
     public ManagedExecutorType() {
@@ -174,10 +174,10 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
         if ("qualifier".equals(localName)) {
             XSDTokenType unchanged_element = new XSDTokenType();
             parser.parse(unchanged_element);
-            if (qualifier == null) {
-                qualifier = new XSDTokenType.ListType();
+            if (qualifiers == null) {
+                qualifiers = new XSDTokenType.ListType();
             }
-            qualifier.add(unchanged_element);
+            qualifiers.add(unchanged_element);
             return true;
         }
 
@@ -211,7 +211,7 @@ public class ManagedExecutorType extends JNDIEnvironmentRefType implements Manag
         diag.describeIfSet("hung-task-threshold", hungTaskThreshold);
         diag.describeIfSet("max-async", maxAsync);
         diag.describeIfSet("virtual", virtual);
-        diag.describeIfSet("qualifier", qualifier);
+        diag.describeIfSet("qualifier", qualifiers);
     }
 
     @Override

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedScheduledExecutorType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedScheduledExecutorType.java
@@ -96,7 +96,7 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
         if (qualifiers != null) {
             return qualifiers.getArray();
         } else {
-            return XSDTokenType.ListType.getEmptyArray();
+            return XSDTokenType.ListType.EMPTY_ARRAY;
         }
     }
 

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedScheduledExecutorType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedScheduledExecutorType.java
@@ -92,9 +92,9 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
     }
 
     @Override
-    public String[] getQualifier() {
-        if (qualifier != null) {
-            return qualifier.getArray();
+    public String[] getQualifiers() {
+        if (qualifiers != null) {
+            return qualifiers.getArray();
         } else {
             return XSDTokenType.ListType.getEmptyArray();
         }
@@ -116,7 +116,7 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
     private XSDIntegerType maxAsync;
     private XSDIntegerType hungTaskThreshold;
     private XSDBooleanType virtual;
-    private XSDTokenType.ListType qualifier;
+    private XSDTokenType.ListType qualifiers;
     private PropertyType.ListType properties;
 
     public ManagedScheduledExecutorType() {
@@ -174,10 +174,10 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
         if ("qualifier".equals(localName)) {
             XSDTokenType unchanged_element = new XSDTokenType();
             parser.parse(unchanged_element);
-            if (qualifier == null) {
-                qualifier = new XSDTokenType.ListType();
+            if (qualifiers == null) {
+                qualifiers = new XSDTokenType.ListType();
             }
-            qualifier.add(unchanged_element);
+            qualifiers.add(unchanged_element);
             return true;
         }
 
@@ -211,7 +211,7 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
         diag.describeIfSet("hung-task-threshold", hungTaskThreshold);
         diag.describeIfSet("max-async", maxAsync);
         diag.describeIfSet("virtual", virtual);
-        diag.describeIfSet("qualifier", qualifier);
+        diag.describeIfSet("qualifier", qualifiers);
     }
 
     @Override

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedScheduledExecutorType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedScheduledExecutorType.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -31,6 +31,8 @@ import com.ibm.ws.javaee.ddmodel.DDParser.ParseException;
 //   <xsd:element name="context-service-ref" type="jakartaee:jndi-nameType" minOccurs="0" maxOccurs="1"/>
 //   <xsd:element name="max-async" type="jakartaee:xsdPositiveIntegerType" minOccurs="0" maxOccurs="1"/>
 //   <xsd:element name="hung-task-threshold" type="jakartaee:xsdPositiveIntegerType" minOccurs="0" maxOccurs="1"/>
+//   <xsd:element name="virtual" type="jakartaee:true-falseType" minOccurs="0" maxOccurs="1"/>
+//   <xsd:element name="qualifier" type="jakartaee:fully-qualified-classType" minOccurs="0" maxOccurs="unbounded"/>
 //   <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded"/>
 // </xsd:sequence>
 // <xsd:attribute name="id" type="xsd:ID"/>
@@ -47,13 +49,13 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
     @SuppressWarnings("unchecked")
     @Override
     public List<Description> getDescriptions() {
-        if ( descriptions != null ) {
+        if (descriptions != null) {
             return (List<Description>) descriptions;
         } else {
             return Collections.emptyList();
         }
     }
-    
+
     @Override
     public String getContextServiceRef() {
         return contextServiceRef == null ? null : contextServiceRef.getValue();
@@ -78,7 +80,26 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
     public long getHungTaskThreshold() {
         return hungTaskThreshold != null ? hungTaskThreshold.getIntValue() : 0;
     }
-    
+
+    @Override
+    public boolean isSetVirtual() {
+        return AnySimpleType.isSet(virtual);
+    }
+
+    @Override
+    public boolean isVirtual() {
+        return virtual != null ? virtual.getBooleanValue() : false;
+    }
+
+    @Override
+    public String[] getQualifier() {
+        if (qualifier != null) {
+            return qualifier.getArray();
+        } else {
+            return XSDTokenType.ListType.getEmptyArray();
+        }
+    }
+
     @Override
     public List<Property> getProperties() {
         if (properties != null) {
@@ -91,16 +112,18 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
     //
 
     private List<? extends Description> descriptions;
-    private JNDINameType contextServiceRef;    
+    private JNDINameType contextServiceRef;
     private XSDIntegerType maxAsync;
     private XSDIntegerType hungTaskThreshold;
-    private PropertyType.ListType properties;    
-    
+    private XSDBooleanType virtual;
+    private XSDTokenType.ListType qualifier;
+    private PropertyType.ListType properties;
+
     public ManagedScheduledExecutorType() {
         super("name");
     }
 
-    @Trivial    
+    @Trivial
     @Override
     public boolean isIdAllowed() {
         return true;
@@ -140,7 +163,24 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
             this.maxAsync = maxAsync;
             return true;
         }
-        
+
+        if ("virtual".equals(localName)) {
+            XSDBooleanType virtual = new XSDBooleanType();
+            parser.parse(virtual);
+            this.virtual = virtual;
+            return true;
+        }
+
+        if ("qualifier".equals(localName)) {
+            XSDTokenType unchanged_element = new XSDTokenType();
+            parser.parse(unchanged_element);
+            if (qualifier == null) {
+                qualifier = new XSDTokenType.ListType();
+            }
+            qualifier.add(unchanged_element);
+            return true;
+        }
+
         if ("property".equals(localName)) {
             PropertyType property = new PropertyType();
             parser.parse(property);
@@ -150,7 +190,7 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
             properties.add(property);
             return true;
         }
-        
+
         return false;
     }
 
@@ -158,8 +198,8 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
 
     @Override
     public void describeHead(DDParser.Diagnostics diag) {
-        if ( descriptions != null ) {
-            diag.describe( "description", (DescriptionType) (descriptions.get(0)) );
+        if (descriptions != null) {
+            diag.describe("description", (DescriptionType) (descriptions.get(0)));
         }
         super.describeHead(diag);
     }
@@ -167,14 +207,17 @@ public class ManagedScheduledExecutorType extends JNDIEnvironmentRefType impleme
     @Override
     public void describeBody(DDParser.Diagnostics diag) {
         super.describeBody(diag);
-        diag.describe("context-service-ref", contextServiceRef);        
-        diag.describeIfSet("hung-task-threshold", hungTaskThreshold);        
+        diag.describe("context-service-ref", contextServiceRef);
+        diag.describeIfSet("hung-task-threshold", hungTaskThreshold);
         diag.describeIfSet("max-async", maxAsync);
+        diag.describeIfSet("virtual", virtual);
+        diag.describeIfSet("qualifier", qualifier);
     }
-    
+
     @Override
     public void describeTail(DDParser.Diagnostics diag) {
         super.describeTail(diag);
         diag.describeIfSet("property", properties);
-    }    
+    }
+
 }

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedThreadFactoryType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedThreadFactoryType.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -30,6 +30,8 @@ import com.ibm.ws.javaee.ddmodel.DDParser.ParseException;
 //   <xsd:element name="name" type="jakartaee:jndi-nameType"/>
 //   <xsd:element name="context-service-ref" type="jakartaee:jndi-nameType" minOccurs="0" maxOccurs="1"/>
 //   <xsd:element name="priority" type="jakartaee:priorityType" minOccurs="0" maxOccurs="1"/>
+//   <xsd:element name="virtual" type="jakartaee:true-falseType" minOccurs="0" maxOccurs="1"/>
+//   <xsd:element name="qualifier" type="jakartaee:fully-qualified-classType" minOccurs="0" maxOccurs="unbounded"/>
 //   <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded"/>
 // </xsd:sequence>
 // <xsd:attribute name="id" type="xsd:ID"/>
@@ -46,13 +48,13 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
     @SuppressWarnings("unchecked")
     @Override
     public List<Description> getDescriptions() {
-        if ( descriptions != null ) {
+        if (descriptions != null) {
             return (List<Description>) descriptions;
         } else {
             return Collections.emptyList();
         }
     }
-    
+
     @Override
     public String getContextServiceRef() {
         return contextServiceRef == null ? null : contextServiceRef.getValue();
@@ -69,6 +71,25 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
     }
 
     @Override
+    public boolean isSetVirtual() {
+        return AnySimpleType.isSet(virtual);
+    }
+
+    @Override
+    public boolean isVirtual() {
+        return virtual != null ? virtual.getBooleanValue() : false;
+    }
+
+    @Override
+    public String[] getQualifier() {
+        if (qualifier != null) {
+            return qualifier.getArray();
+        } else {
+            return XSDTokenType.ListType.getEmptyArray();
+        }
+    }
+
+    @Override
     public List<Property> getProperties() {
         if (properties != null) {
             return properties.getList();
@@ -76,14 +97,16 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
             return Collections.emptyList();
         }
     }
-    
+
     //
 
     private List<? extends Description> descriptions;
-    private JNDINameType contextServiceRef;    
+    private JNDINameType contextServiceRef;
     private XSDIntegerType priority;
+    private XSDBooleanType virtual;
+    private XSDTokenType.ListType qualifier;
     private PropertyType.ListType properties;
-    
+
     public ManagedThreadFactoryType() {
         super("name");
     }
@@ -106,7 +129,6 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
             descriptions = Collections.singletonList(description);
             return true;
         }
-        
 
         if ("context-service-ref".equals(localName)) {
             if (contextServiceRef == null) {
@@ -123,6 +145,23 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
             return true;
         }
 
+        if ("virtual".equals(localName)) {
+            XSDBooleanType virtual = new XSDBooleanType();
+            parser.parse(virtual);
+            this.virtual = virtual;
+            return true;
+        }
+
+        if ("qualifier".equals(localName)) {
+            XSDTokenType unchanged_element = new XSDTokenType();
+            parser.parse(unchanged_element);
+            if (qualifier == null) {
+                qualifier = new XSDTokenType.ListType();
+            }
+            qualifier.add(unchanged_element);
+            return true;
+        }
+
         if ("property".equals(localName)) {
             PropertyType property = new PropertyType();
             parser.parse(property);
@@ -131,7 +170,7 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
             }
             properties.add(property);
             return true;
-        }        
+        }
 
         return false;
     }
@@ -140,8 +179,8 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
 
     @Override
     public void describeHead(DDParser.Diagnostics diag) {
-        if ( descriptions != null ) {
-            diag.describe( "description", (DescriptionType) (descriptions.get(0)) );
+        if (descriptions != null) {
+            diag.describe("description", (DescriptionType) (descriptions.get(0)));
         }
         super.describeHead(diag);
     }
@@ -149,13 +188,16 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
     @Override
     public void describeBody(DDParser.Diagnostics diag) {
         super.describeBody(diag);
-        diag.describe("context-service-ref", contextServiceRef);        
+        diag.describe("context-service-ref", contextServiceRef);
         diag.describeIfSet("priority", priority);
+        diag.describeIfSet("virtual", virtual);
+        diag.describeIfSet("qualifier", qualifier);
     }
-    
+
     @Override
     public void describeTail(DDParser.Diagnostics diag) {
         super.describeTail(diag);
         diag.describeIfSet("property", properties);
     }
+
 }

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedThreadFactoryType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedThreadFactoryType.java
@@ -85,7 +85,7 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
         if (qualifiers != null) {
             return qualifiers.getArray();
         } else {
-            return XSDTokenType.ListType.getEmptyArray();
+            return XSDTokenType.ListType.EMPTY_ARRAY;
         }
     }
 

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedThreadFactoryType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/ManagedThreadFactoryType.java
@@ -81,9 +81,9 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
     }
 
     @Override
-    public String[] getQualifier() {
-        if (qualifier != null) {
-            return qualifier.getArray();
+    public String[] getQualifiers() {
+        if (qualifiers != null) {
+            return qualifiers.getArray();
         } else {
             return XSDTokenType.ListType.getEmptyArray();
         }
@@ -104,7 +104,7 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
     private JNDINameType contextServiceRef;
     private XSDIntegerType priority;
     private XSDBooleanType virtual;
-    private XSDTokenType.ListType qualifier;
+    private XSDTokenType.ListType qualifiers;
     private PropertyType.ListType properties;
 
     public ManagedThreadFactoryType() {
@@ -155,10 +155,10 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
         if ("qualifier".equals(localName)) {
             XSDTokenType unchanged_element = new XSDTokenType();
             parser.parse(unchanged_element);
-            if (qualifier == null) {
-                qualifier = new XSDTokenType.ListType();
+            if (qualifiers == null) {
+                qualifiers = new XSDTokenType.ListType();
             }
-            qualifier.add(unchanged_element);
+            qualifiers.add(unchanged_element);
             return true;
         }
 
@@ -191,7 +191,7 @@ public class ManagedThreadFactoryType extends JNDIEnvironmentRefType implements 
         diag.describe("context-service-ref", contextServiceRef);
         diag.describeIfSet("priority", priority);
         diag.describeIfSet("virtual", virtual);
-        diag.describeIfSet("qualifier", qualifier);
+        diag.describeIfSet("qualifier", qualifiers);
     }
 
     @Override

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/XSDTokenType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/XSDTokenType.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -44,6 +44,20 @@ public class XSDTokenType extends TokenType {
                 stringList.add(token.getValue());
             }
             return stringList;
+        }
+
+        public String[] getArray() {
+            String[] stringArray = new String[list.size()];
+            for (int i = 0; i < list.size(); i++) {
+                stringArray[i] = list.get(i).getValue();
+            }
+            return stringArray;
+        }
+
+        public static final String[] EMPTY_ARRAY = new String[] {};
+
+        public static String[] getEmptyArray() {
+            return EMPTY_ARRAY;
         }
     }
 

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/XSDTokenType.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/common/XSDTokenType.java
@@ -56,9 +56,6 @@ public class XSDTokenType extends TokenType {
 
         public static final String[] EMPTY_ARRAY = new String[] {};
 
-        public static String[] getEmptyArray() {
-            return EMPTY_ARRAY;
-        }
     }
 
     @Override

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/web/WebAppDDParser.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/web/WebAppDDParser.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -35,15 +35,16 @@ public class WebAppDDParser extends DDParserSpec {
         new VersionData("4.0", null, NAMESPACE_JCP_JAVAEE, WebApp.VERSION_4_0, VERSION_8_0_INT),
 
         new VersionData("5.0", null, NAMESPACE_JAKARTA, WebApp.VERSION_5_0, VERSION_9_0_INT),
-        new VersionData("6.0", null, NAMESPACE_JAKARTA, WebApp.VERSION_6_0, VERSION_10_0_INT)
+        new VersionData("6.0", null, NAMESPACE_JAKARTA, WebApp.VERSION_6_0, VERSION_10_0_INT),
+        new VersionData("6.1", null, NAMESPACE_JAKARTA, WebApp.VERSION_6_1, VERSION_11_0_INT)
     };
 
     public static int getMaxTolerated() {
-        return WebApp.VERSION_6_0;
+        return WebApp.VERSION_6_1;
     }
     
     public static int getMaxImplemented() {
-        return WebApp.VERSION_5_0;
+        return WebApp.VERSION_5_0; //TODO should this be updated to 6.0
     }
     
     @Override    

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/web/WebAppDDParser.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/web/WebAppDDParser.java
@@ -44,7 +44,7 @@ public class WebAppDDParser extends DDParserSpec {
     }
     
     public static int getMaxImplemented() {
-        return WebApp.VERSION_5_0; //TODO should this be updated to 6.0
+        return WebApp.VERSION_6_0;
     }
     
     @Override    

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/web/WebFragmentDDParser.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/web/WebFragmentDDParser.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -25,15 +25,16 @@ public class WebFragmentDDParser extends DDParserSpec {
         new VersionData("4.0", null, NAMESPACE_JCP_JAVAEE, WebApp.VERSION_4_0, VERSION_8_0_INT),
 
         new VersionData("5.0", null, NAMESPACE_JAKARTA, WebApp.VERSION_5_0, VERSION_9_0_INT),
-        new VersionData("6.0", null, NAMESPACE_JAKARTA, WebApp.VERSION_6_0, VERSION_10_0_INT)
+        new VersionData("6.0", null, NAMESPACE_JAKARTA, WebApp.VERSION_6_0, VERSION_10_0_INT),
+        new VersionData("6.1", null, NAMESPACE_JAKARTA, WebApp.VERSION_6_1, VERSION_11_0_INT)
     };
 
     public static int getMaxTolerated() {
-        return WebApp.VERSION_6_0;
+        return WebApp.VERSION_6_1;
     }
     
     public static int getMaxImplemented() {
-        return WebApp.VERSION_5_0;
+        return WebApp.VERSION_5_0; //TODO should this be updated to 6.0?
     }
     
     @Override

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/DDJakarta10Elements.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/DDJakarta10Elements.java
@@ -13,6 +13,7 @@
 package com.ibm.ws.javaee.ddmodel;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -124,11 +125,7 @@ import com.ibm.ws.javaee.dd.common.JNDIEnvironmentRefs;
 public class DDJakarta10Elements {
 
     public static List<String> names(String... name0) {
-        List<String> names = new ArrayList<String>(6);
-        for ( String name : names ) {
-            names.add(name);
-        }
-        return names;
+        return new ArrayList<String>(Arrays.asList(name0));
     }
 
     public static void withName(List<String> names, String name, Consumer<List<String>> action) {

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/DDJakarta11Elements.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/DDJakarta11Elements.java
@@ -13,6 +13,7 @@
 package com.ibm.ws.javaee.ddmodel;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -81,11 +82,7 @@ import com.ibm.ws.javaee.dd.common.Property;
 public class DDJakarta11Elements {
 
     public static List<String> names(String... name0) {
-        List<String> names = new ArrayList<String>(6);
-        for (String name : names) {
-            names.add(name);
-        }
-        return names;
+        return new ArrayList<String>(Arrays.asList(name0));
     }
 
     public static void withName(List<String> names, String name, Consumer<List<String>> action) {

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/DDJakarta11Elements.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/DDJakarta11Elements.java
@@ -1,0 +1,432 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.javaee.ddmodel;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.Assert;
+
+import com.ibm.ws.javaee.dd.common.ContextService;
+import com.ibm.ws.javaee.dd.common.Description;
+import com.ibm.ws.javaee.dd.common.JNDIEnvironmentRefs;
+import com.ibm.ws.javaee.dd.common.ManagedExecutor;
+import com.ibm.ws.javaee.dd.common.ManagedScheduledExecutor;
+import com.ibm.ws.javaee.dd.common.ManagedThreadFactory;
+import com.ibm.ws.javaee.dd.common.Property;
+
+/*
+ * jakartaee_10.xsd - jakartaee_9.xsd
+
+  <xsd:group name="jndiEnvironmentRefsGroup">
+      <xsd:element name="context-service" type="jakartaee:context-serviceType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="managed-executor" type="jakartaee:managed-executorType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="managed-scheduled-executor" type="jakartaee:managed-scheduled-executorType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="managed-thread-factory" type="jakartaee:managed-thread-factoryType" minOccurs="0" maxOccurs="unbounded"/>
+
+  j2ee_1_4.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
+  javaee_5.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
+  javaee_6.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
+  javaee_7.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
+  javaee_8.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
+  jakartaee_9.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
+  jakartaee_10.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
+
+  ejb-jar_4_0.xsd:      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+  ejb-jar_4_0.xsd:      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+  ejb-jar_4_0.xsd:      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+  ejb-jar_4_0.xsd:      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+
+  web-app_2_4.xsd:      <xsd:group ref="j2ee:jndiEnvironmentRefsGroup"/>
+  web-app_2_5.xsd:      <xsd:group ref="javaee:jndiEnvironmentRefsGroup"/>
+
+  web-common_3_0.xsd:      <xsd:group ref="javaee:jndiEnvironmentRefsGroup"/>
+  --> web-app_3_0.xsd
+  --> web-fragment_3_0.xsd
+  web-common_5_0.xsd:      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+  --> web-app_5_0.xsd
+  --> web-fragment_5_0.xsd
+  web-common_6_0.xsd:      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+  --> web-app_6_0.xsd
+  --> web-fragment_6_0.xsd
+
+  ejb-jar_4_0.xsd
+    <xsd:complexType name="entity-beanType">
+    <xsd:complexType name="interceptorType">
+    <xsd:complexType name="message-driven-beanType">
+    <xsd:complexType name="session-beanType">
+      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+
+  web-common_6_0.xsd:
+    <xsd:group name="web-commonType">
+      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+ */
+
+/*
+    <xsd:complexType name="context-serviceType">
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0"/>
+      <xsd:element name="name" type="jakartaee:jndi-nameType"/>
+      <xsd:element name="cleared" type="jakartaee:string" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="propagated" type="jakartaee:string" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="unchanged" type="jakartaee:string" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="managed-executorType">
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0"/>
+      <xsd:element name="name" type="jakartaee:jndi-nameType"/>
+      <xsd:element name="context-service-ref" type="jakartaee:jndi-nameType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="max-async" type="jakartaee:xsdPositiveIntegerType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hung-task-threshold" type="jakartaee:xsdPositiveIntegerType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="managed-scheduled-executorType">
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0"/>
+      <xsd:element name="name" type="jakartaee:jndi-nameType"/>
+      <xsd:element name="context-service-ref" type="jakartaee:jndi-nameType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="max-async" type="jakartaee:xsdPositiveIntegerType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="hung-task-threshold" type="jakartaee:xsdPositiveIntegerType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="managed-thread-factoryType">
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0">
+      <xsd:element name="name" type="jakartaee:jndi-nameType"/>
+      <xsd:element name="context-service-ref" type="jakartaee:jndi-nameType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="priority" type="jakartaee:priorityType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+*/
+public class DDJakarta11Elements {
+
+    public static List<String> names(String... name0) {
+        List<String> names = new ArrayList<String>(6);
+        for (String name : names) {
+            names.add(name);
+        }
+        return names;
+    }
+
+    public static void withName(List<String> names, String name, Consumer<List<String>> action) {
+        names.add(name);
+        try {
+            action.accept(names);
+        } finally {
+            names.remove(names.size() - 1);
+        }
+    }
+
+    public static String dotNames(List<String> names) {
+        int numNames = names.size();
+        if (numNames == 0) {
+            return "";
+        }
+
+        String name0 = names.get(0);
+        if (numNames == 1) {
+            return name0;
+        }
+
+        String name1 = names.get(1);
+        if (numNames == 2) {
+            return name0 + '.' + name1;
+        }
+
+        String name2 = names.get(2);
+        if (numNames == 3) {
+            return name0 + '.' + name1 + '.' + name2;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(name0).append('.').append(name1).append('.').append(name2);
+        for (int nameNo = 3; nameNo < numNames; nameNo++) {
+            builder.append('.');
+            builder.append(names.get(nameNo));
+        }
+        return builder.toString();
+    }
+
+    public static void verify(List<String> names, String expected, String actual) {
+        if (((expected == null) && (actual != null)) ||
+            ((expected != null) && !expected.equals(actual))) {
+            Assert.assertEquals(dotNames(names), expected, actual);
+        }
+    }
+
+    public static void verify(List<String> names, int expected, int actual) {
+        if (expected != actual) {
+            Assert.assertEquals(dotNames(names), expected, actual);
+        }
+    }
+
+    public static void verify(
+                              List<String> names,
+                              String expectedLang, String expectedValue,
+                              List<Description> actualDescriptions) {
+
+        if (actualDescriptions.size() != 1) {
+            Assert.assertEquals(
+                                "Descriptions should be a singleton [ " + actualDescriptions + " ] ",
+                                1, actualDescriptions.size());
+        }
+
+        Description actualDescription = actualDescriptions.get(0);
+        withName(names, "lang",
+                 (useNames) -> verify(useNames, expectedLang, actualDescription.getLang()));
+        withName(names, "value",
+                 (useNames) -> verify(useNames, expectedValue, actualDescription.getValue()));
+    }
+
+    public static void verify(
+                              List<String> names,
+                              String expectedName, String expectedValue,
+                              Property actualProperty) {
+
+        withName(names, "name",
+                 (useNames) -> verify(useNames, expectedName, actualProperty.getName()));
+        withName(names, "value",
+                 (useNames) -> verify(useNames, expectedValue, actualProperty.getValue()));
+    }
+
+    public static void verifySize(List<String> names, int expectedSize, List<?> actualList) {
+        withName(names, "size",
+                 (useNames) -> verify(useNames, expectedSize, actualList.size()));
+    }
+
+    public static void verifySize(List<String> names, int expectedSize, String[] actualList) {
+        withName(names, "size",
+                 (useNames) -> verify(useNames, expectedSize, actualList.length));
+    }
+
+    public static void verifyDoubleton(
+                                       List<String> names,
+                                       String expectedName0, String expectedValue0,
+                                       String expectedName1, String expectedValue1,
+                                       List<? extends Property> properties) {
+
+        verifySize(names, 2, properties);
+        withName(names, "[0]",
+                 (useNames) -> verify(useNames, expectedName0, expectedValue0, properties.get(0)));
+        withName(names, "[1]",
+                 (useNames) -> verify(useNames, expectedName1, expectedValue1, properties.get(1)));
+    }
+
+    public static final void verify(List<String> names, List<String> actual, String... expected) {
+        verifySize(names, expected.length, actual);
+
+        for (int elementNo = 0; elementNo < expected.length; elementNo++) {
+            final int finalElementNo = elementNo; // Needed by the compiler.
+            withName(names, "[" + elementNo + "]",
+                     (useNames) -> verify(useNames, expected[finalElementNo], actual.get(finalElementNo)));
+        }
+    }
+
+    public static final void verify(List<String> names, String[] actual, String... expected) {
+        verifySize(names, expected.length, actual);
+
+        for (int elementNo = 0; elementNo < expected.length; elementNo++) {
+            final int finalElementNo = elementNo; // Needed by the compiler.
+            withName(names, "[" + elementNo + "]",
+                     (useNames) -> verify(useNames, expected[finalElementNo], actual[finalElementNo]));
+        }
+    }
+
+    public static final String CONTEXT_SERVICE_XML = "<context-service id=\"CS01\">\n" +
+                                                     "  <description>CS01-desc</description>\n" +
+                                                     "  <name>CS01:name</name>\n" +
+                                                     "  <cleared>Application</cleared>\n" +
+                                                     "  <cleared>Security</cleared>\n" +
+                                                     "  <cleared>Transaction</cleared>\n" +
+                                                     "  <cleared>Remaining</cleared>\n" +
+                                                     "  <cleared>Other</cleared>\n" +
+                                                     "  <propagated>Application</propagated>\n" +
+                                                     "  <propagated>Security</propagated>\n" +
+                                                     "  <propagated>Remaining</propagated>\n" +
+                                                     "  <propagated>Other</propagated>\n" +
+                                                     "  <unchanged>Application</unchanged>\n" +
+                                                     "  <unchanged>Security</unchanged>\n" +
+                                                     "  <unchanged>Transaction</unchanged>\n" +
+                                                     "  <unchanged>Remaining</unchanged>\n" +
+                                                     "  <unchanged>Other</unchanged>\n" +
+                                                     "  <property>\n" +
+                                                     "    <name>CS01</name>\n" +
+                                                     "    <value>CS01-value</value>\n" +
+                                                     "  </property>\n" +
+                                                     "  <property>\n" +
+                                                     "    <name>CS02</name>\n" +
+                                                     "    <value>CS02-value</value>\n" +
+                                                     "  </property>\n" +
+                                                     "</context-service>\n";
+
+    public static void verify(List<String> names, ContextService contextService) {
+        // withName(names, "id",
+        //        (useNames) -> verify("CS01", contextService.getID())); // Can't be accessed here.
+        withName(names, "description",
+                 (useNames) -> verify(useNames, null, "CS01-desc", contextService.getDescriptions()));
+
+        withName(names, "name",
+                 (useNames) -> verify(useNames, "CS01:name", contextService.getName()));
+        withName(names, "cleared",
+                 (useNames) -> verify(useNames,
+                                      contextService.getCleared(),
+                                      "Application", "Security", "Transaction", "Remaining", "Other"));
+        withName(names, "propagated",
+                 (useNames) -> verify(useNames,
+                                      contextService.getPropagated(),
+                                      "Application", "Security", "Remaining", "Other"));
+        withName(names, "unchanged",
+                 (useNames) -> verify(useNames,
+                                      contextService.getUnchanged(),
+                                      "Application", "Security", "Transaction", "Remaining", "Other"));
+        withName(names, "properties",
+                 (useNames) -> verifyDoubleton(useNames,
+                                               "CS01", "CS01-value", "CS02", "CS02-value",
+                                               contextService.getProperties()));
+    }
+
+    public static final String MANAGED_EXECUTOR_XML = "<managed-executor id=\"ME01\">\n" +
+                                                      "  <description>ME01-desc</description>\n" +
+                                                      "  <name>ME01:name</name>\n" +
+                                                      "  <context-service-ref>java:comp</context-service-ref>\n" +
+                                                      "  <max-async>10</max-async>\n" +
+                                                      "  <hung-task-threshold>1000</hung-task-threshold>\n" +
+                                                      "  <property>\n" +
+                                                      "    <name>ME01</name>\n" +
+                                                      "    <value>ME01-value</value>\n" +
+                                                      "  </property>\n" +
+                                                      "  <property>\n" +
+                                                      "    <name>ME02</name>\n" +
+                                                      "    <value>ME02-value</value>\n" +
+                                                      "  </property>\n" +
+                                                      "</managed-executor>\n";
+
+    public static void verify(List<String> names, ManagedExecutor executor) {
+        // withName(names, "id",
+        //        (useNames) -> verify("ME01", executor.getID())); // Can't be accessed here.
+        withName(names, "description",
+                 (useNames) -> verify(useNames, null, "ME01-desc", executor.getDescriptions()));
+        withName(names, "name",
+                 (useNames) -> verify(useNames, "ME01:name", executor.getName()));
+        withName(names, "contextServiceRef",
+                 (useNames) -> verify(useNames, "java:comp", executor.getContextServiceRef()));
+        withName(names, "maxAsync",
+                 (useNames) -> verify(useNames, 10, executor.getMaxAsync()));
+        withName(names, "hungTaskThreshold",
+                 (useNames) -> verify(useNames, 1000, (int) executor.getHungTaskThreshold()));
+        withName(names, "properties",
+                 (useNames) -> verifyDoubleton(useNames,
+                                               "ME01", "ME01-value", "ME02", "ME02-value",
+                                               executor.getProperties()));
+    }
+
+    public static final String MANAGED_SCHEDULED_EXECUTOR_XML = "<managed-scheduled-executor id=\"MSE01\">\n" +
+                                                                "  <description>MSE01-desc</description>\n" +
+                                                                "  <name>MSE01:name</name>\n" +
+                                                                "  <context-service-ref>java:module</context-service-ref>\n" +
+                                                                "  <max-async>11</max-async>\n" +
+                                                                "  <hung-task-threshold>1100</hung-task-threshold>\n" +
+                                                                "  <property>\n" +
+                                                                "    <name>MSE01</name>\n" +
+                                                                "    <value>MSE01-value</value>\n" +
+                                                                "  </property>\n" +
+                                                                "  <property>\n" +
+                                                                "    <name>MSE02</name>\n" +
+                                                                "    <value>MSE02-value</value>\n" +
+                                                                "  </property>\n" +
+                                                                "</managed-scheduled-executor>\n";
+
+    public static void verify(List<String> names, ManagedScheduledExecutor executor) {
+        // withName(names, "id",
+        //        (useNames) -> verify("MSE01", executor.getID())); // Can't be accessed here.
+        withName(names, "description",
+                 (useNames) -> verify(useNames, null, "MSE01-desc", executor.getDescriptions()));
+        withName(names, "name",
+                 (useNames) -> verify(useNames, "MSE01:name", executor.getName()));
+        withName(names, "contextServiceRef",
+                 (useNames) -> verify(useNames, "java:module", executor.getContextServiceRef()));
+        withName(names, "maxAsync",
+                 (useNames) -> verify(useNames, 11, executor.getMaxAsync()));
+        withName(names, "hungTaskThreshold",
+                 (useNames) -> verify(useNames, 1100, (int) executor.getHungTaskThreshold()));
+        withName(names, "properties",
+                 (useNames) -> verifyDoubleton(useNames,
+                                               "MSE01", "MSE01-value", "MSE02", "MSE02-value",
+                                               executor.getProperties()));
+    }
+
+    public static final String MANAGED_THREAD_FACTORY_XML = "<managed-thread-factory id=\"MTF01\">\n" +
+                                                            "  <description>MTF01-desc</description>\n" +
+                                                            "  <name>MTF01:name</name>\n" +
+                                                            "  <context-service-ref>java:app</context-service-ref>\n" +
+                                                            "  <priority>10</priority>\n" +
+                                                            "  <property>\n" +
+                                                            "    <name>MTF01</name>\n" +
+                                                            "    <value>MTF01-value</value>\n" +
+                                                            "  </property>\n" +
+                                                            "  <property>\n" +
+                                                            "    <name>MTF02</name>\n" +
+                                                            "    <value>MTF02-value</value>\n" +
+                                                            "  </property>\n" +
+                                                            "</managed-thread-factory>\n";
+
+    public static void verify(List<String> names, ManagedThreadFactory factory) {
+        // withName(names, "id",
+        //        (useNames) -> verify("MTF01", factory.getID())); // Can't be accessed here.
+        withName(names, "description",
+                 (useNames) -> verify(useNames, null, "MTF01-desc", factory.getDescriptions()));
+        withName(names, "name",
+                 (useNames) -> verify(useNames, "MTF01:name", factory.getName()));
+        withName(names, "contextServiceRef",
+                 (useNames) -> verify(useNames, "java:app", factory.getContextServiceRef()));
+        withName(names, "priority",
+                 (useNames) -> verify(useNames, 10, factory.getPriority()));
+        withName(names, "properties",
+                 (useNames) -> verifyDoubleton(useNames,
+                                               "MTF01", "MTF01-value", "MTF02", "MTF02-value",
+                                               factory.getProperties()));
+    }
+
+    //
+
+    public static void verifyEE10(List<String> names, JNDIEnvironmentRefs refs) {
+        List<ContextService> services = refs.getContextServices();
+        DDJakarta11Elements.verifySize(names, 1, services);
+        DDJakarta11Elements.verify(names, services.get(0));
+
+        List<ManagedExecutor> executors = refs.getManagedExecutors();
+        DDJakarta11Elements.verifySize(names, 1, executors);
+        DDJakarta11Elements.verify(names, executors.get(0));
+
+        List<ManagedScheduledExecutor> scheduledExecutors = refs.getManagedScheduledExecutors();
+        DDJakarta11Elements.verifySize(names, 1, scheduledExecutors);
+        DDJakarta11Elements.verify(names, scheduledExecutors.get(0));
+
+        List<ManagedThreadFactory> factories = refs.getManagedThreadFactories();
+        DDJakarta11Elements.verifySize(names, 1, factories);
+        DDJakarta11Elements.verify(names, factories.get(0));
+    }
+}

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/DDJakarta11Elements.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/DDJakarta11Elements.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -27,99 +27,56 @@ import com.ibm.ws.javaee.dd.common.ManagedThreadFactory;
 import com.ibm.ws.javaee.dd.common.Property;
 
 /*
- * jakartaee_10.xsd - jakartaee_9.xsd
+ * jakartaee_11.xsd - jakartaee_10.xsd
+ *   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
+              schemaLocation="https://www.w3.org/2001/xml.xsd"/>
 
-  <xsd:group name="jndiEnvironmentRefsGroup">
-      <xsd:element name="context-service" type="jakartaee:context-serviceType" minOccurs="0" maxOccurs="unbounded"/>
-      <xsd:element name="managed-executor" type="jakartaee:managed-executorType" minOccurs="0" maxOccurs="unbounded"/>
-      <xsd:element name="managed-scheduled-executor" type="jakartaee:managed-scheduled-executorType" minOccurs="0" maxOccurs="unbounded"/>
-      <xsd:element name="managed-thread-factory" type="jakartaee:managed-thread-factoryType" minOccurs="0" maxOccurs="unbounded"/>
+<xsd:complexType name="context-serviceType">
+      <xsd:element name="qualifier"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+      </xsd:element>
+</xsd:complexType>
 
-  j2ee_1_4.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
-  javaee_5.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
-  javaee_6.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
-  javaee_7.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
-  javaee_8.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
-  jakartaee_9.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
-  jakartaee_10.xsd:  <xsd:group name="jndiEnvironmentRefsGroup">
+<xsd:complexType name="managed-executorType">
+      <xsd:element name="virtual"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+      </xsd:element>
+      <xsd:element name="qualifier"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+      </xsd:element>
+</xsd:complexType>
 
-  ejb-jar_4_0.xsd:      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
-  ejb-jar_4_0.xsd:      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
-  ejb-jar_4_0.xsd:      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
-  ejb-jar_4_0.xsd:      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+<xsd:complexType name="managed-scheduled-executorType">
+      <xsd:element name="virtual"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+      </xsd:element>
+      <xsd:element name="qualifier"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+      </xsd:element>
+</xsd:complexType>
 
-  web-app_2_4.xsd:      <xsd:group ref="j2ee:jndiEnvironmentRefsGroup"/>
-  web-app_2_5.xsd:      <xsd:group ref="javaee:jndiEnvironmentRefsGroup"/>
-
-  web-common_3_0.xsd:      <xsd:group ref="javaee:jndiEnvironmentRefsGroup"/>
-  --> web-app_3_0.xsd
-  --> web-fragment_3_0.xsd
-  web-common_5_0.xsd:      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
-  --> web-app_5_0.xsd
-  --> web-fragment_5_0.xsd
-  web-common_6_0.xsd:      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
-  --> web-app_6_0.xsd
-  --> web-fragment_6_0.xsd
-
-  ejb-jar_4_0.xsd
-    <xsd:complexType name="entity-beanType">
-    <xsd:complexType name="interceptorType">
-    <xsd:complexType name="message-driven-beanType">
-    <xsd:complexType name="session-beanType">
-      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
-
-  web-common_6_0.xsd:
-    <xsd:group name="web-commonType">
-      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
- */
-
-/*
-    <xsd:complexType name="context-serviceType">
-    <xsd:sequence>
-      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0"/>
-      <xsd:element name="name" type="jakartaee:jndi-nameType"/>
-      <xsd:element name="cleared" type="jakartaee:string" minOccurs="0" maxOccurs="unbounded"/>
-      <xsd:element name="propagated" type="jakartaee:string" minOccurs="0" maxOccurs="unbounded"/>
-      <xsd:element name="unchanged" type="jakartaee:string" minOccurs="0" maxOccurs="unbounded"/>
-      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded"/>
-    </xsd:sequence>
-    <xsd:attribute name="id" type="xsd:ID"/>
-  </xsd:complexType>
-
-  <xsd:complexType name="managed-executorType">
-    <xsd:sequence>
-      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0"/>
-      <xsd:element name="name" type="jakartaee:jndi-nameType"/>
-      <xsd:element name="context-service-ref" type="jakartaee:jndi-nameType" minOccurs="0" maxOccurs="1"/>
-      <xsd:element name="max-async" type="jakartaee:xsdPositiveIntegerType" minOccurs="0" maxOccurs="1"/>
-      <xsd:element name="hung-task-threshold" type="jakartaee:xsdPositiveIntegerType" minOccurs="0" maxOccurs="1"/>
-      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded"/>
-    </xsd:sequence>
-    <xsd:attribute name="id" type="xsd:ID"/>
-  </xsd:complexType>
-
-  <xsd:complexType name="managed-scheduled-executorType">
-    <xsd:sequence>
-      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0"/>
-      <xsd:element name="name" type="jakartaee:jndi-nameType"/>
-      <xsd:element name="context-service-ref" type="jakartaee:jndi-nameType" minOccurs="0" maxOccurs="1"/>
-      <xsd:element name="max-async" type="jakartaee:xsdPositiveIntegerType" minOccurs="0" maxOccurs="1"/>
-      <xsd:element name="hung-task-threshold" type="jakartaee:xsdPositiveIntegerType" minOccurs="0" maxOccurs="1"/>
-      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded"/>
-    </xsd:sequence>
-    <xsd:attribute name="id" type="xsd:ID"/>
-  </xsd:complexType>
-
-  <xsd:complexType name="managed-thread-factoryType">
-    <xsd:sequence>
-      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0">
-      <xsd:element name="name" type="jakartaee:jndi-nameType"/>
-      <xsd:element name="context-service-ref" type="jakartaee:jndi-nameType" minOccurs="0" maxOccurs="1"/>
-      <xsd:element name="priority" type="jakartaee:priorityType" minOccurs="0" maxOccurs="1"/>
-      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded"/>
-    </xsd:sequence>
-    <xsd:attribute name="id" type="xsd:ID"/>
-  </xsd:complexType>
+<xsd:complexType name="managed-thread-factoryType">
+      <xsd:element name="virtual"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+      </xsd:element>
+      <xsd:element name="qualifier"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+      </xsd:element>
+</xsd:complexType>
 */
 public class DDJakarta11Elements {
 
@@ -178,6 +135,12 @@ public class DDJakarta11Elements {
     }
 
     public static void verify(List<String> names, int expected, int actual) {
+        if (expected != actual) {
+            Assert.assertEquals(dotNames(names), expected, actual);
+        }
+    }
+
+    public static void verify(List<String> names, boolean expected, boolean actual) {
         if (expected != actual) {
             Assert.assertEquals(dotNames(names), expected, actual);
         }
@@ -272,6 +235,8 @@ public class DDJakarta11Elements {
                                                      "  <unchanged>Transaction</unchanged>\n" +
                                                      "  <unchanged>Remaining</unchanged>\n" +
                                                      "  <unchanged>Other</unchanged>\n" +
+                                                     "  <qualifier>com.ibm.test.Qualifier1</qualifier>\n" +
+                                                     "  <qualifier>com.ibm.test.Qualifier2</qualifier>\n" +
                                                      "  <property>\n" +
                                                      "    <name>CS01</name>\n" +
                                                      "    <value>CS01-value</value>\n" +
@@ -302,6 +267,10 @@ public class DDJakarta11Elements {
                  (useNames) -> verify(useNames,
                                       contextService.getUnchanged(),
                                       "Application", "Security", "Transaction", "Remaining", "Other"));
+        withName(names, "qualifier",
+                 (useNames) -> verify(useNames,
+                                      contextService.getQualifier(),
+                                      "com.ibm.test.Qualifier1", "com.ibm.test.Qualifier2"));
         withName(names, "properties",
                  (useNames) -> verifyDoubleton(useNames,
                                                "CS01", "CS01-value", "CS02", "CS02-value",
@@ -314,6 +283,8 @@ public class DDJakarta11Elements {
                                                       "  <context-service-ref>java:comp</context-service-ref>\n" +
                                                       "  <max-async>10</max-async>\n" +
                                                       "  <hung-task-threshold>1000</hung-task-threshold>\n" +
+                                                      "  <virtual>true</virtual>\n" +
+                                                      "  <qualifier>com.ibm.test.Qualifier3</qualifier>\n" +
                                                       "  <property>\n" +
                                                       "    <name>ME01</name>\n" +
                                                       "    <value>ME01-value</value>\n" +
@@ -337,6 +308,12 @@ public class DDJakarta11Elements {
                  (useNames) -> verify(useNames, 10, executor.getMaxAsync()));
         withName(names, "hungTaskThreshold",
                  (useNames) -> verify(useNames, 1000, (int) executor.getHungTaskThreshold()));
+        withName(names, "virtual",
+                 (useNames) -> verify(useNames, true, executor.isVirtual()));
+        withName(names, "qualifier",
+                 (useNames) -> verify(useNames,
+                                      executor.getQualifier(),
+                                      "com.ibm.test.Qualifier3"));
         withName(names, "properties",
                  (useNames) -> verifyDoubleton(useNames,
                                                "ME01", "ME01-value", "ME02", "ME02-value",
@@ -349,6 +326,9 @@ public class DDJakarta11Elements {
                                                                 "  <context-service-ref>java:module</context-service-ref>\n" +
                                                                 "  <max-async>11</max-async>\n" +
                                                                 "  <hung-task-threshold>1100</hung-task-threshold>\n" +
+                                                                "  <qualifier>com.ibm.test.Qualifier4</qualifier>\n" +
+                                                                "  <qualifier>com.ibm.test.Qualifier5</qualifier>\n" +
+                                                                "  <qualifier>com.ibm.test.Qualifier6</qualifier>\n" +
                                                                 "  <property>\n" +
                                                                 "    <name>MSE01</name>\n" +
                                                                 "    <value>MSE01-value</value>\n" +
@@ -372,6 +352,12 @@ public class DDJakarta11Elements {
                  (useNames) -> verify(useNames, 11, executor.getMaxAsync()));
         withName(names, "hungTaskThreshold",
                  (useNames) -> verify(useNames, 1100, (int) executor.getHungTaskThreshold()));
+        withName(names, "virtual",
+                 (useNames) -> verify(useNames, false, executor.isVirtual())); //Default value should be false
+        withName(names, "qualifier",
+                 (useNames) -> verify(useNames,
+                                      executor.getQualifier(),
+                                      "com.ibm.test.Qualifier4", "com.ibm.test.Qualifier5", "com.ibm.test.Qualifier6"));
         withName(names, "properties",
                  (useNames) -> verifyDoubleton(useNames,
                                                "MSE01", "MSE01-value", "MSE02", "MSE02-value",
@@ -383,6 +369,7 @@ public class DDJakarta11Elements {
                                                             "  <name>MTF01:name</name>\n" +
                                                             "  <context-service-ref>java:app</context-service-ref>\n" +
                                                             "  <priority>10</priority>\n" +
+                                                            "  <virtual>false</virtual>\n" +
                                                             "  <property>\n" +
                                                             "    <name>MTF01</name>\n" +
                                                             "    <value>MTF01-value</value>\n" +
@@ -404,6 +391,11 @@ public class DDJakarta11Elements {
                  (useNames) -> verify(useNames, "java:app", factory.getContextServiceRef()));
         withName(names, "priority",
                  (useNames) -> verify(useNames, 10, factory.getPriority()));
+        withName(names, "virtual",
+                 (useNames) -> verify(useNames, false, factory.isVirtual()));
+        withName(names, "qualifier",
+                 (useNames) -> verify(useNames,
+                                      factory.getQualifier())); //None provided
         withName(names, "properties",
                  (useNames) -> verifyDoubleton(useNames,
                                                "MTF01", "MTF01-value", "MTF02", "MTF02-value",
@@ -412,7 +404,7 @@ public class DDJakarta11Elements {
 
     //
 
-    public static void verifyEE10(List<String> names, JNDIEnvironmentRefs refs) {
+    public static void verifyEE11(List<String> names, JNDIEnvironmentRefs refs) {
         List<ContextService> services = refs.getContextServices();
         DDJakarta11Elements.verifySize(names, 1, services);
         DDJakarta11Elements.verify(names, services.get(0));

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/DDJakarta11Elements.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/DDJakarta11Elements.java
@@ -269,7 +269,7 @@ public class DDJakarta11Elements {
                                       "Application", "Security", "Transaction", "Remaining", "Other"));
         withName(names, "qualifier",
                  (useNames) -> verify(useNames,
-                                      contextService.getQualifier(),
+                                      contextService.getQualifiers(),
                                       "com.ibm.test.Qualifier1", "com.ibm.test.Qualifier2"));
         withName(names, "properties",
                  (useNames) -> verifyDoubleton(useNames,
@@ -312,7 +312,7 @@ public class DDJakarta11Elements {
                  (useNames) -> verify(useNames, true, executor.isVirtual()));
         withName(names, "qualifier",
                  (useNames) -> verify(useNames,
-                                      executor.getQualifier(),
+                                      executor.getQualifiers(),
                                       "com.ibm.test.Qualifier3"));
         withName(names, "properties",
                  (useNames) -> verifyDoubleton(useNames,
@@ -356,7 +356,7 @@ public class DDJakarta11Elements {
                  (useNames) -> verify(useNames, false, executor.isVirtual())); //Default value should be false
         withName(names, "qualifier",
                  (useNames) -> verify(useNames,
-                                      executor.getQualifier(),
+                                      executor.getQualifiers(),
                                       "com.ibm.test.Qualifier4", "com.ibm.test.Qualifier5", "com.ibm.test.Qualifier6"));
         withName(names, "properties",
                  (useNames) -> verifyDoubleton(useNames,
@@ -395,7 +395,7 @@ public class DDJakarta11Elements {
                  (useNames) -> verify(useNames, false, factory.isVirtual()));
         withName(names, "qualifier",
                  (useNames) -> verify(useNames,
-                                      factory.getQualifier())); //None provided
+                                      factory.getQualifiers())); //None provided
         withName(names, "properties",
                  (useNames) -> verifyDoubleton(useNames,
                                                "MTF01", "MTF01-value", "MTF02", "MTF02-value",

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/app/AppTest.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/app/AppTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,22 +15,24 @@ package com.ibm.ws.javaee.ddmodel.app;
 import java.util.List;
 
 import org.junit.Test;
+
 import com.ibm.ws.javaee.dd.app.Application;
 import com.ibm.ws.javaee.dd.common.ContextService;
 import com.ibm.ws.javaee.dd.common.ManagedExecutor;
 import com.ibm.ws.javaee.dd.common.ManagedScheduledExecutor;
 import com.ibm.ws.javaee.dd.common.ManagedThreadFactory;
 import com.ibm.ws.javaee.ddmodel.DDJakarta10Elements;
+import com.ibm.ws.javaee.ddmodel.DDJakarta11Elements;
 
 public class AppTest extends AppTestBase {
     @Test
     public void testApp() throws Exception {
-        for ( int schemaVersion : Application.VERSIONS ) {
-            for ( int maxSchemaVersion : Application.VERSIONS ) {
+        for (int schemaVersion : Application.VERSIONS) {
+            for (int maxSchemaVersion : Application.VERSIONS) {
                 // Open liberty will always parse JavaEE6 and earlier
                 // schema versions.
                 int effectiveMax;
-                if ( maxSchemaVersion < VERSION_6_0_INT ) {
+                if (maxSchemaVersion < VERSION_6_0_INT) {
                     effectiveMax = VERSION_6_0_INT;
                 } else {
                     effectiveMax = maxSchemaVersion;
@@ -38,104 +40,164 @@ public class AppTest extends AppTestBase {
 
                 String altMessage;
                 String[] messages;
-                if ( schemaVersion > effectiveMax ) {
-                    altMessage = UNPROVISIONED_DESCRIPTOR_VERSION_ALT_MESSAGE; 
+                if (schemaVersion > effectiveMax) {
+                    altMessage = UNPROVISIONED_DESCRIPTOR_VERSION_ALT_MESSAGE;
                     messages = UNPROVISIONED_DESCRIPTOR_VERSION_MESSAGES;
                 } else {
                     altMessage = null;
                     messages = null;
                 }
 
-                parseApp( app(schemaVersion, appBody), maxSchemaVersion, altMessage, messages );
+                parseApp(app(schemaVersion, appBody), maxSchemaVersion, altMessage, messages);
             }
         }
     }
 
-    //
-    
+    // Verify new elements to EE 10 cannot be used with EE 9 schema
+
     @Test
     public void testEE10ContextServiceApp90() throws Exception {
-        parseApp( app(Application.VERSION_9, DDJakarta10Elements.CONTEXT_SERVICE_XML),
-                  Application.VERSION_9,
-                  "unexpected.child.element",
-                  "CWWKC2259E", "context-service", "myEAR.ear : META-INF/application.xml" );                
-    }    
-    
+        parseApp(app(Application.VERSION_9, DDJakarta10Elements.CONTEXT_SERVICE_XML),
+                 Application.VERSION_9,
+                 "unexpected.child.element",
+                 "CWWKC2259E", "context-service", "myEAR.ear : META-INF/application.xml");
+    }
+
     @Test
     public void testEE10ManagedExecutorApp90() throws Exception {
-        parseApp( app(Application.VERSION_9, DDJakarta10Elements.MANAGED_EXECUTOR_XML),
-                  Application.VERSION_9,
-                  "unexpected.child.element",
-                  "CWWKC2259E", "managed-executor", "myEAR.ear : META-INF/application.xml" );                
-    }    
+        parseApp(app(Application.VERSION_9, DDJakarta10Elements.MANAGED_EXECUTOR_XML),
+                 Application.VERSION_9,
+                 "unexpected.child.element",
+                 "CWWKC2259E", "managed-executor", "myEAR.ear : META-INF/application.xml");
+    }
 
     @Test
     public void testEE10ManagedScheduledExecutorApp90() throws Exception {
-        parseApp( app(Application.VERSION_9, DDJakarta10Elements.MANAGED_SCHEDULED_EXECUTOR_XML),
-                  Application.VERSION_9,
-                  "unexpected.child.element",
-                  "CWWKC2259E", "managed-scheduled-executor", "myEAR.ear : META-INF/application.xml" );                
+        parseApp(app(Application.VERSION_9, DDJakarta10Elements.MANAGED_SCHEDULED_EXECUTOR_XML),
+                 Application.VERSION_9,
+                 "unexpected.child.element",
+                 "CWWKC2259E", "managed-scheduled-executor", "myEAR.ear : META-INF/application.xml");
     }
 
     @Test
     public void testEE10ManagedThreadFactoryApp90() throws Exception {
-        parseApp( app(Application.VERSION_9, DDJakarta10Elements.MANAGED_THREAD_FACTORY_XML),
-                  Application.VERSION_9,
-                  "unexpected.child.element",
-                  "CWWKC2259E", "managed-thread-factory", "myEAR.ear : META-INF/application.xml" );                
-    }      
+        parseApp(app(Application.VERSION_9, DDJakarta10Elements.MANAGED_THREAD_FACTORY_XML),
+                 Application.VERSION_9,
+                 "unexpected.child.element",
+                 "CWWKC2259E", "managed-thread-factory", "myEAR.ear : META-INF/application.xml");
+    }
 
-    //
+    //  Verify new elements to EE 10 are parsed correctly
 
     @Test
     public void testEE10ContextServiceApp100() throws Exception {
         Application app = parseApp(
-                app(Application.VERSION_10, DDJakarta10Elements.CONTEXT_SERVICE_XML),
-                Application.VERSION_10);
+                                   app(Application.VERSION_10, DDJakarta10Elements.CONTEXT_SERVICE_XML),
+                                   Application.VERSION_10);
 
         List<String> names = DDJakarta10Elements.names("Application", "contextServices");
 
         List<ContextService> services = app.getContextServices();
         DDJakarta10Elements.verifySize(names, 1, services);
-        DDJakarta10Elements.verify(names, services.get(0));        
-    }    
-    
+        DDJakarta10Elements.verify(names, services.get(0));
+    }
+
     @Test
     public void testEE10ManagedExecutorApp100() throws Exception {
         Application app = parseApp(
-                app(Application.VERSION_10, DDJakarta10Elements.MANAGED_EXECUTOR_XML),
-                Application.VERSION_10);
+                                   app(Application.VERSION_10, DDJakarta10Elements.MANAGED_EXECUTOR_XML),
+                                   Application.VERSION_10);
 
         List<String> names = DDJakarta10Elements.names("Application", "managedExecutors");
 
         List<ManagedExecutor> executors = app.getManagedExecutors();
         DDJakarta10Elements.verifySize(names, 1, executors);
-        DDJakarta10Elements.verify(names, executors.get(0));        
-    }    
+        DDJakarta10Elements.verify(names, executors.get(0));
+    }
 
     @Test
     public void testEE10ManagedScheduledExecutorApp100() throws Exception {
         Application app = parseApp(
-                app(Application.VERSION_10, DDJakarta10Elements.MANAGED_SCHEDULED_EXECUTOR_XML),
-                Application.VERSION_10);
+                                   app(Application.VERSION_10, DDJakarta10Elements.MANAGED_SCHEDULED_EXECUTOR_XML),
+                                   Application.VERSION_10);
 
         List<String> names = DDJakarta10Elements.names("Application", "managedScheduledExecutors");
-        
+
         List<ManagedScheduledExecutor> executors = app.getManagedScheduledExecutors();
         DDJakarta10Elements.verifySize(names, 1, executors);
-        DDJakarta10Elements.verify(names, executors.get(0));        
+        DDJakarta10Elements.verify(names, executors.get(0));
     }
 
     @Test
     public void testEE10ManagedThreadFactoryApp100() throws Exception {
         Application app = parseApp(
-                app(Application.VERSION_10, DDJakarta10Elements.MANAGED_THREAD_FACTORY_XML),
-                Application.VERSION_10);
+                                   app(Application.VERSION_10, DDJakarta10Elements.MANAGED_THREAD_FACTORY_XML),
+                                   Application.VERSION_10);
 
         List<String> names = DDJakarta10Elements.names("Application", "managedThreadFactories");
 
         List<ManagedThreadFactory> factories = app.getManagedThreadFactories();
         DDJakarta10Elements.verifySize(names, 1, factories);
         DDJakarta10Elements.verify(names, factories.get(0));
-    }      
+    }
+
+    // TODO Verify new elements to EE 11 cannot be used with EE 10 schema
+    // I do not see any other schema additions testing for this.
+    // I assume it is up to the component (i.e. concurrency) to
+    // warn the user if they configure an element that is for EE 11 while
+    // using the EE 10 feature.
+
+    // Verify new elements to EE 11 are parsed correctly
+
+    @Test
+    public void testEE11ContextServiceApp110() throws Exception {
+        Application app = parseApp(
+                                   app(Application.VERSION_11, DDJakarta11Elements.CONTEXT_SERVICE_XML),
+                                   Application.VERSION_11);
+
+        List<String> names = DDJakarta10Elements.names("Application", "contextServices");
+
+        List<ContextService> services = app.getContextServices();
+        DDJakarta10Elements.verifySize(names, 1, services);
+        DDJakarta10Elements.verify(names, services.get(0));
+    }
+
+    @Test
+    public void testEE11ManagedExecutorApp110() throws Exception {
+        Application app = parseApp(
+                                   app(Application.VERSION_11, DDJakarta11Elements.MANAGED_EXECUTOR_XML),
+                                   Application.VERSION_11);
+
+        List<String> names = DDJakarta10Elements.names("Application", "managedExecutors");
+
+        List<ManagedExecutor> executors = app.getManagedExecutors();
+        DDJakarta10Elements.verifySize(names, 1, executors);
+        DDJakarta10Elements.verify(names, executors.get(0));
+    }
+
+    @Test
+    public void testEE11ManagedScheduledExecutorApp110() throws Exception {
+        Application app = parseApp(
+                                   app(Application.VERSION_11, DDJakarta11Elements.MANAGED_SCHEDULED_EXECUTOR_XML),
+                                   Application.VERSION_11);
+
+        List<String> names = DDJakarta10Elements.names("Application", "managedScheduledExecutors");
+
+        List<ManagedScheduledExecutor> executors = app.getManagedScheduledExecutors();
+        DDJakarta10Elements.verifySize(names, 1, executors);
+        DDJakarta10Elements.verify(names, executors.get(0));
+    }
+
+    @Test
+    public void testEE11ManagedThreadFactoryApp110() throws Exception {
+        Application app = parseApp(
+                                   app(Application.VERSION_11, DDJakarta11Elements.MANAGED_THREAD_FACTORY_XML),
+                                   Application.VERSION_11);
+
+        List<String> names = DDJakarta10Elements.names("Application", "managedThreadFactories");
+
+        List<ManagedThreadFactory> factories = app.getManagedThreadFactories();
+        DDJakarta10Elements.verifySize(names, 1, factories);
+        DDJakarta10Elements.verify(names, factories.get(0));
+    }
 }

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/app/AppTest.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/app/AppTest.java
@@ -141,12 +141,6 @@ public class AppTest extends AppTestBase {
         DDJakarta10Elements.verify(names, factories.get(0));
     }
 
-    // TODO Verify new elements to EE 11 cannot be used with EE 10 schema
-    // I do not see any other schema additions testing for this.
-    // I assume it is up to the component (i.e. concurrency) to
-    // warn the user if they configure an element that is for EE 11 while
-    // using the EE 10 feature.
-
     // Verify new elements to EE 11 are parsed correctly
 
     @Test

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/app/AppTestBase.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/app/AppTestBase.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -26,7 +26,7 @@ public class AppTestBase extends DDTestBase {
             mockery.mock(ServiceReference.class, "sr" + mockId++);
         String versionText = getDottedVersionText(maxSchemaVersion);
         mockery.checking(new Expectations() {
-            {                
+            {
                 allowing(versionRef).getProperty("version");
                 will(returnValue(versionText));
             }
@@ -143,6 +143,16 @@ public class AppTestBase extends DDTestBase {
                    " id=\"Application_ID\"" +
                    ">";
     
+    protected static String app110Head =
+            "<application" +
+                   " xmlns=\"https://jakarta.ee/xml/ns/jakartaee\"" +
+                   " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                   " xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee" +
+                   " https://jakarta.ee/xml/ns/jakartaee/application_11.xsd\"" +
+                   " version=\"11\"" +
+                   " id=\"Application_ID\"" +
+                   ">";
+
     protected static String appBody =
             "<display-name>Deployment Descriptor FAT Enterprise Application</display-name>\n" +
 
@@ -193,7 +203,9 @@ public class AppTestBase extends DDTestBase {
         } else if ( schemaVersion == VERSION_9_0_INT ) {
             appHead = app90Head;
         } else if ( schemaVersion == VERSION_10_0_INT ) {
-            appHead = app100Head;            
+            appHead = app100Head;
+        } else if ( schemaVersion == VERSION_11_0_INT ) {
+            appHead = app110Head; 
         } else {
             throw new IllegalArgumentException("Unknown application version [ " + schemaVersion + " ]");
         }

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/web/WebAppTest.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/web/WebAppTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -28,6 +28,7 @@ import com.ibm.ws.javaee.dd.web.common.AbsoluteOrdering;
 import com.ibm.ws.javaee.dd.web.common.AttributeValue;
 import com.ibm.ws.javaee.dd.web.common.CookieConfig;
 import com.ibm.ws.javaee.ddmodel.DDJakarta10Elements;
+import com.ibm.ws.javaee.ddmodel.DDJakarta11Elements;
 
 public class WebAppTest extends WebAppTestBase {
     // Absolute ordering fragments.
@@ -338,6 +339,60 @@ public class WebAppTest extends WebAppTestBase {
         WebApp webApp = parseWebApp(
                                     webApp(WebApp.VERSION_6_0, DDJakarta10Elements.MANAGED_THREAD_FACTORY_XML),
                                     WebApp.VERSION_6_0);
+
+        List<String> names = DDJakarta10Elements.names("WebApp", "managedThreadFactories");
+
+        List<ManagedThreadFactory> factories = webApp.getManagedThreadFactories();
+        DDJakarta10Elements.verifySize(names, 1, factories);
+        DDJakarta10Elements.verify(names, factories.get(0));
+    }
+
+    //
+
+    @Test
+    public void testEE11ContextServiceWeb61() throws Exception {
+        WebApp webApp = parseWebApp(
+                                    webApp(WebApp.VERSION_6_1, DDJakarta11Elements.CONTEXT_SERVICE_XML),
+                                    WebApp.VERSION_6_1);
+
+        List<String> names = DDJakarta10Elements.names("WebApp", "contextServices");
+
+        List<ContextService> services = webApp.getContextServices();
+        DDJakarta10Elements.verifySize(names, 1, services);
+        DDJakarta10Elements.verify(names, services.get(0));
+    }
+
+    @Test
+    public void testEE11ManagedExecutorWeb61() throws Exception {
+        WebApp webApp = parseWebApp(
+                                    webApp(WebApp.VERSION_6_1, DDJakarta11Elements.MANAGED_EXECUTOR_XML),
+                                    WebApp.VERSION_6_1);
+
+        List<String> names = DDJakarta10Elements.names("WebApp", "managedExecutors");
+
+        List<ManagedExecutor> executors = webApp.getManagedExecutors();
+        DDJakarta10Elements.verifySize(names, 1, executors);
+        DDJakarta10Elements.verify(names, executors.get(0));
+    }
+
+    @Test
+    public void testEE11ManagedScheduledExecutorWeb61() throws Exception {
+        WebApp webApp = parseWebApp(
+                                    webApp(WebApp.VERSION_6_1, DDJakarta11Elements.MANAGED_SCHEDULED_EXECUTOR_XML),
+                                    WebApp.VERSION_6_1);
+
+        List<String> names = DDJakarta10Elements.names("WebApp", "managedScheduledExecutors");
+
+        List<ManagedScheduledExecutor> executors = webApp.getManagedScheduledExecutors();
+        DDJakarta10Elements.verifySize(names, 1, executors);
+        DDJakarta10Elements.verify(names, executors.get(0));
+    }
+
+    @Test
+    public void testEE11ManagedThreadFactoryWeb61() throws Exception {
+        WebApp webApp = parseWebApp(
+                                    webApp(WebApp.VERSION_6_1, DDJakarta11Elements.MANAGED_THREAD_FACTORY_XML),
+                                    WebApp.VERSION_6_1);
 
         List<String> names = DDJakarta10Elements.names("WebApp", "managedThreadFactories");
 

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/web/WebAppTestBase.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/web/WebAppTestBase.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -156,6 +156,15 @@ public class WebAppTestBase extends DDTestBase {
                ">";
     }
 
+    protected static String webApp61Head() {
+        return "<web-app xmlns=\"https://jakarta.ee/xml/ns/jakartaee\"" +
+                   " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                   " xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd\"" +
+                   " version=\"6.1\"" +
+                   " id=\"WebApp_ID\"" +
+               ">";
+    }
+
     protected static String webAppTail() {
         return "</web-app>";
     }
@@ -198,8 +207,9 @@ public class WebAppTestBase extends DDTestBase {
         } else if ( version == WebApp.VERSION_5_0 ) {
             head = webApp50Head();
         } else if ( version == WebApp.VERSION_6_0 ) {
-            head = webApp60Head();  
-            
+            head = webApp60Head();
+        } else if ( version == WebApp.VERSION_6_1 ) {
+            head = webApp61Head();
         } else {
             throw new IllegalArgumentException("Unexpected WebVersion [ " + version + " ]");
         }

--- a/dev/io.openliberty.concurrent.internal/bnd.bnd
+++ b/dev/io.openliberty.concurrent.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2022 IBM Corporation and others.
+# Copyright (c) 2021, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -67,4 +67,4 @@ instrument.classesExcludes: io/openliberty/concurrent/internal/resources/*.class
   com.ibm.ws.logging.core;version=latest,\
   com.ibm.ws.resource;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-  io.openliberty.jakarta.concurrency.3.0;version=latest
+  io.openliberty.jakarta.concurrency.3.1;version=latest

--- a/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
+++ b/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
@@ -46,7 +46,7 @@ CWWKC1204.not.serializable=CWWKC1204E: Cannot create a serializable contextual p
 CWWKC1204.not.serializable.explanation=Third-party thread context types are not compatible with serialization and cannot be configured to be propagated for serializable contextual proxies.
 CWWKC1204.not.serializable.useraction=Update the application to request a non-serializable contextual proxy or ensure that no third-party context types are configured to be propagated.
 
-CWWKC1205.qualifier.class.not.found=CWWKC1205E: The {0} qualifier annotation, which is defined by a deployment descriptor, could not be loaded by the application classloader.
+CWWKC1205.qualifier.class.not.found=CWWKC1205E: The {0} qualifier annotation class, which is defined by a deployment descriptor, could not be loaded by the application classloader.
 CWWKC1205.qualifier.class.not.found.explanation=Qualifier elements that are configured by the application.xml file or the web.xml file contain a class name that could not be loaded.
 CWWKC1205.qualifier.class.not.found.useraction=Verify that the qualifier elements are configured with a fully qualified class name, and that the class is present within the application.
 

--- a/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
+++ b/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
@@ -46,9 +46,9 @@ CWWKC1204.not.serializable=CWWKC1204E: Cannot create a serializable contextual p
 CWWKC1204.not.serializable.explanation=Third-party thread context types are not compatible with serialization and cannot be configured to be propagated for serializable contextual proxies.
 CWWKC1204.not.serializable.useraction=Update the application to request a non-serializable contextual proxy or ensure that no third-party context types are configured to be propagated.
 
-CWWKC1205.qualifier.class.not.found=CWWKC1205E: Qualifier annotation {0}, which is defined by the application deployment descriptor, could not be loaded by application classloader.
-CWWKC1205.qualifier.class.not.found.explanation=The <qualifier> element(s) configured via application.xml or web.xml contained a class name which could not be loaded.
-CWWKC1205.qualifier.class.not.found.useraction=Verify the <qualifier> element(s) were configured with a fully qualified class name, and the class is present within the application.
+CWWKC1205.qualifier.class.not.found=CWWKC1205E: The {0} qualifier annotation, which is defined by a deployment descriptor, could not be loaded by the application classloader.
+CWWKC1205.qualifier.class.not.found.explanation=Qualifier elements that are configured by the application.xml file or the web.xml file contain a class name that could not be loaded.
+CWWKC1205.qualifier.class.not.found.useraction=Verify that the qualifier elements are configured with a fully qualified class name, and that the class is present within the application.
 
 # Messages for @Asynchronous that are shared with other bundles:
 

--- a/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
+++ b/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022,2023 IBM Corporation and others.
+# Copyright (c) 2022, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -46,7 +46,9 @@ CWWKC1204.not.serializable=CWWKC1204E: Cannot create a serializable contextual p
 CWWKC1204.not.serializable.explanation=Third-party thread context types are not compatible with serialization and cannot be configured to be propagated for serializable contextual proxies.
 CWWKC1204.not.serializable.useraction=Update the application to request a non-serializable contextual proxy or ensure that no third-party context types are configured to be propagated.
 
-
+CWWKC1205.qualifier.class.not.found=CWWKC1205E: Qualifier annotation {0}, which is defined by the application deployment descriptor, could not be loaded by application classloader.
+CWWKC1205.qualifier.class.not.found.explanation=The <qualifier> element(s) configured via application.xml or web.xml contained a class name which could not be loaded.
+CWWKC1205.qualifier.class.not.found.useraction=Verify the <qualifier> element(s) were configured with a fully qualified class name, and the class is present within the application.
 
 # Messages for @Asynchronous that are shared with other bundles:
 

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionBinding.java
@@ -163,12 +163,15 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
             XMLunchanged |= true;
         }
 
-        Class<?>[] qualifierValues = toQualifierClassArray(csd.getQualifiers());
+        String[] qualifierValues = csd.getQualifiers();
         if (qualifierValues == null || qualifierValues.length == 0) {
             if (qualifiers == null)
                 qualifiers = DEFAULT_QUALIFIERS;
+        } else if (qualifierValues.length == 1 && qualifierValues[0].isEmpty()) {
+            qualifiers = DEFAULT_QUALIFIERS;
+            XMLqualifers = true;
         } else {
-            qualifiers = mergeXMLValue(qualifiers, qualifierValues, "qualifier", KEY_QUALIFIERS, null);
+            qualifiers = mergeXMLValue(qualifiers, toQualifierClassArray(qualifierValues), "qualifier", KEY_QUALIFIERS, null);
             XMLqualifers = true;
         }
 

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionBinding.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -45,9 +45,12 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
     private static final String KEY_DESCRIPTION = "description";
     private static final String KEY_PROPAGATED = "propagated";
     private static final String KEY_UNCHANGED = "unchanged";
+    private static final String KEY_QUALIFIER = "qualifier";
 
     private static final String[] DEFAULT_CLEARED = new String[] { ContextServiceDefinition.TRANSACTION };
     private static final String[] DEFAULT_PROPAGATED = new String[] { ContextServiceDefinition.ALL_REMAINING };
+    private static final String[] DEFAULT_UNCHANGED = new String[] {};
+    private static final Class<?>[] DEFAULT_QUALIFIER = new Class<?>[] {};
 
     private String[] cleared;
     private boolean XMLcleared;
@@ -58,11 +61,14 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
     private String[] propagated;
     private boolean XMLpropagated;
 
-    private Map<String, String> properties;
-    private final Set<String> XMLProperties = new HashSet<String>();
-
     private String[] unchanged;
     private boolean XMLunchanged;
+
+    private Class<?>[] qualifier;
+    private boolean XMLqualifer;
+
+    private Map<String, String> properties;
+    private final Set<String> XMLProperties = new HashSet<String>();
 
     public ContextServiceDefinitionBinding(String jndiName, ComponentNameSpaceConfiguration nameSpaceConfig) {
         super(null, nameSpaceConfig);
@@ -86,7 +92,8 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
             Tr.entry(this, tc, "merge", toString(annotation), instanceClass, member,
                      (XMLcleared ? "   (xml)" : "        ") + "cleared: " + toString(cleared) + " << " + toString(annotation.cleared()),
                      (XMLpropagated ? "(xml)" : "     ") + "propagated: " + toString(propagated) + " << " + toString(annotation.propagated()),
-                     (XMLunchanged ? " (xml)" : "      ") + "unchanged: " + toString(unchanged) + " << " + toString(annotation.unchanged()));
+                     (XMLunchanged ? " (xml)" : "      ") + "unchanged: " + toString(unchanged) + " << " + toString(annotation.unchanged()),
+                     (XMLqualifer ? "  (xml)" : "      ") + "qualifier: " + toString(qualifier) + " << " + toString(annotation.qualifiers()));
 
         if (member != null) {
             // ContextServiceDefinition is a class-level annotation only.
@@ -101,15 +108,18 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
         propagated = mergeAnnotationValue(propagated == DEFAULT_PROPAGATED ? null : propagated,
                                           XMLpropagated, annotation.propagated(), KEY_PROPAGATED, DEFAULT_PROPAGATED);
 
-        properties = mergeAnnotationProperties(properties, XMLProperties, new String[] {}); // ContextServiceDefinition has no properties attribute
+        unchanged = mergeAnnotationValue(unchanged, XMLunchanged, annotation.unchanged(), KEY_UNCHANGED, DEFAULT_UNCHANGED);
 
-        unchanged = mergeAnnotationValue(unchanged, XMLunchanged, annotation.unchanged(), KEY_UNCHANGED, new String[0]);
+        qualifier = mergeAnnotationValue(qualifier, XMLqualifer, annotation.qualifiers(), KEY_QUALIFIER, DEFAULT_QUALIFIER);
+
+        properties = mergeAnnotationProperties(properties, XMLProperties, new String[] {}); // ContextServiceDefinition has no properties attribute
 
         if (trace)
             Tr.exit(this, tc, "merge", new String[] {
                                                       (XMLcleared ? "   (xml)" : "        ") + "cleared= " + toString(cleared),
                                                       (XMLpropagated ? "(xml)" : "     ") + "propagated= " + toString(propagated),
-                                                      (XMLunchanged ? " (xml)" : "      ") + "unchanged= " + toString(unchanged)
+                                                      (XMLunchanged ? " (xml)" : "      ") + "unchanged= " + toString(unchanged),
+                                                      (XMLqualifer ? "  (xml)" : "      ") + "qualifier= " + toString(qualifier)
             });
     }
 
@@ -119,7 +129,9 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
             Tr.entry(this, tc, "mergeXML", csd, csd.getName(),
                      (XMLcleared ? "   (xml)" : "        ") + "cleared: " + toString(cleared) + " << " + toString(csd.getCleared()),
                      (XMLpropagated ? "(xml)" : "     ") + "propagated: " + toString(propagated) + " << " + toString(csd.getPropagated()),
-                     (XMLunchanged ? " (xml)" : "      ") + "unchanged: " + toString(unchanged) + " << " + toString(csd.getUnchanged()));
+                     (XMLunchanged ? " (xml)" : "      ") + "unchanged: " + toString(unchanged) + " << " + toString(csd.getUnchanged()),
+                     (XMLqualifer ? "  (xml)" : "      ") + "qualifier: " + toString(qualifier) + " << " + toString(csd.getQualifier())
+            );
 
         List<Description> descriptionList = csd.getDescriptions();
 
@@ -146,20 +158,30 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
             XMLpropagated = true;
         }
 
-        List<Property> csdProps = csd.getProperties();
-        properties = mergeXMLProperties(properties, XMLProperties, csdProps);
-
         String[] unchangedValues = csd.getUnchanged();
         if (unchangedValues != null && unchangedValues.length > 0) {
             unchanged = mergeXMLValue(unchanged, unchangedValues, "unchanged", KEY_UNCHANGED, null);
             XMLunchanged |= true;
         }
 
+        Class<?>[] qualifierValues = toQualifierClassArray(csd.getQualifier());
+        if (qualifierValues == null || qualifierValues.length == 0) {
+            if (qualifier == null)
+                qualifier = DEFAULT_QUALIFIER;
+        } else {
+            qualifier = mergeXMLValue(qualifier, qualifierValues, "qualifier", KEY_QUALIFIER, null);
+            XMLqualifer = true;
+        }
+
+        List<Property> csdProps = csd.getProperties();
+        properties = mergeXMLProperties(properties, XMLProperties, csdProps);
+
         if (trace)
             Tr.exit(this, tc, "mergeXML", new String[] {
                                                          (XMLcleared ? "   (xml)" : "        ") + "cleared= " + toString(cleared),
                                                          (XMLpropagated ? "(xml)" : "     ") + "propagated= " + toString(propagated),
-                                                         (XMLunchanged ? " (xml)" : "      ") + "unchanged= " + toString(unchanged)
+                                                         (XMLunchanged ? " (xml)" : "      ") + "unchanged= " + toString(unchanged),
+                                                         (XMLqualifer ? "  (xml)" : "      ") + "qualifier= " + toString(qualifier)
             });
     }
 
@@ -170,8 +192,10 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
         mergeSavedValue(cleared, contextServiceBinding.cleared, "cleared");
         mergeSavedValue(description, contextServiceBinding.description, "description");
         mergeSavedValue(propagated, contextServiceBinding.propagated, "propagated");
-        mergeSavedValue(properties, contextServiceBinding.properties, "properties");
         mergeSavedValue(unchanged, contextServiceBinding.unchanged, "unchanged");
+        mergeSavedValue(qualifier, contextServiceBinding.qualifier, "qualifier");
+        mergeSavedValue(properties, contextServiceBinding.properties, "properties");
+
     }
 
     void resolve() throws InjectionException {
@@ -186,6 +210,7 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
         addOrRemoveProperty(props, KEY_DESCRIPTION, description);
         addOrRemoveProperty(props, KEY_PROPAGATED, propagated);
         addOrRemoveProperty(props, KEY_UNCHANGED, unchanged);
+        addOrRemoveProperty(props, KEY_QUALIFIER, qualifier);
 
         setObjects(null, createDefinitionReference(null, jakarta.enterprise.concurrent.ContextService.class.getName(), props));
     }
@@ -198,17 +223,33 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
                         .append(", cleared=").append(Arrays.toString(anno.cleared())) //
                         .append(", propagated=").append(Arrays.toString(anno.propagated())) //
                         .append(", unchanged=").append(Arrays.toString(anno.unchanged())) //
+                        .append(", qualifier=").append(Arrays.toString(anno.qualifiers())) //
                         .append(")");
         return b.toString();
     }
 
     @Trivial
-    private static final String toString(String[] list) {
+    private static final <T> String toString(T[] list) {
         if (list == null || list.length == 0)
             return "Unspecified";
         boolean none = true;
         for (int i = 0; none && i < list.length; i++)
-            none &= list[i] == null || list[i].length() == 0;
+            none &= list[i] == null || list[i].toString().isEmpty();
         return none ? "None" : Arrays.toString(list);
+    }
+
+    @Trivial
+    private static final Class<?>[] toQualifierClassArray(String[] classList) throws IllegalArgumentException {
+        Class<?>[] clazzArray = new Class<?>[classList.length];
+        for (int i = 0; i < classList.length; i++) {
+            try {
+                //TODO is there a certain classloader I should be using to load this class? ApplicationClassLoader?
+                clazzArray[i] = Class.forName(classList[i]);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException(Tr.formatMessage(tc, "CWWKC1205.qualifier.class.not.found", classList[i]), e);
+            }
+        }
+
+        return clazzArray;
     }
 }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceDefinitionBinding.java
@@ -45,12 +45,12 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
     private static final String KEY_DESCRIPTION = "description";
     private static final String KEY_PROPAGATED = "propagated";
     private static final String KEY_UNCHANGED = "unchanged";
-    private static final String KEY_QUALIFIER = "qualifier";
+    private static final String KEY_QUALIFIERS = "qualifiers";
 
     private static final String[] DEFAULT_CLEARED = new String[] { ContextServiceDefinition.TRANSACTION };
     private static final String[] DEFAULT_PROPAGATED = new String[] { ContextServiceDefinition.ALL_REMAINING };
     private static final String[] DEFAULT_UNCHANGED = new String[] {};
-    private static final Class<?>[] DEFAULT_QUALIFIER = new Class<?>[] {};
+    private static final Class<?>[] DEFAULT_QUALIFIERS = new Class<?>[] {};
 
     private String[] cleared;
     private boolean XMLcleared;
@@ -64,8 +64,8 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
     private String[] unchanged;
     private boolean XMLunchanged;
 
-    private Class<?>[] qualifier;
-    private boolean XMLqualifer;
+    private Class<?>[] qualifiers;
+    private boolean XMLqualifers;
 
     private Map<String, String> properties;
     private final Set<String> XMLProperties = new HashSet<String>();
@@ -93,7 +93,7 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
                      (XMLcleared ? "   (xml)" : "        ") + "cleared: " + toString(cleared) + " << " + toString(annotation.cleared()),
                      (XMLpropagated ? "(xml)" : "     ") + "propagated: " + toString(propagated) + " << " + toString(annotation.propagated()),
                      (XMLunchanged ? " (xml)" : "      ") + "unchanged: " + toString(unchanged) + " << " + toString(annotation.unchanged()),
-                     (XMLqualifer ? "  (xml)" : "      ") + "qualifier: " + toString(qualifier) + " << " + toString(annotation.qualifiers()));
+                     (XMLqualifers ? " (xml)" : "     ") + "qualifiers: " + toString(qualifiers) + " << " + toString(annotation.qualifiers()));
 
         if (member != null) {
             // ContextServiceDefinition is a class-level annotation only.
@@ -110,7 +110,7 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
 
         unchanged = mergeAnnotationValue(unchanged, XMLunchanged, annotation.unchanged(), KEY_UNCHANGED, DEFAULT_UNCHANGED);
 
-        qualifier = mergeAnnotationValue(qualifier, XMLqualifer, annotation.qualifiers(), KEY_QUALIFIER, DEFAULT_QUALIFIER);
+        qualifiers = mergeAnnotationValue(qualifiers, XMLqualifers, annotation.qualifiers(), KEY_QUALIFIERS, DEFAULT_QUALIFIERS);
 
         properties = mergeAnnotationProperties(properties, XMLProperties, new String[] {}); // ContextServiceDefinition has no properties attribute
 
@@ -119,7 +119,7 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
                                                       (XMLcleared ? "   (xml)" : "        ") + "cleared= " + toString(cleared),
                                                       (XMLpropagated ? "(xml)" : "     ") + "propagated= " + toString(propagated),
                                                       (XMLunchanged ? " (xml)" : "      ") + "unchanged= " + toString(unchanged),
-                                                      (XMLqualifer ? "  (xml)" : "      ") + "qualifier= " + toString(qualifier)
+                                                      (XMLqualifers ? " (xml)" : "     ") + "qualifiers= " + toString(qualifiers)
             });
     }
 
@@ -130,8 +130,7 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
                      (XMLcleared ? "   (xml)" : "        ") + "cleared: " + toString(cleared) + " << " + toString(csd.getCleared()),
                      (XMLpropagated ? "(xml)" : "     ") + "propagated: " + toString(propagated) + " << " + toString(csd.getPropagated()),
                      (XMLunchanged ? " (xml)" : "      ") + "unchanged: " + toString(unchanged) + " << " + toString(csd.getUnchanged()),
-                     (XMLqualifer ? "  (xml)" : "      ") + "qualifier: " + toString(qualifier) + " << " + toString(csd.getQualifier())
-            );
+                     (XMLqualifers ? " (xml)" : "     ") + "qualifiers: " + toString(qualifiers) + " << " + toString(csd.getQualifiers()));
 
         List<Description> descriptionList = csd.getDescriptions();
 
@@ -164,13 +163,13 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
             XMLunchanged |= true;
         }
 
-        Class<?>[] qualifierValues = toQualifierClassArray(csd.getQualifier());
+        Class<?>[] qualifierValues = toQualifierClassArray(csd.getQualifiers());
         if (qualifierValues == null || qualifierValues.length == 0) {
-            if (qualifier == null)
-                qualifier = DEFAULT_QUALIFIER;
+            if (qualifiers == null)
+                qualifiers = DEFAULT_QUALIFIERS;
         } else {
-            qualifier = mergeXMLValue(qualifier, qualifierValues, "qualifier", KEY_QUALIFIER, null);
-            XMLqualifer = true;
+            qualifiers = mergeXMLValue(qualifiers, qualifierValues, "qualifier", KEY_QUALIFIERS, null);
+            XMLqualifers = true;
         }
 
         List<Property> csdProps = csd.getProperties();
@@ -181,7 +180,7 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
                                                          (XMLcleared ? "   (xml)" : "        ") + "cleared= " + toString(cleared),
                                                          (XMLpropagated ? "(xml)" : "     ") + "propagated= " + toString(propagated),
                                                          (XMLunchanged ? " (xml)" : "      ") + "unchanged= " + toString(unchanged),
-                                                         (XMLqualifer ? "  (xml)" : "      ") + "qualifier= " + toString(qualifier)
+                                                         (XMLqualifers ? " (xml)" : "     ") + "qualifiers= " + toString(qualifiers)
             });
     }
 
@@ -193,7 +192,7 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
         mergeSavedValue(description, contextServiceBinding.description, "description");
         mergeSavedValue(propagated, contextServiceBinding.propagated, "propagated");
         mergeSavedValue(unchanged, contextServiceBinding.unchanged, "unchanged");
-        mergeSavedValue(qualifier, contextServiceBinding.qualifier, "qualifier");
+        mergeSavedValue(qualifiers, contextServiceBinding.qualifiers, "qualifier");
         mergeSavedValue(properties, contextServiceBinding.properties, "properties");
 
     }
@@ -210,7 +209,7 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
         addOrRemoveProperty(props, KEY_DESCRIPTION, description);
         addOrRemoveProperty(props, KEY_PROPAGATED, propagated);
         addOrRemoveProperty(props, KEY_UNCHANGED, unchanged);
-        addOrRemoveProperty(props, KEY_QUALIFIER, qualifier);
+        addOrRemoveProperty(props, KEY_QUALIFIERS, qualifiers);
 
         setObjects(null, createDefinitionReference(null, jakarta.enterprise.concurrent.ContextService.class.getName(), props));
     }
@@ -223,7 +222,7 @@ public class ContextServiceDefinitionBinding extends InjectionBinding<ContextSer
                         .append(", cleared=").append(Arrays.toString(anno.cleared())) //
                         .append(", propagated=").append(Arrays.toString(anno.propagated())) //
                         .append(", unchanged=").append(Arrays.toString(anno.unchanged())) //
-                        .append(", qualifier=").append(Arrays.toString(anno.qualifiers())) //
+                        .append(", qualifiers=").append(Arrays.toString(anno.qualifiers())) //
                         .append(")");
         return b.toString();
     }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorDefinitionBinding.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,7 @@
 package io.openliberty.concurrent.internal.processor;
 
 import java.lang.reflect.Member;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -45,6 +46,11 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
     private static final String KEY_DESCRIPTION = "description";
     private static final String KEY_HUNG_TASK_THRESHOLD = "hungTaskThreshold";
     private static final String KEY_MAX_ASYNC = "maxAsync";
+    private static final String KEY_VIRTUAL = "virtual";
+    private static final String KEY_QUALIFIER = "qualifier";
+
+    private static final boolean DEFAULT_VIRTUAL = false;
+    private static final Class<?>[] DEFAULT_QUALIFIER = new Class<?>[] {};
 
     private String contextServiceJndiName;
     private boolean XMLContextServiceRef;
@@ -57,6 +63,12 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
 
     private Integer maxAsync;
     private boolean XMLMaxAsync;
+
+    private boolean virtual;
+    private boolean XMLvirtual;
+
+    private Class<?>[] qualifier;
+    private boolean XMLqualifer;
 
     private Map<String, String> properties;
     private final Set<String> XMLProperties = new HashSet<String>();
@@ -83,7 +95,9 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
             Tr.entry(this, tc, "merge", toString(annotation), instanceClass, member,
                      (XMLContextServiceRef ? "(xml)" : "     ") + "contextServiceRef: " + contextServiceJndiName + " << " + annotation.context(),
                      (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold: " + hungTaskThreshold + " << " + annotation.hungTaskThreshold(),
-                     (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync: " + maxAsync + " << " + annotation.maxAsync());
+                     (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync: " + maxAsync + " << " + annotation.maxAsync(),
+                     (XMLvirtual ? "          (xml)" : "               ") + "virtual: " + virtual + " << " + annotation.virtual(),
+                     (XMLqualifer ? "         (xml)" : "             ") + "qualifier: " + toString(qualifier) + " << " + toString(annotation.qualifiers()));
 
         if (member != null) {
             // ManagedExecutorDefinition is a class-level annotation only.
@@ -94,13 +108,17 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
         description = mergeAnnotationValue(description, XMLDescription, "", KEY_DESCRIPTION, ""); // ManagedExecutorDefinition has no description attribute
         hungTaskThreshold = mergeAnnotationValue(hungTaskThreshold, XMLHungTaskThreshold, annotation.hungTaskThreshold(), KEY_HUNG_TASK_THRESHOLD, -1L);
         maxAsync = mergeAnnotationValue(maxAsync, XMLMaxAsync, annotation.maxAsync(), KEY_MAX_ASYNC, -1);
+        virtual = mergeAnnotationBoolean(virtual, XMLvirtual, annotation.virtual(), KEY_VIRTUAL, DEFAULT_VIRTUAL);
+        qualifier = mergeAnnotationValue(qualifier, XMLqualifer, annotation.qualifiers(), KEY_QUALIFIER, DEFAULT_QUALIFIER);
         properties = mergeAnnotationProperties(properties, XMLProperties, new String[] {}); // ManagedExecutorDefinition has no properties attribute
 
         if (trace)
             Tr.exit(this, tc, "merge", new String[] {
                                                       (XMLContextServiceRef ? "(xml)" : "     ") + "contextServiceRef= " + contextServiceJndiName,
                                                       (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold= " + hungTaskThreshold,
-                                                      (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync= " + maxAsync
+                                                      (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync= " + maxAsync,
+                                                      (XMLvirtual ? "          (xml)" : "               ") + "virtual= " + virtual,
+                                                      (XMLqualifer ? "         (xml)" : "             ") + "qualifier= " + toString(qualifier)
             });
     }
 
@@ -110,7 +128,9 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
             Tr.entry(this, tc, "mergeXML", mxd, mxd.getName(),
                      (XMLContextServiceRef ? "(xml)" : "     ") + "contextServiceRef: " + contextServiceJndiName + " << " + mxd.getContextServiceRef(),
                      (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold: " + hungTaskThreshold + " << " + mxd.getHungTaskThreshold(),
-                     (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync: " + maxAsync + " << " + mxd.getMaxAsync());
+                     (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync: " + maxAsync + " << " + mxd.getMaxAsync(),
+                     (XMLvirtual ? "          (xml)" : "               ") + "virtual: " + virtual + " << " + mxd.isVirtual(),
+                     (XMLqualifer ? "         (xml)" : "             ") + "qualifier: " + toString(qualifier) + " << " + toString(mxd.getQualifier()));
 
         List<Description> descriptionList = mxd.getDescriptions();
 
@@ -135,6 +155,20 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
             XMLMaxAsync = true;
         }
 
+        if (mxd.isSetVirtual()) {
+            virtual = mergeXMLValue(virtual, mxd.isVirtual(), "virtual", KEY_VIRTUAL, null);
+            XMLvirtual = true;
+        }
+
+        Class<?>[] qualifierValues = toQualifierClassArray(mxd.getQualifier());
+        if (qualifierValues == null || qualifierValues.length == 0) {
+            if (qualifier == null)
+                qualifier = DEFAULT_QUALIFIER;
+        } else {
+            qualifier = mergeXMLValue(qualifier, qualifierValues, "qualifier", KEY_QUALIFIER, null);
+            XMLqualifer = true;
+        }
+
         List<Property> mxdProps = mxd.getProperties();
         properties = mergeXMLProperties(properties, XMLProperties, mxdProps);
 
@@ -142,7 +176,9 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
             Tr.exit(this, tc, "mergeXML", new String[] {
                                                          (XMLContextServiceRef ? "(xml)" : "     ") + "contextServiceRef= " + contextServiceJndiName,
                                                          (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold= " + hungTaskThreshold,
-                                                         (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync= " + maxAsync
+                                                         (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync= " + maxAsync,
+                                                         (XMLvirtual ? "          (xml)" : "               ") + "virtual= " + virtual,
+                                                         (XMLqualifer ? "         (xml)" : "              ") + "qualifier= " + toString(qualifier)
             });
     }
 
@@ -154,6 +190,8 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
         mergeSavedValue(description, managedExecutorBinding.description, "description");
         mergeSavedValue(hungTaskThreshold, managedExecutorBinding.hungTaskThreshold, "hung-task-threshold");
         mergeSavedValue(maxAsync, managedExecutorBinding.maxAsync, "max-async");
+        mergeSavedValue(virtual, managedExecutorBinding.virtual, "virtual");
+        mergeSavedValue(qualifier, managedExecutorBinding.qualifier, "qualifier");
         mergeSavedValue(properties, managedExecutorBinding.properties, "properties");
     }
 
@@ -169,6 +207,8 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
         addOrRemoveProperty(props, KEY_DESCRIPTION, description);
         addOrRemoveProperty(props, KEY_HUNG_TASK_THRESHOLD, hungTaskThreshold);
         addOrRemoveProperty(props, KEY_MAX_ASYNC, maxAsync);
+        addOrRemoveProperty(props, KEY_VIRTUAL, virtual);
+        addOrRemoveProperty(props, KEY_QUALIFIER, qualifier);
 
         setObjects(null, createDefinitionReference(null, ManagedExecutorService.class.getName(), props));
     }
@@ -181,7 +221,34 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
                         .append(", context=").append(anno.context()) //
                         .append(", hungTaskThreshold=").append(anno.hungTaskThreshold()) //
                         .append(", maxAsync=").append(anno.maxAsync()) //
+                        .append(", virtual=").append(anno.virtual()) //
+                        .append(", qualifier=").append(Arrays.toString(anno.qualifiers())) //
                         .append(")");
         return b.toString();
+    }
+
+    @Trivial
+    private static final <T> String toString(T[] list) {
+        if (list == null || list.length == 0)
+            return "Unspecified";
+        boolean none = true;
+        for (int i = 0; none && i < list.length; i++)
+            none &= list[i] == null || list[i].toString().isEmpty();
+        return none ? "None" : Arrays.toString(list);
+    }
+
+    @Trivial
+    private static final Class<?>[] toQualifierClassArray(String[] classList) throws IllegalArgumentException {
+        Class<?>[] clazzArray = new Class<?>[classList.length];
+        for (int i = 0; i < classList.length; i++) {
+            try {
+                //TODO is there a certain classloader I should be using to load this class? ApplicationClassLoader?
+                clazzArray[i] = Class.forName(classList[i]);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException(Tr.formatMessage(tc, "CWWKC1205.qualifier.class.not.found", classList[i]), e);
+            }
+        }
+
+        return clazzArray;
     }
 }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorDefinitionBinding.java
@@ -160,12 +160,15 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
             XMLvirtual = true;
         }
 
-        Class<?>[] qualifierValues = toQualifierClassArray(mxd.getQualifiers());
+        String[] qualifierValues = mxd.getQualifiers();
         if (qualifierValues == null || qualifierValues.length == 0) {
             if (qualifiers == null)
                 qualifiers = DEFAULT_QUALIFIERS;
+        } else if (qualifierValues.length == 1 && qualifierValues[0].isEmpty()) {
+            qualifiers = DEFAULT_QUALIFIERS;
+            XMLqualifers = true;
         } else {
-            qualifiers = mergeXMLValue(qualifiers, qualifierValues, "qualifier", KEY_QUALIFIERS, null);
+            qualifiers = mergeXMLValue(qualifiers, toQualifierClassArray(qualifierValues), "qualifier", KEY_QUALIFIERS, null);
             XMLqualifers = true;
         }
 

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorDefinitionBinding.java
@@ -47,10 +47,10 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
     private static final String KEY_HUNG_TASK_THRESHOLD = "hungTaskThreshold";
     private static final String KEY_MAX_ASYNC = "maxAsync";
     private static final String KEY_VIRTUAL = "virtual";
-    private static final String KEY_QUALIFIER = "qualifier";
+    private static final String KEY_QUALIFIERS = "qualifiers";
 
     private static final boolean DEFAULT_VIRTUAL = false;
-    private static final Class<?>[] DEFAULT_QUALIFIER = new Class<?>[] {};
+    private static final Class<?>[] DEFAULT_QUALIFIERS = new Class<?>[] {};
 
     private String contextServiceJndiName;
     private boolean XMLContextServiceRef;
@@ -67,8 +67,8 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
     private boolean virtual;
     private boolean XMLvirtual;
 
-    private Class<?>[] qualifier;
-    private boolean XMLqualifer;
+    private Class<?>[] qualifiers;
+    private boolean XMLqualifers;
 
     private Map<String, String> properties;
     private final Set<String> XMLProperties = new HashSet<String>();
@@ -97,7 +97,7 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
                      (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold: " + hungTaskThreshold + " << " + annotation.hungTaskThreshold(),
                      (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync: " + maxAsync + " << " + annotation.maxAsync(),
                      (XMLvirtual ? "          (xml)" : "               ") + "virtual: " + virtual + " << " + annotation.virtual(),
-                     (XMLqualifer ? "         (xml)" : "             ") + "qualifier: " + toString(qualifier) + " << " + toString(annotation.qualifiers()));
+                     (XMLqualifers ? "        (xml)" : "            ") + "qualifiers: " + toString(qualifiers) + " << " + toString(annotation.qualifiers()));
 
         if (member != null) {
             // ManagedExecutorDefinition is a class-level annotation only.
@@ -109,7 +109,7 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
         hungTaskThreshold = mergeAnnotationValue(hungTaskThreshold, XMLHungTaskThreshold, annotation.hungTaskThreshold(), KEY_HUNG_TASK_THRESHOLD, -1L);
         maxAsync = mergeAnnotationValue(maxAsync, XMLMaxAsync, annotation.maxAsync(), KEY_MAX_ASYNC, -1);
         virtual = mergeAnnotationBoolean(virtual, XMLvirtual, annotation.virtual(), KEY_VIRTUAL, DEFAULT_VIRTUAL);
-        qualifier = mergeAnnotationValue(qualifier, XMLqualifer, annotation.qualifiers(), KEY_QUALIFIER, DEFAULT_QUALIFIER);
+        qualifiers = mergeAnnotationValue(qualifiers, XMLqualifers, annotation.qualifiers(), KEY_QUALIFIERS, DEFAULT_QUALIFIERS);
         properties = mergeAnnotationProperties(properties, XMLProperties, new String[] {}); // ManagedExecutorDefinition has no properties attribute
 
         if (trace)
@@ -118,7 +118,7 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
                                                       (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold= " + hungTaskThreshold,
                                                       (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync= " + maxAsync,
                                                       (XMLvirtual ? "          (xml)" : "               ") + "virtual= " + virtual,
-                                                      (XMLqualifer ? "         (xml)" : "             ") + "qualifier= " + toString(qualifier)
+                                                      (XMLqualifers ? "        (xml)" : "            ") + "qualifiers= " + toString(qualifiers)
             });
     }
 
@@ -130,7 +130,7 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
                      (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold: " + hungTaskThreshold + " << " + mxd.getHungTaskThreshold(),
                      (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync: " + maxAsync + " << " + mxd.getMaxAsync(),
                      (XMLvirtual ? "          (xml)" : "               ") + "virtual: " + virtual + " << " + mxd.isVirtual(),
-                     (XMLqualifer ? "         (xml)" : "             ") + "qualifier: " + toString(qualifier) + " << " + toString(mxd.getQualifier()));
+                     (XMLqualifers ? "        (xml)" : "            ") + "qualifiers: " + toString(qualifiers) + " << " + toString(mxd.getQualifiers()));
 
         List<Description> descriptionList = mxd.getDescriptions();
 
@@ -160,13 +160,13 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
             XMLvirtual = true;
         }
 
-        Class<?>[] qualifierValues = toQualifierClassArray(mxd.getQualifier());
+        Class<?>[] qualifierValues = toQualifierClassArray(mxd.getQualifiers());
         if (qualifierValues == null || qualifierValues.length == 0) {
-            if (qualifier == null)
-                qualifier = DEFAULT_QUALIFIER;
+            if (qualifiers == null)
+                qualifiers = DEFAULT_QUALIFIERS;
         } else {
-            qualifier = mergeXMLValue(qualifier, qualifierValues, "qualifier", KEY_QUALIFIER, null);
-            XMLqualifer = true;
+            qualifiers = mergeXMLValue(qualifiers, qualifierValues, "qualifier", KEY_QUALIFIERS, null);
+            XMLqualifers = true;
         }
 
         List<Property> mxdProps = mxd.getProperties();
@@ -178,7 +178,7 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
                                                          (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold= " + hungTaskThreshold,
                                                          (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync= " + maxAsync,
                                                          (XMLvirtual ? "          (xml)" : "               ") + "virtual= " + virtual,
-                                                         (XMLqualifer ? "         (xml)" : "              ") + "qualifier= " + toString(qualifier)
+                                                         (XMLqualifers ? "        (xml)" : "            ") + "qualifiers= " + toString(qualifiers)
             });
     }
 
@@ -191,7 +191,7 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
         mergeSavedValue(hungTaskThreshold, managedExecutorBinding.hungTaskThreshold, "hung-task-threshold");
         mergeSavedValue(maxAsync, managedExecutorBinding.maxAsync, "max-async");
         mergeSavedValue(virtual, managedExecutorBinding.virtual, "virtual");
-        mergeSavedValue(qualifier, managedExecutorBinding.qualifier, "qualifier");
+        mergeSavedValue(qualifiers, managedExecutorBinding.qualifiers, "qualifier");
         mergeSavedValue(properties, managedExecutorBinding.properties, "properties");
     }
 
@@ -208,7 +208,7 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
         addOrRemoveProperty(props, KEY_HUNG_TASK_THRESHOLD, hungTaskThreshold);
         addOrRemoveProperty(props, KEY_MAX_ASYNC, maxAsync);
         addOrRemoveProperty(props, KEY_VIRTUAL, virtual);
-        addOrRemoveProperty(props, KEY_QUALIFIER, qualifier);
+        addOrRemoveProperty(props, KEY_QUALIFIERS, qualifiers);
 
         setObjects(null, createDefinitionReference(null, ManagedExecutorService.class.getName(), props));
     }
@@ -222,7 +222,7 @@ public class ManagedExecutorDefinitionBinding extends InjectionBinding<ManagedEx
                         .append(", hungTaskThreshold=").append(anno.hungTaskThreshold()) //
                         .append(", maxAsync=").append(anno.maxAsync()) //
                         .append(", virtual=").append(anno.virtual()) //
-                        .append(", qualifier=").append(Arrays.toString(anno.qualifiers())) //
+                        .append(", qualifiers=").append(Arrays.toString(anno.qualifiers())) //
                         .append(")");
         return b.toString();
     }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorDefinitionBinding.java
@@ -160,12 +160,15 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
             XMLvirtual = true;
         }
 
-        Class<?>[] qualifierValues = toQualifierClassArray(mxd.getQualifiers());
+        String[] qualifierValues = mxd.getQualifiers();
         if (qualifierValues == null || qualifierValues.length == 0) {
             if (qualifiers == null)
                 qualifiers = DEFAULT_QUALIFIERS;
+        } else if (qualifierValues.length == 1 && qualifierValues[0].isEmpty()) {
+            qualifiers = DEFAULT_QUALIFIERS;
+            XMLqualifers = true;
         } else {
-            qualifiers = mergeXMLValue(qualifiers, qualifierValues, "qualifier", KEY_QUALIFIERS, null);
+            qualifiers = mergeXMLValue(qualifiers, toQualifierClassArray(qualifierValues), "qualifier", KEY_QUALIFIERS, null);
             XMLqualifers = true;
         }
 

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorDefinitionBinding.java
@@ -47,10 +47,10 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
     private static final String KEY_HUNG_TASK_THRESHOLD = "hungTaskThreshold";
     private static final String KEY_MAX_ASYNC = "maxAsync";
     private static final String KEY_VIRTUAL = "virtual";
-    private static final String KEY_QUALIFIER = "qualifier";
+    private static final String KEY_QUALIFIERS = "qualifiers";
 
     private static final boolean DEFAULT_VIRTUAL = false;
-    private static final Class<?>[] DEFAULT_QUALIFIER = new Class<?>[] {};
+    private static final Class<?>[] DEFAULT_QUALIFIERS = new Class<?>[] {};
 
     private String contextServiceJndiName;
     private boolean XMLContextServiceRef;
@@ -67,8 +67,8 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
     private boolean virtual;
     private boolean XMLvirtual;
 
-    private Class<?>[] qualifier;
-    private boolean XMLqualifer;
+    private Class<?>[] qualifiers;
+    private boolean XMLqualifers;
 
     private Map<String, String> properties;
     private final Set<String> XMLProperties = new HashSet<String>();
@@ -97,7 +97,7 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
                      (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold: " + hungTaskThreshold + " << " + annotation.hungTaskThreshold(),
                      (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync: " + maxAsync + " << " + annotation.maxAsync(),
                      (XMLvirtual ? "          (xml)" : "               ") + "virtual: " + virtual + " << " + annotation.virtual(),
-                     (XMLqualifer ? "         (xml)" : "             ") + "qualifier: " + toString(qualifier) + " << " + toString(annotation.qualifiers()));
+                     (XMLqualifers ? "        (xml)" : "            ") + "qualifiers: " + toString(qualifiers) + " << " + toString(annotation.qualifiers()));
 
         if (member != null) {
             // ManagedScheduledExecutorDefinition is a class-level annotation only.
@@ -109,7 +109,7 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
         hungTaskThreshold = mergeAnnotationValue(hungTaskThreshold, XMLHungTaskThreshold, annotation.hungTaskThreshold(), KEY_HUNG_TASK_THRESHOLD, -1L);
         maxAsync = mergeAnnotationValue(maxAsync, XMLMaxAsync, annotation.maxAsync(), KEY_MAX_ASYNC, -1);
         virtual = mergeAnnotationBoolean(virtual, XMLvirtual, annotation.virtual(), KEY_VIRTUAL, DEFAULT_VIRTUAL);
-        qualifier = mergeAnnotationValue(qualifier, XMLqualifer, annotation.qualifiers(), KEY_QUALIFIER, DEFAULT_QUALIFIER);
+        qualifiers = mergeAnnotationValue(qualifiers, XMLqualifers, annotation.qualifiers(), KEY_QUALIFIERS, DEFAULT_QUALIFIERS);
         properties = mergeAnnotationProperties(properties, XMLProperties, new String[] {}); // ManagedScheduledExecutorDefinition has no properties attribute
 
         if (trace)
@@ -118,7 +118,7 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
                                                       (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold= " + hungTaskThreshold,
                                                       (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync= " + maxAsync,
                                                       (XMLvirtual ? "          (xml)" : "               ") + "virtual= " + virtual,
-                                                      (XMLqualifer ? "         (xml)" : "             ") + "qualifier= " + toString(qualifier)
+                                                      (XMLqualifers ? "        (xml)" : "            ") + "qualifiers= " + toString(qualifiers)
             });
     }
 
@@ -130,7 +130,7 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
                      (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold: " + hungTaskThreshold + " << " + mxd.getHungTaskThreshold(),
                      (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync: " + maxAsync + " << " + mxd.getMaxAsync(),
                      (XMLvirtual ? "          (xml)" : "               ") + "virtual: " + virtual + " << " + mxd.isVirtual(),
-                     (XMLqualifer ? "         (xml)" : "             ") + "qualifier: " + toString(qualifier) + " << " + toString(mxd.getQualifier()));
+                     (XMLqualifers ? "        (xml)" : "            ") + "qualifiers: " + toString(qualifiers) + " << " + toString(mxd.getQualifiers()));
 
         List<Description> descriptionList = mxd.getDescriptions();
 
@@ -160,13 +160,13 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
             XMLvirtual = true;
         }
 
-        Class<?>[] qualifierValues = toQualifierClassArray(mxd.getQualifier());
+        Class<?>[] qualifierValues = toQualifierClassArray(mxd.getQualifiers());
         if (qualifierValues == null || qualifierValues.length == 0) {
-            if (qualifier == null)
-                qualifier = DEFAULT_QUALIFIER;
+            if (qualifiers == null)
+                qualifiers = DEFAULT_QUALIFIERS;
         } else {
-            qualifier = mergeXMLValue(qualifier, qualifierValues, "qualifier", KEY_QUALIFIER, null);
-            XMLqualifer = true;
+            qualifiers = mergeXMLValue(qualifiers, qualifierValues, "qualifier", KEY_QUALIFIERS, null);
+            XMLqualifers = true;
         }
 
         List<Property> mxdProps = mxd.getProperties();
@@ -178,7 +178,7 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
                                                          (XMLHungTaskThreshold ? "(xml)" : "     ") + "hungTaskThreshold= " + hungTaskThreshold,
                                                          (XMLMaxAsync ? "         (xml)" : "              ") + "maxAsync= " + maxAsync,
                                                          (XMLvirtual ? "          (xml)" : "               ") + "virtual= " + virtual,
-                                                         (XMLqualifer ? "         (xml)" : "             ") + "qualifier= " + toString(qualifier)
+                                                         (XMLqualifers ? "        (xml)" : "            ") + "qualifiers= " + toString(qualifiers)
             });
     }
 
@@ -191,7 +191,7 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
         mergeSavedValue(hungTaskThreshold, managedScheduledExecutorBinding.hungTaskThreshold, "hung-task-threshold");
         mergeSavedValue(maxAsync, managedScheduledExecutorBinding.maxAsync, "max-async");
         mergeSavedValue(virtual, managedScheduledExecutorBinding.virtual, "virtual");
-        mergeSavedValue(qualifier, managedScheduledExecutorBinding.qualifier, "qualifier");
+        mergeSavedValue(qualifiers, managedScheduledExecutorBinding.qualifiers, "qualifier");
         mergeSavedValue(properties, managedScheduledExecutorBinding.properties, "properties");
     }
 
@@ -208,7 +208,7 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
         addOrRemoveProperty(props, KEY_HUNG_TASK_THRESHOLD, hungTaskThreshold);
         addOrRemoveProperty(props, KEY_MAX_ASYNC, maxAsync);
         addOrRemoveProperty(props, KEY_VIRTUAL, virtual);
-        addOrRemoveProperty(props, KEY_QUALIFIER, qualifier);
+        addOrRemoveProperty(props, KEY_QUALIFIERS, qualifiers);
 
         setObjects(null, createDefinitionReference(null, ManagedScheduledExecutorService.class.getName(), props));
     }
@@ -222,7 +222,7 @@ public class ManagedScheduledExecutorDefinitionBinding extends InjectionBinding<
                         .append(", hungTaskThreshold=").append(anno.hungTaskThreshold()) //
                         .append(", maxAsync=").append(anno.maxAsync()) //
                         .append(", virtual=").append(anno.virtual()) //
-                        .append(", qualifier=").append(Arrays.toString(anno.qualifiers())) //
+                        .append(", qualifiers=").append(Arrays.toString(anno.qualifiers())) //
                         .append(")");
         return b.toString();
     }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryDefinitionBinding.java
@@ -146,12 +146,15 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
             XMLvirtual = true;
         }
 
-        Class<?>[] qualifierValues = toQualifierClassArray(mtfd.getQualifiers());
+        String[] qualifierValues = mtfd.getQualifiers();
         if (qualifierValues == null || qualifierValues.length == 0) {
             if (qualifiers == null)
                 qualifiers = DEFAULT_QUALIFIERS;
+        } else if (qualifierValues.length == 1 && qualifierValues[0].isEmpty()) {
+            qualifiers = DEFAULT_QUALIFIERS;
+            XMLqualifers = true;
         } else {
-            qualifiers = mergeXMLValue(qualifiers, qualifierValues, "qualifier", KEY_QUALIFIERS, null);
+            qualifiers = mergeXMLValue(qualifiers, toQualifierClassArray(qualifierValues), "qualifier", KEY_QUALIFIERS, null);
             XMLqualifers = true;
         }
 

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryDefinitionBinding.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryDefinitionBinding.java
@@ -45,10 +45,10 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
     private static final String KEY_DESCRIPTION = "description";
     private static final String KEY_PRIORITY = "priority";
     private static final String KEY_VIRTUAL = "virtual";
-    private static final String KEY_QUALIFIER = "qualifier";
+    private static final String KEY_QUALIFIERS = "qualifiers";
 
     private static final boolean DEFAULT_VIRTUAL = false;
-    private static final Class<?>[] DEFAULT_QUALIFIER = new Class<?>[] {};
+    private static final Class<?>[] DEFAULT_QUALIFIERS = new Class<?>[] {};
 
     private String contextServiceJndiName;
     private boolean XMLContextServiceRef;
@@ -62,8 +62,8 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
     private boolean virtual;
     private boolean XMLvirtual;
 
-    private Class<?>[] qualifier;
-    private boolean XMLqualifer;
+    private Class<?>[] qualifiers;
+    private boolean XMLqualifers;
 
     private Map<String, String> properties;
     private final Set<String> XMLProperties = new HashSet<String>();
@@ -91,7 +91,7 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
                      (XMLContextServiceRef ? "(xml)" : "     ") + "contextServiceRef: " + contextServiceJndiName + " << " + annotation.context(),
                      (XMLPriority ? "         (xml)" : "              ") + "priority: " + priority + " << " + annotation.priority(),
                      (XMLvirtual ? "          (xml)" : "               ") + "virtual: " + virtual + " << " + annotation.virtual(),
-                     (XMLqualifer ? "         (xml)" : "             ") + "qualifier: " + toString(qualifier) + " << " + toString(annotation.qualifiers()));
+                     (XMLqualifers ? "        (xml)" : "            ") + "qualifiers: " + toString(qualifiers) + " << " + toString(annotation.qualifiers()));
 
         if (member != null) {
             // ManagedThreadFactoryDefinition is a class-level annotation only.
@@ -102,7 +102,7 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
         description = mergeAnnotationValue(description, XMLDescription, "", KEY_DESCRIPTION, ""); // ManagedThreadFactoryDefinition has no description attribute
         priority = mergeAnnotationValue(priority, XMLPriority, annotation.priority(), KEY_PRIORITY, Thread.NORM_PRIORITY);
         virtual = mergeAnnotationBoolean(virtual, XMLvirtual, annotation.virtual(), KEY_VIRTUAL, DEFAULT_VIRTUAL);
-        qualifier = mergeAnnotationValue(qualifier, XMLqualifer, annotation.qualifiers(), KEY_QUALIFIER, DEFAULT_QUALIFIER);
+        qualifiers = mergeAnnotationValue(qualifiers, XMLqualifers, annotation.qualifiers(), KEY_QUALIFIERS, DEFAULT_QUALIFIERS);
         properties = mergeAnnotationProperties(properties, XMLProperties, new String[] {}); // ManagedThreadFactoryDefinition has no properties attribute
 
         if (trace)
@@ -110,7 +110,7 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
                                                       (XMLContextServiceRef ? "(xml)" : "     ") + "contextServiceRef= " + contextServiceJndiName,
                                                       (XMLPriority ? "         (xml)" : "              ") + "priority= " + priority,
                                                       (XMLvirtual ? "          (xml)" : "               ") + "virtual= " + virtual,
-                                                      (XMLqualifer ? "         (xml)" : "             ") + "qualifier= " + toString(qualifier)
+                                                      (XMLqualifers ? "        (xml)" : "            ") + "qualifiers= " + toString(qualifiers)
             });
     }
 
@@ -121,7 +121,7 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
                      (XMLContextServiceRef ? "(xml)" : "     ") + "contextServiceRef: " + contextServiceJndiName + " << " + mtfd.getContextServiceRef(),
                      (XMLPriority ? "         (xml)" : "              ") + "priority: " + priority + " << " + mtfd.getPriority(),
                      (XMLvirtual ? "          (xml)" : "               ") + "virtual: " + virtual + " << " + mtfd.isVirtual(),
-                     (XMLqualifer ? "         (xml)" : "             ") + "qualifier: " + toString(qualifier) + " << " + toString(mtfd.getQualifier()));
+                     (XMLqualifers ? "        (xml)" : "            ") + "qualifiers: " + toString(qualifiers) + " << " + toString(mtfd.getQualifiers()));
 
         List<Description> descriptionList = mtfd.getDescriptions();
 
@@ -146,13 +146,13 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
             XMLvirtual = true;
         }
 
-        Class<?>[] qualifierValues = toQualifierClassArray(mtfd.getQualifier());
+        Class<?>[] qualifierValues = toQualifierClassArray(mtfd.getQualifiers());
         if (qualifierValues == null || qualifierValues.length == 0) {
-            if (qualifier == null)
-                qualifier = DEFAULT_QUALIFIER;
+            if (qualifiers == null)
+                qualifiers = DEFAULT_QUALIFIERS;
         } else {
-            qualifier = mergeXMLValue(qualifier, qualifierValues, "qualifier", KEY_QUALIFIER, null);
-            XMLqualifer = true;
+            qualifiers = mergeXMLValue(qualifiers, qualifierValues, "qualifier", KEY_QUALIFIERS, null);
+            XMLqualifers = true;
         }
 
         List<Property> mxdProps = mtfd.getProperties();
@@ -163,7 +163,7 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
                                                          (XMLContextServiceRef ? "(xml)" : "     ") + "contextServiceRef= " + contextServiceJndiName,
                                                          (XMLPriority ? "         (xml)" : "              ") + "priority= " + priority,
                                                          (XMLvirtual ? "          (xml)" : "               ") + "virtual= " + virtual,
-                                                         (XMLqualifer ? "         (xml)" : "             ") + "qualifier= " + toString(qualifier)
+                                                         (XMLqualifers ? "        (xml)" : "            ") + "qualifiers= " + toString(qualifiers)
             });
     }
 
@@ -175,7 +175,7 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
         mergeSavedValue(description, managedThreadFactoryBinding.description, "description");
         mergeSavedValue(priority, managedThreadFactoryBinding.priority, "priority");
         mergeSavedValue(virtual, managedThreadFactoryBinding.virtual, "virtual");
-        mergeSavedValue(qualifier, managedThreadFactoryBinding.qualifier, "qualifier");
+        mergeSavedValue(qualifiers, managedThreadFactoryBinding.qualifiers, "qualifier");
         mergeSavedValue(properties, managedThreadFactoryBinding.properties, "properties");
     }
 
@@ -191,7 +191,7 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
         addOrRemoveProperty(props, KEY_DESCRIPTION, description);
         addOrRemoveProperty(props, KEY_PRIORITY, priority);
         addOrRemoveProperty(props, KEY_VIRTUAL, virtual);
-        addOrRemoveProperty(props, KEY_QUALIFIER, qualifier);
+        addOrRemoveProperty(props, KEY_QUALIFIERS, qualifiers);
 
         setObjects(null, createDefinitionReference(null, jakarta.enterprise.concurrent.ManagedThreadFactory.class.getName(), props));
     }
@@ -204,7 +204,7 @@ public class ManagedThreadFactoryDefinitionBinding extends InjectionBinding<Mana
                         .append(", context=").append(anno.context()) //
                         .append(", priority=").append(anno.priority()) //
                         .append(", virtual=").append(anno.virtual()) //
-                        .append(", qualifier=").append(Arrays.toString(anno.qualifiers())) //
+                        .append(", qualifiers=").append(Arrays.toString(anno.qualifiers())) //
                         .append(")");
         return b.toString();
     }


### PR DESCRIPTION
Updates our deployment descriptors for new values added for Concurrency 3.1 from the following sources: 
- `virtual=true` annotation atrribute (https://github.com/jakartaee/concurrency/pull/349)
- `qualifiers` annotation attribute (https://github.com/jakartaee/concurrency/pull/348)
- Deployment Descriptor schema (https://github.com/jakartaee/jakartaee-schemas/pull/44)

I think I'm most of the way there just have some questions tagged with //TODO that need some further review.
Would appreciate some feedback @tbitonti. 