### PR TITLE
Update io.openliberty.jaxrs30 API bundle / javadoc and other updates

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.restfulWS-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.restfulWS-3.0.feature
@@ -11,8 +11,9 @@ Subsystem-Name: Jakarta RESTful Web Services 3.0
   io.openliberty.jakarta.activation-2.0, \
   io.openliberty.jakarta.xmlBinding-3.0; apiJar=false
 -bundles=\
-  io.openliberty.jaxrs30; location:="dev/api/ibm/,lib/", \
   io.openliberty.jakarta.restfulWS.3.0;location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.ws.rs:jakarta.ws.rs-api:3.0.0"
+-jars=\
+  io.openliberty.jaxrs30; location:="dev/api/ibm/,lib/"
 -files=\
   dev/api/ibm/javadoc/io.openliberty.jaxrs30_1.0-javadoc.zip
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWS-3.0/io.openliberty.restfulWS-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWS-3.0/io.openliberty.restfulWS-3.0.feature
@@ -13,7 +13,7 @@ Subsystem-Name: Jakarta RESTful Web Services 3.0
   com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=\
  io.openliberty.org.jboss.resteasy.cdi, \
- io.openliberty.org.jboss.resteasy.server.jakarta
+ io.openliberty.org.jboss.resteasy.server
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWSClient-3.1/io.openliberty.restfulWSClient-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWSClient-3.1/io.openliberty.restfulWSClient-3.1.feature
@@ -58,13 +58,14 @@ Subsystem-Name: Jakarta RESTful Web Services 3.1 Client
   io.openliberty.activation.internal-2.1, \
   io.openliberty.jsonp-2.1
 -bundles=\
-  io.openliberty.jaxrs30; location:="dev/api/ibm/,lib/", \
   com.ibm.ws.jaxrs.2.x.config, \
   io.openliberty.org.apache.commons.codec, \
   io.openliberty.org.apache.commons.logging, \
   com.ibm.ws.org.apache.httpcomponents, \
   io.openliberty.org.jboss.logging35, \
   io.openliberty.org.jboss.resteasy.common.ee10
+-jars=\
+  io.openliberty.jaxrs30; location:="dev/api/ibm/,lib/"
 -files=\
   dev/api/ibm/javadoc/io.openliberty.jaxrs30_1.0-javadoc.zip
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWSClient-4.0/io.openliberty.restfulWSClient-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/restfulWSClient-4.0/io.openliberty.restfulWSClient-4.0.feature
@@ -56,13 +56,14 @@ Subsystem-Name: Jakarta RESTful Web Services 4.0 Client
   io.openliberty.activation.internal-2.1, \
   io.openliberty.jsonp-2.1
 -bundles=\
-  io.openliberty.jaxrs30; location:="dev/api/ibm/,lib/", \
   com.ibm.ws.jaxrs.2.x.config, \
   io.openliberty.org.apache.commons.codec, \
   io.openliberty.org.apache.commons.logging, \
   com.ibm.ws.org.apache.httpcomponents, \
   io.openliberty.org.jboss.logging35, \
   io.openliberty.org.jboss.resteasy.common.ee10
+-jars=\
+  io.openliberty.jaxrs30; location:="dev/api/ibm/,lib/"
 -files=\
   dev/api/ibm/javadoc/io.openliberty.jaxrs30_1.0-javadoc.zip
 kind=noship

--- a/dev/io.openliberty.jaxrs30/bnd.bnd
+++ b/dev/io.openliberty.jaxrs30/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2022 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -15,27 +15,19 @@ bVersion: 1.0
 
 Bundle-Name: Jakarta RESTful Web Services 3.0 Engine API
 Bundle-Description: Jakarta RESTful Web Services 3.0 Engine API, version ${bVersion}
-Bundle-SymbolicName: io.openliberty.jaxrs30
+Bundle-SymbolicName: io.openliberty.jaxrs30.javaee
+
+-sub: *.bnd
 
 Import-Package: \
   com.ibm.websphere.jaxrs20.multipart, \
