### PR TITLE
Workaround slowness of first request to OP

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/ShortTokenLifetimePrep.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/utils/ShortTokenLifetimePrep.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@ public class ShortTokenLifetimePrep extends CommonAnnotatedSecurityTests {
      * @param appName - unique name of the app to invoke
      * @throws Exception
      */
-    public void shortTokenLifetimePrep(LibertyServer opServer, String httpsBase, String appName) throws Exception {
+    public void shortTokenLifetimePrep(LibertyServer opServer, String httpsBase, String... appNames) throws Exception {
 
         try {
 
@@ -49,22 +49,21 @@ public class ShortTokenLifetimePrep extends CommonAnnotatedSecurityTests {
             // since we're using this method, we know that this possibility existss - just ignore the message
             opServer.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKS1617E_USERINFO_REQUEST_BAD_TOKEN));
 
-            WebClient webClient = getAndSaveWebClient();
-
             initResponseValues();
 
-            String url = httpsBase + "/" + appName;
+            for (String appName : appNames) {
+                String url = httpsBase + "/" + appName;
+                WebClient webClient = getAndSaveWebClient();
+                Page response = invokeAppReturnLoginPage(webClient, url);
 
-            Page response = invokeAppReturnLoginPage(webClient, url);
-
-            response = actions.doFormLogin(response, Constants.TESTUSER, Constants.TESTUSERPWD);
-            // confirm protected resource was accessed
-            // Just check for a good status code - on faster machines, we'll land on the test app, on
-            // slow machines, we'll land on the logout page (since the token will be expired by the time it's returned
-            Expectations expectations = new Expectations();
-            expectations.addSuccessCodeForCurrentAction();
-            validationUtils.validateResult(response, expectations);
-
+                response = actions.doFormLogin(response, Constants.TESTUSER, Constants.TESTUSERPWD);
+                // confirm protected resource was accessed
+                // Just check for a good status code - on faster machines, we'll land on the test app, on
+                // slow machines, we'll land on the logout page (since the token will be expired by the time it's returned
+                Expectations expectations = new Expectations();
+                expectations.addSuccessCodeForCurrentAction();
+                validationUtils.validateResult(response, expectations);
+            }
         } catch (Exception e) {
             Log.info(thisClass, "shortTokenLifetimePrep",
                      "A failure occurred trying to \"warm up\" the OP (meaning it takes a long time to issue the very first token and short token lifetime tests will time out)");

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTokenMinValidityTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTokenMinValidityTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -108,7 +108,9 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
         ShortTokenLifetimePrep s = new ShortTokenLifetimePrep();
-        s.shortTokenLifetimePrep(opServer, rpHttpsBase, "TokenMinValidity5s/TokenMinValidity5sServlet");
+        s.shortTokenLifetimePrep(opServer, rpHttpsBase, "TokenMinValidity5s/TokenMinValidity5sServlet", "TokenMinValidity20s/TokenMinValidity20sServlet",
+                                 "TokenMinValidity60s/TokenMinValidity60sServlet", "TokenMinValidity90s/TokenMinValidity90sServlet",
+                                 "TokenMinValidity0s/TokenMinValidity0sServlet");
 
     }
 


### PR DESCRIPTION
The OP can be a little slow on the first request for access - our jakarata tests that verify behavior with short lived tokens are having problems on slower machines.
I'm trying to work around that by requesting access once for these apps before the tests start.