### PR TITLE
qualifiers on context service and executor definitions

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -93,4 +93,14 @@ public class ConcurrentCDITest extends FATServletClient {
     public void testInjectManagedScheduledExecutorServiceQualified() throws Exception {
         runTest(server, APP_NAME, testName);
     }
+
+    @Test
+    public void testSelectContextServiceDefaultInstance() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testSelectContextServiceQualified() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
 }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,3 +12,5 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info=enabled:concurrent=all:context=all:concurrencyPolicy=all
+# Java 2 security is not required for Jakarta EE 11 features:
+websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/Unrecognized.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/Unrecognized.java
@@ -21,6 +21,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 /**
@@ -32,4 +33,12 @@ import jakarta.inject.Qualifier;
 @Retention(RUNTIME)
 @Target({ FIELD, METHOD, PARAMETER, TYPE })
 public @interface Unrecognized {
+    public static class Literal extends AnnotationLiteral<Unrecognized> implements Unrecognized {
+        private static final long serialVersionUID = 820070466281499464L;
+
+        public static final Unrecognized INSTANCE = new Literal();
+
+        private Literal() {
+        }
+    }
 }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithAppContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithAppContext.java
@@ -18,10 +18,19 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Qualifier
 @Retention(RUNTIME)
 @Target(FIELD)
 public @interface WithAppContext {
+    public static class Literal extends AnnotationLiteral<WithAppContext> implements WithAppContext {
+        private static final long serialVersionUID = 2122945694024703476L;
+
+        public static final WithAppContext INSTANCE = new Literal();
+
+        private Literal() {
+        }
+    }
 }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithoutAppContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithoutAppContext.java
@@ -19,10 +19,19 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Qualifier
 @Retention(RUNTIME)
 @Target({ FIELD, METHOD })
 public @interface WithoutAppContext {
+    public static class Literal extends AnnotationLiteral<WithoutAppContext> implements WithoutAppContext {
+        private static final long serialVersionUID = -4713624968762573999L;
+
+        public static final WithoutAppContext INSTANCE = new Literal();
+
+        private Literal() {
+        }
+    }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.concurrent.internal.cdi/bnd.bnd
@@ -46,9 +46,11 @@ instrument.classesExcludes: io/openliberty/concurrent/internal/cdi/resources/*.c
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.cdi.interfaces.jakarta;version=latest, \
   com.ibm.ws.concurrent,\
+  com.ibm.ws.container.service;version=latest,\
   com.ibm.ws.context,\
   com.ibm.ws.javaee.version,\
   com.ibm.ws.kernel.service,\
+  com.ibm.ws.resource,\
   com.ibm.ws.threading,\
   io.openliberty.concurrent.internal,\
   io.openliberty.jakarta.annotation.2.1,\

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
@@ -14,13 +14,24 @@ package io.openliberty.concurrent.internal.cdi;
 
 import java.lang.annotation.Annotation;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.cdi.CDIServiceUtils;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
+import com.ibm.wsspi.resource.ResourceFactory;
 
 import io.openliberty.concurrent.internal.cdi.interceptor.AsyncInterceptor;
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
 import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.concurrent.ContextService;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
@@ -42,12 +53,9 @@ import jakarta.enterprise.inject.spi.ProcessInjectionPoint;
 public class ConcurrencyExtension implements Extension {
     private static final TraceComponent tc = Tr.register(ConcurrencyExtension.class);
 
-    private static final Set<Annotation> DEFAULT_QUALIFIER = Set.of(Default.Literal.INSTANCE);
+    private static final Annotation[] DEFAULT_QUALIFIER_ARRAY = new Annotation[] { Default.Literal.INSTANCE };
 
-    /**
-     * Set of qualifier lists found on ContextService injection points.
-     */
-    private final Set<Set<Annotation>> contextServiceQualifiers = new HashSet<>();
+    private static final Set<Annotation> DEFAULT_QUALIFIER_SET = Set.of(Default.Literal.INSTANCE);
 
     /**
      * Set of qualifier lists found on ManagedExecutorService injection points.
@@ -65,20 +73,6 @@ public class ConcurrencyExtension implements Extension {
         beforeBeanDiscovery.addInterceptorBinding(bindingType);
         AnnotatedType<AsyncInterceptor> interceptorType = beanManager.createAnnotatedType(AsyncInterceptor.class);
         beforeBeanDiscovery.addAnnotatedType(interceptorType, CDIServiceUtils.getAnnotatedTypeIdentifier(interceptorType, this.getClass()));
-    }
-
-    /**
-     * Invoked for each matching injection point:
-     *
-     * @Inject {@Qualifier1 @Qualifier2 ...} ContextService contextSvc;
-     *
-     * @param <T>   bean class that has the injection point
-     * @param event event
-     */
-    public <T> void processContextServiceInjectionPoint(@Observes ProcessInjectionPoint<T, ContextService> event) {
-        InjectionPoint injectionPoint = event.getInjectionPoint();
-        Set<Annotation> qualifiers = injectionPoint.getQualifiers();
-        contextServiceQualifiers.add(qualifiers);
     }
 
     /**
@@ -112,31 +106,37 @@ public class ConcurrencyExtension implements Extension {
     public void afterBeanDiscovery(@Observes AfterBeanDiscovery event, BeanManager beanManager) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
+        BundleContext bundleContext = FrameworkUtil.getBundle(ConcurrencyExtension.class).getBundleContext();
+        ServiceReference<QualifiedResourceFactories> ref = bundleContext.getServiceReference(QualifiedResourceFactories.class);
+        ConcurrencyExtensionMetadata ext = (ConcurrencyExtensionMetadata) bundleContext.getService(ref);
+
         CDI<Object> cdi = CDI.current();
 
-        for (Set<Annotation> qualifiers : contextServiceQualifiers) {
-            if (cdi.select(ContextService.class, qualifiers.toArray(new Annotation[qualifiers.size()])).isResolvable()) {
-                if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "ContextService already exists with qualifiers " + qualifiers);
-            } else {
-                // It doesn't already exist, so try to add it:
-                String filter = null;
-                if (DEFAULT_QUALIFIER.equals(qualifiers)) {
-                    filter = "(id=DefaultContextService)";
-                } else { // TODO replace this temporary approach to partially simulate spec function
-                    StringBuilder f = new StringBuilder().append("(&");
-                    for (Annotation q : qualifiers)
-                        f.append("(qualifiers=").append(q.annotationType().getName()).append(')');
-                    filter = f.append(')').toString();
+        if (!cdi.select(ContextService.class, DEFAULT_QUALIFIER_ARRAY).isResolvable())
+            event.addBean(new ContextServiceBean(ext.defaultContextServiceFactory, DEFAULT_QUALIFIER_SET));
+
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cmd == null)
+            throw new IllegalStateException(); // should be unreachable
+
+        List<Map<List<String>, ResourceFactory>> list = ext.removeAll(cmd.getName());
+
+        if (list != null) {
+            Map<List<String>, ResourceFactory> qualifiedContextServices = list.get(QualifiedResourceFactories.Type.ContextService.ordinal());
+            for (Entry<List<String>, ResourceFactory> entry : qualifiedContextServices.entrySet()) {
+                List<String> qualifierList = entry.getKey();
+                ResourceFactory factory = entry.getValue();
+                try {
+                    event.addBean(new ContextServiceBean(factory, qualifierList));
+                } catch (Throwable x) {
+                    // TODO NLS
+                    System.out.println(" E Unable to create a bean for the " +
+                                       factory + " ContextServiceDefinition with the " + qualifierList + " qualifiers" +
+                                       " due to the following error: ");
+                    x.printStackTrace();
                 }
-
-                event.addBean(new ContextServiceBean(filter, qualifiers));
-
-                if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "Added ContextService bean with qualifiers " + qualifiers);
             }
         }
-        contextServiceQualifiers.clear();
 
         for (Set<Annotation> qualifiers : executorQualifiers) {
             if (cdi.select(ManagedExecutorService.class, qualifiers.toArray(new Annotation[qualifiers.size()])).isResolvable()) {
@@ -145,7 +145,7 @@ public class ConcurrencyExtension implements Extension {
             } else {
                 // It doesn't already exist, so try to add it:
                 String filter = null;
-                if (DEFAULT_QUALIFIER.equals(qualifiers)) {
+                if (DEFAULT_QUALIFIER_SET.equals(qualifiers)) {
                     filter = "(id=DefaultManagedExecutorService)";
                 } else { // TODO replace this temporary approach to partially simulate spec function
                     // The filter on config.displayId prevents matching scheduled executor instances with the same qualifiers
@@ -170,7 +170,7 @@ public class ConcurrencyExtension implements Extension {
             } else {
                 // It doesn't already exist, so try to add it:
                 String filter = null;
-                if (DEFAULT_QUALIFIER.equals(qualifiers)) {
+                if (DEFAULT_QUALIFIER_SET.equals(qualifiers)) {
                     filter = "(id=DefaultManagedScheduledExecutorService)";
                 } else { // TODO replace this temporary approach to partially simulate spec function
                     StringBuilder f = new StringBuilder().append("(&");

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
@@ -13,7 +13,6 @@
 package io.openliberty.concurrent.internal.cdi;
 
 import java.lang.annotation.Annotation;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -23,8 +22,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.cdi.CDIServiceUtils;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
@@ -44,24 +41,21 @@ import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.inject.spi.Extension;
-import jakarta.enterprise.inject.spi.InjectionPoint;
-import jakarta.enterprise.inject.spi.ProcessInjectionPoint;
 
 /**
  * CDI Extension for Jakarta Concurrency 3.1+ in Jakarta EE 11+, which corresponds to CDI 4.1+
  */
 public class ConcurrencyExtension implements Extension {
-    private static final TraceComponent tc = Tr.register(ConcurrencyExtension.class);
-
     private static final Annotation[] DEFAULT_QUALIFIER_ARRAY = new Annotation[] { Default.Literal.INSTANCE };
 
     private static final Set<Annotation> DEFAULT_QUALIFIER_SET = Set.of(Default.Literal.INSTANCE);
 
     /**
-     * Set of qualifier lists found on ManagedScheduledExecutorService injection points.
+     * Register interceptors before bean discovery.
+     *
+     * @param beforeBeanDiscovery
+     * @param beanManager
      */
-    private final Set<Set<Annotation>> scheduledExecutorQualifiers = new HashSet<>();
-
     public void beforeBeanDiscovery(@Observes BeforeBeanDiscovery beforeBeanDiscovery, BeanManager beanManager) {
         // register the interceptor binding and the interceptor
         AnnotatedType<Asynchronous> bindingType = beanManager.createAnnotatedType(Asynchronous.class);
@@ -71,21 +65,12 @@ public class ConcurrencyExtension implements Extension {
     }
 
     /**
-     * Invoked for each matching injection point:
+     * Register beans for default instances and qualified instances of concurrency resources after bean discovery.
      *
-     * @Inject {@Qualifier1 @Qualifier2 ...} ManagedScheduledExecutorService scheduledExecutor;
-     *
-     * @param <T>   bean class that has the injection point
-     * @param event event
+     * @param event
+     * @param beanManager
      */
-    public <T> void processScheduledExecutorInjectionPoint(@Observes ProcessInjectionPoint<T, ManagedScheduledExecutorService> event) {
-        InjectionPoint injectionPoint = event.getInjectionPoint();
-        Set<Annotation> qualifiers = injectionPoint.getQualifiers();
-        scheduledExecutorQualifiers.add(qualifiers);
-    }
-
     public void afterBeanDiscovery(@Observes AfterBeanDiscovery event, BeanManager beanManager) {
-        final boolean trace = TraceComponent.isAnyTracingEnabled();
 
         BundleContext bundleContext = FrameworkUtil.getBundle(ConcurrencyExtension.class).getBundleContext();
         ServiceReference<QualifiedResourceFactories> ref = bundleContext.getServiceReference(QualifiedResourceFactories.class);
@@ -98,6 +83,9 @@ public class ConcurrencyExtension implements Extension {
 
         if (!cdi.select(ManagedExecutorService.class, DEFAULT_QUALIFIER_ARRAY).isResolvable())
             event.addBean(new ManagedExecutorBean(ext.defaultManagedExecutorFactory, DEFAULT_QUALIFIER_SET));
+
+        if (!cdi.select(ManagedScheduledExecutorService.class, DEFAULT_QUALIFIER_ARRAY).isResolvable())
+            event.addBean(new ManagedScheduledExecutorBean(ext.defaultManagedScheduledExecutorFactory, DEFAULT_QUALIFIER_SET));
 
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
         if (cmd == null)
@@ -140,30 +128,24 @@ public class ConcurrencyExtension implements Extension {
                 }
             }
 
-        }
+            Map<List<String>, ResourceFactory> qualifiedManagedScheduledExecutors = //
+                            list.get(QualifiedResourceFactories.Type.ManagedScheduledExecutorService.ordinal());
 
-        for (Set<Annotation> qualifiers : scheduledExecutorQualifiers) {
-            if (cdi.select(ManagedScheduledExecutorService.class, qualifiers.toArray(new Annotation[qualifiers.size()])).isResolvable()) {
-                if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "ManagedScheduledExecutorService already exists with qualifiers " + qualifiers);
-            } else {
-                // It doesn't already exist, so try to add it:
-                String filter = null;
-                if (DEFAULT_QUALIFIER_SET.equals(qualifiers)) {
-                    filter = "(id=DefaultManagedScheduledExecutorService)";
-                } else { // TODO replace this temporary approach to partially simulate spec function
-                    StringBuilder f = new StringBuilder().append("(&");
-                    for (Annotation q : qualifiers)
-                        f.append("(qualifiers=").append(q.annotationType().getName()).append(')');
-                    filter = f.append(')').toString();
+            for (Entry<List<String>, ResourceFactory> entry : qualifiedManagedScheduledExecutors.entrySet()) {
+                List<String> qualifierList = entry.getKey();
+                ResourceFactory factory = entry.getValue();
+                try {
+                    event.addBean(new ManagedScheduledExecutorBean(factory, qualifierList));
+                } catch (Throwable x) {
+                    // TODO NLS
+                    System.out.println(" E Unable to create a bean for the " +
+                                       factory + " ManagedScheduledExecutorDefinition with the " + qualifierList + " qualifiers" +
+                                       " due to the following error: ");
+                    x.printStackTrace();
                 }
-
-                event.addBean(new ManagedScheduledExecutorBean(filter, qualifiers));
-
-                if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "Added ManagedScheduledExecutorService bean with qualifiers " + qualifiers);
             }
+
+            // TODO qualified ManagedThreadFactory instances
         }
-        scheduledExecutorQualifiers.clear();
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -65,6 +65,14 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
     protected volatile ResourceFactory defaultManagedExecutorFactory;
 
     /**
+     * ResourceFactory for the default ManagedScheduledExecutorService instance: java:comp/DefaultManagedExecutorService.
+     */
+    @Reference(target = "(&(id=DefaultManagedScheduledExecutorService)(component.name=com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceImpl))",
+               policy = ReferencePolicy.DYNAMIC,
+               policyOption = ReferencePolicyOption.GREEDY)
+    protected volatile ResourceFactory defaultManagedScheduledExecutorFactory;
+
+    /**
      * Jakarta EE version.
      */
     public static Version eeVersion;

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ContextServiceBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ContextServiceBean.java
@@ -13,21 +13,17 @@
 package io.openliberty.concurrent.internal.cdi;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceReference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.wsspi.resource.ResourceFactory;
 
 import jakarta.enterprise.concurrent.ContextService;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -38,8 +34,6 @@ import jakarta.enterprise.inject.spi.PassivationCapable;
 
 /**
  * Bean that delegates to the OSGi service registry to obtain ContextService resources.
- *
- * @param <T> type of resource (such as ManagedExecutorService or ContextService)
  */
 public class ContextServiceBean implements Bean<ContextService>, PassivationCapable {
     private final static TraceComponent tc = Tr.register(ContextServiceBean.class);
@@ -50,9 +44,10 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
     private final Set<Type> beanTypes = Set.of(ContextService.class);
 
     /**
-     * OSGi filter for the resource.
+     * Resource factory that creates the resource.
+     * Null if an OSGi filter is used instead.
      */
-    private final String filter;
+    private final ResourceFactory factory;
 
     /**
      * Qualifiers for the injection points for this bean.
@@ -60,14 +55,37 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
     private final Set<Annotation> qualifiers;
 
     /**
-     * Construct a new Producer/ProducerFactory for this resource.
+     * Construct a new bean for this resource.
      *
-     * @param filter     OSGi filter for the resource.
+     * @param factory    resource factory.
      * @param qualifiers qualifiers for the bean.
      */
-    public ContextServiceBean(String filter, Set<Annotation> qualifiers) {
-        this.filter = filter;
+    ContextServiceBean(ResourceFactory factory, Set<Annotation> qualifiers) {
+        this.factory = factory;
         this.qualifiers = qualifiers;
+    }
+
+    /**
+     * Construct a new bean for this resource.
+     *
+     * @param factory        resource factory.
+     * @param qualifierNames names of qualifier annotations for the bean.
+     */
+    ContextServiceBean(ResourceFactory factory, List<String> qualifierNames) throws ClassNotFoundException {
+        this.factory = factory;
+        this.qualifiers = new LinkedHashSet<Annotation>();
+
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+
+        for (String qualifierClassName : qualifierNames) {
+            Class<?> qualifierClass = loader.loadClass(qualifierClassName);
+            if (!qualifierClass.isInterface())
+                throw new IllegalArgumentException("The " + qualifierClassName + " class is not a valid qualifier class" +
+                                                   " because it is not an annotation."); // TODO NLS
+            qualifiers.add(Annotation.class.cast(Proxy.newProxyInstance(loader,
+                                                                        new Class<?>[] { Annotation.class, qualifierClass },
+                                                                        new QualifierProxy(qualifierClass))));
+        }
     }
 
     @Override
@@ -75,22 +93,16 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
     public ContextService create(CreationalContext<ContextService> cc) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(this, tc, "create", cc, filter, qualifiers);
+            Tr.entry(this, tc, "create", cc, factory, qualifiers);
 
         ContextService instance;
-        Bundle bundle = FrameworkUtil.getBundle(ContextServiceBean.class);
-        BundleContext bundleContext = bundle.getBundleContext();
-        Collection<ServiceReference<ContextService>> refs;
         try {
-            refs = bundleContext.getServiceReferences(ContextService.class, filter);
-        } catch (InvalidSyntaxException x) {
-            throw new IllegalArgumentException(x); // internal error forming the filter?
+            instance = (ContextService) factory.createResource(null);
+        } catch (RuntimeException x) {
+            throw x;
+        } catch (Exception x) {
+            throw new RuntimeException(x);
         }
-        Iterator<ServiceReference<ContextService>> it = refs.iterator();
-        if (it.hasNext())
-            instance = bundleContext.getService(it.next());
-        else
-            throw new IllegalStateException("The ContextService resource with " + filter + " filter cannot be found or is unavailable."); // TODO NLS
 
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "create", instance);
@@ -113,7 +125,7 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
     public String getId() {
         return new StringBuilder(getClass().getName()) //
                         .append(":").append(qualifiers) //
-                        .append(':').append(filter) //
+                        .append(':').append(factory) //
                         .toString();
     }
 
@@ -156,7 +168,7 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
     @Trivial
     public String toString() {
         return new StringBuilder(getClass().getSimpleName()).append('@').append(Integer.toHexString(hashCode())) //
-                        .append(' ').append(filter) //
+                        .append(' ').append(factory) //
                         .append(" with qualifiers ").append(qualifiers) //
                         .toString();
     }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ContextServiceBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ContextServiceBean.java
@@ -45,7 +45,6 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
 
     /**
      * Resource factory that creates the resource.
-     * Null if an OSGi filter is used instead.
      */
     private final ResourceFactory factory;
 
@@ -53,17 +52,6 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
      * Qualifiers for the injection points for this bean.
      */
     private final Set<Annotation> qualifiers;
-
-    /**
-     * Construct a new bean for this resource.
-     *
-     * @param factory    resource factory.
-     * @param qualifiers qualifiers for the bean.
-     */
-    ContextServiceBean(ResourceFactory factory, Set<Annotation> qualifiers) {
-        this.factory = factory;
-        this.qualifiers = qualifiers;
-    }
 
     /**
      * Construct a new bean for this resource.
@@ -88,6 +76,17 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
         }
     }
 
+    /**
+     * Construct a new bean for this resource.
+     *
+     * @param factory    resource factory.
+     * @param qualifiers qualifiers for the bean.
+     */
+    ContextServiceBean(ResourceFactory factory, Set<Annotation> qualifiers) {
+        this.factory = factory;
+        this.qualifiers = qualifiers;
+    }
+
     @Override
     @Trivial
     public ContextService create(CreationalContext<ContextService> cc) {
@@ -99,8 +98,12 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
         try {
             instance = (ContextService) factory.createResource(null);
         } catch (RuntimeException x) {
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "create", x);
             throw x;
         } catch (Exception x) {
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "create", x);
             throw new RuntimeException(x);
         }
 

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedExecutorBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedExecutorBean.java
@@ -45,7 +45,6 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
 
     /**
      * Resource factory that creates the resource.
-     * Null if an OSGi filter is used instead.
      */
     private final ResourceFactory factory;
 
@@ -53,17 +52,6 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
      * Qualifiers for the injection points for this bean.
      */
     private final Set<Annotation> qualifiers;
-
-    /**
-     * Construct a new bean for this resource.
-     *
-     * @param factory    resource factory.
-     * @param qualifiers qualifiers for the bean.
-     */
-    ManagedExecutorBean(ResourceFactory factory, Set<Annotation> qualifiers) {
-        this.factory = factory;
-        this.qualifiers = qualifiers;
-    }
 
     /**
      * Construct a new bean for this resource.
@@ -88,6 +76,17 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
         }
     }
 
+    /**
+     * Construct a new bean for this resource.
+     *
+     * @param factory    resource factory.
+     * @param qualifiers qualifiers for the bean.
+     */
+    ManagedExecutorBean(ResourceFactory factory, Set<Annotation> qualifiers) {
+        this.factory = factory;
+        this.qualifiers = qualifiers;
+    }
+
     @Override
     @Trivial
     public ManagedExecutorService create(CreationalContext<ManagedExecutorService> cc) {
@@ -99,8 +98,12 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
         try {
             instance = (ManagedExecutorService) factory.createResource(null);
         } catch (RuntimeException x) {
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "create", x);
             throw x;
         } catch (Exception x) {
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "create", x);
             throw new RuntimeException(x);
         }
 

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedExecutorBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedExecutorBean.java
@@ -13,21 +13,17 @@
 package io.openliberty.concurrent.internal.cdi;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceReference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.wsspi.resource.ResourceFactory;
 
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -48,9 +44,10 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
     private final Set<Type> beanTypes = Set.of(ManagedExecutorService.class);
 
     /**
-     * OSGi filter for the resource.
+     * Resource factory that creates the resource.
+     * Null if an OSGi filter is used instead.
      */
-    private final String filter;
+    private final ResourceFactory factory;
 
     /**
      * Qualifiers for the injection points for this bean.
@@ -58,14 +55,37 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
     private final Set<Annotation> qualifiers;
 
     /**
-     * Construct a new Producer/ProducerFactory for this resource.
+     * Construct a new bean for this resource.
      *
-     * @param filter     OSGi filter for the resource.
+     * @param factory    resource factory.
      * @param qualifiers qualifiers for the bean.
      */
-    public ManagedExecutorBean(String filter, Set<Annotation> qualifiers) {
-        this.filter = filter;
+    ManagedExecutorBean(ResourceFactory factory, Set<Annotation> qualifiers) {
+        this.factory = factory;
         this.qualifiers = qualifiers;
+    }
+
+    /**
+     * Construct a new bean for this resource.
+     *
+     * @param factory        resource factory.
+     * @param qualifierNames names of qualifier annotations for the bean.
+     */
+    ManagedExecutorBean(ResourceFactory factory, List<String> qualifierNames) throws ClassNotFoundException {
+        this.factory = factory;
+        this.qualifiers = new LinkedHashSet<Annotation>();
+
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+
+        for (String qualifierClassName : qualifierNames) {
+            Class<?> qualifierClass = loader.loadClass(qualifierClassName);
+            if (!qualifierClass.isInterface())
+                throw new IllegalArgumentException("The " + qualifierClassName + " class is not a valid qualifier class" +
+                                                   " because it is not an annotation."); // TODO NLS
+            qualifiers.add(Annotation.class.cast(Proxy.newProxyInstance(loader,
+                                                                        new Class<?>[] { Annotation.class, qualifierClass },
+                                                                        new QualifierProxy(qualifierClass))));
+        }
     }
 
     @Override
@@ -73,22 +93,16 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
     public ManagedExecutorService create(CreationalContext<ManagedExecutorService> cc) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(this, tc, "create", cc, filter, qualifiers);
+            Tr.entry(this, tc, "create", cc, factory, qualifiers);
 
         ManagedExecutorService instance;
-        Bundle bundle = FrameworkUtil.getBundle(ManagedExecutorBean.class);
-        BundleContext bundleContext = bundle.getBundleContext();
-        Collection<ServiceReference<ManagedExecutorService>> refs;
         try {
-            refs = bundleContext.getServiceReferences(ManagedExecutorService.class, filter);
-        } catch (InvalidSyntaxException x) {
-            throw new IllegalArgumentException(x); // internal error forming the filter?
+            instance = (ManagedExecutorService) factory.createResource(null);
+        } catch (RuntimeException x) {
+            throw x;
+        } catch (Exception x) {
+            throw new RuntimeException(x);
         }
-        Iterator<ServiceReference<ManagedExecutorService>> it = refs.iterator();
-        if (it.hasNext())
-            instance = bundleContext.getService(it.next());
-        else
-            throw new IllegalStateException("The ManagedExecutorService resource with " + filter + " filter cannot be found or is unavailable."); // TODO NLS
 
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "create", instance);
@@ -111,7 +125,7 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
     public String getId() {
         return new StringBuilder(getClass().getName()) //
                         .append(":").append(qualifiers) //
-                        .append(':').append(filter) //
+                        .append(':').append(factory) //
                         .toString();
     }
 
@@ -154,7 +168,7 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
     @Trivial
     public String toString() {
         return new StringBuilder(getClass().getSimpleName()).append('@').append(Integer.toHexString(hashCode())) //
-                        .append(' ').append(filter) //
+                        .append(' ').append(factory) //
                         .append(" with qualifiers ").append(qualifiers) //
                         .toString();
     }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/QualifierProxy.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/QualifierProxy.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.concurrent.internal.cdi;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * Proxy that serves as an instance of a qualifier annotation.
+ */
+@Trivial
+public class QualifierProxy implements InvocationHandler {
+    /**
+     * Qualifier annotation class.
+     */
+    private final Class<?> qualifierClass;
+
+    /**
+     * Create a invocation handler for the specified qualifier annotation class.
+     *
+     * @param qualifierClass qualifier annotation class.
+     */
+    QualifierProxy(Class<?> qualifierClass) {
+        this.qualifierClass = qualifierClass;
+    }
+
+    /**
+     * Implements the 4 methods of java.lang.Annotation:
+     * hashCode(), toString(), equals(other), and annotationType().
+     *
+     * TODO implement other methods from the annotation class by returning the default value
+     * and otherwise raising an error.
+     */
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        String methodName = method.getName();
+        int numParams = method.getParameterCount();
+
+        if (numParams == 0 && "hashCode".equals(methodName)) {
+            return qualifierClass.hashCode();
+        } else if (numParams == 0 && "toString".equals(methodName)) {
+            return new StringBuilder(qualifierClass.getName()) //
+                            .append('@').append(Integer.toHexString(qualifierClass.hashCode())) //
+                            .append("(Proxy)") //
+                            .toString();
+        } else if (numParams == 0 && "annotationType".equals(methodName)) {
+            return qualifierClass;
+        } else if (numParams == 1 && "equals".equals(methodName)) {
+            if (qualifierClass.isInstance(args[0]))
+                if (qualifierClass.getMethods().length == 4)
+                    return true;
+                else // TODO For a proper comparison, would need to invoke additional methods
+                     // and compare value from the other instance against with default values from this instance
+                    throw new UnsupportedOperationException();
+            else
+                return false;
+        } else {
+            // This can be implemented to return the default value if there is one,
+            // but otherwise it is an error to use the annotation as a qualifier for Concurrency resources.
+            throw new UnsupportedOperationException(); // TODO implementation and better error message
+        }
+    }
+}

