### PR TITLE
new spec requirements for optimistic locking failure exception

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -2623,12 +2623,9 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             updateCount = remove(arg, queryInfo, em);
                         }
 
-                        if (updateCount < numExpected) {
-                            Class<?> singleType = queryInfo.getSingleResultType();
-                            if (void.class.equals(singleType) || Void.class.equals(singleType))
-                                throw new OptimisticLockingFailureException((numExpected - updateCount) + " of the " +
-                                                                            numExpected + " entities were not found for deletion."); // TODO NLS
-                        }
+                        if (updateCount < numExpected)
+                            throw new OptimisticLockingFailureException((numExpected - updateCount) + " of the " +
+                                                                        numExpected + " entities were not found for deletion."); // TODO NLS
 
                         returnValue = toReturnValue(updateCount, returnType, queryInfo);
                         break;

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/DataStoreTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/DataStoreTestServlet.java
@@ -115,7 +115,7 @@ public class DataStoreTestServlet extends FATServlet {
         assertEquals("TestQualifiedDataSource-3", thirtyOnes.get(1).id);
 
         // Prove it went into the expected database by accessing it from another repository that uses ServerDataSource
-        assertEquals(true, serverDSIdRepo.remove(ServerDSEntity.of("TestQualifiedDataSource-1", 31)));
+        serverDSIdRepo.remove(ServerDSEntity.of("TestQualifiedDataSource-1", 31)); // raises an error if not found
     }
 
     /**
@@ -174,11 +174,11 @@ public class DataStoreTestServlet extends FATServlet {
     public void testServerDataSourceById() {
         ServerDSEntity eighty_seven = ServerDSEntity.of("eighty-seven", 87);
 
-        assertEquals(false, serverDSIdRepo.remove(eighty_seven));
+        assertEquals(false, serverDSIdRepo.existsById("eighty-seven"));
 
         serverDSJNDIRepo.insert(eighty_seven); // other repository with same data source used for the insert
 
-        assertEquals(true, serverDSIdRepo.remove(ServerDSEntity.of("eighty-seven", 87)));
+        serverDSIdRepo.remove(ServerDSEntity.of("eighty-seven", 87)); // raises an error if not found
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/ServerDSIdRepo.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/ServerDSIdRepo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,8 +18,10 @@ import jakarta.data.repository.Repository;
 @Repository(dataStore = "ServerDataSource") // id of dataSource in server.xml
 public interface ServerDSIdRepo {
 
+    boolean existsById(String id);
+
     // Entity type is inferred from the Delete annotation.
     // Do not add other methods or inheritance to this class.
     @Delete
-    boolean remove(ServerDSEntity e);
+    void remove(ServerDSEntity e);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -127,7 +127,7 @@ public interface Cities {
                             @By("stateName") @StartsWith String statePattern);
 
     @Delete
-    boolean remove(City city);
+    void remove(City city);
 
     Streamable<City> removeByStateName(String state);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -89,7 +89,7 @@ public interface Counties {
     }
 
     @Delete
-    boolean remove(County c);
+    void remove(County c);
 
     @Save
     Stream<County> save(County... c);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
@@ -60,7 +60,7 @@ public interface Orders extends CrudRepository<PurchaseOrder, Long> {
     List<Float> findTotalByPurchasedByIn(Iterable<String> purchasers, Sort<?>... sorts);
 
     @Update
-    boolean modify(PurchaseOrder order);
+    void modify(PurchaseOrder order);
 
     @Update
     PurchaseOrder[] modifyAll(PurchaseOrder... orders);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
@@ -40,7 +40,7 @@ public interface Orders extends CrudRepository<PurchaseOrder, Long> {
                               @Param("shipping") float shippingCost);
 
     @Delete
-    int cancel(PurchaseOrder... orders);
+    void cancel(PurchaseOrder... orders);
 
     @Insert
     LinkedList<PurchaseOrder> create(Iterable<PurchaseOrder> order);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Rebates.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Rebates.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2023 IBM Corporation and others.
+ * Copyright (c) 2022,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -56,11 +56,11 @@ public interface Rebates { // Do not allow this interface to inherit from other 
 
     // TODO allow entity return types for Delete?
     @Delete
-    boolean remove(Rebate r);
+    void remove(Rebate r);
 
     @Delete
-    int removeAll(Rebate... r);
+    void removeAll(Rebate... r);
 
     @Delete
-    int removeMultiple(ArrayList<Rebate> r);
+    void removeMultiple(ArrayList<Rebate> r);
 }

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
@@ -55,6 +55,7 @@ public class DataCoreTckLauncher {
     }
 
     @Test
+    @Ignore("Behavior change in spec after M3 caused failures") // TODO re-enable with M4 or RC1
     @AllowedFFDC // The tested exceptions cause FFDC so we have to allow for this.
     public void launchDataTckCorePersistence() throws Exception {
 

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataFullTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataFullTckLauncher.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -58,6 +59,7 @@ public class DataFullTckLauncher {
      * Run the TCK (controlled by autoFVT/publish/tckRunner/tck/*)
      */
     @Test
+    @Ignore("Behavior change in spec after M3 caused failures") // TODO re-enable with M4 or RC1
     @AllowedFFDC // The tested exceptions cause FFDC so we have to allow for this.
     public void launchDataTckFullPersistence() throws Exception {
         // Test groups to run

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -56,6 +57,7 @@ public class DataWebTckLauncher {
      * Run the TCK (controlled by autoFVT/publish/tckRunner/tck/*)
      */
     @Test
+    @Ignore("Behavior change in spec after M3 caused failures") // TODO re-enable with M4 or RC1
     @AllowedFFDC // The tested exceptions cause FFDC so we have to allow for this.
     public void launchDataTckWebPersistence() throws Exception {
         // Test groups to run


### PR DESCRIPTION
Comply with new specification requirements to raise OptimisticLockingFailureException on Delete and Update methods when an entity is not found or doesn't match the database.  Previously, the behavior was to have a boolean or numeric return type that would indicate whether or how many updates had occurred rather than raising the exception.