### PR TITLE
Web tier fat updates

### DIFF
--- a/dev/com.ibm.ws.el.3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.el.3.0_fat/bnd.bnd
@@ -19,9 +19,9 @@ src: \
 fat.project: true
 
 tested.features:\
-    expressionLanguage-4.0,\
-    expressionLanguage-5.0,\
-    expressionLanguage-6.0,\
+    expressionlanguage-4.0,\
+    expressionlanguage-5.0,\
+    expressionlanguage-6.0,\
     noship-1.0,\
     servlet-5.0,\
     servlet-6.0,\

--- a/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/tests/EL30MiscTests.java
+++ b/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/tests/EL30MiscTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,9 +9,7 @@
  *******************************************************************************/
 package com.ibm.ws.el.fat.tests;
 
-import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE11_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_OR_LATER_FEATURES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -105,7 +103,7 @@ public class EL30MiscTests {
      *
      * @throws Exception
      */
-    @SkipForRepeat({ EE9_FEATURES, EE10_FEATURES, EE11_FEATURES })
+    @SkipForRepeat(EE9_OR_LATER_FEATURES)
     @Test
     public void testEL22ServiceLookup() throws Exception {
 

--- a/dev/com.ibm.ws.el.3.0_fat/test-applications/TestEL3.0.war/src/com/ibm/ws/el30/fat/servlets/EL30InvocationMethodExpressionsServlet.java
+++ b/dev/com.ibm.ws.el.3.0_fat/test-applications/TestEL3.0.war/src/com/ibm/ws/el30/fat/servlets/EL30InvocationMethodExpressionsServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,7 @@
  *******************************************************************************/
 package com.ibm.ws.el30.fat.servlets;
 
-import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE11_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE10_OR_LATER_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 import static org.junit.Assert.assertEquals;
@@ -106,7 +105,7 @@ public class EL30InvocationMethodExpressionsServlet extends FATServlet {
      */
     @Test
     @Mode(TestMode.FULL)
-    @SkipForRepeat({ EE10_FEATURES, EE11_FEATURES })
+    @SkipForRepeat(EE10_OR_LATER_FEATURES)
     public void testMethodExpression_isParmetersProvided_available() throws Exception {
         boolean exceptionOccurred = false;
         ELProcessor elp = new ELProcessor();

--- a/dev/com.ibm.ws.jsf.2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsf.2.2_fat/bnd.bnd
@@ -75,8 +75,8 @@ tested.features: \
     servlet-4.0,\
     jsf-2.3,\
     cdi-2.0,\
-    beanValidation-2.0,\
-    expressionLanguage-4.0,\
+    beanvalidation-2.0,\
+    expressionlanguage-4.0,\
     servlet-5.0,\
     faces-3.0,\
     pages-3.0,\

--- a/dev/com.ibm.ws.jsf.2.3_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsf.2.3_fat/bnd.bnd
@@ -19,17 +19,17 @@ fat.test.container.images:\
  alpine:3.16
 
 tested.features: \
- expressionLanguage-4.0, \
+ expressionlanguage-4.0, \
  servlet-5.0, \
  cdi-3.0, \
  websocket-2.0, \
  faces-3.0, \
  pages-3.0,\
  beanvalidation-3.0,\
- xmlBinding-3.0,\
+ xmlbinding-3.0,\
  jpacontainer-3.0,\
  persistence-3.0,\
- expressionLanguage-5.0,\
+ expressionlanguage-5.0,\
  pages-3.1,\
  servlet-6.0,\
  faces-4.0,\

--- a/dev/com.ibm.ws.jsp.2.3_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsp.2.3_fat/bnd.bnd
@@ -27,12 +27,12 @@ tested.features:\
     jsp-2.2,\
     servlet-4.0,\
     cdi-2.0,\
-    expressionLanguage-4.0,\
+    expressionlanguage-4.0,\
     servlet-5.0,\
     pages-3.0,\
     cdi-3.0, \
     servlet-6.0, \
-    expressionLanguage-5.0,\
+    expressionlanguage-5.0,\
     pages-3.1,\
     cdi-4.0
 

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/bnd.bnd
@@ -46,12 +46,12 @@ tested.features:\
     pages-3.0,\
     appsecurity-4.0,\
     cdi-3.0,\
-    expressionLanguage-5.0,\
+    expressionlanguage-5.0,\
     pages-3.1,\
     servlet-6.0,\
     appsecurity-5.0,\
     cdi-4.0,\
-    expressionLanguage-6.0,\
+    expressionlanguage-6.0,\
     noship-1.0,\
     pages-4.0,\
     servlet-6.1,\

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WC400BadRequestTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WC400BadRequestTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,7 @@
  *******************************************************************************/
 package com.ibm.ws.fat.wc.tests;
 
-import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE11_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE10_OR_LATER_FEATURES;
 import static org.junit.Assert.assertTrue;
 
 import java.util.logging.Logger;
@@ -50,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
  */
 
 @RunWith(FATRunner.class)
-@SkipForRepeat({ EE10_FEATURES, EE11_FEATURES })
+@SkipForRepeat(EE10_OR_LATER_FEATURES)
 @Mode(TestMode.FULL)
 public class WC400BadRequestTest {
 

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WC500BadRequestDefaultTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WC500BadRequestDefaultTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,7 @@
  *******************************************************************************/
 package com.ibm.ws.fat.wc.tests;
 
-import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE11_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE10_OR_LATER_FEATURES;
 import static org.junit.Assert.assertTrue;
 
 import java.util.logging.Logger;
@@ -50,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
  */
 
 @RunWith(FATRunner.class)
-@SkipForRepeat({ EE10_FEATURES, EE11_FEATURES })
+@SkipForRepeat(EE10_OR_LATER_FEATURES)
 @Mode(TestMode.FULL)
 public class WC500BadRequestDefaultTest {
 

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServerMiscTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServerMiscTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,9 +9,7 @@
  *******************************************************************************/
 package com.ibm.ws.fat.wc.tests;
 
-import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE11_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_OR_LATER_FEATURES;
 import static org.junit.Assert.assertNull;
 
 import java.util.logging.Logger;
@@ -32,7 +30,7 @@ import componenttest.topology.impl.LibertyServer;
  * Misc Test Class
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat({ EE9_FEATURES, EE10_FEATURES, EE11_FEATURES })
+@SkipForRepeat(EE9_OR_LATER_FEATURES)
 @Mode(TestMode.FULL)
 public class WCServerMiscTest {
 

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServerTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,9 +9,8 @@
  *******************************************************************************/
 package com.ibm.ws.fat.wc.tests;
 
-import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE11_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE10_OR_LATER_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_OR_LATER_FEATURES;
 import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 import static org.junit.Assert.assertTrue;
 
@@ -107,7 +106,7 @@ public class WCServerTest {
      *                       if something goes horribly wrong
      */
     @Test
-    @SkipForRepeat({ EE9_FEATURES, EE10_FEATURES, EE11_FEATURES })
+    @SkipForRepeat(EE9_OR_LATER_FEATURES)
     public void testServletXPoweredByHeader() throws Exception {
         String url = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + SERVLET_40_APP_JAR_NAME + "/MyServlet";
         String expectedResponse = "Hello World";
@@ -174,7 +173,7 @@ public class WCServerTest {
      *                       if something goes horribly wrong
      */
     @Test
-    @SkipForRepeat({ NO_MODIFICATION, EE10_FEATURES, EE11_FEATURES })
+    @SkipForRepeat({ NO_MODIFICATION, EE10_OR_LATER_FEATURES })
     public void testServletXPoweredByHeader_Servlet50_Enabled() throws Exception {
         String url = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + SERVLET_40_APP_JAR_NAME + "/MyServlet";
         String expectedResponse = "Hello World";
@@ -229,7 +228,6 @@ public class WCServerTest {
 
     @Test
     public void testServletContextMajorMinorVersion() throws Exception {
-        String url = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + SERVLET_40_APP_JAR_NAME;
         String majorVersionExpectedResult = "majorVersion: 4";
         if (JakartaEEAction.isEE9Active()) {
             majorVersionExpectedResult = "majorVersion: 5";

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServletContextUnsupportedOperationExceptionTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServletContextUnsupportedOperationExceptionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,7 @@
  *******************************************************************************/
 package com.ibm.ws.fat.wc.tests;
 
-import static componenttest.annotation.SkipForRepeat.EE10_FEATURES;
-import static componenttest.annotation.SkipForRepeat.EE11_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE10_OR_LATER_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
@@ -85,7 +84,7 @@ public class WCServletContextUnsupportedOperationExceptionTest {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat({ EE10_FEATURES, EE11_FEATURES })
+    @SkipForRepeat(EE10_OR_LATER_FEATURES)
     public void test_ProgrammaticListenerAddition_Throws_UnsupportedOperationException() throws Exception {
         // Ensure that the proper exception was output
         String logMessage = server

--- a/dev/io.openliberty.org.apache.jasper.expressionLanguage.5.0_fat/test-applications/EL50BasicTests.war/src/io/openliberty/el50/fat/basic/servlets/EL50BasicTestsServlet.java
+++ b/dev/io.openliberty.org.apache.jasper.expressionLanguage.5.0_fat/test-applications/EL50BasicTests.war/src/io/openliberty/el50/fat/basic/servlets/EL50BasicTestsServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package io.openliberty.el50.fat.basic.servlets;
 
+import static componenttest.annotation.SkipForRepeat.EE11_OR_LATER_FEATURES;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -98,7 +99,7 @@ public class EL50BasicTestsServlet extends FATServlet {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE11_FEATURES) // Expression Language 6.0 removed the getFeatureDescriptors method.
+    @SkipForRepeat(EE11_OR_LATER_FEATURES) // Expression Language 6.0 removed the getFeatureDescriptors method.
     public void testGetFeatureDescriptors_returnsNull() throws Exception {
         ELResolver resolver = new CustomELResolver();
         assertNull("The result was expected to be null for ELResolver getFeatureDescriptors but was not.",

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/bnd.bnd
@@ -30,7 +30,7 @@ fat.project: true
 tested.features:\
     noship-1.0,\
     servlet-6.1,\
-    expressionLanguage-6.0,\
+    expressionlanguage-6.0,\
     pages-4.0
 
 # To define a global minimum java level for the FAT, use the following property.


### PR DESCRIPTION
fixes #27257

1) Update `expressionLanguage` in `tested.features` to `expressionlanguage`.
2) Use the new `OR_LATER_FEATURES` for our `SkipForRepeat` annotations.