### PR TITLE
Improve install performance from directory repository

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -72,6 +72,7 @@ import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.kernel.productinfo.ProductInfoParseException;
 import com.ibm.ws.kernel.productinfo.ProductInfoReplaceException;
 import com.ibm.ws.product.utility.extension.ifix.xml.IFixInfo;
+import com.ibm.ws.repository.common.enums.ReadMode;
 import com.ibm.ws.repository.connections.DirectoryRepositoryConnection;
 import com.ibm.ws.repository.connections.ProductDefinition;
 import com.ibm.ws.repository.connections.RepositoryConnection;
@@ -874,7 +875,7 @@ public class InstallKernelMap implements Map {
             List<File> singleJsonRepos = (List<File>) data.get(InstallConstants.SINGLE_JSON_FILE);
             File directoryBasedRepo = (File) data.get(DIRECTORY_BASED_REPOSITORY);
             if (directoryBasedRepo != null) {
-                RepositoryConnection directRepo = new DirectoryRepositoryConnection(directoryBasedRepo);
+                RepositoryConnection directRepo = new DirectoryRepositoryConnection(directoryBasedRepo, ReadMode.ASSUME_UNCHANGED);
                 repoList.add(directRepo);
             }
 

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ResolveDirector.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ResolveDirector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -53,6 +53,7 @@ import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
 import com.ibm.ws.kernel.feature.provisioning.SubsystemContentType;
 import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.product.utility.extension.ifix.xml.IFixInfo;
+import com.ibm.ws.repository.common.enums.ReadMode;
 import com.ibm.ws.repository.common.enums.ResourceType;
 import com.ibm.ws.repository.common.enums.Visibility;
 import com.ibm.ws.repository.connections.DirectoryRepositoryConnection;
@@ -238,7 +239,7 @@ class ResolveDirector extends AbstractDirector {
                     File repoDir = new File(urlProcessed.getPath());
                     if (repoDir.exists()) {
                         if (repoDir.isDirectory()) {
-                            lie = new DirectoryRepositoryConnection(repoDir);
+                            lie = new DirectoryRepositoryConnection(repoDir, ReadMode.ASSUME_UNCHANGED);
                             loginEntries.add(lie);
                             continue;
                         } else {

--- a/dev/com.ibm.ws.repository.test.utils/src/com/ibm/ws/lars/testutils/clients/DirectoryWriteableClient.java
+++ b/dev/com.ibm.ws.repository.test.utils/src/com/ibm/ws/lars/testutils/clients/DirectoryWriteableClient.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Calendar;
 
+import com.ibm.ws.repository.common.enums.ReadMode;
 import com.ibm.ws.repository.transport.client.DirectoryClient;
 import com.ibm.ws.repository.transport.client.DirectoryUtils;
 import com.ibm.ws.repository.transport.exceptions.BadVersionException;
@@ -36,7 +37,7 @@ public class DirectoryWriteableClient extends AbstractFileWriteableClient {
 
     public DirectoryWriteableClient(File root) {
         _root = root;
-        _readClient = new DirectoryClient(_root);
+        _readClient = new DirectoryClient(_root, ReadMode.DETECT_CHANGES);
     }
 
     public static void writeDiskRepoJSONToFile(Asset asset, final File writeJsonTo) throws IllegalArgumentException, IllegalAccessException, IOException {
@@ -153,8 +154,7 @@ public class DirectoryWriteableClient extends AbstractFileWriteableClient {
                 if ((mainName + ".license").equals(name)) {
                     return true;
                 }
-                if (name.contains(mainName + ".") && DirectoryUtils.isDirectory(dir))
-                {
+                if (name.contains(mainName + ".") && DirectoryUtils.isDirectory(dir)) {
                     // TODO: Is this one we should delete? Another attachment type?
                 }
                 return false;

--- a/dev/com.ibm.ws.repository.test.utils/src/com/ibm/ws/lars/testutils/fixtures/FileRepositoryFixture.java
+++ b/dev/com.ibm.ws.repository.test.utils/src/com/ibm/ws/lars/testutils/fixtures/FileRepositoryFixture.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,6 +15,7 @@ package com.ibm.ws.lars.testutils.fixtures;
 import java.io.File;
 
 import com.ibm.ws.lars.testutils.clients.DirectoryWriteableClient;
+import com.ibm.ws.repository.common.enums.ReadMode;
 import com.ibm.ws.repository.connections.DirectoryRepositoryConnection;
 import com.ibm.ws.repository.connections.RepositoryConnection;
 import com.ibm.ws.repository.transport.client.RepositoryReadableClient;
@@ -28,7 +29,7 @@ public class FileRepositoryFixture extends RepositoryFixture {
     private final File root;
 
     public static FileRepositoryFixture createFixture(File root) {
-        DirectoryRepositoryConnection connection = new DirectoryRepositoryConnection(root);
+        DirectoryRepositoryConnection connection = new DirectoryRepositoryConnection(root, ReadMode.DETECT_CHANGES);
         RepositoryConnection adminConnection = connection;
         RepositoryConnection userConnection = connection;
         RepositoryReadableClient adminClient = connection.createClient();
@@ -75,7 +76,7 @@ public class FileRepositoryFixture extends RepositoryFixture {
     }
 
     public DirectoryRepositoryConnection getWritableConnection() {
-        return new DirectoryRepositoryConnection(root) {
+        return new DirectoryRepositoryConnection(root, ReadMode.DETECT_CHANGES) {
             @Override
             public RepositoryReadableClient createClient() {
                 return new DirectoryWriteableClient(root);

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/common/enums/ReadMode.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/common/enums/ReadMode.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.repository.common.enums;
+
+/**
+ * The mode to use for reading from a directory-based repository
+ * <p>
+ * In production, {@code ASSUME_UNCHANGED} should usually be used
+ */
+public enum ReadMode {
+
+    /**
+     * Assume that the repository contents does not change during the lifetime of the connection
+     * <p>
+     * Allows resources retrieved from the repository to be cached by the client to avoid re-reading and parsing the same data.
+     */
+    ASSUME_UNCHANGED,
+
+    /**
+     * Detect if the repository contents changes between requests and always return up to date data
+     * <p>
+     * Resources cannot be cached by the client
+     */
+    DETECT_CHANGES
+
+}

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/connections/DirectoryRepositoryConnection.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/connections/DirectoryRepositoryConnection.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,6 +14,7 @@ package com.ibm.ws.repository.connections;
 
 import java.io.File;
 
+import com.ibm.ws.repository.common.enums.ReadMode;
 import com.ibm.ws.repository.connections.internal.AbstractRepositoryConnection;
 import com.ibm.ws.repository.transport.client.DirectoryClient;
 import com.ibm.ws.repository.transport.client.RepositoryReadableClient;
@@ -24,12 +25,20 @@ import com.ibm.ws.repository.transport.client.RepositoryReadableClient;
 public class DirectoryRepositoryConnection extends AbstractRepositoryConnection implements RepositoryConnection {
 
     private final File _root;
+    private final ReadMode _readMode;
+    private DirectoryClient client;
 
     /**
-     * @param type
+     * @deprecated Use {@link #DirectoryRepositoryConnection(File, ReadMode)}
      */
+    @Deprecated
     public DirectoryRepositoryConnection(File root) {
+        this(root, ReadMode.DETECT_CHANGES);
+    }
+
+    public DirectoryRepositoryConnection(File root, ReadMode readMode) {
         _root = root;
+        _readMode = readMode;
     }
 
     public File getRoot() {
@@ -43,8 +52,11 @@ public class DirectoryRepositoryConnection extends AbstractRepositoryConnection 
     }
 
     @Override
-    public RepositoryReadableClient createClient() {
-        return new DirectoryClient(getRoot());
+    public synchronized RepositoryReadableClient createClient() {
+        if (client == null) {
+            client = new DirectoryClient(getRoot(), _readMode);
+        }
+        return client;
     }
 
 }

--- a/dev/com.ibm.ws.repository/test/com/ibm/ws/repository/connections/test/RepositoryConnectionTest.java
+++ b/dev/com.ibm.ws.repository/test/com/ibm/ws/repository/connections/test/RepositoryConnectionTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,6 +19,7 @@ import java.io.File;
 
 import org.junit.Test;
 
+import com.ibm.ws.repository.common.enums.ReadMode;
 import com.ibm.ws.repository.connections.DirectoryRepositoryConnection;
 import com.ibm.ws.repository.connections.RestRepositoryConnection;
 import com.ibm.ws.repository.connections.ZipRepositoryConnection;
@@ -42,7 +43,7 @@ public class RepositoryConnectionTest {
     @Test
     public void testDirectoryRepoLocation() {
         File root = new File("C:/root");
-        DirectoryRepositoryConnection dirCon = new DirectoryRepositoryConnection(root);
+        DirectoryRepositoryConnection dirCon = new DirectoryRepositoryConnection(root, ReadMode.DETECT_CHANGES);
         RepositoryResourceImpl mr = new SampleResourceImpl(dirCon);
         assertEquals("The repo url in the resource is not the one we set",
                      root.getAbsolutePath(), mr.getRepositoryConnection().getRepositoryLocation());

--- a/dev/com.ibm.ws.repository_fat/fat/src/com/ibm/ws/repository/transport/client/test/FileClientLicenseTest.java
+++ b/dev/com.ibm.ws.repository_fat/fat/src/com/ibm/ws/repository/transport/client/test/FileClientLicenseTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.ibm.ws.repository.common.enums.AttachmentType;
+import com.ibm.ws.repository.common.enums.ReadMode;
 import com.ibm.ws.repository.transport.client.AbstractFileClient;
 import com.ibm.ws.repository.transport.client.DirectoryClient;
 import com.ibm.ws.repository.transport.client.ZipClient;
@@ -45,7 +46,7 @@ public abstract class FileClientLicenseTest {
      */
     public static class DirectoryClientLicenseTest extends FileClientLicenseTest {
         public DirectoryClientLicenseTest() {
-            _licenseClient = new DirectoryClient(new File(resourcesDir, "licenseTestRepo"));
+            _licenseClient = new DirectoryClient(new File(resourcesDir, "licenseTestRepo"), ReadMode.DETECT_CHANGES);
         }
     }
 

--- a/dev/com.ibm.ws.repository_fat/fat/src/com/ibm/ws/repository/transport/client/test/InvalidDirectoryClientTest.java
+++ b/dev/com.ibm.ws.repository_fat/fat/src/com/ibm/ws/repository/transport/client/test/InvalidDirectoryClientTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.junit.Test;
 
+import com.ibm.ws.repository.common.enums.ReadMode;
 import com.ibm.ws.repository.transport.client.AbstractFileClient;
 import com.ibm.ws.repository.transport.client.DirectoryClient;
 import com.ibm.ws.repository.transport.exceptions.RequestFailureException;
@@ -31,7 +32,7 @@ public class InvalidDirectoryClientTest {
 
     @Test
     public void testRepositoryStatusNoDirFound() throws Exception {
-        AbstractFileClient noDirClient = new DirectoryClient(new File("doesnotexist"));
+        AbstractFileClient noDirClient = new DirectoryClient(new File("doesnotexist"), ReadMode.DETECT_CHANGES);
         try {
             noDirClient.checkRepositoryStatus();
             fail("An exception should have been thrown as the repo should not be reachable");
@@ -43,7 +44,7 @@ public class InvalidDirectoryClientTest {
 
     @Test
     public void testRepositoryStatusRootIsAFileNotADir() throws IOException, RequestFailureException {
-        AbstractFileClient invalidFile = new DirectoryClient(new File(resourceDir, "TestAttachment.txt"));
+        AbstractFileClient invalidFile = new DirectoryClient(new File(resourceDir, "TestAttachment.txt"), ReadMode.DETECT_CHANGES);
         try {
             invalidFile.checkRepositoryStatus();
             fail("An exception should have been thrown as the repo should not be reachable");


### PR DESCRIPTION
Allow the `DirectoryRepositoryClient` to cache results if we can assume that the files on disk do not change during the lifetime of the client.

Fixes #27204