### PR TITLE
More updates for Java security enablement with EE 11 features

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE11Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE11Action.java
@@ -101,31 +101,31 @@ public class JakartaEE11Action extends JakartaEEAction {
                                                   "xmlWS-4.0"
     };
 
-    private static final String[] EE11_ONLY_FEATURES_ARRAY = {
-                                                               "jakartaee-11.0",
-                                                               "webProfile-11.0",
-                                                               "jakartaeeClient-11.0",
-                                                               "appAuthentication-3.1",
-                                                               "appAuthorization-3.0",
-                                                               "appSecurity-6.0",
-                                                               "beanValidation-3.1",
-                                                               "cdi-4.1",
-                                                               "concurrent-3.1",
-                                                               "data-1.0",
-                                                               "expressionLanguage-6.0",
-                                                               "persistence-3.2",
-                                                               "persistenceContainer-3.2",
-                                                               "faces-4.1",
-                                                               "facesContainer-4.1",
-                                                               "pages-4.0",
-                                                               "restfulWS-4.0",
-                                                               "restfulWSClient-4.0",
-                                                               "servlet-6.1",
-                                                               "websocket-2.2"
+    private static final String[] EE11_ONLY_FEATURES_ARRAY_LOWERCASE = {
+                                                                         "jakartaee-11.0",
+                                                                         "webprofile-11.0",
+                                                                         "jakartaeeclient-11.0",
+                                                                         "appauthentication-3.1",
+                                                                         "appauthorization-3.0",
+                                                                         "appsecurity-6.0",
+                                                                         "beanvalidation-3.1",
+                                                                         "cdi-4.1",
+                                                                         "concurrent-3.1",
+                                                                         "data-1.0",
+                                                                         "expressionlanguage-6.0",
+                                                                         "persistence-3.2",
+                                                                         "persistencecontainer-3.2",
+                                                                         "faces-4.1",
+                                                                         "facescontainer-4.1",
+                                                                         "pages-4.0",
+                                                                         "restfulws-4.0",
+                                                                         "restfulwsclient-4.0",
+                                                                         "servlet-6.1",
+                                                                         "websocket-2.2"
     };
 
     public static final Set<String> EE11_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE11_FEATURES_ARRAY)));
-    public static final Set<String> EE11_ONLY_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE11_ONLY_FEATURES_ARRAY)));
+    public static final Set<String> EE11_ONLY_FEATURE_SET_LOWERCASE = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE11_ONLY_FEATURES_ARRAY_LOWERCASE)));
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // This constructor is purposely not public to force people to use the JakartaEEAction class and                 //


### PR DESCRIPTION
- Don't use the ServerConfiguration to get the features since some tests use invalid XML files and will result in parsing errors of the server.xml
- Update the checking of java security errors to be based off of if the server was started with Java security or not since now even if isJava2SecurityEnabled returns true we may not have started it with Java security due to other conditions like EE 11.  Some tests remove the server.xml so then you get an error looking at the server.xml again to see if it had EE 11 features.  This is resolved now as well.
- Update to handle whatever case someone uses for the feature names since feature names are case insensitive.
