### PR TITLE
remove synchronized block when invalidating sip application session to prevent deadlock

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipApplicationSessionImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipApplicationSessionImpl.java
@@ -516,7 +516,9 @@ implements SipApplicationSession {
 	 * @see javax.servlet.sip.SipApplicationSession#invalidate()
 	 */
 	public void invalidate() {
-		synchronized (getSynchronizer()) {
+		//remove synchronized as it has caused deadlocks
+		//see open-liberty issue #27282
+		//synchronized (getSynchronizer()) {
 			if(m_duringInvalidate) {
 				checkIsSessionValid();
 				return;
@@ -603,7 +605,7 @@ implements SipApplicationSession {
 			if (c_logger.isTraceEntryExitEnabled()) {
 				c_logger.traceExit(this, "invalidate", "AppSessionId: " + getId());
 			}
-		}
+		//}
 	}
 
 	/**

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipSessionImplementation.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipSessionImplementation.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+et*******************************************************************************
  * Copyright (c) 2003 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -670,7 +670,9 @@ public class SipSessionImplementation extends ReplicatableImpl implements IBMSip
     /**
      * Send notifications about invalidated SipSession
      */
-    public synchronized void invalidateSipSession() {
+     //remove synchronized as it can cause deadlock
+     //see open-liberty issue #27282
+    public void invalidateSipSession() {
     	if (c_logger.isTraceEntryExitEnabled()) {
     		c_logger.traceEntry(this, "invalidateSipSession", getId());
     	}

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipSessionImplementation.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipSessionImplementation.java
@@ -1,4 +1,4 @@
-et*******************************************************************************
+/*******************************************************************************
  * Copyright (c) 2003 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/WASXSipApplicationSessionImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/WASXSipApplicationSessionImpl.java
@@ -116,10 +116,12 @@ public class WASXSipApplicationSessionImpl extends SipApplicationSessionImpl imp
      * @see javax.servlet.sip.SipApplicationSession#invalidate()
      */
     public void invalidate() {
-		synchronized (getSynchronizer()) {
+                //remove synchronized as it can cause deadlock
+                //see open-liberty issue #27282
+		//synchronized (getSynchronizer()) {
 			destoryHttpSession();
 			super.invalidate();
-		}
+		//}
     }
 
 	/**


### PR DESCRIPTION
pull request for issue #27282