-  com.ibm.websphere.jaxrs.monitor;resolution:=dynamic, \
-  com.ibm.websphere.monitor.jmx;resolution:=dynamic, \
-  com.ibm.websphere.ras, \
-  com.ibm.ws.jaxrs20.multipart.impl;resolution:=optional, \
-  jakarta.activation, \
-  jakarta.ws.rs, \
-  jakarta.ws.rs.client, \
-  jakarta.ws.rs.container, \
-  jakarta.ws.rs.core, \
-  jakarta.ws.rs.ext, \
-  jakarta.ws.rs.sse, \
-  org.jboss.resteasy.plugins.providers.multipart;version="[4.7,7.0)"
-
+  com.ibm.websphere.jaxrs.monitor
+#  com.ibm.websphere.jaxrs.server
 
 Export-Package: \
   com.ibm.websphere.jaxrs20.multipart, \
   com.ibm.websphere.jaxrs.monitor
+#  com.ibm.websphere.jaxrs.server
 
 -includeresource: {META-INF/maven/io.openliberty.api/io.openliberty.jaxrs30/pom.xml=io.openliberty.jaxrs30.pom}
 
@@ -43,10 +35,16 @@ Export-Package: \
  
 publish.wlp.jar.suffix: dev/api/ibm
 
+publish.wlp.jar.include: io.openliberty.jaxrs30.jar
+
+publish.wlp.javadoc.include: io.openliberty.jaxrs30.javadoc.zip
+
 -buildpath: \
-  com.ibm.ws.jaxrs.2.x.monitor.jakarta;version=latest, \
-  com.ibm.ws.jaxrs.2.x.config;version=latest, \
-  io.openliberty.org.jboss.resteasy.common.jakarta;version=latest
+  com.ibm.ws.jaxrs.2.x.monitor;version=latest, \
+  io.openliberty.org.jboss.resteasy.common.jakarta;version=latest, \
+  io.openliberty.org.jboss.resteasy.server;version=latest, \
+  com.ibm.websphere.javaee.servlet.4.0;version=latest, \
+  io.openliberty.jakarta.servlet.5.0;version=latest
 
 -testpath: \
  com.ibm.ws.componenttest;version=latest,\

--- a/dev/io.openliberty.jaxrs30/original.bnd
+++ b/dev/io.openliberty.jaxrs30/original.bnd
@@ -1,16 +1,11 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
+# SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
--include= ~../cnf/resources/bnd/transform.props
 
-Bundle-Name: io.openliberty.org.jboss.resteasy.server Jakarta
-Bundle-SymbolicName: io.openliberty.org.jboss.resteasy.server.jakarta
+Bundle-SymbolicName: io.openliberty.jaxrs30.javaee

--- a/dev/io.openliberty.jaxrs30/transformed.bnd
+++ b/dev/io.openliberty.jaxrs30/transformed.bnd
@@ -1,14 +1,12 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
+# SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
+-include= ~../cnf/resources/bnd/transform.props
 
-Bundle-SymbolicName: io.openliberty.org.jboss.resteasy.server
+Bundle-SymbolicName: io.openliberty.jaxrs30

--- a/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2023 IBM Corporation and others.
+# Copyright (c) 2020, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -117,7 +117,6 @@ Export-Package: \
 # from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the
 # packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
-  javax.activation;version=!, \
   javax.annotation;version=!, \
   javax.annotation.security;version=!, \
   javax.xml.bind;version=!, \
@@ -126,6 +125,7 @@ Import-Package: \
   javax.xml.bind.attachment;version=!, \
   javax.xml.bind.helpers;version=!, \
   javax.xml.bind.util;version=!, \
+  !javax.activation, \
   !javax.json.bind, \
   !javax.json.bind.spi, \
   !javax.mail, \
@@ -210,6 +210,7 @@ Include-Resource:\
 	com.ibm.websphere.javaee.jsonp.1.1,\
 	com.ibm.websphere.javaee.servlet.4.0,\
 	com.ibm.websphere.javaee.validation.2.0;version=latest,\
