### PR TITLE
Performance updates for application start

### DIFF
--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/classsource/internal/ClassSourceImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/classsource/internal/ClassSourceImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -74,10 +74,12 @@ public abstract class ClassSourceImpl implements ClassSource {
      */
     @Trivial
     public String resourceAppend(String head, String tail) {
-        if ( head.isEmpty() ) {
+        int headLength = head.length();
+        if ( headLength == 0 ) {
             return tail;
         } else {
-            return (head + ClassSource.RESOURCE_SEPARATOR_CHAR + tail);
+            StringBuilder sb = new StringBuilder(headLength + tail.length() + 1);
+            return sb.append(head).append(ClassSource.RESOURCE_SEPARATOR_CHAR).append(tail).toString();
         }
     }    
 
@@ -155,9 +157,9 @@ public abstract class ClassSourceImpl implements ClassSource {
      */
     @Trivial
     public static String resourceNameFromClassName(String className) {
-        return
-            className.replace(ClassSource.CLASS_SEPARATOR_CHAR, RESOURCE_SEPARATOR_CHAR) +
-            ClassSource.CLASS_EXTENSION;
+        StringBuilder builder = new StringBuilder(className.length() + 6);
+        return builder.append(className.replace(ClassSource.CLASS_SEPARATOR_CHAR, RESOURCE_SEPARATOR_CHAR))
+                              .append(ClassSource.CLASS_EXTENSION).toString();
     }
 
     /**

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsTableAnnotationsImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsTableAnnotationsImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -45,20 +45,16 @@ public class TargetsTableAnnotationsImpl
 
     public static final String CLASS_NAME = TargetsTableAnnotationsImpl.class.getSimpleName();
 
-    protected final String hashText;
-
     @Override
     @Trivial
     public String getHashText() {
-        return hashText;
+        return getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
     }
 
     //
 
     protected TargetsTableAnnotationsImpl(TargetsTableAnnotationsImpl otherTable, UtilImpl_InternMap classNameInternMap) {
         String methodName = "<init>";
-
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
 
         this.utilFactory = otherTable.getUtilFactory();
         this.classNameInternMap = classNameInternMap;
@@ -71,7 +67,7 @@ public class TargetsTableAnnotationsImpl
         this.i_methodAnnotations = internAnnotations( "Classes with method annotations", otherTable.i_methodAnnotations );
 
         if ( logger.isLoggable(Level.FINER) ) {
-            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.hashText);
+            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.getHashText());
         }
     }
 
@@ -97,8 +93,6 @@ public class TargetsTableAnnotationsImpl
     protected TargetsTableAnnotationsImpl(UtilImpl_Factory utilFactory, UtilImpl_InternMap classNameInternMap) {
         String methodName = "<init>";
 
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
-
         this.utilFactory = utilFactory;
         this.classNameInternMap = classNameInternMap;
 
@@ -112,7 +106,7 @@ public class TargetsTableAnnotationsImpl
                                                                          "annotations", classNameInternMap);
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.hashText);
+            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.getHashText());
         }
     }
 

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsTableClassesImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsTableClassesImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -63,12 +63,10 @@ public class TargetsTableClassesImpl
 
     public static final String CLASS_NAME = TargetsTableClassesImpl.class.getSimpleName(); 
 
-    protected final String hashText;
-
     @Override
     @Trivial
     public String getHashText() {
-        return hashText;
+        return getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
     }
 
     //
@@ -78,8 +76,6 @@ public class TargetsTableClassesImpl
                                       String classSourceName) {
 
         String methodName = "<init>";
-
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
 
         this.utilFactory = otherTable.getUtilFactory();
         this.classNameInternMap = classNameInternMap;
@@ -102,7 +98,7 @@ public class TargetsTableClassesImpl
         this.i_allImplementers = new IdentityHashMap<String, Set<String>>();
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.hashText);
+            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.getHashText());
         }
     }
 
@@ -174,8 +170,6 @@ public class TargetsTableClassesImpl
 
         String methodName = "<init>";
 
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
-
         this.utilFactory = utilFactory;
         this.classNameInternMap = classNameInternMap;
 
@@ -195,7 +189,7 @@ public class TargetsTableClassesImpl
         this.i_allImplementers = new IdentityHashMap<String, Set<String>>();
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.hashText);
+            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.getHashText());
         }
     }
 
@@ -848,7 +842,7 @@ public class TargetsTableClassesImpl
 
         Object[] logParms;
         if ( logger.isLoggable(Level.FINER) ) {
-            logParms = new Object[] { this.hashText, null };
+            logParms = new Object[] { this.getHashText(), null };
         } else {
             logParms = null;
         }
@@ -1022,7 +1016,7 @@ public class TargetsTableClassesImpl
 
         if ( logger.isLoggable(Level.FINER) ) {
             logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ] [ {1} ] ({2})",
-                        new Object[] { hashText, Boolean.valueOf(sameAs), sameAsReason });
+                        new Object[] { getHashText(), Boolean.toString(sameAs), sameAsReason });
         }
         return sameAs;
     }
@@ -1281,6 +1275,7 @@ public class TargetsTableClassesImpl
         i_addModifiers( otherClassTable.i_getModifiers(), i_newlyAddedClassNames );
 
         if ( logger.isLoggable(Level.FINER) ) {
+            String hashText = getHashText();
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                         "[ {0} ]", hashText);
             logger.logp(Level.FINER, CLASS_NAME, methodName,

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsTableClassesMultiImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsTableClassesMultiImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -66,7 +66,7 @@ public class TargetsTableClassesMultiImpl extends TargetsTableClassesImpl
         this.i_classSourceClassNamesMap = new HashMap<String, Set<String>>();
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.hashText);
+            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.getHashText());
         }
     }
 

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsTableImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsTableImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -55,12 +55,10 @@ public class TargetsTableImpl implements TargetsTable {
 
     public static final String CLASS_NAME = TargetsTableImpl.class.getSimpleName();
 
-    protected final String hashText;
-
     @Override
     @Trivial
     public String getHashText() {
-        return hashText;
+        return getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
     }
 
     //
@@ -87,8 +85,6 @@ public class TargetsTableImpl implements TargetsTable {
 
         String methodName = "<init>";
 
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
-
         this.factory = sourceData.getFactory();
 
         this.classNameInternMap = classNameInternMap;
@@ -112,12 +108,13 @@ public class TargetsTableImpl implements TargetsTable {
         //
 
         if ( logger.isLoggable(Level.FINER) ) {
+            String hashText = getHashText();
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                         "[ {0} ] [ {1} ]",
-                        new Object[] { this.hashText, this.classSourceName });
+                        new Object[] { hashText, this.classSourceName });
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                         "[ {0} ] from [ {1} ]",
-                        new Object[] { this.hashText, sourceData.getHashText() });
+                        new Object[] { hashText, sourceData.getHashText() });
         }
     }
 
@@ -173,8 +170,6 @@ public class TargetsTableImpl implements TargetsTable {
 
         String methodName = "<init>";
 
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
-
         this.factory = factory;
 
         this.classNameInternMap = classNameInternMap;
@@ -198,18 +193,19 @@ public class TargetsTableImpl implements TargetsTable {
         //
 
         if ( logger.isLoggable(Level.FINER) ) {
+            String hashText = getHashText();
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                         "[ {0} ] [ {1} ]", 
-                        new Object[] { this.hashText, this.classSourceName });
+                        new Object[] { hashText, this.classSourceName });
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                         "[ {0} ] [ {1} ]",
-                        new Object[] { this.hashText, this.stampTable.getHashText() });
+                        new Object[] { hashText, this.stampTable.getHashText() });
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                         "[ {0} ] [ {1} ]",
-                        new Object[] { this.hashText, this.classTable.getHashText() });
+                        new Object[] { hashText, this.classTable.getHashText() });
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                         "[ {0} ] [ {1} ]",
-                        new Object[] { this.hashText, this.annotationTable.getHashText() });
+                        new Object[] { hashText, this.annotationTable.getHashText() });
         }
     }
 

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsTableTimeStampImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsTableTimeStampImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -36,12 +36,10 @@ public class TargetsTableTimeStampImpl
 
     public static final String CLASS_NAME = TargetsTableTimeStampImpl.class.getSimpleName();
 
-    protected final String hashText;
-
     @Override
     @Trivial
     public String getHashText() {
-        return hashText;
+        return getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
     }
 
     //
@@ -49,20 +47,16 @@ public class TargetsTableTimeStampImpl
     public TargetsTableTimeStampImpl() {
         String methodName = "<init>";
 
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
-
         this.name = null;
         this.stamp = null;
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.hashText);
+            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.getHashText());
         }
     }
 
     public TargetsTableTimeStampImpl(String name) {
         String methodName = "<init>";
-
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
 
         this.name = name;
         this.stamp = null;
@@ -70,14 +64,12 @@ public class TargetsTableTimeStampImpl
         if (logger.isLoggable(Level.FINER)) {
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                         "[ {0} ] [ {1} ]",
-                        new Object[] { this.hashText, this.name });
+                        new Object[] { this.getHashText(), this.name });
         }
     }
 
     public TargetsTableTimeStampImpl(String name, String stamp) {
         String methodName = "<init>";
-
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
 
         this.name = name;
         this.stamp = stamp;
@@ -85,7 +77,7 @@ public class TargetsTableTimeStampImpl
         if (logger.isLoggable(Level.FINER)) {
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                         "[ {0} ] [ {1} ] [ {2} ]",
-                        new Object[] { this.hashText, this.name, this.stamp });
+                        new Object[] { this.getHashText(), this.name, this.stamp });
         }
     }
 

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsVisitorClassImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsVisitorClassImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -106,7 +106,7 @@ public class TargetsVisitorClassImpl extends ClassVisitor {
         Type type = Type.getType(desc);
         String className = type.getClassName();
 
-        String resourceName = className.replace(".", "/");
+        String resourceName = className.replace('.', '/');
 
         return resourceName;
     }
@@ -122,7 +122,7 @@ public class TargetsVisitorClassImpl extends ClassVisitor {
     }
 
     protected static String getClassNameFromPartialResourceName(String partialResourceName) {
-        return partialResourceName.replace("/", ".");
+        return partialResourceName.replace('/', '.');
     }
 
     // Top of the world ...
@@ -153,7 +153,6 @@ public class TargetsVisitorClassImpl extends ClassVisitor {
         super(ASMHelper.getCurrentASM());
 
         String methodName = "<init>";
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
 
         this.targetsData = parentData;
 
@@ -176,12 +175,13 @@ public class TargetsVisitorClassImpl extends ClassVisitor {
         this.annotationVisitor = (recordDetail ? new TargetsVisitorAnnotationImpl(this) : null );
 
         if (logger.isLoggable(Level.FINER)) {
+            String hashText = getHashText();
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                     "[ {0} ] on [ {1} ]",
-                    new Object[] { this.hashText, this.targetsData.getHashText() });
+                    new Object[] { hashText, this.targetsData.getHashText() });
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                     "[ {0} ] detail [ {1} ]",
-                    new Object[] { this.hashText, Boolean.valueOf(recordDetail) });
+                    new Object[] { hashText, Boolean.toString(recordDetail) });
         }
     }
 
@@ -197,11 +197,9 @@ public class TargetsVisitorClassImpl extends ClassVisitor {
 
     // Trace ...
 
-    protected final String hashText;
-
     @Trivial
     public String getHashText() {
-        return hashText;
+        return getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
     }
 
     // The target which is updated by this visitor and associated methods.

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsVisitorJandexConverterImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsVisitorJandexConverterImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -71,13 +71,9 @@ public class TargetsVisitorJandexConverterImpl {
         return (className.substring(0, className.length() - (PACKAGE_INFO_CLASS_NAME.length() + 1)));
     }
 
-    //
-    
-    protected final String hashText;
-
     @Trivial
     public String getHashText() {
-        return hashText;
+        return CLASS_NAME + "@" + Integer.toHexString(hashCode());
     }
 
     public TargetsVisitorJandexConverterImpl(TargetsTableImpl targetsTable) {
@@ -85,8 +81,6 @@ public class TargetsVisitorJandexConverterImpl {
         this.classesTable = targetsTable.getClassTable();
         this.annotationsTable = targetsTable.getAnnotationTable();
         // this.detailsTable = targetsTable.getDetailsTable();
-
-        this.hashText = CLASS_NAME + "@" + Integer.toHexString(hashCode());
     }
 
     //

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsVisitorSparseJandexConverterImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsVisitorSparseJandexConverterImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -62,11 +62,9 @@ public class TargetsVisitorSparseJandexConverterImpl {
 
     //
 
-    protected final String hashText;
-
     @Trivial
     public String getHashText() {
-        return hashText;
+        return CLASS_NAME + "@" + Integer.toHexString(hashCode());
     }
 
     //
@@ -75,8 +73,6 @@ public class TargetsVisitorSparseJandexConverterImpl {
         this.targetsTable = targetsTable;
         this.classesTable = targetsTable.getClassTable();
         this.annotationsTable = targetsTable.getAnnotationTable();
-
-        this.hashText = CLASS_NAME + "@" + Integer.toHexString(hashCode());
     }
 
     //

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_BidirectionalMap.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_BidirectionalMap.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -33,12 +33,11 @@ public class UtilImpl_BidirectionalMap implements Util_BidirectionalMap {
 
     public static final String CLASS_NAME = "UtilImpl_BidirectionalMap";
 
-    protected final String hashText;
-
     @Override
     @Trivial
     public String getHashText() {
-        return hashText;
+        return getClass().getSimpleName() + "@" + Integer.toHexString(hashCode()) +
+                        "(" + holderTag + " : " + heldTag + ")";
     }
 
     //
@@ -50,9 +49,6 @@ public class UtilImpl_BidirectionalMap implements Util_BidirectionalMap {
         super();
 
         String methodName = "<init>";
-
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode()) +
-                        "(" + holderTag + " : " + heldTag + ")";
 
         this.factory = factory;
 
@@ -66,7 +62,7 @@ public class UtilImpl_BidirectionalMap implements Util_BidirectionalMap {
         this.i_heldToHoldersMap = new IdentityHashMap<String, Set<String>>();
 
         if ( logger.isLoggable(Level.FINER) ) {
-            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.hashText);
+            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.getHashText());
         }
     }
 
@@ -99,7 +95,7 @@ public class UtilImpl_BidirectionalMap implements Util_BidirectionalMap {
         return holderTag;
     }
 
-    protected String heldTag;
+    protected final String heldTag;
 
     @Override
     @Trivial
@@ -505,25 +501,27 @@ public class UtilImpl_BidirectionalMap implements Util_BidirectionalMap {
     @Override
     @Trivial
     public void log(Logger useLogger) {
-        String methodName = "log";
-        
-        useLogger.logp(Level.FINER, CLASS_NAME, methodName, "BiDi Map: BEGIN: [ {0} ]", getHashText());
+        if (useLogger.isLoggable(Level.FINER)) {
+            String methodName = "log";
 
-        useLogger.logp(Level.FINER, CLASS_NAME, methodName, "Holder Intern Map:");
-        getHolderInternMap().log(useLogger);
+            useLogger.logp(Level.FINER, CLASS_NAME, methodName, "BiDi Map: BEGIN: [ {0} ]", getHashText());
 
-        useLogger.logp(Level.FINER, CLASS_NAME, methodName, "Held Intern Map:");
-        getHeldInternMap().log(useLogger);
+            useLogger.logp(Level.FINER, CLASS_NAME, methodName, "Holder Intern Map:");
+            getHolderInternMap().log(useLogger);
 
-        logHolderMap(useLogger);
+            useLogger.logp(Level.FINER, CLASS_NAME, methodName, "Held Intern Map:");
+            getHeldInternMap().log(useLogger);
 
-        logHeldMap(useLogger);
+            logHolderMap(useLogger);
 
-        useLogger.logp(Level.FINER, CLASS_NAME, methodName, "BiDi Map: END: [ {0} ]", getHashText());
+            logHeldMap(useLogger);
+
+            useLogger.logp(Level.FINER, CLASS_NAME, methodName, "BiDi Map: END: [ {0} ]", getHashText());
+        }
     }
 
     @Trivial
-    public void logHolderMap(Logger useLogger) {
+    private void logHolderMap(Logger useLogger) {
         String methodName = "logHolderMap";
 
         useLogger.logp(Level.FINER, CLASS_NAME, methodName, "Holder-to-held Map: BEGIN");
@@ -541,7 +539,7 @@ public class UtilImpl_BidirectionalMap implements Util_BidirectionalMap {
     }
 
     @Trivial
-    public void logHeldMap(Logger useLogger) {
+    private void logHeldMap(Logger useLogger) {
         String methodName = "logHeldMap";
 
         useLogger.logp(Level.FINER, CLASS_NAME, methodName, "Held-to-holder Map: BEGIN");
@@ -692,25 +690,27 @@ public class UtilImpl_BidirectionalMap implements Util_BidirectionalMap {
     @Override
     @Trivial
     public void log(TraceComponent useLogger) {
-        Tr.debug(useLogger, MessageFormat.format("BEGIN Intern Map [ {0} ]:", getHashText()));
+        if (useLogger.isDebugEnabled()) {
+            Tr.debug(useLogger, MessageFormat.format("BEGIN Intern Map [ {0} ]:", getHashText()));
 
-        Tr.debug(useLogger, MessageFormat.format("BiDi Map: BEGIN: [ {0} ]", getHashText()));
+            Tr.debug(useLogger, MessageFormat.format("BiDi Map: BEGIN: [ {0} ]", getHashText()));
 
-        Tr.debug(useLogger, "Holder Intern Map:");
-        getHolderInternMap().log(useLogger);
+            Tr.debug(useLogger, "Holder Intern Map:");
+            getHolderInternMap().log(useLogger);
 
-        Tr.debug(useLogger, "Held Intern Map:");
-        getHeldInternMap().log(useLogger);
+            Tr.debug(useLogger, "Held Intern Map:");
+            getHeldInternMap().log(useLogger);
 
-        logHolderMap(useLogger);
+            logHolderMap(useLogger);
 
-        logHeldMap(useLogger);
+            logHeldMap(useLogger);
 
-        Tr.debug(useLogger, MessageFormat.format("BiDi Map: END: [ {0} ]", getHashText()));
+            Tr.debug(useLogger, MessageFormat.format("BiDi Map: END: [ {0} ]", getHashText()));
+        }
     }
 
     @Trivial
-    public void logHolderMap(TraceComponent useLogger) {
+    private void logHolderMap(TraceComponent useLogger) {
         Tr.debug(useLogger, "Holder-to-held Map: BEGIN");
 
         for (Map.Entry<String, Set<String>> i_holderEntry : i_holderToHeldMap.entrySet()) {
@@ -726,7 +726,7 @@ public class UtilImpl_BidirectionalMap implements Util_BidirectionalMap {
     }
 
     @Trivial
-    public void logHeldMap(TraceComponent useLogger) {
+    private void logHeldMap(TraceComponent useLogger) {
         Tr.debug(useLogger, "Held-to-holder Map: BEGIN");
 
         for ( Map.Entry<String, Set<String>> i_heldEntry : i_heldToHoldersMap.entrySet() ) {

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_EmptyBidirectionalMap.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_EmptyBidirectionalMap.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -29,12 +29,11 @@ public class UtilImpl_EmptyBidirectionalMap implements Util_BidirectionalMap {
 
     public static final String CLASS_NAME = "UtilImpl_EmptyBidirectionalMap";
 
-    protected final String hashText;
-
     @Override
     @Trivial
     public String getHashText() {
-        return hashText;
+        return getClass().getSimpleName() + "@" + Integer.toHexString(hashCode()) +
+                        "(" + holderInternMap.getName() + " : " + heldInternMap.getName() + ")";
     }
 
     //
@@ -47,16 +46,13 @@ public class UtilImpl_EmptyBidirectionalMap implements Util_BidirectionalMap {
 
         String methodName = "<init>";
 
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode()) +
-                        "(" + holderTag + " : " + heldTag + ")";
-        
         this.factory = factory;
 
         this.holderInternMap = factory.createEmptyInternMap(holderType, holderTag);
         this.heldInternMap = factory.createEmptyInternMap(heldType, heldTag);
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.hashText);
+            logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ]", this.getHashText());
         }
     }
 

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_EmptyInternMap.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_EmptyInternMap.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -28,12 +28,11 @@ public class UtilImpl_EmptyInternMap implements Util_InternMap {
     private static final Logger logger = Logger.getLogger("com.ibm.ws.annocache.util");
     public static final String CLASS_NAME = "UtilImpl_EmptyInternMap";
 
-    protected final String hashText;
-
     @Override
     @Trivial
     public String getHashText() {
-        return hashText;
+        return getClass().getSimpleName() + "@" + Integer.toHexString(hashCode()) +
+                        "(" + this.name + ")";
     }
 
     @Override
@@ -59,16 +58,13 @@ public class UtilImpl_EmptyInternMap implements Util_InternMap {
 
         this.name = name;
 
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode()) +
-                        "(" + this.name + ")";
-
         this.valueType = valueType;
         this.checkValues = logger.isLoggable(Level.FINER);
 
         if (logger.isLoggable(Level.FINER)) {
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                     "[ {0} ] Value type [ {1} ]",
-                    new Object[] { this.hashText, this.valueType });
+                    new Object[] { this.getHashText(), this.valueType });
         }
     }
 

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_FileStamp.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_FileStamp.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -54,7 +54,8 @@ public class UtilImpl_FileStamp {
 
                 long length = file.length();
                 long lastModified = file.lastModified();
-                return Long.toString(length) + "," + Long.toString(lastModified);
+                StringBuilder stampBuilder = new StringBuilder(40);
+                return stampBuilder.append(length).append(',').append(lastModified).toString();
             }
         } );
     }

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_InternMap.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_InternMap.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -30,12 +30,12 @@ public class UtilImpl_InternMap implements Util_InternMap {
 
     public static final String CLASS_NAME = "UtilImpl_InternMap";
 
-    protected final String hashText;
-
     @Override
     @Trivial
     public String getHashText() {
-        return hashText;
+        return getClass().getSimpleName() + "@" + Integer.toHexString(hashCode()) +
+                        "(" + this.name + ")";
+
     }
 
     public static final int DEFAULT_LOG_THRESHHOLD = 1024 * 4;
@@ -137,9 +137,6 @@ public class UtilImpl_InternMap implements Util_InternMap {
 
         this.name = name;
 
-        this.hashText = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode()) +
-                        "(" + this.name + ")";
-
         this.valueType = valueType;
         this.checkValues = logger.isLoggable(Level.FINER);
 
@@ -150,7 +147,7 @@ public class UtilImpl_InternMap implements Util_InternMap {
         if ( logger.isLoggable(Level.FINER) ) {
             logger.logp(Level.FINER, CLASS_NAME, methodName,
                     "[ {0} ] Value type [ {1} ] Log threshhold [ {2} ]",
-                    new Object[] { this.hashText,
+                    new Object[] { this.getHashText(),
                                    this.valueType,
                                    Integer.valueOf(this.logThreshHold) });
         }
@@ -265,7 +262,7 @@ public class UtilImpl_InternMap implements Util_InternMap {
             if ( logger.isLoggable(Level.FINER) ) {
                 logger.logp(Level.FINER, CLASS_NAME, methodName,
                         "[ {0} ] Total [ {1} ]",
-                        new Object[] { hashText, Integer.valueOf(totalLength) });
+                        new Object[] { getHashText(), Integer.valueOf(totalLength) });
             }
         }
 

--- a/dev/com.ibm.ws.app.manager.module/src/com/ibm/ws/app/manager/module/internal/SimpleDeployedAppInfoBase.java
+++ b/dev/com.ibm.ws.app.manager.module/src/com/ibm/ws/app/manager/module/internal/SimpleDeployedAppInfoBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -42,6 +42,7 @@ import com.ibm.ws.container.service.app.deploy.extended.AltDDEntryGetter;
 import com.ibm.ws.container.service.app.deploy.extended.ApplicationInfoFactory;
 import com.ibm.ws.container.service.app.deploy.extended.ExtendedApplicationInfo;
 import com.ibm.ws.container.service.app.deploy.extended.ExtendedModuleInfo;
+import com.ibm.ws.container.service.app.deploy.extended.ManifestClassPathHelper;
 import com.ibm.ws.container.service.app.deploy.extended.ModuleContainerInfo;
 import com.ibm.ws.container.service.metadata.MetaDataException;
 import com.ibm.ws.container.service.metadata.MetaDataService;
@@ -77,7 +78,7 @@ public abstract class SimpleDeployedAppInfoBase implements DeployedAppInfo {
             if (containerInfos == null) {
                 Set<String> resolved = new HashSet<String>();
                 containerInfos = new ArrayList<ContainerInfo>();
-                ManifestClassPathUtils.processMFClasspath(moduleEntry, containerInfos, resolved);
+                ManifestClassPathHelper.processMFClasspath(moduleEntry, moduleContainer, containerInfos, resolved, false);
                 entryContainerInfosMap.put(entryIdentity, containerInfos);
             }
             return containerInfos;
@@ -276,7 +277,7 @@ public abstract class SimpleDeployedAppInfoBase implements DeployedAppInfo {
                 };
                 this.classesContainerInfo.add(containerInfo);
                 Set<String> resolved = new HashSet<String>();
-                ManifestClassPathUtils.addCompleteJarEntryUrls(this.classesContainerInfo, entry, resolved);
+                ManifestClassPathHelper.addCompleteJarEntryUrls(this.classesContainerInfo, entry, jarContainer, resolved);
                 for (Entry childEntry : jarContainer) {
                     getEntryClassesInfo(childEntry);
                 }
@@ -431,7 +432,7 @@ public abstract class SimpleDeployedAppInfoBase implements DeployedAppInfo {
                                 };
                                 this.classesContainerInfo.add(containerInfo);
 
-                                ManifestClassPathUtils.addCompleteJarEntryUrls(this.classesContainerInfo, entry, resolved);
+                                ManifestClassPathHelper.addCompleteJarEntryUrls(this.classesContainerInfo, entry, jarContainer, resolved);
                             }
                         }
                     }

--- a/dev/com.ibm.ws.app.manager.springboot/src/com/ibm/ws/app/manager/springboot/internal/SpringBootApplicationImpl.java
+++ b/dev/com.ibm.ws.app.manager.springboot/src/com/ibm/ws/app/manager/springboot/internal/SpringBootApplicationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -101,10 +101,10 @@ import com.ibm.ws.app.manager.springboot.util.SpringBootThinUtil;
 import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
 import com.ibm.ws.container.service.app.deploy.ContainerInfo;
 import com.ibm.ws.container.service.app.deploy.ContainerInfo.Type;
-import com.ibm.ws.container.service.app.deploy.ManifestClassPathUtils;
 import com.ibm.ws.container.service.app.deploy.ModuleClassesContainerInfo;
 import com.ibm.ws.container.service.app.deploy.ModuleInfo;
 import com.ibm.ws.container.service.app.deploy.extended.ExtendedApplicationInfo;
+import com.ibm.ws.container.service.app.deploy.extended.ManifestClassPathHelper;
 import com.ibm.ws.container.service.metadata.MetaDataException;
 import com.ibm.ws.container.service.metadata.extended.ModuleMetaDataExtender;
 import com.ibm.ws.container.service.metadata.extended.NestedModuleMetaDataFactory;
@@ -809,7 +809,7 @@ public class SpringBootApplicationImpl extends DeployedAppInfoBase implements Sp
                         if (jarContainer != null) {
                             ContainerInfo containerInfo = new ContainerInfoImpl(Type.WEB_INF_LIB, manifest.getSpringBootLib() + '/' + jarEntryName, jarContainer);
                             result.add(containerInfo);
-                            ManifestClassPathUtils.addCompleteJarEntryUrls(result, entry, resolved);
+                            ManifestClassPathHelper.addCompleteJarEntryUrls(result, entry, jarContainer, resolved);
                         }
                     }
                 }

--- a/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfo.java
+++ b/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfo.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -45,11 +45,11 @@ import com.ibm.ws.container.service.app.deploy.ClientModuleInfo;
 import com.ibm.ws.container.service.app.deploy.ConnectorModuleInfo;
 import com.ibm.ws.container.service.app.deploy.ContainerInfo;
 import com.ibm.ws.container.service.app.deploy.EJBModuleInfo;
-import com.ibm.ws.container.service.app.deploy.ManifestClassPathUtils;
 import com.ibm.ws.container.service.app.deploy.ModuleClassesContainerInfo;
 import com.ibm.ws.container.service.app.deploy.ModuleInfo;
 import com.ibm.ws.container.service.app.deploy.WebModuleInfo;
 import com.ibm.ws.container.service.app.deploy.extended.ExtendedApplicationInfo;
+import com.ibm.ws.container.service.app.deploy.extended.ManifestClassPathHelper;
 import com.ibm.ws.javaee.dd.app.Application;
 import com.ibm.ws.javaee.dd.app.Module;
 import com.ibm.ws.javaee.ddmodel.DDParser;
@@ -402,7 +402,7 @@ public class EARDeployedAppInfo extends DeployedAppInfoBase {
                 useLibsInfos.add(libInfo);
 
                 try {
-                    ManifestClassPathUtils.addCompleteJarEntryUrls(useLibsInfos, libEntry, resolvedManifestIdentities);
+                    ManifestClassPathHelper.addCompleteJarEntryUrls(useLibsInfos, libEntry, libContainer, resolvedManifestIdentities);
                     // throws UnableToAdaptException
                 } catch (UnableToAdaptException e) {
                     // FFDC

--- a/dev/com.ibm.ws.artifact.file/src/com/ibm/ws/artifact/file/internal/FileEntry.java
+++ b/dev/com.ibm.ws.artifact.file/src/com/ibm/ws/artifact/file/internal/FileEntry.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -35,6 +35,7 @@ public class FileEntry implements com.ibm.wsspi.artifact.ArtifactEntry {
     private final ArtifactContainer enclosingContainer;
     private final File file;
     private final FileContainer root;
+    private final String fileName;
 
     /**
      * Builds an Entry for a given File.
@@ -46,6 +47,7 @@ public class FileEntry implements com.ibm.wsspi.artifact.ArtifactEntry {
      */
     FileEntry(ArtifactContainer e, File f, FileContainer r, ContainerFactoryHolder c) {
         file = f;
+        fileName = file.getName();
         enclosingContainer = e;
         if (enclosingContainer == null) {
             throw new IllegalArgumentException("Null enclosing container");
@@ -63,17 +65,19 @@ public class FileEntry implements com.ibm.wsspi.artifact.ArtifactEntry {
     public String getPath() {
         //determine this Entries path by using path for the enclosing container & adding our name
         String path = enclosingContainer.getPath();
-        if (!path.equals("/")) {
-            path += "/" + file.getName();
-        } else {
-            path += file.getName();
+        int pathLength = path.length();
+        StringBuilder pathBuilder = new StringBuilder(pathLength + fileName.length() + 1);
+        pathBuilder.append(path);
+        if (pathLength != 1 || !path.equals("/")) {
+            pathBuilder.append('/');
         }
-        return path;
+        pathBuilder.append(fileName);
+        return pathBuilder.toString();
     }
 
     @Override
     public String getName() {
-        return file.getName();
+        return fileName;
     }
 
     @Override

--- a/dev/com.ibm.ws.artifact.overlay/src/com/ibm/ws/artifact/overlay/internal/DirectoryBasedOverlayContainerImpl.java
+++ b/dev/com.ibm.ws.artifact.overlay/src/com/ibm/ws/artifact/overlay/internal/DirectoryBasedOverlayContainerImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -117,6 +117,8 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
         private static final Set<ArtifactEntry> s = Collections.emptySet();
 
         private ArtifactEntry internalNext;
+        private StringBuilder baseIterBuilder = null;
+        int prefixLength = 0;
 
         /**
          * Build iterator for path, using overlay ArtifactContainer for data.
@@ -190,8 +192,17 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
                     //mask out entries as requested
                     //return overlaid entries if overlaid
                     //original entries if not
+                    if (baseIterBuilder == null) {
+                        baseIterBuilder = new StringBuilder(path);
+                        baseIterBuilder.append('/');
+                        prefixLength = baseIterBuilder.length();
+                    } else {
+                        baseIterBuilder.setLength(prefixLength);
+                    }
+
                     ArtifactEntry possible = baseIter.next();
-                    String possiblePath = path + "/" + possible.getName();
+                    baseIterBuilder.append(possible.getName());
+                    String possiblePath = baseIterBuilder.toString();
 
                     if (!overlay.getMaskedPaths().contains(possiblePath)) {
                         n = overlay.getEntry(possiblePath);

--- a/dev/com.ibm.ws.artifact.url/src/com/ibm/ws/artifact/url/internal/WSJarURLStreamHandler.java
+++ b/dev/com.ibm.ws.artifact.url/src/com/ibm/ws/artifact/url/internal/WSJarURLStreamHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2020 IBM Corporation and others.
+ * Copyright (c) 1997, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -352,7 +352,7 @@ public class WSJarURLStreamHandler extends AbstractURLStreamHandlerService { // 
                     if (length < 0) {
                         // unable to determine the uncompressed size from the ZipFile, so we must
                         // check the size manually by reading the zipEntry's stream
-                        length = Utils.getStreamLength(zipFile.getInputStream(zipEntry));
+                        length = Utils.getStreamLength(zipFileHandle.getInputStream(zipFile, zipEntry));
                     }
                 }
             } catch (IOException ex) {

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileData.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileData.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -598,6 +598,11 @@ ZipFile [Path]
             return new long[] {target.length(), target.lastModified()};
         }
     };
+
+    @Trivial
+    long getLastModified() {
+        return zipLastModified;
+    }
 
     /**
      * Re-acquire the ZIP file.

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileReaper.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileReaper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -160,6 +160,16 @@ public class ZipFileReaper {
             synchronized (completedStorage) {
                 completedStorage.validate();
             }
+        }
+    }
+
+    @Trivial
+    public static class OpenZipFile {
+        public final ZipFile zipFile;
+        final long lastModified;
+        OpenZipFile(ZipFile zipFile, long lastModified) {
+            this.zipFile = zipFile;
+            this.lastModified = lastModified;
         }
     }
 
@@ -1489,12 +1499,12 @@ public class ZipFileReaper {
     }
 
     @Trivial
-    public ZipFile open(String path) throws IOException, ZipException {
+    public OpenZipFile open(String path) throws IOException, ZipException {
         return open( path, System.nanoTime() );
     }
 
     @Trivial
-    public ZipFile open(String path, long openAt) throws IOException, ZipException {
+    public OpenZipFile open(String path, long openAt) throws IOException, ZipException {
         String methodName = "open";
         if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
             Tr.debug(tc, methodName + " Path [ " + path + " ] at [ " + toRelSec_s(initialAt, openAt) + " ]");
@@ -1597,7 +1607,7 @@ public class ZipFileReaper {
                 if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
                     Tr.debug(tc, methodName + " Path [ " + path + " ] [ " + zipFile + " ]");
                 }
-                return zipFile;
+                return new OpenZipFile(zipFile, data.getLastModified());
             }
         } finally {
             reaperLock.releaseReadLock();

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -88,6 +88,7 @@ public class ZipFileContainerUtils {
         private final String parentPath;
 
         private final int[] locations;
+        private final StringBuilder entryPathBuilder = new StringBuilder("/");
         private int index;
 
         @Trivial
@@ -140,25 +141,27 @@ public class ZipFileContainerUtils {
             //            gp/p/c2/gc1
 
             String entryName;
-            String entryPath;
+
+            // Always starts with a `/`
+            entryPathBuilder.setLength(1);
 
             int slashLoc = nextPath.indexOf('/', parentLen);
             if ( slashLoc == -1 ) {
                 // The location is an immediate child.
                 entryName = nextPath.substring(parentLen);
-                entryPath = nextPath;
+                entryPathBuilder.append(nextPath);
             } else {
                 // The location is a grandchild.
                 entryName = nextPath.substring(parentLen, slashLoc);
-                entryPath = nextPath.substring(0, slashLoc);
+                entryPathBuilder.append(nextPath, 0, slashLoc);
                 nextEntryData = null;
             }
 
-            String a_entryPath = "/" + entryPath;
+            String entryPath = entryPathBuilder.toString();
 
             ZipFileEntry nextZipFileEntry = rootContainer.createEntry(
                 nestedContainer,
-                entryName, a_entryPath,
+                entryName, entryPath,
                 nextEntryData);
 
             return nextZipFileEntry;

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileEntry.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileEntry.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011,2018 IBM Corporation and others.
+ * Copyright (c) 2011,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -459,7 +459,7 @@ public class ZipFileEntry implements ExtractableArtifactEntry {
                             enclosingName = r_enclosingPath.substring(lastSlash + 1); // r_enclosingPath = "parent/child/name"
                         }
                         ZipFileEntry entryInEnclosingContainer =
-                            rootContainer.createEntry(enclosingName, a_enclosingPath);
+                            rootContainer.createEntry(enclosingName, a_enclosingPath, r_enclosingPath);
                         enclosingContainer = entryInEnclosingContainer.convertToLocalContainer();
                     }
                 }

--- a/dev/com.ibm.ws.artifact.zip/test/com/ibm/ws/artifact/zip/cache/test/ZipFileReaperTest.java
+++ b/dev/com.ibm.ws.artifact.zip/test/com/ibm/ws/artifact/zip/cache/test/ZipFileReaperTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -1152,7 +1152,7 @@ public class ZipFileReaperTest {
                 try {
                     // debug(methodName, "Open " + actionText(reaper, actualActAt));
                     @SuppressWarnings("unused")
-                    ZipFile zipFile = reaper.open(path, actualActAt); // throws IOException, ZipException
+                    ZipFile zipFile = reaper.open(path, actualActAt).zipFile; // throws IOException, ZipException
                     // debug(methodName, "Opened " + actionText(reaper, actualActAt));
 
                 } catch ( Exception e ) {

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/annocache/internal/AnnotationsImpl.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/annocache/internal/AnnotationsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -260,7 +260,8 @@ public abstract class AnnotationsImpl implements Annotations {
                     targetPath = useModName;
                     targetPathCase = "Mod name replaces empty target path";
                 } else {
-                    targetPath = useModName + "_" + targetPath;
+                    StringBuilder targetPathBuilder = new StringBuilder(useModName.length() + targetPath.length() + 1);
+                    targetPath = targetPathBuilder.append(useModName).append('_').append(targetPath).toString();
                     targetPathCase = "Mod name prefix to non-local target path";
                 }
             }
@@ -269,10 +270,12 @@ public abstract class AnnotationsImpl implements Annotations {
             targetPathCase = "Full local path";
         }
 
-        String message = getClass().getSimpleName() + ".getContainerPath:" +
-            " Container [ " + targetContainer + " ]" +
-            " Path [ " + targetPath + " ]: " + targetPathCase;
-        Tr.debug(tc, message);
+        if (tc.isDebugEnabled()) {
+            String message = getClass().getSimpleName() + ".getContainerPath:" +
+                " Container [ " + targetContainer + " ]" +
+                " Path [ " + targetPath + " ]: " + targetPathCase;
+            Tr.debug(tc, message);
+        }
 
         return targetPath;
     }

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/app/deploy/ManifestClassPathUtils.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/app/deploy/ManifestClassPathUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,18 +12,12 @@
  *******************************************************************************/
 package com.ibm.ws.container.service.app.deploy;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
-import java.util.StringTokenizer;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.container.service.app.deploy.extended.ManifestClassPathHelper;
 import com.ibm.wsspi.adaptable.module.Container;
 import com.ibm.wsspi.adaptable.module.Entry;
 import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
@@ -37,7 +31,7 @@ public class ManifestClassPathUtils {
     /**
      * create an Entry Identity that can identify an entry in an ear/war archive
      * This is used to avoid the cross reference in jar files' Class-Path causing the non-stopping recursion
-     * 
+     *
      * @param entry
      * @return
      * @throws UnableToAdaptException
@@ -56,115 +50,11 @@ public class ManifestClassPathUtils {
         processMFClasspath(jarEntry, containers, resolved, false);
     }
 
-    @SuppressWarnings("deprecation")
     public static void processMFClasspath(Entry jarEntry, List<ContainerInfo> containers, Collection<String> resolved, boolean addRoot) throws UnableToAdaptException {
-        String mfClassPath = null;
         if (jarEntry != null) {
             Container jarContainer = jarEntry.adapt(Container.class);
             if (jarContainer != null) {
-
-                Entry manifestEntry = jarContainer.getEntry("/META-INF/MANIFEST.MF");
-                if (manifestEntry != null) {
-                    InputStream is = null;
-                    try {
-                        is = manifestEntry.adapt(InputStream.class);
-                        Manifest manifest = new Manifest(is);
-                        if (manifest != null) {
-                            mfClassPath = manifest.getMainAttributes().getValue(Attributes.Name.CLASS_PATH);
-                        }
-                    } catch (IOException e) {
-                        throw new UnableToAdaptException(e);
-                    } finally {
-                        if (is != null) {
-                            try {
-                                is.close();
-                            } catch (IOException io) {
-                            }
-                        }
-                    }
-                }
-
-            }//else no probs.. this jarEntry isn't usable as a container.. 
-        }
-
-        if (mfClassPath != null) {
-            for (StringTokenizer tokenizer = new StringTokenizer(mfClassPath, " "); tokenizer.hasMoreTokens();) {
-                String path = tokenizer.nextToken();
-
-                if (path.equals(".")) {
-                    if (addRoot) {
-                        //add the root of the container holding the ear, if there was one..
-                        final Container rootContainer = jarEntry.getRoot();
-                        containers.add(new ContainerInfo() {
-                            @Override
-                            public Type getType() {
-                                return Type.MANIFEST_CLASSPATH;
-                            }
-
-                            @Override
-                            public String getName() {
-                                return "/";
-                            }
-
-                            @Override
-                            public Container getContainer() {
-                                return rootContainer;
-                            }
-                        });
-                    }
-                } else {
-                    URI pathUri;
-                    try {
-                        pathUri = new URI(path);
-                    } catch (URISyntaxException e) {
-                        Tr.warning(tc, "WARN_INVALID_MANIFEST_CLASSPATH_DEFINITION", path, jarEntry.getResource());
-                        continue;
-                    }
-
-                    if (pathUri.isAbsolute()) {
-                        Tr.warning(tc, "WARN_INVALID_MANIFEST_CLASSPATH_DEFINITION", path, jarEntry.getResource());
-                        continue;
-                    }
-
-                    try {
-                        Entry classPathEntry = findClassPathEntry(jarEntry, pathUri); // <----
-                        if (classPathEntry == null) {
-                            Tr.warning(tc, "WARN_MANIFEST_CLASSPATH_NOT_FOUND", path, jarEntry.getResource());
-                            continue;
-                        }
-
-                        //does the entry convert to a container?
-                        final String classPathName = createEntryIdentity(classPathEntry);
-                        final Container classPathContainer = classPathEntry.adapt(Container.class);
-                        if (classPathContainer != null) {
-
-                            containers.add(new ContainerInfo() {
-                                @Override
-                                public Type getType() {
-                                    return Type.MANIFEST_CLASSPATH;
-                                }
-
-                                @Override
-                                public String getName() {
-                                    return classPathName;
-                                }
-
-                                @Override
-                                public Container getContainer() {
-                                    return classPathContainer;
-                                }
-                            });
-                        }
-
-                        //TODO: toLowerCase?
-                        if (classPathEntry.getName().endsWith(".jar")) {
-                            addCompleteJarEntryUrls(containers, classPathEntry, resolved);
-                        }
-                    } catch (URISyntaxException e) {
-                        //could not make sense of manifest entry..
-                        throw new UnableToAdaptException(e);
-                    }
-                }
+                ManifestClassPathHelper.processMFClasspath(jarEntry, jarContainer, containers, resolved, addRoot);
             }
         }
     }
@@ -172,7 +62,7 @@ public class ManifestClassPathUtils {
     /**
      * Add the jar entry URLs and its class path URLs.
      * We need deal with all the thrown exceptions so that it won't interrupt the caller's processing.
-     * 
+     *
      * @param urls
      * @param jarEntry
      */
@@ -181,31 +71,6 @@ public class ManifestClassPathUtils {
         if (!entryIdentity.isEmpty() && !resolved.contains(entryIdentity)) {
             resolved.add(entryIdentity);
             processMFClasspath(jarEntry, containers, resolved);
-        }
-    }
-
-    /**
-     * calculate the class path entry based on the jar entry
-     * 
-     * @param jarEntry
-     * @param pathUri
-     * @return
-     * @throws URISyntaxException
-     * @throws UnableToAdaptException
-     */
-    private static Entry findClassPathEntry(Entry jarEntry, URI pathUri) throws URISyntaxException, UnableToAdaptException {
-        URI relativeJarUri = new URI("/").relativize(new URI(jarEntry.getPath()));
-        URI targetUri = null;
-        targetUri = relativeJarUri.resolve(pathUri);
-
-        if (targetUri.toString().startsWith("..")) {
-            Entry rootEntry = jarEntry.getRoot().adapt(Entry.class);
-            if (rootEntry == null || rootEntry.getPath().isEmpty()) { //already at the outermost
-                return null;
-            }
-            return findClassPathEntry(rootEntry, new URI("..").relativize(targetUri)); // <----
-        } else {
-            return jarEntry.getRoot().getEntry(targetUri.toString());
         }
     }
 }

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/app/deploy/extended/ManifestClassPathHelper.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/app/deploy/extended/ManifestClassPathHelper.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.container.service.app.deploy.extended;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.List;
+import java.util.StringTokenizer;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.container.service.app.deploy.ContainerInfo;
+import com.ibm.ws.container.service.app.deploy.ManifestClassPathUtils;
+import com.ibm.wsspi.adaptable.module.Container;
+import com.ibm.wsspi.adaptable.module.Entry;
+import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
+
+/**
+ * Utilities to assist with processing manifest classpaths. This is an extension of ManifestClassPathUtils to pass in the Container.
+ */
+public class ManifestClassPathHelper {
+    static final TraceComponent tc = Tr.register(ManifestClassPathHelper.class);
+
+    public static void processMFClasspath(Entry jarEntry, Container jarContainer, List<ContainerInfo> containers, Collection<String> resolved,
+                                          boolean addRoot) throws UnableToAdaptException {
+        String mfClassPath = null;
+        if (jarEntry != null && jarContainer != null) {
+            Entry manifestEntry = jarContainer.getEntry("/META-INF/MANIFEST.MF");
+            if (manifestEntry != null) {
+                InputStream is = null;
+                try {
+                    is = manifestEntry.adapt(InputStream.class);
+                    Manifest manifest = new Manifest(is);
+                    if (manifest != null) {
+                        mfClassPath = manifest.getMainAttributes().getValue(Attributes.Name.CLASS_PATH);
+                    }
+                } catch (IOException e) {
+                    throw new UnableToAdaptException(e);
+                } finally {
+                    if (is != null) {
+                        try {
+                            is.close();
+                        } catch (IOException io) {
+                        }
+                    }
+                }
+            }
+        }
+
+        if (mfClassPath != null) {
+            for (StringTokenizer tokenizer = new StringTokenizer(mfClassPath, " "); tokenizer.hasMoreTokens();) {
+                String path = tokenizer.nextToken();
+
+                if (path.equals(".")) {
+                    if (addRoot) {
+                        //add the root of the container holding the ear, if there was one..
+                        final Container rootContainer = jarEntry.getRoot();
+                        containers.add(new ContainerInfo() {
+                            @Override
+                            public Type getType() {
+                                return Type.MANIFEST_CLASSPATH;
+                            }
+
+                            @Override
+                            public String getName() {
+                                return "/";
+                            }
+
+                            @Override
+                            public Container getContainer() {
+                                return rootContainer;
+                            }
+                        });
+                    }
+                } else {
+                    URI pathUri;
+                    try {
+                        pathUri = new URI(path);
+                    } catch (URISyntaxException e) {
+                        Tr.warning(tc, "WARN_INVALID_MANIFEST_CLASSPATH_DEFINITION", path, jarEntry.getResource());
+                        continue;
+                    }
+
+                    if (pathUri.isAbsolute()) {
+                        Tr.warning(tc, "WARN_INVALID_MANIFEST_CLASSPATH_DEFINITION", path, jarEntry.getResource());
+                        continue;
+                    }
+
+                    try {
+                        Entry classPathEntry = findClassPathEntry(jarEntry, pathUri); // <----
+                        if (classPathEntry == null) {
+                            Tr.warning(tc, "WARN_MANIFEST_CLASSPATH_NOT_FOUND", path, jarEntry.getResource());
+                            continue;
+                        }
+
+                        //does the entry convert to a container?
+                        final String classPathName = ManifestClassPathUtils.createEntryIdentity(classPathEntry);
+                        final Container classPathContainer = classPathEntry.adapt(Container.class);
+                        if (classPathContainer != null) {
+
+                            containers.add(new ContainerInfo() {
+                                @Override
+                                public Type getType() {
+                                    return Type.MANIFEST_CLASSPATH;
+                                }
+
+                                @Override
+                                public String getName() {
+                                    return classPathName;
+                                }
+
+                                @Override
+                                public Container getContainer() {
+                                    return classPathContainer;
+                                }
+                            });
+                        }
+
+                        //TODO: toLowerCase?
+                        if (classPathEntry.getName().endsWith(".jar")) {
+                            addCompleteJarEntryUrls(containers, classPathEntry, classPathContainer, resolved);
+                        }
+                    } catch (URISyntaxException e) {
+                        //could not make sense of manifest entry..
+                        throw new UnableToAdaptException(e);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Add the jar entry URLs and its class path URLs.
+     * We need deal with all the thrown exceptions so that it won't interrupt the caller's processing.
+     *
+     * @param urls
+     * @param jarEntry
+     */
+    public static void addCompleteJarEntryUrls(List<ContainerInfo> containers, Entry jarEntry, Container jarContainer, Collection<String> resolved) throws UnableToAdaptException {
+        String entryIdentity = ManifestClassPathUtils.createEntryIdentity(jarEntry);
+        if (!entryIdentity.isEmpty() && !resolved.contains(entryIdentity)) {
+            resolved.add(entryIdentity);
+            processMFClasspath(jarEntry, jarContainer, containers, resolved, false);
+        }
+    }
+
+    /**
+     * calculate the class path entry based on the jar entry
+     *
+     * @param jarEntry
+     * @param pathUri
+     * @return
+     * @throws URISyntaxException
+     * @throws UnableToAdaptException
+     */
+    private static Entry findClassPathEntry(Entry jarEntry, URI pathUri) throws URISyntaxException, UnableToAdaptException {
+        URI relativeJarUri = new URI("/").relativize(new URI(jarEntry.getPath()));
+        URI targetUri = null;
+        targetUri = relativeJarUri.resolve(pathUri);
+
+        if (targetUri.toString().startsWith("..")) {
+            Entry rootEntry = jarEntry.getRoot().adapt(Entry.class);
+            if (rootEntry == null || rootEntry.getPath().isEmpty()) { //already at the outermost
+                return null;
+            }
+            return findClassPathEntry(rootEntry, new URI("..").relativize(targetUri)); // <----
+        } else {
+            return jarEntry.getRoot().getEntry(targetUri.toString());
+        }
+    }
+}

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/app/deploy/internal/WebModuleClassesInfoAdapter.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/app/deploy/internal/WebModuleClassesInfoAdapter.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,8 +18,8 @@ import java.util.List;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.container.service.app.deploy.ContainerInfo;
-import com.ibm.ws.container.service.app.deploy.ManifestClassPathUtils;
 import com.ibm.ws.container.service.app.deploy.WebModuleClassesInfo;
+import com.ibm.ws.container.service.app.deploy.extended.ManifestClassPathHelper;
 import com.ibm.wsspi.adaptable.module.Container;
 import com.ibm.wsspi.adaptable.module.Entry;
 import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
@@ -36,7 +36,7 @@ public class WebModuleClassesInfoAdapter implements ContainerAdapter<WebModuleCl
 
     /*
      * This adapter processes JEE classpath locations..
-     * 
+     *
      * OSGi classpath locations are managed by the WAB installer,
      * and pre-cached to the overlay, to be returned by this adapter
      */
@@ -52,10 +52,10 @@ public class WebModuleClassesInfoAdapter implements ContainerAdapter<WebModuleCl
         ArrayList<String> resolved = new ArrayList<String>();
         final List<ContainerInfo> containerInfos = new ArrayList<ContainerInfo>();
 
-        //This should possibly be processing manifest classpath locations, like the old classloader did.. 
+        //This should possibly be processing manifest classpath locations, like the old classloader did..
         Entry moduleEntry = containerToAdapt.adapt(Entry.class);
         if (moduleEntry != null && !moduleEntry.getPath().isEmpty()) {
-            ManifestClassPathUtils.processMFClasspath(moduleEntry, containerInfos, resolved, true);
+            ManifestClassPathHelper.processMFClasspath(moduleEntry, containerToAdapt, containerInfos, resolved, true);
         }
 
         Entry classesEntry = containerToAdapt.getEntry("WEB-INF/classes");
@@ -113,7 +113,7 @@ public class WebModuleClassesInfoAdapter implements ContainerAdapter<WebModuleCl
                             };
                             containerInfos.add(containerInfo);
 
-                            ManifestClassPathUtils.addCompleteJarEntryUrls(containerInfos, entry, resolved);
+                            ManifestClassPathHelper.addCompleteJarEntryUrls(containerInfos, entry, jarContainer, resolved);
                         }
                     }
                 }

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/app/deploy/internal/WebModuleClassesInfoAdapter.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/app/deploy/internal/WebModuleClassesInfoAdapter.java
@@ -86,11 +86,15 @@ public class WebModuleClassesInfoAdapter implements ContainerAdapter<WebModuleCl
         if (libEntry != null) {
             Container libContainer = libEntry.adapt(Container.class);
             if (libContainer != null) {
+                StringBuilder infoNameBuilder = new StringBuilder("WEB-INF/lib/");
+                int prefixLength = infoNameBuilder.length();
                 for (Entry entry : libContainer) {
                     if (entry.getName().toLowerCase().endsWith(".jar")) {
                         final String jarEntryName = entry.getName();
                         final Container jarContainer = entry.adapt(Container.class);
                         if (jarContainer != null) {
+                            infoNameBuilder.setLength(prefixLength);
+                            final String infoName = infoNameBuilder.append(jarEntryName).toString();
                             ContainerInfo containerInfo = new ContainerInfo() {
                                 @Override
                                 public Type getType() {
@@ -99,7 +103,7 @@ public class WebModuleClassesInfoAdapter implements ContainerAdapter<WebModuleCl
 
                                 @Override
                                 public String getName() {
-                                    return "WEB-INF/lib/" + jarEntryName;
+                                    return infoName;
                                 }
 
                                 @Override

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/internal/WebFragmentsInfoImpl.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/internal/WebFragmentsInfoImpl.java
@@ -1,10 +1,10 @@
 /*********************************************************************
- * Copyright (c) 2012, 2023 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -182,6 +182,8 @@ class WebFragmentsInfoImpl implements WebFragmentsInfo {
         Map<String, WebFragmentItemImpl> webFragmentItemMap = new LinkedHashMap<String, WebFragmentItemImpl>(classesContainers.size());
 
         String internalGeneratedWebFragmentNamePrefix = "ibm_liberty_webfragment_";
+        int internalPrefixLength = internalGeneratedWebFragmentNamePrefix.length();
+        StringBuilder stringBuilder = null;
         int nameSuffix = 0;
         Set<String> usedWebFragmentNames = new HashSet<String>();
         for (ContainerInfo containerInfo : classesContainers) {
@@ -217,12 +219,20 @@ class WebFragmentsInfoImpl implements WebFragmentsInfo {
                     }
                 }
                 if (webFragmentName == null) {
-                    webFragmentName = internalGeneratedWebFragmentNamePrefix + nameSuffix;
-                    while (usedWebFragmentNames.contains(webFragmentName)) {
-                        nameSuffix++;
-                        webFragmentName = internalGeneratedWebFragmentNamePrefix + nameSuffix;
+                    if (stringBuilder == null) {
+                        stringBuilder = new StringBuilder(internalPrefixLength + 8);
+                        stringBuilder.append(internalGeneratedWebFragmentNamePrefix);
+                    } else {
+                        stringBuilder.setLength(internalPrefixLength);
                     }
-                    usedWebFragmentNames.add(webFragmentName);
+                    stringBuilder.append(nameSuffix);
+                    webFragmentName = stringBuilder.toString();
+                    while (!usedWebFragmentNames.add(webFragmentName)) {
+                        nameSuffix++;
+                        stringBuilder.setLength(internalPrefixLength);
+                        stringBuilder.append(nameSuffix);
+                        webFragmentName = stringBuilder.toString();
+                    }
                 }
 
                 webFragmentItemMap.put(webFragmentName, new WebFragmentItemImpl(container, webFragment, libraryURI, webFragmentName, isSeed));

--- a/dev/com.ibm.ws.kernel.filemonitor/src/com/ibm/ws/kernel/filemonitor/internal/DirectoryUpdateMonitor.java
+++ b/dev/com.ibm.ws.kernel.filemonitor/src/com/ibm/ws/kernel/filemonitor/internal/DirectoryUpdateMonitor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -90,7 +90,7 @@ public class DirectoryUpdateMonitor extends UpdateMonitor {
         // Check for special filter values here: ignored in hashCode
         filesOnly = FileMonitor.MONITOR_FILTER_FILES_ONLY.equals(fileFilter);
         directoriesOnly = filesOnly ? false : FileMonitor.MONITOR_FILTER_DIRECTORIES_ONLY.equals(fileFilter);
-        fileNameRegex = (filesOnly || directoriesOnly || filter == null) ? null : Pattern.compile(fileFilter);
+        fileNameRegex = (filesOnly || directoriesOnly || filter == null || ".*".equals(filter)) ? null : Pattern.compile(fileFilter);
     }
 
     /**


### PR DESCRIPTION
- Most of these are minor changes, but are on main line paths that can have cumulative benefits.
- Add isDebugEnabled / isLoggable checks around trace calls.
 - Update to use StringBuilder more efficiently by setting size and reusing an explicit StringBuilder instance instead of the compiler making new ones each time.
- Switch to use String.replace(char,char) instead of replace(String,String) for single character strings.
- Do not eagerly create and store hashText field in UtilsImpl Map objects and just compute it each time since it is only used for trace.
- Update to only use add instead of contains and add when seeing if something can be added to a Set.
- Do not get substring(1) in ZipFileContainer for no reason since nestedContainerEntries is only used in that method.
- ManifestClassPathUtils methods take an Entry object that is adapted from a Container object.  Before this PR the Entry was adapted back to a Container object just to call getEntry on it.  Instead of making a whole new Container object, pass in the original Container that was adapted to the Entry.  Had to put it in a new class since ManifestClassPathUtils is an SPI.

