### PR TITLE
Fix up MANIFEST.MF files that cause transformer error.

### DIFF
--- a/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandlerBadPwd.ear/resources/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandlerBadPwd.ear/resources/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
-Class-Path:
- 
+Class-Path: 
+

--- a/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandlerEmptyPwd.ear/resources/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandlerEmptyPwd.ear/resources/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
-Class-Path:
- 
+Class-Path: 
+

--- a/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandlerEmptyUser.ear/resources/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandlerEmptyUser.ear/resources/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
-Class-Path:
- 
+Class-Path: 
+

--- a/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandlerNullUser.ear/resources/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandlerNullUser.ear/resources/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
-Class-Path:
- 
+Class-Path: 
+

--- a/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandlerUnauthzUser.ear/resources/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandlerUnauthzUser.ear/resources/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
-Class-Path:
- 
+Class-Path: 
+

--- a/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandlerUserNotDefined.ear/resources/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.security.client_fat/test-applications/ProgrammaticLoginWithCallbackHandlerUserNotDefined.ear/resources/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
-Class-Path:
- 
+Class-Path: 
+


### PR DESCRIPTION
- Trying to load the manifest file of a test application fails which causes the transformer to return an error and now with the change introduced in https://github.com/OpenLiberty/open-liberty/pull/27526 this causes the test to fail. This PR updates the manifest files to be able to be parsed.