### PR TITLE
remove BasicRepository.countBy

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3579,7 +3579,7 @@ public class DataTestServlet extends FATServlet {
                                  new Receipt(500L, "C0045-00-054", 155.00f)));
 
         assertEquals(true, receipts.existsById(300L));
-        assertEquals(5L, receipts.countBy());
+        assertEquals(5L, receipts.countByIdBetween(100L, 1000L));
 
         Receipt receipt = receipts.findById(200L).orElseThrow();
         assertEquals(202.40f, receipt.total(), 0.001f);
@@ -3600,7 +3600,7 @@ public class DataTestServlet extends FATServlet {
 
         receipts.deleteById(100L);
 
-        assertEquals(2L, receipts.countBy());
+        assertEquals(2L, receipts.countByIdBetween(100L, 1000L));
 
         receipts.delete(new Receipt(400L, "C0045-00-054", 44.49f));
 
@@ -3613,11 +3613,11 @@ public class DataTestServlet extends FATServlet {
         receipts.deleteAll(List.of(new Receipt(300L, "C0013-00-031", 33.99f),
                                    new Receipt(700L, "C0067-00-076", 17.99f)));
 
-        assertEquals(2L, receipts.countBy());
+        assertEquals(2L, receipts.countByIdBetween(100L, 1000L));
 
         assertEquals(true, receipts.deleteByTotalLessThan(1000000.0f));
 
-        assertEquals(0L, receipts.countBy());
+        assertEquals(0L, receipts.countByIdBetween(100L, 1000L));
     }
 
     /**
@@ -3686,7 +3686,7 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(true, receipts.deleteByTotalLessThan(1000000.0f));
 
-        assertEquals(0L, receipts.countBy());
+        assertEquals(0L, receipts.countByIdBetween(0L, 2000L));
     }
 
     /**
@@ -3699,7 +3699,7 @@ public class DataTestServlet extends FATServlet {
         // remove data that other tests previously inserted to the same table
         reservations.deleteByHostNot("never-ever-used@example.org");
 
-        assertEquals(0, reservations.countBy());
+        assertEquals(0, reservations.countByLocationNotNull());
 
         Reservation r1 = new Reservation();
         r1.host = "testRepository-host1@example.org";
@@ -3722,7 +3722,7 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(true, reservations.existsById(r1.meetingID));
 
-        assertEquals(1, reservations.countBy());
+        assertEquals(1, reservations.countByLocationNotNull());
 
         Reservation r2 = new Reservation();
         r2.host = "testRepository-host2@example.org";
@@ -3783,7 +3783,7 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(true, reservations.existsById(r3.meetingID));
 
-        assertEquals(4, reservations.countBy());
+        assertEquals(4, reservations.countByLocationNotNull());
 
         Map<Long, Reservation> found = reservations.findByIdIn(List.of(r4.meetingID, r2.meetingID))
                         .collect(Collectors.toMap(rr -> rr.meetingID, Function.identity()));
@@ -3801,13 +3801,13 @@ public class DataTestServlet extends FATServlet {
         assertNotNull(r2optional);
         assertEquals(true, r2optional.isEmpty());
 
-        assertEquals(3, reservations.countBy());
+        assertEquals(3, reservations.countByLocationNotNull());
 
         reservations.deleteByIdIn(Set.of(r1.meetingID, r4.meetingID));
 
         assertEquals(false, reservations.existsById(r4.meetingID));
 
-        assertEquals(1, reservations.countBy());
+        assertEquals(1, reservations.countByLocationNotNull());
 
         Optional<Reservation> r3optional = reservations.findById(r3.meetingID);
         assertNotNull(r3optional);
@@ -3833,7 +3833,7 @@ public class DataTestServlet extends FATServlet {
         // remove data that other tests previously inserted to the same table
         reservations.removeByHostNotIn(Set.of("never-ever-used@example.org"));
 
-        assertEquals(0, reservations.countBy());
+        assertEquals(0, reservations.findAll().count());
 
         // set up some data for the test to use
         Reservation r1 = new Reservation();
@@ -4373,7 +4373,7 @@ public class DataTestServlet extends FATServlet {
 
         packages.deleteAll();
 
-        assertEquals(0, packages.countBy());
+        assertEquals(0, packages.findAll().count());
     }
 
     /**
@@ -4653,7 +4653,7 @@ public class DataTestServlet extends FATServlet {
         // remove data that other tests previously inserted to the same table
         reservations.removeByHostNotIn(Set.of("never-ever-used@example.org"));
 
-        assertEquals(0, reservations.countBy());
+        assertEquals(0, reservations.findAll().count());
 
         // set up some data for the test to use
         Reservation r1 = new Reservation();

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
@@ -25,6 +25,8 @@ import jakarta.data.repository.Repository;
 @Repository
 public interface Receipts extends CrudRepository<Receipt, Long> {
 
+    long countByIdBetween(long minId, long maxId);
+
     boolean deleteByTotalLessThan(float max);
 
     Optional<Receipt> deleteByPurchaseId(long purchaseId);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
@@ -53,6 +53,9 @@ import io.openliberty.data.repository.function.Extract;
  */
 @Repository
 public interface Reservations extends BasicRepository<Reservation, Long> {
+
+    int countByLocationNotNull();
+
     boolean deleteByHostIn(List<String> hosts);
 
     long deleteByHostNot(String host);

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/BasicRepository.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/BasicRepository.java
@@ -22,7 +22,6 @@ import jakarta.data.page.PageRequest;
  * Interface methods copied from Jakarta Data.
  */
 public interface BasicRepository<T, K> extends DataRepository<T, K> {
-    long countBy();
 
     @Delete
     void delete(T entity);


### PR DESCRIPTION
Remove BasicRepository.countBy from our copy of the API because it was removed from Jakarta Data.