### PR TITLE
Eagerly load inner classes to fix performance problem for first request

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/restmetrics/src/com/ibm/ws/jaxrs/fat/restmetrics/RestMetricsResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/restmetrics/src/com/ibm/ws/jaxrs/fat/restmetrics/RestMetricsResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -406,12 +406,6 @@ public class RestMetricsResource {
 
         if (responseTime >= 0) {
             double threshold = 100;
-            // With EE10 MP Metrics had to change to a dual filter approach that caused an intermittent increase in
-            // recorded response times.  The threshold will be increased to account for this with issue
-            // https://github.com/OpenLiberty/open-liberty/issues/24693 written to potentially investigate alternatives.
-            if (isEE10OrGreater()) {
-                threshold = 200;
-            }
             monitorResponseTime /= 1000000;
             if (Math.abs(monitorResponseTime - responseTime) > threshold) {
 
@@ -454,15 +448,4 @@ public class RestMetricsResource {
             return "Failed: Expected exeption not received: " + e +", causedBy " + e2;
         }
     }
-
-    private boolean isEE10OrGreater() {
-        try {
-            Class.forName("jakarta.ws.rs.core.EntityPart");
-        } catch (Throwable t){
-            return false;
-        }
-        return true;
-    }
-
-
 }

--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/JaxRsMonitorFilter.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/JaxRsMonitorFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,18 @@ public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResp
     private static final RestMonitorKeyCache monitorKeyCache = new RestMonitorKeyCache();
     private static final String STATS_CONTEXT = "REST_Stats_Context";
 
+    static {
+    	/*
+    	 * Eagerly load the inner classes so that they are not loaded while calculating the amount of time a method took.
+    	 * The first request coming through the filter() logic will end up being way off due to the loading of the inner classes. 
+    	 */
+    	StatsContext.init();
+    	RestMetricInfo.init();
+    }
+
     private static class StatsContext {
+    	static void init() {}
+
         final MonitorKey monitorKey;
         final long startTime;
         StatsContext(MonitorKey monitorKey, long startTime) {
@@ -142,7 +153,7 @@ public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResp
             reqCtx.setProperty(STATS_CONTEXT, new StatsContext(monitorKey, System.nanoTime()));
         }
     }
-    
+
     /**
      * Method : filter(ContainerRequestContext, ContainerResponseContext)
      * 
@@ -352,7 +363,9 @@ public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResp
     }
     
     static class RestMetricInfo {
-        boolean isEar = false;
+    	static void init() {}
+
+    	boolean isEar = false;
         HashSet<String> keys = new HashSet<String>();
 
         void setIsEar() {

--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/RestMonitorKeyCache.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/RestMonitorKeyCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -29,9 +29,21 @@ public class RestMonitorKeyCache {
     private final ConcurrentHashMap<RestResourceMethodKey, MonitorKey> routes = new ConcurrentHashMap<>();
     private final ReferenceQueue<Class<?>> referenceQueue = new ReferenceQueue<>();
 
+    static {
+    	/*
+    	 * Eagerly load the inner classes so that they are not loaded while calculating the amount of time a method took.
+    	 * The first request coming through the filter() logic will end up being way off due to the loading of the inner classes. 
+    	 */
+    	MonitorKey.init();
+    	RestResourceMethodKey.init();
+    	RestMonitorKeyWeakReference.init();
+    }
+
     @Trivial
     static class MonitorKey {
-        final String statsKey;
+    	static void init() {}
+
+    	final String statsKey;
         final String statsKeyPrefix;
         final String statsMethodName;
         MonitorKey(String statsKey, String statsKeyPrefix, String statsMethodName) {
@@ -80,7 +92,9 @@ public class RestMonitorKeyCache {
 
     @Trivial
     private static class RestResourceMethodKey {
-        private final RestMonitorKeyWeakReference<Class<?>> restClassRef;
+    	static void init() {}
+
+    	private final RestMonitorKeyWeakReference<Class<?>> restClassRef;
         private final RestMonitorKeyWeakReference<Method> restMethodRef;
         private final int hash;
 
@@ -122,7 +136,9 @@ public class RestMonitorKeyCache {
 
     @Trivial
     private static class RestMonitorKeyWeakReference<T> extends WeakReference<T> {
-        private final RestResourceMethodKey owningKey;
+    	static void init() {}
+
+    	private final RestResourceMethodKey owningKey;
 
         RestMonitorKeyWeakReference(T referent, RestResourceMethodKey owningKey) {
             super(referent);

--- a/dev/io.openliberty.restfulWS.mpMetrics.filter/src/io/openliberty/restfulws/mpmetrics/RestfulWsMonitorFilter.java
+++ b/dev/io.openliberty.restfulWS.mpMetrics.filter/src/io/openliberty/restfulws/mpmetrics/RestfulWsMonitorFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -58,6 +58,15 @@ public class RestfulWsMonitorFilter implements ContainerRequestFilter, Container
             + "duration within the previous completed full minute and lowest recorded time duration within the "
             + "previous completed full minute.";
 
+    static {
+    	/*
+    	 * Eagerly load the inner classes so that they are not loaded while calculating the amount of time a method took.
+    	 * The first request coming through the filter() logic will end up being way off due to the loading of the inner classes. 
+    	 */
+    	TimerContext.init();
+    	RestMetricInfo.init();
+    }
+
     @Context
     ResourceInfo resourceInfo;
 
@@ -70,6 +79,8 @@ public class RestfulWsMonitorFilter implements ContainerRequestFilter, Container
     private static final String TIMER_CONTEXT = "TIMER_CONTEXT";
 
     private static class TimerContext {
+    	static void init() {}
+
         final String timerKey;
         final long startTime;
         TimerContext(String timerKey, long startTime) {
@@ -326,7 +337,9 @@ public class RestfulWsMonitorFilter implements ContainerRequestFilter, Container
     }
 
     static class RestMetricInfo {
-        boolean isEar = false;
+    	static void init() {}
+
+    	boolean isEar = false;
         HashSet<String> keys = new HashSet<String>();
 
         void setIsEar() {


### PR DESCRIPTION
- The first REST request was causing very large variance due to loading of the inner classes used by the REST filters to calculate the elapsed time that a method took
- All inner classes in the filters and the filter caches used by the filters are now eagerly loaded when the parent class is loaded.
- Update the test to remove the extra threshold added for EE 10 now that we are not seeing the large variances any longer for the first request.

This PR may address the concerns that were raised with issue #24693.