### PR TITLE
Update MP Metrics 5.x Tck -> 5.0.2 and 5.1.1

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.internal.5.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <arquillian.version>1.7.0.Alpha13</arquillian.version>
         <arquillian.liberty.managed.jakarta.version>2.1.1</arquillian.liberty.managed.jakarta.version>
-        <microprofile.metrics.version>5.0.1</microprofile.metrics.version>
+        <microprofile.metrics.version>5.0.2</microprofile.metrics.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>
@@ -183,9 +183,6 @@
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-api-tck</dependency>
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                             </dependenciesToScan>
-                            <excludes>
-                                <exclude>**/MPMetricBaseMetricsTest.java</exclude>
-                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -223,7 +220,6 @@
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                             </dependenciesToScan>
                             <excludes>
-                                <exclude>**/MPMetricBaseMetricsTest.java</exclude>
                                 <exclude>**/TimerTest.java</exclude>
                                 <exclude>**/MeterTest.java</exclude>
                             </excludes>
@@ -264,7 +260,6 @@
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                             </dependenciesToScan>
                             <excludes>
-                                <exclude>**/MPMetricBaseMetricsTest.java</exclude>
                                 <exclude>**/TimerTest.java</exclude>
                                 <exclude>**/MeterTest.java</exclude>
                             </excludes>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <arquillian.version>1.7.0.Alpha13</arquillian.version>
         <arquillian.liberty.managed.jakarta.version>2.1.1</arquillian.liberty.managed.jakarta.version>
-        <microprofile.metrics.version>5.1.0</microprofile.metrics.version>
+        <microprofile.metrics.version>5.1.1</microprofile.metrics.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>
@@ -183,9 +183,6 @@
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-api-tck</dependency>
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                             </dependenciesToScan>
-                            <excludes>
-                                <exclude>**/MPMetricBaseMetricsTest.java</exclude>
-                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -223,7 +220,6 @@
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                             </dependenciesToScan>
                             <excludes>
-                                <exclude>**/MPMetricBaseMetricsTest.java</exclude>
                                 <exclude>**/TimerTest.java</exclude>
                                 <exclude>**/MeterTest.java</exclude>
                             </excludes>
@@ -264,7 +260,6 @@
                                 <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                             </dependenciesToScan>
                             <excludes>
-                                <exclude>**/MPMetricBaseMetricsTest.java</exclude>
                                 <exclude>**/TimerTest.java</exclude>
                                 <exclude>**/MeterTest.java</exclude>
                             </excludes>


### PR DESCRIPTION
The updates to 5.0.2 and 5.1.1 only contains a TCK fix.
Only updating the FAT TCK.

#build