### PR TITLE
Increase app start time in EJBLink FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/publish/clients/com.ibm.ws.ejbcontainer.remote.client.fat.clientInjection/client.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/publish/clients/com.ibm.ws.ejbcontainer.remote.client.fat.clientInjection/client.xml
@@ -1,12 +1,12 @@
 <!--
-    Copyright (c) 2010, 2020 IBM Corporation and others.
+    Copyright (c) 2010, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
+
     Contributors:
         IBM Corporation - initial API and implementation
  -->
@@ -20,7 +20,7 @@
     <keyStore id="defaultKeyStore" password="{xor}EzY9Oi0rJg==" /> <!-- pwd: Liberty, expires1/4/2099 -->
     <sslDefault sslRef="supportedClientAuthenticationSSLConfig"/>
     <ssl id="supportedClientAuthenticationSSLConfig" keyStoreRef="defaultKeyStore" clientAuthenticationSupported="true"/>
-    
+
     <orb id="defaultOrb"  nameService="corbaloc::localhost:${bvt.prop.IIOP}/NameService">
         <clientPolicy.clientContainerCsiv2>
             <layers>
@@ -33,8 +33,10 @@
     <javaPermission className="java.net.SocketPermission" name="*" actions="connect,listen,resolve"/>
     <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
     <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
-    
+
     <orb id="defaultOrb" orbSSLInitTimeout="90"/>
+
+    <applicationManager startTimeout="60s"/>
 
     <logging traceSpecification="com.ibm.ws.clientcontainer.*=all:Naming=all:Injection=all:EJBContainer=all:org.apache.yoko.*=all:com.ibm.ws.security.csiv2.*=all" maxFileSize="0"/>
 </client>

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.client.fat.serverInjection/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.client.fat.serverInjection/server.xml
@@ -1,12 +1,12 @@
 <!--
-    Copyright (c) 2010, 2020 IBM Corporation and others.
+    Copyright (c) 2010, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
+
     Contributors:
         IBM Corporation - initial API and implementation
  -->
@@ -28,11 +28,11 @@
     <quickStartSecurity userName="bob" userPassword="mypwd" />
     <sslDefault sslRef="supportedClientAuthenticationSSLConfig" />
     <ssl id="supportedClientAuthenticationSSLConfig" keyStoreRef="defaultKeyStore" clientAuthenticationSupported="true"/>
-    
+
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" >
         <iiopsOptions iiopsPort="${bvt.prop.IIOP.secure}"  sslRef="supportedClientAuthenticationSSLConfig"/>
     </iiopEndpoint>
-    
+
     <orb id="defaultOrb">
       <serverPolicy.csiv2>
         <layers>
@@ -47,8 +47,10 @@
         </layers>
       </clientPolicy.csiv2>
     </orb>
-    
+
     <orb id="defaultOrb" orbSSLInitTimeout="90"/>
-   
+
+    <applicationManager startTimeout="60s"/>
+
     <logging traceSpecification="*=info:org.apache.yoko.*=all:Naming=all:IIOP=all:com.ibm.ws.jndi.remote.*=all:Injection=all:com.ibm.ws.clientcontainer.*=all:EJBContainer=all:org.apache.yoko.*=all:com.ibm.ws.security.csiv2.*=all" maxFiles="1" maxFileSize="0"/>
 </server>


### PR DESCRIPTION
Application in this FAT is complex and takes longer to start, so allowing more time to start is necessary on slower build hardware.
