### PR TITLE
JAX-WS: Add timeout increase for JAX-WS clients in Interop Tests

### DIFF
--- a/dev/io.openliberty.jaxrs.2.1.jaxws.2.2_fat/fat/src/com/ibm/ws/fat/WebServicesInteroperabilityTest.java
+++ b/dev/io.openliberty.jaxrs.2.1.jaxws.2.2_fat/fat/src/com/ibm/ws/fat/WebServicesInteroperabilityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -45,11 +45,12 @@ public class WebServicesInteroperabilityTest extends FATServletClient {
     @BeforeClass
     public static void setup() throws Exception {
         // Build an application and export it to the dropins directory
-        ShrinkHelper.defaultDropinApp(server, appName, "io.openliberty.interop",
+        ShrinkHelper.defaultDropinApp(server, appName, "io.openliberty.interop", "io.openliberty.interop.util",
                                       "com.ibm.ws.jaxws.test.wsr.server.stub",
                                       "com.ibm.ws.jaxws.fat.util");
 
-        ShrinkHelper.defaultDropinApp(server, "helloServer", "com.ibm.ws.jaxws.test.wsr.server",
+        ShrinkHelper.defaultDropinApp(server, "helloServer", "io.openliberty.interop.util",
+                                      "com.ibm.ws.jaxws.test.wsr.server",
                                       "com.ibm.ws.jaxws.test.wsr.server.impl",
                                       "com.ibm.ws.jaxws.fat.util");
 

--- a/dev/io.openliberty.jaxrs.2.1.jaxws.2.2_fat/publish/servers/WebServicesInteroperabilityServer/bootstrap.properties
+++ b/dev/io.openliberty.jaxrs.2.1.jaxws.2.2_fat/publish/servers/WebServicesInteroperabilityServer/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all:org.jboss.resteasy*=all
+#com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jax*=all:org.apache.cxf.*=all:org.jboss.resteasy*=all
 com.ibm.ws.logging.max.file.size=0
 
 bootstrap.include=../testports.properties

--- a/dev/io.openliberty.jaxrs.2.1.jaxws.2.2_fat/publish/servers/WebServicesInteroperabilityServer/server.xml
+++ b/dev/io.openliberty.jaxrs.2.1.jaxws.2.2_fat/publish/servers/WebServicesInteroperabilityServer/server.xml
@@ -10,6 +10,7 @@
   	<javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
   	
   	<javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read"/>
+  	<javaPermission className="javax.security.auth.AuthPermission" name="getSubject"/>
   	<javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
 	<javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.com.sun.org.apache.xerces.internal.dom" />
   	<javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>    
@@ -24,4 +25,5 @@
 	<javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
   	<javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="get" />
 	<javaPermission className="org.osgi.framework.AdminPermission" name="*" actions="*" />
+	 
 </server>

--- a/dev/io.openliberty.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/InteropStartResource.java
+++ b/dev/io.openliberty.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/InteropStartResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,9 +17,12 @@ import java.net.URL;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.xml.ws.BindingProvider;
 
 import com.ibm.ws.jaxws.test.wsr.server.stub.People;
 import com.ibm.ws.jaxws.test.wsr.server.stub.PeopleService;
+
+import io.openliberty.interop.util.InteropConstants;
 
 @Path("/ep1")
 public class InteropStartResource {
@@ -34,6 +37,12 @@ public class InteropStartResource {
                         .toString();
         PeopleService service = new PeopleService(new URL(WSDL_URL));
         People bill = service.getBillPort();
+
+        // Set the JAX-WS client connection timeouts
+        BindingProvider bp = (BindingProvider) bill;
+        bp.getRequestContext().put("http.conduit.client.ConnectionTimeout", InteropConstants.CONN_TIME_OUT);
+        bp.getRequestContext().put("http.conduit.client.ReceiveTimeout", InteropConstants.CONN_TIME_OUT);
+
         String result = bill.hello();
         return result;
     }

--- a/dev/io.openliberty.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/util/InteropConstants.java
+++ b/dev/io.openliberty.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxrs-interop/src/io/openliberty/interop/util/InteropConstants.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.interop.util;
+
+/*
+ * Common test constants class
+ */
+public class InteropConstants {
+
+    // Client side connection time out value, allows us to change the values for both JAX-RS and JAX-WS clients.
+    public static String CONN_TIME_OUT = "50000";
+}

--- a/dev/io.openliberty.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxws-peopleservice/src/com/ibm/ws/jaxws/test/wsr/server/impl/Bill.java
+++ b/dev/io.openliberty.jaxrs.2.1.jaxws.2.2_fat/test-applications/jaxws-peopleservice/src/com/ibm/ws/jaxws/test/wsr/server/impl/Bill.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,8 @@ import javax.ws.rs.core.Response;
 
 import com.ibm.ws.jaxws.test.wsr.server.People;
 
+import io.openliberty.interop.util.InteropConstants;
+
 @WebService(serviceName = "PeopleService", portName = "BillPort", endpointInterface = "com.ibm.ws.jaxws.test.wsr.server.People",
             targetNamespace = "http://server.wsr.test.jaxws.ws.ibm.com")
 public class Bill implements People {
@@ -30,8 +32,8 @@ public class Bill implements People {
         // Implement JAX-RS call here
         // Increasing the timeouts for the rest client to prevent failures in slow builds
         ClientBuilder cb = ClientBuilder.newBuilder();
-        cb.property("com.ibm.ws.jaxrs.client.connection.timeout", "50000");
-        cb.property("com.ibm.ws.jaxrs.client.receive.timeout", "50000");
+        cb.property("com.ibm.ws.jaxrs.client.connection.timeout", InteropConstants.CONN_TIME_OUT);
+        cb.property("com.ibm.ws.jaxrs.client.receive.timeout", InteropConstants.CONN_TIME_OUT);
 
         Client client = cb.build();
         Response response = client.target(URI_CONTEXT_ROOT)


### PR DESCRIPTION
This PR adds the JAX-WS client timeout configuration to the `io.openliberty.jaxrs.2.1.jaxws.2.2_fat` tests, in order to resolve these test failures:

```
Caused by: java.net.SocketTimeoutException: SocketTimeoutException invoking http://localhost:8010/helloServer/PeopleService: Read timed out
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.mapException(HTTPConduit.java:1481)
	at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.close(HTTPConduit.java:1464)
	at org.apache.cxf.transport.AbstractConduit.close(AbstractConduit.java:56)
	at org.apache.cxf.transport.http.HTTPConduit.close(HTTPConduit.java:711)
	at org.apache.cxf.interceptor.MessageSenderInterceptor$MessageSenderEndingInterceptor.handleMessage(MessageSenderInterceptor.java:63)
	at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:307)
	at org.apache.cxf.endpoint.ClientImpl.doInvoke(ClientImpl.java:535)
	at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:446)
	at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:361)
	at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:319)
	at org.apache.cxf.frontend.ClientProxy.invokeSync(ClientProxy.java:96)
	at org.apache.cxf.jaxws.JaxWsClientProxy.invoke(JaxWsClientProxy.java:140)
```

It also adds the `io.openliberty.interop.util.InteropConstants` class as a way of configuring the timeout values for both JAX-RS and JAX-WS clients in one place. 