### PR TITLE
Update tests to set orbSSLInitTimeout to not time out

### DIFF
--- a/dev/com.ibm.ws.javaee.7.0_fat/publish/servers/javaee7Full.simpleEar/server.xml
+++ b/dev/com.ibm.ws.javaee.7.0_fat/publish/servers/javaee7Full.simpleEar/server.xml
@@ -1,10 +1,10 @@
 <!--
-    Copyright (c) 2017, 2018 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
 
     Contributors:
@@ -26,4 +26,5 @@
          which requires a user registry.  The QSS element
          creates a simple one element user registry. -->
     <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 </server>

--- a/dev/com.ibm.ws.javaee.7.0_fat/publish/servers/javaee7Full.simpleWar/server.xml
+++ b/dev/com.ibm.ws.javaee.7.0_fat/publish/servers/javaee7Full.simpleWar/server.xml
@@ -1,10 +1,10 @@
 <!--
-    Copyright (c) 2017, 2018 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
    
     Contributors:
@@ -26,4 +26,5 @@
          which requires a user registry.  The QSS element
          creates a simple one element user registry. -->
     <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 </server>

--- a/dev/com.ibm.ws.javaee.8.0_fat/publish/servers/javaee8.fat/server.xml
+++ b/dev/com.ibm.ws.javaee.8.0_fat/publish/servers/javaee8.fat/server.xml
@@ -1,10 +1,10 @@
 <!--
-    Copyright (c) 2017, 2018 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
 
     Contributors:
@@ -28,6 +28,7 @@
     
     <keyStore id="defaultKeyStore" password="openliberty"/>
     <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 
     <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
     <javaPermission className="java.lang.RuntimePermission" name="getProtectionDomain"/>

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/ee10toMP/server.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/ee10toMP/server.xml
@@ -1,10 +1,10 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
    
     Contributors:
@@ -18,6 +18,15 @@
         <feature>mpHealth</feature>
     </featureManager>
     
+    <!-- jakartaee-10.0 includs ssl, which requires a keystore -->
+    <keyStore id="defaultKeyStore" password="yourPassword"/>
+
+    <!-- jakartaee-10.0 enables remote EJBs, which require an ORB,
+         which requires a user registry.  The QSS element
+         creates a simple one element user registry. -->
+    <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
+
     <include location="../fatTestCommon.xml"/>
 
 </server>

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/ee7toMP/server.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/ee7toMP/server.xml
@@ -1,10 +1,10 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
    
     Contributors:
@@ -19,5 +19,14 @@
     </featureManager>
     
     <include location="../fatTestCommon.xml"/>
+
+    <!-- javaee-7.0 includs ssl, which requires a keystore -->
+    <keyStore id="defaultKeyStore" password="yourPassword"/>
+
+    <!-- javaee-7.0 enables remote EJBs, which require an ORB,
+         which requires a user registry.  The QSS element
+         creates a simple one element user registry. -->
+    <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 
 </server>

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/ee8toMP/server.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/ee8toMP/server.xml
@@ -1,10 +1,10 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
    
     Contributors:
@@ -18,6 +18,15 @@
         <feature>mpHealth</feature>
     </featureManager>
     
+    <!-- javaee-8.0 includs ssl, which requires a keystore -->
+    <keyStore id="defaultKeyStore" password="yourPassword"/>
+
+    <!-- javaee-8.0 enables remote EJBs, which require an ORB,
+         which requires a user registry.  The QSS element
+         creates a simple one element user registry. -->
+    <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
+
     <include location="../fatTestCommon.xml"/>
 
 </server>

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/ee9toMP/server.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/ee9toMP/server.xml
@@ -1,10 +1,10 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
    
     Contributors:
@@ -18,6 +18,15 @@
         <feature>mpHealth</feature>
     </featureManager>
     
+    <!-- jakartaee-9.1 includs ssl, which requires a keystore -->
+    <keyStore id="defaultKeyStore" password="yourPassword"/>
+
+    <!-- jakartaee-9.1 enables remote EJBs, which require an ORB,
+         which requires a user registry.  The QSS element
+         creates a simple one element user registry. -->
+    <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
+
     <include location="../fatTestCommon.xml"/>
 
 </server>

