### PR TITLE
Revert "update metatype name and desc for back-channel logout"

### DIFF
--- a/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2024 IBM Corporation and others.
+# Copyright (c) 2011, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -187,9 +187,6 @@ proofKeyForCodeExchange.desc=Proof key for code exchange support for OAuth clien
 
 publicClient=Public OAuth client
 publicClient.desc=Specify whether OAuth client is public.
-
-backchannelLogoutUri=Back-channel logout URI
-backchannelLogoutUri.desc=Specifies the back-channel logout URI for an OpenID Connect client.
 
 filter=Request filter
 filter.desc=URI filter selects requests to be authorized by this provider.

--- a/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2024 IBM Corporation and others.
+    Copyright (c) 2019, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -431,7 +431,7 @@
 
            <AD id="publicClient" name="%publicClient" description="%publicClient.desc" required="false" type="Boolean" default="false" />
 
-           <AD id="backchannelLogoutUri" name="%backchannelLogoutUri" description="%backchannelLogoutUri.desc" required="false" type="String" ibm:beta="true" />
+           <AD id="backchannelLogoutUri" name="internal" description="internal use only" required="false" type="String" ibm:beta="true" />
 
     </OCD>
     

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2013, 2024 IBM Corporation and others.
+# Copyright (c) 2013, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -73,9 +73,6 @@ sessionManaged.desc=Indicate by true or false whether session management is supp
 
 idTokenLifetime=ID token lifetime
 idTokenLifetime.desc=Time that ID token is valid (seconds). You can also specify a positive integer followed by a unit of time, which can be hours (h), minutes (m), or seconds (s). For example, specify 30 seconds as 30 or 30s. You can include multiple values in a single entry. For example, 1m30s is equivalent to 90 seconds.
-
-backchannelLogoutRequestTimeout=Back-channel logout request timeout
-backchannelLogoutRequestTimeout.desc=Specifies the amount of time after which a back-channel logout request to an OpenID Connect client times out.
 
 profile.scope=Profile scope
 profile.scope.desc=Specify a comma-separated list of claims associated with the profile scope. 

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2024 IBM Corporation and others.
+    Copyright (c) 2019, 2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -80,7 +80,7 @@
          <AD id="protectedEndpoints" name="internal" description="internal use only" required="false" type="String" default="authorize registration app-passwords app-tokens personalTokenManagement usersTokenManagement clientManagement" /> <!-- separated by space -->
          <AD id="requireOpenidScopeForUserInfo" name="internal" description="internal use only" required="false" type="Boolean" default="true" />
          <AD id="oidcEndpoint" name="internal" description="internal use only" required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.security.oidc.endpoint" cardinality="20" />
-         <AD id="backchannelLogoutRequestTimeout" name="%backchannelLogoutRequestTimeout" description="%backchannelLogoutRequestTimeout.desc" required="false" type="String" default="180s" ibm:type="duration(s)" ibm:beta="true" />
+         <AD id="backchannelLogoutRequestTimeout" name="internal" description="internal use only" required="false" type="String" default="180s" ibm:type="duration(s)" ibm:beta="true" />
      </OCD>
 
     <Designate factoryPid="com.ibm.ws.security.openidconnect.server.oidcServerConfig">


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#27247

Caused a hard break in `com.ibm.ws.security.oidc.server_fat.gui.tokenMgmt: goToEndpoint`

```
junit.framework.AssertionFailedError: 2024-01-08-01:34:25:383 Element "By.xpath: //*[@id="add_edit_client_modal"]/div/div[3]/div[17]/div[2]/div/button/img" of type "LOCATOR" was never found.  Total wait: 60 seconds
	at com.ibm.ws.ui.fat.selenium.tests.AbstractUITest.waitForClickable(AbstractUITest.java:2002)
	at com.ibm.ws.ui.fat.selenium.tests.AbstractUITest.waitForClickable(AbstractUITest.java:1950)
	at com.ibm.ws.ui.fat.selenium.tests.AbstractUITest.waitForClickableByLocator(AbstractUITest.java:1846)
	at com.ibm.ws.ui.fat.selenium.tests.AbstractUITest.clickAndVerify(AbstractUITest.java:1600)
	at com.ibm.ws.ui.fat.selenium.tests.AbstractUITest.clickAndVerify(AbstractUITest.java:1563)
	at com.ibm.ws.ui.fat.selenium.tests.AbstractUITest.clickAndVerify(AbstractUITest.java:1541)
	at com.ibm.ws.ui.fat.selenium.tests.AbstractUITest.clickAndVerify(AbstractUITest.java:1490)
	at com.ibm.ws.security.openidconnect.server_fat.gui.tokenMgmt.tests.ClientManagement.testURIandLogoutURI(ClientManagement.java:456)
	at com.ibm.ws.security.openidconnect.server_fat.gui.tokenMgmt.tests.ClientManagement.testModalAddDialog(ClientManagement.java:221)
	at com.ibm.ws.security.openidconnect.server_fat.gui.tokenMgmt.tests.ClientManagement.goToEndpoint(ClientManagement.java:64)
```