### PR TITLE
Update apache commons to 3.14.0

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1689,7 +1689,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.8</version>
+      <version>3.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -333,7 +333,7 @@ org.apache.bcel:bcel:6.6.1
 org.apache.commons:commons-collections4:4.4
 org.apache.commons:commons-compress:1.21
 org.apache.commons:commons-dbcp2:2.7.0
-org.apache.commons:commons-lang3:3.8
+org.apache.commons:commons-lang3:3.14.0
 org.apache.commons:commons-math:2.2
 org.apache.commons:commons-pool2:2.6.0
 org.apache.commons:commons-text:1.9

--- a/dev/com.ibm.ws.cdi.jee_fat/build.gradle
+++ b/dev/com.ibm.ws.cdi.jee_fat/build.gradle
@@ -19,7 +19,7 @@ dependencies {
       'net.sourceforge.htmlunit:webdriver:2.6',
       'org.seleniumhq.webdriver:webdriver-common:0.9.7376',
       'org.brotli:dec:0.1.2',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       project(':com.ibm.ws.org.apache.commons.io'),
       project(':io.openliberty.org.apache.commons.codec'),
       'org.apache.httpcomponents:httpmime:4.5.3',

--- a/dev/com.ibm.ws.grpc_fat/build.gradle
+++ b/dev/com.ibm.ws.grpc_fat/build.gradle
@@ -165,7 +165,7 @@ dependencies {
       'xalan:xalan:2.7.2',
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       project(':io.openliberty.org.apache.commons.codec'),
       'org.apache.httpcomponents:httpmime:4.5.3',
       project(':com.ibm.ws.org.apache.httpcomponents'),

--- a/dev/com.ibm.ws.jsf.2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jsf.2.2_fat/build.gradle
@@ -20,7 +20,7 @@ dependencies {
       'net.sourceforge.htmlunit:webdriver:2.6',
       'org.seleniumhq.webdriver:webdriver-common:0.9.7376',
       'org.brotli:dec:0.1.2',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       project(':com.ibm.ws.org.apache.commons.io'),
       project(':io.openliberty.org.apache.commons.codec'),
       'org.apache.httpcomponents:httpmime:4.5.3',

--- a/dev/com.ibm.ws.jsf.2.3_fat/build.gradle
+++ b/dev/com.ibm.ws.jsf.2.3_fat/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     requiredLibs 'net.sourceforge.cssparser:cssparser:0.9.23'
     requiredLibs 'net.sourceforge.htmlunit:htmlunit:2.20'
     requiredLibs 'net.sourceforge.htmlunit:htmlunit-core-js:2.17'
-    requiredLibs 'org.apache.commons:commons-lang3:3.8'
+    requiredLibs 'org.apache.commons:commons-lang3:3.14.0'
     requiredLibs project(':io.openliberty.org.apache.commons.codec')
     requiredLibs 'org.apache.httpcomponents:httpmime:4.5.3'
     requiredLibs 'org.apache.httpcomponents:httpclient:4.5.4'

--- a/dev/com.ibm.ws.jsfContainer_fat_2.2/build.gradle
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.2/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     'xalan:xalan:2.7.2',
     project(':com.ibm.ws.org.apache.commons.io'),
     'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
-    'org.apache.commons:commons-lang3:3.8',
+    'org.apache.commons:commons-lang3:3.14.0',
     project(':com.ibm.ws.org.apache.httpcomponents'),
     'org.apache.httpcomponents:httpmime:4.3.1',
     'org.eclipse.jetty:jetty-util:9.4.7.RC0',

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/build.gradle
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     requiredLibs 'net.sourceforge.cssparser:cssparser:0.9.23'
     requiredLibs 'net.sourceforge.htmlunit:htmlunit:2.20'
     requiredLibs 'net.sourceforge.htmlunit:htmlunit-core-js:2.17'
-    requiredLibs 'org.apache.commons:commons-lang3:3.8'
+    requiredLibs 'org.apache.commons:commons-lang3:3.14.0'
     requiredLibs project(':io.openliberty.org.apache.commons.codec')
     requiredLibs 'org.apache.httpcomponents:httpmime:4.5.3'
     requiredLibs 'org.apache.httpcomponents:httpclient:4.5.4'

--- a/dev/com.ibm.ws.org.apache.commons.lang3/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.commons.lang3/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -10,6 +10,6 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.apache.commons:commons-lang3;3.8;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;org.apache.commons:commons-lang3;3.14.0;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
--buildpath: org.apache.commons:commons-lang3;version=3.8
+-buildpath: org.apache.commons:commons-lang3;version=3.14.0

--- a/dev/com.ibm.ws.org.apache.commons.lang3/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.commons.lang3/bnd.overrides
@@ -4,4 +4,4 @@ bVersion=1.0
 Bundle-SymbolicName: com.ibm.ws.org.apache.commons.lang3
 
 Include-Resource: \
-   @${repo;org.apache.commons:commons-lang3;3.8;EXACT}!/!META-INF/maven/*
+   @${repo;org.apache.commons:commons-lang3;3.14.0;EXACT}!/!(META-INF/maven/*|META-INF/versions/9/module-info.class)

--- a/dev/com.ibm.ws.security.fat.common.jwt/build.gradle
+++ b/dev/com.ibm.ws.security.fat.common.jwt/build.gradle
@@ -25,7 +25,7 @@ dependencies {
         'xalan:xalan:2.7.2',
         project(':com.ibm.ws.org.apache.commons.io'),
 				'org.apache.commons:commons-lang3:3.5',
-				'org.apache.commons:commons-lang3:3.8',
+				'org.apache.commons:commons-lang3:3.14.0',
 				project(':com.ibm.ws.org.apache.httpcomponents'),
 				'org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627',
 				'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',

--- a/dev/com.ibm.ws.security.jwt_fat.builder/build.gradle
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/build.gradle
@@ -25,7 +25,7 @@ dependencies {
       'org.brotli:dec:0.1.2',
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/build.gradle
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/build.gradle
@@ -24,7 +24,7 @@ dependencies {
       'org.brotli:dec:0.1.2',
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/build.gradle
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/build.gradle
@@ -26,7 +26,7 @@ dependencies {
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/com.ibm.ws.security.jwtsso_fat.mpJwt-1.1/build.gradle
+++ b/dev/com.ibm.ws.security.jwtsso_fat.mpJwt-1.1/build.gradle
@@ -26,7 +26,7 @@ dependencies {
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/com.ibm.ws.security.jwtsso_fat.mpJwt-1.2/build.gradle
+++ b/dev/com.ibm.ws.security.jwtsso_fat.mpJwt-1.2/build.gradle
@@ -26,7 +26,7 @@ dependencies {
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/com.ibm.ws.security.jwtsso_fat.mpJwt-2.0/build.gradle
+++ b/dev/com.ibm.ws.security.jwtsso_fat.mpJwt-2.0/build.gradle
@@ -26,7 +26,7 @@ dependencies {
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/com.ibm.ws.security.jwtsso_fat.mpJwt-2.1/build.gradle
+++ b/dev/com.ibm.ws.security.jwtsso_fat.mpJwt-2.1/build.gradle
@@ -26,7 +26,7 @@ dependencies {
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/com.ibm.ws.security.jwtsso_fat.noMpJwt/build.gradle
+++ b/dev/com.ibm.ws.security.jwtsso_fat.noMpJwt/build.gradle
@@ -26,7 +26,7 @@ dependencies {
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/com.ibm.ws.springboot.fat20_fat/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20_fat/build.gradle
@@ -18,7 +18,7 @@
     'net.sourceforge.htmlunit:htmlunit:2.44.0',
     'net.sourceforge.htmlunit:neko-htmlunit:2.44.0',
     'net.sourceforge.htmlunit:webdriver:2.6',
-    'org.apache.commons:commons-lang3:3.8',
+    'org.apache.commons:commons-lang3:3.14.0',
     'org.apache.httpcomponents:httpmime:4.3.1',
     'org.apache.tomcat.embed:tomcat-embed-websocket:8.5.23',
     'org.brotli:dec:0.1.2',

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat.2/build.gradle
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat.2/build.gradle
@@ -18,7 +18,7 @@ dependencies {
       'xalan:xalan:2.7.2',
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       project(':io.openliberty.org.apache.commons.codec'),
       'org.apache.httpcomponents:httpmime:4.5.3',
       project(':com.ibm.ws.org.apache.httpcomponents'),

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/build.gradle
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/build.gradle
@@ -21,7 +21,7 @@ dependencies {
       'xalan:xalan:2.7.2',
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       project(':io.openliberty.org.apache.commons.codec'),
       'org.apache.httpcomponents:httpmime:4.5.3',
       project(':com.ibm.ws.org.apache.httpcomponents'),

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/build.gradle
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     requiredLibs 'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0'
     requiredLibs 'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0'
     requiredLibs 'net.sourceforge.htmlunit:neko-htmlunit:2.44.0' 
-    requiredLibs 'org.apache.commons:commons-lang3:3.8'
+    requiredLibs 'org.apache.commons:commons-lang3:3.14.0'
     requiredLibs 'org.apache.httpcomponents:httpclient:4.5.7'
     requiredLibs 'org.apache.httpcomponents:httpcore:4.4.9'
     requiredLibs 'org.apache.httpcomponents:httpmime:4.5.3'

--- a/dev/io.openliberty.org.apache.myfaces.4.1_fat/build.gradle
+++ b/dev/io.openliberty.org.apache.myfaces.4.1_fat/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     requiredLibs 'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0'
     requiredLibs 'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0'
     requiredLibs 'net.sourceforge.htmlunit:neko-htmlunit:2.44.0' 
-    requiredLibs 'org.apache.commons:commons-lang3:3.8'
+    requiredLibs 'org.apache.commons:commons-lang3:3.14.0'
     requiredLibs 'org.apache.httpcomponents:httpclient:4.5.7'
     requiredLibs 'org.apache.httpcomponents:httpcore:4.4.9'
     requiredLibs 'org.apache.httpcomponents:httpmime:4.5.3'

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.1/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.1/build.gradle
@@ -27,7 +27,7 @@ dependencies {
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.2/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.2/build.gradle
@@ -27,7 +27,7 @@ dependencies {
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/build.gradle
@@ -27,7 +27,7 @@ dependencies {
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/build.gradle
@@ -25,7 +25,7 @@ dependencies {
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/build.gradle
@@ -25,7 +25,7 @@ dependencies {
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/build.gradle
@@ -27,7 +27,7 @@ dependencies {
       project(':com.ibm.ws.org.apache.commons.io'),
       'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
       'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
-      'org.apache.commons:commons-lang3:3.8',
+      'org.apache.commons:commons-lang3:3.14.0',
       'org.eclipse.jetty:jetty-websocket:8.2.0.v20160908',
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',

--- a/dev/io.openliberty.springboot.fat30_fat/build.gradle
+++ b/dev/io.openliberty.springboot.fat30_fat/build.gradle
@@ -21,7 +21,7 @@ repositories {
     'net.sourceforge.htmlunit:htmlunit:2.44.0',
     'net.sourceforge.htmlunit:neko-htmlunit:2.44.0',
     'net.sourceforge.htmlunit:webdriver:2.6',
-    'org.apache.commons:commons-lang3:3.8',
+    'org.apache.commons:commons-lang3:3.14.0',
     'org.apache.httpcomponents:httpmime:4.3.1',
     'org.brotli:dec:0.1.2',
     'org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627',


### PR DESCRIPTION
This updates us to the latest version of apache commons, partly because keeping updated is good but mostly because I want to use the more recent version of LazyInitializer in the open telemetry bundle. 