### PR TITLE
Fix up MANIFEST.MF file that cause transformer error.

### DIFF
--- a/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandler.ear/resources/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandler.ear/resources/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
-Class-Path:
- 
+Class-Path: 
+


### PR DESCRIPTION
- Trying to load the manifest file of a test ear fails which causes the transformer to return an error and now with the introduced of #27526 this causes the test to fail.  This PR updates the manifest file to be able to be parsed.