### PR TITLE
Enable non-security JCA, JMS features for InstantOn beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/connectors-2.0/io.openliberty.connectors-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/connectors-2.0/io.openliberty.connectors-2.0.feature
@@ -24,3 +24,4 @@ Subsystem-Category: JakartaEE9Application
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
+WLP-InstantOn-Enabled: true; type:=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/connectors-2.1/io.openliberty.connectors-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/connectors-2.1/io.openliberty.connectors-2.1.feature
@@ -24,3 +24,4 @@ Subsystem-Category: JakartaEE10Application
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
+WLP-InstantOn-Enabled: true; type:=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jca-1.7/com.ibm.websphere.appserver.jca-1.7.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jca-1.7/com.ibm.websphere.appserver.jca-1.7.feature
@@ -24,3 +24,4 @@ Subsystem-Category: JavaEE7Application
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
+WLP-InstantOn-Enabled: true; type:=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jms-2.0/com.ibm.websphere.appserver.jms-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jms-2.0/com.ibm.websphere.appserver.jms-2.0.feature
@@ -20,3 +20,4 @@ Subsystem-Name: Java Message Service 2.0
 -bundles=com.ibm.ws.jms20.feature
 kind=ga
 edition=base
+WLP-InstantOn-Enabled: true; type:=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/messaging-3.0/io.openliberty.messaging-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/messaging-3.0/io.openliberty.messaging-3.0.feature
@@ -22,3 +22,4 @@ Subsystem-Name: Jakarta Messaging 3.0
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
+WLP-InstantOn-Enabled: true; type:=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/messaging-3.1/io.openliberty.messaging-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/messaging-3.1/io.openliberty.messaging-3.1.feature
@@ -22,3 +22,4 @@ Subsystem-Name: Jakarta Messaging 3.1
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
+WLP-InstantOn-Enabled: true; type:=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/messagingClient-3.0/io.openliberty.messagingClient-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/messagingClient-3.0/io.openliberty.messagingClient-3.0.feature
@@ -34,3 +34,4 @@ Subsystem-Name: Messaging Server 3.0 Client
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
+WLP-InstantOn-Enabled: true; type:=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/messagingServer-3.0/io.openliberty.messagingServer-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/messagingServer-3.0/io.openliberty.messagingServer-3.0.feature
@@ -28,3 +28,4 @@ Subsystem-Name: Messaging Server 3.0
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
+WLP-InstantOn-Enabled: true; type:=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsClient-2.0/com.ibm.websphere.appserver.wasJmsClient-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsClient-2.0/com.ibm.websphere.appserver.wasJmsClient-2.0.feature
@@ -33,3 +33,4 @@ Subsystem-Name: JMS 2.0 Client for Message Server
  io.openliberty.netty.internal.impl
 kind=ga
 edition=base
+WLP-InstantOn-Enabled: true; type:=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsServer-1.0/com.ibm.websphere.appserver.wasJmsServer-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsServer-1.0/com.ibm.websphere.appserver.wasJmsServer-1.0.feature
@@ -28,3 +28,4 @@ Subsystem-Name: Message Server 1.0
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.messaging_1.0-javadoc.zip
 kind=ga
 edition=base
+WLP-InstantOn-Enabled: true; type:=beta

