### PR TITLE
qualifiers on context service in application deployment descriptor

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/bnd.bnd
@@ -31,5 +31,6 @@ fat.project: true
 	io.openliberty.jakarta.annotation.2.1;version=latest,\
 	io.openliberty.jakarta.cdi.4.1;version=latest,\
 	io.openliberty.jakarta.concurrency.3.1;version=latest,\
+	io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\
 	io.openliberty.jakarta.servlet.6.1;version=latest,\
 	io.openliberty.jakarta.transaction.2.0;version=latest

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -59,8 +59,12 @@ public class ConcurrentCDITest extends FATServletClient {
         WebArchive concurrentCDIWeb = ShrinkHelper.buildDefaultApp("concurrentCDIWeb", "concurrent.cdi.web");
         ShrinkHelper.addDirectory(concurrentCDIWeb, "test-applications/concurrentCDIWeb/resources");
 
+        JavaArchive concurrentCDIEJB = ShrinkHelper.buildJavaArchive("concurrentCDIEJB", "concurrent.cdi.ejb");
+        ShrinkHelper.addDirectory(concurrentCDIEJB, "test-applications/concurrentCDIEJB/resources");
+
         EnterpriseArchive concurrentCDIApp = ShrinkWrap.create(EnterpriseArchive.class, "concurrentCDIApp.ear");
         concurrentCDIApp.addAsModule(concurrentCDIWeb);
+        concurrentCDIApp.addAsModule(concurrentCDIEJB);
         ShrinkHelper.addDirectory(concurrentCDIApp, "test-applications/concurrentCDIApp/resources");
         ShrinkHelper.exportAppToServer(server, concurrentCDIApp);
 
@@ -81,6 +85,11 @@ public class ConcurrentCDITest extends FATServletClient {
 
     @Test
     public void testContextServiceWithUnrecognizedQualifier() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testEJBSelectContextServiceQualifiedFromAppDD() throws Exception {
         runTest(server, APP_NAME, testName);
     }
 

--- a/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/server.xml
@@ -17,6 +17,7 @@
         <feature>concurrent-3.1</feature>
         <feature>cdi-4.1</feature>
         <feature>componenttest-2.0</feature>
+        <feature>enterpriseBeansLite-4.0</feature>
         <feature>jndi-1.0</feature>
     </featureManager>
 

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/resources/META-INF/application.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/resources/META-INF/application.xml
@@ -23,11 +23,16 @@
       <context-root>/</context-root>
     </web>
   </module>
+
+  <module>
+    <ejb>concurrentCDIEJB.jar</ejb>
+  </module>
+
   <context-service>
     <name>java:app/concurrent/with-location-and-without-app-context</name>
-    <qualifier>concurrent.cdi.web.ClearingAppContext</qualifier>
-    <qualifier>concurrent.cdi.web.PropagatingLocationContext</qualifier>
-    <qualifier>concurrent.cdi.web.IgnoringTransactionContext</qualifier>
+    <qualifier>concurrent.cdi.ejb.ClearingAppContext</qualifier>
+    <qualifier>concurrent.cdi.ejb.PropagatingLocationContext</qualifier>
+    <qualifier>concurrent.cdi.ejb.IgnoringTransactionContext</qualifier>
     <cleared>Application</cleared>
     <propagated>Location</propagated>
     <unchanged>Remaining</unchanged>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIEJB/resources/META-INF/ejb-jar.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIEJB/resources/META-INF/ejb-jar.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<ejb-jar version="4.0" metadata-complete="false"
+         xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd">
+
+  <enterprise-beans>
+    <session>
+      <ejb-name>InvokerEJB</ejb-name>
+
+ <!-- Jakarta EE 11 does not include any updates to the Jakarta Enterprise Beans specification,
+      so there is no way to support definitions of Concurrency resources in ejb-jar.xml -->
+
+    </session>
+  </enterprise-beans>
+
+</ejb-jar>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/ClearingAppContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/ClearingAppContext.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package concurrent.cdi.web;
+package concurrent.cdi.ejb;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -24,12 +24,12 @@ import jakarta.inject.Qualifier;
 @Qualifier
 @Retention(RUNTIME)
 @Target(FIELD)
-public @interface IgnoringTransactionContext {
+public @interface ClearingAppContext {
 
-    public static class Literal extends AnnotationLiteral<IgnoringTransactionContext> implements IgnoringTransactionContext {
-        private static final long serialVersionUID = 1111215772967657236L;
+    public static class Literal extends AnnotationLiteral<ClearingAppContext> implements ClearingAppContext {
+        private static final long serialVersionUID = -6084827420591593705L;
 
-        public static final IgnoringTransactionContext INSTANCE = new Literal();
+        public static final ClearingAppContext INSTANCE = new Literal();
 
         private Literal() {
         }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/IgnoringTransactionContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/IgnoringTransactionContext.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package concurrent.cdi.web;
+package concurrent.cdi.ejb;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -24,12 +24,12 @@ import jakarta.inject.Qualifier;
 @Qualifier
 @Retention(RUNTIME)
 @Target(FIELD)
-public @interface ClearingAppContext {
+public @interface IgnoringTransactionContext {
 
-    public static class Literal extends AnnotationLiteral<ClearingAppContext> implements ClearingAppContext {
-        private static final long serialVersionUID = -6084827420591593705L;
+    public static class Literal extends AnnotationLiteral<IgnoringTransactionContext> implements IgnoringTransactionContext {
+        private static final long serialVersionUID = 1111215772967657236L;
 
-        public static final ClearingAppContext INSTANCE = new Literal();
+        public static final IgnoringTransactionContext INSTANCE = new Literal();
 
         private Literal() {
         }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/Invoker.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/Invoker.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.ejb;
+
+import java.util.concurrent.Callable;
+
+public interface Invoker {
+
+    public <T> T runInEJB(Callable<T> testCode) throws Exception;
+
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/InvokerEJB.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/InvokerEJB.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.ejb;
+
+import java.util.concurrent.Callable;
+
+import jakarta.ejb.Local;
+import jakarta.ejb.Stateless;
+import jakarta.ejb.TransactionManagement;
+import jakarta.ejb.TransactionManagementType;
+
+@Local(Invoker.class)
+@Stateless
+@TransactionManagement(TransactionManagementType.CONTAINER)
+public class InvokerEJB implements Invoker {
+
+    @Override
+    public <T> T runInEJB(Callable<T> testCode) throws Exception {
+        return testCode.call();
+    }
+
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/PropagatingLocationContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/PropagatingLocationContext.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package concurrent.cdi.web;
+package concurrent.cdi.ejb;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;

--- a/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/OSGiInjectionEngineImpl.java
+++ b/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/OSGiInjectionEngineImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -652,6 +652,11 @@ public class OSGiInjectionEngineImpl extends AbstractInjectionEngine implements 
 
         properties.put("declaringApplication", j2eeName.getApplication());
         properties.put("jndiName", InjectionScope.denormalize(refName));
+
+        // Instead of checking the type, we could provide this to all resource factory builders,
+        // and those which are not for Jakarta EE Concurrency could ignore it.
+        if (type.startsWith("jakarta.enterprise.concurrent."))
+            properties.put("declaringClassLoader", compNSConfig.getClassLoader());
 
         ResourceFactory resourceFactory = builder.createResourceFactory(properties);
         Reference ref = new ResourceFactoryReference(type, resourceFactory, properties);

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import org.osgi.framework.BundleContext;
@@ -28,10 +27,10 @@ import com.ibm.websphere.csi.J2EEName;
 import com.ibm.ws.cdi.CDIServiceUtils;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
-import com.ibm.wsspi.resource.ResourceFactory;
 
 import io.openliberty.concurrent.internal.cdi.interceptor.AsyncInterceptor;
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
 import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.concurrent.ContextService;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
@@ -117,12 +116,12 @@ public class ConcurrencyExtension implements Extension {
 
         J2EEName jeeName = cmd.getJ2EEName();
 
-        List<Map<List<String>, ResourceFactory>> listFromModule = ext.removeAll(cmd.getJ2EEName().toString());
+        List<Map<List<String>, QualifiedResourceFactory>> listFromModule = ext.removeAll(cmd.getJ2EEName().toString());
 
         if (listFromModule != null)
             addBeans(event, listFromModule);
 
-        List<Map<List<String>, ResourceFactory>> listFromApp = ext.removeAll(jeeName.getApplication());
+        List<Map<List<String>, QualifiedResourceFactory>> listFromApp = ext.removeAll(jeeName.getApplication());
         if (listFromApp != null)
             addBeans(event, listFromApp);
     }
@@ -137,76 +136,68 @@ public class ConcurrencyExtension implements Extension {
      *                  . . . . . . qualifiers -> ResourceFactory for ManagedScheduledExecutorService,
      *                  . . . . . . qualifiers -> ResourceFactory for ManagedThreadFactory ]
      */
-    private void addBeans(AfterBeanDiscovery event, List<Map<List<String>, ResourceFactory>> list) {
-        Map<List<String>, ResourceFactory> qualifiedContextServices = //
-                        list.get(QualifiedResourceFactories.Type.ContextService.ordinal());
+    private void addBeans(AfterBeanDiscovery event, List<Map<List<String>, QualifiedResourceFactory>> list) {
+        Map<List<String>, QualifiedResourceFactory> qualifiedContextServices = //
+                        list.get(QualifiedResourceFactory.Type.ContextService.ordinal());
 
-        for (Entry<List<String>, ResourceFactory> entry : qualifiedContextServices.entrySet()) {
-            List<String> qualifierList = entry.getKey();
-            ResourceFactory factory = entry.getValue();
+        for (QualifiedResourceFactory factory : qualifiedContextServices.values()) {
             try {
-                event.addBean(new ContextServiceBean(factory, qualifierList));
+                event.addBean(new ContextServiceBean(factory));
             } catch (Throwable x) {
                 // TODO NLS
                 System.out.println(" E Unable to create a bean for the " +
-                                   factory + " ContextServiceDefinition with the " + qualifierList + " qualifiers" +
+                                   factory + " ContextServiceDefinition with the " + factory.getQualifiers() + " qualifiers" +
                                    " due to the following error: ");
                 x.printStackTrace();
             }
         }
 
-        Map<List<String>, ResourceFactory> qualifiedManagedExecutors = //
-                        list.get(QualifiedResourceFactories.Type.ManagedExecutorService.ordinal());
+        Map<List<String>, QualifiedResourceFactory> qualifiedManagedExecutors = //
+                        list.get(QualifiedResourceFactory.Type.ManagedExecutorService.ordinal());
 
-        for (Entry<List<String>, ResourceFactory> entry : qualifiedManagedExecutors.entrySet()) {
-            List<String> qualifierList = entry.getKey();
-            ResourceFactory factory = entry.getValue();
+        for (QualifiedResourceFactory factory : qualifiedManagedExecutors.values()) {
             try {
-                event.addBean(new ManagedExecutorBean(factory, qualifierList));
+                event.addBean(new ManagedExecutorBean(factory));
             } catch (Throwable x) {
                 // TODO NLS
                 System.out.println(" E Unable to create a bean for the " +
-                                   factory + " ManagedExecutorDefinition with the " + qualifierList + " qualifiers" +
+                                   factory + " ManagedExecutorDefinition with the " + factory.getQualifiers() + " qualifiers" +
                                    " due to the following error: ");
                 x.printStackTrace();
             }
         }
 
-        Map<List<String>, ResourceFactory> qualifiedManagedScheduledExecutors = //
-                        list.get(QualifiedResourceFactories.Type.ManagedScheduledExecutorService.ordinal());
+        Map<List<String>, QualifiedResourceFactory> qualifiedManagedScheduledExecutors = //
+                        list.get(QualifiedResourceFactory.Type.ManagedScheduledExecutorService.ordinal());
 
-        for (Entry<List<String>, ResourceFactory> entry : qualifiedManagedScheduledExecutors.entrySet()) {
-            List<String> qualifierList = entry.getKey();
-            ResourceFactory factory = entry.getValue();
+        for (QualifiedResourceFactory factory : qualifiedManagedScheduledExecutors.values()) {
             try {
-                event.addBean(new ManagedScheduledExecutorBean(factory, qualifierList));
+                event.addBean(new ManagedScheduledExecutorBean(factory));
             } catch (Throwable x) {
                 // TODO NLS
                 System.out.println(" E Unable to create a bean for the " +
-                                   factory + " ManagedScheduledExecutorDefinition with the " + qualifierList + " qualifiers" +
+                                   factory + " ManagedScheduledExecutorDefinition with the " + factory.getQualifiers() + " qualifiers" +
                                    " due to the following error: ");
                 x.printStackTrace();
             }
         }
 
-        Map<List<String>, ResourceFactory> qualifiedManagedThreadFactories = //
-                        list.get(QualifiedResourceFactories.Type.ManagedThreadFactory.ordinal());
+        Map<List<String>, QualifiedResourceFactory> qualifiedManagedThreadFactories = //
+                        list.get(QualifiedResourceFactory.Type.ManagedThreadFactory.ordinal());
 
         int count = qualifiedManagedThreadFactories.size();
         if (count > 0) {
             qualifierSetsPerMTF = qualifierSetsPerMTF == null ? new ArrayList<>(count) : qualifierSetsPerMTF;
 
-            for (Entry<List<String>, ResourceFactory> entry : qualifiedManagedThreadFactories.entrySet()) {
-                List<String> qualifierList = entry.getKey();
-                ResourceFactory factory = entry.getValue();
+            for (QualifiedResourceFactory factory : qualifiedManagedThreadFactories.values()) {
                 try {
-                    ManagedThreadFactoryBean bean = new ManagedThreadFactoryBean(factory, qualifierList);
+                    ManagedThreadFactoryBean bean = new ManagedThreadFactoryBean(factory);
                     event.addBean(bean);
-                    qualifierSetsPerMTF.add(bean.getQualifiers());
+                    qualifierSetsPerMTF.add(factory.getQualifiers());
                 } catch (Throwable x) {
                     // TODO NLS
                     System.out.println(" E Unable to create a bean for the " +
-                                       factory + " ManagedThreadFactoryDefinition with the " + qualifierList + " qualifiers" +
+                                       factory + " ManagedThreadFactoryDefinition with the " + factory.getQualifiers() + " qualifiers" +
                                        " due to the following error: ");
                     x.printStackTrace();
                 }
@@ -221,6 +212,13 @@ public class ConcurrencyExtension implements Extension {
      * @param beanManager
      */
     public void afterDeploymentValidation(@Observes AfterDeploymentValidation event, BeanManager beanManager) {
+        // TODO This approach needs to be replaced because it is unpredictable which module this method is invoked from
+        // when the application has multiple modules. One possibility could be to identify from the class loader
+        // of the class that defined the resource which application artifact it is, and capture the context based on it
+        // rather than capturing the context of the current thread, which is unreliable.
+        // It would also be more efficient to avoid forcing initialization just to capture the context.
+        // Maybe add the class loader identifier to the properties of the managed thread factory
+        // and use that as a signal.
         if (qualifierSetsPerMTF != null) {
             CDI<Object> cdi = CDI.current();
 

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -34,6 +34,7 @@ import com.ibm.wsspi.resource.ResourceFactory;
 
 import io.openliberty.cdi.spi.CDIExtensionMetadata;
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
 import jakarta.enterprise.concurrent.ContextService;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
@@ -94,7 +95,7 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
      * . . . . . . qualifiers -> ResourceFactory for ManagedScheduledExecutorService,
      * . . . . . . qualifiers -> ResourceFactory for ManagedThreadFactory ]
      */
-    final private Map<String, List<Map<List<String>, ResourceFactory>>> resourceFactories = new ConcurrentHashMap<>();
+    final private Map<String, List<Map<List<String>, QualifiedResourceFactory>>> resourceFactories = new ConcurrentHashMap<>();
 
     /**
      * Liberty Scheduled Executor.
@@ -113,15 +114,16 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
      * @param resourceFactory the resource factory
      */
     @Override
-    public void add(String jeeName, Type resourceType, List<String> qualifierNames, ResourceFactory resourceFactory) {
-        List<Map<List<String>, ResourceFactory>> list = resourceFactories.get(jeeName);
+    public void add(String jeeName, QualifiedResourceFactory.Type resourceType,
+                    List<String> qualifierNames, QualifiedResourceFactory resourceFactory) {
+        List<Map<List<String>, QualifiedResourceFactory>> list = resourceFactories.get(jeeName);
         if (list == null) {
             list = List.of(new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>());
             resourceFactories.put(jeeName, list);
         }
 
-        Map<List<String>, ResourceFactory> qualifiersToResourceFactory = list.get(resourceType.ordinal());
-        ResourceFactory conflict = qualifiersToResourceFactory.put(qualifierNames, resourceFactory);
+        Map<List<String>, QualifiedResourceFactory> qualifiersToResourceFactory = list.get(resourceType.ordinal());
+        QualifiedResourceFactory conflict = qualifiersToResourceFactory.put(qualifierNames, resourceFactory);
 
         if (conflict != null)
             throw new IllegalStateException("The " + jeeName + " application artifact defines multiple " + //
@@ -156,7 +158,7 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
      *         . . . . . . . . . qualifiers -> ResourceFactory for ManagedThreadFactory ]
      */
     @Override
-    public List<Map<List<String>, ResourceFactory>> removeAll(String jeeName) {
+    public List<Map<List<String>, QualifiedResourceFactory>> removeAll(String jeeName) {
         return resourceFactories.remove(jeeName);
     }
 

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ContextServiceBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ContextServiceBean.java
@@ -13,11 +13,8 @@
 package io.openliberty.concurrent.internal.cdi;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 import com.ibm.websphere.ras.Tr;
@@ -25,6 +22,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.wsspi.resource.ResourceFactory;
 
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
 import jakarta.enterprise.concurrent.ContextService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.spi.CreationalContext;
@@ -56,24 +54,11 @@ public class ContextServiceBean implements Bean<ContextService>, PassivationCapa
     /**
      * Construct a new bean for this resource.
      *
-     * @param factory        resource factory.
-     * @param qualifierNames names of qualifier annotations for the bean.
+     * @param factory resource factory.
      */
-    ContextServiceBean(ResourceFactory factory, List<String> qualifierNames) throws ClassNotFoundException {
+    ContextServiceBean(QualifiedResourceFactory factory) {
         this.factory = factory;
-        this.qualifiers = new LinkedHashSet<Annotation>();
-
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-
-        for (String qualifierClassName : qualifierNames) {
-            Class<?> qualifierClass = loader.loadClass(qualifierClassName);
-            if (!qualifierClass.isInterface())
-                throw new IllegalArgumentException("The " + qualifierClassName + " class is not a valid qualifier class" +
-                                                   " because it is not an annotation."); // TODO NLS
-            qualifiers.add(Annotation.class.cast(Proxy.newProxyInstance(loader,
-                                                                        new Class<?>[] { Annotation.class, qualifierClass },
-                                                                        new QualifierProxy(qualifierClass))));
-        }
+        this.qualifiers = factory.getQualifiers();
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedExecutorBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedExecutorBean.java
@@ -13,11 +13,8 @@
 package io.openliberty.concurrent.internal.cdi;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 import com.ibm.websphere.ras.Tr;
@@ -25,6 +22,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.wsspi.resource.ResourceFactory;
 
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.spi.CreationalContext;
@@ -56,24 +54,11 @@ public class ManagedExecutorBean implements Bean<ManagedExecutorService>, Passiv
     /**
      * Construct a new bean for this resource.
      *
-     * @param factory        resource factory.
-     * @param qualifierNames names of qualifier annotations for the bean.
+     * @param factory resource factory.
      */
-    ManagedExecutorBean(ResourceFactory factory, List<String> qualifierNames) throws ClassNotFoundException {
+    ManagedExecutorBean(QualifiedResourceFactory factory) {
         this.factory = factory;
-        this.qualifiers = new LinkedHashSet<Annotation>();
-
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-
-        for (String qualifierClassName : qualifierNames) {
-            Class<?> qualifierClass = loader.loadClass(qualifierClassName);
-            if (!qualifierClass.isInterface())
-                throw new IllegalArgumentException("The " + qualifierClassName + " class is not a valid qualifier class" +
-                                                   " because it is not an annotation."); // TODO NLS
-            qualifiers.add(Annotation.class.cast(Proxy.newProxyInstance(loader,
-                                                                        new Class<?>[] { Annotation.class, qualifierClass },
-                                                                        new QualifierProxy(qualifierClass))));
-        }
+        this.qualifiers = factory.getQualifiers();
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedScheduledExecutorBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedScheduledExecutorBean.java
@@ -13,11 +13,8 @@
 package io.openliberty.concurrent.internal.cdi;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 import com.ibm.websphere.ras.Tr;
@@ -25,6 +22,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.wsspi.resource.ResourceFactory;
 
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.spi.CreationalContext;
@@ -56,24 +54,11 @@ public class ManagedScheduledExecutorBean implements Bean<ManagedScheduledExecut
     /**
      * Construct a new bean for this resource.
      *
-     * @param factory        resource factory.
-     * @param qualifierNames names of qualifier annotations for the bean.
+     * @param factory resource factory.
      */
-    ManagedScheduledExecutorBean(ResourceFactory factory, List<String> qualifierNames) throws ClassNotFoundException {
+    ManagedScheduledExecutorBean(QualifiedResourceFactory factory) {
         this.factory = factory;
-        this.qualifiers = new LinkedHashSet<Annotation>();
-
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-
-        for (String qualifierClassName : qualifierNames) {
-            Class<?> qualifierClass = loader.loadClass(qualifierClassName);
-            if (!qualifierClass.isInterface())
-                throw new IllegalArgumentException("The " + qualifierClassName + " class is not a valid qualifier class" +
-                                                   " because it is not an annotation."); // TODO NLS
-            qualifiers.add(Annotation.class.cast(Proxy.newProxyInstance(loader,
-                                                                        new Class<?>[] { Annotation.class, qualifierClass },
-                                                                        new QualifierProxy(qualifierClass))));
-        }
+        this.qualifiers = factory.getQualifiers();
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
@@ -13,11 +13,8 @@
 package io.openliberty.concurrent.internal.cdi;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 import com.ibm.websphere.ras.Tr;
@@ -25,6 +22,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.wsspi.resource.ResourceFactory;
 
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
 import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.spi.CreationalContext;
@@ -56,24 +54,11 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
     /**
      * Construct a new bean for this resource.
      *
-     * @param factory        resource factory.
-     * @param qualifierNames names of qualifier annotations for the bean.
+     * @param factory resource factory.
      */
-    ManagedThreadFactoryBean(ResourceFactory factory, List<String> qualifierNames) throws ClassNotFoundException {
+    ManagedThreadFactoryBean(QualifiedResourceFactory factory) {
         this.factory = factory;
-        this.qualifiers = new LinkedHashSet<Annotation>();
-
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-
-        for (String qualifierClassName : qualifierNames) {
-            Class<?> qualifierClass = loader.loadClass(qualifierClassName);
-            if (!qualifierClass.isInterface())
-                throw new IllegalArgumentException("The " + qualifierClassName + " class is not a valid qualifier class" +
-                                                   " because it is not an annotation."); // TODO NLS
-            qualifiers.add(Annotation.class.cast(Proxy.newProxyInstance(loader,
-                                                                        new Class<?>[] { Annotation.class, qualifierClass },
-                                                                        new QualifierProxy(qualifierClass))));
-        }
+        this.qualifiers = factory.getQualifiers();
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/AppDefinedResourceFactory.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/AppDefinedResourceFactory.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013,2022 IBM Corporation and others.
+ * Copyright (c) 2013,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,8 +12,14 @@
  *******************************************************************************/
 package io.openliberty.concurrent.internal.processor;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.osgi.framework.Bundle;
@@ -33,13 +39,15 @@ import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 import com.ibm.wsspi.resource.ResourceFactory;
 import com.ibm.wsspi.resource.ResourceInfo;
 
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
+
 /**
  * AppDefinedResourceFactory is a Future-like wrapper for an application defined resource factory.
  * When createResource is invoked on the AppDefinedResourceFactory,
  * it waits, if necessary for ConfigurationAdmin to finish creating the resource factory, and then
  * delegates createResource to that resource factory.
  */
-public class AppDefinedResourceFactory implements com.ibm.ws.resource.ResourceFactory {
+public class AppDefinedResourceFactory implements QualifiedResourceFactory {
     private static final TraceComponent tc = Tr.register(AppDefinedResourceFactory.class);
 
     /**
@@ -75,6 +83,12 @@ public class AppDefinedResourceFactory implements com.ibm.ws.resource.ResourceFa
     private final String jndiName;
 
     /**
+     * Instances of qualifier annotations that are specified on the resource definition,
+     * or if none are specified then the value is the empty set.
+     */
+    private final Set<Annotation> qualifiers;
+
+    /**
      * Service tracker for this resource factory.
      */
     private final ServiceTracker<ResourceFactory, ResourceFactory> tracker;
@@ -82,25 +96,44 @@ public class AppDefinedResourceFactory implements com.ibm.ws.resource.ResourceFa
     /**
      * Construct a Future-like wrapper for an application-defined resource factory.
      *
-     * @param builder            the resource factory builder
-     * @param bundleContext      the bundle context
-     * @param appName            name of the application that defines the resource factory
-     * @param id                 unique identifier for the resource factory
-     * @param jndiName           JNDI name of the resource factory
-     * @param filter             filter for the resource factory
-     * @param contextSvcJndiName JNDI name of the context service that this resource depends on. Otherwise null.
-     * @param contextSvcFilter   Filter for the context service that this resource depends on. Otherwise null.
+     * @param builder               the resource factory builder
+     * @param bundleContext         the bundle context
+     * @param appName               name of the application that defines the resource factory
+     * @param id                    unique identifier for the resource factory
+     * @param jndiName              JNDI name of the resource factory
+     * @param filter                filter for the resource factory
+     * @param contextSvcJndiName    JNDI name of the context service that this resource depends on. Otherwise null.
+     * @param contextSvcFilter      filter for the context service that this resource depends on. Otherwise null.
+     * @param qualifiersClassLoader class loader for loading qualifiers.
+     * @param qualifierNames        names of qualifier annotation classes from the resource definition. Null indicates none.
      * @throws InvalidSyntaxException if the filter has incorrect syntax
      */
     AppDefinedResourceFactory(ResourceFactoryBuilder builder, BundleContext bundleContext, String appName, //
                               String id, String jndiName, String filter, //
-                              String contextSvcJndiName, String contextSvcFilter) throws InvalidSyntaxException {
+                              String contextSvcJndiName, String contextSvcFilter,
+                              ClassLoader qualifiersClassLoader, List<String> qualifierNames) throws ClassNotFoundException, InvalidSyntaxException {
         this.appName = appName;
         this.builder = builder;
         this.id = id;
         this.jndiName = jndiName;
         this.contextSvcFilter = contextSvcFilter;
         this.contextSvcJndiName = contextSvcJndiName;
+
+        if (qualifierNames == null) {
+            qualifiers = Collections.emptySet();
+        } else {
+            qualifiers = new LinkedHashSet<Annotation>();
+
+            for (String qualifierClassName : qualifierNames) {
+                Class<?> qualifierClass = qualifiersClassLoader.loadClass(qualifierClassName);
+                if (!qualifierClass.isInterface())
+                    throw new IllegalArgumentException("The " + qualifierClassName + " class is not a valid qualifier class" +
+                                                       " because it is not an annotation."); // TODO NLS
+                qualifiers.add(Annotation.class.cast(Proxy.newProxyInstance(qualifiersClassLoader,
+                                                                            new Class<?>[] { Annotation.class, qualifierClass },
+                                                                            new QualifierProxy(qualifierClass))));
+            }
+        }
 
         // The resource factory is activated asynchronously. ServiceTracker is used to wait for it when we need it.
         tracker = new ServiceTracker<ResourceFactory, ResourceFactory>(bundleContext, bundleContext.createFilter(filter), null);
@@ -192,7 +225,21 @@ public class AppDefinedResourceFactory implements com.ibm.ws.resource.ResourceFa
     }
 
     @Override
+    public Set<Annotation> getQualifiers() {
+        return qualifiers;
+    }
+
+    @Override
     public void modify(Map<String, Object> props) throws Exception {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Trivial
+    public String toString() {
+        return new StringBuilder("AppDefinedResourceFactory@") //
+                        .append(Integer.toHexString(hashCode())) //
+                        .append(':').append(id) //
+                        .toString();
     }
 }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
@@ -40,6 +40,7 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
 
 @Component(service = ResourceFactoryBuilder.class,
@@ -61,6 +62,17 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
     private static final String CONFIG_SOURCE = "config.source";
 
     /**
+     * Name of property that identifies the application for java:global data sources.
+     */
+    static final String DECLARING_APPLICATION = "declaringApplication";
+
+    /**
+     * Name of property that identifies the class loader of the application artifact
+     * that defines the ManagedScheduledExecutorDefinition.
+     */
+    static final String DECLARING_CLASS_LOADER = "declaringClassLoader";
+
+    /**
      * Property value that indicates the configuration originated in a configuration file, such as server.xml,
      * rather than being programmatically created via ConfigurationAdmin.
      */
@@ -70,11 +82,6 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
      * Unique identifier attribute name.
      */
     private static final String ID = "id";
-
-    /**
-     * Name of property that identifies the application for java:global data sources.
-     */
-    static final String DECLARING_APPLICATION = "declaringApplication";
 
     /**
      * Name of internal property that enforces unique JNDI names.
@@ -134,6 +141,7 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
             execSvcProps.put(prop.getKey(), value);
         }
 
+        ClassLoader declaringClassLoader = (ClassLoader) execSvcProps.remove(DECLARING_CLASS_LOADER);
         String declaringApplication = (String) execSvcProps.remove(DECLARING_APPLICATION);
         String application = (String) execSvcProps.get("application");
         String module = (String) execSvcProps.get("module");
@@ -217,9 +225,10 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
         BundleContext concurrencyBundleCtx = ContextServiceDefinitionProvider.priv.getBundleContext(FrameworkUtil.getBundle(WSManagedExecutorService.class));
         BundleContext concurrencyPolicyBundleCtx = ContextServiceDefinitionProvider.priv.getBundleContext(FrameworkUtil.getBundle(ConcurrencyPolicy.class));
 
-        ResourceFactory factory = new AppDefinedResourceFactory(this, concurrencyBundleCtx, declaringApplication, //
+        QualifiedResourceFactory factory = new AppDefinedResourceFactory(this, concurrencyBundleCtx, declaringApplication, //
                         managedScheduledExecutorServiceID, jndiName, managedScheduledExecutorSvcFilter.toString(), //
-                        contextSvcJndiName, contextSvcFilter);
+                        contextSvcJndiName, contextSvcFilter, //
+                        declaringClassLoader, qualifierNames);
         try {
             String concurrencyBundleLocation = concurrencyBundleCtx.getBundle().getLocation();
             String concurrencyPolicyBundleLocation = concurrencyPolicyBundleCtx.getBundle().getLocation();
@@ -252,7 +261,7 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
                                                             " because the " + "CDI" + " feature is not enabled."); // TODO NLS
 
                 QualifiedResourceFactories qrf = concurrencyBundleCtx.getService(ref);
-                qrf.add(jeeName, QualifiedResourceFactories.Type.ManagedScheduledExecutorService, qualifierNames, factory);
+                qrf.add(jeeName, QualifiedResourceFactory.Type.ManagedScheduledExecutorService, qualifierNames, factory);
             }
         } catch (Exception x) {
             factory.destroy();

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryResourceFactoryBuilder.java
@@ -39,6 +39,7 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
+import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
 import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
 
 @Component(service = ResourceFactoryBuilder.class,
@@ -60,6 +61,17 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
     private static final String CONFIG_SOURCE = "config.source";
 
     /**
+     * Name of property that identifies the application for java:global data sources.
+     */
+    static final String DECLARING_APPLICATION = "declaringApplication";
+
+    /**
+     * Name of property that identifies the class loader of the application artifact
+     * that defines the ManagedThreadFactoryDefinition.
+     */
+    static final String DECLARING_CLASS_LOADER = "declaringClassLoader";
+
+    /**
      * Property value that indicates the configuration originated in a configuration file, such as server.xml,
      * rather than being programmatically created via ConfigurationAdmin.
      */
@@ -69,11 +81,6 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
      * Unique identifier attribute name.
      */
     private static final String ID = "id";
-
-    /**
-     * Name of property that identifies the application for java:global data sources.
-     */
-    static final String DECLARING_APPLICATION = "declaringApplication";
 
     /**
      * Name of internal property that enforces unique JNDI names.
@@ -132,6 +139,7 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
             threadFactoryProps.put(prop.getKey(), value);
         }
 
+        ClassLoader declaringClassLoader = (ClassLoader) threadFactoryProps.remove(DECLARING_CLASS_LOADER);
         String declaringApplication = (String) threadFactoryProps.remove(DECLARING_APPLICATION);
         String application = (String) threadFactoryProps.get("application");
         String module = (String) threadFactoryProps.get("module");
@@ -182,9 +190,10 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
         managedThreadFactorySvcFilter.append("(&").append(FilterUtils.createPropertyFilter(ID, managedThreadFactoryID));
         managedThreadFactorySvcFilter.append("(component.name=com.ibm.ws.concurrent.internal.ManagedThreadFactoryService)(jndiName=*))");
 
-        ResourceFactory factory = new AppDefinedResourceFactory(this, bundleContext, declaringApplication, //
+        QualifiedResourceFactory factory = new AppDefinedResourceFactory(this, bundleContext, declaringApplication, //
                         managedThreadFactoryID, jndiName, managedThreadFactorySvcFilter.toString(), //
-                        contextSvcJndiName, contextSvcFilter);
+                        contextSvcJndiName, contextSvcFilter, //
+                        declaringClassLoader, qualifierNames);
         try {
             String bundleLocation = bundleContext.getBundle().getLocation();
             ConfigurationAdmin configAdmin = configAdminRef.getService();
@@ -210,7 +219,7 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
                                                             " because the " + "CDI" + " feature is not enabled."); // TODO NLS
 
                 QualifiedResourceFactories qrf = bundleContext.getService(ref);
-                qrf.add(jeeName, QualifiedResourceFactories.Type.ManagedThreadFactory, qualifierNames, factory);
+                qrf.add(jeeName, QualifiedResourceFactory.Type.ManagedThreadFactory, qualifierNames, factory);
             }
         } catch (Exception x) {
             factory.destroy();

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/QualifierProxy.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/QualifierProxy.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.concurrent.internal.cdi;
+package io.openliberty.concurrent.internal.processor;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -85,31 +85,40 @@ public class QualifierProxy implements InvocationHandler {
                     s.append(name).append('=');
 
                     int h;
-                    if (value instanceof Object[] array) {
+                    if (value instanceof Object[]) {
+                        Object[] array = (Object[]) value;
                         h = Arrays.hashCode(array);
                         s.append(Arrays.toString(array));
-                    } else if (value instanceof int[] array) {
+                    } else if (value instanceof int[]) {
+                        int[] array = (int[]) value;
                         h = Arrays.hashCode(array);
                         s.append(Arrays.toString(array));
-                    } else if (value instanceof long[] array) {
+                    } else if (value instanceof long[]) {
+                        long[] array = (long[]) value;
                         h = Arrays.hashCode(array);
                         s.append(Arrays.toString(array));
-                    } else if (value instanceof boolean[] array) {
+                    } else if (value instanceof boolean[]) {
+                        boolean[] array = (boolean[]) value;
                         h = Arrays.hashCode(array);
                         s.append(Arrays.toString(array));
-                    } else if (value instanceof double[] array) {
+                    } else if (value instanceof double[]) {
+                        double[] array = (double[]) value;
                         h = Arrays.hashCode(array);
                         s.append(Arrays.toString(array));
-                    } else if (value instanceof float[] array) {
+                    } else if (value instanceof float[]) {
+                        float[] array = (float[]) value;
                         h = Arrays.hashCode(array);
                         s.append(Arrays.toString(array));
-                    } else if (value instanceof short[] array) {
+                    } else if (value instanceof short[]) {
+                        short[] array = (short[]) value;
                         h = Arrays.hashCode(array);
                         s.append(Arrays.toString(array));
-                    } else if (value instanceof byte[] array) {
+                    } else if (value instanceof byte[]) {
+                        byte[] array = (byte[]) value;
                         h = Arrays.hashCode(array);
                         s.append(Arrays.toString(array));
-                    } else if (value instanceof char[] array) {
+                    } else if (value instanceof char[]) {
+                        char[] array = (char[]) value;
                         h = Arrays.hashCode(array);
                         s.append(Arrays.toString(array));
                     } else {
@@ -165,15 +174,15 @@ public class QualifierProxy implements InvocationHandler {
                             if (trace && tc.isDebugEnabled())
                                 Tr.debug(this, tc, "comparing " + method.getName(), value1, value2);
 
-                            equal = value1 instanceof Object[] array1 ? Arrays.equals(array1, (Object[]) value2) :
-                            /*   */ value1 instanceof int[] array1 ? Arrays.equals(array1, (int[]) value2) :
-                            /*   */ value1 instanceof long[] array1 ? Arrays.equals(array1, (long[]) value2) :
-                            /*   */ value1 instanceof boolean[] array1 ? Arrays.equals(array1, (boolean[]) value2) :
-                            /*   */ value1 instanceof double[] array1 ? Arrays.equals(array1, (double[]) value2) :
-                            /*   */ value1 instanceof float[] array1 ? Arrays.equals(array1, (float[]) value2) :
-                            /*   */ value1 instanceof short[] array1 ? Arrays.equals(array1, (short[]) value2) :
-                            /*   */ value1 instanceof byte[] array1 ? Arrays.equals(array1, (byte[]) value2) :
-                            /*   */ value1 instanceof char[] array1 ? Arrays.equals(array1, (char[]) value2) :
+                            equal = value1 instanceof Object[] ? Arrays.equals((Object[]) value1, (Object[]) value2) :
+                            /*   */ value1 instanceof int[] ? Arrays.equals((int[]) value1, (int[]) value2) :
+                            /*   */ value1 instanceof long[] ? Arrays.equals((long[]) value1, (long[]) value2) :
+                            /*   */ value1 instanceof boolean[] ? Arrays.equals((boolean[]) value1, (boolean[]) value2) :
+                            /*   */ value1 instanceof double[] ? Arrays.equals((double[]) value1, (double[]) value2) :
+                            /*   */ value1 instanceof float[] ? Arrays.equals((float[]) value1, (float[]) value2) :
+                            /*   */ value1 instanceof short[] ? Arrays.equals((short[]) value1, (short[]) value2) :
+                            /*   */ value1 instanceof byte[] ? Arrays.equals((byte[]) value1, (byte[]) value2) :
+                            /*   */ value1 instanceof char[] ? Arrays.equals((char[]) value1, (char[]) value2) :
                             /*   */ Objects.equals(value1, value2);
 
                             if (!equal)

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/qualified/QualifiedResourceFactories.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/qualified/QualifiedResourceFactories.java
@@ -15,8 +15,6 @@ package io.openliberty.concurrent.internal.qualified;
 import java.util.List;
 import java.util.Map;
 
-import com.ibm.wsspi.resource.ResourceFactory;
-
 /**
  * Maintains associations of qualifiers to resource factory for
  * each type of resource and for each JEE name.
@@ -36,12 +34,6 @@ import com.ibm.wsspi.resource.ResourceFactory;
  * This interface is available as an OSGi service component for the above purpose.
  */
 public interface QualifiedResourceFactories {
-    /**
-     * Concurrency resource definition types where qualifiers can be specified.
-     */
-    enum Type {
-        ContextService, ManagedExecutorService, ManagedScheduledExecutorService, ManagedThreadFactory
-    };
 
     /**
      * The resource factory builder invokes this method to add a
@@ -54,7 +46,10 @@ public interface QualifiedResourceFactories {
      * @param qualifierNames  names of qualifier annotation classes
      * @param resourceFactory the resource factory
      */
-    void add(String jeeName, Type resourceType, List<String> qualifierNames, ResourceFactory resourceFactory);
+    void add(String jeeName,
+             QualifiedResourceFactory.Type resourceType,
+             List<String> qualifierNames,
+             QualifiedResourceFactory resourceFactory);
 
     /**
      * The concurrency CDI extension invokes this method to obtain all
@@ -68,5 +63,5 @@ public interface QualifiedResourceFactories {
      *         . . . . . . . . . qualifiers -> ResourceFactory for ManagedScheduledExecutorService,
      *         . . . . . . . . . qualifiers -> ResourceFactory for ManagedThreadFactory ]
      */
-    List<Map<List<String>, ResourceFactory>> removeAll(String jeeName);
+    List<Map<List<String>, QualifiedResourceFactory>> removeAll(String jeeName);
 }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/qualified/QualifiedResourceFactory.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/qualified/QualifiedResourceFactory.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.concurrent.internal.qualified;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import com.ibm.ws.resource.ResourceFactory;
+
+/**
+ * A subclass of ResourceFactory that allows for obtaining a list of
+ * qualifier annotation instances that correspond to the qualifiers class
+ * names that are specified on a resource factory definition.
+ */
+public interface QualifiedResourceFactory extends ResourceFactory {
+    /**
+     * Concurrency resource definition types where qualifiers can be specified.
+     */
+    enum Type {
+        ContextService, ManagedExecutorService, ManagedScheduledExecutorService, ManagedThreadFactory
+    };
+
+    /**
+     * Returns instances of the qualifier annotations for this resource factory.
+     *
+     * @return qualifier annotations for this resource factory.
+     *         Returns the empty set if there are no qualifier classes specified on the resource definition.
+     */
+    Set<Annotation> getQualifiers();
+}


### PR DESCRIPTION
Add the ability to handle qualifier class names that are specified on a context-service definition in application.xml. We need to be able to load these from the application, while still being able to load qualifier classes from web.xml out of the web module. The injection engine already has the correct class loader, and this pull adds code to get it from there and centralizes loading the qualifier classes into a single place.  This was sufficient to get a single test that is added under this pull working.  However, splitting the test application into both web and ejb modules exposed a separate problem where the CDI extension cannot rely on any particular module's thread context being present.  For now, I commented out tests of managed thread factory that are intermittently hitting that issue, with TODO comments where that needs to be addressed, which will be covered in a separate pull.  It should also be noted that more tests need to be written for other 3 resource types and so forth. Those will be covered under another pull as well.  This pull is limited to being a proof of concept of the general solution and only tests out the context-service definition.