### PR TITLE
simulate qualifiers for executors and contextservice

### DIFF
--- a/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
@@ -33,6 +33,7 @@
    <Option value="IGNORE" label="%onError.IGNORE"/>
    <Option value="WARN"   label="%onError.WARN"/>
   </AD>
+  <AD id="qualifiers"                        type="String"  required="false" cardinality="-1000" name="internal" description="internal use only"/>
   <AD id="service.ranking"                   type="Integer" default="0" name="internal" description="internal use only"/>
   <AD id="javaCompDefaultName"               type="String"  required="false" name="internal" description="internal use only" /> 
  </OCD>
@@ -54,6 +55,7 @@
   <AD id="longRunningPolicyRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" required="false" cardinality="-1" name="%longRunningPolicy" description="%longRunningPolicy.desc"/>
   <AD id="LongRunningPolicy.target"              type="String"  ibm:final="true" default="(service.pid=${longRunningPolicyRef})" name="internal" description="internal use only"/>
   <AD id="LongRunningPolicy.cardinality.minimum" type="String"  ibm:final="true" default="${count(longRunningPolicyRef)}" name="internal" description="internal use only"/>
+  <AD id="qualifiers"                            type="String"  required="false" cardinality="-1000" name="internal" description="internal use only"/>
   <AD id="service.ranking"                       type="Integer" default="-1000" name="internal" description="internal use only"/>
  </OCD>
   
@@ -74,6 +76,7 @@
   <AD id="longRunningPolicyRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" required="false" cardinality="-1" name="%longRunningPolicy" description="%longRunningPolicy.desc"/>
   <AD id="LongRunningPolicy.target"              type="String"  ibm:final="true" default="(service.pid=${longRunningPolicyRef})" name="internal" description="internal use only"/>
   <AD id="LongRunningPolicy.cardinality.minimum" type="String"  ibm:final="true" default="${count(longRunningPolicyRef)}" name="internal" description="internal use only"/>
+  <AD id="qualifiers"                            type="String"  required="false" cardinality="-1000" name="internal" description="internal use only"/>
   <AD id="service.ranking"                       type="Integer" default="-1000" name="internal" description="internal use only"/>
  </OCD>
 
@@ -90,6 +93,7 @@
   <AD id="defaultPriority"                    type="Integer" required="false" max="10" min="1" name="%defaultPriority" description="%defaultPriority.desc"/>
   <AD id="jndiName"                           type="String"  required="false" ibm:unique="jndiName" name="%jndiName" description="%jndiName.desc"/>
   <AD id="maxPriority"                        type="Integer" required="false" max="10" min="1" name="%maxPriority" description="%maxPriority.desc"/>
+  <AD id="qualifiers"                         type="String"  required="false" cardinality="-1000" name="internal" description="internal use only"/>
   <AD id="service.ranking"                    type="Integer" default="-1000" name="internal" description="internal use only"/>
   <AD id="virtual"                            type="Boolean" default="false" name="internal" description="internal use only"/>
   <AD id="javaCompDefaultName"                type="String"  required="false" name="internal" description="internal use only" />  

--- a/dev/com.ibm.ws.concurrent_fat_cdi/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2023 IBM Corporation and others.
+# Copyright (c) 2017,2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -30,6 +30,6 @@ fat.project: true
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
 	io.openliberty.jakarta.annotation.2.0;version=latest,\
 	io.openliberty.jakarta.cdi.3.0;version=latest,\
-	io.openliberty.jakarta.concurrency.3.0;version=latest,\
+	io.openliberty.jakarta.concurrency.3.1;version=latest,\
 	io.openliberty.jakarta.servlet.5.0;version=latest,\
 	io.openliberty.jakarta.transaction.2.0;version=latest

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2023 IBM Corporation and others.
+ * Copyright (c) 2017,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -57,6 +57,11 @@ public class ConcurrentCDITest extends FATServletClient {
                           "CWWKC1101E.*scheduled-executor-without-app-context", // tests lack of context from scheduled executor thread
                           "CWWKE1205E" // test case intentionally causes startTimeout to be exceeded
         );
