### PR TITLE
Modifications to work around a Java 8/Shibboleth/LDAP issue

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.common/ShibbolethCommon.gradle
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/ShibbolethCommon.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -95,6 +95,7 @@ task copyShibbolethIdpConfig (dependsOn: [':com.ibm.ws.security.fat.common:assem
       from project(':com.ibm.ws.security.saml.sso_fat.common').buildDir
       into autoFvtDir
       include 'shibboleth-idp/**'
+      exclude 'shibboleth-idp/4.0.1'
     }
   }
 }

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/3.3.1/metadata/spOPMetadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/3.3.1/metadata/spOPMetadata.xml.orig
@@ -50,6 +50,9 @@
 				</ds:X509Data>
 			</ds:KeyInfo>
 		</md:KeyDescriptor>
+                <md:SingleLogoutService
+                        Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/spOP/slo"
+                        Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" />
 		<md:AssertionConsumerService
 			Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/spOP/acs"

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3493,6 +3493,10 @@ public class LibertyServer implements LogMonitorClient {
         Log.exiting(c, method);
     }
 
+    public String getPathToAutoFVTOutputServersFolder() {
+        return pathToAutoFVTOutputServersFolder;
+    }
+
     protected void runJextract(RemoteFile serverFolder) throws Exception {
         RemoteFile[] files = serverFolder.list(false);
         if (files != null) {
@@ -3553,9 +3557,9 @@ public class LibertyServer implements LogMonitorClient {
         }
     }
 
-    protected void recursivelyCopyDirectory(RemoteFile remoteSrcDir,
-                                            LocalFile localDstDir,
-                                            boolean ignoreFailures, boolean skipArchives, boolean moveFile) throws Exception {
+    public void recursivelyCopyDirectory(RemoteFile remoteSrcDir,
+                                         LocalFile localDstDir,
+                                         boolean ignoreFailures, boolean skipArchives, boolean moveFile) throws Exception {
 
         String method = "recursivelyCopyDirectory";
 


### PR DESCRIPTION
With Java 8, Shibboleth 3.3.1 and LDAP, we're seeing an issue where the response that we get from logout is:
 [{ "result": "$logoutPropCtx.result" }]
 We're expecting:
 ["result":  "Success"]
 I searched and found that there is an issue when there is a trailing "/" on the ldap path.
 I found one instance of this in our config, so, I'm trying to change that to see if it resolves this.
 **This is the error info from the Shibboleth app startup** - I'm thinking that this is what ends up causing the issue:

 ```
2023-12-22 06:18:26,578 - INFO [net.shibboleth.idp.attribute.resolver.spring.BaseResolverPluginParser:60] - [] - Parsing configuration for DataConnector plugin with id: myLDAP
2023-12-22 06:18:26,579 - DEBUG [net.shibboleth.idp.attribute.resolver.spring.dc.ldap.impl.LDAPDataConnectorParser:121] - [] - Data Connector 'myLDAP': Parsing v2 configuration [DataConnector: null]
2023-12-22 06:18:26,607 - TRACE [org.ldaptive.provider.jndi.JndiProviderConfig:70] - [] - setting operationExceptionResultCodes: [PROTOCOL_ERROR, SERVER_DOWN]
2023-12-22 06:18:26,609 - TRACE [org.ldaptive.provider.jndi.JndiProviderConfig:144] - [] - setting controlProcessor: org.ldaptive.provider.ControlProcessor@fe133de4
2023-12-22 06:18:26,609 - TRACE [org.ldaptive.provider.jndi.JndiProviderConfig:70] - [] - setting operationExceptionResultCodes: [PROTOCOL_ERROR, SERVER_DOWN]
2023-12-22 06:18:26,610 - TRACE [org.ldaptive.provider.jndi.JndiProviderConfig:144] - [] - setting controlProcessor: org.ldaptive.provider.ControlProcessor@10657e2
2023-12-22 06:18:26,610 - TRACE [org.ldaptive.provider.jndi.JndiProviderConfig:70] - [] - setting operationExceptionResultCodes: [PROTOCOL_ERROR, SERVER_DOWN]
2023-12-22 06:18:26,610 - TRACE [org.ldaptive.provider.jndi.JndiProviderConfig:144] - [] - setting controlProcessor: org.ldaptive.provider.ControlProcessor@510c01fd
2023-12-22 06:18:26,625 - INFO [net.shibboleth.idp.attribute.resolver.spring.BaseResolverPluginParser:60] - [] - Parsing configuration for DataConnector plugin with id: staticAttributes
2023-12-22 06:18:26,626 - TRACE [net.shibboleth.idp.attribute.resolver.spring.dc.impl.StaticDataConnectorParser:90] - [] - Data Connector 'staticAttributes': Attribute: staticX509SubjectNameNameIdValue, adding value "test_X509SubjectNameNameIdValue"
```