### PR TITLE
Add Java 22 specific test to FAT

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -62,6 +62,7 @@ io.openliberty:java-apps:18.0.0
 io.openliberty:java-apps:19.0.0
 io.openliberty:java-apps:20.0.0
 io.openliberty:java-apps:21.0.0
+io.openliberty:java-apps:22.0.0
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0

--- a/dev/io.openliberty.java.internal_fat/build.gradle
+++ b/dev/io.openliberty.java.internal_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2023 IBM Corporation and others.
+ * Copyright (c) 2017,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ configurations {
     app19
     app20
     app21
+    app22
  }
  
  dependencies {
@@ -25,6 +26,7 @@ configurations {
     app19 'io.openliberty:java-apps:19.0.0'
     app20 'io.openliberty:java-apps:20.0.0'
     app21 'io.openliberty:java-apps:21.0.0'
+    app22 'io.openliberty:java-apps:22.0.0'
  }
 
 task copyKernelService(type: Copy) {
@@ -75,6 +77,12 @@ task copyApp21(type: Copy) {
   rename 'java-apps-*.*.*.*', 'io.openliberty.java.internal_fat_21.war'
 }
 
+task copyApp22(type: Copy) {
+  from configurations.app22
+  into new File(autoFvtDir, 'publish/servers/java22-server/apps/')
+  rename 'java-apps-*.*.*.*', 'io.openliberty.java.internal_fat_22.war'
+}
+
 addRequiredLibraries.dependsOn copyKernelService
 addRequiredLibraries.dependsOn copyApp17A
 addRequiredLibraries.dependsOn copyApp17B
@@ -83,3 +91,4 @@ addRequiredLibraries.dependsOn copyApp18B
 addRequiredLibraries.dependsOn copyApp19
 addRequiredLibraries.dependsOn copyApp20
 addRequiredLibraries.dependsOn copyApp21
+addRequiredLibraries.dependsOn copyApp22

--- a/dev/io.openliberty.java.internal_fat/fat/src/io/openliberty/java/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.java.internal_fat/fat/src/io/openliberty/java/internal/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
                 Java19Test.class,
                 Java20Test.class,
                 Java21Test.class,
+                Java22Test.class,
                 JavaIllegalAccessTest.class,
                 AlwaysPassesTest.class
 })

--- a/dev/io.openliberty.java.internal_fat/fat/src/io/openliberty/java/internal/fat/Java22Test.java
+++ b/dev/io.openliberty.java.internal_fat/fat/src/io/openliberty/java/internal/fat/Java22Test.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.java.internal.fat;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.annotation.MaximumJavaLevel;
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpUtils;
+
+@RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 22)
+@MaximumJavaLevel(javaLevel = 22)
+public class Java22Test extends FATServletClient {
+
+    public static final String APP_NAME = "io.openliberty.java.internal_fat_22";
+
+    @Server("java22-server")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // NOTE: This FAT uses a pre-compiled application which is compiled at the bytecode
+        // level of JDK 22, which is higher than what our build systems normally use
+        // Code source files for this WAR file this FAT uses can be found in the src-reference/java22 directory at the root of this FAT
+        // The full project for building the required WAR file can be found here: https://github.com/OpenLiberty/open-liberty-misc/tree/main/io.openliberty.java.internal_fat_22
+        server.addInstalledAppForValidation(APP_NAME);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    @Test
+    public void testJava22App() throws Exception {
+        String appResponse = HttpUtils.getHttpResponseAsString(server, APP_NAME + '/');
+        assertContains(appResponse, "<<< EXIT SUCCESSFUL");
+    }
+
+    private static void assertContains(String str, String lookFor) {
+        assertTrue("Expected to find string '" + lookFor + "' but it was not found in the string: " + str, str.contains(lookFor));
+    }
+}

--- a/dev/io.openliberty.java.internal_fat/publish/servers/java22-server/bootstrap.properties
+++ b/dev/io.openliberty.java.internal_fat/publish/servers/java22-server/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info

--- a/dev/io.openliberty.java.internal_fat/publish/servers/java22-server/jvm.options
+++ b/dev/io.openliberty.java.internal_fat/publish/servers/java22-server/jvm.options
@@ -1,0 +1,1 @@
+--enable-preview

--- a/dev/io.openliberty.java.internal_fat/publish/servers/java22-server/server.xml
+++ b/dev/io.openliberty.java.internal_fat/publish/servers/java22-server/server.xml
@@ -1,0 +1,25 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <featureManager>
+        <feature>servlet-4.0</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>jaxrs-2.1</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <application location="io.openliberty.java.internal_fat_22.war" />
+
+</server>

--- a/dev/io.openliberty.java.internal_fat/src-reference/java22/io/openliberty/java/internal/TestApp.java
+++ b/dev/io.openliberty.java.internal_fat/src-reference/java22/io/openliberty/java/internal/TestApp.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.java.internal;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class TestApp extends Application {
+}

--- a/dev/io.openliberty.java.internal_fat/src-reference/java22/io/openliberty/java/internal/TestService.java
+++ b/dev/io.openliberty.java.internal_fat/src-reference/java22/io/openliberty/java/internal/TestService.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.java.internal;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/")
+@ApplicationScoped
+public class TestService {
+
+    private StringWriter sw = new StringWriter();
+
+    @GET
+    public String test() {
+        try {
+            log(">>> ENTER");
+            doTest();
+            log("<<< EXIT SUCCESSFUL");
+        } catch (Exception e) {
+            e.printStackTrace(System.out);
+            e.printStackTrace(new PrintWriter(sw));
+            log("<<< EXIT FAILED");
+        }
+        String result = sw.toString();
+        sw = new StringWriter();
+        return result;
+    }
+
+
+    private void doTest() throws Exception {
+        log("Beginning Java 22 testing");
+        ArrayList<String> favoriteShows = new ArrayList<String>(Arrays.asList("Outpost","Grimm","Community","Scrubs","Castle","Star Trek"));
+        int count = countElements(favoriteShows);
+
+        if (count != favoriteShows.size()) {
+            log("Failed testing");
+            throw new Exception("Number of elements counted in ArrayList (" + count + ") is not equal to the size (" + favoriteShows.size() + ")!");
+        }
+        
+        log("Goodbye testing");
+    }
+
+    /**
+     * Demonstrate unnamed variables : JEP 456 -> https://openjdk.org/jeps/456
+     * 
+     * @param shows
+     * @return
+     */
+    public int countElements(ArrayList<String> list) {
+        int total = 0;
+        for (var _ : list) {    // Use _ for unnamed variable
+            total++;
+        }
+        return total;
+    }
+
+
+    public void log(String msg) {
+        System.out.println(msg);
+        sw.append(msg);
+        sw.append("<br/>");
+    }
+}

--- a/dev/io.openliberty.java.internal_fat/src-reference/java22/io/openliberty/java/internal/package-info.java
+++ b/dev/io.openliberty.java.internal_fat/src-reference/java22/io/openliberty/java/internal/package-info.java
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.java.internal;


### PR DESCRIPTION
Add a Java 22 specific test to the `io.openliberty.java.internal_fat` FAT to ensure we are running on Java 22.

Note: The source files in this PR under `io.openliberty.java.internal_fat/src-reference/...` are not actually used to build and run the test since they need to be compiled at Java 22.  They are just convenient copies of the source for the test which is kept here -> https://github.com/OpenLiberty/open-liberty-misc/tree/main/io.openliberty.java.internal_fat_22