### PR TITLE
CDI 4.1 repeats for visibility bucket

### DIFF
--- a/dev/com.ibm.ws.cdi.visibility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.visibility_fat/bnd.bnd
@@ -1,14 +1,11 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2022 IBM Corporation and others.
+# Copyright (c) 2018, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 
@@ -23,27 +20,46 @@ src: \
 fat.project: true
 
 tested.features:\
-	cdi-2.0,\
-	servlet-4.0,\
-	servlet-5.0,\
-	cdi-3.0,\
-	connectors-2.0,\
-	restfulwsclient-3.0,\
-	restfulws-3.0,\
-	jsonp-2.0,\
-	appclientsupport-2.0,\
-	enterprisebeans-4.0,\
-	enterprisebeansremote-4.0,\
-	jdbc-4.2,\
-	enterprisebeanshome-4.0,\
-	enterprisebeanslite-4.0,\
-	enterprisebeanspersistenttimer-4.0,\
-	cdi-4.0,\
-	connectors-2.1,\
-	jakartaee-10.0,\
-	servlet-6.0,\
-	mpConfig-3.0,\
-	mpFaultTolerance-4.0
+        cdi-2.0,\
+        servlet-4.0,\
+        servlet-5.0,\
+        cdi-3.0,\
+        connectors-2.0,\
+        restfulwsclient-3.0,\
+        restfulws-3.0,\
+        jsonp-2.0,\
+        appclientsupport-2.0,\
+        enterprisebeans-4.0,\
+        enterprisebeansremote-4.0,\
+        jdbc-4.2,\
+        enterprisebeanshome-4.0,\
+        enterprisebeanslite-4.0,\
+        enterprisebeanspersistenttimer-4.0,\
+        cdi-4.0,\
+        connectors-2.1,\
+        jakartaee-10.0,\
+        servlet-6.0,\
+        mpConfig-3.0,\
+        mpFaultTolerance-4.0,\
+        data-1.0,\
+        webprofile-11.0,\
+        expressionlanguage-6.0,\
+        restfulwsclient-4.0,\
+        faces-4.1,\
+        persistence-3.2,\
+        websocket-2.2,\
+        appauthentication-3.1,\
+        appauthorization-3.0,\
+        pages-4.0,\
+        concurrent-3.1,\
+        persistencecontainer-3.2,\
+        appsecurity-6.0,\
+        restfulws-4.0,\
+        noship-1.0,\
+        jakartaee-11.0,\
+        cdi-4.1,\
+        beanvalidation-3.1,\
+        servlet-6.1
 
 -buildpath: \
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/basic/BasicVisibilityTests.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/basic/BasicVisibilityTests.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.cdi.visibility.tests.basic;
 
@@ -57,7 +54,7 @@ public class BasicVisibilityTests extends FATServletClient {
     public static final String SERVER_NAME = "cdi12BasicServer";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7);
 
     public static final String CLASS_LOAD_APP_NAME = "classloadPrereq";
     public static final String ROOT_CLASSLOADER_APP_NAME = "rootClassLoader";

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/ejb/EJBVisibilityTests.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/ejb/EJBVisibilityTests.java
@@ -53,6 +53,7 @@ public class EJBVisibilityTests extends FATServletClient {
     //Because this test includes Fault Tolerance, the repeat must be done using MicroProfileActions.
     //Fault Tolerance is included as a feature with CDI extension which can see application BDAs.
     //This previously caused issues with masked classes.
+    //At some point we need to repeat this test with EE11 but Fault Tolerance does not yet support EE11.
     @ClassRule
     public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME,
                                                              MicroProfileActions.MP61,

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/sharedlib/SharedLibraryTest.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/sharedlib/SharedLibraryTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.cdi.visibility.tests.sharedlib;
 
@@ -51,7 +48,7 @@ public class SharedLibraryTest extends FATServletClient {
     public static final String SERVER_NAME = "cdi12SharedLibraryServer";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE8);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE8);
 
     public static final String SHARED_NO_INJECT_APP_NAME = "sharedLibraryNoInjection";
     public static final String SHARED_INJECT_APP_NAME = "sharedLibraryInjection";

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/validatorInJar/ValidatorInJarTest.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/validatorInJar/ValidatorInJarTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.cdi.visibility.tests.validatorInJar;
 
