### PR TITLE
cleanup JAX-RS 2.1 feature and upgrade to 2.1.1 API jar

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1519,7 +1519,7 @@
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.1-m09</version>
+      <version>2.1.1</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -299,7 +299,7 @@ javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.websocket:javax.websocket-client-api:1.0
 javax.ws.rs:javax.ws.rs-api:2.0
-javax.ws.rs:javax.ws.rs-api:2.1-m09
+javax.ws.rs:javax.ws.rs-api:2.1.1
 javax.xml.bind:jaxb-api:2.2.12-b140109.1041
 javax.xml.bind:jaxb-api:2.2.7
 javax.xml.bind:jaxb-api:2.3.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.1.feature
@@ -13,7 +13,7 @@ Subsystem-Name: Java RESTful Services API 2.1
   com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
   com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false,\
   com.ibm.websphere.javaee.jaxb.2.2; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false, \
-  com.ibm.websphere.javaee.jaxrs.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.1"
+  com.ibm.websphere.javaee.jaxrs.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.1.1"
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.1-javadoc.zip
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.javaee.jaxrs.2.1/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.jaxrs.2.1/bnd.bnd
@@ -1,3 +1,15 @@
+#*******************************************************************************
+# Copyright (c) 2017, 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
@@ -11,18 +23,6 @@ Export-Package: \
 	javax.ws.rs.ext;version="2.1",\
 	javax.ws.rs.sse;version="2.1"
 
-#*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License 2.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
-#*******************************************************************************
 Import-Package: \
  com.ibm.ws.jaxrs20.client; resolution:=optional, \
  *
@@ -32,4 +32,4 @@ instrument.disabled: true
 publish.wlp.jar.suffix: dev/api/spec
 
 -buildpath: \
-	javax.ws.rs:javax.ws.rs-api;version=2.0.99.b01
+	javax.ws.rs:javax.ws.rs-api;version=2.1.1


### PR DESCRIPTION
Basically just upgrading the API jar from [2.1-m09](https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api/2.1-m09) to [2.1.1](https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api/2.1.1)