### PR TITLE
context propagation to scheduled async methods

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_schedasync/fat/src/test/concurrency/schedasync/ScheduledAsyncMethodsTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_schedasync/fat/src/test/concurrency/schedasync/ScheduledAsyncMethodsTest.java
@@ -47,6 +47,8 @@ public class ScheduledAsyncMethodsTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        runTest(server, APP_NAME + '/' + SchedAsyncTestServlet.class.getSimpleName(), "testScheduledAsynchronousMethodsStopRunning");
+
         server.stopServer();
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_schedasync/test-applications/SchedAsyncWeb/src/test/concurrency/schedasync/web/SchedAsyncAppScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_schedasync/test-applications/SchedAsyncWeb/src/test/concurrency/schedasync/web/SchedAsyncAppScopedBean.java
@@ -53,6 +53,34 @@ public class SchedAsyncAppScopedBean {
     }
 
     /**
+     * Combines 4 different schedules to run on seconds that have a remainder of 1 when divided by 6:
+     * 1 7 13 19 25 31 37 43 49 55.
+     * This could be achieved with a single schedule, but the point of this test is to combine many
+     * schedules, including some that use cron with others that don't.
+     *
+     * @param maxExecutions  number of executions to stop after.
+     * @param executionCount for tracking the total number of executions.
+     * @return null to continue with more executions.
+     *         To stop, returns a completed future with the execution count and current time in nanoseconds.
+     */
+    @Asynchronous(runAt = { @Schedule(cron = "1/12 * * * * *", zone = "America/New_York"),
+                            @Schedule(hours = {}, minutes = {}, seconds = { 19, 55 }, zone = "America/Chicago"),
+                            @Schedule(cron = "31 * * * * *", zone = "America/Denver"),
+                            @Schedule(hours = {}, minutes = {}, seconds = { 7, 43 }, zone = "America/Los_Angeles") })
+    CompletionStage<long[]> everySixSeconds(int maxExecutions, AtomicInteger executionCount) {
+        int count = executionCount.incrementAndGet();
+        System.out.println("> everySixSeconds " + count);
+
+        CompletableFuture<long[]> result = null;
+        if (count >= maxExecutions) {
+            result = Asynchronous.Result.complete(new long[] { count, System.nanoTime() });
+        }
+
+        System.out.println("< everySixSeconds " + result);
+        return result;
+    }
+
+    /**
      * Runs on seconds that are divisible by 2 or 3.
      *
      * @param maxExecutions  number of executions to stop after.

--- a/dev/com.ibm.ws.concurrent_fat_schedasync/test-applications/SchedAsyncWeb/src/test/concurrency/schedasync/web/SchedAsyncTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_schedasync/test-applications/SchedAsyncWeb/src/test/concurrency/schedasync/web/SchedAsyncTestServlet.java
@@ -191,6 +191,29 @@ public class SchedAsyncTestServlet extends FATServlet {
     }
 
     /**
+     * After all other tests have run, check that scheduled asynchronous methods that should have completed
+     * are not still running.
+     */
+    // This test intentionally omits the Test annotation so that it can be invoked after all other tests complete.
+    public void testScheduledAsynchronousMethodsStopRunning() throws Exception {
+
+        // Allow time for an additional execution of most methods
+        TimeUnit.SECONDS.sleep(7);
+
+        assertEquals("If testEveryFiveSeconds3Times passed, then everyFiveSeconds should not run again.",
+                     0, cfEveryFiveSeconds3TimesCountdown.get());
+
+        assertEquals("If testEverySixSeconds3Times passed, then everySixSeconds should not run again.",
+                     3, afterSixSeconds3TimesCount.get());
+
+        assertEquals("If testLookUpEverySixSeconds2Times passed, then lookUpAtSixSecondIntervals2Times should not run again.",
+                     null, lookUpAtSixSecondIntervals2Times.poll());
+
+        assertEquals("If testEveryThreeAndEvenNumberedSeconds8Times passed, then everyThreeOrEvenSeconds should not run again.",
+                     8, cfEveryThreeAndEvenSeconds8TimesCount.get());
+    }
+
+    /**
      * Attempt to schedule an asynchronous method for a time that does not exist (February 30).
      */
     @Test

