### PR TITLE
Allow port retries on test servers

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/rp2_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/rp2_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022 IBM Corporation and others.
+    Copyright (c) 2022, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_5_HTTP_default}"
 		httpsPort="${bvt.prop.security_5_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/rp_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/rp_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022 IBM Corporation and others.
+    Copyright (c) 2022, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/rs_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/publish/files/serversettings/rs_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022 IBM Corporation and others.
+    Copyright (c) 2022, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_4_HTTP_default}"
 		httpsPort="${bvt.prop.security_4_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.fat.common.claimPropagation/publish/files/serversettings/op_external_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.fat.common.claimPropagation/publish/files/serversettings/op_external_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022 IBM Corporation and others.
+    Copyright (c) 2022, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@
 		httpPort="${bvt.prop.security_3_HTTP_default}"
 		httpsPort="${bvt.prop.security_3_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.fat.common.claimPropagation/publish/files/serversettings/rp_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.fat.common.claimPropagation/publish/files/serversettings/rp_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022 IBM Corporation and others.
+    Copyright (c) 2022, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.fat.common.mp.jwt/publish/shared/config/builder_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.fat.common.mp.jwt/publish/shared/config/builder_fatTestPorts.xml
@@ -1,4 +1,16 @@
-<server>
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+ <server>
 
 	<featureManager>
 		<feature>timedexit-1.0</feature>
@@ -10,7 +22,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.fat.common.mp.jwt/publish/shared/config/rs_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.fat.common.mp.jwt/publish/shared/config/rs_fatTestPorts.xml
@@ -1,3 +1,15 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <server>
 
       <featureManager>
@@ -10,7 +22,7 @@
               httpPort="${bvt.prop.security_1_HTTP_default}"
               httpsPort="${bvt.prop.security_1_HTTP_default.secure}"
       >
-              <tcpOptions soReuseAddr="true" />
+              <tcpOptions soReuseAddr="true" portOpenRetries="60" />
       </httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/op_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/op_fatTestPorts.xml
@@ -1,3 +1,15 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <server>
 
 	<featureManager>
@@ -10,7 +22,7 @@
 		httpPort="${bvt.prop.security_1_HTTP_default}"
 		httpsPort="${bvt.prop.security_1_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/rs_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/rs_fatTestPorts.xml
@@ -1,3 +1,15 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <server>
 	<featureManager>
 		<feature>timedexit-1.0</feature>
@@ -9,7 +21,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/publish/shared/config/fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/publish/shared/config/fatTestPorts.xml
@@ -1,3 +1,15 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <server>
 
     <featureManager>
@@ -10,7 +22,7 @@
         httpPort="${bvt.prop.security_1_HTTP_default}"
         httpsPort="${bvt.prop.security_1_HTTP_default.secure}"
     >
-        <tcpOptions soReuseAddr="true" />
+        <tcpOptions soReuseAddr="true" portOpenRetries="60" />
     </httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/publish/shared/config/misc.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/publish/shared/config/misc.xml
@@ -1,3 +1,15 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <server>
 
     <include location="../fatTestCommon.xml" />
@@ -8,7 +20,7 @@
         httpPort="${bvt.prop.security_1_HTTP_default}"
         httpsPort="${bvt.prop.security_1_HTTP_default.secure}"
     >
-        <tcpOptions soReuseAddr="true" />
+        <tcpOptions soReuseAddr="true" portOpenRetries="60" />
     </httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/publish/servers/com.ibm.ws.security.jwtsso.fat/configs/server_noSslPort.xml
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/publish/servers/com.ibm.ws.security.jwtsso.fat/configs/server_noSslPort.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2018 IBM Corporation and others.
+    Copyright (c) 2018, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -22,6 +22,13 @@
 
     <authentication cacheEnabled="false"/>
 
-    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="-1" />
+    <httpEndpoint 
+	id="defaultHttpEndpoint" 
+	host="*" 
+	httpPort="${bvt.prop.HTTP_default}" 
+	httpsPort="-1" 
+    >
+    	<tcpOptions portOpenRetries="60" />
+    </httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/shared/config/client_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/shared/config/client_fatTestPorts.xml
@@ -1,3 +1,15 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <server>
 
       <featureManager>
@@ -10,7 +22,7 @@
 		httpPort="${bvt.prop.security_3_HTTP_default}"
 		httpsPort="${bvt.prop.security_3_HTTP_default.secure}"
       >