+	io.openliberty.jakarta.activation.2.0;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.config.1.4;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/com/ibm/websphere/jaxrs20/multipart/IAttachment.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/com/ibm/websphere/jaxrs20/multipart/IAttachment.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.websphere.jaxrs20.multipart;
 
-import javax.activation.DataHandler;
+import jakarta.activation.DataHandler;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/plugins/providers/multipart/IAttachmentImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/plugins/providers/multipart/IAttachmentImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,8 +20,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
+import jakarta.activation.DataHandler;
+import jakarta.activation.DataSource;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2022 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -45,6 +45,7 @@ Export-Package: \
 
 Import-Package: \
   !javax.enterprise.concurrent,\
+  !jakarta.enterprise.inject.spi,\
   javax.annotation;version='!',\
   javax.inject,\
   javax.ws.rs.core,\
@@ -70,13 +71,14 @@ Include-Resource:\
 
 -buildpath: \
   io.openliberty.org.jboss.resteasy.common,\
-  io.openliberty.org.jboss.resteasy.server,\
+  io.openliberty.org.jboss.resteasy.cdi,\
   org.jboss.resteasy:resteasy-client-microprofile-base;strategy=exact;version=${resteasy-version},\
   org.jboss.resteasy:resteasy-client-microprofile;strategy=exact;version=${resteasy-version},\
   com.ibm.ws.org.apache.commons.io,\
   com.ibm.ws.org.apache.httpcomponents,\
   com.ibm.websphere.javaee.annotation.1.3,\
   com.ibm.websphere.javaee.cdi.2.0,\
