### PR TITLE
Fix access_token parser

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/utils/TokenKeeper.java
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/utils/TokenKeeper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -170,7 +170,11 @@ public class TokenKeeper {
 
     private String getAccessTokenFromResponse(Object response) throws Exception {
 
-        String accessToken = validationTools.getTokenFromResponse(response, Constants.ACCESS_TOKEN_KEY);
+        String accessToken = null;
+        String rawAccessToken = validationTools.getTokenFromResponse(response, Constants.ACCESS_TOKEN_KEY);
+        if (rawAccessToken != null) {
+            accessToken = rawAccessToken.split("}")[0];
+        }
         Log.info(thisClass, "getAccessToken", "access_token:  " + accessToken);
         return accessToken;
 


### PR DESCRIPTION
The back channel logout tests are grabbing the access_token from the formlogin output.  On Windows, we're getting some extra characters.
The tests end up using:
4RMrqTgvCw5w6KOCoVjU6NeBZpfNH7WjqMHmiac}
Private Credential: com.ibm.websphere.security.social.UserProfile@72f19ed6
Private Credential: com.ibm.ws.security.token.internal.SingleSignonTokenImpl@78930bf3
as the access_token instead of:
4RMrqTgvCw5w6KOCoVjU6NeBZpfNH7WjqMHmiac
