### PR TITLE
make managed thread factory bean application scoped

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017,2023 IBM Corporation and others.
+    Copyright (c) 2017,2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,6 +21,15 @@
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>
+
+    <application location="concurrentCDIApp.war">
+        <classloader commonLibraryRef="location-context"/>
+    </application>
+
+    <!-- fake third-party context provider -->
+    <library id="location-context">
+        <file name="${server.config.dir}/lib/location-context.jar"/>
+    </library>
 
     <managedExecutorService jndiName="concurrent/sampleExecutor">
         <concurrencyPolicy max="2" maxQueueSize="2"/>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/context/location/Location.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/context/location/Location.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.context.location;
+
+/**
+ * Example third-party thread context.
+ */
+public class Location {
+    public static final String CONTEXT_NAME = "Location";
+
+    static ThreadLocal<String> local = new ThreadLocal<>();
+
+    // API methods:
+
+    public static final void clear() {
+        local.remove();
+    }
+
+    public static final String get() {
+        return local.get();
+    }
+
+    public static final void set(String newLocation) {
+        if (newLocation == null || newLocation.length() == 0)
+            throw new IllegalArgumentException(newLocation);
+        else
+            local.set(newLocation);
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/context/location/LocationContextProvider.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/context/location/LocationContextProvider.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.context.location;
+
+import java.util.Map;
+
+import jakarta.enterprise.concurrent.spi.ThreadContextProvider;
+import jakarta.enterprise.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * Example third-party thread context provider, to be used for testing purposes.
+ * This context associates a location string with a thread.
+ */
+public class LocationContextProvider implements ThreadContextProvider {
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        return new LocationContextSnapshot(null);
+    }
+
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        return new LocationContextSnapshot(Location.local.get());
+    }
+
+    @Override
+    public String getThreadContextType() {
+        return Location.CONTEXT_NAME;
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/context/location/LocationContextRestorer.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/context/location/LocationContextRestorer.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.context.location;
+
+import jakarta.enterprise.concurrent.spi.ThreadContextRestorer;
+
+/**
+ * Example third-party thread context provider, to be used for testing purposes.
+ * This context associates a location string with a thread.
+ */
+public class LocationContextRestorer implements ThreadContextRestorer {
+    private boolean restored;
+    private final String location;
+
+    LocationContextRestorer(String location) {
+        this.location = location;
+    }
+
+    @Override
+    public void endContext() {
+        if (restored)
+            throw new IllegalStateException("thread context was already restored");
+        if (location == null)
+            Location.local.remove();
+        else
+            Location.local.set(location);
+        restored = true;
+    }
+
+    @Override
+    public String toString() {
+        return "LocationContextRestorer@" + Integer.toHexString(hashCode()) + ":" + location;
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/context/location/LocationContextSnapshot.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/context/location/LocationContextSnapshot.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.context.location;
+
+import jakarta.enterprise.concurrent.spi.ThreadContextRestorer;
+import jakarta.enterprise.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * Example third-party thread context provider, to be used for testing purposes.
+ * This context associates a location string with a thread.
+ */
+public class LocationContextSnapshot implements ThreadContextSnapshot {
+    private final String location;
+
+    LocationContextSnapshot(String location) {
+        this.location = location;
+    }
+
+    @Override
+    public ThreadContextRestorer begin() {
+        ThreadContextRestorer restorer = new LocationContextRestorer(Location.local.get());
+        Location.local.set(location);
+        return restorer;
+    }
+
+    @Override
+    public final int hashCode() {
+        return location == null ? 0 : location.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "LocationContextSnapshot@" + Integer.toHexString(hashCode()) + ":" + location;
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithLocationContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithLocationContext.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.web;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface WithLocationContext {
+    public static class Literal extends AnnotationLiteral<WithLocationContext> implements WithLocationContext {
+        private static final long serialVersionUID = 2667072598927683578L;
+
+        public static final WithLocationContext INSTANCE = new Literal();
+
+        private Literal() {
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithTransactionContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithTransactionContext.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.web;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface WithTransactionContext {
+    public static class Literal extends AnnotationLiteral<WithTransactionContext> implements WithTransactionContext {
+        private static final long serialVersionUID = -938635792865549601L;
+
+        public static final WithTransactionContext INSTANCE = new Literal();
+
+        private Literal() {
+        }
+    }
+}

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
@@ -26,7 +26,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.wsspi.resource.ResourceFactory;
 
 import jakarta.enterprise.concurrent.ManagedThreadFactory;
-import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.InjectionPoint;
@@ -96,6 +96,8 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
 
         ManagedThreadFactory instance;
         try {
+            // TODO send in signal to MTF to defer context capture until newThread?
+            // Or, send in context that we already obtained?
             instance = (ManagedThreadFactory) factory.createResource(null);
         } catch (RuntimeException x) {
             if (trace && tc.isEntryEnabled())
@@ -149,7 +151,7 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
 
     @Override
     public Class<? extends Annotation> getScope() {
-        return RequestScoped.class;
+        return ApplicationScoped.class;
     }
 
     @Override


### PR DESCRIPTION
Make the ManagedThreadFactory bean be application scoped like the others, and verify that behavior for context capture when using qualifiers matches the behavior for context capture when using `@Resource` which is that context is captured once upon creation, as required by the spec.