### PR TITLE
Update MP OpenAPI 3.1 TCK to run against different MP Config versions

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/fat/src/io/openliberty/microprofile/openapi31/fat/tck/OpenAPITckTest.java
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/fat/src/io/openliberty/microprofile/openapi31/fat/tck/OpenAPITckTest.java
@@ -15,8 +15,11 @@ package io.openliberty.microprofile.openapi31.fat.tck;
 import java.util.HashMap;
 import java.util.Map;
 
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,6 +43,9 @@ public class OpenAPITckTest {
 
     @Server(SERVER_NAME)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests repeatTests = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP61, MicroProfileActions.MP60);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/servers/FATServer/server.xml
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/servers/FATServer/server.xml
@@ -14,6 +14,7 @@
         <feature>restfulWS-3.1</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpOpenAPI-3.1</feature>
+        <feature>mpConfig-3.1</feature>
         <feature>arquillian-support-jakarta-2.1</feature>
     </featureManager>
     <javaPermission className="java.security.AllPermission"/>


### PR DESCRIPTION
By default OpenAPI 3.1 will enable MP Config 3.0, so currently it does not test it against MP Config 3.1. so effectively not against MicroProfile 6.1.

Update server.xml to explicitly include Mp Config so that the right version is used for the repeats and add a repeat to the test to cover MicroProfile 6.0 and 6.1