### PR TITLE
Filter out bad values from env var

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
@@ -96,12 +96,30 @@ public class FeatureResolverImpl implements FeatureResolver {
             // nothing
         }
         tc = temp;
+    }
+
+    private void verifyVersionlessEnvVar(FeatureResolver.Repository repository){
         String[] preferredVersions = (preferedFeatureVersions == null) ? new String[] {} : preferedFeatureVersions.split(",");
         String[][] parsedVersions = new String[preferredVersions.length][2];
+        String invalid = "";
+        int invalidPadding = 0;
         for (int i = 0; i < preferredVersions.length; i++) {
-            parsedVersions[i] = parseNameAndVersion(preferredVersions[i].trim());
+            String[] current = parseNameAndVersion(preferredVersions[i].trim());
+            if(current[0] != null && current[1] != null && !current[0].isEmpty() && !current[1].isEmpty() && repository.getFeature(current[0] + "-" + current[1]) != null){
+                parsedVersions[i-invalidPadding] = current;
+            }
+            else{
+                invalidPadding++;
+                if(!invalid.isEmpty()){
+                    invalid += ",";
+                }
+                invalid += " \"" + preferredVersions[i] + "\"";
+            }
         }
-        parsedPreferedVersions = parsedVersions;
+        parsedPreferedVersions = Arrays.copyOf(parsedVersions, parsedVersions.length-invalidPadding);
+        if(!!!invalid.isEmpty()){
+            trace("Removing invalid entries in PREFERRED_FEATURE_VERSIONS:" + invalid);
+        }
     }
 
     @Override
@@ -162,6 +180,8 @@ public class FeatureResolverImpl implements FeatureResolver {
                                   Set<String> allowedMultipleVersions,
                                   EnumSet<ProcessType> supportedProcessTypes) {
         SelectionContext selectionContext = new SelectionContext(repository, allowedMultipleVersions, supportedProcessTypes);
+
+        verifyVersionlessEnvVar(repository);
 
         // this checks if the pre-resolved exists in the repo;
         // if one does not exist then we start over with an empty set of pre-resolved

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
@@ -181,8 +181,10 @@ public class FeatureResolverImpl implements FeatureResolver {
                                   EnumSet<ProcessType> supportedProcessTypes) {
         SelectionContext selectionContext = new SelectionContext(repository, allowedMultipleVersions, supportedProcessTypes);
 
-        verifyVersionlessEnvVar(repository);
-
+        if(isBeta){
+            verifyVersionlessEnvVar(repository);
+        }
+        
         // this checks if the pre-resolved exists in the repo;
         // if one does not exist then we start over with an empty set of pre-resolved
         preResolved = checkPreResolvedExistAndSetFullName(preResolved, selectionContext);


### PR DESCRIPTION
Filter out all non-existing features from the versionless preferred versions environment variable. 

Ex. With the env var being `PREFERRED_FEATURE_VERSIONS=mpHealth-1.0,,a,s, , asdfas, mpHealth, asdf-1.2` the changes now filter out the invalid values `Removing invalid entries in PREFERRED_FEATURE_VERSIONS: "", "a", "s", " ", " asdfas", " mpHealth", " asdf-1.2"` leaving only features that actually exist.