--- a/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/CheckpointImpl.java
+++ b/dev/io.openliberty.checkpoint/src/io/openliberty/checkpoint/internal/CheckpointImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -494,8 +494,10 @@ public class CheckpointImpl implements RuntimeUpdateListener, ServerReadyStatus 
     }
 
     private boolean isInstantOnFeature(ManifestElement[] instantonEnabledHeader, Object featureName) {
+        if (allowedFeatures.contains(featureName)) {
+            return true;
+        }
         if (instantonEnabledHeader != null && instantonEnabledHeader.length > 0) {
-
             if (Boolean.parseBoolean(instantonEnabledHeader[0].getValue())) {
                 // check for beta
                 String type = instantonEnabledHeader[0].getDirective("type");
@@ -505,7 +507,7 @@ public class CheckpointImpl implements RuntimeUpdateListener, ServerReadyStatus 
                 return true;
             }
         }
-        return allowedFeatures.contains(featureName);
+        return false;
     }
 
     public Type getUnknownType() {

--- a/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet1Client/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet1Client/bootstrap.properties
@@ -1,3 +1,5 @@
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:SIBOSGi=all
-io.openliberty.checkpoint.allowed.features=testjmsinternals-1.0,wasJmsClient-2.0,messagingClient-3.0
+# Features wasJmsClient-2.0, messagingClient-3.0 are enabled for InstantOn beta
+io.openliberty.checkpoint.allowed.features=testjmsinternals-1.0
+websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet1Client/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet1Client/jvm.options
@@ -1,0 +1,2 @@
+#Enable Messaging features for InstantOn
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet1Engine/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet1Engine/bootstrap.properties
@@ -1,3 +1,5 @@
 bootstrap.include=../testports.properties
-io.openliberty.checkpoint.allowed.features=testjmsinternals-1.0,wasJmsServer-1.0,messagingServer-3.0
+# Features wasJmsServer-2.0, messagingServer-3.0 are enabled for InstantOn beta
+io.openliberty.checkpoint.allowed.features=testjmsinternals-1.0
 com.ibm.ws.logging.trace.specification=*=info:SIBOSGi=all
+websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet1Engine/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet1Engine/jvm.options
@@ -1,0 +1,2 @@
+#Enable Messaging features for InstantOn
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet2Client/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet2Client/bootstrap.properties
@@ -1,2 +1,4 @@
 bootstrap.include=../testports.properties
-io.openliberty.checkpoint.allowed.features=testjmsinternals-1.0,wasJmsClient-2.0,messagingClient-3.0
+# Features wasJmsClient-2.0, messagingClient-3.0 are enabled for InstantOn beta
+io.openliberty.checkpoint.allowed.features=testjmsinternals-1.0
+websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet2Client/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet2Client/jvm.options
@@ -1,0 +1,2 @@
+#Enable Messaging features for InstantOn
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet2Engine/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet2Engine/bootstrap.properties
@@ -1,2 +1,4 @@
-io.openliberty.checkpoint.allowed.features=testjmsinternals-1.0,wasJmsServer-1.0,messagingServer-3.0
+# Features wasJmsServer-2.0, messagingServer-3.0 are enabled for InstantOn beta
+io.openliberty.checkpoint.allowed.features=testjmsinternals-1.0
 bootstrap.include=../testports.properties
+websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet2Engine/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat_jms/publish/servers/LiteSet2Engine/jvm.options
@@ -1,0 +1,2 @@
+#Enable Messaging features for InstantOn
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.ejbcontainer.mdb.checkpoint_fat/publish/servers/checkpointMsgEndpointServer/bootstrap.properties
+++ b/dev/io.openliberty.ejbcontainer.mdb.checkpoint_fat/publish/servers/checkpointMsgEndpointServer/bootstrap.properties
@@ -4,5 +4,7 @@ osgi.console=5678
 bootstrap.include=../testports.properties
 io.openliberty.ejb.security.startWaitTime=30
 websphere.java.security.exempt=true
-# Features mdb-3.2, mdb-4.0 are enabled for InstantOn beta; jmsMdb-3.2 is superceded by mdb-3.2 and is not formally enabled for InstantOn
-io.openliberty.checkpoint.allowed.features=jca-1.7,connectors-2.0,connectors-2.1,jms-2.0,messaging-3.0,messaging-3.1
+# Features mdb-3.2, mdb-4.0, jca-1.7, connectors-2.0, connectors-2.1, jms-2.0, messaging-3.0, messaging-3.1
+# are enabled for InstantOn beta; feature jmsMdb-3.2 is superceded by mdb-3.2 and is not formally enabled 
+# for InstantOn
+#io.openliberty.checkpoint.allowed.features=jca-1.7,connectors-2.0,connectors-2.1,jms-2.0,messaging-3.0,messaging-3.1


### PR DESCRIPTION
For issue #26039 

Enable EE8+ Connectors and Messaging features for InstantOn beta, where each feature is directly or indirectly exercised by InstantOn FATs (i.e. FAT test classes annotated with `@CheckpointTest`).

This PR excludes messaging and connectors security features (`messagingSecurity-3.0`, `wasJMSSecurity-1.0`, `jcaInboundSecurity-1.0`, `connectorsInboundSecurity-2.0`) as these are not yet exercised. Since `connectorsInboundSecurity-2.1` is auto-included whenever `connectors-2.1` and either `appSecurity-5.0` or `mpJwt-3.0` are configured on a server. it follows that beta releases will not yet support the use of `connectors-2.1` with `appSecurity-5.0`.