### PR TITLE
Work around session cleanup timing issue

### DIFF
--- a/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.fat/server.xml
+++ b/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2021 IBM Corporation and others.
+    Copyright (c) 2020, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -208,7 +208,7 @@
 		httpOnlyCookies="false"
 		allowFailOverToBasicAuth="true" />
 
-	<httpSession cookieHttpOnly="false" />
+	<httpSession cookieHttpOnly="false" useSeparateSessionInvalidatorThreadPool = "false" delayInvalidationAlarmDuringServerStartup = "60" />
 
 	<library id="testLib">
 		<fileset


### PR DESCRIPTION
Looks like a timing issue with session cleanup.
Will update httpSession:
`<httpSession cookieHttpOnly="false" useSeparateSessionInvalidatorThreadPool = "false" delayInvalidationAlarmDuringServerStartup = "60" />`
This looks like the same issue as https://github.com/OpenLiberty/open-liberty/issues/24590.