### PR TITLE
Delete features that match bundle name and add a test

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -14,6 +14,11 @@
     <dependency>
       <groupId>biz.aQute.bnd</groupId>
       <artifactId>biz.aQute.bnd.annotation</artifactId>
+      <version>6.4.1</version>
+    </dependency>
+    <dependency>
+      <groupId>biz.aQute.bnd</groupId>
+      <artifactId>biz.aQute.bnd.annotation</artifactId>
       <version>7.0.0</version>
     </dependency>
     <dependency>
@@ -25,6 +30,11 @@
       <groupId>biz.aQute.bnd</groupId>
       <artifactId>biz.aQute.bnd.transform</artifactId>
       <version>7.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>biz.aQute.bnd</groupId>
+      <artifactId>biz.aQute.bnd</artifactId>
+      <version>6.4.1</version>
     </dependency>
     <dependency>
       <groupId>biz.aQute.bnd</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -1,6 +1,8 @@
+biz.aQute.bnd:biz.aQute.bnd.annotation:6.4.1
 biz.aQute.bnd:biz.aQute.bnd.annotation:7.0.0
 biz.aQute.bnd:biz.aQute.bnd.transform:6.4.1
 biz.aQute.bnd:biz.aQute.bnd.transform:7.0.0
+biz.aQute.bnd:biz.aQute.bnd:6.4.1
 biz.aQute.bnd:biz.aQute.bnd:7.0.0
 cglib:cglib:3.3.0
 ch.qos.logback:logback-classic:1.2.3

