### PR TITLE
295260-Remove SQLJ tests for IBM i

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/SQLJTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/SQLJTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/SQLJTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/SQLJTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -37,6 +37,7 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -46,6 +47,8 @@ import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
+//Skip on IBM i since SQLJ is not supported
+@SkipIfSysProp(SkipIfSysProp.OS_IBMI)
 public class SQLJTest extends FATServletClient {
 
     @Server("com.ibm.ws.sqlj.fat")


### PR DESCRIPTION
SQLJ is not supported on IBM i.  Skipping JDBC SQLJ tests on that platform.