### PR TITLE
JAXB: Update fattest.simplicity/bnd.bnd's JAXB dependency

### DIFF
--- a/dev/com.ibm.ws.tx.jta_fat_hibernate/build.gradle
+++ b/dev/com.ibm.ws.tx.jta_fat_hibernate/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     'javax.transaction:javax.transaction-api:1.2',
     'javax.xml.bind:jaxb-api:2.2.12-b140109.1041',
     project(':com.ibm.ws.jaxb.tools'),
-    project(':com.ibm.ws.jaxb.tools'),
     'javax.activation:activation:1.1'
 }
 

--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2023 IBM Corporation and others.
+ * Copyright (c) 2017,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,10 @@ task assembleBinaryDependencies() {
                     into buildDirLib
                 }
             }
+        }
+        copy {
+            from new File(project(':com.ibm.ws.jaxb.tools').buildDir, 'com.ibm.ws.jaxb.tools.jar')
+            into buildDirLib
         }
     }
 }

--- a/dev/io.openliberty.mail.2.0.internal_fat/build.gradle
+++ b/dev/io.openliberty.mail.2.0.internal_fat/build.gradle
@@ -20,7 +20,6 @@ dependencies {
                'com.ibm.ws.org.apache.yoko:yoko-spec-corba:1.5.+',
                'com.ibm.ws.com.icegreen:greenmail:2.0.0.fd826131f671b0d3230b0d0e1638d8c4',
                // Deps needed for when running on Java 9 (EE-type APIs were removed from JDK)
-               project(':com.ibm.ws.jaxb.tools'),
                project(':com.ibm.ws.jaxb.tools')
 }
 


### PR DESCRIPTION
This PR fixes the following error when a fat bucket runs the RepeatAction:

```
Provider com.sun.xml.bind.v2.ContextFactory not found

javax.xml.bind.JAXBException: Provider com.sun.xml.bind.v2.ContextFactory not found
- with linked exception:
[java.lang.ClassNotFoundException: com.sun.xml.bind.v2.ContextFactory]
at javax.xml.bind.ContextFinder.loadSpi(ContextFinder.java:161)
at javax.xml.bind.ContextFinder.find(ContextFinder.java:106)
at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:65)
at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:56)
at com.ibm.websphere.simplicity.config.ServerConfigurationFactory.<init>(ServerConfigurationFactory.java:76)
at com.ibm.websphere.simplicity.config.ServerConfigurationFactory.getInstance(ServerConfigurationFactory.java:43)
at com.ibm.websphere.simplicity.config.ServerConfigurationFactory.fromFile(ServerConfigurationFactory.java:49)
at componenttest.rules.repeater.FeatureReplacementAction.setFeatures(FeatureReplacementAction.java:601)
at componenttest.rules.repeater.FeatureReplacementAction.setup(FeatureReplacementAction.java:493)
at componenttest.rules.repeater.JakartaEEAction.setup(JakartaEEAction.java:214)
at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:144)
...
```

For reference this PR is needed because of the changes done in PR #26129.