### PR TITLE
Fix telemetry typos from oltp to otlp

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent129Test.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent129Test.java
@@ -97,7 +97,7 @@ public class Agent129Test {
         server.copyFileToLibertyServerRoot("agent-129/opentelemetry-javaagent.jar");
 
         server.addEnvVar(TestConstants.ENV_OTEL_TRACES_EXPORTER, "otlp");
-        server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOltpGrpcUrl());
+        server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOtlpGrpcUrl());
         server.addEnvVar("OTEL_METRICS_EXPORTER", "none");
         server.addEnvVar("OTEL_LOGS_EXPORTER", "none");
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigMultiAppTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigMultiAppTest.java
@@ -100,7 +100,7 @@ public class AgentConfigMultiAppTest {
     @Before
     public void resetServer() throws Exception {
         server.addEnvVar(TestConstants.ENV_OTEL_TRACES_EXPORTER, "otlp");
-        server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOltpGrpcUrl());
+        server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOtlpGrpcUrl());
         server.addEnvVar("OTEL_METRICS_EXPORTER", "none");
         server.addEnvVar("OTEL_LOGS_EXPORTER", "none");
         server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
@@ -120,7 +120,7 @@ public class AgentConfigTest {
 
         // Env vars are cleared when the server starts, so we need to set the core ones up again
         server.addEnvVar(TestConstants.ENV_OTEL_TRACES_EXPORTER, "otlp");
-        server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOltpGrpcUrl());
+        server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOtlpGrpcUrl());
         server.addEnvVar("OTEL_METRICS_EXPORTER", "none");
         server.addEnvVar("OTEL_LOGS_EXPORTER", "none");
         server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentTest.java
@@ -98,7 +98,7 @@ public class AgentTest {
         server.copyFileToLibertyServerRoot("agent-119/opentelemetry-javaagent.jar");
 
         server.addEnvVar(TestConstants.ENV_OTEL_TRACES_EXPORTER, "otlp");
-        server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOltpGrpcUrl());
+        server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOtlpGrpcUrl());
         server.addEnvVar("OTEL_METRICS_EXPORTER", "none");
         server.addEnvVar("OTEL_LOGS_EXPORTER", "none");
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureJaegerTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureJaegerTest.java
@@ -82,7 +82,7 @@ public class CrossFeatureJaegerTest {
         // Inform the test framework that opentracingServer is configured to use the secondary HTTP ports
         opentracingServer.useSecondaryHTTPPort();
 
-        telemetryServer.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOltpGrpcUrl());
+        telemetryServer.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOtlpGrpcUrl());
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
         telemetryServer.addEnvVar("OTEL_PROPAGATORS", "tracecontext, baggage, jaeger"); // Include the jaeger propagation headers

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtlpTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtlpTest.java
@@ -34,7 +34,7 @@ import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContain
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
 
 /**
- * Test exporting traces to a Jaeger server with OLTP
+ * Test exporting traces to a Jaeger server with OTLP
  */
 @RunWith(FATRunner.class)
 public class JaegerOtlpTest extends JaegerBaseTest {
@@ -53,7 +53,7 @@ public class JaegerOtlpTest extends JaegerBaseTest {
         client = new JaegerQueryClient(jaegerContainer);
 
         server.addEnvVar(TestConstants.ENV_OTEL_TRACES_EXPORTER, "otlp");
-        server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOltpGrpcUrl());
+        server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOtlpGrpcUrl());
 
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, "Test service");
         server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/TracingNotEnabledTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/TracingNotEnabledTest.java
@@ -79,7 +79,7 @@ public class TracingNotEnabledTest {
         client = new JaegerQueryClient(jaegerContainer);
 
         server.addEnvVar(TestConstants.ENV_OTEL_TRACES_EXPORTER, "otlp");
-        server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOltpGrpcUrl());
+        server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOtlpGrpcUrl());
 
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, SERVICE_NAME);
         server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/utils/jaeger/JaegerContainer.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/utils/jaeger/JaegerContainer.java
