### PR TITLE
JAX-WS: Add Trace Injection to CXF's SOAP module

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/bnd.bnd
@@ -19,6 +19,25 @@ bVersion=1.0
 cxfImportVersion=3.5.5
 cxfExportVersion=3.4.3
 
+instrument.classesExcludes: \
+    org/apache/cxf/binding/soap/model/SoapBindingInfo.class, \
+    org/apache/cxf/binding/soap/model/SoapBodyInfo.class, \
+    org/apache/cxf/binding/soap/model/SoapOperationInfo.class, \
+    org/apache/cxf/binding/soap/saaj/SAAJStreamWriter.class, \
+    org/apache/cxf/binding/soap/saaj/SAAJUtils.class, \
+    org/apache/cxf/binding/soap/HeaderUtil.class, \
+    org/apache/cxf/binding/soap/SOAPBindingUtil.class, \
+    org/apache/cxf/binding/soap/Soap11.class, \
+    org/apache/cxf/binding/soap/Soap12.class, \
+    org/apache/cxf/binding/soap/SoapBindingConfiguration.class, \
+    org/apache/cxf/binding/soap/SoapBindingConstants.class, \
+    org/apache/cxf/binding/soap/SoapFault.class, \
+    org/apache/cxf/binding/soap/SoapHeader.class, \
+    org/apache/cxf/binding/soap/SoapTransportFactory.class, \
+    org/apache/cxf/binding/soap/SoapVersion.class, \
+    org/apache/cxf/binding/soap/SoapVersionEditor.class, \
+    org/apache/cxf/binding/soap/SoapVersionFactoy.class
+
 # Using version=! in order to not have a version attached to the import for packages that were removed
 # from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
 # packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/build.gradle
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/build.gradle
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+configurations {
+  cxf
+}
+
+dependencies {
+  cxf 'org.apache.cxf:cxf-rt-bindings-soap:3.5.5'
+}
+
+// Copy each class from the CXF jar into the build directory
+// so the build can inject entry/exit trace into the bytecode
+task extractInjectedClasses(type: Copy) {
+  from zipTree(configurations.cxf[0])
+  into compileJava.destinationDir
+}
+
+// Copy each class from the CXF jar into the build directory
+// so the build can inject entry/exit trace into the bytecode
+//compileJava.dependsOn extractInjectedClasses


### PR DESCRIPTION
This pull request enables basic trace injection on the `com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2` and the inherited classes from the CXF module. 