### PR TITLE
FeatureUtility enable no proxy

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
@@ -314,7 +314,7 @@ public class FeatureUtility {
 		}
 
 		// override no_proxy settings
-		if (FeatureUtilityProperties.getNoProxySetting() != null) {
+		if (System.getProperty("featureUtility.beta").equals("true") && FeatureUtilityProperties.getNoProxySetting() != null) {
 		    overrideMap.put("http.nonProxyHosts", FeatureUtilityProperties.getNoProxySetting());
 		}
 

--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
@@ -313,6 +313,11 @@ public class FeatureUtility {
 
 		}
 
+		// override no_proxy settings
+		if (FeatureUtilityProperties.getNoProxySetting() != null) {
+		    overrideMap.put("no_proxy", FeatureUtilityProperties.getNoProxySetting());
+		}
+
         // override the local feature repo
         if(FeatureUtilityProperties.getFeatureLocalRepo() != null){
             overrideMap.put("FEATURE_LOCAL_REPO", FeatureUtilityProperties.getFeatureLocalRepo());
@@ -347,6 +352,13 @@ public class FeatureUtility {
         }
 
 	map.put(InstallConstants.OVERRIDE_ENVIRONMENT_VARIABLES, overrideMap);
+
+	if (map.get(InstallConstants.ACTION_ERROR_MESSAGE) != null) {
+	    // error with installation
+	    fine("action.exception.stacktrace: " + map.get(InstallConstants.ACTION_EXCEPTION_STACKTRACE));
+	    String exceptionMessage = (String) map.get(InstallConstants.ACTION_ERROR_MESSAGE);
+	    throw new InstallException(exceptionMessage);
+	}
     }
 
     /**

--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
@@ -315,7 +315,7 @@ public class FeatureUtility {
 
 		// override no_proxy settings
 		if (FeatureUtilityProperties.getNoProxySetting() != null) {
-		    overrideMap.put("no_proxy", FeatureUtilityProperties.getNoProxySetting());
+		    overrideMap.put("http.nonProxyHosts", FeatureUtilityProperties.getNoProxySetting());
 		}
 
         // override the local feature repo

--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/props/FeatureUtilityProperties.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/props/FeatureUtilityProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/props/FeatureUtilityProperties.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/props/FeatureUtilityProperties.java
@@ -39,7 +39,7 @@ public class FeatureUtilityProperties {
     private final static String FILEPATH_EXT = "/etc/featureUtility.properties";
     private final static String FeatureVerifyQualifier = "feature.verify";
     private final static Set<String> DEFINED_OPTIONS = new HashSet<>(Arrays.asList("proxyHost", "proxyPort",
-	    "proxyUser", "proxyPassword", "featureLocalRepo", FeatureVerifyQualifier));
+	    "proxyUser", "proxyPassword", "http.nonProxyHosts", "featureLocalRepo", FeatureVerifyQualifier));
     private static Map<String, String> definedVariables = new HashMap<>();
     private static List<MavenRepository> repositoryList = new ArrayList<>();
     private static List<String> bomIdList = new ArrayList<>();
@@ -97,6 +97,10 @@ public class FeatureUtilityProperties {
 
     public static String getProxyPassword(){
         return definedVariables.get("proxyPassword"); // char array instead?
+    }
+
+    public static String getNoProxySetting() {
+	return definedVariables.get("http.nonProxyHosts");
     }
 
     public static String getFeatureLocalRepo(){

--- a/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
@@ -1,5 +1,5 @@
-#*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+a#*******************************************************************************
+# Copyright (c) 2019, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
@@ -373,8 +373,8 @@ public abstract class FeatureUtilityToolTest {
 
     protected ProgramOutput runFeatureUtility(String testcase, String[] params, boolean debug) throws Exception {
         Properties envProps = new Properties();
-	// add beta property here
-	// envProps.put("JVM_ARGS", "-Dbeta.property=true");
+        // add beta property here
+	    envProps.put("JVM_ARGS", "-DfeatureUtility.beta=true");
         return runFeatureUtility(testcase, params, envProps);
     }
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
@@ -373,13 +373,13 @@ public abstract class FeatureUtilityToolTest {
 
     protected ProgramOutput runFeatureUtility(String testcase, String[] params, boolean debug) throws Exception {
         Properties envProps = new Properties();
-        // add beta property here
-	    envProps.put("JVM_ARGS", "-DfeatureUtility.beta=true");
         return runFeatureUtility(testcase, params, envProps);
     }
 
     protected ProgramOutput runFeatureUtility(String testcase, String[] params, Properties envProps) throws Exception {
-	// always run feature utility with minified root
+    		// add beta property here
+	    envProps.put("JVM_ARGS", "-DfeatureUtility.beta=true");    
+    		// always run feature utility with minified root
         return runCommand(minifiedRoot, testcase, "featureUtility", params, envProps);
     }
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -45,6 +45,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	private static String userFeatureSigPath = "/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa.asc";
 	static Network network = Network.newNetwork();
 	
+	
 //	@ClassRule
 	/*
 	 * Increased startup timeout because nexus container might take more than 60

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -723,8 +723,6 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	public void testVerifyhttpKeyServer() throws Exception {
 	    final String METHOD_NAME = "testVerifyhttpKeyServer";
 	    Log.entering(c, METHOD_NAME);
-	    Properties envProps = new Properties();
-	    envProps.put("FEATURE_VERIFY", "all");
 
 	    String containerUrl = "http://" + container.getHost() + ":" + container.getMappedPort(8080)
 		    + "/validKey.asc";
@@ -984,7 +982,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	  
 	    try {
 		checkCommandOutput(po, 0, null, filesList);
-	    } catch(Exception e) {
+	    } catch (AssertionError e) {
 		checkProxyLog(METHOD_NAME, proxyContainer);
 		  throw e;
 	    }
@@ -1016,13 +1014,13 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "mavenCentralMirror.user", "admin");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "mavenCentralMirror.password", "golf");
 	    
-	    String[] param1s = { "installFeature", "json-1.0", "--verbose" };
+	    String[] param1s = { "installFeature", "json-1.0", "--verbose", "--noCache" };
 	    String[] filesList = { "/lib/features/com.ibm.websphere.appserver.json-1.0.mf" };
 	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
 
 	    try {
 		checkCommandOutput(po, 0, null, filesList);
-	    } catch (Exception e) {
+	    } catch (AssertionError e) {
 		checkProxyLog(METHOD_NAME, proxyContainer);
 		  throw e;
 	    }
@@ -1056,13 +1054,13 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "mavenCentralMirror.password",
 		    "{xor}ODAzOQ==");
 
-	    String[] param1s = { "installFeature", "json-1.0", "--verbose" };
+	    String[] param1s = { "installFeature", "json-1.0", "--verbose", "--noCache" };
 	    String[] filesList = { "/lib/features/com.ibm.websphere.appserver.json-1.0.mf" };
 	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
 
 	    try {
 		checkCommandOutput(po, 0, null, filesList);
-	    } catch (Exception e) {
+	    } catch (AssertionError e) {
 		checkProxyLog(METHOD_NAME, proxyContainer);
 		throw e;
 	    }
@@ -1070,5 +1068,86 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    Log.exiting(c, METHOD_NAME);
 	    
 	}
+
+	/*
+	 * Test no proxy using environment variable Try downloading public key from
+	 * external key server. It should fail because keyserver can only be connected
+	 * through proxy. (testcontainer network)
+	 */
+	@Test
+	public void testnoProxyEnv() throws Exception {
+	    final String METHOD_NAME = "testnoProxyEnv";
+	    Log.entering(c, METHOD_NAME);
+
+	    String proxyHost = "http://" + proxyContainer.getHost();
+	    String proxyPort = proxyContainer.getMappedPort(3128).toString();
+	    String containerUrl = "http://keyserver:8080/validKey.asc";
+
+	    Properties envProps = new Properties();
+	    envProps.put("no_proxy", "keyserver");
+
+
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "proxyHost", proxyHost);
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "proxyPort", proxyPort);
+	    
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "feature.verify", "all");
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyid", "0x71f8e6239b6834aa");
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl", containerUrl);
+
+	    String[] filesList = { "usr/extension/lib/features/testesa1.mf", "usr/extension/bin/testesa1.bat" };
+
+	    String[] param1s = { "installFeature", "testesa1",
+		    "--featuresBOM=com.ibm.ws.userFeature:features-bom:19.0.0.8", "--verbose" };
+
+	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s, envProps);
+
+	    try {
+		checkCommandOutput(po, InstallException.SIGNATURE_VERIFICATION_FAILED, "CWWKF1506E", null);
+	    } catch (AssertionError e) {
+		checkProxyLog(METHOD_NAME, proxyContainer);
+		throw e;
+	    }
+
+	    Log.exiting(c, METHOD_NAME);
+
+	}
+
+	/*
+	 * Test no proxy using properties
+	 */
+	@Test
+	public void testnoProxyProps() throws Exception {
+	    final String METHOD_NAME = "testnoProxyProps";
+	    Log.entering(c, METHOD_NAME);
+
+	    String proxyHost = "http://" + proxyContainer.getHost();
+	    String proxyPort = proxyContainer.getMappedPort(3128).toString();
+	    String containerUrl = "http://keyserver:8080/validKey.asc";
+
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "proxyHost", proxyHost);
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "proxyPort", proxyPort);
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "http.nonProxyHosts", "keyserver");
+
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "feature.verify", "all");
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyid", "0x71f8e6239b6834aa");
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl", containerUrl);
+
+	    String[] filesList = { "usr/extension/lib/features/testesa1.mf", "usr/extension/bin/testesa1.bat" };
+
+	    String[] param1s = { "installFeature", "testesa1",
+		    "--featuresBOM=com.ibm.ws.userFeature:features-bom:19.0.0.8", "--verbose" };
+	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
+
+	    try {
+		checkCommandOutput(po, InstallException.SIGNATURE_VERIFICATION_FAILED, "CWWKF1506E", null);
+	    } catch (AssertionError e) {
+		checkProxyLog(METHOD_NAME, proxyContainer);
+		throw e;
+	    }
+
+	    Log.exiting(c, METHOD_NAME);
+
+	}
+
 
 }

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
@@ -344,7 +344,6 @@ public class ArtifactDownloader implements AutoCloseable {
         }
 
         conn.connect();
