### PR TITLE
Update test for z/OS

### DIFF
--- a/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/src/app/timeout/TranTimeoutCleanupServlet.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/src/app/timeout/TranTimeoutCleanupServlet.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,12 +12,15 @@
  *******************************************************************************/
 package app.timeout;
 
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
+
 import java.util.logging.Logger;
 
 import javax.servlet.annotation.WebServlet;
 
 import org.junit.Test;
 
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -44,6 +47,7 @@ import fat.util.JobWaiter;
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/TranTimeoutCleanupServlet")
 @Mode(TestMode.FULL)
+@SkipIfSysProp(OS_ZOS) // skip on zos due to derby timeouts
 public class TranTimeoutCleanupServlet extends FATServlet {
 
     public static Logger logger = Logger.getLogger("test");


### PR DESCRIPTION
Update this test to exclude z/OS for derby due to timeout issues.   z/OS is largely tested using DB2 in other zfats but we still have enough derby coverage to exclude this.