### PR TITLE
Add OR LATER Jakarta SkipForRepeat constants

### DIFF
--- a/dev/build.example_fat/fat/src/com/ibm/ws/example/SimpleTest.java
+++ b/dev/build.example_fat/fat/src/com/ibm/ws/example/SimpleTest.java
@@ -13,9 +13,12 @@
 package com.ibm.ws.example;
 
 import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE11_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE10_OR_LATER_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE11_OR_LATER_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE8_OR_LATER_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_OR_LATER_FEATURES;
 import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 import static org.junit.Assert.assertTrue;
 
@@ -81,7 +84,7 @@ public class SimpleTest extends FATServletClient {
     }
 
     @Test
-    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES, EE10_FEATURES, EE11_FEATURES })
+    @SkipForRepeat({ EE8_OR_LATER_FEATURES })
     public void testEE7Only() throws Exception {
         // This test will only run for the EE7 feature iteration (i.e. NO_MODIFICATION)
 
@@ -94,7 +97,7 @@ public class SimpleTest extends FATServletClient {
     }
 
     @Test
-    @SkipForRepeat({ NO_MODIFICATION, EE9_FEATURES, EE10_FEATURES, EE11_FEATURES })
+    @SkipForRepeat({ NO_MODIFICATION, EE9_OR_LATER_FEATURES })
     public void testEE8Only() throws Exception {
         // This test will only run for the EE 8 iteration
 
@@ -107,7 +110,7 @@ public class SimpleTest extends FATServletClient {
     }
 
     @Test
-    @SkipForRepeat({ NO_MODIFICATION, EE8_FEATURES, EE10_FEATURES, EE11_FEATURES })
+    @SkipForRepeat({ NO_MODIFICATION, EE8_FEATURES, EE10_OR_LATER_FEATURES })
     public void testEE9Only() throws Exception {
         // This test will only run for the EE9 iteration
 
@@ -120,7 +123,7 @@ public class SimpleTest extends FATServletClient {
     }
 
     @Test
-    @SkipForRepeat({ NO_MODIFICATION, EE8_FEATURES, EE9_FEATURES, EE11_FEATURES })
+    @SkipForRepeat({ NO_MODIFICATION, EE8_FEATURES, EE9_FEATURES, EE11_OR_LATER_FEATURES })
     public void testEE10Only() throws Exception {
         // This test will only run for the EE10 iteration
 

--- a/dev/fattest.simplicity/src/componenttest/annotation/SkipForRepeat.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/SkipForRepeat.java
@@ -16,6 +16,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import componenttest.rules.repeater.EE7FeatureReplacementAction;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
@@ -26,6 +30,8 @@ import componenttest.rules.repeater.JakartaEEAction;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SkipForRepeat {
 
+    String[] value();
+
     public static final String NO_MODIFICATION = EmptyAction.ID;
     public static final String EE7_FEATURES = EE7FeatureReplacementAction.ID;
     public static final String EE8_FEATURES = EE8FeatureReplacementAction.ID;
@@ -33,6 +39,68 @@ public @interface SkipForRepeat {
     public static final String EE10_FEATURES = JakartaEEAction.EE10_ACTION_ID;
     public static final String EE11_FEATURES = JakartaEEAction.EE11_ACTION_ID;
 
-    String[] value();
+    // Cannot use MultivalueSkips.name() since it isn't a constant at compile time so need to actually
+    // use the string version of the enum name.
+    public static final String EE8_OR_LATER_FEATURES = "EE8_OR_LATER_FEATURES";
+    public static final String EE9_OR_LATER_FEATURES = "EE9_OR_LATER_FEATURES";
+    public static final String EE10_OR_LATER_FEATURES = "EE10_OR_LATER_FEATURES";
+    public static final String EE11_OR_LATER_FEATURES = "EE11_OR_LATER_FEATURES";
 
+    // Using an enum in order to be able to store the array of repeated skip values and to have
+    // a static method to process a given list.  Annotations cannot have a method that takes a parameter.
+    public enum MultivalueSkips {
+        EE8_OR_LATER_FEATURES(new String[] { EE8_FEATURES, EE9_FEATURES, EE10_FEATURES, EE11_FEATURES }),
+        EE9_OR_LATER_FEATURES(new String[] { EE9_FEATURES, EE10_FEATURES, EE11_FEATURES }),
+        EE10_OR_LATER_FEATURES(new String[] { EE10_FEATURES, EE11_FEATURES }),
+        EE11_OR_LATER_FEATURES(new String[] { EE11_FEATURES });
+
+        // These cannot be used as @SkipForRepeat(EE8_OR_LATER_FEATURES.skipValues).  Need to use constants above and then it will
+        // be converted to the multiple skip values.
+        final String[] skipValues;
+
+        private MultivalueSkips(String[] skipValues) {
+            this.skipValues = skipValues;
+        }
+
+        private static final Set<String> OR_LATER_NAMES;
+        static {
+            Set<String> enumNames = new HashSet<>();
+            enumNames.add(EE8_OR_LATER_FEATURES.name());
+            enumNames.add(EE9_OR_LATER_FEATURES.name());
+            enumNames.add(EE10_OR_LATER_FEATURES.name());
+            enumNames.add(EE11_OR_LATER_FEATURES.name());
+            OR_LATER_NAMES = Collections.unmodifiableSet(enumNames);
+        }
+
+        public static String[] getSkipForRepeatValues(String[] skipValues) {
+            boolean containsOrLaterSkip = false;
+            for (String skipValue : skipValues) {
+                if (OR_LATER_NAMES.contains(skipValue)) {
+                    containsOrLaterSkip = true;
+                    break;
+                }
+            }
+
+            // If the array of skip values does not include one of the "or later" constants, just return
+            // the passed in skipValues array.
+            if (!containsOrLaterSkip) {
+                return skipValues;
+            }
+
+            // Otherwise process the "or later" constant(s) and include the values in a final
+            // skip value array.
+            Set<String> updatedSkipValues = new LinkedHashSet<>();
+            for (String skipValue : skipValues) {
+                if (!OR_LATER_NAMES.contains(skipValue)) {
+                    updatedSkipValues.add(skipValue);
+                } else {
+                    MultivalueSkips skipEnum = valueOf(skipValue);
+                    for (String multiSkipValue : skipEnum.skipValues) {
+                        updatedSkipValues.add(multiSkipValue);
+                    }
+                }
+            }
+            return updatedSkipValues.toArray(new String[updatedSkipValues.size()]);
+        }
+    }
 }

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/RepeatTestFilter.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/RepeatTestFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 import org.junit.runners.model.FrameworkMethod;
 
 import componenttest.annotation.SkipForRepeat;
+import componenttest.annotation.SkipForRepeat.MultivalueSkips;
 import componenttest.rules.repeater.RepeatTestAction;
 
 public class RepeatTestFilter {
@@ -55,7 +56,8 @@ public class RepeatTestFilter {
         if (anno == null || anno.value().length == 0)
             return true;
 
-        for (String action : anno.value()) {
+        String[] skipValues = MultivalueSkips.getSkipForRepeatValues(anno.value());
+        for (String action : skipValues) {
             if (repeatStackContainsActionByID(action)) {
                 log.info("Skipping test method " + method.getName() + " on action " + action);
                 return false;
@@ -79,7 +81,8 @@ public class RepeatTestFilter {
 
         FATRunner.requireFATRunner(clazz.getName());
 
-        for (String action : anno.value()) {
+        String[] skipValues = MultivalueSkips.getSkipForRepeatValues(anno.value());
+        for (String action : skipValues) {
             if (repeatStackContainsActionByID(action)) {
                 log.info("Skipping test class " + clazz.getName() + " on action " + action);
                 return false;


### PR DESCRIPTION
- Add constants to represent wanting to skip repeats of tests for Jakarta EE 8 or later, EE 9 or later, EE 10 or later, or EE 11 or later.  As we add new EE levels, the skip list can be easily updated in one place and all tests that use the new constants will see the benefit.
- Update build.example_fat test to use the new constants to show that they are working and give people an example of using them.