--- a/dev/io.openliberty.concurrent.internal/bnd.bnd
+++ b/dev/io.openliberty.concurrent.internal/bnd.bnd
@@ -30,7 +30,8 @@ Import-Package: \
   *
 
 Export-Package: \
-  io.openliberty.concurrent.internal.messages
+  io.openliberty.concurrent.internal.messages,\
+  io.openliberty.concurrent.internal.qualified
 
 Private-Package: \
   io.openliberty.concurrent.internal.context,\

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
@@ -221,10 +221,10 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
         String[] qualifiers = (String[]) contextSvcProps.remove("qualifiers");
 
         // Convert qualifier array to list attribute if present
-        List<String> qualifierList = null;
+        List<String> qualifierNames = null;
         if (qualifiers != null && qualifiers.length > 0) {
-            qualifierList = Arrays.asList(qualifiers);
-            contextSvcProps.put("qualifiers", qualifierList);
+            qualifierNames = Arrays.asList(qualifiers);
+            contextSvcProps.put("qualifiers", qualifierNames);
         }
 
         if (cleared == null)
@@ -370,7 +370,7 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
             Configuration contextServiceConfig = configAdmin.createFactoryConfiguration("com.ibm.ws.context.service", bundleLocation);
             contextServiceConfig.update(contextSvcProps);
 