--- a/dev/com.ibm.ws.transport.iiop.open_fat/publish/servers/bowlingball/server.xml
+++ b/dev/com.ibm.ws.transport.iiop.open_fat/publish/servers/bowlingball/server.xml
@@ -11,4 +11,5 @@
     </featureManager>
     <quickStartSecurity userName="Bob" userPassword="bobpwd" />
     <keyStore id="defaultKeyStore" password="passw0rd" />
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 </server>

--- a/dev/io.openliberty.jakartaee10.internal_fat/publish/servers/jakartaee10.fat/server.xml
+++ b/dev/io.openliberty.jakartaee10.internal_fat/publish/servers/jakartaee10.fat/server.xml
@@ -1,10 +1,10 @@
 <!--
-    Copyright (c) 2017, 2021 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
 
     Contributors:
@@ -28,6 +28,7 @@
     
     <keyStore id="defaultKeyStore" password="openliberty"/>
     <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 
     <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/io.openliberty.jakartaee9.internal_fat/publish/servers/jakartaee9.fat/server.xml
+++ b/dev/io.openliberty.jakartaee9.internal_fat/publish/servers/jakartaee9.fat/server.xml
@@ -1,10 +1,10 @@
 <!--
-    Copyright (c) 2017, 2021 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
 
     Contributors:
@@ -28,6 +28,7 @@
     
     <keyStore id="defaultKeyStore" password="openliberty"/>
     <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 
     <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/io.openliberty.jee.internal_fat/publish/servers/simpleEar/server.xml
+++ b/dev/io.openliberty.jee.internal_fat/publish/servers/simpleEar/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023 IBM Corporation and others.
+    Copyright (c) 2023, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -24,4 +24,5 @@
          which requires a user registry.  The QSS element
          creates a simple one element user registry. -->
     <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 </server>

--- a/dev/io.openliberty.jee.internal_fat/publish/servers/simpleWar/server.xml
+++ b/dev/io.openliberty.jee.internal_fat/publish/servers/simpleWar/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023 IBM Corporation and others.
+    Copyright (c) 2023, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -24,4 +24,5 @@
          which requires a user registry.  The QSS element
          creates a simple one element user registry. -->
     <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 </server>

--- a/dev/io.openliberty.microprofile.internal_fat/publish/servers/MPCompatibleServer/MP40andEE8.xml
+++ b/dev/io.openliberty.microprofile.internal_fat/publish/servers/MPCompatibleServer/MP40andEE8.xml
@@ -9,4 +9,5 @@
     
     <keyStore id="defaultKeyStore" password="openliberty"/>
     <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 </server>

--- a/dev/io.openliberty.microprofile5.internal_fat/publish/servers/MP5CompatibleServer/MP50andEE9.xml
+++ b/dev/io.openliberty.microprofile5.internal_fat/publish/servers/MP5CompatibleServer/MP50andEE9.xml
@@ -9,4 +9,5 @@
     
     <keyStore id="defaultKeyStore" password="openliberty"/>
     <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 </server>

--- a/dev/io.openliberty.microprofile6.internal_fat/publish/servers/MP6andEE10/server.xml
+++ b/dev/io.openliberty.microprofile6.internal_fat/publish/servers/MP6andEE10/server.xml
@@ -9,4 +9,5 @@
     
     <keyStore id="defaultKeyStore" password="openliberty"/>
     <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 </server>

--- a/dev/io.openliberty.microprofile61.internal_fat/publish/servers/MP61andEE10/server.xml
+++ b/dev/io.openliberty.microprofile61.internal_fat/publish/servers/MP61andEE10/server.xml
@@ -9,4 +9,5 @@
     
     <keyStore id="defaultKeyStore" password="openliberty"/>
     <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
 </server>


### PR DESCRIPTION
- Update tests that use the ORB and have SSL enabled for initial server startup where we end up generating the key store and it can take longer than the default 10 seconds
- Update com.ibm.ws.kernel.feature.resolver_fat tests to also include the required settings for a user registry so that the test doesn't fail complaining about the missing user registry when starting the ORB.

#build