-              <tcpOptions soReuseAddr="true" />
+              <tcpOptions soReuseAddr="true" portOpenRetries="60" />
       </httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/publish/files/serversettings/op_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/publish/files/serversettings/op_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021, 2022 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@
 		httpPort="${bvt.prop.security_1_HTTP_default}"
 		httpsPort="${bvt.prop.security_1_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.1/publish/files/serversettings/rp_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/publish/files/serversettings/rp_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/publish/files/serversettings/fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/publish/files/serversettings/fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -19,7 +19,10 @@
     <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_default}"
-                  httpsPort="${bvt.prop.HTTP_default.secure}"/>
+                  httpsPort="${bvt.prop.HTTP_default.secure}" 
+    >
+                  <tcpOptions portOpenRetries="60" />
+    </httpEndpoint>
 
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}">
         <iiopsOptions  iiopsPort="${bvt.prop.IIOP.secure}" sslRef="defaultSSLConfig"/>

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/publish/files/serversettings/rp_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/publish/files/serversettings/rp_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/publish/files/serversettings/rs_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/publish/files/serversettings/rs_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_3_HTTP_default}"
 		httpsPort="${bvt.prop.security_3_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.3/publish/files/serversettings/rp_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.3/publish/files/serversettings/rp_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023 IBM Corporation and others.
+    Copyright (c) 2023, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.4/publish/files/serversettings/rp_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.4/publish/files/serversettings/rp_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023 IBM Corporation and others.
+    Copyright (c) 2023, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/publish/files/serversettings/rp_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/publish/files/serversettings/rp_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/publish/files/serversettings/rs_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/publish/files/serversettings/rs_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_3_HTTP_default}"
 		httpsPort="${bvt.prop.security_3_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.spnego/publish/files/oidc/serversettings/fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.spnego/publish/files/oidc/serversettings/fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -19,7 +19,10 @@
     <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_default}"
-                  httpsPort="${bvt.prop.HTTP_default.secure}"/>
+                  httpsPort="${bvt.prop.HTTP_default.secure}" 
+    >
+                  <tcpOptions portOpenRetries="60" />
+    </httpEndpoint>
 
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}">
         <iiopsOptions  iiopsPort="${bvt.prop.IIOP.secure}" sslRef="defaultSSLConfig"/>

--- a/dev/com.ibm.ws.security.oidc.client_fat.spnego/publish/files/oidc/serversettings/op_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.spnego/publish/files/oidc/serversettings/op_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_1_HTTP_default}"
 		httpsPort="${bvt.prop.security_1_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.spnego/publish/files/oidc/serversettings/rp_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.spnego/publish/files/oidc/serversettings/rp_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.spnego/publish/files/server_modules/configs/host_info.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.spnego/publish/files/server_modules/configs/host_info.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -12,5 +12,11 @@
  -->
 <server>
 	<variable name="defaultHostName" value="${security.spnego.test.system.host.name}" />
-    <httpEndpoint host="${security.spnego.test.system.host.name}" httpPort="9080" id="HostOnly"/>
+    <httpEndpoint 
+	host="${security.spnego.test.system.host.name}" 
+	httpPort="9080" 
+	id="HostOnly" 
+    >
+        <tcpOptions portOpenRetries="60" />
+    </httpEndpoint>
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.spnego/publish/servers/BackendServer/server.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.spnego/publish/servers/BackendServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -70,6 +70,9 @@
 		id="defaultHttpEndpoint"
 		host="*"
 		httpPort="${bvt.prop.HTTP_secondary}"
-		httpsPort="${bvt.prop.HTTP_secondary.secure}" />
+		httpsPort="${bvt.prop.HTTP_secondary.secure}"  
+	>
+                <tcpOptions portOpenRetries="60" />
+        </httpEndpoint>
 	        
 </server>

--- a/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config.commonTest/publish/files/serversettings/rs_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config.commonTest/publish/files/serversettings/rs_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@
 		httpPort="${bvt.prop.security_3_HTTP_default}"
 		httpsPort="${bvt.prop.security_3_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.server_fat.spnego/publish/files/server_modules/configs/host_info.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat.spnego/publish/files/server_modules/configs/host_info.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -12,5 +12,11 @@
  -->
 <server>
 	<variable name="defaultHostName" value="${security.spnego.test.system.host.name}" />
-    <httpEndpoint host="${security.spnego.test.system.host.name}" httpPort="9080" id="HostOnly"/>
+    <httpEndpoint 
+	host="${security.spnego.test.system.host.name}" 
+	httpPort="9080" 
+	id="HostOnly" 
+    >
+        <tcpOptions portOpenRetries="60" />
+    </httpEndpoint>
 </server>

