### PR TITLE
Convert Faces 4.0 FAT Tests to use Selenium

### DIFF
--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/bnd.bnd
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/bnd.bnd
@@ -10,24 +10,29 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+fat.test.container.images:\
+	seleniarm/standalone-chromium:4.8.3,\
+	selenium/standalone-chrome:4.8.3,\
+	alpine:3.16
+
 src: \
-    fat/src,\
-    test-applications/AcceptInputFileTest.war/src,\
-    test-applications/AjaxRenderExecuteThisTest.war/src,\
-    test-applications/AnnotationLiteralsTest.war/src,\
-    test-applications/ClientWindowScopedTest.war/src,\
-    test-applications/ExternalContextAddResponseCookie.war/src,\
-    test-applications/Faces40URN.war/src,\
-    test-applications/FacesContextGetLifecycle.war/src,\
-    test-applications/LayoutAttribute.war/src,\
-    test-applications/SelectItemTests.war/src,\
-    test-applications/UIViewRootGetDoctypeTest.war/src,\
-    test-applications/Faces40ThirdPartyApi.war/src,\
-    test-applications/MultipleInputFileTest.war/src,\
-    test-applications/ProgrammaticFaceletTests.war/src,\
-    test-applications/SubscribeToEventTest.war/src,\
-    test-applications/WebSocket.war/src,\
-    test-applications/MYFACES-4628.war/src
+	fat/src,\
+	test-applications/AcceptInputFileTest.war/src,\
+	test-applications/AjaxRenderExecuteThisTest.war/src,\
+	test-applications/AnnotationLiteralsTest.war/src,\
+	test-applications/ClientWindowScopedTest.war/src,\
+	test-applications/ExternalContextAddResponseCookie.war/src,\
+	test-applications/Faces40URN.war/src,\
+	test-applications/FacesContextGetLifecycle.war/src,\
+	test-applications/LayoutAttribute.war/src,\
+	test-applications/SelectItemTests.war/src,\
+	test-applications/UIViewRootGetDoctypeTest.war/src,\
+	test-applications/Faces40ThirdPartyApi.war/src,\
+	test-applications/MultipleInputFileTest.war/src,\
+	test-applications/ProgrammaticFaceletTests.war/src,\
+	test-applications/SubscribeToEventTest.war/src,\
+	test-applications/WebSocket.war/src,\
+	test-applications/MYFACES-4628.war/src
 
 tested.features:\
     expressionlanguage-6.0,\
@@ -43,6 +48,7 @@ javac.source: 11
 javac.target: 11
 
 -buildpath: \
+	com.google.guava:guava;version=latest,\
 	io.openliberty.jakarta.faces.4.0;version=latest,\
 	io.openliberty.jakarta.cdi.4.0;version=latest,\
 	io.openliberty.org.apache.myfaces.4.0;version=latest,\
@@ -52,4 +58,10 @@ javac.target: 11
 	io.openliberty.org.apache.xercesImpl;version=latest,\
 	io.openliberty.jakarta.servlet.6.0;version=latest,\
 	io.openliberty.jakarta.annotation.2.1;version=latest,\
-	io.openliberty.jakarta.expressionLanguage.5.0;version=latest
+	io.openliberty.jakarta.expressionLanguage.5.0;version=latest,\
+	io.openliberty.org.testcontainers;version=latest,\
+	org.seleniumhq.selenium:selenium-api;version=4.8.3,\
+	org.seleniumhq.selenium:selenium-chrome-driver;version=4.8.3,\
+	org.seleniumhq.selenium:selenium-chromium-driver;version=4.8.3,\
+	org.seleniumhq.selenium:selenium-remote-driver;version=4.8.3,\
+	org.seleniumhq.selenium:selenium-support;version=4.8.3

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/build.gradle
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/build.gradle
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
  
+ apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
+
 // To test snapshots locally
 //repositories {
 //   mavenLocal()
