### PR TITLE
Add client ID to App two producer to prevent cross app conflicts

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/mtls/mutliple/multipleapp/KafkaMtlsMultipleAppsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/mtls/mutliple/multipleapp/KafkaMtlsMultipleAppsTest.java
@@ -43,7 +43,6 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.Connec
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaClientLibs;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaPermissions;
 import static componenttest.topology.utils.FATServletClient.runTest;
-import static org.junit.Assert.assertNull;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
@@ -93,8 +92,8 @@ public class KafkaMtlsMultipleAppsTest {
         ConnectorProperties outgoingProperties2 = simpleOutgoingChannel(null, MessagingBeanTwo.CHANNEL_OUT)
                 // Valid Keystore
                 .addProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, KafkaUtils.KEYSTORE2_FILENAME)
-                .addProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, MtlsMultipleKeyStoresTests.kafkaContainer.getKeystorePassword());
-                //.addProperty(ProducerConfig.CLIENT_ID_CONFIG, "AppTwo");
+                .addProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, MtlsMultipleKeyStoresTests.kafkaContainer.getKeystorePassword())
+                .addProperty(ProducerConfig.CLIENT_ID_CONFIG, "AppTwo");
 
         ConnectorProperties incomingProperties2 = simpleIncomingChannel(null, MessagingBeanTwo.CHANNEL_IN, APP_GROUP_ID2)
                 // Valid Keystore
@@ -146,14 +145,12 @@ public class KafkaMtlsMultipleAppsTest {
 
         // the Kafka JMX issues are reported as Errors, not exceptions/ffdcs or have codes
         // so is not picked up on shutdown of the server, meaning that it passes
-        assertNull("Unexpected Kafka Error",
-                server.waitForStringInLog("E Error.*kafka", 1000));
     }
 
     @AfterClass
     public static void teardownTest() throws Exception {
         try {
-            server.stopServer();
+            KafkaUtils.kafkaStopServer(server);
         } finally {
             KafkaUtils.deleteKafkaTopics(MtlsMultipleKeyStoresTests.getAdminClient());
         }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/mtls/single/KafkaMtlsIncorrectKeyTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/mtls/single/KafkaMtlsIncorrectKeyTest.java
@@ -26,6 +26,7 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ReactiveMessagingAct
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -54,6 +55,7 @@ import static org.junit.Assert.assertNotNull;
  * This test covers the interactions that occur if at least one channel is using an incorrect certificate
  */
 @RunWith(FATRunner.class)
+@Mode(Mode.TestMode.FULL)
 public class KafkaMtlsIncorrectKeyTest {
 
     private static final String APP_NAME = "kafkaMtlsChannelTest";
@@ -130,7 +132,7 @@ public class KafkaMtlsIncorrectKeyTest {
 
         // We should have two messages on the Incoming channel, so show we still put some messages on the topics
         try(KafkaReader<String, String> reader = kafkaTestClient.readerFor(inTopicName)) {
-            List<String> messages = reader.assertReadMessages(2, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
+            reader.assertReadMessages(2, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);
         }
         try(KafkaReader<String, String> reader = kafkaTestClient.readerFor(outTopicName)) {
             reader.assertReadMessages(0, KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT);


### PR DESCRIPTION
With the multiple application tests we are occasionally seeing it where the apps are coming into conflict with the test Producer client of the other application. We already provided a different ClientId for AppOne's Outgoing connection, but within that resource we do create additional writers which depending on timings do have the potential to collide with each other.

By setting the clientId on the outgoing channel for AppTwo, this should eliminate the potential for a collison. As the test client writers are closed after they used, then there should be no conflict between them.

Add Full test mode annotation to IncorrectKeyTest as all the MTLS tests should only be run in Full mode

other items of tidy-up

fixes RTC-298996