### PR TITLE
Re-enable #build with IM and z/OS buckets disabled

### DIFF
--- a/.ci-orchestrator/pb.yml
+++ b/.ci-orchestrator/pb.yml
@@ -35,24 +35,35 @@ triggers:
     - stepName: Determine FATs Needed
     - stepName: Distributed Lite FATs
 
-# DISABLED - this causes #biuld to run 2 builds, one of which always appears to run the z/OS tests.
-# This is creating contention on the limitted available z/OS hardware
-#- type: github
-#  triggerName: "ol-pbbeta-build"
-#  triggerRank: 50
-#  groups: ["LibertyDev"]
-#  keyword: "#build"
-#  propertyDefinitions:
-#  # If a user defines this property, set it for all steps that use it except the "Distributed Full FATs" step
-#  # because those steps are set to use a value calculated by the PR Changes step.
-#  - name: fat.buckets.to.run
-#    defaultValue: ${PR Changes:fat.buckets.to.run}
-#    steps:
-#    - stepName: Compile Liberty Images
-#    - stepName: Compile FATs
-#    - stepName: Determine FATs Needed
-#    - stepName: Distributed Lite FATs
-    
+- type: github
+  triggerName: "ol-pbbeta-build"
+  triggerRank: 50
+  groups: ["LibertyDev"]
+  keyword: "#build"
+  propertyDefinitions:
+  # If a user defines this property, set it for all steps that use it except the "Distributed Full FATs" step
+  # because those steps are set to use a value calculated by the PR Changes step.
+  - name: fat.buckets.to.run
+    defaultValue: ${PR Changes:fat.buckets.to.run}
+    steps:
+    - stepName: Compile Liberty Images
+    - stepName: Compile FATs
+    - stepName: Determine FATs Needed
+    - stepName: Distributed Lite FATs
+  # Disable IM buckets.
+  - name: create.im.repo
+    defaultValue: false
+    steps:
+    - stepName: Compile Liberty Images
+  # Disable z/OS buckets.
+  - name: spawn.zos
+    defaultValue: false
+    steps:
+    - stepName: Compile Liberty Images
+    - stepName: Compile FATs
+    - stepName: z/OS FATs
+    - stepName: z/OS Unittests
+
 - type: manual
   triggerName: "ol-pbbeta-manual"
   triggerRank: 50

--- a/.ci-orchestrator/pb.yml
+++ b/.ci-orchestrator/pb.yml
@@ -358,7 +358,7 @@ steps:
 
 - stepName: Unittest Open Liberty
   workType: RTC
-  projectName: "Liberty Personal Build CI Orchestrator - EBC"
+  projectName: "Open Liberty Personal Build CI Orchestrator - EBC"
   dependsOn:
   - stepName: PR Changes
     awaitOutputProperties: true
@@ -375,7 +375,7 @@ steps:
 
 - stepName: Compile FATs
   workType: RTC
-  projectName: "Liberty Personal Build CI Orchestrator - EBC"
+  projectName: "Open Liberty Personal Build CI Orchestrator - EBC"
   dependsOn:
   - stepName: PR Changes
     awaitOutputProperties: true


### PR DESCRIPTION
- Avoid overuse of z/OS hardware by disabling IM and z/OS FATs when users type #build. IM and z/OS FATs can be requested by the trigger keyword `fullpbbeta`.