### PR TITLE
Remove potential null timestamps from TCKs and add report generation time

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -17,6 +17,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -91,7 +93,12 @@ public class TCKResultsWriter {
 
         Path outputPath = Paths.get("results", filename);
         File outputFile = outputPath.toFile();
-        String adocContent = getADocHeader(filename, fullSpecName, specURL, openLibertyVersion, javaMajorVersion, javaVersion, osName, osVersion, tckURL, tckSHA1, tckSHA256);
+
+        String timestamp = Instant.now()
+                        .truncatedTo(ChronoUnit.SECONDS)
+                        .toString();
+        String adocContent = getADocHeader(filename, fullSpecName, specURL, openLibertyVersion, javaMajorVersion, javaVersion, osName, osVersion, timestamp, tckURL, tckSHA1,
+                                           tckSHA256);
 
         try (FileWriter output = new FileWriter(outputFile)) {
             Path junitPath = Paths.get("results", "junit");
@@ -129,7 +136,7 @@ public class TCKResultsWriter {
     }
 
     private static String getADocHeader(String filename, String fullSpecName, String specURL, String openLibertyVersion, String javaMajorVersion, String javaVersion,
-                                        String osName, String osVersion, String tckURL, String tckSHA1, String tckSHA256) {
+                                        String osName, String osVersion, String timestamp, String tckURL, String tckSHA1, String tckSHA256) {
         StringBuilder builder = new StringBuilder();
 
         builder.append(":page-layout: certification ").append(NEW_LINE);
@@ -183,6 +190,9 @@ public class TCKResultsWriter {
         builder.append(osName);
         builder.append(": ");
         builder.append(osVersion).append(NEW_LINE);
+        builder.append(NEW_LINE);
+
+        builder.append("Report generated at: " + timestamp);
         builder.append(NEW_LINE);
 
         builder.append("Test results:").append(NEW_LINE);

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TestSuiteResult.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TestSuiteResult.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -48,7 +48,8 @@ public class TestSuiteResult {
         } else {
             pass = "FAILED";
         }
-        strBuild.append("Test suite: " + name + " " + timestamp);
+        // if the timestamp is null then omit from results - occurs in TCKs running JUnit rather than testng
+        strBuild.append("Test suite: " + name + " " + (timestamp != null ? timestamp : ""));
         strBuild.append(System.lineSeparator());
         strBuild.append("Tests:" + tests + " Failures:" + failures + " Errors:" + errors);
         strBuild.append(System.lineSeparator());


### PR DESCRIPTION
Fixes #27438 
This change removes null timestamps from our TCKs that do not use the `testng` framework (e.g. reactive messaging 3.0, jakarta json-b and more). This also adds a report generation time (in **UTC**) for TCKs which is as follows:

```
...
* Java runtime used to run the implementation:
+
Java 17: IBM Semeru Runtime Open Edition (17.0.8.1+1)

* Summary of the information for the certification environment, operating system, cloud, ...:
+
Mac OS X: ---

Report generated at: 2024-02-09T15:59:16 UTC
Test results:

[source, text]
----
Test suite: org.eclipse.microprofile.reactive.messaging.tck.channel.overflow.DefaultOverflowStrategyTest 
Tests:1 Failures:0 Errors:0
   org.eclipse.microprofile.reactive.messaging.tck.channel.overflow.DefaultOverflowStrategyTest.testNormal Passed!
Test suite: org.eclipse.microprofile.reactive.messaging.tck.channel.overflow.DropOverflowStrategyOverflowTest 
...
----
```