### PR TITLE
JAXB: Update fattest.simplicity/build.gradle to force dependency order

### DIFF
--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -21,6 +21,7 @@ task assembleBootstrap(type: Copy) {
 }
 
 task assembleBinaryDependencies() {
+    dependsOn ':com.ibm.ws.jaxb.tools:jar'
     File buildDirLib = new File(buildDir, 'lib')
     outputs.dir buildDirLib
     doLast {


### PR DESCRIPTION
This PR fixes the following error: 

```
javax.xml.bind.JAXBException: Provider com.sun.xml.bind.v2.ContextFactory not found
 - with linked exception:
[java.lang.ClassNotFoundException: com.sun.xml.bind.v2.ContextFactory]
	at javax.xml.bind.ContextFinder.loadSpi(ContextFinder.java:161)
	at javax.xml.bind.ContextFinder.find(ContextFinder.java:106)
	at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:65)
	at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:56)
	at com.ibm.websphere.simplicity.config.ServerConfigurationFactory.<init>(ServerConfigurationFactory.java:76)
	at com.ibm.websphere.simplicity.config.ServerConfigurationFactory.getInstance(ServerConfigurationFactory.java:43)
	at com.ibm.websphere.simplicity.config.ServerConfigurationFactory.fromFile(ServerConfigurationFactory.java:49)
	at componenttest.rules.repeater.FeatureReplacementAction.setFeatures(FeatureReplacementAction.java:601)
	at componenttest.rules.repeater.FeatureReplacementAction.setup(FeatureReplacementAction.java:493)
	at componenttest.rules.repeater.JakartaEEAction.setup(JakartaEEAction.java:214)
	at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:144)
	at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:363)
	at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:177)
	at org.testcontainers.containers.FailureDetectingExternalResource$1.evaluate(FailureDetectingExternalResource.java:29)
Caused by: java.lang.ClassNotFoundException: com.sun.xml.bind.v2.ContextFactory
	at java.base/java.lang.Class.forNameImpl(Native Method)
	at java.base/java.lang.Class.forName(Class.java:429)
	at org.apache.geronimo.osgi.locator.ProviderLocator.loadClass(ProviderLocator.java:195)
	at javax.xml.bind.ContextFinder.loadSpi(ContextFinder.java:159)
```

This is caused by the `com.ibm.ws.jaxb.tools` project not being built prior to the `fattest.simplicity` project.  This PR forces the dependency to be built prior to copying it to `build/libs/lib/com.ibm.ws.jaxb.tools.jar`