### PR TITLE
force order of JUnit tests

### DIFF
--- a/dev/com.ibm.ws.os.packaging_fat/fat/src/com/ibm/ws/os/packaging/fat/InstallRhelTest.java
+++ b/dev/com.ibm.ws.os.packaging_fat/fat/src/com/ibm/ws/os/packaging/fat/InstallRhelTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -40,6 +40,7 @@ public class InstallRhelTest extends InstallUtilityToolTest {
             createServerEnv();
         } else {
             logger.info("OpenLiberty did not install successfully");
+            Assume.assumeTrue(openLibExists);
         }
     }
 
@@ -62,90 +63,72 @@ public class InstallRhelTest extends InstallUtilityToolTest {
     @Test
     public void testVerifyRpmInstall() throws Exception {
 
-        if (openLibExists) {
-            String METHOD_NAME = "testVerifyRpmInstall";
-            entering(c, METHOD_NAME);
-
-            String[] param1s = { "-qi", "openliberty" };
-            ProgramOutput po = runCommand(METHOD_NAME, "rpm", param1s);
-            assertEquals("Expected exit code", 0, po.getReturnCode());
-            exiting(c, METHOD_NAME);
-        } else {
-            logger.info("OpenLiberty did not install successfully");
-        }
-    }
-
-    @Test
-    public void testServices() throws Exception {
-
-        String METHOD_NAME = "testServices";
+        String METHOD_NAME = "testVerifyRpmInstall";
         entering(c, METHOD_NAME);
+
+        String[] param1s = { "-qi", "openliberty" };
+        ProgramOutput po = runCommand(METHOD_NAME, "rpm", param1s);
+        assertEquals("Expected exit code", 0, po.getReturnCode());
+
+        // testServices
         // append JAVA_HOME to server.env
         //sudo sh -c 'echo line > file'
 
-        String[] param1j = { "sh -c ", " 'echo JAVA_HOME=" + javaHome + " >> /opt/ol/etc/server.env'" };
-        ProgramOutput po1j = runCommand(METHOD_NAME, "sudo ", param1j);
-        Log.info(c, METHOD_NAME, "setup server.env permissions RC:" + po1j.getReturnCode());
+        String[] paramSetJavaHome = { "sh -c ", " 'echo JAVA_HOME=" + javaHome + " >> /opt/ol/etc/server.env'" };
+        ProgramOutput poSetJavaHome = runCommand(METHOD_NAME, "sudo ", paramSetJavaHome);
+        Log.info(c, METHOD_NAME, "setup server.env permissions RC:" + poSetJavaHome.getReturnCode());
 
         // Output contents of server.env
         Log.info(c, METHOD_NAME, "Contents of opt/ol/etc/server.env");
-        String[] param2b = { "cat", "/opt/ol/etc/server.env" };
-        ProgramOutput po2b = runCommand(METHOD_NAME, "sudo ", param2b);
+        String[] paramCatServerEnv = { "cat", "/opt/ol/etc/server.env" };
+        ProgramOutput poCatServerEnv = runCommand(METHOD_NAME, "sudo ", paramCatServerEnv);
 
         // service tests
         Log.info(c, METHOD_NAME, "Starting defaultServer");
-        ProgramOutput po2 = serviceCommand(METHOD_NAME, "start", "defaultServer");
+        ProgramOutput poServerStart = serviceCommand(METHOD_NAME, "start", "defaultServer");
         TimeUnit.SECONDS.sleep(2);
-        ProgramOutput po2a = serviceCommand(METHOD_NAME, "status", "defaultServer");
+        ProgramOutput poServerStatus1 = serviceCommand(METHOD_NAME, "status", "defaultServer");
 
         Log.info(c, METHOD_NAME, "Stopping defaultServer");
-        ProgramOutput po3 = serviceCommand(METHOD_NAME, "stop", "defaultServer");
+        ProgramOutput poServerStop1 = serviceCommand(METHOD_NAME, "stop", "defaultServer");
         TimeUnit.SECONDS.sleep(2);
-        ProgramOutput po3a = serviceCommand(METHOD_NAME, "status", "defaultServer");
+        ProgramOutput poServerStatus2 = serviceCommand(METHOD_NAME, "status", "defaultServer");
 
         Log.info(c, METHOD_NAME, "Re-starting defaultServer");
-        ProgramOutput po4 = serviceCommand(METHOD_NAME, "restart", "defaultServer");
+        ProgramOutput poServerRestart = serviceCommand(METHOD_NAME, "restart", "defaultServer");
         TimeUnit.SECONDS.sleep(2);
-        ProgramOutput po4a = serviceCommand(METHOD_NAME, "status", "defaultServer");
+        ProgramOutput poServerStatus3 = serviceCommand(METHOD_NAME, "status", "defaultServer");
 
         Log.info(c, METHOD_NAME, "Stopping defaultServer");
-        ProgramOutput po5 = serviceCommand(METHOD_NAME, "stop", "defaultServer");
+        ProgramOutput poServerStop2 = serviceCommand(METHOD_NAME, "stop", "defaultServer");
 
         Log.info(c, METHOD_NAME, "Test Results Summary:\n"
                                  + "===================="
-                                 + "start defaultServer.service RC2:" + po2.getReturnCode() + "\n"
-                                 + "status defaultServer.service RC2a:" + po2a.getReturnCode() + "\n"
-                                 + "stop defaultServer.service RC3:" + po3.getReturnCode() + "\n"
-                                 + "status defaultServer.service RC3a:" + po3a.getReturnCode() + "\n"
-                                 + "restart defaultServer.service RC4:" + po4.getReturnCode() + "\n"
-                                 + "status defaultServer.service RC4a:" + po4a.getReturnCode() + "\n"
-                                 + "stop defaultServer.service RC5:" + po5.getReturnCode() + "\n");
+                                 + "start defaultServer.service RC2:" + poServerStart.getReturnCode() + "\n"
+                                 + "status defaultServer.service RC2a:" + poServerStatus1.getReturnCode() + "\n"
+                                 + "stop defaultServer.service RC3:" + poServerStop1.getReturnCode() + "\n"
+                                 + "status defaultServer.service RC3a:" + poServerStatus2.getReturnCode() + "\n"
+                                 + "restart defaultServer.service RC4:" + poServerRestart.getReturnCode() + "\n"
+                                 + "status defaultServer.service RC4a:" + poServerStatus3.getReturnCode() + "\n"
+                                 + "stop defaultServer.service RC5:" + poServerStop2.getReturnCode() + "\n");
 
-        Boolean testsPassed = ((po2.getReturnCode() == 0) && (po3.getReturnCode() == 0) && (po4.getReturnCode() == 0)
-                               && (po5.getReturnCode() == 0));
+        Boolean testsPassed = ((poServerStart.getReturnCode() == 0) && (poServerStop1.getReturnCode() == 0) && (poServerRestart.getReturnCode() == 0)
+                               && (poServerStop2.getReturnCode() == 0));
         Assert.assertTrue("Non zero return code in service test case. "
-                          + "start defaultServer.service RC2:" + po2.getReturnCode() + "\n"
-                          + "status defaultServer.service RC2a:" + po2a.getReturnCode() + "\n"
-                          + "stop defaultServer.service RC3:" + po3.getReturnCode() + "\n"
-                          + "status defaultServer.service RC3a:" + po3a.getReturnCode() + "\n"
-                          + "restart defaultServer.service RC4:" + po4.getReturnCode() + "\n"
-                          + "status defaultServer.service RC4a:" + po4a.getReturnCode() + "\n"
-                          + "stop defaultServer.service RC5:" + po5.getReturnCode() + "\n", testsPassed);
-    }
+                          + "start defaultServer.service RC2:" + poServerStart.getReturnCode() + "\n"
+                          + "status defaultServer.service RC2a:" + poServerStatus1.getReturnCode() + "\n"
+                          + "stop defaultServer.service RC3:" + poServerStop1.getReturnCode() + "\n"
+                          + "status defaultServer.service RC3a:" + poServerStatus2.getReturnCode() + "\n"
+                          + "restart defaultServer.service RC4:" + poServerRestart.getReturnCode() + "\n"
+                          + "status defaultServer.service RC4a:" + poServerStatus3.getReturnCode() + "\n"
+                          + "stop defaultServer.service RC5:" + poServerStop2.getReturnCode() + "\n", testsPassed);
 
