### PR TITLE
Updating MP Config 3.1 API maven coordinates to match version in maven central

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.config-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.config-3.1.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.org.eclipse.microprofile.config-3.1
 singleton=true
 -features=io.openliberty.mpCompatible-6.1, \
   io.openliberty.jakarta.cdi-4.0
--bundles=io.openliberty.org.eclipse.microprofile.config.3.1; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.config:microprofile-config-api:3.1.0"
+-bundles=io.openliberty.org.eclipse.microprofile.config.3.1; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.config:microprofile-config-api:3.1"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel


### PR DESCRIPTION
- Updating the maven coordinates for MP Config 3.1. From 3.1.0 >> 3.1

Fixes #27125 