### PR TITLE
Update resteasy-tracing-api exports to correct version

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2023 IBM Corporation and others.
+# Copyright (c) 2022, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -112,8 +112,8 @@ Export-Package: \
   org.jboss.resteasy.spi;version=${resteasy-version};thread-context=true, \
   org.jboss.resteasy.statistics;version=${resteasy-version}, \
   org.jboss.resteasy.test;version=${resteasy-version}, \
-  org.jboss.resteasy.tracing.api.providers;version=1.0.0, \
-  org.jboss.resteasy.tracing.api;version=1.0.0, \
+  org.jboss.resteasy.tracing.api.providers;version=${resteasy-tracing-api-version},\
+  org.jboss.resteasy.tracing.api;version=${resteasy-tracing-api-version},\
   org.jboss.resteasy.tracing;version=${resteasy-version}, \
   org.jboss.resteasy.util.snapshot;version=${resteasy-version}, \
   org.jboss.resteasy.util;version=${resteasy-version}

--- a/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
@@ -107,8 +107,8 @@ Export-Package: \
   org.jboss.resteasy.spi;version=${resteasy-version};thread-context=true, \
   org.jboss.resteasy.statistics;version=${resteasy-version}, \
   org.jboss.resteasy.test;version=${resteasy-version}, \
-  org.jboss.resteasy.tracing.api.providers;version=1.0.0, \
-  org.jboss.resteasy.tracing.api;version=1.0.0, \
+  org.jboss.resteasy.tracing.api.providers;version=${resteasy-tracing-api-version},\
+  org.jboss.resteasy.tracing.api;version=${resteasy-tracing-api-version},\
   org.jboss.resteasy.tracing;version=${resteasy-version}, \
   org.jboss.resteasy.util.snapshot;version=${resteasy-version}, \
   org.jboss.resteasy.util;version=${resteasy-version}


### PR DESCRIPTION
It was brought to my attention that the EE9 and EE10 versions of Restful Web Services were exporting a  very old version of org.jboss.resteasy:resteasy-tracing-api.   It appears that the 1.0.0 was not updated to 1.1.0 in the exports when the RESTEasy version was updated to 4.7.0.  