### PR TITLE
Reactive Messaging: validate context service

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
@@ -150,7 +150,7 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory, Quiesce
             // Create the kafkaConsumer
             KafkaConsumer<String, Object> kafkaConsumer = getKafkaConsumerWithRetry(consumerConfig, retrySeconds, channelName);
 
-            RMAsyncProvider asyncProvider = asyncProviderFactory.getAsyncProvider(contextServiceRef);
+            RMAsyncProvider asyncProvider = asyncProviderFactory.getAsyncProvider(contextServiceRef, channelName);
 
             PartitionTrackerFactory partitionTrackerFactory = new PartitionTrackerFactory();
             partitionTrackerFactory.setAsyncProvider(asyncProvider);

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/invalid/KafkaInvalidContextBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/invalid/KafkaInvalidContextBean.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context.custom.invalid;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+/**
+ * A bean which has an incoming channel, used to test with invalid incoming channel config
+ */
+@ApplicationScoped
+public class KafkaInvalidContextBean {
+
+    public static final String CHANNEL_NAME = "invalid-context-bean";
+
+    @Incoming(CHANNEL_NAME)
+    public void incoming(String data) {
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/invalid/KakfaInvalidContextTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/invalid/KakfaInvalidContextTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context.custom.invalid;
+
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaClientLibs;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaPermissions;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.AppValidator;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingActions;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.KafkaConnectorConstants;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * Test invalid context service configuration
+ */
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class KakfaInvalidContextTest extends FATServletClient {
+    public static final String SERVER_NAME = "CustomContextRxMessagingServer";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = ReactiveMessagingActions.repeat(SERVER_NAME,
+                                                                  ReactiveMessagingActions.MP61_RM30,
+                                                                  ReactiveMessagingActions.MP50_RM30,
+                                                                  ReactiveMessagingActions.MP20_RM10);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        try {
+            server.stopServer();
+        } finally {
+            KafkaUtils.deleteKafkaTopics(PlaintextTests.getAdminClient());
+        }
+    }
+
+    @Test
+    @AllowedFFDC
+    public void testInvalidContextService() throws Exception {
+
+        ConnectorProperties config = ConnectorProperties.simpleIncomingChannel(PlaintextTests.connectionProperties(),
+                                                                               KafkaInvalidContextBean.CHANNEL_NAME,
+                                                                               "invalid")
+                        .addProperty(KafkaConnectorConstants.CONTEXT_SERVICE, "invalid-context-service");
+
+        AppValidator.validateAppOn(server)
+                        .withAppName("testInvalidContextService")
+                        .withClass(KafkaInvalidContextBean.class)
+                        .withAppConfig(config)
+                        .withLibrary(kafkaClientLibs())
+                        .withManifestResource(kafkaPermissions(), "permissions.xml")
+                        .failsWith("CWMRX1200E: .*" + KafkaInvalidContextBean.CHANNEL_NAME + ".*invalid-context-service")
+                        .run();
+        // CWMRX1200E: The {0} channel is configured to use the {1} context service, but no such context service was found.
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
@@ -27,6 +27,7 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.ack.auto.KafkaAutoAc
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.containers.ExtendedKafkaContainer;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context.KafkaDefaultContextTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context.custom.KafkaCustomContextTest;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.context.custom.invalid.KakfaInvalidContextTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.delivery.KafkaAcknowledgementTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.flatmap.KafkaFlatMapTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.message.ConsumerRecordTest;
@@ -57,6 +58,7 @@ import componenttest.containers.TestContainerSuite;
                 KafkaCustomKeySerializerTest.class,
                 KafkaDefaultContextTest.class,
                 KafkaFlatMapTest.class,
+                KakfaInvalidContextTest.class,
                 KafkaPartitionTest.class,
                 KafkaSharedLibTest.class,
                 MissingGroupIDTest.class,

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/resources/io/openliberty/microprofile/reactive/messaging/internal/ReactiveMessagingProvider.nlsprops
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/resources/io/openliberty/microprofile/reactive/messaging/internal/ReactiveMessagingProvider.nlsprops
@@ -27,6 +27,6 @@
 # CWMRX   1000-1999       MicroProfile Reactive Messaging
 #-----------------------------------------------------------------------------------------------------------------------------
 
-missing.context.service.CWMRX1200E=CWMRX1200E: The {0} channel is configured to use the {1} context service, but no such context service was found. Ensure that the context service is defined in the server.xml and that the concurrent feature is enabled.
-missing.context.service.CWMRX1200E.explanation=The Reactive Messaging channel is configured to use a named context service, but a context service with that name cannot be found.
-missing.context.service.CWMRX1200E.useraction=Define the context service in server.xml, or remove the context.service configuration property for the channel.
+missing.context.service.CWMRX1200E=CWMRX1200E: The {0} channel is configured to use the {1} context service, but no such context service was found. Ensure that the context service is defined in the server.xml file and that the Java EE or Jakarta Concurrency feature is enabled.
+missing.context.service.CWMRX1200E.explanation=The Reactive Messaging channel is configured to use a named context service, but no context service with that name can be found.
+missing.context.service.CWMRX1200E.useraction=Either define the context service in the server.xml file or remove the context.service configuration property for the channel.

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/resources/io/openliberty/microprofile/reactive/messaging/internal/ReactiveMessagingProvider.nlsprops
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/resources/io/openliberty/microprofile/reactive/messaging/internal/ReactiveMessagingProvider.nlsprops
@@ -1,0 +1,32 @@
+#CMVCPATHNAME N/A
+#COMPONENTPREFIX CWMRX
+#COMPONENTNAMEFOR CWMRX MicroProfile Reactive
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#ISMESSAGEFILE true
+# #########################################################################
+###############################################################################
+# Copyright (c) 2023 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+# This file follows the WebSphere Message Guidelines.
+# For more information, visit:
+# http://washome.austin.ibm.com/xwiki/bin/view/MessagesTeam/
+#
+
+#-----------------------------------------------------------------------------------------------------------------------------
+# CWMRX   0000-0999       MicroProfile Reactive Streams
+# CWMRX   1000-1999       MicroProfile Reactive Messaging
+#-----------------------------------------------------------------------------------------------------------------------------
+
+missing.context.service.CWMRX1200E=CWMRX1200E: The {0} channel is configured to use the {1} context service, but no such context service was found. Ensure that the context service is defined in the server.xml and that the concurrent feature is enabled.
+missing.context.service.CWMRX1200E.explanation=The Reactive Messaging channel is configured to use a named context service, but a context service with that name cannot be found.
+missing.context.service.CWMRX1200E.useraction=Define the context service in server.xml, or remove the context.service configuration property for the channel.

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMAsyncProviderFactory.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/interfaces/RMAsyncProviderFactory.java
@@ -20,7 +20,8 @@ public interface RMAsyncProviderFactory {
      * Creates an {@code RMAsyncProvider} which uses the named context service to capture thread context
      *
      * @param contextServiceName the context service name, or {@code null} to use the default context service
+     * @param channelName the channel the async provider is used for. Used in error messages.
      * @return the async provider
      */
-    RMAsyncProvider getAsyncProvider(String contextServiceName);
+    RMAsyncProvider getAsyncProvider(String contextServiceName, String channelName);
 }

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/package-info.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal/src/io/openliberty/microprofile/reactive/messaging/internal/package-info.java
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-@TraceOptions(traceGroup = "REACTIVEMESSAGE")
+@TraceOptions(traceGroup = "REACTIVEMESSAGE", messageBundle = "io.openliberty.microprofile.reactive.messaging.internal.ReactiveMessagingProvider")
 package io.openliberty.microprofile.reactive.messaging.internal;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/AppValidator.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/AppValidator.java
@@ -47,7 +47,8 @@ import componenttest.topology.impl.LibertyServer;
  * </pre>
  *
  * <p>
- * This creates a web application containing just {@code MyInvalidClass}, deploys it, checks that it either succeeds or fails to start. In the case of failure, it checks that a message containing {@code CWMFT5001E} is found in the
+ * This creates a web application containing just {@code MyInvalidClass}, deploys it, checks that it either succeeds or fails to start. In the case of failure, it checks that a
+ * message containing {@code CWMFT5001E} is found in the
  * log, and then undeploys it.
  */
 public class AppValidator {
@@ -184,7 +185,7 @@ public class AppValidator {
                 RemoteFile logFile = server.getDefaultLogFile();
                 server.setMarkToEndOfLog(logFile);
 
-                ShrinkHelper.exportArtifact(app, "tmp/apps");
+                ShrinkHelper.exportArtifact(app, "tmp/apps", true/* print contents */, true/* overwrite */);
                 server.copyFileToLibertyServerRoot("tmp/apps", "dropins", archiveName);
 
                 for (String stringToFind : stringsToFind) {


### PR DESCRIPTION
If the user configures a channel to use a config service but the config service can't be found, report an appropriate error.

Fixes #27189 