### PR TITLE
Shutdown Liberty directly when administrator issue server stop xxx --force option

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/ServerCommandListener.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/ServerCommandListener.java
@@ -447,11 +447,25 @@ public class ServerCommandListener extends ServerCommand implements CheckpointHo
         if (STATUS_START_COMMAND.equals(command)) {
             asyncResponse(command, sc);
             sc = null;
-        } else if (STOP_COMMAND.equals(command) || FORCE_STOP_COMMAND.equals(command)) {
+        } else if (STOP_COMMAND.equals(command) ) { // || FORCE_STOP_COMMAND.equals(command)) {
             Tr.audit(tc, "info.stop.request.received", new Date(), serverName);
             asyncResponse(command, sc);
             sc = null;
             frameworkManager.shutdownCommand(FORCE_STOP_COMMAND.equals(command));
+        } else if (FORCE_STOP_COMMAND.equals(command)) {
+            Tr.audit(tc, "info.stop.request.received", new Date(), serverName);
+            asyncResponse(command, sc);
+            sc = null;
+            frameworkManager.shutdownCommand(FORCE_STOP_COMMAND.equals(command));
+            Tr.audit(tc, "info.serverStopping", new Object[] {this.serverName });
+			try {
+			    Thread.sleep(10 * 1000);
+				System.exit(0);
+				}
+				catch(Exception e)
+				{
+				}
+			Tr.audit(tc, "info.serverStopped", new Object[] {this.serverName });
         } else if (command.startsWith(INTROSPECT_COMMAND)) {
             String arg = command.substring(command.indexOf('#') + 1);
 


### PR DESCRIPTION
After for 10 * 1000 ms and shutdown Liberty directly when administrator issue server stop xxx --force option.

Especially there have some threads launched by customer self and not managed by Liberty server, Liberty can't not stop these threads smoothly and will hung.
