### PR TITLE
Update TCKResultsWriter to generate a separate file for each repeat

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/RepeatTestFilter.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/RepeatTestFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/RepeatTestFilter.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/RepeatTestFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
@@ -14,6 +14,7 @@ package componenttest.topology.utils.tck;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
@@ -44,6 +45,7 @@ public class TCKResultsInfo {
     private final String specName;// = resultInfo.get("feature_name");
     private final TCKJarInfo tckJarInfo;
     private final LibertyServer server;
+    private final String repeat; // = RepeatTestFilter.getRepeatActionsAsString();
 
     public TCKResultsInfo(Type type, String specName, LibertyServer server, TCKJarInfo tckJarInfo) {
         this.type = type;
@@ -53,6 +55,7 @@ public class TCKResultsInfo {
         this.javaMajorVersion = String.valueOf(javaInfo.majorVersion());
         this.server = server;
         this.tckJarInfo = tckJarInfo;
+        this.repeat = RepeatTestFilter.getRepeatActionsAsString();
     }
 
     /**
@@ -112,6 +115,13 @@ public class TCKResultsInfo {
      */
     public String getSpecName() {
         return specName;
+    }
+
+    /**
+     * @return the repeatID
+     */
+    public String getRepeat() {
+        return repeat;
     }
 
     /**

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -36,7 +36,7 @@ public class TCKResultsWriter {
      *
      * @param resultInfo TCK Results metadata
      */
-    public static void preparePublicationFile(TCKResultsInfo resultInfo) {
+    public static void preparePublicationFile(TCKResultsInfo resultInfo, String repeat) {
         String javaMajorVersion = resultInfo.getJavaMajorVersion();
         String javaVersion = resultInfo.getJavaVersion();
         String openLibertyVersion = resultInfo.getOpenLibertyVersion();
@@ -74,7 +74,7 @@ public class TCKResultsWriter {
             specURL = "https://jakarta.ee/specifications/" + specName + "/" + specVersion;
             tckURL = "https://download.eclipse.org/ee4j/" + specName + "/jakartaee10/promoted/eftl/" + specName + "-tck-" + specVersion + ".zip"; //just a placeholder, needs to be manually updated
         }
-        String filename = openLibertyVersion + "-" + fullSpecName.replace(" ", "-") + "-Java" + javaMajorVersion + "-TCKResults.adoc";
+        String filename = openLibertyVersion + "-" + fullSpecName.replace(" ", "-") + "-Java" + javaMajorVersion + "-TCKResults" + repeat + ".adoc";
         Path outputPath = Paths.get("results", filename);
         File outputFile = outputPath.toFile();
         String adocContent = getADocHeader(filename, fullSpecName, specURL, openLibertyVersion, javaMajorVersion, javaVersion, osName, osVersion, tckURL, tckSHA1, tckSHA256);
@@ -94,7 +94,10 @@ public class TCKResultsWriter {
             }
             output.write(adocContent);
             for (TestSuiteResult result : xmlParser.getResults()) {
-                output.write(result.toString());
+                if (result.toString().contains(repeat)) {
+                    String newResult = result.toString().replace(repeat, "");
+                    output.write(newResult);
+                }
             }
             output.write("----");
 

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -36,7 +36,7 @@ public class TCKResultsWriter {
      *
      * @param resultInfo TCK Results metadata
      */
-    public static void preparePublicationFile(TCKResultsInfo resultInfo, String repeat) {
+    public static void preparePublicationFile(TCKResultsInfo resultInfo) {
         String javaMajorVersion = resultInfo.getJavaMajorVersion();
         String javaVersion = resultInfo.getJavaVersion();
         String openLibertyVersion = resultInfo.getOpenLibertyVersion();
@@ -45,6 +45,7 @@ public class TCKResultsWriter {
         String osVersion = resultInfo.getOsVersion();
         String specName = resultInfo.getSpecName();
         String specVersion = resultInfo.getSpecVersion();
+        String repeat = resultInfo.getRepeat();
 
         SAXParserFactory factory = null;
         SAXParser saxParser = null;
@@ -74,7 +75,8 @@ public class TCKResultsWriter {
             specURL = "https://jakarta.ee/specifications/" + specName + "/" + specVersion;
             tckURL = "https://download.eclipse.org/ee4j/" + specName + "/jakartaee10/promoted/eftl/" + specName + "-tck-" + specVersion + ".zip"; //just a placeholder, needs to be manually updated
         }
-        String filename = openLibertyVersion + "-" + fullSpecName.replace(" ", "-") + "-Java" + javaMajorVersion + "-TCKResults" + repeat + ".adoc";
+        // Replace the "_" with "-" in filename to keep consistency
+        String filename = (openLibertyVersion + "-" + fullSpecName.replace(" ", "-") + "-Java" + javaMajorVersion + "-TCKResults" + repeat + ".adoc").replace("_", "-");
         Path outputPath = Paths.get("results", filename);
         File outputFile = outputPath.toFile();
         String adocContent = getADocHeader(filename, fullSpecName, specURL, openLibertyVersion, javaMajorVersion, javaVersion, osName, osVersion, tckURL, tckSHA1, tckSHA256);
@@ -94,7 +96,11 @@ public class TCKResultsWriter {
             }
             output.write(adocContent);
             for (TestSuiteResult result : xmlParser.getResults()) {
-                // Checking if the result is for the correct repeat (avoiding adding wrong repeat results to wrong TCK report repeat files)
+                /*
+                 * Checking if the result is for the correct repeat (avoiding adding wrong repeat results to wrong TCK report repeat files)
+                 * This will never be null because when calling RepeatTestFilter.getRepeatActionsAsString()
+                 * if REPEAT_ACTION_STACK is empty it will return an empty string instead ("")
+                 */
                 if (result.toString().contains(repeat)) {
                     // Removing repeat ID from the test results
                     String newResult = result.toString().replace(repeat, "");

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -76,7 +76,7 @@ public class TCKResultsWriter {
             tckURL = "https://download.eclipse.org/ee4j/" + specName + "/jakartaee10/promoted/eftl/" + specName + "-tck-" + specVersion + ".zip"; //just a placeholder, needs to be manually updated
         }
         // Replace the "_" with "-" in filename to keep consistency
-        String filename = (openLibertyVersion + "-" + fullSpecName.replace(" ", "-") + "-Java" + javaMajorVersion + "-TCKResults" + repeat + ".adoc").replace("_", "-");
+        String filename = (openLibertyVersion + "-" + fullSpecName.replace(" ", "-") + "-Java" + javaMajorVersion + repeat + "-TCKResults.adoc").replace("_", "-");
         Path outputPath = Paths.get("results", filename);
         File outputFile = outputPath.toFile();
         String adocContent = getADocHeader(filename, fullSpecName, specURL, openLibertyVersion, javaMajorVersion, javaVersion, osName, osVersion, tckURL, tckSHA1, tckSHA256);

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -75,8 +75,20 @@ public class TCKResultsWriter {
             specURL = "https://jakarta.ee/specifications/" + specName + "/" + specVersion;
             tckURL = "https://download.eclipse.org/ee4j/" + specName + "/jakartaee10/promoted/eftl/" + specName + "-tck-" + specVersion + ".zip"; //just a placeholder, needs to be manually updated
         }
+        String filename = null;
+        if (repeat.contains("FeatureReplacementAction")) {
+            String newRepeat = repeat.replaceAll("FeatureReplacementAction.*REMOVE", "remove")
+                            .replaceAll("\\[", "")
+                            .replaceAll("\\]", "")
+                            .replaceAll("ADD", "add")
+                            .replaceAll("  ", " ")
+                            .replaceAll(" ", "_");
+            filename = (openLibertyVersion + "-" + fullSpecName.replace(" ", "-") + "-Java" + javaMajorVersion + newRepeat + "-TCKResults.adoc").replace("_", "-");
+        } else {
+            filename = (openLibertyVersion + "-" + fullSpecName.replace(" ", "-") + "-Java" + javaMajorVersion + repeat + "-TCKResults.adoc").replace("_", "-");
+        }
         // Replace the "_" with "-" in filename to keep consistency
-        String filename = (openLibertyVersion + "-" + fullSpecName.replace(" ", "-") + "-Java" + javaMajorVersion + repeat + "-TCKResults.adoc").replace("_", "-");
+
         Path outputPath = Paths.get("results", filename);
         File outputFile = outputPath.toFile();
         String adocContent = getADocHeader(filename, fullSpecName, specURL, openLibertyVersion, javaMajorVersion, javaVersion, osName, osVersion, tckURL, tckSHA1, tckSHA256);

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -94,7 +94,9 @@ public class TCKResultsWriter {
             }
             output.write(adocContent);
             for (TestSuiteResult result : xmlParser.getResults()) {
+                // Checking if the result is for the correct repeat (avoiding adding wrong repeat results to wrong TCK report repeat files)
                 if (result.toString().contains(repeat)) {
+                    // Removing repeat ID from the test results
                     String newResult = result.toString().replace(repeat, "");
                     output.write(newResult);
                 }

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -228,7 +228,7 @@ public class TCKRunner {
         if (TCKUtilities.useArtifactory()) {
             Properties wrapperProperties = TCKUtilities.updateWrapperPropertiesFile(wrapperPropertiesFile, TCKUtilities.getArtifactoryServer());
 
-            // Pre-download wrapper jar and set up a temporary maven home directory (if not already created
+            // Pre-download wrapper jar and set up a temporary maven home directory (if not already created)
             this.artifactoryAuthenticator = new ArtifactoryAuthenticator();
             TCKUtilities.downloadMvnWrapperJar(tckRunnerDir, wrapperProperties, this.artifactoryAuthenticator);
             this.mavenUserHome = TCKUtilities.getTemporaryMavenHomeDir();
@@ -258,7 +258,8 @@ public class TCKRunner {
         List<String> dependencyOutput = runDependencyCmd();
         TCKJarInfo tckJarInfo = TCKUtilities.getTCKJarInfo(this.type, dependencyOutput);
         TCKResultsInfo resultsInfo = new TCKResultsInfo(this.type, this.specName, this.server, tckJarInfo);
-        TCKResultsWriter.preparePublicationFile(resultsInfo);
+        String repeat = RepeatTestFilter.getRepeatActionsAsString();
+        TCKResultsWriter.preparePublicationFile(resultsInfo, repeat);
     }
 
     /**

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
@@ -258,8 +258,7 @@ public class TCKRunner {
         List<String> dependencyOutput = runDependencyCmd();
         TCKJarInfo tckJarInfo = TCKUtilities.getTCKJarInfo(this.type, dependencyOutput);
         TCKResultsInfo resultsInfo = new TCKResultsInfo(this.type, this.specName, this.server, tckJarInfo);
-        String repeat = RepeatTestFilter.getRepeatActionsAsString();
-        TCKResultsWriter.preparePublicationFile(resultsInfo, repeat);
+        TCKResultsWriter.preparePublicationFile(resultsInfo);
     }
 
     /**


### PR DESCRIPTION
- TCKResultsWriter now creates a separate report file per each repeat
- The test names no longer have the repeat ID appended to them

Fixes #27169 

