### PR TITLE
Update earlier fix and try different way for ffdc checking

### DIFF
--- a/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/TranTimeoutCleanupTest.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/TranTimeoutCleanupTest.java
@@ -14,6 +14,8 @@ package fat.junit;
 
 import java.io.File;
 
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -26,6 +28,7 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import app.timeout.TranTimeoutCleanupServlet;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
@@ -53,6 +56,7 @@ import componenttest.topology.utils.FATServletClient;
  */
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
+@SkipIfSysProp(OS_ZOS)
 public class TranTimeoutCleanupTest extends FATServletClient {
 
     @ClassRule

--- a/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/src/app/timeout/TranTimeoutCleanupServlet.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/test-applications/implicit/src/app/timeout/TranTimeoutCleanupServlet.java
@@ -12,15 +12,12 @@
  *******************************************************************************/
 package app.timeout;
 
-import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
-
 import java.util.logging.Logger;
 
 import javax.servlet.annotation.WebServlet;
 
 import org.junit.Test;
 
-import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -47,7 +44,6 @@ import fat.util.JobWaiter;
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/TranTimeoutCleanupServlet")
 @Mode(TestMode.FULL)
-@SkipIfSysProp(OS_ZOS) // skip on zos due to derby timeouts
 public class TranTimeoutCleanupServlet extends FATServlet {
 
     public static Logger logger = Logger.getLogger("test");

--- a/dev/com.ibm.ws.jbatch.open.partition_fat/fat/src/batch/fat/junit/PartitionReducerTest.java
+++ b/dev/com.ibm.ws.jbatch.open.partition_fat/fat/src/batch/fat/junit/PartitionReducerTest.java
@@ -14,7 +14,6 @@ package batch.fat.junit;
 
 import static org.junit.Assert.assertTrue;
 
-import java.util.List;
 import java.util.Properties;
 
 import javax.json.JsonObject;
@@ -30,6 +29,7 @@ import com.ibm.ws.jbatch.test.BatchRestUtils;
 import com.ibm.ws.jbatch.test.FatUtils;
 
 import batch.fat.util.BatchFATHelper;
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
@@ -68,8 +68,8 @@ public class PartitionReducerTest extends BatchFATHelper {
         }
     }
 
-    @ExpectedFFDC({ "java.lang.IllegalStateException",
-                    "com.ibm.jbatch.container.exception.BatchContainerRuntimeException" })
+    @ExpectedFFDC({ "com.ibm.jbatch.container.exception.BatchContainerRuntimeException" })
+    @AllowedFFDC({ "java.lang.IllegalStateException" })
     @Test
     public void testPartitionReducerMethodsForceFailure() throws Exception {
 
@@ -89,16 +89,7 @@ public class PartitionReducerTest extends BatchFATHelper {
 
         assertTrue(exitStatus.contains("rollbackPartitionedStep"));
 
-        // log these for some debugging if possible
-        List<String> ffdclist = server.listFFDCFiles(server.getServerName());
-        for (int i = 0; i < ffdclist.size(); i++) {
-            log("testPartitionReducerMethodsForceFailure", "ffdc: " + ffdclist.get(i));
-        }
-
-        ffdclist = server.listFFDCSummaryFiles(server.getServerName());
-        for (int i = 0; i < ffdclist.size(); i++) {
-            log("testPartitionReducerMethodsForceFailure", "ffdc summary: " + ffdclist.get(i));
-        }
+        assertTrue(!server.findStringsInLogs("com.ibm.jbatch.container.exception.BatchContainerRuntimeException.*Forcing failure in batchlet").isEmpty());
 
     }
 


### PR DESCRIPTION
A previous pull request added some logic for skipping some tests on z/OS but it was in the wrong place, so this PR is moving it.

Also an update to testPartitionReducerMethodsForceFailure to handle how it checks for expected exceptions.  It appears there can be a timing issue where not all the expected exceptions are present, so we'll look for what we need in a different way.

I have a personal build running now