-    @Test
-    public void testUninstallRpm() throws Exception {
+        // testUninstall
+        String[] param1u = { "remove", "-y", "openliberty" };
+        ProgramOutput poUninstall = runCommand(METHOD_NAME, "sudo yum", param1u);
+        assertEquals("Expected exit code", 0, poUninstall.getReturnCode());
 
-        if (openLibExists) {
-            String METHOD_NAME = "testUninstallRpm";
-            entering(c, METHOD_NAME);
+        exiting(c, METHOD_NAME);
 
-            String[] param1s = { "remove", "-y", "openliberty" };
-            ProgramOutput po = runCommand(METHOD_NAME, "sudo yum", param1s);
-            assertEquals("Expected exit code", 0, po.getReturnCode());
-            exiting(c, METHOD_NAME);
-        } else {
-            logger.info("OpenLiberty did not install successfully");
-        }
     }
 }

--- a/dev/com.ibm.ws.os.packaging_fat/fat/src/com/ibm/ws/os/packaging/fat/InstallUbuntuTest.java
+++ b/dev/com.ibm.ws.os.packaging_fat/fat/src/com/ibm/ws/os/packaging/fat/InstallUbuntuTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -42,6 +42,7 @@ public class InstallUbuntuTest extends InstallUtilityToolTest {
             createServerEnv();
         } else {
             logger.info("OpenLiberty did not install successfully");
+            Assume.assumeTrue(openLibExists);
         }
     }
 
