### PR TITLE
Upgrade postgres test driver

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -4089,7 +4089,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.4.2</version>
+      <version>42.7.2</version>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -813,7 +813,7 @@ org.ow2.asm:asm-commons:9.6
 org.ow2.asm:asm-tree:9.6
 org.ow2.asm:asm-util:9.6
 org.ow2.asm:asm:9.6
-org.postgresql:postgresql:42.4.2
+org.postgresql:postgresql:42.7.2
 org.powermock:powermock-core:1.5
 org.quartz-scheduler:quartz:2.3.2
 org.reactivestreams:reactive-streams-examples:1.0.4

--- a/dev/com.ibm.ws.jdbc_fat_postgresql/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2023 IBM Corporation and others.
+# Copyright (c) 2019, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_postgresql/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/bnd.bnd
@@ -26,7 +26,7 @@ fat.test.container.images: kyleaure/postgres-ssl:1.0
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
 	fattest.simplicity;version=latest,\
-	org.postgresql:postgresql;version=42.4.2,\
+	org.postgresql:postgresql;version=42.7.2,\
 	software.amazon.jdbc:aws-advanced-jdbc-wrapper;version=2.2.3,\
 	com.ibm.ws.jca.cm;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\

--- a/dev/com.ibm.ws.jdbc_fat_postgresql/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_postgresql/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/build.gradle
@@ -25,7 +25,7 @@ dependencies {
            "software.amazon.awssdk:secretsmanager:${awsSDKVerion}", // Used for Secrets Manager
            "software.amazon.awssdk:rds:${awsSDKVerion}", // Used for Identity and Access Management
            project(':io.openliberty.com.fasterxml.jackson')
-  postgres 'org.postgresql:postgresql:42.4.2'
+  postgres 'org.postgresql:postgresql:42.7.2'
 }
 
 task copyAWS(type: Copy) {

--- a/dev/com.ibm.ws.transaction.db_fat/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.db_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2023 IBM Corporation and others.
+# Copyright (c) 2019, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.transaction.db_fat/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.db_fat/bnd.bnd
@@ -31,7 +31,6 @@ tested.features:\
 	com.ibm.tx.jta;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
 	fattest.simplicity;version=latest,\
-	org.postgresql:postgresql;version=42.4.2,\
 	io.openliberty.org.testcontainers;version=latest,\
 	com.ibm.ws.transaction.fat.util;version=latest,\
 	com.ibm.ws.transaction.test.util;version=latest

--- a/dev/com.ibm.ws.transaction.db_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.db_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.transaction.db_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.db_fat/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 }
 
 dependencies {
-  postgres 'org.postgresql:postgresql:42.4.2'
+  postgres 'org.postgresql:postgresql:42.7.2'
 }
 
 task copySharedPostgres(type: Copy) {

--- a/dev/com.ibm.ws.wsat.migration_fat.6/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.migration_fat.6/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2023 IBM Corporation and others.
+# Copyright (c) 2020, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.wsat.migration_fat.6/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.migration_fat.6/bnd.bnd
@@ -55,5 +55,4 @@ tested.features:\
 	com.ibm.ws.wsat.migration_fat.1;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations,\
 	io.openliberty.org.testcontainers;version=latest,\
-	javax.activation:activation;version='1.1',\
-	org.postgresql:postgresql;version=42.4.2
+	javax.activation:activation;version='1.1'

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -53,7 +53,7 @@ dependencies {
   derby 'org.apache.derby:derby:10.11.1.1'
 
   jdbcDrivers 'com.ibm.db2:jcc:11.1.4.4',
-		'org.postgresql:postgresql:42.4.2',
+		'org.postgresql:postgresql:42.7.2',
 		'com.microsoft.sqlserver:mssql-jdbc:9.2.1.jre8',
 		'org.apache.derby:derbyclient:10.11.1.1',
 		'org.apache.derby:derby:10.11.1.1',


### PR DESCRIPTION
Updating the postgres driver used in Open Liberty tests.

Removing a few unnecessary postgres drivers in build paths.