### PR TITLE
Fix for CWWKS9590W Warning

### DIFF
--- a/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/security/csiv2/config/ssl/SSLConfig.java
+++ b/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/security/csiv2/config/ssl/SSLConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -193,7 +193,11 @@ public class SSLConfig {
                                        | clientAuthSupported), (short) (Integrity.value | Confidentiality.value | clientAuthRequired));
     }
 
-    static final Pattern p = Pattern.compile("(?:(SSL)|(TLS))_([A-Z0-9]*)(_anon)?(_[a-zA-Z0-9]*)??(_EXPORT)?_WITH_([A-Z0-9]*)(?:_(\\d*))?([_a-zA-Z0-9]*)?_(?:(?:(SHA)(\\d*))|(MD5))");
+    //static final Pattern p = Pattern.compile("(?:(SSL)|(TLS))_([A-Z0-9]*)(_anon)?(_[a-zA-Z0-9]*)??(_EXPORT)?_WITH_([A-Z0-9]*)(?:_(\\d*))?([_a-zA-Z0-9]*)?_(?:(?:(SHA)(\\d*))|(MD5))");
+    //Removed "WITH" from the above pattern to accommodate ciphers without the substring "WITH" 
+    static final Pattern p = Pattern.compile("(?:(SSL)|(TLS))_([A-Z0-9]*)(_anon)?(_[a-zA-Z0-9]*)??(_EXPORT)?([A-Z0-9]*)(?:_(\\d*))?([_a-zA-Z0-9]*)?_(?:(?:(SHA)(\\d*))|(MD5))");
+    
+    
 //[1 null, 2 TLS, 3 ECDHE, 4 null, 5 _ECDSA, 6 null, 7 AES, 8 128, 9 _CBC, 10 SHA, 11 256, 12 null]
     private static final int SSL_INDEX = 1;
     private static final int TLS_INDEX = 2;


### PR DESCRIPTION
CWWKS9590W warning messages showed up when some newer ciphers are configured on OL 23.0.0.12.
Updated the regex to handle new cipher string with no "_WITH_" as a sub-string inside the cipher name.

E.g. for ciphers with no "_WITH_" inside their names:
  TLS_AES_256_GCM_SHA384
  TLS_AES_128_GCM_SHA256

Issue [27659](https://github.com/OpenLiberty/open-liberty/issues/27659)
IFix# OLGH27659