@@ -61,118 +62,79 @@ public class InstallUbuntuTest extends InstallUtilityToolTest {
         }
     }
 
-//    @Test
-    public void testJavaInstall() throws Exception {
-        if (openLibExists) {
-            String METHOD_NAME = "testJavaInstall";
-            entering(c, METHOD_NAME);
-
-            String[] param1s = { "install", "-y", "default-jdk" }; //any java works
-            ProgramOutput po = runCommand(METHOD_NAME, "sudo apt-get", param1s);
-            assertEquals("Expected exit code", 0, po.getReturnCode()); //if already installed, exit is 0
-            exiting(c, METHOD_NAME);
-        } else {
-            logger.info("OpenLiberty did not install successfully");
-        }
-
-    }
-
     @Test
     public void testVerifyDebInstall() throws Exception {
+        String METHOD_NAME = "testVerifyDebInstall";
+        entering(c, METHOD_NAME);
 
-        if (openLibExists) {
-            String METHOD_NAME = "testVerifyDebInstall";
-            entering(c, METHOD_NAME);
+        //check Open Liberty was installed
 
-            String[] param1s = { "-s", "openliberty" };
-            ProgramOutput po = runCommand(METHOD_NAME, "dpkg", param1s);
-            assertEquals("Expected exit code", 0, po.getReturnCode());
-            String output = po.getStdout();
-            assertTrue("Should contain installed status",
-                       output.indexOf("Status: install ok installed") >= 0);
-            exiting(c, METHOD_NAME);
-        } else {
-            logger.info("OpenLiberty did not install successfully");
-        }
-    }
+        String[] paramInstallStatus = { "-s", "openliberty" };
+        ProgramOutput poInstallStatus = runCommand(METHOD_NAME, "dpkg", paramInstallStatus);
+        assertEquals("Expected exit code", 0, poInstallStatus.getReturnCode());
+        String output = poInstallStatus.getStdout();
+        assertTrue("Should contain installed status",
+                   output.indexOf("Status: install ok installed") >= 0);
 