--- a/dev/com.ibm.ws.security.oidc.server_fat.spnego/publish/files/serversettings/fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat.spnego/publish/files/serversettings/fatTestPorts.xml
@@ -1,3 +1,15 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <server>
 
 	<featureManager>
@@ -9,7 +21,7 @@
 		host="*"
 		httpPort="${bvt.prop.security_1_HTTP_default}"
 		httpsPort="${bvt.prop.security_1_HTTP_default.secure}">
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.server_fat.spnego/publish/files/serversettings/op_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat.spnego/publish/files/serversettings/op_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_1_HTTP_default}"
 		httpsPort="${bvt.prop.security_1_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.oidc.server_fat.spnego/publish/servers/BackendServer/server.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat.spnego/publish/servers/BackendServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -70,6 +70,9 @@
 		id="defaultHttpEndpoint"
 		host="*"
 		httpPort="${bvt.prop.HTTP_secondary}"
-		httpsPort="${bvt.prop.HTTP_secondary.secure}" />
+		httpsPort="${bvt.prop.HTTP_secondary.secure}"  
+	>
+                <tcpOptions portOpenRetries="60" />
+    	</httpEndpoint>
 	        
 </server>

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@
 		httpPort="${bvt.prop.security_1_HTTP_default}"
 		httpsPort="${bvt.prop.security_1_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.shibboleth/configs/server_orig.xml
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.shibboleth/configs/server_orig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -54,7 +54,14 @@
 
     <keyStore id="defaultKeyStore" password="keyspass" /> 
 
-    <httpEndpoint host="localhost" httpPort="${bvt.prop.security_3_HTTP_default}" httpsPort="${bvt.prop.security_3_HTTP_default.secure}" id="defaultHttpEndpoint"/>   
+    <httpEndpoint 
+	host="localhost" 
+	httpPort="${bvt.prop.security_3_HTTP_default}" 
+	httpsPort="${bvt.prop.security_3_HTTP_default.secure}" 
+	id="defaultHttpEndpoint" 
+    >
+        <tcpOptions portOpenRetries="60" />
+    </httpEndpoint>   
 
 <!--
     <application type="war" id="idp" name="idp" location="${server.config.dir}/test-apps/idp.war">

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.shibboleth/configs/server_samesite.xml
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.shibboleth/configs/server_samesite.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -54,7 +54,14 @@
 
     <keyStore id="defaultKeyStore" password="keyspass" /> 
 
-    <httpEndpoint host="localhost" httpPort="${bvt.prop.security_3_HTTP_default}" httpsPort="${bvt.prop.security_3_HTTP_default.secure}" id="defaultHttpEndpoint"/>   
+    <httpEndpoint 
+	host="localhost" 
+	httpPort="${bvt.prop.security_3_HTTP_default}" 
+	httpsPort="${bvt.prop.security_3_HTTP_default.secure}" 
+	id="defaultHttpEndpoint" 
+    >
+        <tcpOptions portOpenRetries="60" />
+    </httpEndpoint>   
 
 <!--
     <application type="war" id="idp" name="idp" location="${server.config.dir}/test-apps/idp.war">

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/publish/files/serversettings/misc2.xml
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/publish/files/serversettings/misc2.xml
@@ -1,6 +1,6 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,10 @@
 		id="defaultHttpEndpoint"
 		host="*"
 		httpPort="${bvt.prop.HTTP_secondary}"
-		httpsPort="${bvt.prop.HTTP_secondary.secure}" />
+		httpsPort="${bvt.prop.HTTP_secondary.secure}"  
+	>
+                <tcpOptions portOpenRetries="60" />
+	</httpEndpoint>
 
 	<iiopEndpoint
 		id="defaultIiopEndpoint"

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/publish/files/serversettings/fatTestPorts2.xml
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/publish/files/serversettings/fatTestPorts2.xml
@@ -1,6 +1,6 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,10 @@
 		id="defaultHttpEndpoint"
 		host="*"
 		httpPort="${bvt.prop.HTTP_secondary}"
-		httpsPort="${bvt.prop.HTTP_secondary.secure}" />
+		httpsPort="${bvt.prop.HTTP_secondary.secure}"  
+	>
+                <tcpOptions portOpenRetries="60" />
+	</httpEndpoint>
 
 	<iiopEndpoint
 		id="defaultIiopEndpoint"

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/publish/files/serversettings/fatTestPorts2.xml
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/publish/files/serversettings/fatTestPorts2.xml
@@ -1,6 +1,6 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,10 @@
 		id="defaultHttpEndpoint"
 		host="*"
 		httpPort="${bvt.prop.HTTP_secondary}"
