### PR TITLE
Upgrade pipeline JVM to Oracle HotSpot OpenJDK 21 GA

### DIFF
--- a/.ci-orchestrator/jvms/dev/linux_x86_64.properties
+++ b/.ci-orchestrator/jvms/dev/linux_x86_64.properties
@@ -1,3 +1,3 @@
-reportingJVM=IBM_OPEN_SEMERUJDK11_64
-jvmUnderTestPath=/liberty/jvms/linux_x86_64/ibm-semerujdk-11.0.14.1_1_openj9-0.30.1/jdk-11.0.14.1+1.tar.gz
-jvmFrameworkPath=/liberty/jvms/linux_x86_64/ibm-semerujdk-11.0.14.1_1_openj9-0.30.1/jdk-11.0.14.1+1.tar.gz
+reportingJVM=ORACLE_OPEN_JDK_21
+jvmUnderTestPath=/liberty/jvms/linux_x64/Oracle_Hotspot_openjdk-21-ga/jdk-21.tar.gz
+jvmFrameworkPath=/liberty/jvms/linux_x64/Oracle_Hotspot_openjdk-21-ga/jdk-21.tar.gz


### PR DESCRIPTION
- Upgrade JVM from ibm-semerujdk-11.0.14.1_1_openj9-0.30.1 to Oracle HotSpot OpenJDK 21 GA.