### PR TITLE
Fix for CWWKS9590W Warning with ciphers without "WITH" in their names.

### DIFF
--- a/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/security/csiv2/config/ssl/SSLConfig.java
+++ b/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/security/csiv2/config/ssl/SSLConfig.java
@@ -194,7 +194,7 @@ public class SSLConfig {
     }
 
     //static final Pattern p = Pattern.compile("(?:(SSL)|(TLS))_([A-Z0-9]*)(_anon)?(_[a-zA-Z0-9]*)??(_EXPORT)?_WITH_([A-Z0-9]*)(?:_(\\d*))?([_a-zA-Z0-9]*)?_(?:(?:(SHA)(\\d*))|(MD5))");
-    //Removed "WITH" from the above pattern to accommodate ciphers without the substring "WITH" 
+    //Made "WITH" as optional from the above pattern to accommodate ciphers without the substring "WITH" 
     static final Pattern p = Pattern.compile("(?:(SSL)|(TLS))_([A-Z0-9]*)(_anon)?(_[a-zA-Z0-9]*)??(_EXPORT)??_WITH_?([A-Z0-9]*)(?:_(\\d*))?([_a-zA-Z0-9]*)?_(?:(?:(SHA)(\\d*))|(MD5))");
     
     

--- a/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/security/csiv2/config/ssl/SSLConfig.java
+++ b/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/security/csiv2/config/ssl/SSLConfig.java
@@ -195,10 +195,10 @@ public class SSLConfig {
 
     //static final Pattern p = Pattern.compile("(?:(SSL)|(TLS))_([A-Z0-9]*)(_anon)?(_[a-zA-Z0-9]*)??(_EXPORT)?_WITH_([A-Z0-9]*)(?:_(\\d*))?([_a-zA-Z0-9]*)?_(?:(?:(SHA)(\\d*))|(MD5))");
     //Removed "WITH" from the above pattern to accommodate ciphers without the substring "WITH" 
-    static final Pattern p = Pattern.compile("(?:(SSL)|(TLS))_([A-Z0-9]*)(_anon)?(_[a-zA-Z0-9]*)??(_EXPORT)?([A-Z0-9]*)(?:_(\\d*))?([_a-zA-Z0-9]*)?_(?:(?:(SHA)(\\d*))|(MD5))");
+    static final Pattern p = Pattern.compile("(?:(SSL)|(TLS))_([A-Z0-9]*)(_anon)?(_[a-zA-Z0-9]*)??(_EXPORT)??_WITH_?([A-Z0-9]*)(?:_(\\d*))?([_a-zA-Z0-9]*)?_(?:(?:(SHA)(\\d*))|(MD5))");
     
     
-//[1 null, 2 TLS, 3 ECDHE, 4 null, 5 _ECDSA, 6 null, 7 AES, 8 128, 9 _CBC, 10 SHA, 11 256, 12 null]
+    //[1 null, 2 TLS, 3 ECDHE, 4 null, 5 _ECDSA, 6 null, 7 AES, 8 128, 9 _CBC, 10 SHA, 11 256, 12 null]
     private static final int SSL_INDEX = 1;
     private static final int TLS_INDEX = 2;
     private static final int KEY_NEGOTIATION_PROTOCOL_INDEX = 3;


### PR DESCRIPTION
CWWKS9590W warning messages showed up when some newer ciphers are configured on OL 23.0.0.12.
Updated the regex to handle new cipher string with no "WITH" as a sub-string inside the cipher name.

E.g. for ciphers with no "WITH" inside their names:
TLS_AES_256_GCM_SHA384
TLS_AES_128_GCM_SHA256

Issue https://github.com/OpenLiberty/open-liberty/issues/27659
IFix# OLGH27659