### PR TITLE
Add Beta guards to Liberty-kafka connector new options

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/bnd.bnd
@@ -46,6 +46,7 @@ Include-Resource: \
   com.ibm.ws.logging;version=latest, \
   com.ibm.ws.logging.core;version=latest, \
   org.eclipse.osgi;version=latest, \
+  com.ibm.ws.kernel.boot.core;version=latest,\
   com.ibm.websphere.javaee.cdi.2.0;version=latest, \
   com.ibm.websphere.org.osgi.core;version=latest, \
   com.ibm.websphere.org.osgi.service.component;version=latest, \

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
@@ -29,6 +29,7 @@ import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
@@ -129,8 +130,9 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory, Quiesce
             int maxPollRecords = config.getOptionalValue(KafkaConnectorConstants.MAX_POLL_RECORDS, Integer.class).orElse(500);
             int unackedLimit = config.getOptionalValue(KafkaConnectorConstants.UNACKED_LIMIT, Integer.class).orElse(maxPollRecords);
             int retrySeconds = config.getOptionalValue(KafkaConnectorConstants.CREATION_RETRY_SECONDS, Integer.class).orElse(0);
-            boolean fastAck = config.getOptionalValue(KafkaConnectorConstants.FAST_ACK, Boolean.class).orElse(false);
-            String contextServiceRef = config.getOptionalValue(KafkaConnectorConstants.CONTEXT_SERVICE, String.class).orElse(null);
+            // If Beta is false, apply the default value as if the property had not been set.
+            boolean fastAck = ProductInfo.getBetaEdition() ? config.getOptionalValue(KafkaConnectorConstants.FAST_ACK, Boolean.class).orElse(false) : false;
+            String contextServiceRef = ProductInfo.getBetaEdition() ? config.getOptionalValue(KafkaConnectorConstants.CONTEXT_SERVICE, String.class).orElse(null): null;
 
             // Configure our defaults
             Map<String, Object> consumerConfig = new HashMap<>();
@@ -149,8 +151,9 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory, Quiesce
 
             // Create the kafkaConsumer
             KafkaConsumer<String, Object> kafkaConsumer = getKafkaConsumerWithRetry(consumerConfig, retrySeconds, channelName);
+            RMAsyncProvider asyncProvider;
 
-            RMAsyncProvider asyncProvider = asyncProviderFactory.getAsyncProvider(contextServiceRef, channelName);
+            asyncProvider = asyncProviderFactory.getAsyncProvider(contextServiceRef, channelName);
 
             PartitionTrackerFactory partitionTrackerFactory = new PartitionTrackerFactory();
             partitionTrackerFactory.setAsyncProvider(asyncProvider);

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/KafkaCustomContextTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/KafkaCustomContextTest.java
@@ -35,6 +35,8 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
+import java.util.Arrays;
+
 /**
  * Test context propagation with concurrent enabled and custom context services defined
  */
@@ -102,6 +104,8 @@ public class KafkaCustomContextTest extends FATServletClient {
         KafkaUtils.addKafkaTestFramework(war, PlaintextTests.connectionProperties());
 
         ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/invalid/KakfaInvalidContextTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/invalid/KakfaInvalidContextTest.java
@@ -34,6 +34,8 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
+import java.util.Arrays;
+
 /**
  * Test invalid context service configuration
  */
@@ -53,6 +55,7 @@ public class KakfaInvalidContextTest extends FATServletClient {
 
     @BeforeClass
     public static void setup() throws Exception {
+        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
@@ -37,6 +37,8 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
+import java.util.Arrays;
+
 @RunWith(FATRunner.class)
 public class KafkaAcknowledgementTest {
 
@@ -72,6 +74,8 @@ public class KafkaAcknowledgementTest {
                         .addPackage(KafkaTestConstants.class.getPackage())
                         .addPackage(AbstractKafkaTestServlet.class.getPackage())
                         .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
 
         ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
         server.startServer();

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
@@ -15,6 +15,7 @@ package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -118,6 +119,8 @@ public class KafkaPartitionTest {
                         .addAsResource(appConfig, "META-INF/microprofile-config.properties");
 
         ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
 
         server.startServer();
     }


### PR DESCRIPTION
fast.ack and context.service are new attributes for the liberty-kafka connector. However, this are not currently ready to GA and as such require beta guards.

If they are specified based on the RM specification they should be ignored as they outside of beta should not have any impact upon the operations.

For `fast.ack` this is applied at the point where it is checked to determine the kafka acknowledgemnt behavior.
For `context.service` this is applied when we attempt to look up the defined `context.service` and we set it to use the default provided. This does mean that for both RM 1.0 and 3.0 proper looks are still performed in relation to using the context service provided by the `concurrent` feature if it is enabled (which is always the case for 1.0) or the default Liberty context service.

Update relate kafka tests to set the beta flag.