### PR TITLE
Fix DateFormat issue introduced in Java 20

### DIFF
--- a/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/DataFormatHelper.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/DataFormatHelper.java
@@ -56,6 +56,8 @@ public class DataFormatHelper {
         newPattern = newPattern.replace('K', 'H');
         newPattern = newPattern.replace('k', 'H');
         newPattern = newPattern.replace('a', ' ');
+        // Java 20 added a narrow no-break space character into the format (Unicode 202F character)
+        newPattern = newPattern.replace('\u202f', ' ');
         newPattern = newPattern.trim();
         pattern = newPattern;
         DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder().appendPattern(pattern);

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/DateFormatHelper.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/DateFormatHelper.java
@@ -65,7 +65,8 @@ public class DateFormatHelper {
         while (start <= end && ((letter = sb.charAt(start)) == ' ' || letter == 'a'))
             start++;
         // trim right side
-        while (end > start && ((letter = sb.charAt(end)) == ' ' || letter == 'a'))
+        // Java 20 added a narrow no-break space character into the format (Unicode 202F character)
+        while (end > start && ((letter = sb.charAt(end)) == ' ' || letter == 'a' || letter == '\u202f'))
             end--;
         // replace characters 'h', 'k', and 'K' to 'H' and 'a' to ' '
         for (int i = start; i <= end; i++) {

--- a/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/collector/BurstDateFormatterTest.java
+++ b/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/collector/BurstDateFormatterTest.java
@@ -35,6 +35,22 @@ public class BurstDateFormatterTest {
     private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
     private static final boolean aboveJava8 = !System.getProperty("java.version").startsWith("1.");
 
+    // If this test fails, there is likely an update is needed to the getFormatter methods and to DateFormatHelper and DataFormatHelper
+    // This test was added due to a change in Java 20 to add an additional space character to the format.
+    // See https://bugs.openjdk.org/browse/JDK-8304925
+    @Test
+    public void testEnglishUnchanged() {
+        String pattern = DateTimeFormatterBuilder.getLocalizedDateTimePattern(FormatStyle.SHORT, FormatStyle.MEDIUM, Chronology.ofLocale(Locale.ENGLISH), Locale.ENGLISH);
+        pattern = getFormatter(pattern);
+        StringBuilder sb = new StringBuilder();
+        sb.append("M/d/yy");
+        if (aboveJava8) {
+            sb.append(',');
+        }
+        sb.append(" H:mm:ss:SSS z");
+        assertEquals(sb.toString(), pattern);
+    }
+
     @Test
     public void checkAllLocalesTest() {
         for (Locale locale : Locale.getAvailableLocales()) {
@@ -229,7 +245,7 @@ public class BurstDateFormatterTest {
     }
 
     /**
-     * A partial copy of DateFormatHelper.getDateFormat so that we can work with different locales
+     * A partial copy of DataFormatHelper code so that we can work with different locales
      */
     public DateFormat getFormatter(DateFormat formatter) {
         String pattern;
@@ -251,6 +267,8 @@ public class BurstDateFormatterTest {
             newPattern = newPattern.replace('K', 'H');
             newPattern = newPattern.replace('k', 'H');
             newPattern = newPattern.replace('a', ' ');
+            // Java 20 added a narrow no-break space character into the format (Unicode 202F character)
+            newPattern = newPattern.replace('\u202f', ' ');
             newPattern = newPattern.trim();
             sdFormatter.applyPattern(newPattern);
             formatter = sdFormatter;
@@ -272,6 +290,8 @@ public class BurstDateFormatterTest {
         newPattern = newPattern.replace('K', 'H');
         newPattern = newPattern.replace('k', 'H');
         newPattern = newPattern.replace('a', ' ');
+        // Java 20 added a narrow no-break space character into the format (Unicode 202F character)
+        newPattern = newPattern.replace('\u202f', ' ');
         newPattern = newPattern.trim();
         return newPattern;
     }


### PR DESCRIPTION
- Remove narrow no-break space character added due to new CLDR version added in Java 20.  See https://bugs.openjdk.org/browse/JDK-8304925.
- Add test cases to detect this problem easily with a unit test and FAT test.

Fixes #27208
