### PR TITLE
server script not working on IBM i after verbose:gc changes

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1118,7 +1118,7 @@ serverCmd()
   # Check for any verbose:gc variable set by user
   # By default we set this to be true unless user specifies otherwise
   # if [ ! jvmargs, javaoptions, jvmoptionsquoted contains verbose:gc, verbosegc, etc] then SERVER_IBM_JAVA_OPTIONS += -Xverbosegclog:verbosegc.%seq.log,10,1024
-  if [ -n "${JVM_OPTIONS_QUOTED##*"verbosegc"*}" ] && [ -n "${JVM_OPTIONS_QUOTED##*"verbose:gc"*}"  ] && ! [ "${VERBOSEGC}" = "false" ]
+  if [ -n "${JVM_OPTIONS_QUOTED##*"verbosegc"*}" ] && [ -n "${JVM_OPTIONS_QUOTED##*"verbose:gc"*}"  ] && [ ! "${VERBOSEGC}" = "false" ]
   then
     OPENJ9_JAVA_OPTIONS="-Xverbosegclog:${X_LOG_DIR}/verbosegc.%seq.log,10,1024 ${OPENJ9_JAVA_OPTIONS}"
   fi


### PR DESCRIPTION
On IBM i, with the changes introduced to the server command line script in PR https://github.com/OpenLiberty/open-liberty/pull/26215, the server command with any option fails on 24.0.0.3 with this error:

server: 001-0050 Syntax error on line 1121: token "!" not expected.

The problematic line (1121) in question is:

`if [ -n "${JVM_OPTIONS_QUOTED##*"verbosegc"*}" ] && [ -n "${JVM_OPTIONS_QUOTED##*"verbose:gc"*}"  ] && ! [ "${VERBOSEGC}" = "false" ]`

Changing it to:

`if [ -n "${JVM_OPTIONS_QUOTED##*"verbosegc"*}" ] && [ -n "${JVM_OPTIONS_QUOTED##*"verbose:gc"*}"  ] && [ ! "${VERBOSEGC}" = "false" ]`

Removes that issue.

Steps to Reproduce
Install Liberty 24.0.0.3 and attempt to use the server command.

Expected behavior
The server command should function correctly.

Diagnostic information:

    OpenLiberty Version: 24.0.0.3
    Affected feature(s) All
    Java Version: N/A
