### PR TITLE
Start tests at the top of the minute

### DIFF
--- a/dev/com.ibm.ws.logging_2_fat/fat/src/com/ibm/ws/logging/fat/TimeBasedLogRolloverTest.java
+++ b/dev/com.ibm.ws.logging_2_fat/fat/src/com/ibm/ws/logging/fat/TimeBasedLogRolloverTest.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-//import com.ibm.ws.logging.internal.impl.DateFormatProvider;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;

--- a/dev/com.ibm.ws.logging_2_fat/fat/src/com/ibm/ws/logging/fat/TimeBasedLogRolloverTest.java
+++ b/dev/com.ibm.ws.logging_2_fat/fat/src/com/ibm/ws/logging/fat/TimeBasedLogRolloverTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,38 +12,27 @@
  *******************************************************************************/
 package com.ibm.ws.logging.fat;
 
-//import com.ibm.ws.logging.internal.impl.DateFormatProvider;
-import java.text.SimpleDateFormat;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.ProtocolException;
-
-import com.ibm.websphere.simplicity.RemoteFile;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.List;
+//import com.ibm.ws.logging.internal.impl.DateFormatProvider;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Logging;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
@@ -54,8 +43,6 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
-import componenttest.topology.utils.HttpUtils;
-
 
 /**
  *
@@ -64,16 +51,13 @@ import componenttest.topology.utils.HttpUtils;
 public class TimeBasedLogRolloverTest {
     private static Class<?> c = TimeBasedLogRolloverTest.class;
 
-    private static final String LOG_DIRECTORY = "logs";
     private static final String MESSAGES_LOG_PREFIX = "messages";
     private static final String TRACE_LOG_PREFIX = "trace";
-    private static final String MESSAGES_LOG_NAME = "/messages.log";
     private static final String TRACE_LOG_NAME = "/trace.log";
     private static final String LOG_EXT = ".0.log";
     private static final String FILE_SEPARATOR = "/";
     private static final SimpleDateFormat FILE_DATE = new SimpleDateFormat("_yy.MM.dd_HH.mm.ss");
     private static final long FILE_WAIT_SECONDS_PADDING = 1000;
-    private static final int CONN_TIMEOUT = 10;
     private static final String CLASS_NAME = TimeBasedLogRolloverTest.class.getName();
     private static final String TEST_SEPARATOR = "*******************";
 
@@ -116,12 +100,24 @@ public class TimeBasedLogRolloverTest {
     }
 
     public void setUp(LibertyServer server, String method) throws Exception {
-        LOG.logp(Level.INFO, CLASS_NAME, method, TEST_SEPARATOR+ " TEST: "+method+" "+TEST_SEPARATOR);
+        LOG.logp(Level.INFO, CLASS_NAME, method, TEST_SEPARATOR + " TEST: " + method + " " + TEST_SEPARATOR);
         serverInUse = server;
+        waitForBeginningOfMinute();
         if (server != null && !server.isStarted()) {
             // Restore the original server configuration, before starting the server for each test case.
             server.restoreServerConfiguration();
             server.startServer();
+        }
+    }
+
+    private static void waitForBeginningOfMinute() {
+        //wait for the beginning of the minute
+        if (Calendar.getInstance().get(Calendar.SECOND) != 0) {
+            try {
+                Thread.sleep((60000 - Calendar.getInstance().get(Calendar.SECOND) * 1000));
+                Thread.sleep(2000); //padding
+            } catch (InterruptedException e) {
+            }
         }
     }
 
@@ -134,52 +130,46 @@ public class TimeBasedLogRolloverTest {
     }
 
     /*
-     * Tests setting WLP_LOGGING_ROLLOVER_START_TIME=00:00 
+     * Tests setting WLP_LOGGING_ROLLOVER_START_TIME=00:00
      * and WLP_LOGGING_ROLLOVER_INTERVAL=1m in server.env.
      */
     @Test
     public void testTimedRolloverEnv() throws Exception {
-        //waits until start of minute before setting up server config
-        //due to the env setup, sometimes the messages log rolls before all the server startup code is validated
-        if (Calendar.getInstance().get(Calendar.SECOND) != 0) {
-            Thread.sleep((60000 - Calendar.getInstance().get(Calendar.SECOND)*1000));
-            Thread.sleep(2000); //padding
-        }
         setUp(server_env, "testTimedRolloverEnv");
-        checkForRolledLogsAtTime(getNextRolloverTime(0,1));
+        checkForRolledLogsAtTime(getNextRolloverTime(0, 1));
     }
 
     /*
-     * Tests setting com.ibm.ws.logging.rollover.start.time 
+     * Tests setting com.ibm.ws.logging.rollover.start.time
      * and com.ibm.ws.logging.rollover.interval in bootstrap.properties.
      */
     @Test
     public void testTimedRolloverBootstrap() throws Exception {
         setUp(server_bootstrap, "testTimedRolloverBootstrap");
-        checkForRolledLogsAtTime(getNextRolloverTime(0,1));
+        checkForRolledLogsAtTime(getNextRolloverTime(0, 1));
     }
 
     /*
-     * Tests setting 
-     * <logging rolloverStartTime="00:00" rolloverInterval="1m"/> 
+     * Tests setting
+     * <logging rolloverStartTime="00:00" rolloverInterval="1m"/>
      * in server.xml.
      */
     @Test
     public void testTimedRolloverXML() throws Exception {
         setUp(server_xml, "testTimedRolloverXML");
-        checkForRolledLogsAtTime(getNextRolloverTime(0,1));
+        checkForRolledLogsAtTime(getNextRolloverTime(0, 1));
     }
 
     /*
-     * Tests setting 
-     * <logging rolloverStartTime="00:00" rolloverInterval="1m"/> 
+     * Tests setting
+     * <logging rolloverStartTime="00:00" rolloverInterval="1m"/>
      * in server.xml, with json logging.
      */
     @Test
     @Mode(TestMode.FULL)
     public void testTimedRolloverJsonLogs() throws Exception {
         setUp(server_json_logs, "testTimedRolloverXML");
-        checkForRolledLogsAtTime(getNextRolloverTime(0,1));
+        checkForRolledLogsAtTime(getNextRolloverTime(0, 1));
     }
 
     /*
@@ -190,18 +180,18 @@ public class TimeBasedLogRolloverTest {
     @Mode(TestMode.FULL)
     public void testTimedRolloverXMLOverrides() throws Exception {
         setUp(server_bootstrap, "testTimedRolloverXMLOverrides");
-        /** 
-        * In the case where the current minutes value is an odd number,
-        * an updated rollover interval of 2m in reference to 00:00 will still
-        * rollover at the next minute, which doesn't properly check the update.
-        * In this case, sleep for 1m to get an even minute that should rollover 
-        * 2 minutes (or at least > 1 minute) from the current time.
-        */
+        /**
+         * In the case where the current minutes value is an odd number,
+         * an updated rollover interval of 2m in reference to 00:00 will still
+         * rollover at the next minute, which doesn't properly check the update.
+         * In this case, sleep for 1m to get an even minute that should rollover
+         * 2 minutes (or at least > 1 minute) from the current time.
+         */
         if (Calendar.getInstance().get(Calendar.MINUTE) % 2 != 0) {
             Thread.sleep(60000);
         }
         setServerConfiguration(true, true, false, "00:00", "2m", 0);