-		httpsPort="${bvt.prop.HTTP_secondary.secure}" />
+		httpsPort="${bvt.prop.HTTP_secondary.secure}"  
+	>
+                <tcpOptions portOpenRetries="60" />
+	</httpEndpoint>
 
 	<iiopEndpoint
 		id="defaultIiopEndpoint"

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/publish/files/serversettings/fattestports2.xml
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/publish/files/serversettings/fattestports2.xml
@@ -1,6 +1,6 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,10 @@
 		id="defaultHttpEndpoint"
 		host="*"
 		httpPort="${bvt.prop.HTTP_secondary}"
-		httpsPort="${bvt.prop.HTTP_secondary.secure}" />
+		httpsPort="${bvt.prop.HTTP_secondary.secure}"  
+	>
+                <tcpOptions portOpenRetries="60" />
+	</httpEndpoint>
 
 	<iiopEndpoint
 		id="defaultIiopEndpoint"

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/rp_samesite_misc.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/rp_samesite_misc.xml
@@ -1,6 +1,6 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 	<webAppSecurity

--- a/dev/com.ibm.ws.security.social_fat.delegated/publish/files/serversettings/external_op_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.social_fat.delegated/publish/files/serversettings/external_op_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2022 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@
         httpPort="${bvt.prop.security_3_HTTP_default}"
         httpsPort="${bvt.prop.security_3_HTTP_default.secure}"
     >
-        <tcpOptions soReuseAddr="true" />
+        <tcpOptions soReuseAddr="true" portOpenRetries="60" />
     </httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.social_fat.delegated/publish/files/serversettings/op_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.social_fat.delegated/publish/files/serversettings/op_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2022 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@
 		httpPort="${bvt.prop.security_1_HTTP_default}"
 		httpsPort="${bvt.prop.security_1_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.social_fat.delegated/publish/files/serversettings/rp_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.social_fat.delegated/publish/files/serversettings/rp_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2022 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.social_fat.multiProvider/publish/files/serversettings/op_fatTestPorts.xml
+++ b/dev/com.ibm.ws.security.social_fat.multiProvider/publish/files/serversettings/op_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2022 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 		httpPort="${bvt.prop.security_1_HTTP_default}"
 		httpsPort="${bvt.prop.security_1_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/com.ibm.ws.security.social_fat.okdServiceLogin/publish/files/serversettings/op_misc.xml
+++ b/dev/com.ibm.ws.security.social_fat.okdServiceLogin/publish/files/serversettings/op_misc.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020, 2022 IBM Corporation and others.
+    Copyright (c) 2020, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@
 		httpPort="${bvt.prop.security_1_HTTP_default}"
 		httpsPort="${bvt.prop.security_1_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 	<javaPermission className="javax.security.auth.AuthPermission" name="wssecurity.getRunAsSubject" />

--- a/dev/com.ibm.ws.security.social_fat/publish/files/serversettings/misc.xml
+++ b/dev/com.ibm.ws.security.social_fat/publish/files/serversettings/misc.xml
@@ -1,6 +1,6 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 	<javaPermission className="javax.security.auth.AuthPermission" name="wssecurity.getRunAsSubject" />

--- a/dev/com.ibm.ws.security.social_fat/publish/shared/config/misc.xml
+++ b/dev/com.ibm.ws.security.social_fat/publish/shared/config/misc.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2018 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
-		<tcpOptions soReuseAddr="true" />
+		<tcpOptions soReuseAddr="true" portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/publish/shared/config/op_fatTestPorts.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/publish/shared/config/op_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022 IBM Corporation and others.
+    Copyright (c) 2022, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@
 		httpPort="${bvt.prop.security_1_HTTP_default}"
 		httpsPort="${bvt.prop.security_1_HTTP_default.secure}"
 	>
-	</httpEndpoint>
+                <tcpOptions portOpenRetries="60" />
+    	</httpEndpoint>
 
 </server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/publish/shared/config/rp_fatTestPorts.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/publish/shared/config/rp_fatTestPorts.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022 IBM Corporation and others.
+    Copyright (c) 2022, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@
 		httpPort="${bvt.prop.security_2_HTTP_default}"
 		httpsPort="${bvt.prop.security_2_HTTP_default.secure}"
 	>
+		<tcpOptions portOpenRetries="60" />
 	</httpEndpoint>
 
 </server>


### PR DESCRIPTION
Add portOpenRetries="60" to the httpEndpoint configs.  Port on z/OS and iSeries are not available from time to time especially when we're starting/stopping server multiple times in a single FAT project.
This will allow the FATs to get past what is an OS issue.

