### PR TITLE
Fix JavaIllegalAccessTest dns test values

### DIFF
--- a/dev/io.openliberty.java.internal_fat/test-applications/illegalaccess/src/test/web/IllegalAccessTestServlet.java
+++ b/dev/io.openliberty.java.internal_fat/test-applications/illegalaccess/src/test/web/IllegalAccessTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package test.web;
 
+import java.net.InetAddress;
 import java.util.Properties;
 
 import javax.naming.Context;
@@ -34,8 +35,12 @@ public class IllegalAccessTestServlet extends FATServlet {
             env.put(Context.PROVIDER_URL, "dns:");
             InitialDirContext dirContext = new InitialDirContext(env);
 
-            // This will cause an illegalAccessException FFDC if the proper entry is not in the java9.options file.
-            Attributes attrs = dirContext.getAttributes("dns:/www.github.com");
+            // This will cause an illegalAccessException FFDC if the following entry is not in the java9.options file:
+            // --add-exports
+            // jdk.naming.dns/com.sun.jndi.url.dns=ALL-UNNAMED
+            // 
+            // Attempt a DNS lookup of the local host name using the underlying machine's DNS config
+            Attributes attrs = dirContext.getAttributes("dns:/" + InetAddress.getLocalHost().getHostName());
         } catch (NameNotFoundException nnfe) { // dirContext.getAttributes may throw a NameNotFoundException, it can be ignored
             // Ignore
         }


### PR DESCRIPTION
Fixes the problem where in our testing we see this error:
```
Test Failure: io.openliberty.java.internal.fat.JavaIllegalAccessTest.IllegalAccessTestServlet.testJdkNamingDnsDoesNotExportComSunJndiUurlDns

IllegalAccessTestServlet.testJdkNamingDnsDoesNotExportComSunJndiUurlDns:junit.framework.AssertionFailedError: 2023-08-05-08:12:27:454 ERROR: Caught exception attempting to call test method testJdkNamingDnsDoesNotExportComSunJndiUurlDns on servlet test.web.IllegalAccessTestServlet
javax.naming.CommunicationException: DNS error [Root exception is java.net.SocketTimeoutException: Receive timed out]; remaining name '[www.github.com](http://www.github.com/)'
at com.sun.jndi.dns.DnsClient.query(DnsClient.java:321)
at com.sun.jndi.dns.Resolver.query(Resolver.java:81)
at com.sun.jndi.dns.DnsContext.c_getAttributes(DnsContext.java:434)
at java.naming/com.sun.jndi.toolkit.ctx.ComponentDirContext.p_getAttributes(ComponentDirContext.java:235)
at java.naming/com.sun.jndi.toolkit.ctx.PartialCompositeDirContext.getAttributes(PartialCompositeDirContext.java:141)
at java.naming/com.sun.jndi.toolkit.url.GenericURLDirContext.getAttributes(GenericURLDirContext.java:103)
at org.apache.aries.jndi.DelegateContext.getAttributes(DelegateContext.java:263)
...
```

Originally, the DNS host name value to be resolved was `www.github.com` and that would fail sometimes (servers the tests ran on could not resolve internet host names?).  Rather than rely on name resolution for external servers, now the test DNS value to be resolved is the local host name of the test server.