### PR TITLE
Make sure that all JWT Consumer test classes wait for the jwtconsumerclient app to start

### DIFF
--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerAPIMinimumHSARunnableConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerAPIMinimumHSARunnableConfigTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -54,6 +54,7 @@ public class JwtConsumerAPIMinimumHSARunnableConfigTests extends CommonSecurityF
 
         serverTracker.addServer(consumerServer);
         skipRestoreServerTracker.addServer(consumerServer);
+        consumerServer.addInstalledAppForValidation(JwtConsumerConstants.JWT_CONSUMER_SERVLET);
         consumerServer.startServerUsingExpandedConfiguration("server_minimumHS256Config.xml");
         SecurityFatHttpUtils.saveServerPorts(consumerServer, JwtConsumerConstants.BVT_SERVER_1_PORT_NAME_ROOT);
 

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerAPIMinimumSSLConsumerConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerAPIMinimumSSLConsumerConfigTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -56,6 +56,7 @@ public class JwtConsumerAPIMinimumSSLConsumerConfigTests extends CommonSecurityF
 
         serverTracker.addServer(consumerServer);
         skipRestoreServerTracker.addServer(consumerServer);
+        consumerServer.addInstalledAppForValidation(JwtConsumerConstants.JWT_CONSUMER_SERVLET);
         consumerServer.startServerUsingExpandedConfiguration("server_minimumConfig_SSLInConsumer.xml");
         SecurityFatHttpUtils.saveServerPorts(consumerServer, JwtConsumerConstants.BVT_SERVER_1_PORT_NAME_ROOT);
 

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerAPIMinimumSSLGlobalConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerAPIMinimumSSLGlobalConfigTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -40,8 +40,6 @@ import componenttest.topology.impl.LibertyServer;
 @RunWith(FATRunner.class)
 public class JwtConsumerAPIMinimumSSLGlobalConfigTests extends CommonSecurityFat {
 
-    public final String AppStartMsg = ".*CWWKZ0001I.*" + JwtConsumerConstants.JWT_CONSUMER_SERVLET + ".*";
-
     @Server("com.ibm.ws.security.jwt_fat.consumer")
     public static LibertyServer consumerServer;
 
@@ -58,6 +56,7 @@ public class JwtConsumerAPIMinimumSSLGlobalConfigTests extends CommonSecurityFat
 
         serverTracker.addServer(consumerServer);
         skipRestoreServerTracker.addServer(consumerServer);
+        consumerServer.addInstalledAppForValidation(JwtConsumerConstants.JWT_CONSUMER_SERVLET);
         consumerServer.startServerUsingExpandedConfiguration("server_minimumConfig_ServerWideSSL.xml");
         SecurityFatHttpUtils.saveServerPorts(consumerServer, JwtConsumerConstants.BVT_SERVER_1_PORT_NAME_ROOT);
 


### PR DESCRIPTION
The tests in the com.ibm.ws.security.jwt_fat.consumer need to make sure that the jwtconsumerclient test app is ready for requests.  3 of the test classes weren't waiting.  The app usually came up fast enough that there wasn't an issue when the first test made a request.  But, we finally had an instance where the app wasn't ready.
I'm adding the app to the list of applications that the server startup should wait for.