### PR TITLE
Increase tolerance in EJB timer FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerCoreTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerCoreTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2022 IBM Corporation and others.
+ * Copyright (c) 2009, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -40,6 +40,7 @@ import com.ibm.ws.ejbcontainer.timer.persistent.core.web.TimerAccessOperationsSe
 import com.ibm.ws.ejbcontainer.timer.persistent.core.web.TimerSFOperationsServlet;
 import com.ibm.ws.ejbcontainer.timer.persistent.core.web.TimerSLOperationsServlet;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
@@ -130,6 +131,7 @@ public class PersistentTimerCoreTest extends FATServletClient {
     @Test
     @Mode(Mode.TestMode.FULL)
     //Full because test sleeps for over 5 minutes
+    @AllowedFFDC({ "java.lang.IllegalArgumentException" }) // Tolerate security scans
     public void testDefaultLateTimerMessage() throws Exception {
         String warningRegExp = "CNTR0333W(?=.*LateWarning)(?=.*PersistentTimerCoreEJB.jar)(?=.*PersistentTimerCoreApp)";
         String timeoutRegExp = "WTRN0006W.*120";
@@ -152,6 +154,7 @@ public class PersistentTimerCoreTest extends FATServletClient {
     @Test
     @Mode(Mode.TestMode.FULL)
     //Full because test sleeps for over 5 minutes
+    @AllowedFFDC({ "java.lang.IllegalArgumentException" }) // Tolerate security scans
     public void testDisabledLateTimerMessage() throws Exception {
         String warningRegExp = "CNTR0333W:.*";
         String timeoutRegExp = "WTRN0006W.*120";

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/PersistentTimerCoreEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/core/ejb/StatelessTimedBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/PersistentTimerCoreEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/core/ejb/StatelessTimedBean.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -312,11 +312,13 @@ public class StatelessTimedBean implements SessionBean, TimedObject {
 
     /** Never called for Stateless Session Bean. **/
     @Override
-    public void ejbActivate() {}
+    public void ejbActivate() {
+    }
 
     /** Never called for Stateless Session Bean. **/
     @Override
-    public void ejbPassivate() {}
+    public void ejbPassivate() {
+    }
 
     /**
      * Test getTimerService()/TimerService access from a method on a Stateless
@@ -601,6 +603,14 @@ public class StatelessTimedBean implements SessionBean, TimedObject {
         // See if all except cancelled timers have expired once...
         for (int i = 0; i < timer.length; i++) {
             switch (i) {
+                case 2:
+                case 4:
+                    if (svTimeoutCounts[i] < 1) {
+                        successful = false;
+                        svLogger.info("Timer[" + i + "] not executed at least once: " + timer[i]);
+                    }
+                    break;
+
                 case 5:
                     if (svTimeoutCounts[i] != 0) {
                         successful = false;


### PR DESCRIPTION
- tolerate pauses in test hardware that may result in timer catchup
- tolerate scans of test hardware that may result in unrelated FFDC
