### PR TITLE
metadata for ManagedThreadFactory beans

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedThreadFactoryService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedThreadFactoryService.java
@@ -292,9 +292,10 @@ public class ManagedThreadFactoryService implements ResourceFactory, Application
                             throw new IllegalStateException("Web module " + mData.getJ2EEName() + " is not available."); // TODO NLS
                     }
                 } else {
-                    // TODO implement
-                    throw new UnsupportedOperationException("Managed thread factory definitions are not supported in " +
-                                                            "application.xml yet. Metadata: " + metadata);
+                    // Should be unreachable because mock ComponentMetaData is created for resources defined in application.xml.
+                    throw new UnsupportedOperationException("A ManagedThreadFactory resource defined is in the " +
+                                                            metadata.getName() + " application artifact with " +
+                                                            metadata.getClass().getName() + " metadata.");
                 }
 
                 appName = cData.getJ2EEName().getApplication();

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -154,6 +154,11 @@ public class ConcurrentCDITest extends FATServletClient {
     }
 
     @Test
+    public void testInjectManagedThreadFactoryQualifiedFromAppDD() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
     public void testInjectManagedThreadFactoryQualifiedFromWebDD() throws Exception {
         runTest(server, APP_NAME, testName);
     }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/resources/META-INF/application.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/resources/META-INF/application.xml
@@ -28,6 +28,16 @@
     <ejb>concurrentCDIEJB.jar</ejb>
   </module>
 
+  <!-- ENV ENTRIES -->
+
+  <env-entry>
+    <env-entry-name>java:app/env/entry1</env-entry-name>
+    <env-entry-type>java.lang.String</env-entry-type>
+    <env-entry-value>value1</env-entry-value>
+  </env-entry>
+
+  <!-- resource definitions -->
+
   <context-service>
     <name>java:app/concurrent/with-location-and-without-app-context</name>
     <qualifier>concurrent.cdi.ejb.ClearingAppContext</qualifier>
@@ -37,5 +47,19 @@
     <propagated>Location</propagated>
     <unchanged>Remaining</unchanged>
   </context-service>
+
+  <managed-thread-factory>
+    <name>java:app/concurrent/thread-factory-app-dd-with-app-context</name>
+    <qualifier>concurrent.cdi.ejb.PropagatingAppContext</qualifier>
+    <context-service-ref>java:app/concurrent/with-app-context</context-service-ref>
+    <priority>1</priority>
+  </managed-thread-factory>
+
+  <managed-thread-factory>
+    <name>java:app/concurrent/thread-factory-app-dd-without-app-context</name>
+    <qualifier>concurrent.cdi.ejb.ClearingAppContext</qualifier>
+    <context-service-ref>java:app/concurrent/with-location-and-tx-context</context-service-ref>
+    <priority>2</priority>
+  </managed-thread-factory>
 
 </application>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/PropagatingAppContext.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/PropagatingAppContext.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.ejb;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface PropagatingAppContext {
+
+    public static class Literal extends AnnotationLiteral<PropagatingAppContext> implements PropagatingAppContext {
+        private static final long serialVersionUID = 1L;
+
+        public static final PropagatingAppContext INSTANCE = new Literal();
+
+        private Literal() {
+        }
+    }
+}

--- a/dev/io.openliberty.concurrent.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.concurrent.internal.cdi/bnd.bnd
@@ -29,11 +29,13 @@ Import-Package: \
 
 Private-Package: \
   io.openliberty.concurrent.internal.cdi.*,\
+  io.openliberty.concurrent.internal.cdi.metadata,\
   io.openliberty.concurrent.internal.cdi.resources.*
 
 -cdiannotations:
 
--dsannotations: io.openliberty.concurrent.internal.cdi.ConcurrencyExtensionMetadata
+-dsannotations: io.openliberty.concurrent.internal.cdi.ConcurrencyExtensionMetadata,\
+                io.openliberty.concurrent.internal.cdi.metadata.MTFDeferredMetaDataFactory
 
 instrument.classesExcludes: io/openliberty/concurrent/internal/cdi/resources/*.class
 
@@ -45,6 +47,7 @@ instrument.classesExcludes: io/openliberty/concurrent/internal/cdi/resources/*.c
   com.ibm.wsspi.org.osgi.service.component.annotations,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.cdi.interfaces.jakarta;version=latest, \
+  com.ibm.ws.classloading,\
   com.ibm.ws.concurrent,\
   com.ibm.ws.container.service;version=latest,\
   com.ibm.ws.context,\

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.ws.cdi.extension.CDIExtensionMetadataInternal;
+import com.ibm.ws.container.service.metadata.extended.DeferredMetaDataFactory;
 import com.ibm.ws.javaee.version.JavaEEVersion;
 import com.ibm.wsspi.resource.ResourceFactory;
 
@@ -85,6 +86,12 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
      * Jakarta EE version.
      */
     public static Version eeVersion;
