### PR TITLE
Update FeatureList and EsaResourceImpl for Java 22

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -91,7 +91,7 @@ public class FeatureList {
             addJVM(possibleJavaVersions, "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
-            addJVM(possibleJavaVersions, "21", "20", "19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
+            addJVM(possibleJavaVersions, "22", "21", "20", "19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
 
             List<GenericMetadata> mostGeneralRange = ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=1.7))\"");
 
@@ -105,6 +105,7 @@ public class FeatureList {
             eeToCapability.put("JavaSE-11", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=11))\""));
             eeToCapability.put("JavaSE-17", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=17))\""));
             eeToCapability.put("JavaSE-21", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=21))\""));
+            eeToCapability.put("JavaSE-22", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=22))\""));
         }
 
         gaBuild = isGABuild();

--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
@@ -91,6 +91,7 @@ public class FeatureList {
             addJVM(possibleJavaVersions, "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
+            addJVM(possibleJavaVersions, "21", "20", "19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "22", "21", "20", "19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
 
             List<GenericMetadata> mostGeneralRange = ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=1.7))\"");

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2023 IBM Corporation and others.
+ * Copyright (c) 2015,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -234,10 +234,10 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
             return;
         }
 
-        String minJava21 = "Java SE 21";
-        String minJava17 = "Java SE 17, Java SE 21";
-        String minJava11 = "Java SE 11, Java SE 17, Java SE 21";
-        String minJava8 = "Java SE 8, Java SE 11, Java SE 17, Java SE 21";
+        String minJava21 = "Java SE 21, Java SE 22";
+        String minJava17 = "Java SE 17, Java SE 21, Java SE 22";
+        String minJava11 = "Java SE 11, Java SE 17, Java SE 21, Java SE 22";
+        String minJava8 = "Java SE 8, Java SE 11, Java SE 17, Java SE 21, Java SE 22";
 
         // The min version should have been validated when the ESA was constructed
         // so checking for the version string should be safe


### PR DESCRIPTION
Update FeatureList and EsaResourceImpl to add the Java 22 version.

Previous version for reference -> https://github.com/OpenLiberty/open-liberty/pull/25444

This PR should not be merged until after the GM build is cut for the release `prior` to the release that we plan to support Java 22.