### PR TITLE
Increase Concurrent Polling FAT timeout

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/fat/src/com/ibm/ws/concurrent/persistent/fat/initial/polling/InitialPollingTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/fat/src/com/ibm/ws/concurrent/persistent/fat/initial/polling/InitialPollingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -221,8 +221,8 @@ public class InitialPollingTest {
             ServerConfiguration config = originalConfig.clone();
             config.getPersistentExecutors().removeById("executor2");
 
-            // Double the standard timeout for this test
-            server.setConfigUpdateTimeout(360 * 1000);
+            // Triple the standard timeout for this test
+            server.setConfigUpdateTimeout(540 * 1000);
 
             // Schedule tasks
             StringBuilder output = runInServlet(
@@ -261,7 +261,7 @@ public class InitialPollingTest {
             taskIdE = output.substring(start += TASK_ID_SEARCH_TEXT.length(), output.indexOf(".", start));
 
             // Do config updates while the Tasks are running.
-            for (int xx = 1; xx <= 10; xx++) {
+            for (int xx = 1; xx <= 7; xx++) {
                 //String newtime = Integer.toString(xx + 20) + 's';
                 //config.getPersistentExecutors().getBy("id", "executor2").setInitialPollDelay(newtime);
 


### PR DESCRIPTION
- allow additional time to detect config updates on slow systems
- reduce number of config update iterations
