### PR TITLE
Remove RM and RSO 3.0 beta guards and update features to GA

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpReactiveStreams3.0-cdi3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpReactiveStreams3.0-cdi3.0.feature
@@ -6,6 +6,6 @@ IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.cdi-3.0)(osgi.identity=io.openliberty.cdi-4.0)))"
 -bundles=io.openliberty.microprofile.reactive.streams.operators30.cdi
 IBM-Install-Policy: when-satisfied
-kind=beta
+kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.reactive.messaging-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.reactive.messaging-3.0.feature
@@ -8,6 +8,6 @@ singleton=true
   io.openliberty.org.eclipse.microprofile.reactive.streams.operators-3.0, \
   io.openliberty.org.eclipse.microprofile.config-3.0; ibm.tolerates:="3.1", \
   io.openliberty.jakarta.cdi-3.0; ibm.tolerates:="4.0"
-kind=beta
+kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.reactive.streams.operators-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.reactive.streams.operators-3.0.feature
@@ -7,6 +7,6 @@ singleton=true
   com.ibm.websphere.appserver.org.reactivestreams.reactive-streams-1.0
 -bundles=\
   io.openliberty.org.eclipse.microprofile.reactive.streams.operators.3.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-api:3.0"
-kind=beta
+kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging-3.0/io.openliberty.mpReactiveMessaging-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging-3.0/io.openliberty.mpReactiveMessaging-3.0.feature
@@ -24,7 +24,7 @@ Subsystem-Name: MicroProfile Reactive Messaging 3.0
  com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl, \
  io.openliberty.microprofile.reactive.messaging.internal,\
  io.openliberty.microprofile.reactive.messaging.3.0.internal
-kind=beta
+kind=ga
 edition=core
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams-3.0/io.openliberty.mpReactiveStreams-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams-3.0/io.openliberty.mpReactiveStreams-3.0.feature
@@ -20,7 +20,7 @@ IBM-API-Package: \
   io.openliberty.io.smallrye.reactive.mutiny,\
   io.openliberty.io.smallrye.common2, \
   io.openliberty.org.jboss.logging35
-kind=beta
+kind=ga
 edition=core
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/bnd.bnd
@@ -46,7 +46,6 @@ Include-Resource: \
   com.ibm.ws.logging;version=latest, \
   com.ibm.ws.logging.core;version=latest, \
   org.eclipse.osgi;version=latest, \
-  com.ibm.ws.kernel.boot.core;version=latest,\
   com.ibm.websphere.javaee.cdi.2.0;version=latest, \
   com.ibm.websphere.org.osgi.core;version=latest, \
   com.ibm.websphere.org.osgi.service.component;version=latest, \

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
@@ -29,7 +29,6 @@ import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import com.ibm.ws.kernel.productinfo.ProductInfo;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
@@ -130,9 +129,8 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory, Quiesce
             int maxPollRecords = config.getOptionalValue(KafkaConnectorConstants.MAX_POLL_RECORDS, Integer.class).orElse(500);
             int unackedLimit = config.getOptionalValue(KafkaConnectorConstants.UNACKED_LIMIT, Integer.class).orElse(maxPollRecords);
             int retrySeconds = config.getOptionalValue(KafkaConnectorConstants.CREATION_RETRY_SECONDS, Integer.class).orElse(0);
-            // If Beta is false, apply the default value as if the property had not been set.
-            boolean fastAck = ProductInfo.getBetaEdition() ? config.getOptionalValue(KafkaConnectorConstants.FAST_ACK, Boolean.class).orElse(false) : false;
-            String contextServiceRef = ProductInfo.getBetaEdition() ? config.getOptionalValue(KafkaConnectorConstants.CONTEXT_SERVICE, String.class).orElse(null): null;
+            boolean fastAck = config.getOptionalValue(KafkaConnectorConstants.FAST_ACK, Boolean.class).orElse(false);
+            String contextServiceRef = config.getOptionalValue(KafkaConnectorConstants.CONTEXT_SERVICE, String.class).orElse(null);
 
             // Configure our defaults
             Map<String, Object> consumerConfig = new HashMap<>();
@@ -151,9 +149,7 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory, Quiesce
 
             // Create the kafkaConsumer
             KafkaConsumer<String, Object> kafkaConsumer = getKafkaConsumerWithRetry(consumerConfig, retrySeconds, channelName);
-            RMAsyncProvider asyncProvider;
-
-            asyncProvider = asyncProviderFactory.getAsyncProvider(contextServiceRef, channelName);
+            RMAsyncProvider asyncProvider = asyncProviderFactory.getAsyncProvider(contextServiceRef, channelName);
 
             PartitionTrackerFactory partitionTrackerFactory = new PartitionTrackerFactory();
             partitionTrackerFactory.setAsyncProvider(asyncProvider);

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/KafkaCustomContextTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/KafkaCustomContextTest.java
@@ -35,8 +35,6 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
-import java.util.Arrays;
-
 /**
  * Test context propagation with concurrent enabled and custom context services defined
  */
@@ -104,8 +102,6 @@ public class KafkaCustomContextTest extends FATServletClient {
         KafkaUtils.addKafkaTestFramework(war, PlaintextTests.connectionProperties());
 
         ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
-
-        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/invalid/KakfaInvalidContextTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/context/custom/invalid/KakfaInvalidContextTest.java
@@ -34,8 +34,6 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
-import java.util.Arrays;
-
 /**
  * Test invalid context service configuration
  */
@@ -55,7 +53,6 @@ public class KakfaInvalidContextTest extends FATServletClient {
 
     @BeforeClass
     public static void setup() throws Exception {
-        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
@@ -37,8 +37,6 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
-import java.util.Arrays;
-
 @RunWith(FATRunner.class)
 public class KafkaAcknowledgementTest {
 
@@ -74,8 +72,6 @@ public class KafkaAcknowledgementTest {
                         .addPackage(KafkaTestConstants.class.getPackage())
                         .addPackage(AbstractKafkaTestServlet.class.getPackage())
                         .addAsResource(appConfig, "META-INF/microprofile-config.properties");
-
-        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
 
         ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
         server.startServer();

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
@@ -15,7 +15,6 @@ package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -119,8 +118,6 @@ public class KafkaPartitionTest {
                         .addAsResource(appConfig, "META-INF/microprofile-config.properties");
 
         ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
-
-        server.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true"));
 
         server.startServer();
     }


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.microprofile.reactive.messaging_fat,com.ibm.ws.microprofile.reactive.messaging_fat_tck,com.ibm.ws.microprofile.reactive.streams.operators_fat,com.ibm.ws.microprofile.reactive.streams.operators_fat_tck,io.openliberty.microprofile.reactive.messaging30.internal_fat_tck,io.openliberty.microprofile.reactive.messaging.internal_fat,io.openliberty.microprofile.reactive.streams.operators30.internal_fat_tck