### PR TITLE
Update 02_feature_request.md to use new label

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
+labels: "Feature Request: External"
 assignees: ''
 
 ---


### PR DESCRIPTION
I’m updating the "Feature request" OL issue template to automatically add the "Feature Request: External" label instead of the "enhancement" label. This will make it clear the issue was specifically opened as a feature request by an external contributor.

The new "Feature Request: External" label is meant to be used only by the feature request template for external users creating a new feature request issue. Please do not use this new label outside of that capacity.