@@ -45,7 +42,7 @@ public class ValidatorInJarTest extends FATServletClient {
     public static final String SERVER_NAME = "cdi12ValidatorInJarServer";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE7);
 
     public static final String TEST_VALIDATOR_APP_NAME = "TestValidatorInJar";
 

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/VisTest.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/VisTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * Copyright (c) 2015, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.cdi.visibility.tests.vistest;
 
@@ -137,7 +134,7 @@ public class VisTest extends FATServletClient {
     public static final String CLIENT_NAME = "visTestClient";
 
     @ClassRule
-    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE8, EERepeatActions.EE7);
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE8, EERepeatActions.EE7);
 
     @Server(SERVER_NAME)
     public static LibertyServer server;
@@ -730,13 +727,13 @@ public class VisTest extends FATServletClient {
     public static void afterClass() throws Exception {
 
         //We put this in an AutoCloseable because try-with-resource will order the exceptions correctly.
-        //That means an exception from stopServer will by the primary exception, and any errors from 
+        //That means an exception from stopServer will by the primary exception, and any errors from
         //uninstallSystemFeature will be recorded as suppressed exceptions.
         AutoCloseable uninstallFeatures = () -> {
             server.uninstallSystemFeature("visTest-1.2");
             server.uninstallSystemFeature("visTest-3.0");
         };
-        
+
         try (AutoCloseable c = uninstallFeatures) {
             if (server != null) {
                 server.stopServer();

--- a/dev/com.ibm.ws.cdi.visibility_fat/publish/features/visTest-3.0.mf
+++ b/dev/com.ibm.ws.cdi.visibility_fat/publish/features/visTest-3.0.mf
@@ -8,7 +8,7 @@ Subsystem-Content:
 Subsystem-Type: osgi.subsystem.feature
 
 X-Comment: This is an autofeature because there's a hardcoded limitation on what features you can list in a client.xml
-IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.cdi-3.0)(osgi.identity=io.openliberty.cdi-4.0)))"
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.cdi-3.0)(osgi.identity=io.openliberty.cdi-4.0)(osgi.identity=io.openliberty.cdi-4.1)))"
 
 IBM-API-Package: 
   com.ibm.ws.cdi.visibility.tests.vistest.framework,

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/TransformSubActionImpl.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/TransformSubActionImpl.java
@@ -1,16 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package componenttest.rules.repeater;
+
+import org.eclipse.transformer.Transformer.ResultCode;
 
 public class TransformSubActionImpl implements TransformSubAction {
 
@@ -19,6 +18,9 @@ public class TransformSubActionImpl implements TransformSubAction {
         // Note the use of 'com.ibm.ws.JakartaTransformer'.
         // 'org.eclipse.transformer.Transformer' might also be used instead.
 
-        org.eclipse.transformer.cli.TransformerCLI.runWith(new org.eclipse.transformer.cli.JakartaTransformerCLI(System.out, System.err, args));
+        ResultCode rc = org.eclipse.transformer.cli.TransformerCLI.runWith(new org.eclipse.transformer.cli.JakartaTransformerCLI(System.out, System.err, args));
+        if (rc != ResultCode.SUCCESS_RC) {
+            throw new RuntimeException("Non-success result code from Transformer: " + rc);
+        }
     }
 }


### PR DESCRIPTION
Repeat the CDI Visibility bucket against EE11.
Also included a small improvement to the code which runs the transformer, to ensure that failures result in an exception ... which in turn means that the logs are kept.

