### PR TITLE
Update buildpath in jaxws FAT for Eclipse

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2023 IBM Corporation and others.
+# Copyright (c) 2019, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -90,6 +90,7 @@ tested.features: jaxws-2.3, \
 	com.ibm.ws.org.apache.cxf.cxf.rt.management.3.2;version=latest,\
 	com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2;version=latest,\
 	com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2;version=latest,\
+	com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2;version=latest,\
 	org.apache.cxf.xjcplugins:cxf-xjc-boolean;version='2.6.0',\
 	org.apache.cxf.xjcplugins:cxf-xjc-bug671;version='2.6.0',\
 	org.apache.cxf.xjcplugins:cxf-xjc-dv;version='2.6.0',\


### PR DESCRIPTION
PartInfoNamespaceCorrectionTestServlet has a javadoc reference that cannot be resolved in Eclipse
- add com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2 to resolve the missing reference for Eclipse
