### PR TITLE
scheduled asynchronous methods on virtual threads

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_schedasync/publish/servers/com.ibm.ws.concurrent.fat.schedasync/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_schedasync/publish/servers/com.ibm.ws.concurrent.fat.schedasync/server.xml
@@ -24,4 +24,12 @@
 
   <application location="SchedAsyncWeb.war"/>
 
+  <!--  TODO remove this once virtual=true can be sent in through ManagedExecutorDefinition -->
+  <managedExecutorService jndiName="concurrent/temp-max-2-executor">
+    <concurrencyPolicy max="2" virtual="true"/>
+    <contextService>
+      <classloaderContext/>
+      <jeeMetadataContext/>
+    </contextService>
+  </managedExecutorService>
 </server>

--- a/dev/com.ibm.ws.concurrent_fat_schedasync/test-applications/SchedAsyncWeb/src/test/concurrency/schedasync/web/SchedAsyncAppScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_schedasync/test-applications/SchedAsyncWeb/src/test/concurrency/schedasync/web/SchedAsyncAppScopedBean.java
@@ -56,6 +56,25 @@ public class SchedAsyncAppScopedBean {
     }
 
     /**
+     * Run every 4 seconds on seconds that have a remainder of 2 when divided by 4.
+     *
+     * @param countdown executions remaining.
+     * @param threads   a queue for recording the threads where executions have occurred.
+     */
+    @Asynchronous(executor = "java:module/concurrent/max-2-executor",
+                  runAt = @Schedule(cron = "2/4 * * * * *"))
+    void everyFourSecondsVirtual(AtomicInteger countdown, LinkedBlockingQueue<Thread> threads) {
+        System.out.println("> everyFourSecondsVirtual " + countdown);
+
+        threads.add(Thread.currentThread());
+
+        if (countdown.decrementAndGet() == 0)
+            Asynchronous.Result.complete(null);
+
+        System.out.println("< everyFourSecondsVirtual executed on " + Thread.currentThread());
+    }
+
+    /**
      * Combines 4 different schedules to run on seconds that have a remainder of 1 when divided by 6:
      * 1 7 13 19 25 31 37 43 49 55.
      * This could be achieved with a single schedule, but the point of this test is to combine many

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2023 IBM Corporation and others.
+ * Copyright (c) 2017,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -281,7 +281,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
         @Trivial
         private VirtualThreadExecutor() {
-            threadFactory = virtualThreadOps.createFactoryOfVirtualThreads(identifier + '-', 1L, false, null);
+            threadFactory = virtualThreadOps.createFactoryOfVirtualThreads(identifier + ':', 1L, false, null);
         }
 
         @Override

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/vtpolicyapp/src/web/vt/PolicyVirtualThreadServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/vtpolicyapp/src/web/vt/PolicyVirtualThreadServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -171,10 +171,10 @@ public class PolicyVirtualThreadServlet extends HttpServlet {
         assertEquals(true, isVirtual(thread3));
         assertEquals(true, isVirtual(thread4));
 
-        assertEquals(thread1.getName(), true, thread1.getName().startsWith("PolicyExecutorProvider-testMaxConcurrencyWithVirtualThreads-"));
-        assertEquals(thread2.getName(), true, thread2.getName().startsWith("PolicyExecutorProvider-testMaxConcurrencyWithVirtualThreads-"));
-        assertEquals(thread3.getName(), true, thread3.getName().startsWith("PolicyExecutorProvider-testMaxConcurrencyWithVirtualThreads-"));
-        assertEquals(thread4.getName(), true, thread4.getName().startsWith("PolicyExecutorProvider-testMaxConcurrencyWithVirtualThreads-"));
+        assertEquals(thread1.getName(), true, thread1.getName().startsWith("PolicyExecutorProvider-testMaxConcurrencyWithVirtualThreads:"));
+        assertEquals(thread2.getName(), true, thread2.getName().startsWith("PolicyExecutorProvider-testMaxConcurrencyWithVirtualThreads:"));
+        assertEquals(thread3.getName(), true, thread3.getName().startsWith("PolicyExecutorProvider-testMaxConcurrencyWithVirtualThreads:"));
+        assertEquals(thread4.getName(), true, thread4.getName().startsWith("PolicyExecutorProvider-testMaxConcurrencyWithVirtualThreads:"));
 
         Set<String> threadNames = new TreeSet<>();
         threadNames.add(thread1.getName());
@@ -245,10 +245,10 @@ public class PolicyVirtualThreadServlet extends HttpServlet {
         // invokeAll can run on the same thread if it remains under max concurrency
         String curThreadName = Thread.currentThread().getName();
 
-        assertEquals(name1, true, name1.equals(curThreadName) || name1.startsWith("PolicyExecutorProvider-testMaxPolicyStrictWithVirtualThreads-"));
-        assertEquals(name2, true, name2.equals(curThreadName) || name2.startsWith("PolicyExecutorProvider-testMaxPolicyStrictWithVirtualThreads-"));
-        assertEquals(name3, true, name3.equals(curThreadName) || name3.startsWith("PolicyExecutorProvider-testMaxPolicyStrictWithVirtualThreads-"));
-        assertEquals(name4, true, name4.equals(curThreadName) || name4.startsWith("PolicyExecutorProvider-testMaxPolicyStrictWithVirtualThreads-"));
+        assertEquals(name1, true, name1.equals(curThreadName) || name1.startsWith("PolicyExecutorProvider-testMaxPolicyStrictWithVirtualThreads:"));
+        assertEquals(name2, true, name2.equals(curThreadName) || name2.startsWith("PolicyExecutorProvider-testMaxPolicyStrictWithVirtualThreads:"));
+        assertEquals(name3, true, name3.equals(curThreadName) || name3.startsWith("PolicyExecutorProvider-testMaxPolicyStrictWithVirtualThreads:"));
+        assertEquals(name4, true, name4.equals(curThreadName) || name4.startsWith("PolicyExecutorProvider-testMaxPolicyStrictWithVirtualThreads:"));
 
         Set<String> threadNames = new TreeSet<>();
         threadNames.add(name1);


### PR DESCRIPTION
Run scheduled asynchronous methods on virtual threads by supplying and executor with virtual=true.
Because virtual=true on ManagedExecutorDefinition isn't implemented yet, this temporarily uses an internal setting on the concurrency policy to simulate it.