### PR TITLE
JAX-WS: Prevent creation of MessagePartInfo while correcting its namespace

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/SoapBindingFactory.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/SoapBindingFactory.java
@@ -661,7 +661,9 @@ public class SoapBindingFactory extends AbstractWSDLBindingFactory {
                 String partElementQnameSpace = partElementQname.getNamespaceURI();
                 
                 // Correct Namespace while keeping everything else intact. 
-                if (partElementQnameSpace != null && !partElementQnameSpace.equals(minfo.getName().getNamespaceURI())) { // Use ElementQnameSpace to check for correct Namespace
+                // Use ElementQname to check for correct QName
+                // Fix 27103 prevents creation of MessagePartInfo (pi) when it's null in system
+                if (partElementQnameSpace != null && pi != null && !partElementQnameSpace.equals(minfo.getName().getNamespaceURI())) { 
                     QName newPartTypeQName = new QName(partElementQnameSpace, pqname.getLocalPart());
                     pi = minfo.addOutOfBandMessagePart(newPartTypeQName);
                  // Fix 26846 end


### PR DESCRIPTION
Fixes #27103