### PR TITLE
Fix permissions in EJB FAT

### DIFF
--- a/dev/com.ibm.ws.couchdb_fat/publish/servers/com.ibm.ws.couchdb.fat.server/server.xml
+++ b/dev/com.ibm.ws.couchdb_fat/publish/servers/com.ibm.ws.couchdb.fat.server/server.xml
@@ -42,4 +42,7 @@
     <javaPermission codebase="${EktorpCodebase}" className="java.util.PropertyPermission" name="line.separator" actions="read"/>
     <javaPermission codebase="${EktorpCodebase}" className="java.util.PropertyPermission" name="com.fasterxml.jackson.*" actions="read"/>
 
+    <!-- Needed for com.ibm.ws.org.slf4j.api.jar -->
+    <javaPermission codebase="${EktorpCodebase}" className="java.util.PropertyPermission" name="slf4j.detectLoggerNameMismatch" actions="read"/>
+
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/test-applications/EJB3INJSATestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/test-applications/EJB3INJSATestApp.ear/resources/META-INF/permissions.xml
@@ -5,10 +5,11 @@
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
 
+    <!-- Permissions for ORB -->
     <permission>
         <class-name>java.util.PropertyPermission</class-name>
-        <name>line.separator</name>
-        <actions>read</actions>
+        <name>*</name>
+        <actions>read,write</actions>
     </permission> 
 
     <permission>

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/test-applications/EJB3INJSMTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/test-applications/EJB3INJSMTestApp.ear/resources/META-INF/permissions.xml
@@ -5,10 +5,11 @@
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
 
+    <!-- Permissions for ORB -->
     <permission>
         <class-name>java.util.PropertyPermission</class-name>
-        <name>line.separator</name>
-        <actions>read</actions>
+        <name>*</name>
+        <actions>read,write</actions>
     </permission> 
 
     <permission>

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/test-applications/EJB3INJSXTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/test-applications/EJB3INJSXTestApp.ear/resources/META-INF/permissions.xml
@@ -5,10 +5,11 @@
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
 
+    <!-- Permissions for ORB -->
     <permission>
         <class-name>java.util.PropertyPermission</class-name>
-        <name>line.separator</name>
-        <actions>read</actions>
+        <name>*</name>
+        <actions>read,write</actions>
     </permission> 
 
     <permission>

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/test-applications/LookupOverrideTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/test-applications/LookupOverrideTestApp.ear/resources/META-INF/permissions.xml
@@ -5,10 +5,11 @@
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
 
+    <!-- Permissions for ORB -->
     <permission>
         <class-name>java.util.PropertyPermission</class-name>
-        <name>line.separator</name>
-        <actions>read</actions>
+        <name>*</name>
+        <actions>read,write</actions>
     </permission> 
 
     <permission>

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/EJBinWARTestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/EJBinWARTestApp.ear/resources/META-INF/permissions.xml
@@ -4,13 +4,14 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
-<!--
+
+    <!-- Permissions for ORB -->
     <permission>
         <class-name>java.util.PropertyPermission</class-name>
-        <name>line.separator</name>
-        <actions>read</actions>
+        <name>*</name>
+        <actions>read,write</actions>
     </permission> 
--->
+
     <permission>
         <class-name>java.lang.RuntimePermission</class-name>
         <name>getClassLoader</name>


### PR DESCRIPTION
Several EJB FAT need to grant permissions to allow the ORB to read system properties when Java 2 security is enabled. Only an issue if the application accesses the ORB first, causing initialization.

Also a similar update for the CouchDB driver accessing a system property.
