### PR TITLE
remove logout call on auth exception to fix bug sessionCache

### DIFF
--- a/dev/com.ibm.ws.security.token.ltpa_fat/publish/servers/com.ibm.ws.security.token.ltpa.fat.ltpaKeyRotationTestServer/server.xml
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/publish/servers/com.ibm.ws.security.token.ltpa.fat.ltpaKeyRotationTestServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023 IBM Corporation and others.
+    Copyright (c) 2023, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -72,6 +72,8 @@
     </application>
 
     <authentication id="Basic" cacheEnabled="true" />
+    
+    <httpSession securityIntegrationEnabled="false"/>
 
     <ltpa monitorInterval = "10" monitorValidationKeysDir="true" expiration="10m" updateTrigger="polled" keysFileName="${server.config.dir}/resources/security/ltpa.keys" keysPassword="{xor}Lz4sLCgwLTs=">
         <validationKeys fileName="configuredValidation1.keys" password="{xor}Lz4sLCgwLTs=" validUntilDate="2099-01-01T00:00:00Z"/>

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
@@ -189,12 +189,6 @@ public class SSOAuthenticator implements WebAuthenticator {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Tr.debug(tc, "handleSSO Exception: ", new Object[] { e });
                         }
-                        // Perform logout steps
-                        // If the ltpa.keys are changed, and an existing LTPA token cookie is no longer valid.
-                        // we will logout the user, so they are properly redirected to the login page to login again and get a new LTPA token
-                        //TODO - Only do this if the key rotation feature is enabled to
-                        cleanupLoggedOutToken(req, res, false);
-
                         //TODO - Remove authentication cache.
                     }
                 }

--- a/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/SSOAuthenticatorTest.java
+++ b/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/SSOAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -240,13 +240,6 @@ public class SSOAuthenticatorTest {
 
                 one(authService).authenticate(with(equal(JaasLoginConfigConstants.SYSTEM_WEB_INBOUND)), with(any(AuthenticationData.class)), with(equal((Subject) null)));
                 will(throwException(new AuthenticationException("Invalid LTPAToken")));
-
-                //add logoutforInvalidToken expectations
-                one(req).getAuthType();
-                one(req).getSession(false);
-                one(ssoCookieHelper).removeSSOCookieFromResponse(resp);
-                one(ssoCookieHelper).createLogoutCookies(req, resp);
-                one(resp).getStatus();
             }
         });
 
@@ -329,13 +322,6 @@ public class SSOAuthenticatorTest {
                 will(throwException(new AuthenticationException("Authentication failed")));
 
                 one(ssoCookieHelper).createLogoutCookies(req, resp);
-
-                //add logoutforInvalidToken expectations
-                one(req).getAuthType();
-                one(req).getSession(false);
-                one(ssoCookieHelper).removeSSOCookieFromResponse(resp);
-                one(ssoCookieHelper).createLogoutCookies(req, resp);
-                one(resp).getStatus();
             }
         });
 


### PR DESCRIPTION
The `cleanupLoggedOutToken` call was originally added to fix a blank login page issue that would happen when an LTPA token became invalid after ltpa.keys changed. 

This caused a new bug for Liberty users with their own Http Auth Mech(HAM) implemented where LTPA tokens are not used but Liberty security still processes them and produces an error as a result of the session being invalidated from the `cleanupLoggedOutToken` call.