+    }
+
+    // TODO enable once implemented correctly @Test
+    public void testContextServiceWithUnrecognizedQualifier() throws Exception {
+        runTest(server, APP_NAME, testName);
     }
 
     @Test

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2023 IBM Corporation and others.
+ * Copyright (c) 2017,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,6 @@ import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -50,16 +49,22 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
 @ContextServiceDefinition(name = "java:global/concurrent/with-app-context",
+                          qualifiers = WithAppContext.class,
                           propagated = APPLICATION, cleared = ALL_REMAINING)
 @ContextServiceDefinition(name = "java:global/concurrent/without-app-context",
+                          qualifiers = WithoutAppContext.class,
                           cleared = APPLICATION, propagated = ALL_REMAINING)
 @ManagedExecutorDefinition(name = "java:global/concurrent/executor-with-app-context",
+                           qualifiers = WithAppContext.class,
                            context = "java:global/concurrent/with-app-context")
 @ManagedExecutorDefinition(name = "java:global/concurrent/executor-without-app-context",
+                           qualifiers = WithoutAppContext.class,
                            context = "java:global/concurrent/without-app-context")
 @ManagedScheduledExecutorDefinition(name = "java:global/concurrent/scheduled-executor-with-app-context",
+                                    qualifiers = WithAppContext.class,
                                     context = "java:global/concurrent/with-app-context")
 @ManagedScheduledExecutorDefinition(name = "java:global/concurrent/scheduled-executor-without-app-context",
+                                    qualifiers = WithoutAppContext.class,
                                     context = "java:global/concurrent/without-app-context")
 @SuppressWarnings("serial")
 @WebServlet("/*")
