### PR TITLE
CIOrch - Removing Schedules from TestPBs 

### DIFF
--- a/.ci-orchestrator/pb.yml
+++ b/.ci-orchestrator/pb.yml
@@ -6,7 +6,7 @@ triggers:
 - type: github
   triggerName: "ol-pbbeta"
   triggerRank: 50
-  triggerMonitored: false
+  groups: ["LibertyDev"]
   keyword: "#pbbeta"
   propertyDefinitions:
   # If a user defines this property, set it for all steps that use it except the "Distributed Full FATs" step
@@ -22,7 +22,7 @@ triggers:
 - type: github
   triggerName: "ol-exclamation-pbbeta"
   triggerRank: 50
-  triggerMonitored: false
+  groups: ["LibertyDev"]
   keyword: "!pbbeta"
   propertyDefinitions:
   # If a user defines this property, set it for all steps that use it except the "Distributed Full FATs" step
@@ -38,7 +38,7 @@ triggers:
 - type: github
   triggerName: "ol-pbbeta-build"
   triggerRank: 50
-  triggerMonitored: false
+  groups: ["LibertyDev"]
   keyword: "#build"
   propertyDefinitions:
   # If a user defines this property, set it for all steps that use it except the "Distributed Full FATs" step
@@ -54,7 +54,7 @@ triggers:
 - type: manual
   triggerName: "ol-pbbeta-manual"
   triggerRank: 50
-  triggerMonitored: false
+  groups: ["LibertyDev"]
   propertyDefinitions:
   - name: github_pr_user
     isRequired: true
@@ -71,7 +71,7 @@ triggers:
 - type: github
   triggerName: "ol-exclamation-pbbeta-build"
   triggerRank: 50
-  triggerMonitored: false
+  groups: ["LibertyDev"]
   keyword: "!build"
   propertyDefinitions:
   # If a user defines this property, set it for all steps that use it except the "Distributed Full FATs" step
@@ -87,7 +87,7 @@ triggers:
 - type: github
   triggerName: "ol-fullpbbeta"
   triggerRank: 50
-  triggerMonitored: false
+  groups: ["LibertyDev"]
   keyword: "#fullpbbeta"
   propertyDefinitions:
   # Run all buckets in full mode.
@@ -114,7 +114,7 @@ triggers:
 - type: github
   triggerName: "ol-exclamation-fullpbbeta"
   triggerRank: 50
-  triggerMonitored: false
+  groups: ["LibertyDev"]
   keyword: "!fullpbbeta"
   propertyDefinitions:
   # Run all buckets in full mode.
@@ -138,13 +138,10 @@ triggers:
     - stepName: z/OS FATs
     - stepName: z/OS Unittests
 
-- type: schedule
+- type: manual
   triggerName: "Open Liberty Personal product only change"
   triggerRank: 50
-  triggerMonitored: false
-  triggerThreshold: 100
-  every:
-    hours: 168
+  groups: ["CSD"]
   propertyDefinitions:
   - name: git.laos.clone.repository.username
     defaultValue: "fritze2"
@@ -174,13 +171,10 @@ triggers:
     steps:
     - stepName: PR Changes
 
-- type: schedule
+- type: manual
   triggerName: "Open Liberty Personal unittest only change"
   triggerRank: 50
-  triggerMonitored: false
-  triggerThreshold: 100
-  every:
-    hours: 168
+  groups: ["CSD"]
   propertyDefinitions:
   - name: git.laos.clone.repository.username
     defaultValue: "fritze2"
@@ -210,13 +204,10 @@ triggers:
     steps:
     - stepName: PR Changes
 
-- type: schedule
+- type: manual
   triggerName: "Open Liberty Personal FAT only change"
   triggerRank: 50
-  triggerMonitored: false
-  triggerThreshold: 100
-  every:
-    hours: 168
+  groups: ["CSD"]
   propertyDefinitions:
   - name: git.laos.clone.repository.username
     defaultValue: "fritze2"
@@ -246,13 +237,10 @@ triggers:
     steps:
     - stepName: PR Changes
 
-- type: schedule
+- type: manual
   triggerName: "Open Liberty Personal BVT only change"
   triggerRank: 50
-  triggerMonitored: false
-  triggerThreshold: 100
-  every:
-    hours: 168
+  groups: ["CSD"]
   propertyDefinitions:
   - name: git.laos.clone.repository.username
     defaultValue: "fritze2"
@@ -282,13 +270,10 @@ triggers:
     steps:
     - stepName: PR Changes
 
-- type: schedule
+- type: manual
   triggerName: "Open Liberty Personal infrastructure only change"
   triggerRank: 50
-  triggerMonitored: false
-  triggerThreshold: 100
-  every:
-    hours: 168
+  groups: ["CSD"]
   propertyDefinitions:
   - name: git.laos.clone.repository.username
     defaultValue: "fritze2"

--- a/.ci-orchestrator/pbRTCBuild.yml
+++ b/.ci-orchestrator/pbRTCBuild.yml
@@ -6,31 +6,31 @@ triggers:
 - type: github
   triggerName: "ol-pb"
   triggerRank: 20
-  triggerMonitored: false
+  groups: ["LibertyDev"]
   keyword: "#pb"
 
 - type: github
   triggerName: "ol-exclamation-pb"
   triggerRank: 20
-  triggerMonitored: false
+  groups: ["LibertyDev"]
   keyword: "!pb"
 
 #- type: github
 #  triggerName: "ol-pb-build"
 #  triggerRank: 20
-#  triggerMonitored: false
+#  groups: ["LibertyDev"]
 #  keyword: "#build"
 
 - type: github
   triggerName: "ol-pb-exclamation-build"
   triggerRank: 20
-  triggerMonitored: false
+  groups: ["LibertyDev"]
   keyword: "!build"
 
 - type: github
   triggerName: "ol-fullpb"
   triggerRank: 20
-  triggerMonitored: false
+  groups: ["LibertyDev"]
   keyword: "#fullpb"
   propertyDefinitions:
   - name: fat.test.mode
@@ -53,7 +53,7 @@ triggers:
 - type: github
   triggerName: "ol-exclamation-fullpb"
   triggerRank: 20
-  triggerMonitored: false
+  groups: ["LibertyDev"]
   keyword: "!fullpb"
   propertyDefinitions:
   - name: fat.test.mode


### PR DESCRIPTION
we have enough data without the scheduled builds. convert scheduled PB to be on manual request rather than all the time.

I have also updated to use the latest groups concept so that OL builds appear on the right page in the new cognitive UI.

No need for a PB as its only changing the config files for CI Orchestrator and is not exercises by a PB.