--- a/dev/com.ibm.ws.concurrent_fat_schedasync/test-applications/SchedAsyncWeb/src/test/concurrency/schedasync/web/SchedAsyncTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_schedasync/test-applications/SchedAsyncWeb/src/test/concurrency/schedasync/web/SchedAsyncTestServlet.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.fail;
 import java.time.DateTimeException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -38,6 +39,8 @@ public class SchedAsyncTestServlet extends FATServlet {
      */
     private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
 
+    private static LinkedBlockingQueue<long[]> afterSixSeconds3Times = new LinkedBlockingQueue<>();
+
     @Inject
     private SchedAsyncAppScopedBean bean;
 
@@ -54,16 +57,29 @@ public class SchedAsyncTestServlet extends FATServlet {
     public void destroy() {
     }
 
+    /**
+     * To make the tests run faster, schedule the asynchronous methods upon init
+     * and have individual tests make assertions about them.
+     */
     @Override
     public void init(ServletConfig config) throws ServletException {
         init_ns = System.nanoTime();
 
         cfEveryFiveSeconds3Times = bean.everyFiveSeconds(new AtomicInteger(3));
 
+        bean.everySixSeconds(3, new AtomicInteger()).thenAccept(l -> afterSixSeconds3Times.add(l));
+
         cfEveryThreeAndEvenSeconds8Times = bean.everyThreeOrEvenSeconds(8, new AtomicInteger());
+
+        // Seconds at which the above will aim to run:
+        //
+        // 00        05        10        15        20        25        30        35        40        45        50        55
+        //   01          07          13          19          25          31          37          43          49          55
+        // 00  02..04  06  08..10  12  14..16  18  20..22  24  26..28  30  32..34  36  38..40  42  44..46  48  50..52  54  56..58
     }
 
     /**
+     * Attempt to schedule an asynchronous method specifying the seconds empty.
      */
     @Test
     public void testEmptySeconds() throws Exception {
@@ -86,6 +102,25 @@ public class SchedAsyncTestServlet extends FATServlet {
         long elapsed = timeOfFinalExecution - init_ns;
         if (elapsed < TimeUnit.SECONDS.toNanos(10L))
             fail("A task that runs every 5 seconds must not complete 3 executions in under 10 seconds. Elapsed nanoseconds: " + elapsed);
+    }
+
+    /**
+     * An asynchronous method that combines multiple schedules, intermixing cron and basic schedules
+     * to run every 6 seconds for 3 executions and then complete must run exactly 3 times.
+     */
+    @Test
+    public void testEverySixSeconds3Times() throws Exception {
+        long[] result = afterSixSeconds3Times.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+
+        long numExecutions = result[0];
+        long timeOfFinalExecution = result[1];
+
+        assertEquals(3L, numExecutions);
+
+        long elapsed = timeOfFinalExecution - init_ns;
+        if (elapsed < TimeUnit.SECONDS.toNanos(12L))
+            fail("A task that runs at 6 second intervals must not complete 3 executions in under 12 seconds." +
+                 " Elapsed nanoseconds: " + elapsed);
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/AsyncInterceptor.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/AsyncInterceptor.java
@@ -14,7 +14,6 @@ package io.openliberty.concurrent.internal.cdi.interceptor;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -121,21 +120,7 @@ public class AsyncInterceptor implements Serializable {
             List<ScheduleCronTrigger> triggers = new ArrayList<>();
             for (Schedule schedule : schedules) {
                 skipIfLateBySeconds.add(schedule.skipIfLateBy());
-
-                String zone = schedule.zone();
-                ZoneId zoneId = zone.length() == 0 ? ZoneId.systemDefault() : ZoneId.of(zone);
-
-                String cron = schedule.cron();
-                if (cron.length() > 0)
-                    triggers.add(new ScheduleCronTrigger(cron, zoneId));
-                else
-                    triggers.add((ScheduleCronTrigger) new ScheduleCronTrigger(zoneId) //
-                                    .months(schedule.months()) //
-                                    .daysOfMonth(schedule.daysOfMonth()) //
-                                    .daysOfWeek(schedule.daysOfWeek()) //
-                                    .hours(schedule.hours()) //
-                                    .minutes(schedule.minutes()) //
-                                    .seconds(schedule.seconds()));
+                triggers.add(ScheduleCronTrigger.create(schedule));
             }
 
             return new ScheduledAsyncMethod(invocation, this, managedExecutor, triggers, skipIfLateBySeconds).future;

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/ScheduleCronTrigger.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/ScheduleCronTrigger.java
@@ -12,12 +12,15 @@
  *******************************************************************************/
 package io.openliberty.concurrent.internal.cdi.interceptor;
 
+import java.time.DayOfWeek;
+import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 
 import jakarta.enterprise.concurrent.CronTrigger;
+import jakarta.enterprise.concurrent.Schedule;
 
 /**
  * Inherits from the CronTrigger class to expose the next(ZonedDateTime) method
@@ -25,14 +28,93 @@ import jakarta.enterprise.concurrent.CronTrigger;
  */
 class ScheduleCronTrigger extends CronTrigger {
 
+    private static final Month[] ALL_MONTHS = Month.values();
+
+    private static final int[] ALL_DAYS_OF_MONTH = //
+                    new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+                                31 };
+
+    private static final DayOfWeek[] ALL_DAYS_OF_WEEK = //
+                    new DayOfWeek[] { DayOfWeek.SUNDAY, DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
+                                      DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY,
+                                      DayOfWeek.SATURDAY };
+
+    private static final int[] ALL_HOURS = //
+                    new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+                                12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 };
+
+    private static final int[] ALL_MINUTES = //
+                    new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                                10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                                30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                                40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+                                50, 51, 52, 53, 54, 55, 56, 57, 58, 59 };
+
     @Trivial
-    ScheduleCronTrigger(String cron, ZoneId zoneId) {
+    private ScheduleCronTrigger(String cron, ZoneId zoneId) {
         super(cron, zoneId);
     }
 
     @Trivial
-    ScheduleCronTrigger(ZoneId zoneId) {
+    private ScheduleCronTrigger(ZoneId zoneId) {
         super(zoneId);
+    }
+
+    /**
+     * Create a CronTrigger from a Schedule.
+     *
+     * @param schedule the schedule.
+     * @return the trigger.
+     */
+    @Trivial
+    static ScheduleCronTrigger create(Schedule schedule) {
+        ScheduleCronTrigger trigger;
+
+        String zone = schedule.zone();
+        ZoneId zoneId = zone.length() == 0 ? ZoneId.systemDefault() : ZoneId.of(zone);
+
+        String cron = schedule.cron();
+
+        if (cron.length() > 0) {
+            trigger = new ScheduleCronTrigger(cron, zoneId);
+        } else {
+            trigger = new ScheduleCronTrigger(zoneId);
+
+            Month[] months = schedule.months();
+            if (months.length == 0)
+                months = ALL_MONTHS;
+
+            int[] daysOfMonth = schedule.daysOfMonth();
+            if (daysOfMonth.length == 0)
+                daysOfMonth = ALL_DAYS_OF_MONTH;
+
+            DayOfWeek[] daysOfWeek = schedule.daysOfWeek();
+            if (daysOfWeek.length == 0)
+                daysOfWeek = ALL_DAYS_OF_WEEK;
+
+            int[] hours = schedule.hours();
+            if (hours.length == 0)
+                hours = ALL_HOURS;
+
+            int[] minutes = schedule.minutes();
+            if (minutes.length == 0)
+                minutes = ALL_MINUTES;
+
+            int[] seconds = schedule.seconds();
+            if (seconds.length == 0)
+                throw new IllegalArgumentException("seconds: {}"); // TODO NLS The seconds field cannot be ignored because no other units of Schedule are more granular.
+
+            trigger.months(months) //
+                            .daysOfMonth(daysOfMonth) //
+                            .daysOfWeek(daysOfWeek) //
+                            .hours(hours) //
+                            .minutes(minutes) //
+                            .seconds(seconds);
+        }
+        return trigger;
     }
 
     @Override


### PR DESCRIPTION
Thread context propagation to each execution of scheduled asynchronous methods.
This pull also includes handling for schedule components that are assign to empty (They are excluded from the schedule, except for the most granular unit of seconds which much be specified or left at its default value of {0}) and test coverage to verify that scheduled asynchronous methods that should have completed are not continuing to run additional executions.