-        checkForRolledLogsAtTime(getNextRolloverTime(0,2));
+        checkForRolledLogsAtTime(getNextRolloverTime(0, 2));
     }
 
     /*
@@ -212,7 +202,7 @@ public class TimeBasedLogRolloverTest {
     @Mode(TestMode.FULL)
     public void testMultipleRollovers() throws Exception {
         setUp(server_xml, "testMultipleRollovers");
-        Calendar cal = getNextRolloverTime(0,1);
+        Calendar cal = getNextRolloverTime(0, 1);
         checkForRolledLogsAtTime(cal);
         cal.add(Calendar.MINUTE, 1);
         checkForRolledLogsAtTime(cal);
@@ -227,19 +217,19 @@ public class TimeBasedLogRolloverTest {
     @Mode(TestMode.FULL)
     public void testTimedRolloverXMLUpdates() throws Exception {
         setUp(server_xml, "testTimedRolloverXMLUpdates");
-        checkForRolledLogsAtTime(getNextRolloverTime(0,1));
-        /** 
-        * In the case where the current minutes value is an odd number,
-        * an updated rollover interval of 2m in reference to 00:00 will still
-        * rollover at the next minute, which doesn't properly check the update.
-        * In this case, sleep for 1m to get an even minute that should rollover 
-        * 2 minutes (or at least > 1 minute) from the current time.
-        */
+        checkForRolledLogsAtTime(getNextRolloverTime(0, 1));
+        /**
+         * In the case where the current minutes value is an odd number,
+         * an updated rollover interval of 2m in reference to 00:00 will still
+         * rollover at the next minute, which doesn't properly check the update.
+         * In this case, sleep for 1m to get an even minute that should rollover
+         * 2 minutes (or at least > 1 minute) from the current time.
+         */
         if (Calendar.getInstance().get(Calendar.MINUTE) % 2 != 0) {
             Thread.sleep(60000);
         }
         setServerConfiguration(true, true, false, "00:00", "2m", 0);
