### PR TITLE
Fixes for build and running FATs with Java 21.

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -23,6 +23,11 @@
     </dependency>
     <dependency>
       <groupId>biz.aQute.bnd</groupId>
+      <artifactId>biz.aQute.bnd.transform</artifactId>
+      <version>7.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>biz.aQute.bnd</groupId>
       <artifactId>biz.aQute.bnd</artifactId>
       <version>7.0.0</version>
     </dependency>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -1,5 +1,6 @@
 biz.aQute.bnd:biz.aQute.bnd.annotation:7.0.0
 biz.aQute.bnd:biz.aQute.bnd.transform:6.4.1
+biz.aQute.bnd:biz.aQute.bnd.transform:7.0.0
 biz.aQute.bnd:biz.aQute.bnd:7.0.0
 cglib:cglib:3.3.0
 ch.qos.logback:logback-classic:1.2.3

--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2023 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -123,6 +123,19 @@
 		</condition>
 		<property name="use.java.security.manager" value=""/>
 		
+		<!-- Reuse the is.java15.orHigher for Java 17 or higher because we no longer run with Java 15 or 16.
+		     This condition picks which of the bnd transform jars to exclude from the test path.  We want to use
+                     the BND 7.0.0 bundle for Java 17 or later and the 6.4.1 for Java 8 and 11 because 7.0.0 requires
+                     Java 17 since it is Java 17 byte code.  With Java 21 compiled code there is an issue with BND 6.4.1
+		     which is why we can't just use the 6.4.1 version everywhere.  Right now on the build systems we use
+                     Java 17 to build and run with Java 21 to run the FATs, but people can build and run with Java 21 for
+                     Open Liberty and run into this problem. -->
+		<condition property="bnd.transform.jar.to.exclude" value="biz.aQute.bnd.transform-6.4.1.jar" else="biz.aQute.bnd.transform-7.0.0.jar">
+			<and>
+				<istrue value="${is.java15.orHigher}"/>
+			</and>
+		</condition>
+
 		<tstamp>
 			<format property="today.day" pattern="EEEE" />
 		</tstamp>
@@ -177,6 +190,7 @@
 			<!-- We want our doctored simplicity high on the classpath -->
 			<fileset dir="${basedir}/lib/">
 				<include name="*.jar" />
+				<exclude name="${bnd.transform.jar.to.exclude}" />
 			</fileset>
 
 			<!-- shared libraries from bootstrapping.properties -->

--- a/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2023 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -245,6 +245,19 @@
 		</condition>
 		<property name="illegal.access.permit" value=""/>
 		
+		<!-- Reuse the is.java15.orHigher for Java 17 or higher because we no longer run with Java 15 or 16.
+		     This condition picks which of the bnd transform jars to exclude from the test path.  We want to use
+                     the BND 7.0.0 bundle for Java 17 or later and the 6.4.1 for Java 8 and 11 because 7.0.0 requires
+                     Java 17 since it is Java 17 byte code.  With Java 21 compiled code there is an issue with BND 6.4.1
+		     which is why we can't just use the 6.4.1 version everywhere.  Right now on the build systems we use
+                     Java 17 to build and run with Java 21 to run the FATs, but people can build and run with Java 21 for
+                     Open Liberty and run into this problem. -->
+		<condition property="bnd.transform.jar.to.exclude" value="biz.aQute.bnd.transform-6.4.1.jar" else="biz.aQute.bnd.transform-7.0.0.jar">
+			<and>
+				<istrue value="${is.java15.orHigher}"/>
+			</and>
+		</condition>
+
 		<!-- Replace LDAP ports of all 3 Apache DS instance in configuration with updated ports from port selector and kill any apache ds related processes -->
 		<replaceLdapPorts />
 		<iff if="unix.mac.environment">
@@ -282,6 +295,7 @@
 			<!-- We want our doctored simplicity high on the classpath -->
 			<fileset dir="${basedir}/lib/">
 				<include name="*.jar" />
+				<exclude name="${bnd.transform.jar.to.exclude}" />
 			</fileset>
 
 			<!-- shared libraries from bootstrapping.properties -->

--- a/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2023 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -245,6 +245,19 @@
 		</condition>
 		<property name="illegal.access.permit" value=""/>
 		
+		<!-- Reuse the is.java15.orHigher for Java 17 or higher because we no longer run with Java 15 or 16.
+		     This condition picks which of the bnd transform jars to exclude from the test path.  We want to use
+                     the BND 7.0.0 bundle for Java 17 or later and the 6.4.1 for Java 8 and 11 because 7.0.0 requires
+                     Java 17 since it is Java 17 byte code.  With Java 21 compiled code there is an issue with BND 6.4.1
+		     which is why we can't just use the 6.4.1 version everywhere.  Right now on the build systems we use
+                     Java 17 to build and run with Java 21 to run the FATs, but people can build and run with Java 21 for
+                     Open Liberty and run into this problem. -->
+		<condition property="bnd.transform.jar.to.exclude" value="biz.aQute.bnd.transform-6.4.1.jar" else="biz.aQute.bnd.transform-7.0.0.jar">
+			<and>
+				<istrue value="${is.java15.orHigher}"/>
+			</and>
+		</condition>
+
 		<!-- Replace LDAP ports of all 3 Apache DS instance in configuration with updated ports from port selector and kill any apache ds related processes -->
 		<replaceLdapPorts />
 		<iff if="unix.mac.environment">
@@ -282,6 +295,7 @@
 			<!-- We want our doctored simplicity high on the classpath -->
 			<fileset dir="${basedir}/lib/">
 				<include name="*.jar" />
+				<exclude name="${bnd.transform.jar.to.exclude}" />
 			</fileset>
 
 			<!-- shared libraries from bootstrapping.properties -->

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -1,10 +1,10 @@
 <!--