--- a/dev/com.ibm.websphere.appserver.features/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.features/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -35,5 +35,5 @@ feature.project: true
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-	biz.aQute.bnd:biz.aQute.bnd;version=7.0.0;packages=**,\
+	biz.aQute.bnd:biz.aQute.bnd;strategy=exact;version=6.4.1;packages=**,\
 	org.apache.aries:org.apache.aries.util;version=1.1.3

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/SymbolicNameTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/SymbolicNameTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020,2021 IBM Corporation and others.
+ * Copyright (c) 2020,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,9 +15,12 @@ package com.ibm.ws.feature.tests;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -25,6 +28,9 @@ import org.junit.Test;
 
 import com.ibm.ws.feature.utils.FeatureFileList;
 import com.ibm.ws.feature.utils.FeatureInfo;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.build.Workspace;
 
 public class SymbolicNameTest {
 
@@ -37,6 +43,7 @@ public class SymbolicNameTest {
 
     @Test
     public void testSymbolicName() {
+        StringBuilder errorMessage = new StringBuilder();
         for (File featureFile : featureFileList) {
             FeatureInfo featureInfo = new FeatureInfo(featureFile);
             String symbolicName = featureInfo.getName();
@@ -45,7 +52,12 @@ public class SymbolicNameTest {
             if (index != -1) {
                 fileName = fileName.substring(0, index);
             }
-            Assert.assertEquals("symbolicName doesn't match the name of the file", fileName, symbolicName);
+            if (!fileName.equals(symbolicName)) {
+                errorMessage.append("Symbolic name ").append(symbolicName).append(" doesn't match the name of the file ").append(fileName).append('\n');
+            }
+        }
+        if (errorMessage.length() != 0) {
+            Assert.fail("Found features where symbolic name doesn't match the file name: " + '\n' + errorMessage.toString());
         }
     }
 
@@ -69,8 +81,8 @@ public class SymbolicNameTest {
             String symbolicName = featureInfo.getName();
             // javaeePlatform and appSecurity are special because they have dependencies on each other.
             if (symbolicName.startsWith("io.openliberty.jakartaeePlatform")
-                    || symbolicName.startsWith("com.ibm.websphere.appserver.javaeePlatform")
-                    || symbolicName.startsWith("com.ibm.websphere.appserver.appSecurity")) {
+                || symbolicName.startsWith("com.ibm.websphere.appserver.javaeePlatform")
+                || symbolicName.startsWith("com.ibm.websphere.appserver.appSecurity")) {
                 continue;
             }
 
@@ -101,8 +113,8 @@ public class SymbolicNameTest {
                         if (!featureInfo.isSingleton()) {
                             errorMessage.append("Found issues with " + featureInfo.getName() + '\n');
                             errorMessage.append(
-                                    "     There are other versions with the same name and it isn't marked as a singleton: "
-                                            + '\n');
+                                                "     There are other versions with the same name and it isn't marked as a singleton: "
+                                                + '\n');
                         }
                     }
                 }
@@ -110,6 +122,37 @@ public class SymbolicNameTest {
         }
         if (errorMessage.length() != 0) {
             Assert.fail("Found features that aren't correctly marked as singletons: " + '\n' + errorMessage.toString());
+        }
+    }
+
+    /**
+     * When exporting bundles and features in gradle-bootstrap, if a feature and bundle have the same name, they will conflict. They have different
+     * versions and different types, esa vs jar, but there is only one pom file with the same name so it won't work if a bundle matches a feature name.
+     */
+    @Test
+    public void testBundleFeatureConflict() throws Exception {
+        StringBuilder errorMessage = new StringBuilder();
+        Set<String> symbolicNames = new HashSet<>();
+        for (File featureFile : featureFileList) {
+            FeatureInfo featureInfo = new FeatureInfo(featureFile);
+            symbolicNames.add(featureInfo.getName());
+        }
+        File workspaceDir = new File(System.getProperty("user.dir")).getAbsoluteFile().getParentFile();
+
+        Workspace bndWorkspace = new Workspace(workspaceDir);
+        Collection<Project> projects = bndWorkspace.getAllProjects();
+        for (Project project : projects) {
+            Collection<String> bsns = project.getBsns();
+            for (String bsn : bsns) {
+                if (symbolicNames.contains(bsn)) {
+                    errorMessage.append(bsn).append(" in project ").append(project.getName()).append('\n');
+                }
+            }
+        }
+        bndWorkspace.close();
+
+        if (errorMessage.length() != 0) {
+            Assert.fail("Found features where symbolic name matches a bundle name: " + '\n' + errorMessage.toString());
         }
     }
 }

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.io.netty.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.io.netty.feature
@@ -1,8 +1,0 @@
--include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.io.netty
-WLP-DisableAllFeatures-OnConflict: false
-singleton=true
--bundles=io.openliberty.io.netty; location:="lib/";
-kind=noship
-edition=full
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.io.netty.ssl.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.io.netty.ssl.feature
@@ -1,8 +1,0 @@
--include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.io.netty.ssl
-WLP-DisableAllFeatures-OnConflict: false
-singleton=true
--bundles=io.openliberty.io.netty.ssl; location:="lib/";
-kind=noship
-edition=full
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.netty.internal-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.netty.internal-1.0.feature
@@ -3,10 +3,9 @@ symbolicName=io.openliberty.netty.internal-1.0
 WLP-DisableAllFeatures-OnConflict: false
 Subsystem-Name: Netty internal implementation 1.0
 singleton=true
--features=\
-  io.openliberty.io.netty, \
-  io.openliberty.io.netty.ssl
 -bundles=\
+  io.openliberty.io.netty, \
+  io.openliberty.io.netty.ssl, \
   com.ibm.ws.wsbytebuffer, \
   io.openliberty.endpoint, \
   io.openliberty.netty.internal, \

--- a/dev/com.ibm.ws.bnd.annotations/bnd.bnd
+++ b/dev/com.ibm.ws.bnd.annotations/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2023 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -26,5 +26,5 @@ Private-Package: com.ibm.ws.bnd.metatype.annotation, \
 publish.wlp.jar.disabled: true
 
 -buildpath: \
-	biz.aQute.bnd:biz.aQute.bnd.annotation;version=7.0.0, \
+	biz.aQute.bnd:biz.aQute.bnd.annotation;strategy=exact;version=6.4.1, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest


### PR DESCRIPTION
- Delete io.openliberty.io.netty and io.openliberty.io.netty.ssl features and update io.openliberty.netty.internal-1.0 to just use the
bundles
- Update to use 6.4.1 for bnd for some projects so that they can run in Eclipse with Java 8.
- Add test for bundle and feature name conflict to prevent this from happening in the future.

Fixes #27640