### PR TITLE
spec update to allow sort criteria from entity subclasses

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -2362,7 +2362,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                     throw new DataException("Repository method " + method + " cannot have multiple Limit parameters."); // TODO NLS
                             } else if (param instanceof Order) {
                                 @SuppressWarnings("unchecked")
-                                Order<Object> order = (Order<Object>) param;
+                                Iterable<Sort<Object>> order = (Iterable<Sort<Object>>) param;
                                 sortList = queryInfo.combineSorts(sortList, order);
                             } else if (param instanceof PageRequest) {
                                 if (pagination == null)

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/Order.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/Order.java
@@ -20,16 +20,16 @@ import jakarta.data.page.PageRequest;
 /**
  * Method signatures copied from jakarta.data.Order from the Jakarta Data repo.
  */
-public class Order<T> implements Iterable<Sort<T>> {
+public class Order<T> implements Iterable<Sort<? super T>> {
 
-    private final List<Sort<T>> sortBy;
+    private final List<Sort<? super T>> sortBy;
 
-    private Order(List<Sort<T>> sortBy) {
+    private Order(List<Sort<? super T>> sortBy) {
         this.sortBy = sortBy;
     }
 
     @SafeVarargs
-    public static final <T> Order<T> by(Sort<T>... sortBy) {
+    public static <T> Order<T> by(Sort<? super T>... sortBy) {
         return new Order<T>(List.of(sortBy));
     }
 
@@ -39,7 +39,7 @@ public class Order<T> implements Iterable<Sort<T>> {
                other instanceof Order && sortBy.equals(((Order<?>) other).sortBy);
     }
 
-    public List<Sort<T>> sorts() {
+    public List<Sort<? super T>> sorts() {
         return sortBy;
     }
 
@@ -49,7 +49,7 @@ public class Order<T> implements Iterable<Sort<T>> {
     }
 
     @Override
-    public Iterator<Sort<T>> iterator() {
+    public Iterator<Sort<? super T>> iterator() {
         return sortBy.iterator();
     }
 

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/PageRequest.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/PageRequest.java
@@ -70,21 +70,23 @@ public interface PageRequest<T> {
 
     public int size();
 
-    public List<Sort<T>> sorts();
+    public List<Sort<? super T>> sorts();
 
     public PageRequest<T> page(long page);
 
     public PageRequest<T> size(int size);
 
-    public PageRequest<T> sortBy(Iterable<Sort<T>> sorts);
+    public PageRequest<T> sortBy(Iterable<Sort<? super T>> sorts);
 
-    public PageRequest<T> sortBy(Sort<T> sort);
+    public PageRequest<T> sortBy(Sort<? super T> sort);
 
-    public PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2);
+    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2);
 
-    public PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2, Sort<T> sort3);
+    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3);
 
-    public PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2, Sort<T> sort3, Sort<T> sort4);
+    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3,
+                                 Sort<? super T> sort4);
 
-    public PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2, Sort<T> sort3, Sort<T> sort4, Sort<T> sort5);
+    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3,
+                                 Sort<? super T> sort4, Sort<? super T> sort5);
 }

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Pagination.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Pagination.java
@@ -28,7 +28,7 @@ import jakarta.data.page.PageRequest.Mode;
  */
 record Pagination<T>(long page,
                 int size,
-                List<Sort<T>> sorts,
+                List<Sort<? super T>> sorts,
                 Mode mode,
                 Cursor type)
                 implements PageRequest<T> {
@@ -119,34 +119,40 @@ record Pagination<T>(long page,
     }
 
     @Override
-    public Pagination<T> sortBy(Iterable<Sort<T>> sorts) {
-        List<Sort<T>> sortList = sorts instanceof List ? List.copyOf((List<Sort<T>>) sorts) : sorts == null ? Collections.emptyList() : StreamSupport.stream(sorts.spliterator(),
-                                                                                                                                                             false).collect(Collectors.toUnmodifiableList());
+    public Pagination<T> sortBy(Iterable<Sort<? super T>> sorts) {
+        List<Sort<? super T>> sortList = sorts instanceof List //
+                        ? List.copyOf((List<Sort<? super T>>) sorts) //
+                        : sorts == null //
+                                        ? Collections.emptyList() //
+                                        : StreamSupport.stream(sorts.spliterator(), false) //
+                                                        .collect(Collectors.toUnmodifiableList());
         return new Pagination<T>(page, size, sortList, mode, type);
     }
 
     @Override
-    public PageRequest<T> sortBy(Sort<T> sort) {
+    public PageRequest<T> sortBy(Sort<? super T> sort) {
         return new Pagination<T>(page, size, List.of(sort), mode, type);
     }
 
     @Override
-    public PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2) {
+    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2) {
         return new Pagination<T>(page, size, List.of(sort1, sort2), mode, type);
     }
 
     @Override
-    public PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2, Sort<T> sort3) {
+    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3) {
         return new Pagination<T>(page, size, List.of(sort1, sort2, sort3), mode, type);
     }
 
     @Override
-    public PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2, Sort<T> sort3, Sort<T> sort4) {
+    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3,
+                                 Sort<? super T> sort4) {
         return new Pagination<T>(page, size, List.of(sort1, sort2, sort3, sort4), mode, type);
     }
 
     @Override
-    public PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2, Sort<T> sort3, Sort<T> sort4, Sort<T> sort5) {
+    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3,
+                                 Sort<? super T> sort4, Sort<? super T> sort5) {
         return new Pagination<T>(page, size, List.of(sort1, sort2, sort3, sort4, sort5), mode, type);
     }
 
@@ -157,7 +163,7 @@ record Pagination<T>(long page,
         if (type != null)
             b.append(", mode=").append(mode).append(", ").append(type.size()).append(" keys");
 
-        for (Sort<T> o : sorts) {
+        for (Sort<? super T> o : sorts) {
             b.append(", ").append(o.property()).append(o.ignoreCase() ? " IGNORE CASE" : "").append(o.isDescending() ? " DESC" : " ASC");
         }
 


### PR DESCRIPTION
Align with the spec update that was just made to allow sort criteria from entity subclasses to be used.