### PR TITLE
Increase EJB Timer FAT delay tolerance

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/test-applications/NpTimerConfigRetryWeb.war/src/com/ibm/ws/ejbcontainer/timer/np/config/retry/web/NpTimerConfigRetryServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/test-applications/NpTimerConfigRetryWeb.war/src/com/ibm/ws/ejbcontainer/timer/np/config/retry/web/NpTimerConfigRetryServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corporation and others.
+ * Copyright (c) 2009, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -39,7 +39,8 @@ public class NpTimerConfigRetryServlet extends FATServlet {
     private static final String CLASS_NAME = NpTimerConfigRetryServlet.class.getName();
     private static final Logger svLogger = Logger.getLogger(CLASS_NAME);
 
-    private static final int TIMER_DELAY = 2500; // 602131
+    private static final int TIMER_DELAY = 2500;
+    private static final int LONG_TIMER_DELAY = 85000;
     private static final long NO_CANCEL_DELAY = 0;
 
     @EJB
@@ -76,8 +77,10 @@ public class NpTimerConfigRetryServlet extends FATServlet {
      */
     private boolean verifyRetryIntervalAcceptable(long timestampForFirstAttempt, long timestampForSecondAttempt, long minimumDifference) {
         long difference = timestampForSecondAttempt - timestampForFirstAttempt;
+        // allow longer timer delay for longer minimum differences
+        long timer_delay = (minimumDifference < 2 * LONG_TIMER_DELAY) ? TIMER_DELAY : LONG_TIMER_DELAY;
         // 500 ms fudge factor for Windows time math and preInvoke delays
-        long maxDifference = minimumDifference + TIMER_DELAY + 500;
+        long maxDifference = minimumDifference + timer_delay + 500;
         minimumDifference = minimumDifference - 500;
 
         if (difference < minimumDifference) {


### PR DESCRIPTION
Accuracy of EJB timer schedule is diminished on slower VMs, especially over longer intervals
- increase the EJB timer delay tolerance for timer scheduled over longer intervals