@@ -23,6 +25,8 @@
 
 // Define G:A:V coordinates of each dependency
 dependencies {
+    requiredLibs 'org.seleniumhq.selenium:selenium-java:4.8.3'
+    requiredLibs 'com.google.guava:guava:32.0.1-jre'
     requiredLibs 'net.sourceforge.htmlunit:htmlunit:2.44.0'
     requiredLibs 'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0'
     requiredLibs 'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0'
@@ -87,3 +91,4 @@ dependencies {
 //    dependsOn addMojarra40
 //}
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/FATSuite.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+import org.testcontainers.utility.DockerImageName;
 
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.fat.util.FatLogHandler;
@@ -47,6 +48,8 @@ import io.openliberty.org.apache.myfaces40.fat.tests.UIViewRootGetDoctypeTest;
 import io.openliberty.org.apache.myfaces40.fat.tests.WebSocketTests;
 import io.openliberty.org.apache.myfaces40.fat.tests.bugfixes.MyFaces4628Test;
 
+import componenttest.containers.TestContainerSuite;
+
 @RunWith(Suite.class)
 @SuiteClasses({
                 AcceptInputFileTest.class,
@@ -73,7 +76,7 @@ import io.openliberty.org.apache.myfaces40.fat.tests.bugfixes.MyFaces4628Test;
 
 })
 
-public class FATSuite {
+public class FATSuite  extends TestContainerSuite {
 
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new EmptyAction().conditionalFullFATOnly(EmptyAction.GREATER_THAN_OR_EQUAL_JAVA_17))
@@ -103,6 +106,14 @@ public class FATSuite {
             fos.write(xmlContent.getBytes());
         } catch (Exception e) {
             //ignore only using for debugging
+        }
+    }
+
+    public static DockerImageName getChromeImage() {
+        if (FATRunner.ARM_ARCHITECTURE) {
+            return DockerImageName.parse("seleniarm/standalone-chromium:4.8.3").asCompatibleSubstituteFor("selenium/standalone-chrome");
+        } else {
+            return DockerImageName.parse("selenium/standalone-chrome:4.8.3");
         }
     }
 

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/JSFUtils.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/JSFUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -56,6 +56,30 @@ public class JSFUtils {
           .append(contextRoot)
           .append("/")
           .append(path);
+
+        return sb.toString();
+    }
+
+    /**
+     * Construct a URL for a selenium test case so a request can be made. URL uses host.testcontainers.internal. 
+     *
+     * @param server      - The server that is under test, this is used to get the port and host name.
+     * @param contextRoot - The context root of the application
+     * @param path        - Additional path information for the request.
+     * @return - A fully formed URL string.
+     * @throws Exception
+     */
+    public static String createSeleniumURLString(LibertyServer server, String contextRoot, String path) {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("http://")
+                        .append("host.testcontainers.internal")
+                        .append(":")
+                        .append(server.getHttpDefaultPort())
+                        .append("/")
+                        .append(contextRoot)
+                        .append("/")
+                        .append(path);
 
         return sb.toString();
     }

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/selenium_util/CustomDriver.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/selenium_util/CustomDriver.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package io.openliberty.org.apache.myfaces40.fat.selenium_util;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+/**
+*  Used in conjunction with WebPage to behave similarly as HTMLUnit's HtmlPage
+* 
+* Copied over from ChromeDevtoolsDriver 
+* - https://github.com/jakartaee/faces/blob/1d71aae51f7d5ae684a3f43db0521b7e7e6aa4f6/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
+* Modified because chrome dev tools is unavailable via Test Containers 
+* - Created https://github.com/testcontainers/testcontainers-java/issues/7242 requesting chrome dev tool support 
+* 
+*/
+public class CustomDriver implements ExtendedWebDriver {
+
+    RemoteWebDriver driver;
+
+    public CustomDriver(RemoteWebDriver driver){
+        this.driver = driver;
+    }
+
+    public RemoteWebDriver getRemoteWebDriver(){
+        return this.driver;
+    }
+
+    @Override
+    public String getPageText() {
+        String head = this.driver.findElement(By.tagName("head")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
+        String body = this.driver.findElement(By.tagName("body")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
+        return head + " " + body;
+    }
+
+    @Override
+    public String getPageTextReduced() {
+        String head = this.driver.findElement(By.tagName("head")).getAttribute("innerText");
+        String body = this.driver.findElement(By.tagName("body")).getAttribute("innerText");
+        // handle blanks and nbsps
+        return (head + " " + body).replaceAll("[\\s\\u00A0]+", " ");
+    }
+
+    @Override
+    public WebDriver.Options manage() {
+        return driver.manage();
+    }
+
+    @Override
+    public WebDriver.Navigation navigate() {
+        return driver.navigate();
+    }
+    
+    public Set<String> getWindowHandles() {
+        return driver.getWindowHandles();
+    }
+
+    public String getWindowHandle() {
+        return driver.getWindowHandle();
+    }
+
+    public WebDriver.TargetLocator switchTo() {
+        return driver.switchTo();
+    }
+
+    public void close() {
+        driver.close();
+    }
+
+    public void quit() {
+        driver.quit();
+    }
+
+    public void get(String url) {
+        driver.get(url);
+    }
+
+    public String getCurrentUrl() {
+        return driver.getCurrentUrl();
+    }
+
+    public String getTitle() {
+        return driver.getTitle();
+    }
+
+    public String getPageSource() {
+        return driver.getPageSource();
+    }
+
+
+    public WebElement findElement(By by) {
+        return driver.findElement(by);
+    }
+
+    public List<WebElement> findElements(By by) {
+        return driver.findElements(by);
+    }
+
+}

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/selenium_util/ExtendedWebDriver.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/selenium_util/ExtendedWebDriver.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package io.openliberty.org.apache.myfaces40.fat.selenium_util;
+
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+/**
+ * an extended web driver interface which takes the response into consideration
+ * selenium does not have an official api but several webdrivers
+ * allow access to the data via various means
+ *
+ * Another possibility would have been a proxy, but I could not find any properly
+ * working proxy for selenium
+ * 
+ * Copied and Modified from https://github.com/jakartaee/faces/blob/1d71aae51f7d5ae684a3f43db0521b7e7e6aa4f6/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ExtendedWebDriver.java
+ */
+public interface ExtendedWebDriver extends WebDriver {
+
+    /**
+     * @return the innerText of the Page
+     */
+    String getPageText();
+
+    /**
+     * returns the innerText of the page in a blank reduced state (more than one blank is reduced to one
+     * invisible blanks like nbsp are replaced by normal blanks)
+     * @return 
+     */
+    String getPageTextReduced();
+
+    /*
+     * Return the wrapped remote web driver
+     */
+    RemoteWebDriver getRemoteWebDriver();
+
+
+}

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/selenium_util/WebPage.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/selenium_util/WebPage.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package io.openliberty.org.apache.myfaces40.fat.selenium_util;
+
+import org.openqa.selenium.*;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Mimics the html unit webpage
+ * Modified from original source as Chrome Dev Tools are not accessible when used with TestContainers
+ * See issue https://github.com/testcontainers/testcontainers-java/issues/7242
+ */
+public class WebPage {
+
+    public static final Duration STD_TIMEOUT = Duration.ofMillis(8000);
+    public static final Duration LONG_TIMEOUT = Duration.ofMillis(16000);
+
+    protected ExtendedWebDriver webDriver;
+
+    public WebPage(ExtendedWebDriver webDriver) {
+        this.webDriver = webDriver;
+    }
+
+    public WebDriver getWebDriver() {
+        return (WebDriver) webDriver;
+    }
+
+    public void setWebDriver(ExtendedWebDriver webDriver) {
+        this.webDriver = webDriver;
+    }
+
+    public void get(String url) {
+        webDriver.get(url);
+    }
+
+    public String getTitle() {
+        return webDriver.getTitle();
+    }
+
+    /**
+     * waits for a certain condition is met, until a timeout is hit. In case of exceeding the condition, a runtime exception
+     * is thrown!
+     *
+     * @param isTrue the condition lambda to check
+     * @param timeout timeout duration
+     */
+    public <V> void waitForCondition(Function<? super WebDriver, V> isTrue, Duration timeout) {
+        synchronized (webDriver) {
+            WebDriverWait wait = new WebDriverWait(webDriver, timeout);
+            wait.until(isTrue);
+        }
+    }
+
+    /**
+     * The same as before, but with the long default timeout of LONG_TIMEOUT (16000ms)
+     *
+     * @param isTrue condition lambda
+     */
+    public <V> void waitForCondition(Function<? super WebDriver, V> isTrue) {
+        synchronized (webDriver) {
+            WebDriverWait wait = new WebDriverWait(webDriver, LONG_TIMEOUT);
+            wait.until(isTrue);
+        }
+    }
+
+    /**
+     * Wait for a certain period of time
+     *
+     * @param timeout the timeout to wait (note due to the asynchronous nature of the web drivers, any code running on the
+     * browser itself will proceed (aka javascript) only the client operations are stalled.
+     */
+    public void wait(Duration timeout) {
+        synchronized (webDriver) {
+            try {
+                webDriver.wait(timeout.toMillis());
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * wait until the current Ajax request targeting the same page has stopped and then tests for blocking running scripts
+     * still running. A small initial delay cannot hurt either
+     */
+    public void waitReqJs() {
+        this.wait(STD_TIMEOUT);
+    }
+
+    /**
+     * waits for backgrounds processes on the browser to complete
+     *
+     * @param timeOut the timeout duration until the wait can proceed before being interupopted
+     */
+    public void waitForPageToLoad(Duration timeOut) {
+        ExpectedCondition<Boolean> expectation =
+            driver -> webDriver.getRemoteWebDriver().executeScript("return document.readyState")
+                               .equals("complete");
+
+        synchronized (webDriver) {
+            WebDriverWait wait = new WebDriverWait(webDriver, timeOut);
+            wait.until(expectation);
+        }
+    }
+
+        /**
+     * wait until the page load is finished
+     */
+    public void waitForPageToLoad() {
+        waitForPageToLoad(STD_TIMEOUT);
+    }
+
+    /**
+     * conditional waiter and checker which checks whether the page text is present we add our own waiter internally,
+     * because pageSource always delivers
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isInPageText(String text) {
+        try {
+            // values are not returned by getPageText
+            String values = getInputValues();
+
+            waitForCondition(webDriver1 -> (webDriver.getPageText() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    public boolean isInPageTextReduced(String text) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> (webDriver.getPageTextReduced() + values.replaceAll("\\s+", " ")).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    public boolean matchesPageText(String regexp) {
+        try {
+            waitForCondition(webDriver1 -> webDriver.getPageText().matches(regexp), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * adds the reduced page text functionality to the regexp match
+     *
+     * @param regexp
+     * @return
+     */
+    public boolean matchesPageTextReduced(String regexp) {
+        try {
+            waitForCondition(webDriver1 -> webDriver.getPageTextReduced().matches(regexp), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is not in the page we add our own waiter internally,
+     * because pageSource always delivers
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isNotInPageText(String text) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> !(webDriver.getPageText() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is in the page we add our own waiter internally, because
+     * pageSource always delivers this version of isInPage checks explicitly the full markup not only the text
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isInPage(String text) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> (webDriver.getPageSource() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is not in the page we add our own waiter internally,
+     * because pageSource always delivers we need to add two different condition checkers herte because a timeout
+     * automatically throws internally an error which is mapped to false We therefore cannot simply wait for the condition
+     * either being met or timeout with one method
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isNotInPage(String text) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> !(webDriver.getPageSource() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is in the page we add our own waiter internally, because
+     * pageSource always delivers we need to add two different condition checkers herte because a timeout automatically
+     * throws internally an error which is mapped to false We therefore cannot simply wait for the condition either being
+     * met or timeout with one method
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isInPage(String text, boolean allowExceptions) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> (webDriver.getPageSource() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException exception) {
+            if (allowExceptions) {
+                throw exception;
+            }
+            exception.printStackTrace();
+            return false;
+        }
+    }
+
+
+    public WebElement findElement(By by) {
+        return webDriver.findElement(by);
+    }
+
+    public List<WebElement> findElements(By by) {
+        return webDriver.findElements(by);
+    }
+
+        public String getPageSource() {
+        return webDriver.getPageSource();
+    }
+
+    /**
+     * Convenience method to get all anchor elmements
+     *
+     * @return a list of a hrefs as WebElements
+     */
+    public List<WebElement> getAnchors() {
+        return webDriver.findElements(By.cssSelector("a[href]"));
+    }
+
+        private String getInputValues() {
+        return webDriver.findElements(By.cssSelector("input, textarea, select")).stream()
+                .map(webElement -> webElement.getAttribute("value")).reduce("", (str1, str2) -> str1 + " " + str2);
+    }
+
+}

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/tests/MultipleInputFileTest.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/tests/MultipleInputFileTest.java
@@ -15,36 +15,39 @@ import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Iterator;
+import java.util.List;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-import org.xml.sax.helpers.AttributesImpl;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.BrowserWebDriverContainer;
 
-import com.gargoylesoftware.htmlunit.NicelyResynchronizingAjaxController;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.DomElement;
-import com.gargoylesoftware.htmlunit.html.HtmlElement;
-import com.gargoylesoftware.htmlunit.html.HtmlFileInput;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.parser.neko.HtmlUnitNekoHtmlParser;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.HttpUtils;
 import io.openliberty.org.apache.myfaces40.fat.FATSuite;
+import io.openliberty.org.apache.myfaces40.fat.JSFUtils;
+import io.openliberty.org.apache.myfaces40.fat.selenium_util.CustomDriver;
+import io.openliberty.org.apache.myfaces40.fat.selenium_util.ExtendedWebDriver;
+import io.openliberty.org.apache.myfaces40.fat.selenium_util.WebPage;
 
 /**
  * Tests for the <h:inputFile/> with multiple attribute which is a new feature for Faces 4.0.
@@ -101,10 +104,24 @@ public class MultipleInputFileTest {
     @Rule
     public TestName name = new TestName();
 
+    @ClassRule
+    public static BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>(FATSuite.getChromeImage()).withCapabilities(new ChromeOptions())
+                    .withAccessToHost(true)
+                    .withSharedMemorySize(2147483648L); // avoids "message":"Duplicate mount point: /dev/shm"
+
+    private static ExtendedWebDriver driver;
+
     @BeforeClass
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(server, APP_NAME + ".war", "io.openliberty.org.apache.faces40.fat.inputfile.beans");
         server.startServer(c.getSimpleName() + ".log");
+
+        Testcontainers.exposeHostPorts(server.getHttpDefaultPort(), server.getHttpDefaultSecurePort());
+
+        driver = new CustomDriver(new RemoteWebDriver(chrome.getSeleniumAddress(), new ChromeOptions().setAcceptInsecureCerts(true)));
+
+        // Upload files from the local machine, not within the container
+        driver.getRemoteWebDriver().setFileDetector(new LocalFileDetector());
     }
 
     @AfterClass
@@ -113,122 +130,114 @@ public class MultipleInputFileTest {
         if (server != null && server.isStarted()) {
             server.stopServer();
         }
+
+        driver.quit(); // closes all sessions and terminutes the webdriver
+    }
+
+    /*
+     * Clear cookies for the selenium webdriver, so that session don't carry over between tests
+     */
+    @After
+    public void clearCookies()
+    {
+        driver.getRemoteWebDriver().manage().deleteAllCookies();
     }
 
     @Test
     public void testNoMultiple_NoAjax_SingleFile() throws Exception {
-        URL url = HttpUtils.createURL(server, "/" + APP_NAME + "/MutipleInputFile.xhtml" + "?" + Form.NO_MULTIPLE_NO_AJAX.testParam);
+        String url = JSFUtils.createSeleniumURLString(server, APP_NAME, "MutipleInputFile.xhtml" + "?" + Form.NO_MULTIPLE_NO_AJAX.testParam);;
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-        try (WebClient webClient = new WebClient()) {
-            // Drive a request to the page.
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
-            FATSuite.logOutputForDebugging(server, page.asXml(), name.getMethodName() + ".html");
-
-            assertSingleSelection(page, Field.SINGLE);
-        }
+        assertSingleSelection(page, Field.SINGLE);
     }
 
-    @Test
-    public void testNoMultiple_NoAjax_MultipleFiles() throws Exception {
-        URL url = HttpUtils.createURL(server, "/" + APP_NAME + "/MutipleInputFile.xhtml" + "?" + Form.NO_MULTIPLE_NO_AJAX.testParam);
+    /*
+     * Disabled: Selenium doesn't allow multiple files for a single upload.
+     * Gives error: "invalid argument: the element can not hold multiple files"
+     */
+    // @Test
+    // public void testNoMultiple_NoAjax_MultipleFiles() throws Exception {
+    //     String url = JSFUtils.createSeleniumURLString(server, APP_NAME, "MutipleInputFile.xhtml" + "?" + Form.NO_MULTIPLE_NO_AJAX.testParam);;
+    //     WebPage page = new WebPage(driver);
+    //     page.get(url);
+    //     page.waitForPageToLoad();
 
-        try (WebClient webClient = new WebClient()) {
-            // Drive a request to the page.
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
-            FATSuite.logOutputForDebugging(server, page.asXml(), name.getMethodName() + ".html");
-
-            assertMultipleSelectionProducesSingleResult(page);
-        }
-    }
+    //     assertMultipleSelectionProducesSingleResult(page);
+    // }
 
     @Test
     public void testWithMultiple_NoAjax_SingleFile() throws Exception {
-        URL url = HttpUtils.createURL(server, "/" + APP_NAME + "/MutipleInputFile.xhtml" + "?" + Form.WITH_MULTIPLE_NO_AJAX.testParam);
+        String url = JSFUtils.createSeleniumURLString(server, APP_NAME, "MutipleInputFile.xhtml" + "?" + Form.WITH_MULTIPLE_NO_AJAX.testParam);;
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-        try (WebClient webClient = new WebClient()) {
-            // Drive a request to the page.
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
-            FATSuite.logOutputForDebugging(server, page.asXml(), name.getMethodName() + ".html");
-
-            assertSingleSelection(page, Field.MULTIPLE);
-        }
+        assertSingleSelection(page, Field.MULTIPLE);
     }
 
     @Test
     public void testWithMultiple_NoAjax_MultipleFiles() throws Exception {
-        URL url = HttpUtils.createURL(server, "/" + APP_NAME + "/MutipleInputFile.xhtml" + "?" + Form.WITH_MULTIPLE_NO_AJAX.testParam);
+        String url = JSFUtils.createSeleniumURLString(server, APP_NAME, "MutipleInputFile.xhtml" + "?" + Form.WITH_MULTIPLE_NO_AJAX.testParam);;
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-        try (WebClient webClient = new WebClient()) {
-            // Drive a request to the page.
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
-            FATSuite.logOutputForDebugging(server, page.asXml(), name.getMethodName() + ".html");
-
-            assertMultipleSelection(page);
-        }
+        assertMultipleSelection(page);
     }
 
     @Test
     @Mode(FULL)
-    @SkipForRepeat({SkipForRepeat.NO_MODIFICATION,SkipForRepeat.EE11_FEATURES}) // Skipped due to HTMLUnit / JavaScript incompatibility (New JS in RC5)
     public void testNoMultiple_WithAjax_SingleFile() throws Exception {
-        URL url = HttpUtils.createURL(server, "/" + APP_NAME + "/MutipleInputFile.xhtml" + "?" + Form.NO_MULTIPLE_WITH_AJAX.testParam);
+        String url = JSFUtils.createSeleniumURLString(server, APP_NAME, "MutipleInputFile.xhtml" + "?" + Form.NO_MULTIPLE_WITH_AJAX.testParam);;
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-        try (WebClient webClient = new WebClient()) {
-            // Drive a request to the page.
-            webClient.setAjaxController(new NicelyResynchronizingAjaxController());
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
-            FATSuite.logOutputForDebugging(server, page.asXml(), name.getMethodName() + ".html");
-
-            assertSingleSelection(page, Field.SINGLE);
-        }
+        assertSingleSelection(page, Field.SINGLE);
     }
+
+    /*
+     * Disabled: Selenium doesn't allow multiple files for a single upload.
+     * Gives error: "invalid argument: the element can not hold multiple files"
+     */
+    // @Test
+    // @Mode(FULL)
+    // @SkipForRepeat(SkipForRepeat.NO_MODIFICATION) // Skipped due to HTMLUnit / JavaScript incompatibility (New JS in RC5)
+    // public void testNoMultiple_WithAjax_MultipleFiles() throws Exception {
+    //     URL url = HttpUtils.createURL(server, "/" + APP_NAME + "/MutipleInputFile.xhtml" + "?" + Form.NO_MULTIPLE_WITH_AJAX.testParam);
+
+    //     try (WebClient webClient = new WebClient()) {
+    //         // Drive a request to the page.
+    //         webClient.setAjaxController(new NicelyResynchronizingAjaxController());
+    //         HtmlPage page = (HtmlPage) webClient.getPage(url);
+    //         FATSuite.logOutputForDebugging(server, page.asXml(), name.getMethodName() + ".html");
+
+    //         assertMultipleSelectionProducesSingleResult(page);
+    //     }
+    // }
 
     @Test
     @Mode(FULL)
-    @SkipForRepeat({SkipForRepeat.NO_MODIFICATION,SkipForRepeat.EE11_FEATURES}) // Skipped due to HTMLUnit / JavaScript incompatibility (New JS in RC5)
-    public void testNoMultiple_WithAjax_MultipleFiles() throws Exception {
-        URL url = HttpUtils.createURL(server, "/" + APP_NAME + "/MutipleInputFile.xhtml" + "?" + Form.NO_MULTIPLE_WITH_AJAX.testParam);
-
-        try (WebClient webClient = new WebClient()) {
-            // Drive a request to the page.
-            webClient.setAjaxController(new NicelyResynchronizingAjaxController());
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
-            FATSuite.logOutputForDebugging(server, page.asXml(), name.getMethodName() + ".html");
-
-            assertMultipleSelectionProducesSingleResult(page);
-        }
-    }
-
-    @Test
-    @Mode(FULL)
-    @SkipForRepeat({SkipForRepeat.NO_MODIFICATION,SkipForRepeat.EE11_FEATURES}) // Skipped due to HTMLUnit / JavaScript incompatibility (New JS in RC5)
     public void testWithMultiple_WithAjax_SingleFile() throws Exception {
-        URL url = HttpUtils.createURL(server, "/" + APP_NAME + "/MutipleInputFile.xhtml" + "?" + Form.WITH_MULTIPLE_WITH_AJAX.testParam);
+        String url = JSFUtils.createSeleniumURLString(server, APP_NAME, "MutipleInputFile.xhtml" + "?" + Form.WITH_MULTIPLE_WITH_AJAX.testParam);;
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-        try (WebClient webClient = new WebClient()) {
-            // Drive a request to the page.
-            webClient.setAjaxController(new NicelyResynchronizingAjaxController());
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
-            FATSuite.logOutputForDebugging(server, page.asXml(), name.getMethodName() + ".html");
-
-            assertSingleSelection(page, Field.MULTIPLE);
-        }
+        assertSingleSelection(page, Field.MULTIPLE);
     }
 
     @Test
     @Mode(FULL)
-    @SkipForRepeat({SkipForRepeat.NO_MODIFICATION,SkipForRepeat.EE11_FEATURES}) // Skipped due to HTMLUnit / JavaScript incompatibility (New JS in RC5)
     public void testWithMultiple_WithAjax_MultipleFiles() throws Exception {
-        URL url = HttpUtils.createURL(server, "/" + APP_NAME + "/MutipleInputFile.xhtml" + "?" + Form.WITH_MULTIPLE_WITH_AJAX.testParam);
+        String url = JSFUtils.createSeleniumURLString(server, APP_NAME, "MutipleInputFile.xhtml" + "?" + Form.WITH_MULTIPLE_WITH_AJAX.testParam);;
+        WebPage page = new WebPage(driver);
+        page.get(url);
+        page.waitForPageToLoad();
 
-        try (WebClient webClient = new WebClient()) {
-            // Drive a request to the page.
-            webClient.setAjaxController(new NicelyResynchronizingAjaxController());
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
-            FATSuite.logOutputForDebugging(server, page.asXml(), name.getMethodName() + ".html");
-
-            assertMultipleSelection(page);
-        }
+        assertMultipleSelection(page);
     }
 
     /**
@@ -239,29 +248,32 @@ public class MultipleInputFileTest {
      * @param field - is the form input using single, or multiple inputs
      * @throws Exception - Thrown if we were not able to execute the assertion testing
      */
-    private void assertSingleSelection(HtmlPage page, Field field) throws Exception {
+    private void assertSingleSelection(WebPage page, Field field) throws Exception {
         //Assert the correct multiple attribute is set
-        HtmlFileInput input = page.getHtmlElementById("form:input");
+        WebElement element = page.findElement(By.id("form:input"));
         if (field == Field.MULTIPLE) {
-            assertEquals("Multiple attribute is set", "multiple", input.getAttribute("multiple"));
+            assertEquals("Multiple attribute is set", "true", element.getAttribute("multiple"));
         } else {
-            assertEquals("Multiple attribute should NOT be set", "", input.getAttribute("multiple"));
+            assertEquals("Multiple attribute should NOT be set", null, element.getAttribute("multiple"));
         }
 
         //Create a single file and add it to the input attribute
         File file = generateTempFile("file", "bin", 123);
-        input.setValueAttribute(file.getAbsolutePath());
+        ((WebElement)page.findElement(By.id("form:input"))).sendKeys(file.getAbsolutePath());
 
         //Click submit
-        page = page.getHtmlElementById("form:submit").click();
-        FATSuite.logOutputForDebugging(server, page.asXml(), name.getMethodName() + ".clicked.html");
+        page.findElement(By.id("form:submit")).click();
+
+        page.waitForCondition(driver -> page.isInPage("Received Message!"));
+
+        FATSuite.logOutputForDebugging(server, page.getPageSource(), name.getMethodName() + ".clicked.html");
 
         //Assert expected messages are present
-        HtmlElement messages = page.getHtmlElementById("messages");
-        assertEquals("There is 1 message", 1, messages.getChildElementCount());
+        List<WebElement> children = page.findElement(By.id("messages")).findElements(By.xpath("*"));
+        assertEquals("There is 1 message", 1, children.size());
 
-        Iterator<DomElement> iterator = messages.getChildElements().iterator();
-        assertEquals("Uploaded file has been received", "field: " + field.name + ", name: " + file.getName() + ", size: " + file.length(), iterator.next().asText());
+        Iterator<WebElement> iterator = children.iterator();
+        assertEquals("Uploaded file has been received", "Received Message! field: " + field.name + ", name: " + file.getName() + ", size: " + file.length(), iterator.next().getText());
         assertFalse("Iterator should not have had another element", iterator.hasNext());
     }
 
@@ -271,68 +283,76 @@ public class MultipleInputFileTest {
      * @param page - The html page
      * @throws Exception - Thrown if we were not able to execute the assertion testing
      */
-    private void assertMultipleSelection(HtmlPage page) throws Exception {
+    private void assertMultipleSelection(WebPage page) throws Exception {
         //Get the file input element
-        HtmlFileInput input = page.getHtmlElementById("form:input");
-        assertEquals("Multiple attribute is set", "multiple", input.getAttribute("multiple"));
+        WebElement element = page.findElement(By.id("form:input"));
+        assertEquals("Multiple attribute is set", "true", element.getAttribute("multiple"));
 
         //Create files and add them to the input attribute
         File file1 = generateTempFile("file1", "bin", 123);
         File file2 = generateTempFile("file2", "bin", 234);
         File file3 = generateTempFile("file3", "bin", 345);
-        input.setValueAttribute(file1.getAbsolutePath());
-        addValueAttribute(input, file2.getAbsolutePath());
-        addValueAttribute(input, file3.getAbsolutePath());
+
+        String[] files = {file1.getAbsolutePath(),file2.getAbsolutePath(),file3.getAbsolutePath()};
+        ((WebElement)page.findElement(By.id("form:input"))).sendKeys(String.join("\n", files));
 
         //Click submit
-        page = page.getHtmlElementById("form:submit").click();
-        FATSuite.logOutputForDebugging(server, page.asXml(), name.getMethodName() + ".clicked.html");
+        page.findElement(By.id("form:submit")).click();
+        page.waitForCondition(driver -> page.isInPage("Received Message!"));
+        FATSuite.logOutputForDebugging(server, page.getPageSource(), name.getMethodName() + ".clicked.html");
 
         //Assert messages are expected
-        HtmlElement messages = page.getHtmlElementById("messages");
-        assertEquals("There are 3 messages", 3, messages.getChildElementCount());
+        List<WebElement> children = page.findElement(By.id("messages")).findElements(By.xpath("*"));
+        assertEquals("There are 3 message", 3, children.size());
 
-        Iterator<DomElement> iterator = messages.getChildElements().iterator();
-        assertEquals("First uploaded file has been received", "field: multipleSelection, name: " + file1.getName() + ", size: " + file1.length(),
-                     iterator.next().asText());
-        assertEquals("Second uploaded file has been received", "field: multipleSelection, name: " + file2.getName() + ", size: " + file2.length(),
-                     iterator.next().asText());
-        assertEquals("Third uploaded file has been received", "field: multipleSelection, name: " + file3.getName() + ", size: " + file3.length(),
-                     iterator.next().asText());
+        Iterator<WebElement> iterator = children.iterator();
+        assertEquals("First uploaded file has been received", "Received Message! field: multipleSelection, name: " + file1.getName() + ", size: " + file1.length(),
+                     iterator.next().getText());
+        assertEquals("Second uploaded file has been received", "Received Message! field: multipleSelection, name: " + file2.getName() + ", size: " + file2.length(),
+                     iterator.next().getText());
+        assertEquals("Third uploaded file has been received", "Received Message! field: multipleSelection, name: " + file3.getName() + ", size: " + file3.length(),
+                     iterator.next().getText());
         assertFalse("Iterator should not have had another element", iterator.hasNext());
     }
 
+    /*
+     * Selenium doesn't allow multiple files for a single upload.
+     * Gives error: "invalid argument: the element can not hold multiple files"
+     * Thus, this method is commented out.
+     */
     /**
      * Asserts that a multiple file selection results in a single output.
      *
      * @param page - The html page
      * @throws IOException
      */
-    private void assertMultipleSelectionProducesSingleResult(HtmlPage page) throws IOException {
-        //Get the file input element
-        HtmlFileInput input = page.getHtmlElementById("form:input");
-        assertEquals("Multiple attribute should NOT be set", "", input.getAttribute("multiple"));
+    // private void assertMultipleSelectionProducesSingleResult(WebPage page) throws IOException {
+    //     WebElement element = page.findElement(By.id("form:input"));
+    //     assertEquals("Multiple attribute should NOT be set", null, element.getAttribute("multiple"));
 
-        //Create files and add them to the input attribute
-        File file1 = generateTempFile("file1", "bin", 123);
-        File file2 = generateTempFile("file2", "bin", 234);
-        File file3 = generateTempFile("file3", "bin", 345);
-        input.setValueAttribute(file1.getAbsolutePath());
-        addValueAttribute(input, file2.getAbsolutePath());
-        addValueAttribute(input, file3.getAbsolutePath());
+    //     //Create files and add them to the input attribute
+    //     File file1 = generateTempFile("file1", "bin", 123);
+    //     File file2 = generateTempFile("file2", "bin", 234);
+    //     File file3 = generateTempFile("file3", "bin", 345);
 
-        //Click submit
-        page = page.getHtmlElementById("form:submit").click();
-        FATSuite.logOutputForDebugging(server, page.asXml(), name.getMethodName() + ".clicked.html");
+    //     String[] files = {file1.getAbsolutePath(),file2.getAbsolutePath(),file3.getAbsolutePath()};
+    //     ((WebElement)page.findElement(By.id("form:input"))).sendKeys(String.join("\n", files));
 
-        //Assert messages are expected
-        HtmlElement messages = page.getHtmlElementById("messages");
-        assertEquals("There is 1 message", 1, messages.getChildElementCount());
+    //     //Click submit
+    //     page.findElement(By.id("form:submit")).click();
+    //     page.waitForCondition(driver -> page.isInPage("Received Message!"));
 
-        Iterator<DomElement> iterator = messages.getChildElements().iterator();
-        assertEquals("Uploaded file has been received", "field: singleSelection, name: " + file1.getName() + ", size: " + file1.length(), iterator.next().asText());
-        assertFalse("Iterator should not have had another element", iterator.hasNext());
-    }
+    //     FATSuite.logOutputForDebugging(server, page.getPageSource(), name.getMethodName() + ".clicked.html");
+
+    //     //Assert expected messages are present
+    //     List<WebElement> children = page.findElement(By.id("messages")).findElements(By.xpath("*"));
+    //     assertEquals("There is 1 message", 1, children.size());
+
+    //     //Assert messages are expected
+    //     Iterator<WebElement> iterator = children.iterator();
+    //     assertEquals("Uploaded file has been received", "Received Message! field: singleSelection, name: " + file1.getName() + ", size: " + file1.length(), iterator.next().getText());
+    //     assertFalse("Iterator should not have had another element", iterator.hasNext());
+    // }
 
     /**
      * Generates a temporary file and returns the file object
@@ -348,12 +368,12 @@ public class MultipleInputFileTest {
      * HtmlUnit's HtmlFileInput doesn't support submitting multiple values.
      * The below is a work-around, found on https://stackoverflow.com/a/19654060
      */
-    private static void addValueAttribute(HtmlFileInput input, String valueAttribute) {
-        AttributesImpl attributes = new AttributesImpl();
-        attributes.addAttribute(null, null, "type", null, "file");
-        attributes.addAttribute(null, null, "name", null, input.getNameAttribute());
-        HtmlFileInput cloned = (HtmlFileInput) new HtmlUnitNekoHtmlParser().getFactory("input").createElementNS(input.getPage(), null, "input", attributes);
-        input.getParentNode().appendChild(cloned);
-        cloned.setValueAttribute(valueAttribute);
-    }
+    // private static void addValueAttribute(HtmlFileInput input, String valueAttribute) {
+    //     AttributesImpl attributes = new AttributesImpl();
+    //     attributes.addAttribute(null, null, "type", null, "file");
+    //     attributes.addAttribute(null, null, "name", null, input.getNameAttribute());
+    //     HtmlFileInput cloned = (HtmlFileInput) new HtmlUnitNekoHtmlParser().getFactory("input").createElementNS(input.getPage(), null, "input", attributes);
+    //     input.getParentNode().appendChild(cloned);
+    //     cloned.setValueAttribute(valueAttribute);
+    // }
 }

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/MultipleInputFileTest.war/src/io/openliberty/org/apache/faces40/fat/inputfile/beans/MultipleFilesAcceptedBean.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/test-applications/MultipleInputFileTest.war/src/io/openliberty/org/apache/faces40/fat/inputfile/beans/MultipleFilesAcceptedBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -75,7 +75,7 @@ public class MultipleFilesAcceptedBean {
         String name = Paths.get(part.getSubmittedFileName()).getFileName().toString();
         long size = part.getSize();
 
-        FacesContext.getCurrentInstance().addMessage(null, new FacesMessage("field: " + field + ", name: " + name + ", size: " + size));
+        FacesContext.getCurrentInstance().addMessage(null, new FacesMessage("Received Message! field: " + field + ", name: " + name + ", size: " + size));
     }
 
 }


### PR DESCRIPTION
This has been a low priority item since these test are run on the TCK. However, with Faces 4.1 underway, we we should repeat these tests against EE11.

Related to #24387

- [ ] fat/src/io/openliberty/org/apache/myfaces40/fat/tests/AjaxRenderExecuteThisTest.java (Will be done in another PR)
- [x] fat/src/io/openliberty/org/apache/myfaces40/fat/tests/WebSocketTests.java
- [x] fat/src/io/openliberty/org/apache/myfaces40/fat/tests/MultipleInputFileTest.java