### PR TITLE
Allow expected FFDC for RM tests which interact with MP metrics

### DIFF
--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/metrics/MetricsTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/metrics/MetricsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
 import com.ibm.ws.microprofile.reactive.messaging.fat.metrics.MetricsUtils;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -48,6 +49,9 @@ import io.openliberty.microprofile.reactive.messaging.fat.suite.ReactiveMessagin
  *
  */
 @RunWith(FATRunner.class)
+// Allowing InstanceNotFoundException as it is possible for mpmetrics to be queried during server shutdown when
+// the MBean is not present, this is an expected FFDC in the metrics FAT so we must allow for it here as these tests interact with metrics.
+@AllowedFFDC("javax.management.InstanceNotFoundException")
 public class MetricsTest extends FATServletClient {
 
     public static final String APP_NAME = "MetricsTest";

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/metrics/MultiAppMetricsTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/kafka/metrics/MultiAppMetricsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,6 +36,7 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKa
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClientProvider;
 import com.ibm.ws.microprofile.reactive.messaging.fat.metrics.MetricsUtils;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
@@ -49,6 +50,9 @@ import io.openliberty.microprofile.reactive.messaging.fat.suite.ReactiveMessagin
  *
  */
 @RunWith(FATRunner.class)
+// Allowing InstanceNotFoundException as it is possible for mpmetrics to be queried during server shutdown when
+// the MBean is not present, this is an expected FFDC in the metrics FAT so we must allow for it here as these tests interact with metrics.
+@AllowedFFDC("javax.management.InstanceNotFoundException")
 public class MultiAppMetricsTest extends FATServletClient {
 
     public static final String APP_ONE_NAME = "MetricsTestOne";

--- a/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/fat/src/io/openliberty/microprofile/reactive/messaging30/tck/ReactiveMessagingTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/fat/src/io/openliberty/microprofile/reactive/messaging30/tck/ReactiveMessagingTCKLauncher.java
@@ -1,16 +1,22 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.microprofile.reactive.messaging30.tck;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
@@ -21,11 +27,6 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 /**
  * This is a test class that runs a whole Maven TCK as one test FAT test.
@@ -53,7 +54,11 @@ public class ReactiveMessagingTCKLauncher {
 
     @Test
     @Mode(TestMode.FULL)
-    @AllowedFFDC({ "org.jboss.weld.exceptions.DeploymentException", "com.ibm.ws.container.service.state.StateChangeException", "jakarta.enterprise.inject.spi.DeploymentException" }) // The tested deployment exceptions cause FFDC so we have to allow for this.
+    @AllowedFFDC({ "javax.management.InstanceNotFoundException", "org.jboss.weld.exceptions.DeploymentException", "com.ibm.ws.container.service.state.StateChangeException",
+                   "jakarta.enterprise.inject.spi.DeploymentException" })
+    // The tested deployment exceptions cause FFDC so we have to allow for this.
+    // InstanceNotFoundException is allowed as it is possible for mpmetrics to be queried during server shutdown when
+    // the MBean is not present, this is an expected FFDC in the metrics FAT so we must allow for it here as these tests interact with metrics.
     public void launchReactiveMessaging30Tck() throws Exception {
         String bucketName = "io.openliberty.microprofile.reactive.messaging30.internal_fat_tck";
         String testName = this.getClass() + ":launchReactiveMessaging30Tck";


### PR DESCRIPTION
RTC 298681
Fixes #27483

RM TCK and metrics test bug fixed by adding AllowedFFDC annotation for the InstanceNotFoundException, as the metrics are being queried when the server stops and the MBean is no longer available. Same fix that was provided in the Metrics FAT #26795 to fix the same issue but we never had this annotation to prevent the issue arising when RM interacts with metrics.