-        checkForRolledLogsAtTime(getNextRolloverTime(0,2));
+        checkForRolledLogsAtTime(getNextRolloverTime(0, 2));
     }
 
     /*
@@ -251,27 +241,27 @@ public class TimeBasedLogRolloverTest {
     @Mode(TestMode.FULL)
     public void testRolloverNoTraceSpecification() throws Exception {
         setUp(server_no_trace, "testRolloverNoTraceSpecification");
-        checkForRolledLogsAtTime(getNextRolloverTime(0,1), false);
+        checkForRolledLogsAtTime(getNextRolloverTime(0, 1), false);
 
         //checks that no trace* prefixed logs exist
         File logsDir = new File(getLogsDirPath());
         String[] logsDirFiles = logsDir.list();
         List<String> traceLogs = new ArrayList<String>();
 
-        for (int i = 0; i < logsDirFiles.length ; i++) {
+        for (int i = 0; i < logsDirFiles.length; i++) {
             if (logsDirFiles[i].startsWith(TRACE_LOG_PREFIX))
                 traceLogs.add(logsDirFiles[i]);
         }
 
         assertTrue("There should be no trace prefixed logs. Instead, these are the trace "
-        +"prefixed logs: "+traceLogs.toString(), traceLogs.size() == 0);
+                   + "prefixed logs: " + traceLogs.toString(), traceLogs.size() == 0);
     }
 
     /*
-     * Tests missing rolloverStartTime and specified rolloverInterval. 
+     * Tests missing rolloverStartTime and specified rolloverInterval.
      * Should set rolloverStartTime to default 00:00.
      * <logging rolloverInterval="3m"/>
-     * Hard to calculate/find root rolloverStartTime from behaviour, so will 
+     * Hard to calculate/find root rolloverStartTime from behaviour, so will
      * search in trace to find the message where rolloverStartTime is set.
      */
     @Test
@@ -285,10 +275,10 @@ public class TimeBasedLogRolloverTest {
     }
 
     /*
-     * Tests missing rolloverInterval and specified rolloverStartTime. 
+     * Tests missing rolloverInterval and specified rolloverStartTime.
      * Should set rolloverInterval to default 1d.
      * <logging rolloverStartTime="00:00"/>
-     * Cannot wait for 1 day for the logs to rollover, so will search 
+     * Cannot wait for 1 day for the logs to rollover, so will search
      * in trace to find the info message where rolloverInterval it is set.
      */
     @Test