-    @Test
-    public void testServices() throws Exception {
+        // test Open Liberty services
+        // append JAVA_HOME to server.env
+        //sudo sh -c 'echo line > file'
 
-        if (openLibExists) {
+        String[] paramSetJavaHome = { "sh -c ", " 'echo JAVA_HOME=" + javaHome + " >> /opt/ol/etc/server.env'" };
+        ProgramOutput poSetJavaHome = runCommand(METHOD_NAME, "sudo ", paramSetJavaHome);
+        Log.info(c, METHOD_NAME, "setup server.env permissions RC:" + poSetJavaHome.getReturnCode());
 
-            String METHOD_NAME = "testServices";
-            entering(c, METHOD_NAME);
-            // append JAVA_HOME to server.env
-            //sudo sh -c 'echo line > file'
+        // Output contents of server.env
+        Log.info(c, METHOD_NAME, "Contents of opt/ol/etc/server.env");
+        String[] paramCatServerEnv = { "cat", "/opt/ol/etc/server.env" };
+        ProgramOutput poCatServerEnv = runCommand(METHOD_NAME, "sudo ", paramCatServerEnv);
 
-            String[] param1j = { "sh -c ", " 'echo JAVA_HOME=" + javaHome + " >> /opt/ol/etc/server.env'" };
-            ProgramOutput po1j = runCommand(METHOD_NAME, "sudo ", param1j);
-            Log.info(c, METHOD_NAME, "setup server.env permissions RC:" + po1j.getReturnCode());
+        // service tests
+        Log.info(c, METHOD_NAME, "Starting defaultServer");
+        ProgramOutput poServerStart = serviceCommand(METHOD_NAME, "start", "defaultServer");
+        TimeUnit.SECONDS.sleep(2);
+        ProgramOutput poServerStatus1 = serviceCommand(METHOD_NAME, "status", "defaultServer");
 
-            // Output contents of server.env
-            Log.info(c, METHOD_NAME, "Contents of opt/ol/etc/server.env");
-            String[] param2b = { "cat", "/opt/ol/etc/server.env" };
-            ProgramOutput po2b = runCommand(METHOD_NAME, "sudo ", param2b);
+        Log.info(c, METHOD_NAME, "Stopping defaultServer");
+        ProgramOutput poServerStop1 = serviceCommand(METHOD_NAME, "stop", "defaultServer");
+        TimeUnit.SECONDS.sleep(2);
+        ProgramOutput poServerStatus2 = serviceCommand(METHOD_NAME, "status", "defaultServer");
 
-            // service tests
-            Log.info(c, METHOD_NAME, "Starting defaultServer");
-            ProgramOutput po2 = serviceCommand(METHOD_NAME, "start", "defaultServer");
-            TimeUnit.SECONDS.sleep(2);
-            ProgramOutput po2a = serviceCommand(METHOD_NAME, "status", "defaultServer");
+        Log.info(c, METHOD_NAME, "Re-starting defaultServer");
+        ProgramOutput poServerRestart = serviceCommand(METHOD_NAME, "restart", "defaultServer");
+        TimeUnit.SECONDS.sleep(2);
+        ProgramOutput poServerStatus3 = serviceCommand(METHOD_NAME, "status", "defaultServer");
 
-            Log.info(c, METHOD_NAME, "Stopping defaultServer");
-            ProgramOutput po3 = serviceCommand(METHOD_NAME, "stop", "defaultServer");
-            TimeUnit.SECONDS.sleep(2);
-            ProgramOutput po3a = serviceCommand(METHOD_NAME, "status", "defaultServer");
+        Log.info(c, METHOD_NAME, "Stopping defaultServer");
+        ProgramOutput poServerStop2 = serviceCommand(METHOD_NAME, "stop", "defaultServer");
 
-            Log.info(c, METHOD_NAME, "Re-starting defaultServer");
-            ProgramOutput po4 = serviceCommand(METHOD_NAME, "restart", "defaultServer");
-            TimeUnit.SECONDS.sleep(2);
-            ProgramOutput po4a = serviceCommand(METHOD_NAME, "status", "defaultServer");
+        Log.info(c, METHOD_NAME, "Test Results Summary:\n"
+                                 + "===================="
+                                 + "start defaultServer.service RC2:" + poServerStart.getReturnCode() + "\n"
+                                 + "status defaultServer.service RC2a:" + poServerStatus1.getReturnCode() + "\n"
+                                 + "stop defaultServer.service RC3:" + poServerStop1.getReturnCode() + "\n"
+                                 + "status defaultServer.service RC3a:" + poServerStatus2.getReturnCode() + "\n"
+                                 + "restart defaultServer.service RC4:" + poServerRestart.getReturnCode() + "\n"
+                                 + "status defaultServer.service RC4a:" + poServerStatus3.getReturnCode() + "\n"
+                                 + "stop defaultServer.service RC5:" + poServerStop2.getReturnCode() + "\n");
 
-            Log.info(c, METHOD_NAME, "Stopping defaultServer");
-            ProgramOutput po5 = serviceCommand(METHOD_NAME, "stop", "defaultServer");
+        Boolean testsPassed = ((poServerStart.getReturnCode() == 0) && (poServerStop1.getReturnCode() == 0) && (poServerRestart.getReturnCode() == 0)
+                               && (poServerStop2.getReturnCode() == 0));
+        Assert.assertTrue("Non zero return code in service test case. "
+                          + "start defaultServer.service RC2:" + poServerStart.getReturnCode() + "\n"
+                          + "status defaultServer.service RC2a:" + poServerStatus1.getReturnCode() + "\n"
+                          + "stop defaultServer.service RC3:" + poServerStop1.getReturnCode() + "\n"
+                          + "status defaultServer.service RC3a:" + poServerStatus2.getReturnCode() + "\n"
+                          + "restart defaultServer.service RC4:" + poServerRestart.getReturnCode() + "\n"
+                          + "status defaultServer.service RC4a:" + poServerStatus3.getReturnCode() + "\n"
+                          + "stop defaultServer.service RC5:" + poServerStop2.getReturnCode() + "\n", testsPassed);
 
-            Log.info(c, METHOD_NAME, "Test Results Summary:\n"
-                                     + "===================="
-                                     + "start defaultServer.service RC2:" + po2.getReturnCode() + "\n"
-                                     + "status defaultServer.service RC2a:" + po2a.getReturnCode() + "\n"
-                                     + "stop defaultServer.service RC3:" + po3.getReturnCode() + "\n"
-                                     + "status defaultServer.service RC3a:" + po3a.getReturnCode() + "\n"
-                                     + "restart defaultServer.service RC4:" + po4.getReturnCode() + "\n"
-                                     + "status defaultServer.service RC4a:" + po4a.getReturnCode() + "\n"
-                                     + "stop defaultServer.service RC5:" + po5.getReturnCode() + "\n");
+        // test Uninstall
 
-            Boolean testsPassed = ((po2.getReturnCode() == 0) && (po3.getReturnCode() == 0) && (po4.getReturnCode() == 0)
-                                   && (po5.getReturnCode() == 0));
-            Assert.assertTrue("Non zero return code in service test case. "
-                              + "start defaultServer.service RC2:" + po2.getReturnCode() + "\n"
-                              + "status defaultServer.service RC2a:" + po2a.getReturnCode() + "\n"
-                              + "stop defaultServer.service RC3:" + po3.getReturnCode() + "\n"
-                              + "status defaultServer.service RC3a:" + po3a.getReturnCode() + "\n"
-                              + "restart defaultServer.service RC4:" + po4.getReturnCode() + "\n"
-                              + "status defaultServer.service RC4a:" + po4a.getReturnCode() + "\n"
-                              + "stop defaultServer.service RC5:" + po5.getReturnCode() + "\n", testsPassed);
-        } else {
-            logger.info("OpenLiberty did not install successfully");
-        }
-    }
+        String[] paramUninstall = { "remove", "-y", "openliberty" };
+        ProgramOutput poUninstall = runCommand(METHOD_NAME, "sudo apt-get", paramUninstall);
+        assertEquals("Expected exit code", 0, poUninstall.getReturnCode());
 
-    @Test
-    public void testUninstallDeb() throws Exception {
-
-        if (openLibExists) {
-            String METHOD_NAME = "testUninstallDeb";
-            entering(c, METHOD_NAME);
-
-            String[] param1s = { "remove", "-y", "openliberty" };
-            ProgramOutput po = runCommand(METHOD_NAME, "sudo apt-get", param1s);
-            assertEquals("Expected exit code", 0, po.getReturnCode());
-            exiting(c, METHOD_NAME);
-        } else {
-            logger.info("OpenLiberty did not install successfully");
-        }
-
+        exiting(c, METHOD_NAME);
     }
 }


### PR DESCRIPTION
The com.ibm.ws.os.packaging_fat has JUnits which must run in a particular order.
Starting with Java 21, the JUnits run in a different order.

This PR collapses the JUnits into a single test method to ensure proper execution order.