### PR TITLE
Update features to be singletons when WebSphere Liberty has a version

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -397,7 +397,7 @@ public class VisibilityTest {
                 } else {
                     errorMessage.append("     Auto feature filter only depends on one feature " + filterFeatures[0] + ".\n");
                     errorMessage.append("     The feature and/or bundle dependencies in this auto feature should just be a dependency of that feature\n");
-                    errorMessage.append("     OR this should be turned into a private feature that " + filterFeatures[0] + " depends on.");
+                    errorMessage.append("     OR this should be turned into a private feature that " + filterFeatures[0] + " depends on.\n");
                 }
             }
         }

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureFileList.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureFileList.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,12 +22,12 @@ import java.util.Queue;
 
 public class FeatureFileList implements Iterable<File> {
 
-    private final String dirRoot;
+    private final String[] dirRoots;
     private final List<File> featureList = new ArrayList<File>();
     private boolean isInit = false;
 
-    public FeatureFileList(String root) {
-        this.dirRoot = root;
+    public FeatureFileList(String... roots) {
+        this.dirRoots = roots;
 
     }
 
@@ -38,28 +38,30 @@ public class FeatureFileList implements Iterable<File> {
 
         Queue<File> directories = new LinkedList<File>();
 
-        File root = new File(this.dirRoot);
+        for (String dirRoot : dirRoots) {
+            File root = new File(dirRoot);
 
-        directories.add(root);
+            directories.add(root);
 
-        while (!directories.isEmpty()) {
+            while (!directories.isEmpty()) {
 
-            File nextDirectory = directories.poll();
-            //System.out.println("inspecting directory: " + nextDirectory.getName());
-            File[] nextDirectoryListing = nextDirectory.listFiles();
-            if (nextDirectoryListing == null)
-                continue;
+                File nextDirectory = directories.poll();
+                //System.out.println("inspecting directory: " + nextDirectory.getName());
+                File[] nextDirectoryListing = nextDirectory.listFiles();
+                if (nextDirectoryListing == null)
+                    continue;
 
-            for (File file : nextDirectoryListing) {
-                if (file.isDirectory()) { //Going down just one step.
-                    for (File child : file.listFiles()) {
-                        if (child.getName().endsWith(".feature")) {
-                            this.featureList.add(child);
+                for (File file : nextDirectoryListing) {
+                    if (file.isDirectory()) { //Going down just one step.
+                        for (File child : file.listFiles()) {
+                            if (child.getName().endsWith(".feature")) {
+                                this.featureList.add(child);
+                            }
                         }
-                    }
-                    directories.add(file); //use this if we want to search every directory and subdirectory
-                    //By adding the directories we find into the queue of all directories
+                        directories.add(file); //use this if we want to search every directory and subdirectory
+                        //By adding the directories we find into the queue of all directories
 
+                    }
                 }
             }
         }

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureMapFactory.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureMapFactory.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,7 +19,7 @@ import java.util.Map;
 
 public class FeatureMapFactory {
 
-    public static Map<String, FeatureInfo> getFeatureMapFromFile(String fileLoc) {
+    public static Map<String, FeatureInfo> getFeatureMapFromFile(String... fileLoc) {
         Map<String, FeatureInfo> features = new LinkedHashMap<String, FeatureInfo>();
 
         for (File featureFile : new FeatureFileList(fileLoc)) {

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jmsMdb-3.2/com.ibm.websphere.appserver.jmsMdb-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jmsMdb-3.2/com.ibm.websphere.appserver.jmsMdb-3.2.feature
@@ -2,6 +2,7 @@
 symbolicName=com.ibm.websphere.appserver.jmsMdb-3.2
 WLP-DisableAllFeatures-OnConflict: false
 visibility=public
+singleton=true
 IBM-App-ForceRestart: install, \
  uninstall
 IBM-ShortName: jmsMdb-3.2

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/scim-2.0/com.ibm.websphere.appserver.scim-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/scim-2.0/com.ibm.websphere.appserver.scim-2.0.feature
@@ -1,6 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.scim-2.0
 visibility=public
+singleton=true
 IBM-ShortName: scim-2.0
 Subsystem-Name: System for Cross-domain Identity Management 2.0
 -features=com.ibm.websphere.appserver.restHandler-1.0, \


### PR DESCRIPTION
- Update scim-2.0 and jmsMdb-3.2 to be singleton to conflict with 1.0 and 3.1 versions of the features respectively that are part of WebSphere Liberty
- Update FeatureFileList and FeatureMapFactory to handle multiple directories containing .feature files
- Small update in error output for VisibilityTest.testAutoFeatures test

#build