### PR TITLE
qualifiers on managed thread factory definition

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -95,12 +95,27 @@ public class ConcurrentCDITest extends FATServletClient {
     }
 
     @Test
+    public void testInjectManagedThreadFactoryDefaultInstance() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectManagedThreadFactoryQualified() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
     public void testSelectContextServiceDefaultInstance() throws Exception {
         runTest(server, APP_NAME, testName);
     }
 
     @Test
     public void testSelectContextServiceQualified() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testSelectManagedThreadFactoryDefaultInstance() throws Exception {
         runTest(server, APP_NAME, testName);
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -73,6 +73,14 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
     protected volatile ResourceFactory defaultManagedScheduledExecutorFactory;
 
     /**
+     * ResourceFactory for the default ManagedThreadFactory instance: java:comp/DefaultManagedThreadFactory.
+     */
+    @Reference(target = "(&(id=DefaultManagedThreadFactory)(component.name=com.ibm.ws.concurrent.internal.ManagedThreadFactoryService))",
+               policy = ReferencePolicy.DYNAMIC,
+               policyOption = ReferencePolicyOption.GREEDY)
+    protected volatile ResourceFactory defaultManagedThreadFactoryFactory;
+
+    /**
      * Jakarta EE version.
      */
     public static Version eeVersion;

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.concurrent.internal.cdi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.wsspi.resource.ResourceFactory;
+
+import jakarta.enterprise.concurrent.ManagedThreadFactory;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.PassivationCapable;
+
+/**
+ * Bean that delegates to the OSGi service registry to obtain ManagedThreadFactory resources.
+ */
+public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, PassivationCapable {
+    private final static TraceComponent tc = Tr.register(ManagedThreadFactoryBean.class);
+
+    /**
+     * Injectable bean types.
+     */
+    private final Set<Type> beanTypes = Set.of(ManagedThreadFactory.class);
+
+    /**
+     * Resource factory that creates the resource.
+     */
+    private final ResourceFactory factory;
+
+    /**
+     * Qualifiers for the injection points for this bean.
+     */
+    private final Set<Annotation> qualifiers;
+
+    /**
+     * Construct a new bean for this resource.
+     *
+     * @param factory        resource factory.
+     * @param qualifierNames names of qualifier annotations for the bean.
+     */
+    ManagedThreadFactoryBean(ResourceFactory factory, List<String> qualifierNames) throws ClassNotFoundException {
+        this.factory = factory;
+        this.qualifiers = new LinkedHashSet<Annotation>();
+
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+
+        for (String qualifierClassName : qualifierNames) {
+            Class<?> qualifierClass = loader.loadClass(qualifierClassName);
+            if (!qualifierClass.isInterface())
+                throw new IllegalArgumentException("The " + qualifierClassName + " class is not a valid qualifier class" +
+                                                   " because it is not an annotation."); // TODO NLS
+            qualifiers.add(Annotation.class.cast(Proxy.newProxyInstance(loader,
+                                                                        new Class<?>[] { Annotation.class, qualifierClass },
+                                                                        new QualifierProxy(qualifierClass))));
+        }
+    }
+
+    /**
+     * Construct a new bean for this resource.
+     *
+     * @param factory    resource factory.
+     * @param qualifiers qualifiers for the bean.
+     */
+    ManagedThreadFactoryBean(ResourceFactory factory, Set<Annotation> qualifiers) {
+        this.factory = factory;
+        this.qualifiers = qualifiers;
+    }
+
+    @Override
+    @Trivial
+    public ManagedThreadFactory create(CreationalContext<ManagedThreadFactory> cc) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "create", cc, factory, qualifiers);
+
+        ManagedThreadFactory instance;
+        try {
+            instance = (ManagedThreadFactory) factory.createResource(null);
+        } catch (RuntimeException x) {
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "create", x);
+            throw x;
+        } catch (Exception x) {
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "create", x);
+            throw new RuntimeException(x);
+        }
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "create", instance);
+        return instance;
+    }
+
+    @Override
+    public void destroy(ManagedThreadFactory instance, CreationalContext<ManagedThreadFactory> creationalContext) {
+    }
+
+    @Override
+    public Class<ManagedThreadFactory> getBeanClass() {
+        return ManagedThreadFactory.class;
+    }
+
+    /**
+     * @return unique identifier for PassivationCapable.
+     */
+    @Override
+    public String getId() {
+        return new StringBuilder(getClass().getName()) //
+                        .append(":").append(qualifiers) //
+                        .append(':').append(factory) //
+                        .toString();
+    }
+
+    @Override
+    public Set<InjectionPoint> getInjectionPoints() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        return qualifiers;
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return RequestScoped.class;
+    }
+
+    @Override
+    public Set<Class<? extends Annotation>> getStereotypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<Type> getTypes() {
+        return beanTypes;
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    @Trivial
+    public String toString() {
+        return new StringBuilder(getClass().getSimpleName()).append('@').append(Integer.toHexString(hashCode())) //
+                        .append(' ').append(factory) //
+                        .append(" with qualifiers ").append(qualifiers) //
+                        .toString();
+    }
+}

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryResourceFactoryBuilder.java
@@ -12,8 +12,10 @@
  *******************************************************************************/
 package io.openliberty.concurrent.internal.processor;
 
