### PR TITLE
Remove test that times out because it legitimately needs longer than …

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
@@ -23,11 +23,6 @@
                     <include name="testAsyncTimeout"/>
                 </methods>
             </class>
-            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest">
-                <methods>
-                    <include name="testCircuitBreakerAroundBulkheadSync"/>
-                </methods>
-            </class>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest">
                 <methods>
                     <exclude name="testRetriesSucceedWhenCircuitCloses"/>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -29,6 +29,12 @@
                     <exclude name="testBulkheadClassAsynchFutureDoneAfterGet"/>
                 </methods>
             </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest">
+               <!-- This was removed because the test could legitimately take longer than the 2second timeout. This bug is fixed in TCK version 3 -->
+                <methods>
+                    <exclude name="testCircuitBreakerAroundBulkheadSync"/>
+                </methods>
+            </class>
         </classes>
     </test>
 </suite>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
@@ -27,11 +27,6 @@
             </class>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest"></class>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest"></class>
-            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest">
-                <methods>
-                    <include name="testCircuitBreakerAroundBulkheadSync"/>
-                </methods>
-            </class>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest"></class> <!-- new functionality -->
             <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest">
                 <methods>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -29,6 +29,12 @@
                     <exclude name="testBulkheadClassAsynchFutureDoneAfterGet"/>
                 </methods>
             </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest">
+               <!-- This was removed because the test could legitimately take longer than the 2second timeout. This bug is fixed in TCK version 3 -->
+                <methods>
+                    <exclude name="testCircuitBreakerAroundBulkheadSync"/>
+                </methods>
+            </class>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
…the timeout to run

