### PR TITLE
Fix web-app 6.1 schema issues

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta_11/test-applications/Concurrency31TestWeb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_11/test-applications/Concurrency31TestWeb/resources/WEB-INF/web.xml
@@ -11,8 +11,10 @@
     Contributors:
         IBM Corporation - initial API and implementation
  -->
-<!-- TODO 6.1 -->
-<web-app version="6.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
+<web-app version="6.1" 
+	xmlns="https://jakarta.ee/xml/ns/jakartaee" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd">
 
   <!-- TODO concurrency resources with virtual=true -->
 

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/internal/WebFragmentsInfoImpl.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/internal/WebFragmentsInfoImpl.java
@@ -49,6 +49,13 @@ class WebFragmentsInfoImpl implements WebFragmentsInfo {
 
     //
 
+    private static final HashSet<Integer> METADATA_COMPLETE_SUPPORT = //
+                    new HashSet<>(Arrays.asList(WebApp.VERSION_2_5,
+                                                WebApp.VERSION_3_0, WebApp.VERSION_3_1,
+                                                WebApp.VERSION_4_0,
+                                                WebApp.VERSION_5_0,
+                                                WebApp.VERSION_6_0, WebApp.VERSION_6_1));
+
     /**
      * Create aggregate fragment information for a web module.
      *
@@ -66,8 +73,7 @@ class WebFragmentsInfoImpl implements WebFragmentsInfo {
         WebApp webApp = containerToAdapt.adapt(WebApp.class); // throws UnableToAdaptException
         if (webApp != null) {
             this.servletSchemaLevel = webApp.getVersion();
-            int servletSchemaLevelInt = PlatformVersion.getVersionInt(servletSchemaLevel);
-            if (Arrays.binarySearch(WebApp.METADATA_COMPLETE_SUPPORT, servletSchemaLevelInt) >= 0) {
+            if (isMetadataCompleteSupported(servletSchemaLevel)) {
                 this.isMetadataComplete = webApp.isSetMetadataComplete() && webApp.isMetadataComplete();
             } else {
                 this.isMetadataComplete = true; // Default to true for earlier versions.
@@ -120,6 +126,24 @@ class WebFragmentsInfoImpl implements WebFragmentsInfo {
     @Override
     public String getServletSchemaLevel() {
         return servletSchemaLevel;
+    }
+
+    /**
+     * Verify if the web-app version supports metadata-complete elements.
+     * metadata-complete was added in version 2.5.
+     *
+     * @param version
+     *
+     * @return true if metadata-complete is supported,
+     *         false if metadata-complete is not supported or the schema version is unknown
+     */
+    private boolean isMetadataCompleteSupported(String version) {
+        try {
+            int intVersion = PlatformVersion.getVersionInt(version);
+            return METADATA_COMPLETE_SUPPORT.contains(intVersion);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     /** Cache of the 'metadata-complete' attribute of the web module descriptor. */

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/internal/WebFragmentsInfoImpl.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/internal/WebFragmentsInfoImpl.java
@@ -1,10 +1,10 @@
 /*********************************************************************
- * Copyright (c) 2012, 2023 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,7 @@
 package com.ibm.ws.container.service.config.internal;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -30,6 +31,7 @@ import com.ibm.ws.container.service.app.deploy.ContainerInfo.Type;
 import com.ibm.ws.container.service.app.deploy.WebModuleClassesInfo;
 import com.ibm.ws.container.service.config.WebFragmentInfo;
 import com.ibm.ws.container.service.config.WebFragmentsInfo;
+import com.ibm.ws.javaee.dd.PlatformVersion;
 import com.ibm.ws.javaee.dd.web.WebApp;
 import com.ibm.ws.javaee.dd.web.WebFragment;
 import com.ibm.ws.javaee.dd.web.common.AbsoluteOrdering;
@@ -61,13 +63,11 @@ class WebFragmentsInfoImpl implements WebFragmentsInfo {
         this.servletSpecLevel = servletSpecLevel;
 
         // Web app ...
-
         WebApp webApp = containerToAdapt.adapt(WebApp.class); // throws UnableToAdaptException
         if (webApp != null) {
             this.servletSchemaLevel = webApp.getVersion();
-            if ("6.0".equals(servletSchemaLevel) || "5.0".equals(servletSchemaLevel) || "4.0".equals(servletSchemaLevel) || "3.1".equals(servletSchemaLevel)
-                || "3.0".equals(servletSchemaLevel)
-                || "2.5".equals(servletSchemaLevel)) {
+            int servletSchemaLevelInt = PlatformVersion.getVersionInt(servletSchemaLevel);
+            if (Arrays.binarySearch(WebApp.METADATA_COMPLETE_SUPPORT, servletSchemaLevelInt) >= 0) {
                 this.isMetadataComplete = webApp.isSetMetadataComplete() && webApp.isMetadataComplete();
             } else {
                 this.isMetadataComplete = true; // Default to true for earlier versions.

--- a/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/PlatformVersion.java
+++ b/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/PlatformVersion.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -143,22 +143,14 @@ public interface PlatformVersion {
             case "3.0" : return 30 ;
             case "3.1" : return 31 ;
             case "3.2" : return 32 ;
-            case "4"   : return 40 ;
             case "4.0" : return 40 ;
-            case "5"   : return 50 ;
             case "5.0" : return 50 ;
-            case "6"   : return 60 ;
             case "6.0" : return 60 ;
             case "6.1" : return 61 ;
-            case "7"   : return 70 ;
             case "7.0" : return 70 ;
-            case "8"   : return 80 ;
             case "8.0" : return 80 ;
-            case "9"   : return 90 ;
             case "9.0" : return 90 ;
-            case "10"  : return 100 ;
             case "10.0": return 100 ;
-            case "11"  : return 110 ;
             case "11.0": return 110 ;
             default:  throw new IllegalArgumentException("Unknown schema version [ " + version + " ]");
             

--- a/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/PlatformVersion.java
+++ b/dev/com.ibm.ws.javaee.dd.common/src/com/ibm/ws/javaee/dd/PlatformVersion.java
@@ -122,4 +122,46 @@ public interface PlatformVersion {
             default:  throw new IllegalArgumentException("Unknown schema version [ " + version + " ]");
         }
     }
+    
+    public static int getVersionInt(String version) {
+        switch ( version ) {
+            case "0.9" : return 9 ;
+            case "1.0" : return 10 ;
+            case "1.1" : return 11 ;
+            case "1.2" : return 12 ;
+            case "1.3" : return 13 ;
+            case "1.4" : return 14 ;
+            case "1.5" : return 15 ;
+            case "1.6" : return 16 ;
+            case "1.7" : return 17 ;
+            case "2.0" : return 20 ;
+            case "2.1" : return 21 ;
+            case "2.2" : return 22 ;
+            case "2.3" : return 23 ;
+            case "2.4" : return 24 ;
+            case "2.5" : return 25 ;
+            case "3.0" : return 30 ;
+            case "3.1" : return 31 ;
+            case "3.2" : return 32 ;
+            case "4"   : return 40 ;
+            case "4.0" : return 40 ;
+            case "5"   : return 50 ;
+            case "5.0" : return 50 ;
+            case "6"   : return 60 ;
+            case "6.0" : return 60 ;
+            case "6.1" : return 61 ;
+            case "7"   : return 70 ;
+            case "7.0" : return 70 ;
+            case "8"   : return 80 ;
+            case "8.0" : return 80 ;
+            case "9"   : return 90 ;
+            case "9.0" : return 90 ;
+            case "10"  : return 100 ;
+            case "10.0": return 100 ;
+            case "11"  : return 110 ;
+            case "11.0": return 110 ;
+            default:  throw new IllegalArgumentException("Unknown schema version [ " + version + " ]");
+            
+        }
+    }
 }

--- a/dev/com.ibm.ws.javaee.dd/resources/com/ibm/ws/javaee/dd/schemas/web-fragment_6_1.xsd
+++ b/dev/com.ibm.ws.javaee.dd/resources/com/ibm/ws/javaee/dd/schemas/web-fragment_6_1.xsd
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="6.1">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the Servlet 6.1 deployment descriptor.
+      The deployment descriptor must be named "META-INF/web-fragment.xml"
+      in the web fragment's jar file.  All Servlet deployment descriptors
+      must indicate the web application schema by using the Jakarta EE
+      namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and by indicating the version of the schema by
+      using the version element as shown below:
+      
+      <web-fragment xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="6.1">
+      ...
+      </web-fragment>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/web-fragment_6_1.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="web-common_6_1.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="web-fragment"
+               type="jakartaee:web-fragmentType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The web-fragment element is the root of the deployment
+        descriptor for a web fragment.  Note that the sub-elements
+        of this element can be in the arbitrary order. Because of
+        that, the multiplicity of the elements of distributable,
+        session-config, welcome-file-list, jsp-config, login-config,
+        and locale-encoding-mapping-list was changed from "?" to "*"
+        in this schema.  However, the deployment descriptor instance
+        file must not contain multiple elements of session-config,
+        jsp-config, and login-config. When there are multiple elements of
+        welcome-file-list or locale-encoding-mapping-list, the container
+        must concatenate the element contents.  The multiple occurence
+        of the element distributable is redundant and the container
+        treats that case exactly in the same way when there is only
+        one distributable.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="web-common-servlet-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The servlet element contains the name of a servlet.
+          The name must be unique within the web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:servlet"/>
+      <xsd:field xpath="jakartaee:servlet-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-filter-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The filter element contains the name of a filter.
+          The name must be unique within the web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:filter"/>
+      <xsd:field xpath="jakartaee:filter-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-ejb-local-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-local-ref-name element contains the name of an 
+          enterprise bean reference. The enterprise bean reference
+          is an entry in the web application's environment and is relative
+          to the java:comp/env context.  The name must be unique within
+          the web application.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:ejb-local-ref"/>
+      <xsd:field xpath="jakartaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-ejb-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-ref-name element contains the name of an  
+          enterprise bean reference. The enterprise bean reference 
+          is an entry in the web application's environment and is relative 
+          to the java:comp/env context.  The name must be unique within
+          the web application.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:ejb-ref"/>
+      <xsd:field xpath="jakartaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-resource-env-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The resource-env-ref-name element specifies the name of
+          a resource environment reference; its value is the
+          environment entry name used in the web application code.
+          The name is a JNDI name relative to the java:comp/env
+          context and must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-env-ref"/>
+      <xsd:field xpath="jakartaee:resource-env-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-message-destination-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The message-destination-ref-name element specifies the name of
+          a message destination reference; its value is the
+          environment entry name used in the web application code.
+          The name is a JNDI name relative to the java:comp/env
+          context and must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:message-destination-ref"/>
+      <xsd:field xpath="jakartaee:message-destination-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-res-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The res-ref-name element specifies the name of a
+          resource manager connection factory reference.  The name
+          is a JNDI name relative to the java:comp/env context.
+          The name must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-ref"/>
+      <xsd:field xpath="jakartaee:res-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-env-entry-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The env-entry-name element contains the name of a web
+          application's environment entry.  The name is a JNDI
+          name relative to the java:comp/env context.  The name
+          must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:env-entry"/>
+      <xsd:field xpath="jakartaee:env-entry-name"/>
+    </xsd:unique>
+    <xsd:key name="web-common-role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          A role-name-key is specified to allow the references
+          from the security-role-refs.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:security-role"/>
+      <xsd:field xpath="jakartaee:role-name"/>
+    </xsd:key>
+    <xsd:keyref name="web-common-role-name-references"
+                refer="jakartaee:web-common-role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The keyref indicates the references from
+          security-role-ref to a specified role-name.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:servlet/jakartaee:security-role-ref"/>
+      <xsd:field xpath="jakartaee:role-link"/>
+    </xsd:keyref>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="web-fragmentType">
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"/>
+      <xsd:group ref="jakartaee:web-commonType"/>
+      <xsd:element name="ordering"
+                   type="jakartaee:orderingType"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="jakartaee:web-common-attributes"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="orderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Please see section 8.2.2 of the specification for details.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="after"
+                   type="jakartaee:ordering-orderingType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="before"
+                   type="jakartaee:ordering-orderingType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ordering-orderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This element contains a sequence of "name" elements, each of
+        which
+        refers to an application configuration resource by the "name"
+        declared on its web.xml fragment.  This element can also contain
+        a single "others" element which specifies that this document
+        comes
+        before or after other documents within the application.
+        See section 8.2.2 of the specification for details.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="others"
+                   type="jakartaee:ordering-othersType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/web/WebApp.java
+++ b/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/web/WebApp.java
@@ -41,6 +41,14 @@ public interface WebApp extends ModuleDeploymentDescriptor, DeploymentDescriptor
                        VERSION_6_1
     };
 
+    int[] METADATA_COMPLETE_SUPPORT = {
+                                        VERSION_2_5,
+                                        VERSION_3_0, VERSION_3_1,
+                                        VERSION_4_0,
+                                        VERSION_5_0,
+                                        VERSION_6_0, VERSION_6_1
+    };
+
     String getVersion();
 
     boolean isSetMetadataComplete();

--- a/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/web/WebApp.java
+++ b/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/web/WebApp.java
@@ -41,14 +41,6 @@ public interface WebApp extends ModuleDeploymentDescriptor, DeploymentDescriptor
                        VERSION_6_1
     };
 
-    int[] METADATA_COMPLETE_SUPPORT = {
-                                        VERSION_2_5,
-                                        VERSION_3_0, VERSION_3_1,
-                                        VERSION_4_0,
-                                        VERSION_5_0,
-                                        VERSION_6_0, VERSION_6_1
-    };
-
     String getVersion();
 
     boolean isSetMetadataComplete();

--- a/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/web/WebFragment.java
+++ b/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/web/WebFragment.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,13 +21,14 @@ public interface WebFragment extends DeploymentDescriptor, WebCommon {
     String DD_NAME = "META-INF/web-fragment.xml";
 
     int[] VERSIONS = {
-        WebApp.VERSION_3_0, WebApp.VERSION_3_1, WebApp.VERSION_4_0,
-        WebApp.VERSION_5_0, WebApp.VERSION_6_0
+                       WebApp.VERSION_3_0, WebApp.VERSION_3_1, WebApp.VERSION_4_0,
+                       WebApp.VERSION_5_0, WebApp.VERSION_6_0, WebApp.VERSION_6_1
     };
-    
+
     String getVersion();
 
     boolean isSetMetadataComplete();
+
     boolean isMetadataComplete();
 
     String getName();

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/web/WebFragmentTest.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/web/WebFragmentTest.java
@@ -24,6 +24,7 @@ import com.ibm.ws.javaee.dd.common.ManagedThreadFactory;
 import com.ibm.ws.javaee.dd.web.WebApp;
 import com.ibm.ws.javaee.dd.web.WebFragment;
 import com.ibm.ws.javaee.ddmodel.DDJakarta10Elements;
+import com.ibm.ws.javaee.ddmodel.DDJakarta11Elements;
 
 /**
  * Web fragment descriptor parsing unit tests.
@@ -221,5 +222,67 @@ public class WebFragmentTest extends WebFragmentTestBase {
         List<ManagedThreadFactory> factories = webFragment.getManagedThreadFactories();
         DDJakarta10Elements.verifySize(names, 1, factories);
         DDJakarta10Elements.verify(names, factories.get(0));
-    }       
+    }    
+    
+    // EE11 element testing
+
+    @Test
+    public void testEE11ContextServiceWeb61() throws Exception {
+        WebFragment webFragment = parse(
+                webFragment( WebApp.VERSION_6_1, DDJakarta11Elements.CONTEXT_SERVICE_XML),
+                WebApp.VERSION_6_1);
+
+        List<String> names = new ArrayList<String>(5);
+        names.add("WebFragment");
+        names.add("contextServices");
+
+        List<ContextService> services = webFragment.getContextServices();
+        DDJakarta11Elements.verifySize(names, 1, services);
+        DDJakarta11Elements.verify(names, services.get(0));        
+    }   
+    
+    @Test
+    public void testEE11ManagedExecutorWebFragment61() throws Exception {
+        WebFragment webFragment = parse(
+                webFragment( WebApp.VERSION_6_1, DDJakarta11Elements.MANAGED_EXECUTOR_XML),
+                WebApp.VERSION_6_1);
+
+        List<String> names = new ArrayList<String>(5);
+        names.add("WebFragment");
+        names.add("managedExecutors");
+
+        List<ManagedExecutor> executors = webFragment.getManagedExecutors();
+        DDJakarta11Elements.verifySize(names, 1, executors);
+        DDJakarta11Elements.verify(names, executors.get(0));        
+    }    
+
+    @Test
+    public void testEE11ManagedScheduledExecutorWebFragment61() throws Exception {
+        WebFragment webFragment = parse(
+                webFragment( WebApp.VERSION_6_1, DDJakarta11Elements.MANAGED_SCHEDULED_EXECUTOR_XML),
+                WebApp.VERSION_6_1);
+
+        List<String> names = new ArrayList<String>(5);
+        names.add("WebFragment");
+        names.add("managedScheduledExecutors");
+        
+        List<ManagedScheduledExecutor> executors = webFragment.getManagedScheduledExecutors();
+        DDJakarta11Elements.verifySize(names, 1, executors);
+        DDJakarta11Elements.verify(names, executors.get(0));        
+    }        
+
+    @Test
+    public void testEE11ManagedThreadFactoryWebFragment61() throws Exception {
+        WebFragment webFragment = parse(
+                webFragment( WebApp.VERSION_6_1, DDJakarta11Elements.MANAGED_THREAD_FACTORY_XML),
+                WebApp.VERSION_6_1);
+
+        List<String> names = new ArrayList<String>(5);
+        names.add("WebFragment");
+        names.add("managedThreadFactories");
+        
+        List<ManagedThreadFactory> factories = webFragment.getManagedThreadFactories();
+        DDJakarta11Elements.verifySize(names, 1, factories);
+        DDJakarta11Elements.verify(names, factories.get(0));
+    }
 }

--- a/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/web/WebFragmentTestBase.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/test/com/ibm/ws/javaee/ddmodel/web/WebFragmentTestBase.java
@@ -146,7 +146,17 @@ public class WebFragmentTestBase extends DDTestBase {
                ">" +
                    body +
                webFragmentTail();
-    }    
+    }
+    
+    protected static String webFragment61(String body) {
+        return "<web-fragment xmlns=\"https://jakarta.ee/xml/ns/jakartaee\"" +
+                   " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                   " xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-fragment_6_1.xsd\"" +
+                   " version=\"6.1\"" +
+               ">" +
+                   body +
+               webFragmentTail();
+    } 
 
     protected static String webFragment(int schemaVersion) {
         return webFragment(schemaVersion, WebAppTestBase.webAppBody());
@@ -163,6 +173,8 @@ public class WebFragmentTestBase extends DDTestBase {
             return webFragment50(body);
         } else if ( version == WebApp.VERSION_6_0 ) {
             return webFragment60(body);
+        } else if ( version == WebApp.VERSION_6_1 ) {
+            return webFragment61(body);
         } else {
             throw new IllegalArgumentException("Unexpected WebFragment version [ " + version + " ]");
         }


### PR DESCRIPTION
- Looks like i missed creating a 6.1 version of the web-fragment schema which inherits from web-common.
- The main issue that caused the 6.1 web.xml files to cause the server to not create the correct context root was a version check using strings which I did not now existed
  - I updated this check instead search an array stored in the WebApp interface.
- Updated our functional test to use web-app 6.1

Schema update has been opened here: https://github.com/jakartaee/jakartaee-schemas/pull/45