@@ -38,8 +38,8 @@ public class JaegerContainer extends GenericContainer<JaegerContainer> {
 
     private static final Class<?> c = JaegerContainer.class;
 
-    public static final int OLTP_GRPC_PORT = 4317;
-    public static final int OLTP_HTTP_PORT = 4318;
+    public static final int OTLP_GRPC_PORT = 4317;
+    public static final int OTLP_HTTP_PORT = 4318;
     public static final int JAEGER_LEGACY_PORT = 14250;
     public static final int JAEGER_THRIFT_PORT = 14268;
     public static final int ZIPKIN_PORT = 9411;
@@ -56,8 +56,8 @@ public class JaegerContainer extends GenericContainer<JaegerContainer> {
         super(imageName);
         Log.info(c, "JaegerContainer", "creating JaegerContainer with imageName");
 
-        withExposedPorts(OLTP_GRPC_PORT,
-                         OLTP_HTTP_PORT,
+        withExposedPorts(OTLP_GRPC_PORT,
+                         OTLP_HTTP_PORT,
                          JAEGER_LEGACY_PORT,
                          JAEGER_THRIFT_PORT,
                          GRPC_QUERY_PORT,
@@ -79,8 +79,8 @@ public class JaegerContainer extends GenericContainer<JaegerContainer> {
 
         Log.info(c, "JaegerContainer", "creating JaegerContainer with tls certificate and keys");
 
-        withExposedPorts(OLTP_GRPC_PORT,
-                         OLTP_HTTP_PORT,
+        withExposedPorts(OTLP_GRPC_PORT,
+                         OTLP_HTTP_PORT,
                          JAEGER_LEGACY_PORT,
                          JAEGER_THRIFT_PORT,
                          GRPC_QUERY_PORT,
@@ -94,47 +94,47 @@ public class JaegerContainer extends GenericContainer<JaegerContainer> {
     }
 
     /**
-     * Get the port to use to send OLTP spans via gRPC
+     * Get the port to use to send OTLP spans via gRPC
      * <p>
      * Only valid when the container is started
      *
-     * @return the OLTP gRPC port
+     * @return the OTLP gRPC port
      */
-    public int getOltpGrpcPort() {
-        return getMappedPort(OLTP_GRPC_PORT);
+    public int getOtlpGrpcPort() {
+        return getMappedPort(OTLP_GRPC_PORT);
     }
 
     /**
-     * Get the URL to use to send OLTP spans via gRPC
+     * Get the URL to use to send OTLP spans via gRPC
      * <p>
      * Only valid when the container is started
      *
-     * @return the OLTP gRPC URL
+     * @return the OTLP gRPC URL
      */
-    public String getOltpGrpcUrl() {
-        return "http://" + getHost() + ":" + getOltpGrpcPort();
+    public String getOtlpGrpcUrl() {
+        return "http://" + getHost() + ":" + getOtlpGrpcPort();
     }
 
     /**
-     * Get the URL to use to send OLTP spans via gRPC over tls
+     * Get the URL to use to send OTLP spans via gRPC over tls
      * <p>
      * Only valid when the container is started
      *
-     * @return the OLTP gRPC URL
+     * @return the OTLP gRPC URL
      */
     public String getSecureOtlpGrpcUrl() {
-        return "https://" + getHost() + ":" + getOltpGrpcPort();
+        return "https://" + getHost() + ":" + getOtlpGrpcPort();
     }
 
     /**
-     * Get the port to use to send OLTP spans via HTTP
+     * Get the port to use to send OTLP spans via HTTP
      * <p>
      * Only valid when the container is started
      *
-     * @return the OLTP HTTP port
+     * @return the OTLP HTTP port
      */
-    public int getOltpHttpPort() {
-        return getMappedPort(OLTP_HTTP_PORT);
+    public int getOtlpHttpPort() {
+        return getMappedPort(OTLP_HTTP_PORT);
     }
 
     /**

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/utils/otelCollector/OtelCollectorContainer.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/utils/otelCollector/OtelCollectorContainer.java
@@ -96,11 +96,11 @@ public class OtelCollectorContainer extends GenericContainer<OtelCollectorContai
     }
 
     /**
-     * Get the URL to use to send OLTP spans via gRPC over tls
+     * Get the URL to use to send OTLP spans via gRPC over tls
      * <p>
      * Only valid when the container is started
      *
-     * @return the OLTP gRPC URL
+     * @return the OTLP gRPC URL
      */
     public String getSecureOtlpGrpcUrl() {
         return "https://" + getHost() + ":" + getOtlpGrpcPort();


### PR DESCRIPTION
"Otlp" was wrongly referred to as "Oltp" in a few files. 