### PR TITLE
page impls and method to obtain Cursor from spec

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/io.openliberty.data-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/io.openliberty.data-1.0.feature
@@ -13,6 +13,7 @@ IBM-API-Package: \
   jakarta.data.metamodel; type="spec",\
   jakarta.data.metamodel.impl; type="spec",\
   jakarta.data.page; type="spec",\
+  jakarta.data.page.impl; type="spec",\
   jakarta.data.repository; type="spec"
 Subsystem-Name: Jakarta Data 1.0
 #TODO io.openliberty.jakartaeePlatform-11.0

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/KeysetAwarePageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/KeysetAwarePageImpl.java
@@ -150,11 +150,6 @@ public class KeysetAwarePageImpl<T> implements KeysetAwarePage<T> {
     }
 
     @Override
-    public long number() {
-        return pagination.page();
-    }
-
-    @Override
     public int numberOfElements() {
         int size = results.size();
         int max = pagination.size();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/KeysetAwarePageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/KeysetAwarePageImpl.java
@@ -17,7 +17,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.util.AbstractList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -35,6 +34,7 @@ import jakarta.data.Sort;
 import jakarta.data.exceptions.DataException;
 import jakarta.data.page.KeysetAwarePage;
 import jakarta.data.page.PageRequest;
+import jakarta.data.page.PageRequest.Cursor;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
@@ -146,7 +146,7 @@ public class KeysetAwarePageImpl<T> implements KeysetAwarePage<T> {
                 throw new DataException(x.getCause());
             }
 
-        return new Cursor(keyValues);
+        return Cursor.forKeyset(keyValues);
     }
 
     @Override