@@ -310,35 +300,35 @@ public class TimeBasedLogRolloverTest {
     public void testEnableDisableTimedRollover() throws Exception {
         setUp(server_time_rollover_disabled, "testEnableDisableTimedRollover");
         setServerConfiguration(true, true, false, "00:00", "1m", 0); //enable
-        Calendar cal = getNextRolloverTime(0,1);
-        checkForRolledLogsAtTime(cal); 
+        Calendar cal = getNextRolloverTime(0, 1);
+        checkForRolledLogsAtTime(cal);
         cal.add(Calendar.MINUTE, 1);
-        
+
         serverInUse.restoreServerConfiguration(); //restore disabled server config
         serverInUse.waitForStringInLogUsingMark("CWWKG0017I"); //wait for server config update
 
         long nextRollover = cal.getTimeInMillis() - Calendar.getInstance().getTimeInMillis();
         if (nextRollover > 0)
-            Thread.sleep(nextRollover+FILE_WAIT_SECONDS_PADDING); //sleep for another length of the old specified log rolloverInterval
+            Thread.sleep(nextRollover + FILE_WAIT_SECONDS_PADDING); //sleep for another length of the old specified log rolloverInterval
 
-        //check that only 2 messages*/trace* prefixed logs exist 
+        //check that only 2 messages*/trace* prefixed logs exist
         //aka the messages/trace logs were not rolled over again
         File logsDir = new File(getLogsDirPath());
         String[] logsDirFiles = logsDir.list();
         List<String> messagesLogs = new ArrayList<String>();
         List<String> traceLogs = new ArrayList<String>();
 
-        for (int i = 0; i < logsDirFiles.length ; i++) {
+        for (int i = 0; i < logsDirFiles.length; i++) {
             if (logsDirFiles[i].startsWith(MESSAGES_LOG_PREFIX))
                 messagesLogs.add(logsDirFiles[i]);
             if (logsDirFiles[i].startsWith(TRACE_LOG_PREFIX))
                 traceLogs.add(logsDirFiles[i]);
         }
 
-        assertTrue("The number of messages prefixed log files should be equal to 2. Instead, "+
-        "these are the messages prefixed logs: "+messagesLogs.toString(), messagesLogs.size() == 2);
-        assertTrue("The number of trace prefixed log files should be equal to 2. Instead, "+
-        "these are the trace prefixed logs: "+traceLogs.toString(), traceLogs.size() == 2);
+        assertTrue("The number of messages prefixed log files should be equal to 2. Instead, " +
+                   "these are the messages prefixed logs: " + messagesLogs.toString(), messagesLogs.size() == 2);
+        assertTrue("The number of trace prefixed log files should be equal to 2. Instead, " +
+                   "these are the trace prefixed logs: " + traceLogs.toString(), traceLogs.size() == 2);
     }
 
     /*
@@ -347,24 +337,12 @@ public class TimeBasedLogRolloverTest {
      */
     @Test
     public void testInvalidRolloverStartTime() throws Exception {
-
-        //wait to do a server config update at the start of the minute
-        //this allows enough time for timedexit check
-        if (Calendar.getInstance().get(Calendar.SECOND) != 0) {
-            Thread.sleep((60000 - Calendar.getInstance().get(Calendar.SECOND)*1000));
-            Thread.sleep(2000); //padding
-        }
-
         setUp(server_xml, "testInvalidRolloverStartTime");
-        
-        //wait to do a server config update at the start of the minute
-        if (Calendar.getInstance().get(Calendar.SECOND) != 0) {
-            Thread.sleep((60000 - Calendar.getInstance().get(Calendar.SECOND)*1000));
-            Thread.sleep(2000); //padding
-        }
+
+        waitForBeginningOfMinute();
         setServerConfiguration(true, false, false, "24:00", "", 0);
         List<String> lines = serverInUse.findStringsInLogs("TRAS3015W");
-        LOG.logp(Level.INFO, CLASS_NAME, "testInvalidRolloverStartTime", "Found warning: "+lines.toString());
+        LOG.logp(Level.INFO, CLASS_NAME, "testInvalidRolloverStartTime", "Found warning: " + lines.toString());
         assertTrue("No TRAS3015W warning was found indicating that 24:00 is an invalid rolloverStartTime", lines.size() > 0);
     }
 
@@ -374,43 +352,29 @@ public class TimeBasedLogRolloverTest {
      */
     @Test
     public void testInvalidRolloverInterval() throws Exception {
-        //wait to do a server startup at the start of the minute so that it has sufficient time for timedexit check
-        if (Calendar.getInstance().get(Calendar.SECOND) != 0) {
-            Thread.sleep((60000 - Calendar.getInstance().get(Calendar.SECOND)*1000));
-            Thread.sleep(2000); //padding
-        }
         setUp(server_xml, "testInvalidRolloverInterval");
 
-        //wait to do a server config update at the start of the minute
-        if (Calendar.getInstance().get(Calendar.SECOND) != 0) {
-            Thread.sleep((60000 - Calendar.getInstance().get(Calendar.SECOND)*1000));
-            Thread.sleep(2000); //padding
-        }
+        waitForBeginningOfMinute();
         setServerConfiguration(false, true, false, "", "30s", 0);
         List<String> lines = serverInUse.findStringsInLogs("TRAS3013W");
-        LOG.logp(Level.INFO, CLASS_NAME, "testInvalidRolloverInterval", "Found warning: "+lines.toString());
+        LOG.logp(Level.INFO, CLASS_NAME, "testInvalidRolloverInterval", "Found warning: " + lines.toString());
         assertTrue("No TRAS3013W warning was found indicating that 24:00 is an invalid rolloverStartTime", lines.size() > 0);
     }
 
     /*
      * Tests that maxFileSize takes priority over timed log rollover.
-     * 
+     *
      */
     @Test
     @Mode(TestMode.FULL)
     public void testMaxFileSizePriorityRolling() throws Exception {
         setUp(server_xml, "testMaxFileSizeRolling");
 
-        //wait to do a server config update at the start of the minute
-        if (Calendar.getInstance().get(Calendar.SECOND) != 0) {
-            Thread.sleep((60000 - Calendar.getInstance().get(Calendar.SECOND)*1000));
-            Thread.sleep(2000); //padding
-        }
-
+        waitForBeginningOfMinute();
         setServerConfiguration(false, false, true, "", "", 1);
 
         //check for rolled log first, to ensure we start writing messages at the next minute
-        checkForRolledLogsAtTime(getNextRolloverTime(0,1)); 
+        checkForRolledLogsAtTime(getNextRolloverTime(0, 1));
 
         getHttpServlet("/quicklogtest/QuickLogTest?threads=1&duration=10&messageSize=0&delay=0&action=log&stepThreads=false", server_xml);
 
@@ -418,20 +382,19 @@ public class TimeBasedLogRolloverTest {
         String[] logsDirFiles = logsDir.list();
         List<String> messagesLogs = new ArrayList<String>();
 
-        for (int i = 0; i < logsDirFiles.length ; i++) {
+        for (int i = 0; i < logsDirFiles.length; i++) {
             if (logsDirFiles[i].startsWith(MESSAGES_LOG_PREFIX))
                 messagesLogs.add(logsDirFiles[i]);
         }
 
         //at least three messages_*.log files: the first rolled over by time,
         //the second rolloed over by size, and then the newest file
-        assertTrue("There should be at least 3 messages prefixed log files. Instead, "+
-        "these are the messages prefixed logs: "+messagesLogs.toString(), messagesLogs.size() >= 3);
-        
-        //check Log is rolled over at next rollover time
-        checkForRolledLogsAtTime(getNextRolloverTime(0,1)); 
-    }
+        assertTrue("There should be at least 3 messages prefixed log files. Instead, " +
+                   "these are the messages prefixed logs: " + messagesLogs.toString(), messagesLogs.size() >= 3);
 
+        //check Log is rolled over at next rollover time
+        checkForRolledLogsAtTime(getNextRolloverTime(0, 1));
+    }
 
     private static String getLogsDirPath() throws Exception {
         return serverInUse.getDefaultLogFile().getParentFile().getAbsolutePath();
@@ -442,7 +405,7 @@ public class TimeBasedLogRolloverTest {
     }
 
     private static void checkForRolledLogsAtTime(Calendar cal, boolean trace) throws Exception {
-        LOG.logp(Level.INFO, CLASS_NAME, "checkForRolledLogsAtTime", "The next log rollover is scheduled to be at: "+cal.getTime());
+        LOG.logp(Level.INFO, CLASS_NAME, "checkForRolledLogsAtTime", "The next log rollover is scheduled to be at: " + cal.getTime());
 
         String date = FILE_DATE.format(cal.getTime());
         String messagesLogName = FILE_SEPARATOR + MESSAGES_LOG_PREFIX + date + LOG_EXT;
@@ -454,12 +417,12 @@ public class TimeBasedLogRolloverTest {
 
         long timeToFirstRollover = cal.getTimeInMillis() - Calendar.getInstance().getTimeInMillis();
         if (timeToFirstRollover > 0)
-            Thread.sleep(timeToFirstRollover+FILE_WAIT_SECONDS_PADDING); //sleep until next time the log is set to rollover
+            Thread.sleep(timeToFirstRollover + FILE_WAIT_SECONDS_PADDING); //sleep until next time the log is set to rollover
 
-        assertTrue("The rolled messages.log file "+messagesLog+" doesn't exist.", messagesLog.exists());
+        assertTrue("The rolled messages.log file " + messagesLog + " doesn't exist.", messagesLog.exists());
 
         if (trace)
-            assertTrue("The rolled trace.log file "+traceLog+" doesn't exist.", traceLog.exists());
+            assertTrue("The rolled trace.log file " + traceLog + " doesn't exist.", traceLog.exists());
     }
 
     private static Calendar getNextRolloverTime(int rolloverStartHour, int rolloverInterval) {
@@ -473,22 +436,21 @@ public class TimeBasedLogRolloverTest {
 
         if (currCal.before(sched)) { //if currTime before startTime, firstRollover = startTime - n(interval)
             while (currCal.before(sched)) {
-                sched.add(Calendar.MINUTE, rolloverInterval*(-1));
+                sched.add(Calendar.MINUTE, rolloverInterval * (-1));
             }
             sched.add(Calendar.MINUTE, rolloverInterval); //add back interval due to time overlap
-        }
-        else if (currCal.after(sched)) { //if currTime after startTime, firstRollover = startTime + n(interval)
+        } else if (currCal.after(sched)) { //if currTime after startTime, firstRollover = startTime + n(interval)
             while (currCal.after(sched)) {
                 sched.add(Calendar.MINUTE, rolloverInterval);
             }
-        }
-        else if (currCal.equals(sched)) { //if currTime == startTime, set first rollover to next rolloverInterval
+        } else if (currCal.equals(sched)) { //if currTime == startTime, set first rollover to next rolloverInterval
             sched.add(Calendar.MINUTE, rolloverInterval);
         }
         return sched;
     }
 
-    private static void setServerConfiguration(boolean isRolloverStartTime, boolean isRolloverInterval, boolean isMaxFileSize, String newRolloverStartTime, String newRolloverInterval, int maxFileSize) throws Exception {
+    private static void setServerConfiguration(boolean isRolloverStartTime, boolean isRolloverInterval, boolean isMaxFileSize, String newRolloverStartTime,
+                                               String newRolloverInterval, int maxFileSize) throws Exception {
         Logging loggingObj;
         ServerConfiguration serverConfig = serverInUse.getServerConfiguration();
         loggingObj = serverConfig.getLogging();


### PR DESCRIPTION
Fixes #27738 

Make every test to start at the top of the minute so that the server has enough time to start up before the one minute log rollover.