-        logger.fine(conn.getHeaderFields().toString());
 
         destination.getParentFile().mkdirs();
         File tempFile = File.createTempFile(destination.getName(), null, destination.getParentFile());

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
@@ -322,8 +322,10 @@ public class ArtifactDownloader implements AutoCloseable {
 
     private void downloadInternal(URI address, File destination, MavenRepository repository) throws IOException, InstallException {
         URL url = address.toURL();
-        logger.fine("non Proxy Hosts: " + System.getProperty("http.nonProxyHosts"));
-        logger.fine("url: " + url.getHost());
+        if (System.getProperty("featureUtility.beta").equals("true")) {
+            logger.fine("non Proxy Hosts: " + System.getProperty("http.nonProxyHosts"));
+        }
+        logger.fine("downloadInternal url host: " + url.getHost());
         String proxyEncodedAuth = "";
         if (url.getProtocol().equals("https") && envMap.get("https.proxyHost") != null) {
             proxyEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication((String) envMap.get("https.proxyUser"), (String) envMap.get("https.proxyPassword"));

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
@@ -112,7 +112,6 @@ public class ArtifactDownloaderUtils {
     public static int exists(String URLName, Map<String, Object> envMap, MavenRepository repository) throws IOException {
         try {
             URL url = new URL(URLName);
-            logger.fine("heelo");
             String proxyEncodedAuth = "";
             if (url.getProtocol().equals("https") && envMap.get("https.proxyHost") != null) {
                 proxyEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication((String) envMap.get("https.proxyUser"), (String) envMap.get("https.proxyPassword"));

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
@@ -22,8 +22,6 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.security.MessageDigest;
@@ -114,20 +112,15 @@ public class ArtifactDownloaderUtils {
     public static int exists(String URLName, Map<String, Object> envMap, MavenRepository repository) throws IOException {
         try {
             URL url = new URL(URLName);
-
-            Proxy proxy;
+            logger.fine("heelo");
             String proxyEncodedAuth = "";
-            if (envMap.get("https.proxyHost") != null) {
-                proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress((String) envMap.get("https.proxyHost"), Integer.parseInt((String) envMap.get("https.proxyPort"))));
+            if (url.getProtocol().equals("https") && envMap.get("https.proxyHost") != null) {
                 proxyEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication((String) envMap.get("https.proxyUser"), (String) envMap.get("https.proxyPassword"));
             } else if (envMap.get("http.proxyHost") != null) {
-                proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress((String) envMap.get("http.proxyHost"), Integer.parseInt((String) envMap.get("http.proxyPort"))));
                 proxyEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication((String) envMap.get("http.proxyUser"), (String) envMap.get("http.proxyPassword"));
-            } else {
-                proxy = Proxy.NO_PROXY;
             }
 
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection(proxy);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             String repoEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication(repository.getUserId(), repository.getPassword());
             if (!repoEncodedAuth.isEmpty()) {
                 conn.setRequestProperty("Authorization", repoEncodedAuth);
@@ -139,6 +132,7 @@ public class ArtifactDownloaderUtils {
             conn.setConnectTimeout(10000);
             conn.setInstanceFollowRedirects(true);
             conn.connect();
+
             return conn.getResponseCode();
 
         } catch (ConnectException e) {
@@ -318,32 +312,6 @@ public class ArtifactDownloaderUtils {
             return Base64.getEncoder().encodeToString(userInfo.getBytes("UTF-8"));
         } catch (UnsupportedEncodingException encodingException) {
             throw new RuntimeException("Failed to get bytes for user info using UTF-8.", encodingException);
-        }
-    }
-
-    public static void checkValidProxy(Map<String, Object> envMap) throws InstallException {
-        //set up basic auth HTTP tunnel
-        System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
-
-        String protocol = null;
-        if (envMap.get("https.proxyUser") != null) {
-            protocol = "https";
-        } else if (envMap.get("http.proxyUser") != null) {
-            protocol = "http";
-        }
-
-        String proxyPort = (String) envMap.get(protocol + ".proxyPort");
-        if (protocol != null) {
-            int proxyPortnum = Integer.parseInt(proxyPort);
-            if (((String) envMap.get(protocol + ".proxyHost")).isEmpty()) {
-                throw ExceptionUtils.createByKey("ERROR_TOOL_PROXY_HOST_MISSING");
-            } else if (proxyPortnum < 0 || proxyPortnum > 65535) {
-                throw ExceptionUtils.createByKey("ERROR_TOOL_INVALID_PROXY_PORT", proxyPort);
-            } else if (((String) envMap.get(protocol + ".proxyPassword")).isEmpty() ||
-                       envMap.get(protocol + ".proxyPassword") == null) {
-                throw ExceptionUtils.createByKey("ERROR_TOOL_PROXY_PWD_MISSING");
-            }
-            verifyPassword((String) envMap.get(protocol) + ".proxyPassword");
         }
     }
 

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -1138,7 +1138,7 @@ public class InstallKernelMap implements Map {
                     System.setProperty("https.proxyPort", (String) envMap.get("http.proxyPort"));
                 }
             }
-            if (envMap.get("http.nonProxyHosts") != null) {
+            if (System.getProperty("featureUtility.beta").equals("true") && envMap.get("http.nonProxyHosts") != null) {
                 String noProxyHosts = (String) envMap.get("http.nonProxyHosts");
                 //if users provide list of hosts using ",", replace to "|"
                 noProxyHosts = noProxyHosts.replace(",", "|");
@@ -1958,7 +1958,9 @@ public class InstallKernelMap implements Map {
                 envMapRet.put(key, httpsProxyVariables.get(key));
             }
         }
-        envMapRet.put("http.nonProxyHosts", System.getenv("no_proxy"));
+        if (System.getProperty("featureUtility.beta").equals("true")) {
+            envMapRet.put("http.nonProxyHosts", System.getenv("no_proxy"));
+        }
 
         envMapRet.put("FEATURE_REPO_URL", System.getenv("FEATURE_REPO_URL"));
         envMapRet.put("FEATURE_REPO_USER", System.getenv("FEATURE_REPO_USER"));
@@ -1974,7 +1976,7 @@ public class InstallKernelMap implements Map {
         envMapRet.put("FEATURE_VERIFY", System.getenv("FEATURE_VERIFY"));
 
         //search through the properties file to look for overrides if they exist
-        //TODO remove?
+        //TODO remove? - Do we use featureUtility.env ?
         Map<String, String> propsFileMap = getFeatureUtilEnvProps();
         if (!propsFileMap.isEmpty()) {
             fine("The properties found in featureUtility.env will override latent environment variables of the same name");

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -1159,8 +1159,8 @@ public class InstallKernelMap implements Map {
                 throw ExceptionUtils.createByKey("ERROR_TOOL_PROXY_HOST_MISSING");
             } else if (proxyPortnum < 0 || proxyPortnum > 65535) {
                 throw ExceptionUtils.createByKey("ERROR_TOOL_INVALID_PROXY_PORT", proxyPort);
-            } else if (((String) envMap.get(protocol + ".proxyPassword")).isEmpty() ||
-                       envMap.get(protocol + ".proxyPassword") == null) {
+            } else if (envMap.get(protocol + "proxyUser") != null && (envMap.get(protocol + ".proxyPassword") == null
+                                                                      || ((String) envMap.get(protocol + ".proxyPassword")).isEmpty())) {
                 throw ExceptionUtils.createByKey("ERROR_TOOL_PROXY_PWD_MISSING");
             }
         }

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/VerifySignatureUtility.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/VerifySignatureUtility.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/VerifySignatureUtility.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/VerifySignatureUtility.java
@@ -19,9 +19,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
-import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
 import java.time.Instant;
@@ -146,20 +144,15 @@ public class VerifySignatureUtility {
             URLConnection conn;
             try {
                 logger.fine("Downloading key... " + key.getValue());
-                ArtifactDownloaderUtils.checkValidProxy(envMap);
                 URL keyUrl = new URL(key.getValue());
-                Proxy proxy;
                 String proxyEncodedAuth = "";
-                if (envMap.get("https.proxyHost") != null) {
-                    proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress((String) envMap.get("https.proxyHost"), Integer.parseInt((String) envMap.get("https.proxyPort"))));
+                if (keyUrl.getProtocol().equals("https") && envMap.get("https.proxyHost") != null) {
                     proxyEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication((String) envMap.get("https.proxyUser"), (String) envMap.get("https.proxyPassword"));
                 } else if (envMap.get("http.proxyHost") != null) {
-                    proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress((String) envMap.get("http.proxyHost"), Integer.parseInt((String) envMap.get("http.proxyPort"))));
                     proxyEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication((String) envMap.get("http.proxyUser"), (String) envMap.get("http.proxyPassword"));
-                } else {
-                    proxy = Proxy.NO_PROXY;
                 }
-                conn = keyUrl.openConnection(proxy);
+
+                conn = keyUrl.openConnection();
                 conn.setConnectTimeout(10000);
 
                 if (!proxyEncodedAuth.isEmpty()) {


### PR DESCRIPTION
Implemented no proxy for featureUtility
To set no_proxy using the environment variable, use `no_proxy`.
To set it using `featureUtility.properties`, use `http.nonProxyHosts` (name used by jvm system properties)