### PR TITLE
spec updates for PageableRepository and sort convenience on Pageable

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -4292,7 +4292,7 @@ public class DataTestServlet extends FATServlet {
 
         packages.delete(p3);
 
-        Page<Package> page = packages.findAll(Pageable.ofSize(3).sortBy(Sort.desc("id")));
+        Page<Package> page = packages.findAll(Pageable.of(Package.class).size(3).sortBy(Sort.desc("id")));
         assertIterableEquals(List.of(990006, 990005, 990004),
                              page.stream().map(pack -> pack.id).collect(Collectors.toList()));
 

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Pageable.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Pageable.java
@@ -48,11 +48,19 @@ public interface Pageable<T> {
 
     public Pageable<T> afterKeysetCursor(Pageable.Cursor cursor);
 
+    public Pageable<T> asc(String property);
+
+    public Pageable<T> ascIgnoreCase(String property);
+
     public Pageable<T> beforeKeyset(Object... keyset);
 
     public Pageable<T> beforeKeysetCursor(Pageable.Cursor cursor);
 
     public Optional<Cursor> cursor();
+
+    public Pageable<T> desc(String property);
+
+    public Pageable<T> descIgnoreCase(String property);
 
     public Mode mode();
 

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Pagination.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Pagination.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package jakarta.data.page;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -49,6 +50,29 @@ record Pagination<T>(long page,
         return new Pagination<T>(page, size, sorts, Mode.CURSOR_NEXT, cursor);
     }
 
+    private static final <E> List<E> append(List<E> list, E element) {
+        int size = list.size();
+        if (size == 0) {
+            return List.of(element);
+        } else {
+            Object[] array = list.toArray(new Object[size + 1]);
+            array[size] = element;
+            @SuppressWarnings("unchecked")
+            List<E> newList = (List<E>) Collections.unmodifiableList(Arrays.asList(array));
+            return newList;
+        }
+    }
+
+    @Override
+    public Pageable<T> asc(String property) {
+        return new Pagination<T>(page, size, append(sorts, Sort.asc(property)), mode, type);
+    }
+
+    @Override
+    public Pageable<T> ascIgnoreCase(String attribute) {
+        return new Pagination<T>(page, size, append(sorts, Sort.ascIgnoreCase(attribute)), mode, type);
+    }
+
     @Override
     public Pageable<T> beforeKeyset(Object... keyset) {
         return new Pagination<T>(page, size, sorts, Mode.CURSOR_PREVIOUS, new KeysetCursor(keyset));
@@ -62,6 +86,16 @@ record Pagination<T>(long page,
     @Override
     public Optional<Cursor> cursor() {
         return type == null ? Optional.empty() : Optional.of(type);
+    }
+
+    @Override
+    public Pageable<T> desc(String attribute) {
+        return new Pagination<T>(page, size, append(sorts, Sort.desc(attribute)), mode, type);
+    }
+
+    @Override
+    public Pageable<T> descIgnoreCase(String attribute) {
+        return new Pagination<T>(page, size, append(sorts, Sort.descIgnoreCase(attribute)), mode, type);
     }
 
     @Override

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/PageableRepository.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/PageableRepository.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,5 +19,5 @@ import jakarta.data.page.Pageable;
  * Interface methods copied from the Jakarta Data git repository.
  */
 public interface PageableRepository<T, K> extends BasicRepository<T, K> {
-    Page<T> findAll(Pageable pageable);
+    Page<T> findAll(Pageable<T> pageable);
 }


### PR DESCRIPTION
This adds the type parameter on PageableRepository.findAll(Pageable) and the convenience methods for appending individual sort criteria to new instances of Pageable.