+
+    /**
+     * Creates dummy component metadata for ManagedThreadFactories based on the application metadata.
+     */
+    @Reference(target = "(deferredMetaData=MTF)")
+    public volatile DeferredMetaDataFactory mtfMetadataFactory;
 
     /**
      * Maintains associations of qualifiers to resource factory for

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/metadata/MTFComponentMetaData.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/metadata/MTFComponentMetaData.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.concurrent.internal.cdi.metadata;
+
+import com.ibm.websphere.csi.J2EEName;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.container.service.metadata.extended.IdentifiableComponentMetaData;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.MetaDataImpl;
+import com.ibm.ws.runtime.metadata.ModuleMetaData;
+
+/**
+ * Dummy ComponentMetaData for a module or application.
+ * This metadata is used as the application context for a ManagedThreadFactory.
+ */
+class MTFComponentMetaData extends MetaDataImpl implements ComponentMetaData, IdentifiableComponentMetaData {
+
+    final ClassLoader classLoader;
+    private final String identifier;
+    private final ModuleMetaData moduleMetadata;
+
+    MTFComponentMetaData(String identifier, ModuleMetaData metadata, ClassLoader classLoader) {
+        super(0);
+
+        this.classLoader = classLoader;
+        this.identifier = identifier;
+        this.moduleMetadata = metadata;
+    }
+
+    @Override
+    @Trivial
+    public J2EEName getJ2EEName() {
+        return moduleMetadata.getJ2EEName();
+    }
+
+    @Override
+    public ModuleMetaData getModuleMetaData() {
+        return moduleMetadata;
+    }
+
+    @Override
+    public String getName() {
+        return moduleMetadata.getJ2EEName().toString();
+    }
+
+    @Override
+    public String getPersistentIdentifier() {
+        return identifier;
+    }
+}

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/metadata/MTFDeferredMetaDataFactory.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/metadata/MTFDeferredMetaDataFactory.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.concurrent.internal.cdi.metadata;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.service.component.annotations.Component;
+
+import com.ibm.websphere.csi.J2EEName;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.container.service.metadata.extended.DeferredMetaDataFactory;
+import com.ibm.ws.runtime.metadata.ApplicationMetaData;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.MetaData;
+import com.ibm.ws.runtime.metadata.ModuleMetaData;
+
+/**
+ * Factory for dummy ComponentMetaData for a module or application.
+ * This metadata is used as the application context for a ManagedThreadFactory.
+ */
+@Component(service = DeferredMetaDataFactory.class,
+           property = { "deferredMetaData=MTF" })
+public class MTFDeferredMetaDataFactory implements DeferredMetaDataFactory {
+
+    private final ConcurrentHashMap<String, MTFComponentMetaData> metadatas = new ConcurrentHashMap<>();
+
+    public ComponentMetaData createComponentMetadata(MetaData metadata, ClassLoader classLoader) {
+        J2EEName jeeName;
+        ModuleMetaData moduleMetadata;
+
+        if (metadata instanceof ModuleMetaData) {
+            moduleMetadata = (ModuleMetaData) metadata;
+            jeeName = moduleMetadata.getJ2EEName();
+        } else if (metadata instanceof ApplicationMetaData) {
+            ApplicationMetaData adata = (ApplicationMetaData) metadata;
+            jeeName = adata.getJ2EEName();
+            moduleMetadata = new MTFModuleMetaData(jeeName, adata);
+        } else {
+            throw new IllegalArgumentException(metadata == null ? null : metadata.getClass().getName());
+        }
+
+        String identifier = "MTF#" + jeeName;
+
+        MTFComponentMetaData componentMetadata = new MTFComponentMetaData(identifier, moduleMetadata, classLoader);
+        MTFComponentMetaData existing = metadatas.putIfAbsent(identifier, componentMetadata);
+        return existing == null ? componentMetadata : existing;
+    }
+
+    @Override
+    public ComponentMetaData createComponentMetaData(String identifier) {
+        return metadatas.get(identifier);
+    }
+
+    @Override
+    public ClassLoader getClassLoader(ComponentMetaData metadata) {
+        return metadata instanceof MTFComponentMetaData ? ((MTFComponentMetaData) metadata).classLoader : null;
+    }
+
+    @Override
+    public String getMetaDataIdentifier(String appName, String moduleName, String componentName) {
+        StringBuilder b = new StringBuilder("MTF#").append(appName);
+        if (moduleName != null)
+            b.append('#').append(moduleName);
+        if (componentName != null)
+            b.append('#').append(componentName);
+        return b.toString();
+    }
+
+    @Override
+    @Trivial
+    public void initialize(ComponentMetaData metadata) throws IllegalStateException {
+    }
+}

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/metadata/MTFModuleMetaData.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/metadata/MTFModuleMetaData.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.concurrent.internal.cdi.metadata;
+
+import com.ibm.websphere.csi.J2EEName;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.runtime.metadata.ApplicationMetaData;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.MetaDataImpl;
+import com.ibm.ws.runtime.metadata.ModuleMetaData;
+
+/**
+ * Dummy ModuleMetaData for a module or application.
+ * This metadata is used as part of the application context for a ManagedThreadFactory.
+ */
+class MTFModuleMetaData extends MetaDataImpl implements ModuleMetaData {
+    private final ApplicationMetaData appMetadata;
+    private final J2EEName jeeName;
+
+    MTFModuleMetaData(J2EEName jeeName, ApplicationMetaData appMetadata) {
+        super(0);
+
+        this.appMetadata = appMetadata;
+        this.jeeName = jeeName;
+    }
+
+    @Override
+    public ApplicationMetaData getApplicationMetaData() {
+        return appMetadata;
+    }
+
+    @Override
+    public ComponentMetaData[] getComponentMetaDatas() {
+        return null;
+    }
+
+    @Override
+    @Trivial
+    public J2EEName getJ2EEName() {
+        return jeeName;
+    }
+
+    @Override
+    public String getName() {
+        return jeeName.toString();
+    }
+}

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/metadata/package-info.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/metadata/package-info.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "concurrent", messageBundle = "io.openliberty.concurrent.internal.resources.CWWKCMessages")
+package io.openliberty.concurrent.internal.cdi.metadata;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;


### PR DESCRIPTION
managed-thread-factory from application.xml as well as default instances for the application need to have component metadata that corresponds to the application rather than randomly choosing a module/component or it being absent.  This will allow lookups from java:app.  This pull does not cover the classloader, which we will need to figure out separately how to obtain.