### PR TITLE
Increase appMgr startTimeout for server checkpointFaces-backendServices

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-backendServices/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-backendServices/server.xml
@@ -16,6 +16,8 @@
   <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
                 id="defaultHttpEndpoint" host="*" />
 
+  <applicationManager startTimeout="60s" />
+
   <application location="backendServices.war" type="war" context-root="/"></application>
 
   <!-- Derby Library Configuration -->


### PR DESCRIPTION
Fixes RTC 299197

Allow more time for the application to start before the test server starts the checkpoint.