### PR TITLE
Enable pb.yml pipeline on #build keyword

### DIFF
--- a/.ci-orchestrator/pb.yml
+++ b/.ci-orchestrator/pb.yml
@@ -9,6 +9,7 @@ triggers:
   groups: ["LibertyDev"]
   keyword: "!pbbeta"
   aliasKeywords:
+  - "#build"
   - "!build"
   - "#pbbeta"
   propertyDefinitions:


### PR DESCRIPTION
- Enable pb.yml pipeline on #build keyword to begin collecting data for comparison.