### PR TITLE
Remove app bound vendor metrics during application shutdown

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,7 +21,8 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import org.junit.AfterClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,13 +86,15 @@ public class GrpcMetricsTest extends FATServletClient {
 
         LOG.info("GrpcMetricsTest : setUp() : start the grpc servers");
         GrpcClientOnly.useSecondaryHTTPPort();
-        GrpcClientOnly.startServer(GrpcMetricsTest.class.getSimpleName() + ".client.log");
-        GrpcServerOnly.startServer(GrpcMetricsTest.class.getSimpleName() + ".server.log");
+    }
+
+    @Before
+    public void before() {
         clientCallCount = 0;
     }
 
-    @AfterClass
-    public static void tearDown() throws Exception {
+    @After
+    public void after() throws Exception {
         GrpcClientOnly.stopServer();
         GrpcServerOnly.stopServer();
     }
@@ -103,6 +106,9 @@ public class GrpcMetricsTest extends FATServletClient {
      */
     @Test
     public void testGrpcMetricsSeparateServers() throws Exception {
+
+        GrpcClientOnly.startServer(GrpcMetricsTest.class.getSimpleName() + ".client.log");
+        GrpcServerOnly.startServer(GrpcMetricsTest.class.getSimpleName() + ".server.log");
 
         // enable mpMetrics-2.3 on both servers
         GrpcTestUtils.setServerConfiguration(GrpcClientOnly, null, GRPC_CLIENT_METRICS, appName, LOG);
@@ -166,6 +172,8 @@ public class GrpcMetricsTest extends FATServletClient {
      */
     @Test
     public void testGrpcMetricsSingleServer() throws Exception {
+
+        GrpcClientOnly.startServer(GrpcMetricsTest.class.getSimpleName() + ".client.log");
 
         // enable mpMetrics-2.3 along with grpc-1.0 and grpcClient-1.0 on GrpcClientOnly
         GrpcTestUtils.setServerConfiguration(GrpcClientOnly, null, GRPC_BOTH_METRICS, appName_srv, LOG);

--- a/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/ApplicationListener.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/ApplicationListener.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -52,7 +52,8 @@ public class ApplicationListener implements ApplicationStateListener {
     @Override
     public void applicationStopped(ApplicationInfo appInfo) {
         MetricRegistry[] registryArray = new MetricRegistry[] { sharedMetricRegistry.getOrCreate(MetricRegistry.Type.APPLICATION.getName()),
-                                                                sharedMetricRegistry.getOrCreate(MetricRegistry.Type.BASE.getName()) };
+                                                                sharedMetricRegistry.getOrCreate(MetricRegistry.Type.BASE.getName()),
+                                                                sharedMetricRegistry.getOrCreate(MetricRegistry.Type.VENDOR.getName()) };
         for (MetricRegistry registry : registryArray) {
             if (MetricRegistryImpl.class.isInstance(registry)) {
                 MetricRegistryImpl impl = (MetricRegistryImpl) registry;

--- a/dev/com.ibm.ws.microprofile.metrics/src/com/ibm/ws/microprofile/metrics/ApplicationListener.java
+++ b/dev/com.ibm.ws.microprofile.metrics/src/com/ibm/ws/microprofile/metrics/ApplicationListener.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -30,23 +30,31 @@ public class ApplicationListener implements ApplicationStateListener {
 
     /** {@inheritDoc} */
     @Override
-    public void applicationStarting(ApplicationInfo appInfo) throws StateChangeException {}
+    public void applicationStarting(ApplicationInfo appInfo) throws StateChangeException {
+    }
 
     /** {@inheritDoc} */
     @Override
-    public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {}
+    public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {
+    }
 
     /** {@inheritDoc} */
     @Override
-    public void applicationStopping(ApplicationInfo appInfo) {}
+    public void applicationStopping(ApplicationInfo appInfo) {
+    }
 
     /** {@inheritDoc} */
     @Override
     public void applicationStopped(ApplicationInfo appInfo) {
-        MetricRegistry registry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.APPLICATION.getName());
-        if (MetricRegistryImpl.class.isInstance(registry)) {
-            MetricRegistryImpl impl = (MetricRegistryImpl) registry;
-            impl.unRegisterApplicationMetrics(appInfo.getDeploymentName());
+
+        //No application bound BASE metrics were introduced in mpMetrics-1.x
+        MetricRegistry[] registryArray = new MetricRegistry[] { sharedMetricRegistry.getOrCreate(MetricRegistry.Type.APPLICATION.getName()),
+                                                                sharedMetricRegistry.getOrCreate(MetricRegistry.Type.VENDOR.getName()) };
+        for (MetricRegistry registry : registryArray) {
+            if (MetricRegistryImpl.class.isInstance(registry)) {
+                MetricRegistryImpl impl = (MetricRegistryImpl) registry;
+                impl.unRegisterApplicationMetrics(appInfo.getDeploymentName());
+            }
         }
     }
 

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/ApplicationListener50.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/ApplicationListener50.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -61,8 +61,8 @@ public class ApplicationListener50 implements ApplicationStateListener {
     public void applicationStopped(ApplicationInfo appInfo) {
 
         Set<String> scopeNamesSet = sharedMetricRegistry.getMetricRegistryScopeNames();
-        if (scopeNamesSet.contains(MetricRegistry.VENDOR_SCOPE)) {
-            scopeNamesSet.remove(MetricRegistry.VENDOR_SCOPE);
+        if (!scopeNamesSet.contains(MetricRegistry.VENDOR_SCOPE)) {
+            scopeNamesSet.add(MetricRegistry.VENDOR_SCOPE);
         } else if (!scopeNamesSet.contains(MetricRegistry.APPLICATION_SCOPE)) {
             scopeNamesSet.add(MetricRegistry.APPLICATION_SCOPE);
         } else if (!scopeNamesSet.contains(MetricRegistry.BASE_SCOPE)) {

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0/src/io/openliberty/microprofile/metrics30/internal/ApplicationListener30.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0/src/io/openliberty/microprofile/metrics30/internal/ApplicationListener30.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -53,7 +53,8 @@ public class ApplicationListener30 implements ApplicationStateListener {
     @Override
     public void applicationStopped(ApplicationInfo appInfo) {
         MetricRegistry[] registryArray = new MetricRegistry[] { sharedMetricRegistry.getOrCreate(MetricRegistry.Type.APPLICATION.getName()),
-                                                                sharedMetricRegistry.getOrCreate(MetricRegistry.Type.BASE.getName()) };
+                                                                sharedMetricRegistry.getOrCreate(MetricRegistry.Type.BASE.getName()),
+                                                                sharedMetricRegistry.getOrCreate(MetricRegistry.Type.VENDOR.getName()) };
         for (MetricRegistry registry : registryArray) {
             if (MetricRegistry30Impl.class.isInstance(registry)) {
                 MetricRegistry30Impl impl = (MetricRegistry30Impl) registry;


### PR DESCRIPTION
Remove app bound vendor metrics during application shutdown; use set over list for memory savings; temp work-around grpc fat

GRPC issue encountered is that MBeans are not deregistered during application shut down.
Tracked with: https://github.com/OpenLiberty/open-liberty/issues/27432

This PR will cause issue with the `GRPCMetricsTest` as it runs two test on the client server. Upon server config update, this would force an application restart. With this PR, the GRPC metrics would be unloaded from the vendor metric registry. However, since the GRPC MBeans persist from a previous runtime of the application, no "new" Mbeans are created and therefore no new grpc metrics are created. The temprorary work around is to restart the servers for each test in the `GrpcMetricsTest`.

fixes #27439 

#build 