### PR TITLE
Fix bnd 7.0.0 library being added to build/libs/autoFVT/lib directory

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/build.gradle
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/build.gradle
@@ -4,12 +4,18 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
 addRequiredLibraries.dependsOn addDerby
 addRequiredLibraries.dependsOn addJakartaTransformer
+
+configurations {
+  requiredLibs {
+    transitive = false
+  }
+}
 
 dependencies {
   requiredLibs project(':com.ibm.websphere.security')

--- a/dev/io.openliberty.microprofile41.internal_fat/build.gradle
+++ b/dev/io.openliberty.microprofile41.internal_fat/build.gradle
@@ -1,15 +1,21 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
+configurations {
+  requiredLibs {
+    transitive = false
+  }
+}
 
 dependencies {
   //if there is a existing project, reference it directly

--- a/dev/io.openliberty.org.eclipse.microprofile/bnd.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
@@ -26,6 +26,5 @@ instrument.disabled: true
   com.ibm.websphere.javaee.annotation.1.3;version=latest,\
   com.ibm.websphere.javaee.cdi.2.0;version=latest,\
   com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
-  com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
-  biz.aQute.bnd:biz.aQute.bnd;version=7.0.0
+  com.ibm.websphere.javaee.jaxrs.2.1;version=latest
 

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -44,7 +44,7 @@ configurations {
   jdbcDrivers { transitive = false; }
   testcontainers { transitive = false; }
   derby
-  jakartaTransformer
+  jakartaTransformer { transitive = false; }
 }
 
 dependencies {


### PR DESCRIPTION
- Update to have configurations not be transitive where they are not needed to be transitive.
- Remove unnecessary bnd 7.0.0 dependency that was causing test failures for Java 8 and Java 11 test platforms since bnd 7.0.0 requires Java 17.

This is fixing a problem that was introduced by #24097
