### PR TITLE
GRPC as a servlet: Move flushing of last frame of a stream to occur as part of trailer writing

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceConfigTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceConfigTests.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -110,7 +110,8 @@ public class ServiceConfigTests extends FATServletClient {
         GrpcTestUtils.stopGrpcService(worldChannel);
         // The testInvalidMaxInboundMessageSize() test generates this log message, don't flag it as an error
         // CWWKT0203E: The maxInboundMessageSize -1 is not valid. Sizes must greater than 0.
-        grpcServer.stopServer("CWWKT0203E");
+        // SRVE9015E: This occurs during testInvalidMaxInboundMessageSize where the protocol error prevents the response body being accessed
+        grpcServer.stopServer("CWWKT0203E", "SRVE9015E");
     }
 
     /**

--- a/dev/io.openliberty.grpc.1.0.internal/src/io/grpc/servlet/ServletServerStream.java
+++ b/dev/io.openliberty.grpc.1.0.internal/src/io/grpc/servlet/ServletServerStream.java
@@ -300,19 +300,7 @@ final class ServletServerStream extends AbstractServerStream {
           trailerSupplier.get().putIfAbsent(key, newValue);
         }
       }
-      try {
-        // Liberty change - our stack now needs a flush at this point which has now been
-        // removed from later versions of GRPC.
-        // See:
-        //   https://github.com/grpc/grpc-java/pull/9177/files#diff-2de04da34f7e35c085ca26dc596410983f5ded55a8de11eb97811264dea011f2
-        // grpc-java: AbstractServerStream::deliverFrame:
-        //   "Since endOfStream is triggered by the sending of trailers, avoid flush here and just flush after the trailers."
-        // So the last deliverFrame will have flush parameter false, and so we also have to flush as part of writing the trailers: 
-        writer.flush();
-      }catch(IOException ioe) {
-        logger.warning( ioe.getMessage() );
-      }
-      writer.complete();
+      writer.completeWithFlush();
     }
 
     @Override


### PR DESCRIPTION
As part of  
```
https://github.com/grpc/grpc-java/pull/9177/files#diff-2de04da34f7e35c085ca26dc596410983f5ded55a8de11eb97811264dea011f2
```
the grpc-java developers removed the flush from the last frame of the stream as their code
stack always flushed as part of sending trailers.

Our code stack did not match this and and this led to occasional EOS errors, 
so a patch was put in to 'undo' the google change local to where it was done, 
but this is a better fix that instead ensures flushing when the trailers are sent.

Relevant to rtc 291087

I have followed the existing convention on not updating any copyright notices for files
which are substantially from open source with only minor IBM changes.

I can confirm that the initial three builds that 'failed' over the weekend were all from the caught exception
being spotted in the logs by the test infrastructure.
(see second line below).

The actual testcase was happy but the infrastructure software still spotted the caught error code in the log,
as this situation only occurs when testing invalid gRPC frames being sent to the server in an error
testcase I think that it is best to leave this message there as it will not occur unless there is a genuine error
that will prevent any response body - and so there will always be errors in the log to look at. The log entry
for the SRVE9015E will never occur if valid gRCP frames are being flowed.

As exception is logged before being thrown up to the gRPC Servlet level I cannot hide is completely via a catch in the grpc-servlet only code layer anyway. I do not want to change the underlying IBM http2 code, partly as there will
be netty and non netty versions and it might change in the future.

fixes #26590

An alternative design would be to downcast the AsyncContext to the (IBM) AsyncContextImpl, whereapon I could
test the state and not attempt to get the response - but I think that is an inferior solution to allowing the testcase
to allow the logged error when invalid gRPC frames are sent to the server.
```
[2/3/24, 2:58:57:408 UTC] 0000002c com.ibm.ws.webcontainer31.async.AsyncContext31Impl           E SRVE9015E: Cannot obtain the request or response object after an AsyncContext.dispatch() or AsyncContext.complete().
[2/3/24, 2:58:57:409 UTC] 0000002c io.grpc.servlet.AsyncServletOutputStreamWriter               I [ServletAdapter<17>]Not flushing gRPC response buffer as response body is cancelled, see earlier gRPC protocol error.
```