### PR TITLE
Qualifier attribute comparisons and qualifiers in web deployment descriptor

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/bnd.bnd
@@ -28,8 +28,8 @@ fat.project: true
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
-	io.openliberty.jakarta.annotation.2.0;version=latest,\
-	io.openliberty.jakarta.cdi.3.0;version=latest,\
+	io.openliberty.jakarta.annotation.2.1;version=latest,\
+	io.openliberty.jakarta.cdi.4.1;version=latest,\
 	io.openliberty.jakarta.concurrency.3.1;version=latest,\
-	io.openliberty.jakarta.servlet.5.0;version=latest,\
+	io.openliberty.jakarta.servlet.6.1;version=latest,\
 	io.openliberty.jakarta.transaction.2.0;version=latest

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -81,7 +81,12 @@ public class ConcurrentCDITest extends FATServletClient {
     }
 
     @Test
-    public void testInjectContextServiceQualified() throws Exception {
+    public void testInjectContextServiceQualifiedFromAnno() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectContextServiceQualifiedFromWebDD() throws Exception {
         runTest(server, APP_NAME, testName);
     }
 
@@ -91,7 +96,12 @@ public class ConcurrentCDITest extends FATServletClient {
     }
 
     @Test
-    public void testInjectManagedExecutorServiceQualified() throws Exception {
+    public void testInjectManagedExecutorServiceQualifiedFromAnno() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectManagedExecutorServiceQualifiedFromWebDD() throws Exception {
         runTest(server, APP_NAME, testName);
     }
 
@@ -101,7 +111,12 @@ public class ConcurrentCDITest extends FATServletClient {
     }
 
     @Test
-    public void testInjectManagedScheduledExecutorServiceQualified() throws Exception {
+    public void testInjectManagedScheduledExecutorServiceQualifiedFromAnno() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectManagedScheduledExecutorServiceQualifiedFromWebDD() throws Exception {
         runTest(server, APP_NAME, testName);
     }
 
@@ -111,7 +126,12 @@ public class ConcurrentCDITest extends FATServletClient {
     }
 
     @Test
-    public void testInjectManagedThreadFactoryQualified() throws Exception {
+    public void testInjectManagedThreadFactoryQualifiedFromAnno() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectManagedThreadFactoryQualifiedFromWebDD() throws Exception {
         runTest(server, APP_NAME, testName);
     }
 

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -70,7 +70,7 @@ public class ConcurrentCDITest extends FATServletClient {
         );
     }
 
-    // TODO enable once implemented correctly @Test
+    @Test
     public void testContextServiceWithUnrecognizedQualifier() throws Exception {
         runTest(server, APP_NAME, testName);
     }
@@ -137,6 +137,21 @@ public class ConcurrentCDITest extends FATServletClient {
 
     @Test
     public void testLookUpManagedThreadFactory() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testQualifierEquals() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testQualifierHashCode() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testQualifierToString() throws Exception {
         runTest(server, APP_NAME, testName);
     }
 

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/resources/WEB-INF/beans.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/resources/WEB-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://jakarta.ee/xml/ns/jakartaee"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
-    version="4.0" bean-discovery-mode="all">
-</beans>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/resources/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="5.0"
+<web-app version="6.0"
     xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
     id="WebApp_ID">
 
   <display-name>Concurrent CDI FAT</display-name>
@@ -14,5 +14,38 @@
     <env-entry-type>java.lang.String</env-entry-type>
     <env-entry-value>value2</env-entry-value>
   </env-entry>
+
+  <!-- Concurrency Resource Definitions -->
+
+  <context-service>
+    <name>java:module/concurrent/without-location-and-tx-context</name>
+    <qualifier>concurrent.cdi.web.WithoutLocationContext</qualifier>
+    <qualifier>concurrent.cdi.web.WithoutTransactionContext</qualifier>
+    <cleared>Location</cleared>
+    <cleared>Transaction</cleared>
+    <propagated>Remaining</propagated>
+  </context-service>
+
+  <managed-executor>
+    <name>java:module/concurrent/executor-without-location-and-tx-context</name>
+    <context-service-ref>java:module/concurrent/without-location-and-tx-context</context-service-ref>
+    <qualifier>concurrent.cdi.web.WithoutTransactionContext</qualifier>
+    <qualifier>concurrent.cdi.web.WithoutLocationContext</qualifier>
+  </managed-executor>
+
+  <managed-scheduled-executor>
+    <name>java:comp/concurrent/scheduled-executor-without-location-and-tx-context</name>
+    <context-service-ref>java:module/concurrent/without-location-and-tx-context</context-service-ref>
+    <qualifier>concurrent.cdi.web.WithoutLocationContext</qualifier>
+  </managed-scheduled-executor>
+
+  <managed-thread-factory>
+    <name>java:comp/concurrent/thread-factory-without-location-and-tx-context</name>
+    <context-service-ref>java:module/concurrent/without-location-and-tx-context</context-service-ref>
+    <qualifier>concurrent.cdi.web.WithoutLocationContext</qualifier>
+    <qualifier>concurrent.cdi.web.WithoutTransactionContext</qualifier>
+    <priority>3</priority>
+    <virtual>false</virtual>
+  </managed-thread-factory>
 
 </web-app>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithLocationContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithLocationContext.java
@@ -19,18 +19,38 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
 import jakarta.inject.Qualifier;
 
 @Qualifier
 @Retention(RUNTIME)
 @Target(FIELD)
 public @interface WithLocationContext {
+    /**
+     * Can include array type attributes on qualifiers if non-binding is specified,
+     * in which case the attribute is ignored when determining whether a bean can inject.
+     */
+    @Nonbinding
+    String[] pairedWith() default {};
+
     public static class Literal extends AnnotationLiteral<WithLocationContext> implements WithLocationContext {
         private static final long serialVersionUID = 2667072598927683578L;
 
         public static final WithLocationContext INSTANCE = new Literal();
 
-        private Literal() {
+        private final String[] otherTypes;
+
+        private Literal(String... otherContextTypes) {
+            otherTypes = otherContextTypes;
+        }
+
+        @Override
+        public String[] pairedWith() {
+            return otherTypes;
+        }
+
+        public static WithLocationContext with(String... otherContextTypes) {
+            return new Literal(otherContextTypes);
         }
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithTransactionContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithTransactionContext.java
@@ -19,18 +19,55 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
 import jakarta.inject.Qualifier;
 
 @Qualifier
 @Retention(RUNTIME)
 @Target(FIELD)
 public @interface WithTransactionContext {
+    /**
+     * Array type attribute is allowed on qualifier as non-binding,
+     * which means the attribute is ignored when determining whether a bean can inject.
+     */
+    @Nonbinding
+    Class<?>[] classes() default { long.class, int.class, short.class };
+
+    /**
+     * Array type attribute is allowed on qualifier as non-binding,
+     * which means the attribute is ignored when determining whether a bean can inject.
+     */
+    @Nonbinding
+    int[] numbers() default { 216, 713, 745 };
+
     public static class Literal extends AnnotationLiteral<WithTransactionContext> implements WithTransactionContext {
         private static final long serialVersionUID = -938635792865549601L;
 
-        public static final WithTransactionContext INSTANCE = new Literal();
+        public static final WithTransactionContext INSTANCE = new Literal( //
+                        new Class<?>[] { long.class, int.class, short.class }, //
+                        new int[] { 216, 713, 745 });
 
-        private Literal() {
+        private final Class<?>[] classes;
+        private final int[] numbers;
+
+        private Literal(Class<?>[] classes, int[] numbers) {
+            this.classes = classes;
+            this.numbers = numbers;
         }
+
+        @Override
+        public Class<?>[] classes() {
+            return classes;
+        }
+
+        @Override
+        public int[] numbers() {
+            return numbers;
+        }
+
+        public static final WithTransactionContext of(Class<?>[] classes, int[] numbers) {
+            return new Literal(classes, numbers);
+        }
+
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithoutLocationContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithoutLocationContext.java
@@ -25,12 +25,44 @@ import jakarta.inject.Qualifier;
 @Retention(RUNTIME)
 @Target(FIELD)
 public @interface WithoutLocationContext {
+
+    /**
+     * A qualifier attribute such as this must have a default value to be usable
+     * on a Concurrency resource definition.
+     */
+    String letter() default "A";
+
+    /**
+     * A qualifier attribute such as this must have a default value to be usable
+     * on a Concurrency resource definition.
+     */
+    int number() default 10;
+
     public static class Literal extends AnnotationLiteral<WithoutLocationContext> implements WithoutLocationContext {
         private static final long serialVersionUID = 2230596759465927237L;
 
-        public static final WithoutLocationContext INSTANCE = new Literal();
+        public static final WithoutLocationContext INSTANCE = new Literal("A", 10);
 
-        private Literal() {
+        private final String letter;
+        private final int number;
+
+        private Literal(String letter, int number) {
+            this.letter = letter;
+            this.number = number;
+        }
+
+        @Override
+        public String letter() {
+            return letter;
+        }
+
+        @Override
+        public int number() {
+            return number;
+        }
+
+        public static final WithoutLocationContext of(String letter, int number) {
+            return new Literal(letter, number);
         }
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithoutLocationContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithoutLocationContext.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.web;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface WithoutLocationContext {
+    public static class Literal extends AnnotationLiteral<WithoutLocationContext> implements WithoutLocationContext {
+        private static final long serialVersionUID = 2230596759465927237L;
+
+        public static final WithoutLocationContext INSTANCE = new Literal();
+
+        private Literal() {
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithoutTransactionContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithoutTransactionContext.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.web;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface WithoutTransactionContext {
+    public static class Literal extends AnnotationLiteral<WithoutTransactionContext> implements WithoutTransactionContext {
+        private static final long serialVersionUID = -3978433230176629819L;
+
+        public static final WithoutTransactionContext INSTANCE = new Literal();
+
+        private Literal() {
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithoutTransactionContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/WithoutTransactionContext.java
@@ -25,12 +25,45 @@ import jakarta.inject.Qualifier;
 @Retention(RUNTIME)
 @Target(FIELD)
 public @interface WithoutTransactionContext {
+
+    /**
+     * A qualifier attribute such as this must have a default value to be usable
+     * on a Concurrency resource definition.
+     */
+    String letter() default "A";
+
+    /**
+     * A qualifier attribute such as this must have a default value to be usable
+     * on a Concurrency resource definition.
+     */
+    int number() default 10;
+
     public static class Literal extends AnnotationLiteral<WithoutTransactionContext> implements WithoutTransactionContext {
         private static final long serialVersionUID = -3978433230176629819L;
 
-        public static final WithoutTransactionContext INSTANCE = new Literal();
+        public static final WithoutTransactionContext INSTANCE = new Literal("A", 10);
 
-        private Literal() {
+        private final String letter;
+        private final int number;
+
+        private Literal(String letter, int number) {
+            this.letter = letter;
+            this.number = number;
         }
+
+        @Override
+        public String letter() {
+            return letter;
+        }
+
+        @Override
+        public int number() {
+            return number;
+        }
+
+        public static final WithoutTransactionContext of(String letter, int number) {
+            return new Literal(letter, number);
+        }
+
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ContextServiceBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ContextServiceBean.java
@@ -117,6 +117,7 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
     }
 
     @Override
+    @Trivial
     public Class<ContextService> getBeanClass() {
         return ContextService.class;
     }
@@ -125,6 +126,7 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
      * @return unique identifier for PassivationCapable.
      */
     @Override
+    @Trivial
     public String getId() {
         return new StringBuilder(getClass().getName()) //
                         .append(":").append(qualifiers) //
@@ -133,36 +135,43 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
     }
 
     @Override
+    @Trivial
     public Set<InjectionPoint> getInjectionPoints() {
         return Collections.emptySet();
     }
 
     @Override
+    @Trivial
     public String getName() {
         return null;
     }
 
     @Override
+    @Trivial
     public Set<Annotation> getQualifiers() {
         return qualifiers;
     }
 
     @Override
+    @Trivial
     public Class<? extends Annotation> getScope() {
         return ApplicationScoped.class;
     }
 
     @Override
+    @Trivial
     public Set<Class<? extends Annotation>> getStereotypes() {
         return Collections.emptySet();
     }
 
     @Override
+    @Trivial
     public Set<Type> getTypes() {
         return beanTypes;
     }
 
     @Override
+    @Trivial
     public boolean isAlternative() {
         return false;
     }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedExecutorBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedExecutorBean.java
@@ -117,6 +117,7 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
     }
 
     @Override
+    @Trivial
     public Class<ManagedExecutorService> getBeanClass() {
         return ManagedExecutorService.class;
     }
@@ -125,6 +126,7 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
      * @return unique identifier for PassivationCapable.
      */
     @Override
+    @Trivial
     public String getId() {
         return new StringBuilder(getClass().getName()) //
                         .append(":").append(qualifiers) //
@@ -133,36 +135,43 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
     }
 
     @Override
+    @Trivial
     public Set<InjectionPoint> getInjectionPoints() {
         return Collections.emptySet();
     }
 
     @Override
+    @Trivial
     public String getName() {
         return null;
     }
 
     @Override
+    @Trivial
     public Set<Annotation> getQualifiers() {
         return qualifiers;
     }
 
     @Override
+    @Trivial
     public Class<? extends Annotation> getScope() {
         return ApplicationScoped.class;
     }
 
     @Override
+    @Trivial
     public Set<Class<? extends Annotation>> getStereotypes() {
         return Collections.emptySet();
     }
 
     @Override
+    @Trivial
     public Set<Type> getTypes() {
         return beanTypes;
     }
 
     @Override
+    @Trivial
     public boolean isAlternative() {
         return false;
     }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedScheduledExecutorBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedScheduledExecutorBean.java
@@ -117,6 +117,7 @@ public class ManagedScheduledExecutorBean implements Bean<ManagedScheduledExecut
     }
 
     @Override
+    @Trivial
     public Class<ManagedScheduledExecutorService> getBeanClass() {
         return ManagedScheduledExecutorService.class;
     }
@@ -125,6 +126,7 @@ public class ManagedScheduledExecutorBean implements Bean<ManagedScheduledExecut
      * @return unique identifier for PassivationCapable.
      */
     @Override
+    @Trivial
     public String getId() {
         return new StringBuilder(getClass().getName()) //
                         .append(":").append(qualifiers) //
@@ -133,36 +135,43 @@ public class ManagedScheduledExecutorBean implements Bean<ManagedScheduledExecut
     }
 
     @Override
+    @Trivial
     public Set<InjectionPoint> getInjectionPoints() {
         return Collections.emptySet();
     }
 
     @Override
+    @Trivial
     public String getName() {
         return null;
     }
 
     @Override
+    @Trivial
     public Set<Annotation> getQualifiers() {
         return qualifiers;
     }
 
     @Override
+    @Trivial
     public Class<? extends Annotation> getScope() {
         return ApplicationScoped.class;
     }
 
     @Override
+    @Trivial
     public Set<Class<? extends Annotation>> getStereotypes() {
         return Collections.emptySet();
     }
 
     @Override
+    @Trivial
     public Set<Type> getTypes() {
         return beanTypes;
     }
 
     @Override
+    @Trivial
     public boolean isAlternative() {
         return false;
     }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
@@ -119,6 +119,7 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
     }
 
     @Override
+    @Trivial
     public Class<ManagedThreadFactory> getBeanClass() {
         return ManagedThreadFactory.class;
     }
@@ -127,6 +128,7 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
      * @return unique identifier for PassivationCapable.
      */
     @Override
+    @Trivial
     public String getId() {
         return new StringBuilder(getClass().getName()) //
                         .append(":").append(qualifiers) //
@@ -135,36 +137,43 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
     }
 
     @Override
+    @Trivial
     public Set<InjectionPoint> getInjectionPoints() {
         return Collections.emptySet();
     }
 
     @Override
+    @Trivial
     public String getName() {
         return null;
     }
 
     @Override
+    @Trivial
     public Set<Annotation> getQualifiers() {
         return qualifiers;
     }
 
     @Override
+    @Trivial
     public Class<? extends Annotation> getScope() {
         return ApplicationScoped.class;
     }
 
     @Override
+    @Trivial
     public Set<Class<? extends Annotation>> getStereotypes() {
         return Collections.emptySet();
     }
 
     @Override
+    @Trivial
     public Set<Type> getTypes() {
         return beanTypes;
     }
 
     @Override
+    @Trivial
     public boolean isAlternative() {
         return false;
     }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/QualifierProxy.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/QualifierProxy.java
@@ -14,7 +14,14 @@ package io.openliberty.concurrent.internal.cdi;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 
 /**
@@ -22,10 +29,27 @@ import com.ibm.websphere.ras.annotation.Trivial;
  */
 @Trivial
 public class QualifierProxy implements InvocationHandler {
+    private static final TraceComponent tc = Tr.register(QualifierProxy.class);
+
+    /**
+     * The hash code value for the qualifier annotation.
+     */
+    private final int hashCode;
+
+    /**
+     * Accessor methods for annotation fields.
+     */
+    private final List<Method> methods;
+
     /**
      * Qualifier annotation class.
      */
     private final Class<?> qualifierClass;
+
+    /**
+     * The toString value for the qualifier annotation.
+     */
+    private final String stringValue;
 
     /**
      * Create a invocation handler for the specified qualifier annotation class.
@@ -34,14 +58,150 @@ public class QualifierProxy implements InvocationHandler {
      */
     QualifierProxy(Class<?> qualifierClass) {
         this.qualifierClass = qualifierClass;
+        String qualifierClassName = qualifierClass.getName();
+
+        Method[] m = qualifierClass.getMethods();
+        methods = new ArrayList<>(m.length - 4); // leaving out annotationType, equals, hashCode, toString
+        int hash = 0;
+        StringBuilder s = new StringBuilder(m.length * 30 + qualifierClassName.length()) //
+                        .append('@').append(qualifierClassName).append('(');
+
+        boolean first = true;
+        for (Method method : m)
+            if (method.getParameterCount() == 0) {
+                String name = method.getName();
+                if (!"annotationType".equals(name)
+                    && !"hashCode".equals(name)
+                    && !"toString".equals(name)) {
+                    methods.add(method);
+
+                    Object value = method.getDefaultValue();
+
+                    if (first)
+                        first = false;
+                    else
+                        s.append(", ");
+
+                    s.append(name).append('=');
+
+                    int h;
+                    if (value instanceof Object[] array) {
+                        h = Arrays.hashCode(array);
+                        s.append(Arrays.toString(array));
+                    } else if (value instanceof int[] array) {
+                        h = Arrays.hashCode(array);
+                        s.append(Arrays.toString(array));
+                    } else if (value instanceof long[] array) {
+                        h = Arrays.hashCode(array);
+                        s.append(Arrays.toString(array));
+                    } else if (value instanceof boolean[] array) {
+                        h = Arrays.hashCode(array);
+                        s.append(Arrays.toString(array));
+                    } else if (value instanceof double[] array) {
+                        h = Arrays.hashCode(array);
+                        s.append(Arrays.toString(array));
+                    } else if (value instanceof float[] array) {
+                        h = Arrays.hashCode(array);
+                        s.append(Arrays.toString(array));
+                    } else if (value instanceof short[] array) {
+                        h = Arrays.hashCode(array);
+                        s.append(Arrays.toString(array));
+                    } else if (value instanceof byte[] array) {
+                        h = Arrays.hashCode(array);
+                        s.append(Arrays.toString(array));
+                    } else if (value instanceof char[] array) {
+                        h = Arrays.hashCode(array);
+                        s.append(Arrays.toString(array));
+                    } else {
+                        h = value.hashCode();
+                        s.append(value);
+                    }
+
+                    // JavaDoc for Annotation requires the hash code to be the sum of
+                    // 127 times each member's name xor with the hash code of its value
+                    hash += (127 * name.hashCode()) ^ h;
+                }
+            }
+
+        stringValue = s.append(")[QualifierProxy]").toString();
+        hashCode = hash;
+    }
+
+    /**
+     * Compare a proxy qualifier with another instance.
+     *
+     * @param proxy qualifier that is implemented by QualifierProxy.
+     * @param other other object that is possibly a matching qualifier instance.
+     * @return true if both represent the same qualifier, otherwise false.
+     */
+    private boolean equals(Object proxy, Object other) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "equals",
+                     proxy == null ? null : proxy.toString(),
+                     other == null ? null : other.toString());
+
+        boolean equal;
+        if (proxy == other) {
+            equal = true;
+        } else if (qualifierClass.isInstance(other)) {
+            try {
+                boolean isProxy = Proxy.isProxyClass(other.getClass());
+                InvocationHandler otherHandler = isProxy ? Proxy.getInvocationHandler(other) : null;
+                if (otherHandler instanceof QualifierProxy) {
+                    equal = ((QualifierProxy) otherHandler).qualifierClass.equals(qualifierClass);
+                } else {
+                    // The other instance is not a QualifierProxy, but it might still match.
+                    if (methods.size() == 0) {
+                        equal = true;
+                    } else {
+                        // For a proper comparison, meeting the requirements of the JavaDoc for Annotation.equals
+                        // we need to invoke all methods (except for annotationType/equals/hashCode/toString)
+                        // on both instances and compare the values.
+                        equal = true;
+                        for (Method method : methods) {
+                            Object value1 = method.getDefaultValue();
+                            Object value2 = method.invoke(other);
+                            if (trace && tc.isDebugEnabled())
+                                Tr.debug(this, tc, "comparing " + method.getName(), value1, value2);
+
+                            equal = value1 instanceof Object[] array1 ? Arrays.equals(array1, (Object[]) value2) :
+                            /*   */ value1 instanceof int[] array1 ? Arrays.equals(array1, (int[]) value2) :
+                            /*   */ value1 instanceof long[] array1 ? Arrays.equals(array1, (long[]) value2) :
+                            /*   */ value1 instanceof boolean[] array1 ? Arrays.equals(array1, (boolean[]) value2) :
+                            /*   */ value1 instanceof double[] array1 ? Arrays.equals(array1, (double[]) value2) :
+                            /*   */ value1 instanceof float[] array1 ? Arrays.equals(array1, (float[]) value2) :
+                            /*   */ value1 instanceof short[] array1 ? Arrays.equals(array1, (short[]) value2) :
+                            /*   */ value1 instanceof byte[] array1 ? Arrays.equals(array1, (byte[]) value2) :
+                            /*   */ value1 instanceof char[] array1 ? Arrays.equals(array1, (char[]) value2) :
+                            /*   */ Objects.equals(value1, value2);
+
+                            if (!equal)
+                                break;
+                        }
+                    }
+                }
+            } catch (RuntimeException x) {
+                throw x;
+            } catch (Exception x) {
+                throw new RuntimeException(x);
+            }
+        } else {
+            equal = false;
+        }
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "equals", equal);
+        return equal;
     }
 
     /**
      * Implements the 4 methods of java.lang.Annotation:
      * hashCode(), toString(), equals(other), and annotationType().
      *
-     * TODO implement other methods from the annotation class by returning the default value
-     * and otherwise raising an error.
+     * Handles annotation fields with default values by delegating to the default value.
+     *
+     * @throws UnsupportedOperationException for all other methods.
      */
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
@@ -49,27 +209,15 @@ public class QualifierProxy implements InvocationHandler {
         int numParams = method.getParameterCount();
 
         if (numParams == 0 && "hashCode".equals(methodName)) {
-            return qualifierClass.hashCode();
+            return hashCode;
         } else if (numParams == 0 && "toString".equals(methodName)) {
-            return new StringBuilder(qualifierClass.getName()) //
-                            .append('@').append(Integer.toHexString(qualifierClass.hashCode())) //
-                            .append("(Proxy)") //
-                            .toString();
+            return stringValue;
         } else if (numParams == 0 && "annotationType".equals(methodName)) {
             return qualifierClass;
         } else if (numParams == 1 && "equals".equals(methodName)) {
-            if (qualifierClass.isInstance(args[0]))
-                if (qualifierClass.getMethods().length == 4)
-                    return true;
-                else // TODO For a proper comparison, would need to invoke additional methods
-                     // and compare value from the other instance against with default values from this instance
-                    throw new UnsupportedOperationException();
-            else
-                return false;
+            return equals(proxy, args[0]);
         } else {
-            // This can be implemented to return the default value if there is one,
-            // but otherwise it is an error to use the annotation as a qualifier for Concurrency resources.
-            throw new UnsupportedOperationException(); // TODO implementation and better error message
+            return method.getDefaultValue();
         }
     }
 }


### PR DESCRIPTION
This pull adds tests for qualifiers defined on the resource definitions for the four types of Concurrency resources in the web.xml deployment descriptor.

It also implements the annotation methods of generated qualifiers (toString, hashCode, equals, annotationType) according to the requirements of the Annotation JavaDoc, and then adds test coverage for each of these methods.

It covers nonbinding qualifier attributes, which do count for annotation equals comparisons, but do not count for resolving beans.