@@ -80,27 +85,31 @@ public class ConcurrentCDIServlet extends HttpServlet {
     ManagedScheduledExecutorService defaultManagedScheduledExecutor;
 
     @Inject
-    @Named("java:global/concurrent/executor-with-app-context")
+    @WithAppContext
     ManagedExecutorService executorWithAppContext;
 
     @Inject
-    @Named("java:global/concurrent/executor-without-app-context")
+    @WithoutAppContext
     ManagedExecutorService executorWithoutAppContext;
 
     @Inject
-    @Named("java:global/concurrent/scheduled-executor-with-app-context")
+    @WithAppContext
     ManagedScheduledExecutorService scheduledExecutorWithAppContext;
 
     @Inject
-    @Named("java:global/concurrent/scheduled-executor-without-app-context")
+    @WithoutAppContext
     ManagedScheduledExecutorService scheduledExecutorWithoutAppContext;
 
     @Inject
-    @Named("java:global/concurrent/with-app-context")
+    @Unrecognized
+    ContextService unknownContextService;
+
+    @Inject
+    @WithAppContext
     ContextService withAppContext;
 
     @Inject
-    @Named("java:global/concurrent/without-app-context")
+    @WithoutAppContext
     ContextService withoutAppContext;
 
     private ExecutorService unmanagedThreads;
@@ -159,6 +168,13 @@ public class ConcurrentCDIServlet extends HttpServlet {
         writer.close();
 
         System.out.println("<<< END:   " + method);
+    }
+
+    /**
+     * Attempt to inject a ContextService with an unrecognized qualifier.
+     */
+    public void testContextServiceWithUnrecognizedQualifier() throws Exception {
+        assertEquals(null, unknownContextService);
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/Unrecognized.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/Unrecognized.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.web;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Qualifier;
+
+/**
+ * Do not list this qualifier on definitions for any of the Concurrency resources.
+ * It is used to test what happens when an attempt is made to inject a Concurrency resource
+ * into an injection point that has unrecognized qualifiers.
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD, PARAMETER, TYPE })
+public @interface Unrecognized {
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithAppContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithAppContext.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.web;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface WithAppContext {
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithoutAppContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithoutAppContext.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.web;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD })
+public @interface WithoutAppContext {
+}

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ContextServiceBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ContextServiceBean.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2023,2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.concurrent.internal.cdi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+
+import jakarta.enterprise.concurrent.ContextService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.PassivationCapable;
+
+/**
+ * Bean that delegates to the OSGi service registry to obtain ContextService resources.
+ *
+ * @param <T> type of resource (such as ManagedExecutorService or ContextService)
+ */
+public class ContextServiceBean implements Bean<ContextService>, PassivationCapable {
+    private final static TraceComponent tc = Tr.register(ContextServiceBean.class);
+
+    /**
+     * Injectable bean types.
+     */
+    private final Set<Type> beanTypes = Set.of(ContextService.class);
+
+    /**
+     * OSGi filter for the resource.
+     */
+    private final String filter;
+
+    /**
+     * Qualifiers for the injection points for this bean.
+     */
+    private final Set<Annotation> qualifiers;
+
+    /**
+     * Construct a new Producer/ProducerFactory for this resource.
+     *
+     * @param filter     OSGi filter for the resource.
+     * @param qualifiers qualifiers for the bean.
+     */
+    public ContextServiceBean(String filter, Set<Annotation> qualifiers) {
+        this.filter = filter;
+        this.qualifiers = qualifiers;
+    }
+
+    @Override
+    @Trivial
+    public ContextService create(CreationalContext<ContextService> cc) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "create", cc, filter, qualifiers);
+
+        ContextService instance;
+        Bundle bundle = FrameworkUtil.getBundle(ContextServiceBean.class);
+        BundleContext bundleContext = bundle.getBundleContext();
+        Collection<ServiceReference<ContextService>> refs;
+        try {
+            refs = bundleContext.getServiceReferences(ContextService.class, filter);
+        } catch (InvalidSyntaxException x) {
+            throw new IllegalArgumentException(x); // internal error forming the filter?
+        }
+        Iterator<ServiceReference<ContextService>> it = refs.iterator();
+        if (it.hasNext())
+            instance = bundleContext.getService(it.next());
+        else
+            throw new IllegalStateException("The ContextService resource with " + filter + " filter cannot be found or is unavailable."); // TODO NLS
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "create", instance);
+        return instance;
+    }
+
+    @Override
+    public void destroy(ContextService instance, CreationalContext<ContextService> creationalContext) {
+    }
+
+    @Override
+    public Class<ContextService> getBeanClass() {
+        return ContextService.class;
+    }
+
+    /**
+     * @return unique identifier for PassivationCapable.
+     */
+    @Override
+    public String getId() {
+        return new StringBuilder(getClass().getName()) //
+                        .append(":").append(qualifiers) //
+                        .append(':').append(filter) //
+                        .toString();
+    }
+
+    @Override
+    public Set<InjectionPoint> getInjectionPoints() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        return qualifiers;
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return ApplicationScoped.class;
+    }
+
+    @Override
+    public Set<Class<? extends Annotation>> getStereotypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<Type> getTypes() {
+        return beanTypes;
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    @Trivial
+    public String toString() {
+        return new StringBuilder(getClass().getSimpleName()).append('@').append(Integer.toHexString(hashCode())) //
+                        .append(' ').append(filter) //
+                        .append(" with qualifiers ").append(qualifiers) //
+                        .toString();
+    }
+}

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedScheduledExecutorBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedScheduledExecutorBean.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.concurrent.internal.cdi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.PassivationCapable;
+
+/**
+ * Bean that delegates to the OSGi service registry to obtain ManagedScheduledExecutorService resources.
+ */
+public class ManagedScheduledExecutorBean implements Bean<ManagedScheduledExecutorService>, PassivationCapable {
+    private final static TraceComponent tc = Tr.register(ManagedScheduledExecutorBean.class);
+
+    /**
+     * Injectable bean types.
+     */
+    private final Set<Type> beanTypes = Set.of(ManagedScheduledExecutorService.class);
+
+    /**
+     * OSGi filter for the resource.
+     */
+    private final String filter;
+
+    /**
+     * Qualifiers for the injection points for this bean.
+     */
+    private final Set<Annotation> qualifiers;
+
+    /**
+     * Construct a new Producer/ProducerFactory for this resource.
+     *
+     * @param filter     OSGi filter for the resource.
+     * @param qualifiers qualifiers for the bean.
+     */
+    public ManagedScheduledExecutorBean(String filter, Set<Annotation> qualifiers) {
+        this.filter = filter;
+        this.qualifiers = qualifiers;
+    }
+
+    @Override
+    @Trivial
+    public ManagedScheduledExecutorService create(CreationalContext<ManagedScheduledExecutorService> cc) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "create", cc, filter, qualifiers);
+
+        ManagedScheduledExecutorService instance;
+        Bundle bundle = FrameworkUtil.getBundle(ManagedScheduledExecutorBean.class);
+        BundleContext bundleContext = bundle.getBundleContext();
+        Collection<ServiceReference<ManagedScheduledExecutorService>> refs;
+        try {
+            refs = bundleContext.getServiceReferences(ManagedScheduledExecutorService.class, filter);
+        } catch (InvalidSyntaxException x) {
+            throw new IllegalArgumentException(x); // internal error forming the filter?
+        }
+        Iterator<ServiceReference<ManagedScheduledExecutorService>> it = refs.iterator();
+        if (it.hasNext())
+            instance = bundleContext.getService(it.next());
+        else
+            throw new IllegalStateException("The ManagedScheduledExecutorService resource with " + filter + " filter cannot be found or is unavailable."); // TODO NLS
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "create", instance);
+        return instance;
+    }
+
+    @Override
+    public void destroy(ManagedScheduledExecutorService instance, CreationalContext<ManagedScheduledExecutorService> creationalContext) {
+    }
+
+    @Override
+    public Class<ManagedScheduledExecutorService> getBeanClass() {
+        return ManagedScheduledExecutorService.class;
+    }
+
+    /**
+     * @return unique identifier for PassivationCapable.
+     */
+    @Override
+    public String getId() {
+        return new StringBuilder(getClass().getName()) //
+                        .append(":").append(qualifiers) //
+                        .append(':').append(filter) //
+                        .toString();
+    }
+
+    @Override
+    public Set<InjectionPoint> getInjectionPoints() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        return qualifiers;
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return ApplicationScoped.class;
+    }
+
+    @Override
+    public Set<Class<? extends Annotation>> getStereotypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<Type> getTypes() {
+        return beanTypes;
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    @Trivial
+    public String toString() {
+        return new StringBuilder(getClass().getSimpleName()).append('@').append(Integer.toHexString(hashCode())) //
+                        .append(' ').append(filter) //
+                        .append(" with qualifiers ").append(qualifiers) //
+                        .toString();
+    }
+}

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2021,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,6 +17,7 @@ import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -214,6 +215,15 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
         String[] propagated = (String[]) contextSvcProps.remove("propagated");
         String[] unchanged = (String[]) contextSvcProps.remove("unchanged");
         String[] properties = (String[]) contextSvcProps.remove("properties"); // TODO process these?