@@ -228,53 +228,6 @@ public class KeysetAwarePageImpl<T> implements KeysetAwarePage<T> {
     public Stream<T> stream() {
         return content().stream();
     }
-
-    /**
-     * Keyset cursor
-     */
-    @Trivial
-    private static class Cursor implements PageRequest.Cursor {
-        private final Object[] keyValues;
-
-        private Cursor(Object[] keyValues) {
-            this.keyValues = keyValues;
-        }
-
-        @Override
-        public List<?> elements() {
-            return List.of(keyValues);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            return this == o || o != null
-                                && getClass() == o.getClass()
-                                && Arrays.equals(keyValues, ((Cursor) o).keyValues);
-        }
-
-        @Override
-        public Object getKeysetElement(int index) {
-            return keyValues[index];
-        }
-
-        @Override
-        public int hashCode() {
-            return Arrays.hashCode(keyValues);
-        }
-
-        @Override
-        public int size() {
-            return keyValues.length;
-        }
-
-        @Override
-        public String toString() {
-            return new StringBuilder(47) //
-                            .append("KeysetAwarePageImpl.Cursor@").append(Integer.toHexString(hashCode())) //
-                            .append(" with ").append(keyValues.length).append(" keys") //
-                            .toString();
-        }
-    };
 
     /**
      * Iterator that restricts the number of results to the specified amount.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -103,11 +103,6 @@ public class PageImpl<T> implements Page<T> {
     }
 
     @Override
-    public long number() {
-        return pagination.page();
-    }
-
-    @Override
     public int numberOfElements() {
         int size = results.size();
         int max = pagination.size();

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -2469,7 +2469,7 @@ public class DataTestServlet extends FATServlet {
         // Page 1
         page = packages.findByHeightGreaterThan(10.0f, PageRequest.ofSize(4));
 
-        assertEquals(1L, page.number());
+        assertEquals(1L, page.pageRequest().page());
 
         assertIterableEquals(List.of(114, 144, 133, 151),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2481,7 +2481,7 @@ public class DataTestServlet extends FATServlet {
         // Page 2
         page = packages.findByHeightGreaterThan(10.0f, page.nextPageRequest());
 
-        assertEquals(2L, page.number());
+        assertEquals(2L, page.pageRequest().page());
 
         assertIterableEquals(List.of(150, 148, 128, 117),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2530,7 +2530,7 @@ public class DataTestServlet extends FATServlet {
 
         page = packages.whereVolumeWithin(5000.0f, 123456.0f, previous);
 
-        assertEquals(1L, page.number());
+        assertEquals(1L, page.pageRequest().page());
 
         assertIterableEquals(List.of(114, 133, 128),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2661,7 +2661,7 @@ public class DataTestServlet extends FATServlet {
         // Page 3
         page = packages.findByHeightGreaterThanOrderByLengthAscWidthDescHeightDescIdAsc(20.0f, PageRequest.ofSize(3).page(3).beforeKeyset(40.0f, 94.0f, 42.0f, 240));
 
-        assertEquals(3L, page.number());
+        assertEquals(3L, page.pageRequest().page());
 
         assertIterableEquals(List.of(230, 233, 236),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2669,7 +2669,7 @@ public class DataTestServlet extends FATServlet {
         // Page 2
         page = packages.findByHeightGreaterThanOrderByLengthAscWidthDescHeightDescIdAsc(20.0f, page.previousPageRequest());
 
-        assertEquals(2L, page.number());
+        assertEquals(2L, page.pageRequest().page());
 
         assertIterableEquals(List.of(220, 224, 228),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2677,7 +2677,7 @@ public class DataTestServlet extends FATServlet {
         // Page 1
         page = packages.findByHeightGreaterThanOrderByLengthAscWidthDescHeightDescIdAsc(20.0f, page.previousPageRequest());
 
-        assertEquals(1L, page.number());
+        assertEquals(1L, page.pageRequest().page());
 
         assertIterableEquals(List.of(210, 215),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2723,28 +2723,28 @@ public class DataTestServlet extends FATServlet {
 
         page = packages.findByHeightGreaterThan(20.0f, PageRequest.ofSize(2).page(3).beforeKeysetCursor(cursor));
 
-        assertEquals(3L, page.number());
+        assertEquals(3L, page.pageRequest().page());
 
         assertIterableEquals(List.of(233, 220),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
 
         page = packages.findByHeightGreaterThan(20.0f, page.previousPageRequest());
 
-        assertEquals(2L, page.number());
+        assertEquals(2L, page.pageRequest().page());
 
         assertIterableEquals(List.of(236, 224),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
 
         page = packages.findByHeightGreaterThan(20.0f, page.previousPageRequest());
 
-        assertEquals(1L, page.number());
+        assertEquals(1L, page.pageRequest().page());
 
         assertIterableEquals(List.of(215, 210),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
 
         page = packages.findByHeightGreaterThan(20.0f, page.previousPageRequest());
 
-        assertEquals(1L, page.number()); // page numbers cannot go to 0 or negative
+        assertEquals(1L, page.pageRequest().page()); // page numbers cannot go to 0 or negative
 
         assertIterableEquals(List.of(230, 228),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2755,7 +2755,7 @@ public class DataTestServlet extends FATServlet {
 
         page = packages.findByHeightGreaterThan(20.0f, page.nextPageRequest());
 
-        assertEquals(2L, page.number());
+        assertEquals(2L, page.pageRequest().page());
 
         assertIterableEquals(List.of(215, 210),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2785,7 +2785,7 @@ public class DataTestServlet extends FATServlet {
                         .beforeKeyset(p230.width, p230.length, p230.id);
         page = packages.whereHeightNotWithin(20.0f, 38.5f, pagination);
 
-        assertEquals(5L, page.number());
+        assertEquals(5L, page.pageRequest().page());
 
         assertIterableEquals(List.of(215, 216, 210, 228),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2794,7 +2794,7 @@ public class DataTestServlet extends FATServlet {
 
         page = packages.whereHeightNotWithin(20.0f, 38.5f, page.previousPageRequest());
 
-        assertEquals(4L, page.number());
+        assertEquals(4L, page.pageRequest().page());
 
         assertIterableEquals(List.of(233, 224, 219, 236),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2803,7 +2803,7 @@ public class DataTestServlet extends FATServlet {
 
         page = packages.whereHeightNotWithin(20.0f, 38.5f, page.previousPageRequest());
 
-        assertEquals(3L, page.number());
+        assertEquals(3L, page.pageRequest().page());
 
         assertIterableEquals(List.of(240),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2817,7 +2817,7 @@ public class DataTestServlet extends FATServlet {
 
         page = packages.whereHeightNotWithin(20.0f, 38.5f, next);
 
-        assertEquals(4L, page.number());
+        assertEquals(4L, page.pageRequest().page());
 
         assertIterableEquals(List.of(233, 224, 219, 236),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2852,7 +2852,7 @@ public class DataTestServlet extends FATServlet {
         // Page 3
         page = packages.findByHeightGreaterThan(20.0f, PageRequest.ofPage(3).size(3).beforeKeyset(10.0f, 31.0f, 310));
 
-        assertEquals(3L, page.number());
+        assertEquals(3L, page.pageRequest().page());
 
         assertIterableEquals(List.of(355, 333, 330),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2864,7 +2864,7 @@ public class DataTestServlet extends FATServlet {
         // Page 2
         page = packages.findByHeightGreaterThan(20.0f, page.previousPageRequest());
 
-        assertEquals(2L, page.number());
+        assertEquals(2L, page.pageRequest().page());
 
         assertIterableEquals(List.of(370, 350, 351),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2874,7 +2874,7 @@ public class DataTestServlet extends FATServlet {
         // Page 1
         page = packages.findByHeightGreaterThan(20.0f, page.previousPageRequest());
 
-        assertEquals(1L, page.number());
+        assertEquals(1L, page.pageRequest().page());
 
         assertIterableEquals(List.of(379, 376, 373),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2903,7 +2903,7 @@ public class DataTestServlet extends FATServlet {
                                                              .sortBy(Sort.asc("height"), Sort.desc("length"), Sort.asc("id"))
                                                              .beforeKeyset(40.0f, 0.0f, 0));
 
-        assertEquals(5L, page.number());
+        assertEquals(5L, page.pageRequest().page());
 
         assertIterableEquals(List.of(315, 373),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2912,7 +2912,7 @@ public class DataTestServlet extends FATServlet {
 
         page = packages.whereHeightNotWithin(32.0f, 35.5f, page.previousPageRequest());
 
-        assertEquals(4L, page.number());
+        assertEquals(4L, page.pageRequest().page());
 
         assertIterableEquals(List.of(351, 370),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2921,14 +2921,14 @@ public class DataTestServlet extends FATServlet {
 
         page = packages.whereHeightNotWithin(32.0f, 35.5f, page.previousPageRequest());
 
-        assertEquals(3L, page.number());
+        assertEquals(3L, page.pageRequest().page());
 
         assertIterableEquals(List.of(379, 331),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
 
         page = packages.whereHeightNotWithin(32.0f, 35.5f, page.previousPageRequest());
 
-        assertEquals(2L, page.number());
+        assertEquals(2L, page.pageRequest().page());
 
         assertIterableEquals(List.of(330, 310),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
@@ -2942,7 +2942,7 @@ public class DataTestServlet extends FATServlet {
 
         page = packages.whereHeightNotWithin(32.0f, 35.5f, page.previousPageRequest());
 
-        assertEquals(1L, page.number());
+        assertEquals(1L, page.pageRequest().page());
 
         assertIterableEquals(Collections.EMPTY_LIST, page.content());
 
@@ -2959,7 +2959,7 @@ public class DataTestServlet extends FATServlet {
         // This is not a recommended pattern. Testing to see how it is handled.
         KeysetAwarePage<Prime> page = primes.findByNumberIdBetween(15L, 45L, Limit.of(5));
 
-        assertEquals(1L, page.number());
+        assertEquals(1L, page.pageRequest().page());
         assertEquals(5L, page.numberOfElements());
         assertEquals(5L, page.pageRequest().size());
         assertEquals(1L, page.pageRequest().page());
@@ -2976,7 +2976,6 @@ public class DataTestServlet extends FATServlet {
 
         page = primes.findByNumberIdBetween(15L, 45L, page.nextPageRequest());
 
-        assertEquals(2L, page.number());
         assertEquals(3L, page.numberOfElements());
         assertEquals(5L, page.pageRequest().size());
         assertEquals(2L, page.pageRequest().page());
@@ -4122,7 +4121,7 @@ public class DataTestServlet extends FATServlet {
 
         // Page of nothing
         page1 = reservations.findByHostStartsWith("Not Found", PageRequest.ofSize(100), Sort.asc("meetingID"));
-        assertEquals(1L, page1.number());
+        assertEquals(1L, page1.pageRequest().page());
         assertEquals(false, page1.hasContent());
         assertEquals(0, page1.numberOfElements());
         assertEquals(null, page1.nextPageRequest());
@@ -4776,7 +4775,7 @@ public class DataTestServlet extends FATServlet {
         // This is not a recommended pattern. Testing to see how it is handled.
         Slice<Prime> slice = primes.findByRomanNumeralEndsWithAndIdLessThan("II", 50L, Limit.of(4), Sort.desc("id"));
 
-        assertEquals(1L, slice.number());
+        assertEquals(1L, slice.pageRequest().page());
         assertEquals(4L, slice.numberOfElements());
         assertEquals(4L, slice.pageRequest().size());
         assertEquals(1L, slice.pageRequest().page());
@@ -4788,7 +4787,7 @@ public class DataTestServlet extends FATServlet {
 
         slice = primes.findByRomanNumeralEndsWithAndIdLessThan("II", 50L, slice.nextPageRequest(), Sort.desc("id"));
 
-        assertEquals(2L, slice.number());
+        assertEquals(2L, slice.pageRequest().page());
         assertEquals(4L, slice.numberOfElements());
         assertEquals(4L, slice.pageRequest().size());
         assertEquals(2L, slice.pageRequest().page());
@@ -4800,7 +4799,7 @@ public class DataTestServlet extends FATServlet {
 
         slice = primes.findByRomanNumeralEndsWithAndIdLessThan("II", 50L, slice.nextPageRequest(), Sort.desc("id"));
 
-        assertEquals(3L, slice.number());
+        assertEquals(3L, slice.pageRequest().page());
         assertEquals(1L, slice.numberOfElements());
         assertEquals(4L, slice.pageRequest().size());
         assertEquals(3L, slice.pageRequest().page());
@@ -4820,7 +4819,7 @@ public class DataTestServlet extends FATServlet {
         Slice<Prime> slice = primes.findByRomanNumeralEndsWithAndIdLessThan("I", 50L,
                                                                             PageRequest.ofSize(5),
                                                                             Sort.asc("sumOfBits"), Sort.desc("id"));
-        assertEquals(1L, slice.number());
+        assertEquals(1L, slice.pageRequest().page());
         assertEquals(5, slice.numberOfElements());
         assertEquals(1L, slice.pageRequest().page());
         assertEquals(5, slice.pageRequest().size());
@@ -4831,7 +4830,7 @@ public class DataTestServlet extends FATServlet {
         slice = primes.findByRomanNumeralEndsWithAndIdLessThan("I", 50L,
                                                                slice.nextPageRequest(),
                                                                Sort.asc("sumOfBits"), Sort.desc("id"));
-        assertEquals(2L, slice.number());
+        assertEquals(2L, slice.pageRequest().page());
         assertEquals(5, slice.numberOfElements());
         assertEquals(2L, slice.pageRequest().page());
         assertEquals(5, slice.pageRequest().size());
@@ -4842,7 +4841,7 @@ public class DataTestServlet extends FATServlet {
         slice = primes.findByRomanNumeralEndsWithAndIdLessThan("I", 50L,
                                                                slice.nextPageRequest(),
                                                                Sort.asc("sumOfBits"), Sort.desc("id"));
-        assertEquals(3L, slice.number());
+        assertEquals(3L, slice.pageRequest().page());
         assertEquals(2, slice.numberOfElements());
         assertEquals(3L, slice.pageRequest().page());
         assertEquals(5, slice.pageRequest().size());
@@ -4859,7 +4858,7 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testSliceWithSortCriteriaInOrderByAnnotation() {
         Slice<Prime> slice = primes.findByRomanNumeralStartsWithAndIdLessThan("X", 50L, PageRequest.ofSize(4));
-        assertEquals(1L, slice.number());
+        assertEquals(1L, slice.pageRequest().page());
         assertEquals(4, slice.numberOfElements());
         assertEquals(1L, slice.pageRequest().page());
         assertEquals(4, slice.pageRequest().size());
@@ -4868,7 +4867,7 @@ public class DataTestServlet extends FATServlet {
                              slice.stream().map(p -> p.name).collect(Collectors.toList()));
 
         slice = primes.findByRomanNumeralStartsWithAndIdLessThan("X", 50L, slice.nextPageRequest());
-        assertEquals(2L, slice.number());
+        assertEquals(2L, slice.pageRequest().page());
         assertEquals(4, slice.numberOfElements());
         assertEquals(2L, slice.pageRequest().page());
         assertEquals(4, slice.pageRequest().size());
@@ -4877,7 +4876,7 @@ public class DataTestServlet extends FATServlet {
                              slice.stream().map(p -> p.name).collect(Collectors.toList()));
 
         slice = primes.findByRomanNumeralStartsWithAndIdLessThan("X", 50L, slice.nextPageRequest());
-        assertEquals(3L, slice.number());
+        assertEquals(3L, slice.pageRequest().page());
         assertEquals(3, slice.numberOfElements());
         assertEquals(3L, slice.pageRequest().page());
         assertEquals(4, slice.pageRequest().size());
@@ -4895,7 +4894,7 @@ public class DataTestServlet extends FATServlet {
     public void testSliceWithSortCriteriaInPageRequest() {
         Slice<Prime> slice = primes.findByRomanNumeralEndsWithAndIdLessThan("II", 50L,
                                                                             PageRequest.ofSize(6).sortBy(Sort.desc("numberId")));
-        assertEquals(1L, slice.number());
+        assertEquals(1L, slice.pageRequest().page());
         assertEquals(6, slice.numberOfElements());
         assertEquals(1L, slice.pageRequest().page());
         assertEquals(6, slice.pageRequest().size());
@@ -4905,7 +4904,7 @@ public class DataTestServlet extends FATServlet {
 
         slice = primes.findByRomanNumeralEndsWithAndIdLessThan("II", 50L,
                                                                slice.nextPageRequest());
-        assertEquals(2L, slice.number());
+        assertEquals(2L, slice.pageRequest().page());
         assertEquals(3, slice.numberOfElements());
         assertEquals(2L, slice.pageRequest().page());
         assertEquals(6, slice.pageRequest().size());

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -696,7 +696,7 @@ public class DataJPATestServlet extends FATServlet {
                                              .map(b -> b.location.address.houseNum)
                                              .collect(Collectors.toList()));
 
-        assertEquals(3, page.number());
+        assertEquals(3, page.pageRequest().page());
 
         page = businesses.findByZipIn(zipCodes, page.nextPageRequest());
 
@@ -707,7 +707,7 @@ public class DataJPATestServlet extends FATServlet {
                                              .collect(Collectors.toList()));
 
         assertEquals(2, page.numberOfElements());
-        assertEquals(4, page.number());
+        assertEquals(4, page.pageRequest().page());
         assertEquals(null, page.nextPageRequest());
 
         page = businesses.findByZipIn(zipCodes, page.previousPageRequest());
@@ -718,7 +718,7 @@ public class DataJPATestServlet extends FATServlet {
                                              .map(b -> b.location.address.houseNum)
                                              .collect(Collectors.toList()));
 
-        assertEquals(3, page.number());
+        assertEquals(3, page.pageRequest().page());
     }
 
     /**

--- a/dev/io.openliberty.jakarta.data.1.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.data.1.0/bnd.bnd
@@ -28,6 +28,7 @@ Export-Package: \
   jakarta.data.metamodel;version="1.0.0",\
   jakarta.data.metamodel.impl;version="1.0.0",\
   jakarta.data.page;version="1.0.0",\
+  jakarta.data.page.impl;version="1.0.0",\
   jakarta.data.repository;version="1.0.0"
 
 instrument.classesExcludes: jakarta/data/*.class

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/PageRequest.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/PageRequest.java
@@ -27,6 +27,10 @@ public interface PageRequest<T> {
     }
 
     public interface Cursor {
+        public static Cursor forKeyset(Object... keysetValues) {
+            return new KeysetCursor(keysetValues);
+        }
+
         public List<?> elements();
 
         public Object getKeysetElement(int index);

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Slice.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Slice.java
@@ -22,8 +22,6 @@ import jakarta.data.Streamable;
 public interface Slice<T> extends Streamable<T> {
     List<T> content();
 
-    long number(); // from Spring Data and Micronaut. Not currently in Jakarta Data.
-
     int numberOfElements();
 
     PageRequest<T> pageRequest();

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/KeysetAwarePageRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/KeysetAwarePageRecord.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.page.impl;
+
+import java.util.Iterator;
+import java.util.List;
+
+import jakarta.data.page.KeysetAwarePage;
+import jakarta.data.page.PageRequest;
+import jakarta.data.page.PageRequest.Cursor;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+public record KeysetAwarePageRecord<T>(
+                List<T> content,
+                List<Cursor> cursors,
+                long totalElements,
+                PageRequest<T> pageRequest,
+                PageRequest<T> nextPageRequest,
+                PageRequest<T> previousPageRequest)
+                implements KeysetAwarePage<T> {
+
+    @Override
+    public Cursor getKeysetCursor(int i) {
+        return cursors.get(i);
+    }
+
+    @Override
+    public boolean hasContent() {
+        return !content.isEmpty();
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return content.iterator();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E> PageRequest<E> nextPageRequest(Class<E> entityClass) {
+        return (PageRequest<E>) nextPageRequest();
+    }
+
+    @Override
+    public int numberOfElements() {
+        return content.size();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E> PageRequest<E> pageRequest(Class<E> entityClass) {
+        return (PageRequest<E>) pageRequest;
+    }
+
+    @Override
+    public long totalPages() {
+        int maxPageSize = pageRequest.size();
+        return (totalElements + (maxPageSize - 1)) / maxPageSize;
+    }
+}

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/KeysetAwareSliceRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/KeysetAwareSliceRecord.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.page.impl;
+
+import java.util.Iterator;
+import java.util.List;
+
+import jakarta.data.page.KeysetAwareSlice;
+import jakarta.data.page.PageRequest;
+import jakarta.data.page.PageRequest.Cursor;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+public record KeysetAwareSliceRecord<T>(
+                List<T> content,
+                List<Cursor> cursors,
+                PageRequest<T> pageRequest,
+                PageRequest<T> nextPageRequest,
+                PageRequest<T> previousPageRequest)
+                implements KeysetAwareSlice<T> {
+
+    @Override
+    public Cursor getKeysetCursor(int i) {
+        return cursors.get(i);
+    }
+
+    @Override
+    public boolean hasContent() {
+        return !content.isEmpty();
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return content.iterator();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E> PageRequest<E> nextPageRequest(Class<E> entityClass) {
+        return (PageRequest<E>) nextPageRequest();
+    }
+
+    @Override
+    public int numberOfElements() {
+        return content.size();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E> PageRequest<E> pageRequest(Class<E> entityClass) {
+        return (PageRequest<E>) pageRequest;
+    }
+}

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/PageRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/PageRecord.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.page.impl;
+
+import java.util.Iterator;
+import java.util.List;
+
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+public record PageRecord<T>(PageRequest<T> pageRequest,
+                List<T> content,
+                long totalElements,
+                boolean moreResults)
+                implements Page<T> {
+
+    public PageRecord(PageRequest<T> req,
+                      List<T> content,
+                      long total) {
+        this(req, //
+             content, //
+             total, //
+             content.size() == req.size() && req.page() * req.size() < total);
+    }
+
+    @Override
+    public boolean hasContent() {
+        return !content.isEmpty();
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return content.iterator();
+    }
+
+    @Override
+    public PageRequest<T> nextPageRequest() {
+        if (moreResults)
+            return pageRequest.next();
+        else
+            return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E> PageRequest<E> nextPageRequest(Class<E> entityClass) {
+        return (PageRequest<E>) nextPageRequest();
+    }
+
+    @Override
+    public int numberOfElements() {
+        return content.size();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E> PageRequest<E> pageRequest(Class<E> entityClass) {
+        return (PageRequest<E>) pageRequest;
+    }
+
+    @Override
+    public long totalPages() {
+        int maxPageSize = pageRequest.size();
+        return (totalElements + (maxPageSize - 1)) / maxPageSize;
+    }
+}

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/SliceRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/SliceRecord.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.page.impl;
+
+import java.util.Iterator;
+import java.util.List;
+
+import jakarta.data.page.PageRequest;
+import jakarta.data.page.Slice;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+public record SliceRecord<T>(PageRequest<T> pageRequest,
+                List<T> content,
+                boolean moreResults)
+                implements Slice<T> {
+
+    public SliceRecord(PageRequest<T> req,
+                       List<T> content) {
+        this(req, //
+             content, //
+             req.size() == content.size());
+    }
+
+    @Override
+    public boolean hasContent() {
+        return !content.isEmpty();
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return content.iterator();
+    }
+
+    @Override
+    public PageRequest<T> nextPageRequest() {
+        if (moreResults)
+            return pageRequest.next();
+        else
+            return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E> PageRequest<E> nextPageRequest(Class<E> entityClass) {
+        return (PageRequest<E>) nextPageRequest();
+    }
+
+    @Override
+    public int numberOfElements() {
+        return content.size();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E> PageRequest<E> pageRequest(Class<E> entityClass) {
+        return (PageRequest<E>) pageRequest;
+    }
+}


### PR DESCRIPTION
Add the built-in slice/page implementations from the spec, along with the method to obtain a Cursor.
In the case of the latter, we can switch over to obtaining the Cursor instance from the spec and remove our own.
Also, I spotted an extra method for returning the page number that isn't in the spec, so I removed it and updated tests with an alternative way to obtain the page number that follows the spec.