+import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 
 import org.osgi.framework.BundleContext;
@@ -30,9 +32,14 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.resource.ResourceFactory;
 import com.ibm.ws.resource.ResourceFactoryBuilder;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.wsspi.kernel.service.location.VariableRegistry;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.kernel.service.utils.FilterUtils;
+
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
+import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
 
 @Component(service = ResourceFactoryBuilder.class,
            property = "creates.objectClass=jakarta.enterprise.concurrent.ManagedThreadFactory") //  TODO more types?
@@ -132,6 +139,14 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
         String jndiName = (String) threadFactoryProps.get(ResourceFactory.JNDI_NAME);
         String contextSvcJndiName = (String) threadFactoryProps.remove("context");
         Integer priority = (Integer) threadFactoryProps.remove("priority");
+        String[] qualifiers = (String[]) threadFactoryProps.remove("qualifiers");
+
+        // Convert qualifier array to list attribute if present
+        List<String> qualifierNames = null;
+        if (qualifiers != null && qualifiers.length > 0) {
+            qualifierNames = Arrays.asList(qualifiers);
+            threadFactoryProps.put("qualifiers", qualifierNames);
+        }
 
         String managedThreadFactoryID = getManagedThreadFactoryID(application, module, component, jndiName);
         String contextServiceId = contextSvcJndiName == null || "java:comp/DefaultContextService".equals(contextSvcJndiName) //
@@ -176,6 +191,23 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
 
             Configuration managedThreadFactorySvcConfig = configAdmin.createFactoryConfiguration("com.ibm.ws.concurrent.managedThreadFactory", bundleLocation);
             managedThreadFactorySvcConfig.update(threadFactoryProps);
+
+            if (qualifierNames != null) {
+                ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+                if (cmd == null)
+                    throw new IllegalStateException(); // should be unreachable
+
+                ServiceReference<QualifiedResourceFactories> ref = bundleContext.getServiceReference(QualifiedResourceFactories.class);
+
+                if (ref == null)
+                    throw new UnsupportedOperationException("The " + cmd.getName() + " application cannot specify the " +
+                                                            qualifierNames + " qualifiers on the " +
+                                                            jndiName + " " + ManagedThreadFactoryDefinition.class.getSimpleName() +
+                                                            " because the " + "CDI" + " feature is not enabled."); // TODO NLS
+
+                QualifiedResourceFactories qrf = bundleContext.getService(ref);
+                qrf.add(cmd.getName(), QualifiedResourceFactories.Type.ManagedThreadFactory, qualifierNames, factory);
+            }
         } catch (Exception x) {
             factory.destroy();
             throw x;


### PR DESCRIPTION
Initial changes to implement qualifiers for ManagedThreadFactoryDefinition.
To start with, this is oversimplified and ignores the requirements around when to capture thread context for ManagedThreadFactory.