### PR TITLE
Fix InstantOn persistence FAT break 298584

### DIFF
--- a/dev/io.openliberty.checkpoint_fat_persistence/fat/src/io/openliberty/checkpoint/fat/DB2Test.java
+++ b/dev/io.openliberty.checkpoint_fat_persistence/fat/src/io/openliberty/checkpoint/fat/DB2Test.java
@@ -34,8 +34,8 @@ import org.testcontainers.utility.DockerImageName;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
-import componenttest.annotation.Server;
 import componenttest.annotation.CheckpointTest;
+import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
@@ -69,10 +69,11 @@ public class DB2Test extends FATServletClient {
                     .withLogConsumer(new SimpleLogConsumer(FATSuite.class, "db2-ssl"))
                     .withReuse(true);
 
+    final static String SERVER_NAME = "io.openliberty.checkpoint.jdbc.fat.db2";
     @ClassRule
-    public static RepeatTests rt = RepeatTests.with(new FeatureReplacementAction().removeFeatures(Collections.singleton("jdbc-*")).addFeature("jdbc-4.1").withID("JDBC4.1"))
-                    .andWith(new FeatureReplacementAction().removeFeatures(Collections.singleton("jdbc-*")).addFeature("jdbc-4.2").withID("JDBC4.2").fullFATOnly())
-                    .andWith(new FeatureReplacementAction().removeFeatures(Collections.singleton("jdbc-*"))
+    public static RepeatTests rt = RepeatTests.with(new FeatureReplacementAction().forServers(SERVER_NAME).removeFeatures(Collections.singleton("jdbc-*")).addFeature("jdbc-4.1").withID("JDBC4.1"))
+                    .andWith(new FeatureReplacementAction().forServers(SERVER_NAME).removeFeatures(Collections.singleton("jdbc-*")).addFeature("jdbc-4.2").withID("JDBC4.2").fullFATOnly())
+                    .andWith(new FeatureReplacementAction().forServers(SERVER_NAME).removeFeatures(Collections.singleton("jdbc-*"))
                                     .addFeature("jdbc-4.3")
                                     .withID("JDBC4.3")
                                     .withMinJavaLevel(SEVersion.JAVA11)
@@ -81,7 +82,7 @@ public class DB2Test extends FATServletClient {
     public static final String APP_NAME = "db2fat";
     public static final String SERVLET_NAME = "DB2TestServlet";
 
-    @Server("io.openliberty.checkpoint.jdbc.fat.db2")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = DB2TestServlet.class, path = APP_NAME + '/' + SERVLET_NAME)
     public static LibertyServer server;
 

--- a/dev/io.openliberty.checkpoint_fat_persistence/fat/src/io/openliberty/checkpoint/fat/SessionDatabaseTest.java
+++ b/dev/io.openliberty.checkpoint_fat_persistence/fat/src/io/openliberty/checkpoint/fat/SessionDatabaseTest.java
@@ -43,16 +43,18 @@ import io.openliberty.checkpoint.spi.CheckpointPhase;
 @CheckpointTest
 public class SessionDatabaseTest extends FATServletClient {
 
-    @Server("sessionDatabaseServer")
+    static final String SERVER_NAME = "sessionDatabaseServer";
+
+    @Server(SERVER_NAME)
     public static LibertyServer server;
 
     public static SessionDatabaseApp app = null;
     private static int DERBY_PORT = 1528;
 
     @ClassRule
-    public static RepeatTests rt = RepeatTests.with(new FeatureReplacementAction().removeFeatures(Collections.singleton("jdbc-*")).addFeature("jdbc-4.2").withID("JDBC4.2"))
-                    .andWith(new FeatureReplacementAction().removeFeatures(Collections.singleton("jdbc-*")).addFeature("jdbc-4.1").withID("JDBC4.1").fullFATOnly())
-                    .andWith(new FeatureReplacementAction().removeFeatures(Collections.singleton("jdbc-*"))
+    public static RepeatTests rt = RepeatTests.with(new FeatureReplacementAction().forServers(SERVER_NAME).removeFeatures(Collections.singleton("jdbc-*")).addFeature("jdbc-4.2").withID("JDBC4.2"))
+                    .andWith(new FeatureReplacementAction().forServers(SERVER_NAME).removeFeatures(Collections.singleton("jdbc-*")).addFeature("jdbc-4.1").withID("JDBC4.1").fullFATOnly())
+                    .andWith(new FeatureReplacementAction().forServers(SERVER_NAME).removeFeatures(Collections.singleton("jdbc-*"))
                                     .addFeature("jdbc-4.3")
                                     .withID("JDBC4.3")
                                     .withMinJavaLevel(SEVersion.JAVA11)


### PR DESCRIPTION
A feature replacement action introduces an incompatible feature into the server used by test `JPATest` of the `io.openliberty.checkpoint_fat_persistence` FAT suite. Modify the repeat rules in the suite to apply only to servers named in the FAT test classes. 

> Stack Dump = java.lang.IllegalArgumentException: Unable to load conflicting versions of features "com.ibm.websphere.appserver.jdbc-4.1" and "com.ibm.websphere.appserver.jdbc-4.2". The feature dependency chains that led to the conflict are: com.ibm.websphere.appserver.jdbc-4.1 and com.ibm.websphere.appserver.jpa-2.2 -> com.ibm.websphere.appserver.jdbc-4.2