### PR TITLE
Use unique group ids for custom context tests

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/KafkaCustomContextTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/KafkaCustomContextTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -59,14 +59,14 @@ public class KafkaCustomContextTest extends FATServletClient {
     public static void setup() throws Exception {
         ConnectorProperties configuredDefaultInput = simpleIncomingChannel(PlaintextTests.connectionProperties(),
                                                                            KakfaCustomContextTestBean.DEFAULT_IN,
-                                                                           APP_NAME);
+                                                                           APP_NAME + KakfaCustomContextTestBean.DEFAULT_IN);
 
         ConnectorProperties configuredDefaultOutput = simpleOutgoingChannel(PlaintextTests.connectionProperties(),
                                                                             KakfaCustomContextTestBean.DEFAULT_OUT);
 
         ConnectorProperties propagateAllInput = simpleIncomingChannel(PlaintextTests.connectionProperties(),
                                                                       KakfaCustomContextTestBean.PROPAGATE_ALL_IN,
-                                                                      APP_NAME)
+                                                                      APP_NAME + KakfaCustomContextTestBean.PROPAGATE_ALL_IN)
                         .addProperty(KafkaConnectorConstants.CONTEXT_SERVICE, "propagateAll");
 
         ConnectorProperties propagateAllOutput = simpleOutgoingChannel(PlaintextTests.connectionProperties(),
@@ -74,7 +74,7 @@ public class KafkaCustomContextTest extends FATServletClient {
 
         ConnectorProperties propagateNoneInput = simpleIncomingChannel(PlaintextTests.connectionProperties(),
                                                                        KakfaCustomContextTestBean.PROPAGATE_NONE_IN,
-                                                                       APP_NAME)
+                                                                       APP_NAME + KakfaCustomContextTestBean.PROPAGATE_NONE_IN)
                         .addProperty(KafkaConnectorConstants.CONTEXT_SERVICE, "propagateNone");
 
         ConnectorProperties propagateNoneOutput = simpleOutgoingChannel(PlaintextTests.connectionProperties(),
@@ -82,7 +82,7 @@ public class KafkaCustomContextTest extends FATServletClient {
 
         ConnectorProperties propagateAppInput = simpleIncomingChannel(PlaintextTests.connectionProperties(),
                                                                       KakfaCustomContextTestBean.PROPAGATE_APP_IN,
-                                                                      APP_NAME);
+                                                                      APP_NAME + KakfaCustomContextTestBean.PROPAGATE_APP_IN);
 
         ConnectorProperties propagateAppOutput = simpleOutgoingChannel(PlaintextTests.connectionProperties(),
                                                                        KakfaCustomContextTestBean.PROPAGATE_APP_OUT);


### PR DESCRIPTION
Occasionally, during the running of these tests a reblancing of the consumer group used by all the connectors in the test might occur at a point during the test that means we get multiple reads of a ingoing channel by the connector. By assigning unique groups to the channels, we should no longer see any occasionally rebalancing.
