### PR TITLE
Update install kernel map lib

### DIFF
--- a/dev/com.ibm.ws.install.map/bnd.bnd
+++ b/dev/com.ibm.ws.install.map/bnd.bnd
@@ -26,6 +26,7 @@ Require-Bundle: com.ibm.ws.install; version="[1,1.0.100)", \
   com.ibm.ws.kernel.service; version="[1.3,1.3.100)", \
   com.ibm.ws.kernel.boot; version="[1,1.0.100)", \
   com.ibm.ws.logging; version="[1,1.0.100)", \
+  com.ibm.ws.logging.core; version="[1,1.0.100)", \
   com.ibm.ws.product.utility; version="[1,1.0.100)", \
   org.eclipse.osgi; version="[3.10,4)", \
   com.ibm.ws.org.eclipse.equinox.metatype; version="[1,1.0.100)", \


### PR DESCRIPTION
This fixes `java.lang.NoClassDefFoundError: com/ibm/websphere/ras/DataFormatHelper` error in LGP/LMP.
Issue ref: https://github.com/OpenLiberty/ci.gradle/issues/867

`com.ibm.ws.logging.core` package has DataFormatHelper class, which is a class used to format logs in verbose mode. 
