### PR TITLE
Allow leeway when checking Thread.sleep lasted the expected time

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/servlet/HttpTraceTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/servlet/HttpTraceTestServlet.java
@@ -141,9 +141,10 @@ public class HttpTraceTestServlet extends FATServlet {
                         .withAttribute(SemanticAttributes.NET_HOST_PORT, Long.valueOf(serverPort))
 
         );
-        // Make sure the duration is longer than 2 seconds as there is a sleep for 2 seconds in the servlet
+        // Make sure the duration is longer than 1.90 seconds as there is a sleep for 2 seconds in the servlet
+        // The leeway is because Thread.sleep depends on precision and accuracy of system timers and schedulers.
         long duration = servletSpan.getEndEpochNanos() - servletSpan.getStartEpochNanos();
-        assertTrue(duration > TimeUnit.SECONDS.toNanos(2));
+        assertTrue(duration > TimeUnit.NANOSECONDS.toNanos(1900000000));
 
     }
 


### PR DESCRIPTION
Fixes: https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=298799

Thread.sleep depends on the accuracy of underlying system and can last less time than expected so adding some leeway to the test. 