-    Copyright (c) 2017, 2023 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
  -->
 <project name="standard.launch.tasks">
@@ -218,6 +218,19 @@
 		</condition>
 		<property name="use.java.security.manager" value=""/>
 		
+		<!-- Reuse the is.java15.orHigher for Java 17 or higher because we no longer run with Java 15 or 16.
+		     This condition picks which of the bnd transform jars to exclude from the test path.  We want to use
+                     the BND 7.0.0 bundle for Java 17 or later and the 6.4.1 for Java 8 and 11 because 7.0.0 requires
+                     Java 17 since it is Java 17 byte code.  With Java 21 compiled code there is an issue with BND 6.4.1
+		     which is why we can't just use the 6.4.1 version everywhere.  Right now on the build systems we use
+                     Java 17 to build and run with Java 21 to run the FATs, but people can build and run with Java 21 for
+                     Open Liberty and run into this problem. -->
+		<condition property="bnd.transform.jar.to.exclude" value="biz.aQute.bnd.transform-6.4.1.jar" else="biz.aQute.bnd.transform-7.0.0.jar">
+			<and>
+				<istrue value="${is.java15.orHigher}"/>
+			</and>
+		</condition>
+
 		<!-- Replace LDAP ports of all 3 Apache DS instance in configuration with updated ports from port selector and kill any apache ds related processes -->
 		<replaceLdapPorts />
 		<iff if="unix.mac.environment">
@@ -255,6 +268,7 @@
 			<!-- We want our doctored simplicity high on the classpath -->
 			<fileset dir="${basedir}/lib/">
 				<include name="*.jar" />
+				<exclude name="${bnd.transform.jar.to.exclude}" />
 			</fileset>
 
 			<!-- shared libraries from bootstrapping.properties -->

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -82,7 +82,7 @@ fat.test.container.images: testcontainers/ryuk:0.5.1, testcontainers/sshd:1.1.0,
     org.eclipse.transformer:org.eclipse.transformer.bnd.analyzer;version=0.5.0,\
     org.eclipse.transformer:org.eclipse.transformer.jakarta;version=0.5.0,\
     org.eclipse.transformer:org.eclipse.transformer;version=0.5.0,\
-    biz.aQute.bnd:biz.aQute.bnd.transform;version=6.4.1,\
+    biz.aQute.bnd:biz.aQute.bnd.transform;version=7.0.0,\
     commons-cli:commons-cli;version=latest,\
     com.ibm.ws.common.encoder;version=latest,\
     com.ibm.ws.componenttest;version=latest,\

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -45,6 +45,8 @@ configurations {
   testcontainers { transitive = false; }
   derby
   jakartaTransformer { transitive = false; }
+  jakartaTransformerPreJava17 { transitive = false; }
+  jakartaTransformerJava17Plus { transitive = false; }
 }
 
 dependencies {
@@ -57,14 +59,25 @@ dependencies {
 		'org.apache.derby:derby:10.11.1.1',
 		'com.oracle.database.jdbc.debug:ojdbc8_g:21.8.0.0'
 
-  jakartaTransformer 'biz.aQute.bnd:biz.aQute.bnd.transform:6.4.1',
-       'commons-cli:commons-cli:1.5.0',
+  jakartaTransformer 'commons-cli:commons-cli:1.5.0',
        project(':com.ibm.ws.org.slf4j.api'),
        project(':com.ibm.ws.org.slf4j.simple'),
        'org.eclipse.transformer:org.eclipse.transformer:0.5.0',
        'org.eclipse.transformer:org.eclipse.transformer.jakarta:0.5.0',
        'org.eclipse.transformer:org.eclipse.transformer.cli:0.5.0',
        'org.eclipse.transformer:org.eclipse.transformer.bnd.analyzer:0.5.0'
+
+  jakartaTransformerPreJava17('biz.aQute.bnd:biz.aQute.bnd.transform') {
+                         version {
+                            strictly '6.4.1'
+                         }
+                     }
+
+  jakartaTransformerJava17Plus('biz.aQute.bnd:biz.aQute.bnd.transform') {
+                         version {
+                            strictly '7.0.0'
+                         }
+                     }
 
   testcontainers project(':io.openliberty.org.testcontainers'),
         project(':com.ibm.ws.org.slf4j.api')
@@ -88,6 +101,8 @@ task addJakartaTransformer(type: Copy) {
   mustRunAfter jar
   dependsOn addJakartaTransformerRules
   from configurations.jakartaTransformer
+  from configurations.jakartaTransformerPreJava17
+  from configurations.jakartaTransformerJava17Plus
   into new File(autoFvtDir, 'lib')
 }
 

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -301,7 +301,7 @@ if (bnd.get('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd.get('pub
     }
 
     dependencies {
-      jakartaeeTransformJars 'biz.aQute.bnd:biz.aQute.bnd.transform:6.4.1',
+      jakartaeeTransformJars 'biz.aQute.bnd:biz.aQute.bnd.transform:7.0.0',
                              'commons-cli:commons-cli:1.5.0',
                              'org.slf4j:slf4j-api:1.7.36',
                              'org.slf4j:slf4j-simple:1.7.36',


### PR DESCRIPTION
- When building with Java 21, inner classes have issues that require a newer version of bnd transform jar.
- This change uses the old bnd transform jar when running FATs with Java 8 and 11 (which was the current behavior before this change), but uses the new one with Java 17 and later because bnd 7.0.0 requires Java 17.
- With this change, if you build with Java 21 (which is only done on local development machines), you will still have failures when trying to run a FAT with Java 8 and 11.  This PR will not resolve that problem because it would require a bnd update to bnd 6.x to backport the fix which they do not want to do.