### PR TITLE
Fix EJB remote FAT http port

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.SecureRemoteServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.SecureRemoteServer/server.xml
@@ -9,6 +9,11 @@
 
     <include location="../fatTestCommon.xml" />
 
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="${bvt.prop.HTTP_default}"
+                  httpsPort="${bvt.prop.HTTP_default.secure}"/>
+
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" >
         <iiopsOptions iiopsPort="${bvt.prop.IIOP.secure}"  sslRef="defaultSSLConfig"/>
     </iiopEndpoint>


### PR DESCRIPTION
http ports not configured, resulting in use of defaults that are not available on build systems
- update to use ports provided by build system