+        String[] qualifiers = (String[]) contextSvcProps.remove("qualifiers");
+
+        // Convert qualifier array to list attribute if present
+        if (qualifiers != null && qualifiers.length > 0) {
+            List<String> qualifierList = Arrays.asList(qualifiers);
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(tc, "qualifiers", qualifierList);
+            contextSvcProps.put("qualifiers", qualifierList);
+        }
 
         if (cleared == null)
             cleared = new String[0];

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,8 +12,10 @@
  *******************************************************************************/
 package io.openliberty.concurrent.internal.processor;
 
+import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 
 import org.osgi.framework.BundleContext;
@@ -133,6 +135,15 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
         String component = (String) execSvcProps.get("component");
         String jndiName = (String) execSvcProps.get(ResourceFactory.JNDI_NAME);
         String contextSvcJndiName = (String) execSvcProps.remove("context");
+        String[] qualifiers = (String[]) execSvcProps.remove("qualifiers");
+
+        // Convert qualifier array to list attribute if present
+        if (qualifiers != null && qualifiers.length > 0) {
+            List<String> qualifierList = Arrays.asList(qualifiers);
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(tc, "qualifiers", qualifierList);
+            execSvcProps.put("qualifiers", qualifierList);
+        }
 
         Long hungTaskThreshold = (Long) execSvcProps.remove("hungTaskThreshold");
         Integer maxAsync = (Integer) execSvcProps.remove("maxAsync");

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,8 +12,10 @@
  *******************************************************************************/
 package io.openliberty.concurrent.internal.processor;
 
+import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 
 import org.osgi.framework.BundleContext;
@@ -133,6 +135,15 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
         String component = (String) execSvcProps.get("component");
         String jndiName = (String) execSvcProps.get(ResourceFactory.JNDI_NAME);
         String contextSvcJndiName = (String) execSvcProps.remove("context");
+        String[] qualifiers = (String[]) execSvcProps.remove("qualifiers");
+
+        // Convert qualifier array to list attribute if present
+        if (qualifiers != null && qualifiers.length > 0) {
+            List<String> qualifierList = Arrays.asList(qualifiers);
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(tc, "qualifiers", qualifierList);
+            execSvcProps.put("qualifiers", qualifierList);
+        }
 
         Long hungTaskThreshold = (Long) execSvcProps.remove("hungTaskThreshold");
         Integer maxAsync = (Integer) execSvcProps.remove("maxAsync");


### PR DESCRIPTION
The pull updates a test bucket to specify a single qualifier on ContextServiceDefinition, ManagedExecutorDefinition, and ManagedScheduledExecutorDefinition and inject with the qualifier, after modifying code path to simulate this function.  This is an oversimplified solution that isn't complete, but is enough to make those tests work.