### PR TITLE
trim env var to allow for spaces

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
@@ -99,7 +99,7 @@ public class FeatureResolverImpl implements FeatureResolver {
         String[] preferredVersions = (preferedFeatureVersions == null) ? new String[] {} : preferedFeatureVersions.split(",");
         String[][] parsedVersions = new String[preferredVersions.length][2];
         for (int i = 0; i < preferredVersions.length; i++) {
-            parsedVersions[i] = parseNameAndVersion(preferredVersions[i]);
+            parsedVersions[i] = parseNameAndVersion(preferredVersions[i].trim());
         }
         parsedPreferedVersions = parsedVersions;
     }


### PR DESCRIPTION
#27492 trim each feature version in the environment variable to allow for spaces