### PR TITLE
Update .classpath and bnd files

### DIFF
--- a/dev/com.ibm.ws.cdi.lifecycle_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.lifecycle_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2022 IBM Corporation and others.
+# Copyright (c) 2018, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -16,19 +16,7 @@ bVersion=1.0
 # Define the bundle for this FAT
 
 src: \
-	fat/src,\
-	test-applications/eventMetaData.war/src,\
-	test-applications/ObservesInitializedInJars.war/src,\
-	test-applications/ObservesInitializedInJarsManifestJar.jar/src,\
-	test-applications/ObservesInitializedInJarsSecondWar.war/src,\
-	test-applications/ObservesInitializedInJarsWebInfJar.jar/src,\
-	test-applications/passivationBean.war/src,\
-	test-applications/scopeActivationDestructionSecondApp.war/src,\
-	test-applications/scopeActivationDestructionTests.war/src,\
-    test-applications/transientReferenceInSessionPersist.war/src,\
-    test-applications/WebListener.war/src
-	
-	
+	fat/src
 	
 test.project: true
 

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/.classpath
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/.classpath
@@ -5,6 +5,7 @@
 	<classpathentry kind="src" path="test-applications/ConcurrencyTestEJB/src"/>
 	<classpathentry kind="src" path="test-applications/ConcurrencyTestWeb/src"/>
 	<classpathentry kind="src" path="test-applications/ConcurrencyTestError/src"/>
+	<classpathentry kind="src" path="test-applications/Concurrency31TestWeb/src"/>
 	<classpathentry kind="src" path="test-libraries/LocationUtils/src"/>
 	<classpathentry kind="src" path="test-libraries/PriorityContext/src"/>
 	<classpathentry kind="src" path="test-libraries/StatUtils/src"/>

--- a/dev/com.ibm.ws.install.featureUtility/.classpath
+++ b/dev/com.ibm.ws.install.featureUtility/.classpath
@@ -5,6 +5,5 @@
 	<classpathentry kind="src" output="bin_test" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jbatch.open.bonuspayout_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jbatch.open.bonuspayout_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -15,10 +15,6 @@ bVersion=1.0
 
 src: \
  fat/src,\
- test-applications/batchFAT.war/src,\
- test-applications/batchFAT.war/resources,\
- test-applications/batchSecurity.war/src,\
- test-applications/batchSecurity.war/resources,\
  test-applications/fat.common/DbServletApp.war/src,\
  test-applications/fat.common/DbServletApp.war/resources
 

--- a/dev/com.ibm.ws.jbatch.open.partition_fat/.classpath
+++ b/dev/com.ibm.ws.jbatch.open.partition_fat/.classpath
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/batchFAT.war/src"/>
+	<classpathentry kind="src" path="test-applications/batchFAT.war/resources"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jbatch.open.partition_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jbatch.open.partition_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -17,8 +17,6 @@ src: \
  fat/src,\
  test-applications/batchFAT.war/src,\
  test-applications/batchFAT.war/resources,\
- test-applications/batchSecurity.war/src,\
- test-applications/batchSecurity.war/resources,\
  test-applications/fat.common/DbServletApp.war/src,\
  test-applications/fat.common/DbServletApp.war/resources,\
  test-applications/fat.common/BonusPayout.war/src,\

--- a/dev/com.ibm.ws.jbatch.open.security_fat/.classpath
+++ b/dev/com.ibm.ws.jbatch.open.security_fat/.classpath
@@ -2,7 +2,9 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/batchFAT.war/src"/>
+	<classpathentry kind="src" path="test-applications/batchFAT.war/resources"/>
 	<classpathentry kind="src" path="test-applications/batchSecurity.war/src"/>
+	<classpathentry kind="src" path="test-applications/batchSecurity.war/resources"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jbatch.open_fat/.classpath
+++ b/dev/com.ibm.ws.jbatch.open_fat/.classpath
@@ -3,6 +3,7 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/batchSecurity.war/src"/>
 	<classpathentry kind="src" path="test-applications/batchFAT.war/src"/>
+	<classpathentry kind="src" path="test-applications/batchFAT.war/resources"/>
 	<classpathentry kind="src" path="com.ibm.ws.jbatch.fat.common-BonusPayout"/>
 	<classpathentry kind="src" path="com.ibm.ws.jbatch.fat.common-DbServletApp"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.logging_fat/bnd.bnd
+++ b/dev/com.ibm.ws.logging_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -25,7 +25,6 @@ src: \
 	test-applications/missing-feature-servlet/src, \
 	test-applications/RealFlushTestApp/src, \
 	test-applications/add-extension-fields/src, \
-	test-applications/quick-log-test/src, \
 	test-bundles/sample.source.handler/src, \
 	test-bundles/message.source.handler/src, \
 	test-bundles/ffdc.source.handler/src, \

--- a/dev/com.ibm.ws.security.jaspic.jakarta10_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.jaspic.jakarta10_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2022 IBM Corporation and others.
+# Copyright (c) 2020, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -16,7 +16,7 @@
 bVersion=1.0
 
 javac.source: 11
-javac.target: 11 
+javac.target: 11
 
 src: \
 	fat/src,\

--- a/dev/io.openliberty.ejbcontainer.mdb.checkpoint_fat/.classpath
+++ b/dev/io.openliberty.ejbcontainer.mdb.checkpoint_fat/.classpath
@@ -3,7 +3,6 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/MsgEndpointEJB.jar/src"/>
 	<classpathentry kind="src" path="test-applications/MsgEndpointWeb.war/src"/>
-	<classpathentry kind="src" path="test-resourceadapters/AdapterForEJB.rar/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.io.opentelemetry/.classpath
+++ b/dev/io.openliberty.io.opentelemetry/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2023 IBM Corporation and others.
+# Copyright (c) 2023, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -20,5 +20,4 @@ src: \
 fat.project: true
 
 javac.source: 11
-javac.target: 11	
-	
+javac.target: 11

--- a/dev/io.openliberty.pages.3.1.internal_fat/.classpath
+++ b/dev/io.openliberty.pages.3.1.internal_fat/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
     <classpathentry kind="src" path="fat/src"/>
+    <classpathentry kind="src" path="test-applications/Misc.war/src"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
     <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
     <classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.restfulWS.internal.globalhandler/.classpath
+++ b/dev/io.openliberty.restfulWS.internal.globalhandler/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.restfulWS.mpMetrics.filter/.classpath
+++ b/dev/io.openliberty.restfulWS.mpMetrics.filter/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/.classpath
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="src" path="test" output="bin_test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>


### PR DESCRIPTION
- Add missing source directory for new test-application to get things building in eclipse
- Update .classpath files to include appropriate source to match what is in bnd.bnd
- Update .classpath to remove source directory that is copied with gradle so it isn't there otherwise.
- Update to remove source folders that don't exists from bnd.bnd files.
- Remove JUNIT_CONTAINER for .classpath
- Remove trailing spaces from javac.target that causes an error in eclipse about mismatch of Java versions in bnd and eclipse.