-            if (qualifierList != null) {
+            if (qualifierNames != null) {
                 ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
                 if (cmd == null)
                     throw new IllegalStateException(); // should be unreachable
@@ -379,12 +379,12 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
 
                 if (ref == null)
                     throw new UnsupportedOperationException("The " + cmd.getName() + " application cannot specify the " +
-                                                            qualifierList + " qualifiers on the " +
+                                                            qualifierNames + " qualifiers on the " +
                                                             jndiName + " " + ContextServiceDefinition.class.getSimpleName() +
                                                             " because the " + "CDI" + " feature is not enabled."); // TODO NLS
 
                 QualifiedResourceFactories qrf = bundleContext.getService(ref);
-                qrf.add(cmd.getName(), QualifiedResourceFactories.Type.ContextService, qualifierList, factory);
+                qrf.add(cmd.getName(), QualifiedResourceFactories.Type.ContextService, qualifierNames, factory);
             }
         } catch (Exception x) {
             factory.destroy();

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
@@ -38,11 +38,14 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.resource.ResourceFactory;
 import com.ibm.ws.resource.ResourceFactoryBuilder;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.wsspi.kernel.service.location.VariableRegistry;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 import com.ibm.wsspi.kernel.service.utils.OnErrorUtil;
 
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
 import jakarta.enterprise.concurrent.ContextServiceDefinition;
 
 @Component(service = ResourceFactoryBuilder.class,
@@ -218,10 +221,9 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
         String[] qualifiers = (String[]) contextSvcProps.remove("qualifiers");
 
         // Convert qualifier array to list attribute if present
+        List<String> qualifierList = null;
         if (qualifiers != null && qualifiers.length > 0) {
-            List<String> qualifierList = Arrays.asList(qualifiers);
-            if (trace && tc.isDebugEnabled())
-                Tr.debug(tc, "qualifiers", qualifierList);
+            qualifierList = Arrays.asList(qualifiers);
             contextSvcProps.put("qualifiers", qualifierList);
         }
 
@@ -367,6 +369,23 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
 
             Configuration contextServiceConfig = configAdmin.createFactoryConfiguration("com.ibm.ws.context.service", bundleLocation);
             contextServiceConfig.update(contextSvcProps);
+
+            if (qualifierList != null) {
+                ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+                if (cmd == null)
+                    throw new IllegalStateException(); // should be unreachable
+
+                ServiceReference<QualifiedResourceFactories> ref = bundleContext.getServiceReference(QualifiedResourceFactories.class);
+
+                if (ref == null)
+                    throw new UnsupportedOperationException("The " + cmd.getName() + " application cannot specify the " +
+                                                            qualifierList + " qualifiers on the " +
+                                                            jndiName + " " + ContextServiceDefinition.class.getSimpleName() +
+                                                            " because the " + "CDI" + " feature is not enabled."); // TODO NLS
+
+                QualifiedResourceFactories qrf = bundleContext.getService(ref);
+                qrf.add(cmd.getName(), QualifiedResourceFactories.Type.ContextService, qualifierList, factory);
+            }
         } catch (Exception x) {
             factory.destroy();
             throw x;

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
@@ -33,9 +33,14 @@ import com.ibm.ws.concurrency.policy.ConcurrencyPolicy;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.resource.ResourceFactory;
 import com.ibm.ws.resource.ResourceFactoryBuilder;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.wsspi.kernel.service.location.VariableRegistry;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.kernel.service.utils.FilterUtils;
+
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
+import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
 
 @Component(service = ResourceFactoryBuilder.class,
            property = "creates.objectClass=jakarta.enterprise.concurrent.ManagedExecutorService") //  TODO more types?
@@ -138,11 +143,10 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
         String[] qualifiers = (String[]) execSvcProps.remove("qualifiers");
 
         // Convert qualifier array to list attribute if present
+        List<String> qualifierNames = null;
         if (qualifiers != null && qualifiers.length > 0) {
-            List<String> qualifierList = Arrays.asList(qualifiers);
-            if (trace && tc.isDebugEnabled())
-                Tr.debug(tc, "qualifiers", qualifierList);
-            execSvcProps.put("qualifiers", qualifierList);
+            qualifierNames = Arrays.asList(qualifiers);
+            execSvcProps.put("qualifiers", qualifierNames);
         }
 
         Long hungTaskThreshold = (Long) execSvcProps.remove("hungTaskThreshold");
@@ -226,6 +230,23 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
             Configuration managedExecutorSvcConfig = configAdmin.createFactoryConfiguration("com.ibm.ws.concurrent.managedExecutorService",
                                                                                             concurrencyBundleLocation);
             managedExecutorSvcConfig.update(execSvcProps);
+
+            if (qualifierNames != null) {
+                ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+                if (cmd == null)
+                    throw new IllegalStateException(); // should be unreachable
+
+                ServiceReference<QualifiedResourceFactories> ref = concurrencyBundleCtx.getServiceReference(QualifiedResourceFactories.class);
+
+                if (ref == null)
+                    throw new UnsupportedOperationException("The " + cmd.getName() + " application cannot specify the " +
+                                                            qualifierNames + " qualifiers on the " +
+                                                            jndiName + " " + ManagedExecutorDefinition.class.getSimpleName() +
+                                                            " because the " + "CDI" + " feature is not enabled."); // TODO NLS
+
+                QualifiedResourceFactories qrf = concurrencyBundleCtx.getService(ref);
+                qrf.add(cmd.getName(), QualifiedResourceFactories.Type.ManagedExecutorService, qualifierNames, factory);
+            }
         } catch (Exception x) {
             factory.destroy();
             throw x;

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/qualified/QualifiedResourceFactories.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/qualified/QualifiedResourceFactories.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.concurrent.internal.qualified;
+
+import java.util.List;
+import java.util.Map;
+
+import com.ibm.wsspi.resource.ResourceFactory;
+
+/**
+ * Maintains associations of qualifiers to resource factory for
+ * each type of resource and for each Java EE name.
+ *
+ * JEEName -> [qualifiers -> ResourceFactory for ContextService,
+ * . . . . . . qualifiers -> ResourceFactory for ManagedExecutorService,
+ * . . . . . . qualifiers -> ResourceFactory for ManagedScheduledExecutorService,
+ * . . . . . . qualifiers -> ResourceFactory for ManagedThreadFactory ]
+ *
+ * List index positions correspond to the ordinal value of the respective Type
+ * enumeration constant.
+ *
+ * The *ResourceFactoryBuilder classes populate it with the resource factories
+ * that they create. The ConcurrencyExtension removes all entries for the
+ * JEE name that is present on the thread and registers beans with the qualifiers.
+ *
+ * This interface is available as an OSGi service component for the above purpose.
+ */
+public interface QualifiedResourceFactories {
+    /**
+     * Concurrency resource definition types where qualifiers can be specified.
+     */
+    enum Type {
+        ContextService, ManagedExecutorService, ManagedScheduledExecutorService, ManagedThreadFactory
+    };
+
+    /**
+     * The resource factory builder invokes this method to add a
+     * resource factory with qualifiers to be processed by the
+     * concurrency CDI extension.
+     *
+     * @param jeeName         Java EE name obtained from ComponentMetaData.getName()
+     * @param resourceType    type of resource definition
+     * @param qualifierNames  names of qualifier annotation classes
+     * @param resourceFactory the resource factory
+     */
+    void add(String jeeName, Type resourceType, List<String> qualifierNames, ResourceFactory resourceFactory);
+
+    /**
+     * The concurrency CDI extension invokes this method to obtain all
+     * of the resource factories so it can register them as beans with
+     * their respective qualifiers.
+     *
+     * @param jeeName Java EE name obtained from ComponentMetaData.getName()
+     * @return list of the form [qualifiers -> ResourceFactory for ContextService,
+     *         . . . . . . . . . qualifiers -> ResourceFactory for ManagedExecutorService,
+     *         . . . . . . . . . qualifiers -> ResourceFactory for ManagedScheduledExecutorService,
+     *         . . . . . . . . . qualifiers -> ResourceFactory for ManagedThreadFactory ]
+     */
+    List<Map<List<String>, ResourceFactory>> removeAll(String jeeName);
+}

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/qualified/package-info.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/qualified/package-info.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "concurrent", messageBundle = "io.openliberty.concurrent.internal.resources.CWWKCMessages")
+package io.openliberty.concurrent.internal.qualified;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;


### PR DESCRIPTION
Provide a more correct implementation of support for qualifiers on ContextServiceDefinition, ManagedExecutorDefinition, and ManagedScheduledExecutorDefinition that allows for CDI.current.select as well as injection.