### PR TITLE
versionless features resolve to correct versions

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
@@ -672,6 +672,7 @@ public class FeatureResolverImpl implements FeatureResolver {
         static class Permutation {
             final Map<String, Chain> _selected = new HashMap<String, Chain>();
             final Map<String, Chains> _postponed = new LinkedHashMap<String, Chains>();
+            final Set<String> _postponedVersionless = new HashSet<String>();
             final Set<String> _blockedFeatures = new HashSet<String>();
             final ResultImpl _result = new ResultImpl();
 
@@ -886,20 +887,14 @@ public class FeatureResolverImpl implements FeatureResolver {
 
             //if a versionless feature is postponed, process that first
             if(isBeta){
-                if(_current._postponed.keySet().contains("io.openliberty.internal.versionless.mpMetrics")){
-                    Chain selected = _current._postponed.get("io.openliberty.internal.versionless.mpMetrics").select("io.openliberty.internal.versionless.mpMetrics", this);
+                if(!!!_current._postponedVersionless.isEmpty()){
+                    String postponedVersionless = _current._postponedVersionless.iterator().next();
+                    Chain selected = _current._postponed.get(postponedVersionless).select(postponedVersionless, this);
                     if (selected != null) {
-                        _current._selected.put("io.openliberty.internal.versionless.mpMetrics", selected);
+                        _current._selected.put(postponedVersionless, selected);
                     }
                     _current._postponed.clear();
-                    return;
-                }
-                else if(_current._postponed.keySet().contains("io.openliberty.internal.versionless.mpHealth")){
-                    Chain selected = _current._postponed.get("io.openliberty.internal.versionless.mpHealth").select("io.openliberty.internal.versionless.mpHealth", this);
-                    if (selected != null) {
-                        _current._selected.put("io.openliberty.internal.versionless.mpHealth", selected);
-                    }
-                    _current._postponed.clear();
+                    _current._postponedVersionless.clear();
                     return;
                 }
             }
@@ -971,6 +966,11 @@ public class FeatureResolverImpl implements FeatureResolver {
             if (existing == null) {
                 existing = new Chains();
                 _current._postponed.put(baseName, existing);
+                if(isBeta){
+                    if(baseName.startsWith("io.openliberty.internal.versionless.")){
+                        _current._postponedVersionless.add(baseName);
+                    }
+                }
             }
             existing.add(chain);
         }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
@@ -883,6 +883,27 @@ public class FeatureResolverImpl implements FeatureResolver {
             // The decision of one postpone may effect the path of the
             // dependency in such a way to make later postponed decisions
             // unnecessary
+
+            //if a versionless feature is postponed, process that first
+            if(isBeta){
+                if(_current._postponed.keySet().contains("io.openliberty.internal.versionless.mpMetrics")){
+                    Chain selected = _current._postponed.get("io.openliberty.internal.versionless.mpMetrics").select("io.openliberty.internal.versionless.mpMetrics", this);
+                    if (selected != null) {
+                        _current._selected.put("io.openliberty.internal.versionless.mpMetrics", selected);
+                    }
+                    _current._postponed.clear();
+                    return;
+                }
+                else if(_current._postponed.keySet().contains("io.openliberty.internal.versionless.mpHealth")){
+                    Chain selected = _current._postponed.get("io.openliberty.internal.versionless.mpHealth").select("io.openliberty.internal.versionless.mpHealth", this);
+                    if (selected != null) {
+                        _current._selected.put("io.openliberty.internal.versionless.mpHealth", selected);
+                    }
+                    _current._postponed.clear();
+                    return;
+                }
+            }
+
             Map.Entry<String, Chains> firstPostponed = _current._postponed.entrySet().iterator().next();
             // try to find a good selection
             Chain selected = firstPostponed.getValue().select(firstPostponed.getKey(), this);

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/ee10toMP.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/ee10toMP.java
@@ -48,8 +48,8 @@ public class ee10toMP {
         server.addEnvVar("PREFERRED_FEATURE_VERSIONS", envVar);
         server.startServer();
 
-        assertNotNull("Expected mpMetrics-5.0 after features resolved but got: " + server.findStringsInLogs("CWWKF0012I: The server installed the following features:"),
-                      server.waitForStringInLog("mpMetrics-5.0"));
+        assertNotNull("Expected mpMetrics-5.1 after features resolved but got: " + server.findStringsInLogs("CWWKF0012I: The server installed the following features:"),
+                      server.waitForStringInLog("mpMetrics-5.1"));
         assertNotNull("Expected mpHealth-4.0 after features resolved but got: " + server.findStringsInLogs("CWWKF0012I: The server installed the following features:"),
                       server.waitForStringInLog("mpHealth-4.0"));
 


### PR DESCRIPTION
A bug is noticed with the combination of Health and metrics for servlet servlet-6.0 (i.e., ee10)
using servlet-6.0 and:
PREFERRED_FEATURE_VERSIONS=mpHealth-4.0,mpMetrics-5.0,mpMetrics-5.1

Previously:
Will start mpHealth-4.0 and mpMetrics-5.0 as expected. Swapping mpMetrics-5.1 and mpMetrics-5.0 should cause mpMetrics-5.1 to to be activated, but it is still mpMetrics-5.0.

After changes:
mpMetrics-5.1 will now get resolved in the above scenario.

#27490 