### PR TITLE
Added NLS_MESSAGEFORMAT_VAR to the MP Health NLSPROPS file

### DIFF
--- a/dev/io.openliberty.microprofile.health.internal.common/resources/io/openliberty/microprofile/health/resources/Health.nlsprops
+++ b/dev/io.openliberty.microprofile.health.internal.common/resources/io/openliberty/microprofile/health/resources/Health.nlsprops
@@ -2,7 +2,7 @@
 #COMPONENTPREFIX CWMMH
 #COMPONENTNAMEFOR CWMMH MicroProfile Health API 
 #NLS_ENCODING=UNICODE
-#NLS_MESSAGEFORMAT_NONE
+#NLS_MESSAGEFORMAT_VAR
 #ISMESSAGEFILE true
 # #########################################################################
 ###############################################################################


### PR DESCRIPTION
fixes #27777 
- The MP Health NLSProps file had `NLS_MESSAGEFORMAT_NONE` which prevents the translation tool from adding 2 consecutive quotes ('') for messages that contain a single quote and contain replacement variables. Thus, the MessageFormat class will not replace the variables.
- Added the `NLS_MESSAGEFORMAT_VAR` instead, which tells the tool to substitute single quote into 2 consecutive quotes.