### PR TITLE
metamodel attribute impl added to spec

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/io.openliberty.data-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/io.openliberty.data-1.0.feature
@@ -11,6 +11,7 @@ IBM-API-Package: \
   jakarta.data; type="spec",\
   jakarta.data.exceptions; type="spec",\
   jakarta.data.metamodel; type="spec",\
+  jakarta.data.metamodel.impl; type="spec",\
   jakarta.data.page; type="spec",\
   jakarta.data.repository; type="spec"
 Subsystem-Name: Jakarta Data 1.0

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/model/Model.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/model/Model.java
@@ -23,9 +23,11 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 
 import jakarta.data.metamodel.Attribute;
-import jakarta.data.metamodel.CollectionAttribute;
 import jakarta.data.metamodel.SortableAttribute;
 import jakarta.data.metamodel.TextAttribute;
+import jakarta.data.metamodel.impl.AttributeRecord;
+import jakarta.data.metamodel.impl.SortableAttributeRecord;
+import jakarta.data.metamodel.impl.TextAttributeRecord;
 
 /**
  * Utility class for the static metamodel.
@@ -36,7 +38,6 @@ public class Model {
     private static final Set<Class<?>> ATTRIBUTE_TYPES = new HashSet<>();
     static {
         ATTRIBUTE_TYPES.add(Attribute.class);
-        ATTRIBUTE_TYPES.add(CollectionAttribute.class);
         ATTRIBUTE_TYPES.add(SortableAttribute.class);
         ATTRIBUTE_TYPES.add(String.class);
         ATTRIBUTE_TYPES.add(TextAttribute.class);
@@ -67,13 +68,11 @@ public class Model {
                                 if (String.class.equals(fieldType))
                                     value = attrName;
                                 else if (SortableAttribute.class.equals(fieldType))
-                                    value = SortableAttributeImpl.create(fieldName);
+                                    value = new SortableAttributeRecord<>(fieldName);
                                 else if (TextAttribute.class.equals(fieldType))
-                                    value = TextAttributeImpl.create(fieldName);
-                                else if (CollectionAttribute.class.equals(fieldType))
-                                    value = CollectionAttributeImpl.create(fieldName);
+                                    value = new TextAttributeRecord<>(fieldName);
                                 else
-                                    value = AttributeImpl.create(fieldName);
+                                    value = new AttributeRecord(fieldName);
 
                                 field.set(null, value);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2689,7 +2689,7 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Tests direct usage of StaticMetamodel auto-populated CollectionAttribute field.
+     * Tests direct usage of StaticMetamodel auto-populated Attribute field for a collection type.
      */
     @Test
     public void testStaticMetamodelCollectionAttribute() {

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/_TaxPayer.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/_TaxPayer.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
-import jakarta.data.metamodel.CollectionAttribute;
+import jakarta.data.metamodel.Attribute;
 import jakarta.data.metamodel.SortableAttribute;
 import jakarta.data.metamodel.StaticMetamodel;
 
@@ -19,7 +19,7 @@ import jakarta.data.metamodel.StaticMetamodel;
  */
 @StaticMetamodel(TaxPayer.class)
 public class _TaxPayer {
-    public static volatile CollectionAttribute bankAccounts;
+    public static volatile Attribute bankAccounts;
     public static volatile SortableAttribute filingStatus;
     public static volatile SortableAttribute income;
     public static volatile SortableAttribute numDependents;

--- a/dev/io.openliberty.jakarta.data.1.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.data.1.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2023 IBM Corporation and others.
+# Copyright (c) 2022, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ Export-Package: \
   jakarta.data;version="1.0.0",\
   jakarta.data.exceptions;version="1.0.0",\
   jakarta.data.metamodel;version="1.0.0",\
+  jakarta.data.metamodel.impl;version="1.0.0",\
   jakarta.data.page;version="1.0.0",\
   jakarta.data.repository;version="1.0.0"
 

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/metamodel/impl/AttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/metamodel/impl/AttributeRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel;
+package jakarta.data.metamodel.impl;
+
+import jakarta.data.metamodel.Attribute;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-public interface CollectionAttribute extends Attribute {
-
+public record AttributeRecord(String name) implements Attribute {
 }

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/metamodel/impl/SortableAttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/metamodel/impl/SortableAttributeRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,21 +10,23 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.data.internal.persistence.model;
+package jakarta.data.metamodel.impl;
 
-import com.ibm.websphere.ras.annotation.Trivial;
-
-import jakarta.data.metamodel.CollectionAttribute;
+import jakarta.data.Sort;
+import jakarta.data.metamodel.SortableAttribute;
 
 /**
- * Attribute information for the static metamodel.
+ * Method signatures are copied from Jakarta Data.
  */
-@Trivial
-public record CollectionAttributeImpl(
-                String name)
-                implements CollectionAttribute {
+public record SortableAttributeRecord<T>(String name) implements SortableAttribute<T> {
 
-    public static CollectionAttributeImpl create(String name) {
-        return new CollectionAttributeImpl(name);
+    @Override
+    public Sort<T> asc() {
+        return Sort.asc(name);
+    }
+
+    @Override
+    public Sort<T> desc() {
+        return Sort.desc(name);
     }
 }

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/metamodel/impl/TextAttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/metamodel/impl/TextAttributeRecord.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.metamodel.impl;
+
+import jakarta.data.Sort;
+import jakarta.data.metamodel.TextAttribute;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+
+    @Override
+    public Sort<T> asc() {
+        return Sort.asc(name);
+    }
+
+    @Override
+    public Sort<T> ascIgnoreCase() {
+        return Sort.ascIgnoreCase(name);
+    }
+
+    @Override
+    public Sort<T> desc() {
+        return Sort.desc(name);
+    }
+
+    @Override
+    public Sort<T> descIgnoreCase() {
+        return Sort.descIgnoreCase(name);
+    }
+}


### PR DESCRIPTION
Align with metamodel attribute impl package that is being added to Jakarta Data.
Also, it looks like we accidentally left an outdated CollectionAttribute subclass around that isn't in the spec. I'll delete that under this pull.