### PR TITLE
Fix CommunicationException in JavaIllegalAccessTest

### DIFF
--- a/dev/io.openliberty.java.internal_fat/test-applications/illegalaccess/src/test/web/IllegalAccessTestServlet.java
+++ b/dev/io.openliberty.java.internal_fat/test-applications/illegalaccess/src/test/web/IllegalAccessTestServlet.java
@@ -12,6 +12,7 @@ package test.web;
 import java.net.InetAddress;
 import java.util.Properties;
 
+import javax.naming.CommunicationException;
 import javax.naming.Context;
 import javax.naming.NameNotFoundException;
 import javax.naming.directory.Attributes;
@@ -38,10 +39,12 @@ public class IllegalAccessTestServlet extends FATServlet {
             // This will cause an illegalAccessException FFDC if the following entry is not in the java9.options file:
             // --add-exports
             // jdk.naming.dns/com.sun.jndi.url.dns=ALL-UNNAMED
-            // 
+
             // Attempt a DNS lookup of the local host name using the underlying machine's DNS config
+            // Intermittently, a javax.naming.CommunicationException is thrown when trying the DNS lookup and that is permissible (seems to vary from platform to platform)
+            // The purpose of this test is to attempt the DNS connection to ensure the illegalAccessException FFDC is not created, not to ensure the DNS resolution was successful
             Attributes attrs = dirContext.getAttributes("dns:/" + InetAddress.getLocalHost().getHostName());
-        } catch (NameNotFoundException nnfe) { // dirContext.getAttributes may throw a NameNotFoundException, it can be ignored
+        } catch (CommunicationException | NameNotFoundException ex) { // dirContext.getAttributes may also throw a NameNotFoundException and it can also be ignored
             // Ignore
         }
     }


### PR DESCRIPTION
This is a continuation of fix #27357.

Previously I attempted a DNS lookup of the local host name using the underlying machine's DNS config, but intermittently, a `javax.naming.CommunicationException` is thrown when trying the DNS lookup.  This exception is permissible since the purpose of this test is to attempt the DNS connection to ensure the illegalAccessException FFDC is not created, not to ensure the DNS resolution is successful.

So added `CommunicationException` to the catch block to ignore any of those exceptions.