### PR TITLE
remove versionless features from console output

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -1227,6 +1227,9 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
             FeatureDefinition fd = getFeatureDefinition(feature);
 
             if (fd != null && fd.getVisibility() == Visibility.PUBLIC) {
+                if(fd.getSymbolicName().contains("versionless")){
+                    continue;
+                }
                 // get name from feature definition.
                 // input ones come from the cache which is lower case.
                 // If we don't want to include auto features, then check each feature before adding it.


### PR DESCRIPTION
#27493 

The console when versionless features were used would display both the versionless and versioned features

```
CWWKF0012I: The server installed the following features: [cdi-4.0, distributedMap-1.0, jndi-1.0, json-1.0, monitor-1.0, mpConfig-3.0, mpHealth, mpHealth-4.0, mpMetrics, mpMetrics-5.0, servlet-6.0, ssl-1.0, transportSecurity-1.0]
```

Now it doesn't display the versionless features in the console log

```
CWWKF0012I: The server installed the following features: [cdi-4.0, distributedMap-1.0, jndi-1.0, json-1.0, monitor-1.0, mpConfig-3.0, mpHealth-4.0, mpMetrics-5.0, servlet-6.0, ssl-1.0, transportSecurity-1.0]
```