### PR TITLE
Skip FATs that require Java 21 when executing with Java 20

### DIFF
--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <project name="standard.launch.tasks">
 
@@ -114,6 +111,7 @@
 				<and> <equals arg1="17" arg2="${fat.minimum.java.level}"/> <equals arg1="11"  arg2="${java.specification.version}"/> </and>
 				<and> <equals arg1="21" arg2="${fat.minimum.java.level}"/> <equals arg1="11"  arg2="${java.specification.version}"/> </and>
 				<and> <equals arg1="21" arg2="${fat.minimum.java.level}"/> <equals arg1="17"  arg2="${java.specification.version}"/> </and>
+				<and> <equals arg1="21" arg2="${fat.minimum.java.level}"/> <equals arg1="20"  arg2="${java.specification.version}"/> </and>
 		    </or>
 		</condition>
 		


### PR DESCRIPTION
fixes #27151