+  io.openliberty.jakarta.cdi.3.0; version=latest,\
   com.ibm.websphere.javaee.interceptor.1.2,\
   com.ibm.websphere.javaee.jaxb.2.2,\
   com.ibm.websphere.javaee.jaxrs.2.1,\

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
@@ -120,7 +120,7 @@ public class RestClientBuilderImpl implements RestClientBuilder {
         }
         if (getBeanManager() != null) {
             builderDelegate.getProviderFactory()
-                    .setInjectorFactory(new CdiInjectorFactory(getBeanManager()));
+                    .setInjectorFactory(new CdiInjectorFactory((jakarta.enterprise.inject.spi.BeanManager) getBeanManager())); // Liberty change for transformation
         }
         configurationWrapper = new ConfigurationWrapper(builderDelegate.getConfiguration());
 

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
@@ -166,7 +166,7 @@ public class LibertyRestClientBuilderImpl implements RestClientBuilder {
         BeanManager beanManager = getBeanManager();
         if (beanManager != null) {
             builderDelegate.getProviderFactory()
-                    .setInjectorFactory(new CdiInjectorFactory(beanManager));
+                    .setInjectorFactory(new CdiInjectorFactory((jakarta.enterprise.inject.spi.BeanManager) beanManager));
         }
         configurationWrapper = new ConfigurationWrapper(builderDelegate.getConfiguration());
 

--- a/dev/io.openliberty.org.jboss.resteasy.server.ee10/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.server.ee10/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -59,13 +59,11 @@ instrument.ffdc: false
 instrument.disabled: false
 
 Include-Resource:\
-  @${repo;org.jboss.resteasy:resteasy-cdi;${resteasy-version};EXACT}, \
   @${repo;org.jboss.resteasy:resteasy-servlet-initializer;${resteasy-version};EXACT}, \
   com/ibm/websphere=${bin}/com/ibm/websphere, \
   io/openliberty=${bin}/io/openliberty
 
 -buildpath: \
-  org.jboss.resteasy:resteasy-cdi;strategy=exact;version='${resteasy-version}',\
   org.jboss.resteasy:resteasy-core-spi;strategy=exact;version='${resteasy-version}',\
   org.jboss.resteasy:resteasy-core;strategy=exact;version='${resteasy-version}',\
   org.jboss.resteasy:resteasy-servlet-initializer;strategy=exact;version='${resteasy-version}',\

--- a/dev/io.openliberty.org.jboss.resteasy.server/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.server/bnd.bnd
@@ -1,23 +1,21 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= ~../cnf/resources/bnd/bundle.props
+-include= ~../cnf/resources/bnd/bundle.props, ~../cnf/resources/bnd/transform.props
 
--sub: *.bnd
+Bundle-Name: io.openliberty.org.jboss.resteasy.server Jakarta
+Bundle-SymbolicName: io.openliberty.org.jboss.resteasy.server
 
 bVersion=1.0
-
-# Only publish the Jakarta one
-publish.wlp.jar.include: io.openliberty.org.jboss.resteasy.server.jakarta.jar
 
 resteasy-version=4.7.2.Final
 
@@ -72,13 +70,11 @@ instrument.disabled: false
 
 
 Include-Resource:\
-  @${repo;org.jboss.resteasy:resteasy-cdi;${resteasy-version};EXACT}, \
   @${repo;org.jboss.resteasy:resteasy-servlet-initializer;${resteasy-version};EXACT}, \
   com/ibm/websphere=${bin}/com/ibm/websphere, \
   io/openliberty=${bin}/io/openliberty
 
 -buildpath: \
-  org.jboss.resteasy:resteasy-cdi;strategy=exact;version=${resteasy-version},\
   org.jboss.resteasy:resteasy-servlet-initializer;strategy=exact;version=${resteasy-version},\
   com.ibm.ws.org.apache.commons.io,\
   com.ibm.ws.org.apache.httpcomponents,\

--- a/dev/io.openliberty.org.jboss.resteasy.validator.provider.ee10/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.validator.provider.ee10/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2023 IBM Corporation and others.
+# Copyright (c) 2022, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -57,7 +57,7 @@ org/jboss/resteasy=${bin}/org/jboss/resteasy
   org.jboss.resteasy:resteasy-validator-provider;strategy=exact;version='${resteasy-version}',\
   io.openliberty.org.jboss.logging35,\
   io.openliberty.org.jboss.resteasy.common.ee10,\
-  io.openliberty.org.jboss.resteasy.server.ee10,\
+  io.openliberty.org.jboss.resteasy.cdi.ee10,\
   com.ibm.ws.com.fasterxml.classmate;version=latest,\
   io.openliberty.jakarta.cdi.4.0,\
   io.openliberty.jakarta.validation.3.0;version=latest,\

--- a/dev/io.openliberty.org.jboss.resteasy.validator.provider/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.validator.provider/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2020, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -52,11 +52,12 @@ org/jboss/resteasy=${bin}/org/jboss/resteasy
 	com.ibm.websphere.javaee.validation.2.0;version=latest,\
 	com.ibm.ws.cdi.interfaces;version=latest,\
 	com.ibm.websphere.javaee.cdi.2.0,\
+	io.openliberty.jakarta.cdi.3.0; version=latest,\
 	com.ibm.websphere.javaee.jaxrs.2.1,\
 	com.ibm.ws.logging.core,\
 	com.ibm.ws.org.jboss.logging,\
 	io.openliberty.org.jboss.resteasy.common,\
-	io.openliberty.org.jboss.resteasy.server,\
+	io.openliberty.org.jboss.resteasy.cdi,\
 	com.ibm.ws.com.fasterxml.classmate;version=latest
 
 instrument.ffdc: false


### PR DESCRIPTION
- Update io.openliberty.jaxrs30 API bundle and javadoc to have jakarta prefixed classes instead of javax
- Update the restfulWS features to bring in the io.openliberty.jaxrs30 API bundle jar as a jar instead of as a bundle similar to how we do other API bundles.
- Update to only have a transformed bundle for the resteasy server bundle.
- Do not include resteasy-cdi in the server bundles.  Just have it in the io.openliberty.org.jboss.resteasy.cdi bundles
- Initially was going to also add com.ibm.websphere.jaxrs.server package to io.openliberty.jaxrs30 PR, but exploring to add it in a future PR after some issues are discussed and addressed.