### PR TITLE
JAX-WS and JAX-RS 2.1: Add Guard statements to CXF trace

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/attachment/AttachmentSerializer.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/attachment/AttachmentSerializer.java
@@ -427,18 +427,23 @@ public class AttachmentSerializer {
     // Try to decode the string assuming the decoding may fail, the original string is going to
     // be returned in this case.
     private static String tryDecode(String s, Charset charset) {
+        boolean isFinestEnabled = LOG.isLoggable(Level.FINEST); // Liberty Change
         try { 
 	    String dString = decode(s, charset); // Liberty Change Start
-            if (LOG.isLoggable(Level.FINEST)) {
+            if (isFinestEnabled) {
                LOG.finest("tryDecode: Original string:  " + s + ", charset: " + charset + 
 			", Decoded string: " + dString);
 	    }
             return dString;  // Liberty Change End
         } catch (IllegalArgumentException ex) {
-            LOG.finest("tryDecode: IllegalArgumentException exception: " + ex); // Liberty Change
+            if (isFinestEnabled) {
+                LOG.finest("tryDecode: IllegalArgumentException exception: " + ex); // Liberty Change
+            }
             return s;
         } catch (UnsupportedEncodingException ex) {
-            LOG.finest("tryDecode: UnsupportedEncodingException exception: " + ex); // Liberty Change
+            if (isFinestEnabled) {
+                LOG.finest("tryDecode: UnsupportedEncodingException exception: " + ex); // Liberty Change
+            }
             return s;
         }
     }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/attachment/AttachmentUtil.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/attachment/AttachmentUtil.java
@@ -113,6 +113,8 @@ public final class AttachmentUtil {
 
         @Override
         public synchronized CommandInfo[] getAllCommands(String mimeType) {
+            
+            boolean isFinestEnabled = LOG.isLoggable(Level.FINEST); // Liberty Change
 
             CommandInfo[] commands = super.getAllCommands(mimeType);
             CommandInfo[] defaultCommands = DEFAULT_COMMAND_MAP.getAllCommands(mimeType);
@@ -123,19 +125,19 @@ public final class AttachmentUtil {
                 String defCmdName = defCmdInfo.getCommandName();
                 boolean cmdNameExist = false;
                 for (CommandInfo cmdInfo : commands) {
-	            if (LOG.isLoggable(Level.FINEST)) { //Liberty Change Start
+	            if (isFinestEnabled) { //Liberty Change Start
 	               LOG.finest("getAllCommands: processing cmd: " + cmdInfo.getCommandName());
 	            } //Liberty Change End
                     if (cmdInfo.getCommandName().equals(defCmdName)) {
                         cmdNameExist = true;
-	                if (LOG.isLoggable(Level.FINEST)) { //Liberty Change Start
+	                if (isFinestEnabled) { //Liberty Change Start
 	                   LOG.finest("getAllCommands: Found command " + defCmdName);
 	                } //Liberty Change End
                         break;
                     }
                 }
                 if (!cmdNameExist) {
-	            if (LOG.isLoggable(Level.FINEST)) { //Liberty Change Start
+	            if (isFinestEnabled) { //Liberty Change Start
 	               LOG.finest("getAllCommands: Cmd does not exist, using default: " + defCmdName);
 	            } //Liberty Change End
                     cmdList.add(defCmdInfo);

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/bus/osgi/CXFExtensionBundleListener.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/bus/osgi/CXFExtensionBundleListener.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.cxf.Bus;
@@ -66,10 +67,15 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
                 String bundleName = bundle.toString();
                 if(!bundleName.startsWith("com.ibm.ws.org.apache.cxf") && !bundleName.startsWith("com.ibm.ws.wssecurity")) {
                     // don't register non-cxf bundles
-                    LOG.finest("Non-CXF bundle: Do not register bundle " + bundleName);
+
+                    if (LOG.isLoggable(Level.FINEST)) {  // Liberty Change Start
+                        LOG.finest("Non-CXF bundle: Do not register bundle " + bundleName);
+                    }
                 }
                 else {
-                    LOG.finest("CXF bundle: Register bundle " + bundleName);
+                    if (LOG.isLoggable(Level.FINEST)) { 
+                        LOG.finest("CXF bundle: Register bundle " + bundleName);
+                    }
                     register(bundle);
 		}
                 //Liberty Change End
@@ -80,10 +86,15 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
     /** {@inheritDoc}*/
     public void bundleChanged(BundleEvent event) {
         if (event.getType() == BundleEvent.RESOLVED && id != event.getBundle().getBundleId()) {
-            LOG.finest("bundleChanged: Register bundle " + event.getBundle()); //Liberty Change
+
+            if (LOG.isLoggable(Level.FINEST)) {  // Liberty Change Start
+                LOG.finest("bundleChanged: Register bundle " + event.getBundle()); 
+            } // Liberty Change End
             register(event.getBundle());
         } else if (event.getType() == BundleEvent.UNRESOLVED || event.getType() == BundleEvent.UNINSTALLED) {
-            LOG.finest("bundleChanged: Unregister bundle " + event.getBundle()); //Liberty Change
+            if (LOG.isLoggable(Level.FINEST)) {  // Liberty Change Start
+                LOG.finest("bundleChanged: Unregister bundle " + event.getBundle()); //Liberty Change
+            } // Liberty Change End
             unregister(event.getBundle().getBundleId());
         }
     }
@@ -97,25 +108,39 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
     }
 
     private boolean addExtensions(final Bundle bundle, List<Extension> orig) {
+        
+        boolean isFinestEnabled = LOG.isLoggable(Level.FINEST);  //Liberty Change
         if (orig.isEmpty()) {
-            LOG.finest("Extension list is empty!");  //Liberty Change
+            if (isFinestEnabled) {
+                LOG.finest("Extension list is empty!");  //Liberty Change
+            }
             return false;
         }
 
         List<String> names = new ArrayList<>(orig.size());
         for (Extension ext : orig) {
-            LOG.finest("register: Adding extension: " + ext.toString()); //Liberty Change
+            if (isFinestEnabled) {
+                LOG.finest("register: Adding extension: " + ext.toString()); //Liberty Change
+            }
             names.add(ext.getName());
         }
-        LOG.finest("Adding the extensions from bundle " + bundle.getSymbolicName() // Liberty Change: Log at finest
+
+        if (isFinestEnabled) {
+            LOG.finest("Adding the extensions from bundle " + bundle.getSymbolicName() // Liberty Change: Log at finest
                  + " (" + bundle.getBundleId() + ") " + names);
+        }
         List<OSGiExtension> list = extensions.get(bundle.getBundleId());
         if (list == null) {
-            LOG.finest("Extension list is NULL!");  // Liberty Change
+
+            if (isFinestEnabled) {
+                LOG.finest("Extension list is NULL!");  // Liberty Change
+            }
             list = new CopyOnWriteArrayList<>();
             List<OSGiExtension> preList = extensions.putIfAbsent(bundle.getBundleId(), list);
             if (preList != null) {
-                LOG.finest("Setting list to preList");  //Liberty Change
+                if (isFinestEnabled) {
+                    LOG.finest("Setting list to preList");  //Liberty Change
+                }
                 list = preList;
             }
         }
@@ -129,7 +154,9 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
     protected void unregister(final long bundleId) {
         List<OSGiExtension> list = extensions.remove(bundleId);
         if (list != null) {
-            LOG.finest("Removing the extensions for bundle " + bundleId);  // Liberty Change: Log at finest
+            if (LOG.isLoggable(Level.FINEST)) { 
+                LOG.finest("Removing the extensions for bundle " + bundleId);  // Liberty Change: Log at finest
+            }
             ExtensionRegistry.removeExtensions(list);
         }
     }
@@ -175,7 +202,9 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
                         }
                     }
                 } catch (Throwable ex) {
-                    LOG.finest("Failed to get BundleContext due to error: " + ex);
+                    if (LOG.isLoggable(Level.FINEST)) {
+                        LOG.finest("Failed to get BundleContext due to error: " + ex);
+                    }
                 }
             } else {
                 if (interfaceName == null && bundle.getBundleContext() != null) {
@@ -203,7 +232,9 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
                     c = AccessController.doPrivileged(new PrivilegedExceptionAction<Class<?>>() {
                         @Override
                         public Class<?> run() throws ClassNotFoundException {
-                            LOG.finest("tryClass: Loading class: " + className);  //Liberty Change
+                            if (LOG.isLoggable(Level.FINEST)) { 
+                                LOG.finest("tryClass: Loading class: " + className);  //Liberty Change
+                            }
                             return bundle.loadClass(className);
                         }
                     });
@@ -217,7 +248,9 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
                 // End Liberty Change
 
             } catch (Throwable e) {
-                LOG.finest("tryClass: Setting origExc to: " + e);  // Liberty Change
+                if (LOG.isLoggable(Level.FINEST)) { 
+                    LOG.finest("tryClass: Setting origExc to: " + e);  // Liberty Change
+                }
                 origExc = e;
             }
             if (c == null) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/jaxb/JAXBUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/jaxb/JAXBUtils.java
@@ -191,7 +191,9 @@ public final class JAXBUtils {
                 ((Closeable)u).close();
             } catch (IOException e) {
                 //ignore
-                LOG.finest("Unexpected IOException when closing Unmarshaller: " + e);  // Liberty Change
+                if (LOG.isLoggable(Level.FINEST)) { 
+                    LOG.finest("Unexpected IOException when closing Unmarshaller: " + e);  // Liberty Change
+                }
             }
         }
     }
@@ -601,12 +603,16 @@ public final class JAXBUtils {
 
     @FFDCIgnore({Exception.class, Exception.class}) // Liberty Change
     private static synchronized ClassLoader getXJCClassLoader() {
+        boolean isFinestEnabled = LOG.isLoggable(Level.FINEST);
         if (jaxbXjcLoader == null) {
             try {
                 Class.forName("com.sun.tools.internal.xjc.api.XJC");
                 jaxbXjcLoader = ClassLoader.getSystemClassLoader();
             } catch (Exception t2) {
-                LOG.finest("getXJCClassLoader Exception received: " + t2);  // Liberty Change
+
+                if (isFinestEnabled) { 
+                    LOG.finest("getXJCClassLoader Exception received: " + t2);  // Liberty Change
+                }
                 //couldn't find either, probably cause tools.jar isn't on
                 //the classpath.   Let's see if we can find the tools jar
                 String s = SystemPropertyAction.getProperty("java.home");
@@ -617,12 +623,16 @@ public final class JAXBUtils {
                         jar = new File(home, "../lib/tools.jar");
                     }
                     if (jar.exists()) {
-                        LOG.fine("getXJCClassLoader: Found tools.jar: " + jar.getAbsolutePath());  // Liberty Change
+                        if(LOG.isLoggable(Level.FINE)) {
+                            LOG.fine("getXJCClassLoader: Found tools.jar: " + jar.getAbsolutePath());  // Liberty Change
+                        }
                         try {
                             jaxbXjcLoader = new URLClassLoader(new URL[] {jar.toURI().toURL()});
                             Class.forName("com.sun.tools.internal.xjc.api.XJC", false, jaxbXjcLoader);
                         } catch (Exception e) {
-                            LOG.finest("getXJCClassLoader: Error loading tools.jar: " + e);  // Liberty Change
+                            if(isFinestEnabled) {
+                                LOG.finest("getXJCClassLoader: Error loading tools.jar: " + e);  // Liberty Change
+                            }
                             jaxbXjcLoader = null;
                         }
                     }
@@ -639,7 +649,9 @@ public final class JAXBUtils {
         Object mapper = classLoaderService.createNamespaceWrapperInstance(marshaller.getClass(), nspref);
         if (mapper != null) {
 	    //Liberty change begin: Add checks for Jakarta and IBM Namespace Mappers
-	    LOG.fine("setNamespaceMapper: Checking marshaller: " + marshaller.getClass().getName());
+            if (LOG.isLoggable(Level.FINE)) { 
+                LOG.fine("setNamespaceMapper: Checking marshaller: " + marshaller.getClass().getName());
+            }
             if (marshaller.getClass().getName().startsWith("org.glassfish.")) {
                 marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", mapper);
             } else if (marshaller.getClass().getName().startsWith("com.ibm")) {
@@ -681,8 +693,10 @@ public final class JAXBUtils {
                    refClass = Class.forName(pkg + "api.TypeReference", true, getXJCClassLoader());
                 }
             }
-	    LOG.fine("createBridge: JAXBContext class: " + (cls != null ? cls.getCanonicalName() : "null")  + 
+            if(LOG.isLoggable(Level.FINE)) {
+                LOG.fine("createBridge: JAXBContext class: " + (cls != null ? cls.getCanonicalName() : "null")  + 
 			" and refclass: " + (refClass != null ? refClass.getCanonicalName() : "null") );
+            }
             //Liberty change end
             Object ref = refClass.getConstructor(QName.class,
                                                  Type.class,
@@ -741,14 +755,20 @@ public final class JAXBUtils {
                 cls = Class.forName("com.sun.tools.xjc.api.XJC");
                 sc = cls.getMethod("createSchemaCompiler").invoke(null);
             } catch (Throwable e) {
-		LOG.finest("createSchemaCompiler: Caught Throwable: " + e);  // Liberty Change
+                if (LOG.isLoggable(Level.FINEST)) { 
+                    LOG.finest("createSchemaCompiler: Caught Throwable: " + e);  // Liberty Change
+                }
                 cls = Class.forName("com.sun.tools.internal.xjc.api.XJC", true, getXJCClassLoader());
                 sc = cls.getMethod("createSchemaCompiler").invoke(null);
             }
-	    LOG.fine("createSchemaCompiler: sc: " + sc.getClass().getCanonicalName());  // Liberty Change
+            if(LOG.isLoggable(Level.FINE)) {
+                LOG.fine("createSchemaCompiler: sc: " + sc.getClass().getCanonicalName());  // Liberty Change
+            }
 
 	    SchemaCompiler ret_sc = ReflectionInvokationHandler.createProxyWrapper(sc, SchemaCompiler.class);
-	    LOG.fine("createSchemaCompiler: Returning SC: " + ret_sc);
+	    if(LOG.isLoggable(Level.FINE)) {
+	        LOG.fine("createSchemaCompiler: Returning SC: " + ret_sc);
+	    }
 	    return ret_sc;
         } catch (Exception ex) {
             throw new JAXBException(ex);
@@ -792,7 +812,7 @@ public final class JAXBUtils {
             }
         }
 
-        logger.log(Level.FINE, "Created classes: " + sb.toString());
+        logger.log(Level.FINEST, "Created classes: " + sb.toString()); // Liberty Change
     }
 
     public static List<String> getGeneratedClassNames(JCodeModel codeModel) {
@@ -826,7 +846,9 @@ public final class JAXBUtils {
                               .newInstance(f, encoding);
                 } catch (Exception ex) {
                     // try a single argument constructor
-		    LOG.finest("createFileCodeWriter: Exception ignored: " + ex);
+                    if(LOG.isLoggable(Level.FINEST)) {
+                        LOG.finest("createFileCodeWriter: Exception ignored: " + ex);
+                    }
                 }
             }
             return cls.getConstructor(File.class).newInstance(f);
@@ -890,10 +912,15 @@ public final class JAXBUtils {
                                     Class<?>[] extraClass,
                                     Map<Package, CachedClass> objectFactoryCache) {
 
+        boolean isFineEnabled = LOG.isLoggable(Level.FINE); // Liberty Change
+
+        boolean isFinestEnabled = LOG.isLoggable(Level.FINEST); // Liberty Change
         // add user extra class into jaxb context
         if (extraClass != null && extraClass.length > 0) {
             for (Class<?> clz : extraClass) {
-		LOG.fine("scanPackages: Adding extra class: " + (clz != null ? clz.getCanonicalName() : "null")); // Liberty Change
+                if(isFineEnabled) {
+                    LOG.fine("scanPackages: Adding extra class: " + (clz != null ? clz.getCanonicalName() : "null")); // Liberty Change
+                }
                 classes.add(clz);
             }
         }
@@ -906,19 +933,19 @@ public final class JAXBUtils {
         Map<String, InputStream> packages = new HashMap<>();
         Map<String, ClassLoader> packageLoaders = new HashMap<>();
         Set<Class<?>> objectFactories = new HashSet<>();
+        
         for (Class<?> jcls : classes) {
             String pkgName = PackageUtils.getPackageName(jcls);
             if (!packages.containsKey(pkgName)) {
                 Package pkg = jcls.getPackage();
 
-	        if (LOG.isLoggable(Level.FINE)) {  // Liberty Change begin
+	        if (isFineEnabled) {  // Liberty Change begin
 		   InputStream is1 = jcls.getResourceAsStream("jaxb.index");
 		   if (is1 != null) {
 		      LOG.fine("scanPackages: jaxb.index file found for: " + jcls.getCanonicalName());
 		   }
 		   packages.put(pkgName, is1);
-	        }
-		else {
+	        } else {
                    packages.put(pkgName, jcls.getResourceAsStream("jaxb.index"));
 		}  // Liberty Change end
 
@@ -939,13 +966,19 @@ public final class JAXBUtils {
                         ofactory = Class.forName(objectFactoryClassName, false, getClassLoader(jcls));
                         objectFactories.add(ofactory);
                         addToObjectFactoryCache(pkg, ofactory, objectFactoryCache);
-			LOG.fine("ObjectFactory class: " + (ofactory != null ? ofactory.getCanonicalName() : "null")); // Liberty Change
+                        if(isFineEnabled) {
+                            LOG.fine("ObjectFactory class: " + (ofactory != null ? ofactory.getCanonicalName() : "null")); // Liberty Change
+                        }
                     } catch (ClassNotFoundException e) {
-			LOG.finest("ObjectFactory class not found: " + e); // Liberty Change
+                        if(isFinestEnabled) {
+                            LOG.finest("ObjectFactory class not found: " + e); // Liberty Change
+                        }
                         addToObjectFactoryCache(pkg, null, objectFactoryCache);
                     }
                 } else {
-		    LOG.fine("scanPackages: Adding ObjectFactory: " + ofactory.getCanonicalName()); // Liberty Change
+                    if(isFineEnabled) {
+                        LOG.fine("scanPackages: Adding ObjectFactory: " + ofactory.getCanonicalName()); // Liberty Change
+                    }
                     objectFactories.add(ofactory);
                 }
             }
@@ -971,7 +1004,10 @@ public final class JAXBUtils {
                                 Class<?> ncls = Class.forName(pkg + line, false, loader);
                                 classes.add(ncls);
                             } catch (Exception e) {
-			        LOG.finest("scanPackages: Ignoring exception: " + e); // Liberty Change
+
+                                if(isFinestEnabled) {
+                                    LOG.finest("scanPackages: Ignoring exception: " + e); // Liberty Change
+                                }
                                 // ignore
                             }
                         }
@@ -979,13 +1015,18 @@ public final class JAXBUtils {
                     }
                 } catch (IOException e) {
                     // ignore
-                    LOG.finest("Unexpected IOException in scanPackages: " + e);  // Liberty Change
+
+                    if(isFinestEnabled) {
+                        LOG.finest("Unexpected IOException in scanPackages: " + e);  // Liberty Change
+                    }
                 } finally {
                     try {
                         entry.getValue().close();
                     } catch (IOException e) {
                         // ignore
-                        LOG.finest("Unexpected IOException when closing input stream: " + e);  // Liberty Change
+                        if(isFinestEnabled) {
+                            LOG.finest("Unexpected IOException when closing input stream: " + e);  // Liberty Change
+                        }
                     }
                 }
             }
@@ -1012,8 +1053,12 @@ public final class JAXBUtils {
         if (objectFactoryPkg == null || objectFactoryCache == null) {
             return;
         }
+		
+	    if (LOG.isLoggable(Level.FINEST)) { 
+			LOG.finest("Adding ObjectFactory package to cache: " + objectFactoryPkg); // Liberty Change
+        }
+		
         synchronized (objectFactoryCache) {
-	    LOG.finest("Adding ObjectFactory package to cache: " + objectFactoryPkg); // Liberty Change
             objectFactoryCache.put(objectFactoryPkg,
                                      new CachedClass(ofactory));
         }
@@ -1041,8 +1086,10 @@ public final class JAXBUtils {
                 fullPckClass = packageName + "." + fullClassName;
             }
             typesClassNames.add(fullPckClass);
-	    LOG.fine("assignClassName: Added FullPckClass to typesClassNames: " + fullPckClass + 
+            if (LOG.isLoggable(Level.FINE)) { 
+                LOG.fine("assignClassName: Added FullPckClass to typesClassNames: " + fullPckClass + 
 		  " and returning fullClassName: " + fullClassName);  // Liberty Change
+            }
             return fullClassName;
         }
 
@@ -1215,7 +1262,9 @@ public final class JAXBUtils {
             }
             
             if (propertyName != null && escapeHandler != null) {
-                LOG.fine("Setting ESC handler on marshaller: " + propertyName + " to " + escapeHandler);  // Liberty Change
+                if (LOG.isLoggable(Level.FINE)) { 
+                    LOG.fine("Setting ESC handler on marshaller: " + propertyName + " to " + escapeHandler);  // Liberty Change
+                }
                 marshaller.setProperty(propertyName, escapeHandler);
             }
             //Liberty change end
@@ -1238,7 +1287,9 @@ public final class JAXBUtils {
             //Liberty change begin
             if (cls.getName().startsWith("com.ibm.xml")) {
                 // Do not use escape handlers with XLXP
-                LOG.fine("createEscapeHandler: XLXP found, returning null");
+                if (LOG.isLoggable(Level.FINE)) { 
+                    LOG.fine("createEscapeHandler: XLXP found, returning null");
+                }
                 return null;
             }
             String packageName;
@@ -1255,7 +1306,9 @@ public final class JAXBUtils {
                 packageName = "com.sun.xml" + postFix + ".bind.marshaller";
             }
 
-            LOG.fine("createEscapeHandler: packageName = " + packageName);
+            if (LOG.isLoggable(Level.FINE)) { 
+                LOG.fine("createEscapeHandler: packageName = " + packageName);
+            }
 
             Class<?> handlerClass = ClassLoaderUtils.loadClass(packageName + "." + simpleClassName,
                                                                cls);

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/spi/NamespaceClassGenerator.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/spi/NamespaceClassGenerator.java
@@ -62,7 +62,11 @@ public class NamespaceClassGenerator extends ClassGeneratorClassLoader implement
 
         String className = "org.apache.cxf.jaxb.NamespaceMapper";
         className += postFix;
-	LOG.fine("Calling findClass for: " + className); // Liberty Change
+        if(LOG.isLoggable(Level.FINE)) {
+            LOG.fine("Calling findClass for: " + className); // Liberty Change
+        }
+
+        boolean isFinestEnabled = LOG.isLoggable(Level.FINEST); // Liberty Change
         Class<?> cls = findClass(className, NamespaceClassCreator.class);
         Throwable t = null;
         if (cls == null) {
@@ -74,7 +78,10 @@ public class NamespaceClassGenerator extends ClassGeneratorClassLoader implement
                     try {
                         return loadClass(className, NamespaceClassCreator.class, bts);
                     } catch(NoClassDefFoundError e) {
-	                LOG.finest("loadClass for : " + className + " returned NCDF, trying RI"); // Liberty Change
+
+                        if(isFinestEnabled) {
+                            LOG.finest("loadClass for : " + className + " returned NCDF, trying RI"); // Liberty Change
+                        }
                         postFix = "RI";
                         className = "org.apache.cxf.jaxb.NamespaceMapper";
                         className += postFix;
@@ -82,7 +89,10 @@ public class NamespaceClassGenerator extends ClassGeneratorClassLoader implement
                         
                         bts = createNamespaceWrapperInternal(postFix);
 		        Class<?> lc = loadClass(className, NamespaceClassCreator.class, bts); // Liberty Change begin
-			LOG.finest("createNamespaceWrapperClass returning: " + lc);
+
+	                if(isFinestEnabled) {
+	                    LOG.finest("createNamespaceWrapperClass returning: " + lc);
+	                }
                         return lc;
                     }
                 }
@@ -92,7 +102,9 @@ public class NamespaceClassGenerator extends ClassGeneratorClassLoader implement
 
             } catch (RuntimeException ex) {
                 // continue
-		LOG.finest("createNamespaceWrapperClass: RuntimeException: " + ex);  // Liberty Change
+                if(isFinestEnabled) {
+                    LOG.finest("createNamespaceWrapperClass: RuntimeException: " + ex);  // Liberty Change
+                }
                 t = ex;
             }
         }
@@ -103,7 +115,9 @@ public class NamespaceClassGenerator extends ClassGeneratorClassLoader implement
                         NamespaceClassCreator.class);
             } catch (Throwable ex2) {
                 // ignore
-		LOG.finest("createNamespaceWrapperClass: Exception: " + ex2);  // Liberty Change
+                if(isFinestEnabled) {
+                    LOG.finest("createNamespaceWrapperClass: Exception: " + ex2);  // Liberty Change
+                }
                 t = ex2;
             }
         }
@@ -111,7 +125,10 @@ public class NamespaceClassGenerator extends ClassGeneratorClassLoader implement
                    LOG.log(Level.FINEST, "Could not create a NamespaceMapper compatible with Marshaller class " 
                            + mcls.getName(), t); // Liberty Change - Level to FINEST
                 }
-		LOG.fine("createNamespaceWrapperClass returning class: " + cls); // Liberty Change
+
+                if(LOG.isLoggable(Level.FINE)) {
+                    LOG.fine("createNamespaceWrapperClass returning class: " + cls); // Liberty Change
+                }
 		return cls;
     }
 
@@ -164,7 +181,9 @@ public class NamespaceClassGenerator extends ClassGeneratorClassLoader implement
         String slashedName = "org/apache/cxf/jaxb/EclipseNamespaceMapper";
         ASMHelper.ClassWriter cw = helper.createClassWriter();
         if (cw == null) {
-	    LOG.fine("doCreateEclipseNamespaceMapper: Could not create ASM classwriter, returning null");  // Liberty Change
+            if(LOG.isLoggable(Level.FINE)) {
+                LOG.fine("doCreateEclipseNamespaceMapper: Could not create ASM classwriter, returning null");  // Liberty Change
+            }
             return null;
         }
         String superName = "org/eclipse/persistence/internal/oxm/record/namespaces/MapNamespacePrefixMapper";
@@ -342,7 +361,9 @@ public class NamespaceClassGenerator extends ClassGeneratorClassLoader implement
         String postFixedName = "org/apache/cxf/jaxb/NamespaceMapper" + postFix;
         ASMHelper.ClassWriter cw = helper.createClassWriter();
         if (cw == null) {
-	    LOG.fine("createNamespaceWrapperInternal: Could not create ASM classwriter, returning null");  // Liberty Change
+            if(LOG.isLoggable(Level.FINE)) {
+                LOG.fine("createNamespaceWrapperInternal: Could not create ASM classwriter, returning null");  // Liberty Change
+            }
             return null;
         }
         ASMHelper.FieldVisitor fv;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/util/ProxyHelper.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/util/ProxyHelper.java
@@ -111,12 +111,16 @@ public class ProxyHelper {
     private boolean canSeeAllInterfaces(ClassLoader loader, Class<?>[] interfaces) {
         for (Class<?> currentInterface : interfaces) {
             String ifName = currentInterface.getName();
-	    LOG.finest("canSeeAllInterfaces: Checking interface: " + ifName);
+            if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest("canSeeAllInterfaces: Checking interface: " + ifName);
+            }
             try {
                 Class<?> ifClass = Class.forName(ifName, true, loader);
                 if (ifClass != currentInterface) {
-	            LOG.fine("canSeeAllInterfaces returning false; ifClass " + ifClass + " does not match " + 
-			"current interface " + currentInterface);
+                    if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                        LOG.fine("canSeeAllInterfaces returning false; ifClass " + ifClass + " does not match " + 
+                                        "current interface " + currentInterface);
+                    }
                     return false;
                 }
                 //we need to check all the params/returns as well as the Proxy creation
@@ -134,7 +138,9 @@ public class ProxyHelper {
                     }
                 }
             } catch (NoClassDefFoundError | ClassNotFoundException e) {
-	        LOG.finest("canSeeAllInterfaces: Exception caught, returning false: " + e);  // Liberty Change end
+                if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("canSeeAllInterfaces: Exception caught, returning false: " + e);  // Liberty Change end
+                }
                 return false;
             }
         }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/AttachmentOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/AttachmentOutInterceptor.java
@@ -34,6 +34,8 @@ import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
 import org.apache.cxf.common.logging.LogUtils;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class AttachmentOutInterceptor extends AbstractPhaseInterceptor<Message> {
@@ -57,14 +59,21 @@ public class AttachmentOutInterceptor extends AbstractPhaseInterceptor<Message> 
     }
 
     public void handleMessage(Message message) {
+        
+
+        boolean isFineEnabled = LOG.isLoggable(Level.FINE); // Liberty Change
         //avoid AttachmentOutInterceptor invoked twice on the 
         //same message
         if (message.get(ATTACHMENT_OUT_CHECKED) != null
             && (boolean)message.get(ATTACHMENT_OUT_CHECKED)) {
-	    LOG.fine("ATTACHMENT_OUT_CHECKED is set, interceptor already invoked, returning"); // Liberty Change
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("ATTACHMENT_OUT_CHECKED is set, interceptor already invoked, returning"); // Liberty Change
+            }
             return;
         } else {
-	    LOG.fine("AttachmentOutInterceptor handleMessage: Setting ATTACHMENT_OUT_CHECKED"); // Liberty Change
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("AttachmentOutInterceptor handleMessage: Setting ATTACHMENT_OUT_CHECKED"); // Liberty Change
+            }
             message.put(ATTACHMENT_OUT_CHECKED, Boolean.TRUE);
         }
         // Make it possible to step into this process in spite of Eclipse
@@ -75,11 +84,15 @@ public class AttachmentOutInterceptor extends AbstractPhaseInterceptor<Message> 
 
         writeOptionalTypeParameters = MessageUtils.getContextualBoolean(message, WRITE_OPTIONAL_TYPE_PARAMETERS, true);
         if (!mtomEnabled && !writeAtts) {
-	    LOG.fine("AttachmentOutInterceptor: MTOM not enabled and WRITE_ATTACHMENTS is false"); // Liberty Change
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("AttachmentOutInterceptor: MTOM not enabled and WRITE_ATTACHMENTS is false"); // Liberty Change
+            }
             return;
         }
         if (message.getContent(OutputStream.class) == null) {
-	    LOG.fine("AttachmentOutInterceptor: OutputStream.class is null, returning"); // Liberty Change
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("AttachmentOutInterceptor: OutputStream.class is null, returning"); // Liberty Change
+            }
             return;
         }
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/OneWayProcessorInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/OneWayProcessorInterceptor.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.cxf.common.logging.LogUtils;
@@ -64,7 +65,9 @@ public class OneWayProcessorInterceptor extends AbstractPhaseInterceptor<Message
                 try {
                     in.close();
                 } catch (IOException e) {
-		    LOG.finest("OneWayProcessorInterceptor: Ignoring IOException 1: " + e); // Liberty Change
+                    if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                        LOG.finest("OneWayProcessorInterceptor: Ignoring IOException 1: " + e); // Liberty Change
+                    }
                     //ignore
                 }
             }
@@ -124,7 +127,9 @@ public class OneWayProcessorInterceptor extends AbstractPhaseInterceptor<Message
                     message.getExchange().setInMessage(message);
                 }
             } catch (IOException e) {
-		LOG.finest("OneWayProcessorInterceptor: Ignoring IOException 2: " + e); // Liberty Change
+                if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("OneWayProcessorInterceptor: Ignoring IOException 2: " + e); // Liberty Change
+                }
                 //IGNORE
             }
 
@@ -159,7 +164,9 @@ public class OneWayProcessorInterceptor extends AbstractPhaseInterceptor<Message
                     }
 
                 } catch (InterruptedException e) {
-		    LOG.finest("OneWayProcessorInterceptor: Ignoring InterruptedException: " + e); // Liberty Change
+                    if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                        LOG.finest("OneWayProcessorInterceptor: Ignoring InterruptedException: " + e); // Liberty Change
+                    }
                     //ignore - likely a busy work queue so we'll just let the one-way go
                 }
             }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/OutgoingChainInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/OutgoingChainInterceptor.java
@@ -84,7 +84,9 @@ public class OutgoingChainInterceptor extends AbstractPhaseInterceptor<Message> 
                 outChain = OutgoingChainInterceptor.getChain(ex, chainCache);
                 out.setInterceptorChain(outChain);
             } else if (outChain.getState() == InterceptorChain.State.PAUSED) {
-		LOG.finest("OutgoingChainInterceptor: Chain was paused, resumimg"); // Liberty Change
+                if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("OutgoingChainInterceptor: Chain was paused, resumimg"); // Liberty Change
+                }
                 outChain.resume();
                 return;
             }
@@ -100,7 +102,9 @@ public class OutgoingChainInterceptor extends AbstractPhaseInterceptor<Message> 
                 is.close();
                 message.removeContent(InputStream.class);
             } catch (IOException ioex) {
-		LOG.finest("closeInput: Ignoring IOException: " + ioex); // Liberty Change
+                if(LOG.isLoggable(Level.FINEST)) {
+                    LOG.finest("closeInput: Ignoring IOException: " + ioex); // Liberty Change
+                }
                 //ignore
             }
         }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/ServiceInvokerInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/ServiceInvokerInterceptor.java
@@ -63,6 +63,8 @@ public class ServiceInvokerInterceptor extends AbstractPhaseInterceptor<Message>
         Runnable invocation = new Runnable() {
 
             public void run() {
+                boolean isFinestEnabled = LOG.isLoggable(Level.FINEST); // Liberty Change
+                    
                 Exchange runableEx = message.getExchange();
                 Object result = invoker.invoke(runableEx, getInvokee(message));
                 if (!exchange.isOneWay()) {
@@ -80,16 +82,24 @@ public class ServiceInvokerInterceptor extends AbstractPhaseInterceptor<Message>
                         MessageContentsList resList = null;
                         if (result instanceof MessageContentsList) {
 			    // Liberty Change start
-			    LOG.finest("Result is instance of MessageContentsList"); 
+                            if(isFinestEnabled) {
+                                LOG.finest("Result is instance of MessageContentsList");
+                            }
                             resList = (MessageContentsList)result;
                         } else if (result instanceof List) {
-			    LOG.finest("Result is instance of List");
+                            if(isFinestEnabled) {
+                                LOG.finest("Result is instance of List");
+                            }
                             resList = new MessageContentsList((List<?>)result);
                         } else if (result.getClass().isArray()) {
                             resList = new MessageContentsList((Object[])result);
-			    LOG.finest("Result is Array");
+                            if(isFinestEnabled) {
+                                LOG.finest("Result is Array");
+                            }
                         } else {
-			    LOG.finest("Calling setContent for Object.class");    
+                            if(isFinestEnabled) {
+                                LOG.finest("Calling setContent for Object.class");
+                            }
 			    // Liberty Change end	
                             outMessage.setContent(Object.class, result);
                         }
@@ -162,13 +172,18 @@ public class ServiceInvokerInterceptor extends AbstractPhaseInterceptor<Message>
 
     private Object getInvokee(Message message) {
 	// Liberty Change start
-        LOG.finest("getInvokee: getContent from List: " + message.getClass().getCanonicalName());
+        boolean isFinestEnabled = LOG.isLoggable(Level.FINEST);
+        if(isFinestEnabled) {
+            LOG.finest("getInvokee: getContent from List: " + message.getClass().getCanonicalName());
+        }
         Object invokee = message.getContent(List.class);
         if (invokee == null) {
-	    LOG.finest("getInvokee: getContent from Object");
+            if(isFinestEnabled) {
+                LOG.finest("getInvokee: getContent from Object");
+            }
             invokee = message.getContent(Object.class);
         }
-	if (LOG.isLoggable(Level.FINEST)) {
+	if (isFinestEnabled) {
 	   if (invokee instanceof List) {
               for (Object o1 : (List)invokee) {
 		 if (o1 != null) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/StaxInEndingInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/StaxInEndingInterceptor.java
@@ -27,6 +27,8 @@ import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
 import org.apache.cxf.staxutils.StaxUtils;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.cxf.common.logging.LogUtils;
 import com.ibm.websphere.ras.annotation.Sensitive; // Liberty Change
@@ -49,7 +51,9 @@ public class StaxInEndingInterceptor extends AbstractPhaseInterceptor<Message> {
 
     public void handleMessage(@Sensitive Message message) {  // Liberty Change
         XMLStreamReader xtr = message.getContent(XMLStreamReader.class);
-	LOG.finest("XMLStreamReader class: " + (xtr != null ? xtr.getClass().getCanonicalName() : "NULL")); // Liberty Change
+        if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+            LOG.finest("XMLStreamReader class: " + (xtr != null ? xtr.getClass().getCanonicalName() : "NULL")); // Liberty Change
+        }
         if (xtr != null && !MessageUtils.getContextualBoolean(message, STAX_IN_NOCLOSE, false)) {
             try {
                 StaxUtils.close(xtr);

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/StaxInInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/StaxInInterceptor.java
@@ -26,6 +26,7 @@ import java.io.Reader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.xml.stream.XMLInputFactory;
@@ -61,8 +62,12 @@ public class StaxInInterceptor extends AbstractPhaseInterceptor<Message> {
     }
 
     public void handleMessage(Message message) {
+        boolean isFinestEnabled = LOG.isLoggable(Level.FINEST); // Liberty Change
+            
         if (isGET(message) || message.getContent(XMLStreamReader.class) != null) {
-            LOG.finest("StaxInInterceptor skipped.");
+            if(isFinestEnabled) { // Liberty Change
+                LOG.finest("StaxInInterceptor skipped.");
+            }
             return;
         }
         InputStream is = message.getContent(InputStream.class);
@@ -70,7 +75,9 @@ public class StaxInInterceptor extends AbstractPhaseInterceptor<Message> {
         if (is == null) {
             reader = message.getContent(Reader.class);
             if (reader == null) {
-                LOG.fine("Reader is null, returning."); // Liberty Change
+                if( LOG.isLoggable(Level.FINE)) {
+                    LOG.fine("Reader is null, returning."); // Liberty Change
+                }
                 return;
             }
         }
@@ -98,7 +105,9 @@ public class StaxInInterceptor extends AbstractPhaseInterceptor<Message> {
                     LOG, (htmlMessage.length() == 0) ? "(none)" : htmlMessage));
         }
         if (contentType == null) {
-	    LOG.finest("contentType is null"); // Liberty Change
+            if(isFinestEnabled) { // Liberty Change
+                LOG.finest("contentType is null"); // Liberty Change
+            }
             //if contentType is null, this is likely a an empty post/put/delete/similar, lets see if it's
             //detectable at all
             Map<String, List<String>> m = CastUtils.cast((Map<?, ?>)message.get(Message.PROTOCOL_HEADERS));
@@ -119,7 +128,10 @@ public class StaxInInterceptor extends AbstractPhaseInterceptor<Message> {
         }
 
         String encoding = (String)message.get(Message.ENCODING);
-        LOG.finest("Message encoding: " + encoding); // Liberty Change
+        
+        if(isFinestEnabled) { // Liberty Change
+            LOG.finest("Message encoding: " + encoding); // Liberty Change
+        }
 
         XMLStreamReader xreader;
         try {
@@ -148,9 +160,13 @@ public class StaxInInterceptor extends AbstractPhaseInterceptor<Message> {
                 }
             }
 	    // Liberty Change start
-	    LOG.finest("XMLStreamReader before configureReader: " + xreader.getClass().getCanonicalName());
+            if(isFinestEnabled) { // Liberty Change
+                LOG.finest("XMLStreamReader before configureReader: " + xreader.getClass().getCanonicalName());
+            }
             xreader = StaxUtils.configureReader(xreader, message);
-	    LOG.finest("XMLStreamReader after configureReader: " + xreader.getClass().getCanonicalName());
+            if(isFinestEnabled) { // Liberty Change
+                LOG.finest("XMLStreamReader after configureReader: " + xreader.getClass().getCanonicalName());
+            }
 	    // Liberty Change end
         } catch (XMLStreamException e) {
             throw new Fault(new org.apache.cxf.common.i18n.Message("STREAM_CREATE_EXC",

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/StaxOutEndingInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/StaxOutEndingInterceptor.java
@@ -31,6 +31,8 @@ import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.cxf.common.logging.LogUtils;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class StaxOutEndingInterceptor extends AbstractPhaseInterceptor<Message> {
@@ -55,7 +57,9 @@ public class StaxOutEndingInterceptor extends AbstractPhaseInterceptor<Message> 
     public void handleMessage(Message message) {
         try {
             XMLStreamWriter xtw = message.getContent(XMLStreamWriter.class);
-	    LOG.finest("XMLStreamWriter class: " + (xtw != null ? xtw.getClass().getCanonicalName() : "NULL")); // Liberty Change
+            if(LOG.isLoggable(Level.FINEST)) {
+                LOG.finest("XMLStreamWriter class: " + (xtw != null ? xtw.getClass().getCanonicalName() : "NULL")); // Liberty Change
+            }
             if (xtw != null) {
                 try {
                     xtw.writeEndDocument();

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/StaxOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/interceptor/StaxOutInterceptor.java
@@ -41,6 +41,8 @@ import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.cxf.common.logging.LogUtils;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 
@@ -107,8 +109,9 @@ public class StaxOutInterceptor extends AbstractPhaseInterceptor<Message> {
                     }
                 }
             }
-
-	    LOG.finest("XMLStreamWriter class: " + (xwriter != null ? xwriter.getClass().getCanonicalName() : "NULL")); // Liberty Change
+            if(LOG.isLoggable(Level.FINEST)) {
+                LOG.finest("XMLStreamWriter class: " + (xwriter != null ? xwriter.getClass().getCanonicalName() : "NULL")); // Liberty Change
+            }
 
             if (MessageUtils.getContextualBoolean(message, FORCE_START_DOCUMENT, false)) {
                 xwriter.writeStartDocument(encoding, "1.0");

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/message/MessageImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/message/MessageImpl.java
@@ -118,12 +118,9 @@ public class MessageImpl extends StringMapImpl implements Message {
         boolean isFinestEnabled = LOG.isLoggable(Level.FINEST);
 
         for (int x = 0; x < index; x += 2) {
-            if (isFinestEnabled) {
-                LOG.finest("getContent processing class: " + contents[x].getClass().getCanonicalName());
-            }
             if (contents[x] == format) {
                 if (isFinestEnabled) {
-                    LOG.finest("getContent returning class: " + contents[x+1].getClass().getCanonicalName());
+                    LOG.finest("getContent returning class: " + (contents[x+1] != null ? contents[x+1].getClass().getCanonicalName() : "NULL"));
                 }
                 if (LOG.isLoggable(Level.FINER)) {
                     LOG.exiting("MessageImpl", "getContent");
@@ -132,7 +129,7 @@ public class MessageImpl extends StringMapImpl implements Message {
             }
         }
         if (LOG.isLoggable(Level.FINER)) {
-            LOG.exiting("MessageImpl", "getContent");
+            LOG.exiting("MessageImpl", "getContent", "contents did not match format.");
         }
         // Liberty code change end
         return null;
@@ -145,7 +142,6 @@ public class MessageImpl extends StringMapImpl implements Message {
         }
         boolean isFinestEnabled = LOG.isLoggable(Level.FINEST);
         if (isFinestEnabled) {
-            LOG.finest("setContent: Logging content for format: " + (format != null ? format.getCanonicalName() : "null"));
             logContent(content);
         }
         for (int x = 0; x < index; x += 2) {
@@ -187,8 +183,7 @@ public class MessageImpl extends StringMapImpl implements Message {
         for (int x = 0; x < index; x += 2) {
             if (contents[x] == format) {
                 if (isFinestEnabled) {
-                    LOG.finest("removeContent: Found content for format: " +
-                        (format != null ? format.getCanonicalName() : "null"));
+                    LOG.finest("removeContent: Found content for format: " + (format != null ? format.getCanonicalName() : "null"));
                 }
                 index -= 2;
                 if (x != index) {
@@ -301,7 +296,7 @@ public class MessageImpl extends StringMapImpl implements Message {
 
     private void logContent(Object content) {
 
-	if (content instanceof List) {
+		if (content instanceof List) {
            for (Object o1 : (List)content) {
                 if (o1 != null && o1.getClass() != null) {
                    LOG.finest("Setcontent param: " + o1.getClass().getCanonicalName());
@@ -337,18 +332,17 @@ public class MessageImpl extends StringMapImpl implements Message {
                     if ((p = ei.getBinding().getProperties()) != null) {
                         if (!p.isEmpty()) {
                             keys.addAll(p.keySet());
-                    }
+                    	}
                     }
                     if ((p = ei.getProperties()) != null) {
                         if (!p.isEmpty()) {
                             keys.addAll(p.keySet());
-                }
-            }
-        }
-                
+                		}
+            		}
+        		}
                 if (!ep.isEmpty()) {
                     keys.addAll(ep.keySet());
-    }
+    			}
             }
             if (!ex.isEmpty()) {
                 keys.addAll(ex.keySet());

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/phase/PhaseInterceptorChain.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/phase/PhaseInterceptorChain.java
@@ -161,14 +161,19 @@ public class PhaseInterceptorChain implements InterceptorChain {
     }
 
     public static boolean setCurrentMessage(PhaseInterceptorChain chain, Message m) {
+        boolean isFineEnabled = LOG.isLoggable(Level.FINE);   // Liberty Change
         if (getCurrentMessage() == m) {
-            LOG.fine("Current message same as message passed, returning false.");  // Liberty Change
+            if(isFineEnabled) {
+                LOG.fine("Current message same as message passed, returning false.");  // Liberty Change
+            }
             return false;
         }
         if (chain.iterator.hasPrevious()) {
             chain.iterator.previous();
             if (chain.iterator.next() instanceof ServiceInvokerInterceptor) {
-                LOG.fine("Setting current message to message passed.");  // Liberty Change
+                if(isFineEnabled) {
+                    LOG.fine("Setting current message to message passed.");  // Liberty Change
+                }
                 CURRENT_MESSAGE.set(m);
                 return true;
             }
@@ -176,7 +181,10 @@ public class PhaseInterceptorChain implements InterceptorChain {
             LOG.warning(error);
             throw new IllegalStateException(error);
         }
-        LOG.fine("setCurrentMessage returning false.");  // Liberty Change
+
+        if(isFineEnabled) {
+            LOG.fine("setCurrentMessage returning false.");  // Liberty Change
+        }
         return false;
 
     }
@@ -193,10 +201,10 @@ public class PhaseInterceptorChain implements InterceptorChain {
             try {
                 this.wait();
             } catch (InterruptedException ex) {
-                LOG.finest("Unexpected exception in releaseAndAcquireChain: " + ex); 
+                    LOG.finest("Unexpected exception in releaseAndAcquireChain: " + ex); 
+                }
                 // ignore
             }
-        }
         chainReleased = false;
         if (isFineLogging) {
             LOG.fine("Sucessfully acquired chain.");
@@ -446,7 +454,9 @@ public class PhaseInterceptorChain implements InterceptorChain {
             PhaseInterceptor<? extends Message> currentInterceptor
                 = (PhaseInterceptor<? extends Message>)iterator.next();
             if (currentInterceptor.getId().equals(startingAfterInterceptorID)) {
-                LOG.fine("doInterceptStartingAfter: Found interceptor slot!");  // Liberty Change
+                if (isFineLogging) {  // Liberty Change Start
+                    LOG.fine("doInterceptStartingAfter: Found interceptor slot!");  // Liberty Change
+                }
                 break;
             }
         }
@@ -472,7 +482,9 @@ public class PhaseInterceptorChain implements InterceptorChain {
                 = (PhaseInterceptor<? extends Message>)iterator.next();
             if (currentInterceptor.getId().equals(startingAtInterceptorID)) {
                 iterator.previous();
-                LOG.fine("doInterceptStartingAt: Found interceptor slot!"); // Liberty Change
+                if (isFineLogging) {  // Liberty Change Start
+                    LOG.fine("doInterceptStartingAt: Found interceptor slot!"); // Liberty Change
+                }
                 break;
             }
         }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/service/invoker/AbstractInvoker.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/service/invoker/AbstractInvoker.java
@@ -236,7 +236,9 @@ public abstract class AbstractInvoker implements Invoker {
             for (Class<?> iface : targetObject.getClass().getInterfaces()) {
                 Method m = getMostSpecificMethod(methodToMatch, iface);
                 if (!methodToMatch.equals(m)) {
-	            LOG.fine("matchMethod: Returning method: " + m.getName());
+                    if (LOG.isLoggable(Level.FINE)) { // Liberty Change
+                        LOG.fine("matchMethod: Returning method: " + m.getName());
+                    }
                     return m;
                 }
             }
@@ -272,7 +274,9 @@ public abstract class AbstractInvoker implements Invoker {
             try {
                 method = targetClass.getMethod(method.getName(), method.getParameterTypes());
             } catch (NoSuchMethodException ex) {
-		LOG.fine("getMostSpecificMethod: This is OK, using original method " + ex); // Liberty Change
+                if (LOG.isLoggable(Level.FINE)) { // Liberty change
+                    LOG.fine("getMostSpecificMethod: This is OK, using original method " + ex); // Liberty Change
+                }
                 // Perhaps the target class doesn't implement this method:
                 // that's fine, just use the original method
             }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/service/model/AbstractMessageContainer.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/service/model/AbstractMessageContainer.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.cxf.common.logging.LogUtils;
 
@@ -83,7 +84,10 @@ public abstract class AbstractMessageContainer extends AbstractPropertiesHolder 
         }
 
         MessagePartInfo part = new MessagePartInfo(name, this);
-	LOG.finest("addMessagePart: Created new MessagePartInfo: " +  part);  // Liberty Change
+
+        if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+            LOG.finest("addMessagePart: Created new MessagePartInfo: " +  part);  // Liberty Change
+        }
         addMessagePart(part);
         return part;
     }
@@ -148,7 +152,9 @@ public abstract class AbstractMessageContainer extends AbstractPropertiesHolder 
     public void removeMessagePart(QName name) {
         MessagePartInfo messagePart = getMessagePart(name);
         if (messagePart != null) {
-	    LOG.finest("removeMessagePart: " + name);  // Liberty Change
+            if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest("removeMessagePart: " + name);  // Liberty Change
+            }
             messageParts.remove(name);
         }
     }
@@ -199,7 +205,9 @@ public abstract class AbstractMessageContainer extends AbstractPropertiesHolder 
         }
 
         MessagePartInfo part = new MessagePartInfo(name, this);
-	LOG.finest("addOutOfBandMessagePart: Created new Msg Part: " + part);  // Liberty Change
+        if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+            LOG.finest("addOutOfBandMessagePart: Created new Msg Part: " + part);  // Liberty Change
+        }
         if (outOfBandParts == null) {
             outOfBandParts = new ArrayList<>(1);
         }
@@ -232,10 +240,14 @@ public abstract class AbstractMessageContainer extends AbstractPropertiesHolder 
     public MessagePartInfo getFirstMessagePart() {
         if (!messageParts.isEmpty()) {
 	    // Liberty Change start
-	    LOG.finest("Returning first MessagePart");
+            if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest("Returning first MessagePart");
+            }
             return messageParts.values().iterator().next();
         } else if (outOfBandParts != null && !outOfBandParts.isEmpty()) {
-	    LOG.finest("Returning first outOfBandParts");
+            if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest("Returning first outOfBandParts");
+            }
 	    // Liberty Change end	
             return outOfBandParts.get(0);
         } else {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/service/model/EndpointInfo.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/service/model/EndpointInfo.java
@@ -21,6 +21,8 @@ package org.apache.cxf.service.model;
 
 import javax.xml.namespace.QName;
 import org.apache.cxf.common.logging.LogUtils;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.cxf.ws.addressing.AttributedURIType;
@@ -101,7 +103,9 @@ public class EndpointInfo extends AbstractDescriptionElement implements NamedIte
     public String getAddress() {
         EndpointReferenceType address = threadLocal.get(); //Liberty #3669
         if (address == null) {
-	    LOG.fine("getAddress: Setting address to lastAddressSet"); // Liberty Change
+            if (LOG.isLoggable(Level.FINE)) { // Liberty Change
+                LOG.fine("getAddress: Setting address to lastAddressSet"); // Liberty Change
+            }
             address = lastAddressSet; //Liberty
         }
         return (null != address && null != address.getAddress()) ? address.getAddress().getValue() : null;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxSource.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxSource.java
@@ -38,6 +38,8 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.AttributesImpl;
 import org.apache.cxf.common.logging.LogUtils;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 
@@ -81,7 +83,9 @@ public class StaxSource extends SAXSource implements XMLReader {
                     char[] chars = streamReader.getTextCharacters();
                     contentHandler.characters(chars, start, length);
                     if (lexicalHandler != null) {
-			LOG.fine("parse: CDATA:  " + String.valueOf(chars)); // Liberty Change
+                        if (LOG.isLoggable(Level.FINE)) { // Liberty Change
+                            LOG.fine("parse: CDATA:  " + String.valueOf(chars)); // Liberty Change
+                        }
                         lexicalHandler.endCDATA();
                     }
                     break;
@@ -147,13 +151,17 @@ public class StaxSource extends SAXSource implements XMLReader {
                         String nsPrefix = streamReader.getNamespacePrefix(i);
                         String nsUri = streamReader.getNamespaceURI(i);
                         if (nsUri == null) {
-		            LOG.fine("parse: nsUri is null, setting to empty string");  // Liberty Change
+                            if (LOG.isLoggable(Level.FINE)) { // Liberty Change
+                                LOG.fine("parse: nsUri is null, setting to empty string");  // Liberty Change
+                            }
                             nsUri = "";
                         }
                         
                         // Liberty Change Start - Handle a null nsPrefix to prevent NPE in TRAX
                         if (nsPrefix == null) {
-		            LOG.fine("parse: nsPrefix is null, setting to empty string");  // Liberty Change
+                            if (LOG.isLoggable(Level.FINE)) { // Liberty Change
+                                LOG.fine("parse: nsPrefix is null, setting to empty string");  // Liberty Change
+                            }
                             nsPrefix = "";
                         } 
                         // Liberty Change End

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/staxutils/StaxUtils.java
@@ -243,7 +243,9 @@ public final class StaxUtils {
             }
             return i;
         } catch (Throwable t) {
-            LOG.finest("getInteger: Ignoring exception: " + t);  // Liberty Change
+            if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest("getInteger: Ignoring exception: " + t);  // Liberty Change
+            }
             //ignore
         }
         return def;
@@ -260,7 +262,9 @@ public final class StaxUtils {
             }
             return i;
         } catch (Throwable t) {
-            LOG.finest("getLong: Ignoring exception: " + t);  // Liberty Change
+            if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest("getLong: Ignoring exception: " + t);  // Liberty Change
+            }
             //ignore
         }
         return def;
@@ -392,7 +396,9 @@ public final class StaxUtils {
             f.setProperty(p,  o);
             return true;
         } catch (Throwable t) {
-	    LOG.finest("setProperty: Ignoring exception: " + t);  // Liberty Change
+            if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest("setProperty: Ignoring exception: " + t);  // Liberty Change
+            }
             //ignore
         }
         return false;
@@ -597,7 +603,9 @@ public final class StaxUtils {
             try {
                 writer.flush();
             } catch (XMLStreamException ex) {
-	        LOG.finest("copy: Ignoring XMLStreamException: " + ex); // Liberty Change
+                if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("copy: Ignoring XMLStreamException: " + ex); // Liberty Change
+                }
                 //ignore
             }
             StaxUtils.close(writer);
@@ -628,12 +636,16 @@ public final class StaxUtils {
                             reader.setFeature("http://xml.org/sax/features/namespaces", true);
                         } catch (Throwable t) {
                             //ignore
-	        	    LOG.finest("copy: Ignoring reader.setFeature exception: " + t);  // Liberty Change
+                            if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                                LOG.finest("copy: Ignoring reader.setFeature exception: " + t);  // Liberty Change
+                            }
                         }
                         try {
                             reader.setProperty("http://xml.org/sax/properties/lexical-handler", ch);
                         } catch (Throwable t) {
-	        	    LOG.finest("copy: Ignoring reader.setProperty exception: " + t); // Liberty Change
+                            if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                                LOG.finest("copy: Ignoring reader.setProperty exception: " + t); // Liberty Change
+                            }
                             //ignore
                         }
                         reader.parse(((SAXSource)source).getInputSource());
@@ -672,7 +684,9 @@ public final class StaxUtils {
             d.setDocumentURI(doc.getDocumentURI());
         } catch (Exception ex) {
             //ignore - probably not DOM level 3
-	    LOG.finest("copy Doc: Ignoring d.setDocumentURI exception: " + ex);  // Liberty Change
+            if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest("copy Doc: Ignoring d.setDocumentURI exception: " + ex);  // Liberty Change
+            }
         }
         return d;
     }
@@ -1123,7 +1137,9 @@ public final class StaxUtils {
                     writer.writeDTD(((DocumentType)n).getTextContent());
                 }
             } catch (UnsupportedOperationException ex) {
-	        LOG.finest("writeNode: Ignoring exception: " + ex);  // Liberty Change
+                if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("writeNode: Ignoring exception: " + ex);  // Liberty Change
+                }
                 //can we ignore?  DOM writers really don't allow this
                 //as there isn't a way to write a DTD in dom
             }
@@ -1141,7 +1157,9 @@ public final class StaxUtils {
             try {
                 reader.close();
             } catch (Exception ex) {
-	        LOG.finest("read Src: Ignoring exception: " + ex);  // Liberty Change
+                if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("read Src: Ignoring exception: " + ex);  // Liberty Change
+                }
                 //ignore
             }
         }
@@ -1154,7 +1172,9 @@ public final class StaxUtils {
             try {
                 reader.close();
             } catch (Exception ex) {
-	        LOG.finest("read IS: Ignoring exception: " + ex);  // Liberty Change
+                if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("read IS: Ignoring exception: " + ex);  // Liberty Change
+                }
                 //ignore
             }
         }
@@ -1195,7 +1215,9 @@ public final class StaxUtils {
             try {
                 doc.setDocumentURI(reader.getLocation().getSystemId());
             } catch (Exception e) {
-	        LOG.finest("read: Ignoring exception 1: " + e);  // Liberty Change
+                if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("read: Ignoring exception 1: " + e);  // Liberty Change
+                }
                 //ignore - probably not DOM level 3
             }
         }
@@ -1211,7 +1233,9 @@ public final class StaxUtils {
             try {
                 doc.setDocumentURI(reader.getLocation().getSystemId());
             } catch (Exception e) {
-	        LOG.finest("read: Ignoring exception 2: " + e);  // Liberty Change
+                if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("read: Ignoring exception 2: " + e);  // Liberty Change
+                }
                 //ignore - probably not DOM level 3
             }
         }
@@ -1732,7 +1756,9 @@ public final class StaxUtils {
                 ss.setPublicId(pubId);
                 return new AutoCloseableXMLStreamReader(createXMLStreamReader(ss), is);
             } catch (Exception ex) {
-	        LOG.finest("createXMLStreamReader: Ignoring exception: " + ex);  // Liberty Change
+                if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("createXMLStreamReader: Ignoring exception: " + ex);  // Liberty Change
+                }
                 //ignore - not a valid URL
             }
         }
@@ -1823,7 +1849,9 @@ public final class StaxUtils {
                 try {
                     reader = factory.createXMLStreamReader(source);
                 } catch (UnsupportedOperationException e) {
-	            LOG.finest("createXMLStreamReader: Ignoring exception 2: " + e);	// Liberty Change
+                    if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                        LOG.finest("createXMLStreamReader: Ignoring exception 2: " + e);	// Liberty Change
+                    }
                     //ignore
                 }
                 if (reader == null && source instanceof StreamSource) {
@@ -1952,9 +1980,11 @@ public final class StaxUtils {
                 StaxUtils.close(writer);
             }
 			// Liberty Change - Prevent from going to message logs
-            LOG.finest(sw.toString());
+            if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest(sw.toString());
+            }
         } catch (XMLStreamException e) {
-            LOG.severe(e.getMessage());
+                LOG.severe(e.getMessage());
         }
     }
 
@@ -2144,7 +2174,9 @@ public final class StaxUtils {
             try {
                 writer.close();
             } catch (Exception e) {
-	        LOG.finest("close writer: Ignoring exception: " + e);	// Liberty Change
+                if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("close writer: Ignoring exception: " + e);	// Liberty Change
+                }
                 //ignore
             }
         }
@@ -2159,7 +2191,9 @@ public final class StaxUtils {
                 return true;
             }
         } catch (Exception ex) {
-	    LOG.finest("isSecureReader: Ignoring exception: " + ex);	// Liberty Change
+            if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest("isSecureReader: Ignoring exception: " + ex);	// Liberty Change
+            }
             //ignore
         }
         return false;
@@ -2239,7 +2273,9 @@ public final class StaxUtils {
         } catch (ClassCastException cce) {
             //not an XMLStreamReader2
             if (ALLOW_INSECURE_PARSER_VAL) {
-                LOG.finest("INSTANCE_NOT_XMLSTREAMREADER2");  // Liberty Change
+                if (LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("INSTANCE_NOT_XMLSTREAMREADER2");  // Liberty Change
+                }
             } else {
                 throw new XMLStreamException(cce.getMessage(), cce);
             }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/transport/ChainInitiationObserver.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/transport/ChainInitiationObserver.java
@@ -42,6 +42,8 @@ import org.apache.cxf.service.Service;
 import org.apache.cxf.service.model.EndpointInfo;
 import org.apache.cxf.transport.https.CertConstraintsInterceptor;
 import org.apache.cxf.common.logging.LogUtils;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
@@ -78,7 +80,9 @@ public class ChainInitiationObserver implements MessageObserver {
                 synchronized (phaseChain) {
                     if (phaseChain.getState() == InterceptorChain.State.PAUSED
                         || phaseChain.getState() == InterceptorChain.State.SUSPENDED) {
-			LOG.fine("onMessage: Phase Chain was paused/suspended, resuming"); // Liberty Change
+                        if (LOG.isLoggable(Level.FINE)) { // Liberty Change
+                            LOG.fine("onMessage: Phase Chain was paused/suspended, resuming"); // Liberty Change
+                        }
                         phaseChain.resume();
                         return;
                     }
@@ -145,7 +149,9 @@ public class ChainInitiationObserver implements MessageObserver {
 			// Liberty Change Start:
             // This helps us to detect if CertConstraintsInterceptor  needs to be added to chain
             String rqURL = (String) m.get(Message.REQUEST_URL);
-	    LOG.fine("addToChain: Request URL: " + rqURL);
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                LOG.fine("addToChain: Request URL: " + rqURL);
+            }
             boolean isHttps = (rqURL != null && rqURL.indexOf("https:") > -1) ? true : false;
             for (Interceptor<? extends Message> i : is) {
                 if (i instanceof CertConstraintsInterceptor && isHttps == false) {
@@ -166,6 +172,8 @@ public class ChainInitiationObserver implements MessageObserver {
     }
 
     protected void setExchangeProperties(Exchange exchange, Message m) {
+        boolean isFineEnabled = LOG.isLoggable(Level.FINE); // Liberty Change
+            
         exchange.put(Endpoint.class, endpoint);
         exchange.put(Binding.class, getBinding());
         exchange.put(Bus.class, bus);
@@ -179,23 +187,31 @@ public class ChainInitiationObserver implements MessageObserver {
 
             if (endpointInfo.getService() != null) {
                 QName serviceQName = endpointInfo.getService().getName();
-	        LOG.fine("setExchangeProperties: WSDL service Qname: " + serviceQName);  // Liberty Change
+                if(isFineEnabled) { // Liberty Change
+                    LOG.fine("setExchangeProperties: WSDL service Qname: " + serviceQName);  // Liberty Change
+                }
                 exchange.put(Message.WSDL_SERVICE, serviceQName);
 
                 QName interfaceQName = endpointInfo.getService().getInterface().getName();
                 exchange.put(Message.WSDL_INTERFACE, interfaceQName);
 
                 QName portQName = endpointInfo.getName();
-	        LOG.fine("setExchangeProperties: WSDL Port Qname: " + portQName);  // Liberty Change
+                if(isFineEnabled) { // Liberty Change
+                    LOG.fine("setExchangeProperties: WSDL Port Qname: " + portQName);  // Liberty Change
+                }
                 exchange.put(Message.WSDL_PORT, portQName);
                 URI wsdlDescription = endpointInfo.getProperty("URI", URI.class);
                 if (wsdlDescription == null && !endpointInfo.hasProperty("URI")) {
                     String address = endpointInfo.getAddress();
-	            LOG.fine("setExchangeProperties: Endpoint address: " + address);  // Liberty Change
+                    if(isFineEnabled) { // Liberty Change
+                        LOG.fine("setExchangeProperties: Endpoint address: " + address);  // Liberty Change
+                    }
                     try {
                         wsdlDescription = new URI(address + "?wsdl");
                     } catch (URISyntaxException e) {
-	                 LOG.fine("setExchangeProperties: Ignoring URISyntaxException: " + e);  // Liberty Change
+                        if(isFineEnabled) { // Liberty Change
+                            LOG.fine("setExchangeProperties: Ignoring URISyntaxException: " + e);  // Liberty Change
+                        }
                         // do nothing
                     }
                     endpointInfo.setProperty("URI", wsdlDescription);
@@ -203,7 +219,9 @@ public class ChainInitiationObserver implements MessageObserver {
                 exchange.put(Message.WSDL_DESCRIPTION, wsdlDescription);
             }
         } else {
-	    LOG.fine("setExchangeProperties: Setting Service.class to null");  // Liberty Change
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("setExchangeProperties: Setting Service.class to null");  // Liberty Change
+            }
             exchange.put(Service.class, null);
         }
     }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/PolicyEngineImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/PolicyEngineImpl.java
@@ -87,7 +87,10 @@ public class PolicyEngineImpl implements PolicyEngine, BusExtension {
     static {
 
         String skipPolicyCheck = System.getProperty("cxf.ignore.unsupported.policy");
-        LOG.log(Level.FINE, "cxf.ignore.unsupported.policy property is set to " + skipPolicyCheck);
+
+        if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+            LOG.log(Level.FINE, "cxf.ignore.unsupported.policy property is set to " + skipPolicyCheck);
+        }
 
         if (skipPolicyCheck != null 
             && skipPolicyCheck.trim().length() > 0
@@ -121,7 +124,9 @@ public class PolicyEngineImpl implements PolicyEngine, BusExtension {
     public final void setBus(Bus b) {
         if (this.bus == b) {
             //avoid bus init twice through injection
-	    LOG.finest("setBus: Bus already initialized, returning");  // Liberty Change
+            if(LOG.isLoggable(Level.FINEST)) {
+                LOG.finest("setBus: Bus already initialized, returning");  // Liberty Change
+            }
             return;
         }
         bus = b;
@@ -130,7 +135,10 @@ public class PolicyEngineImpl implements PolicyEngine, BusExtension {
         if (fblm != null) {
             for (FactoryBeanListener l : fblm.getListeners()) {
                 if (l instanceof PolicyAnnotationListener) {
-		    LOG.finest("setBus: PolicyAnnotationListener instance found, returning");  // Liberty Change
+
+                    if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                        LOG.finest("setBus: PolicyAnnotationListener instance found, returning");  // Liberty Change
+                    }
                     return;
                 }
             }
@@ -268,7 +276,10 @@ public class PolicyEngineImpl implements PolicyEngine, BusExtension {
                     }
                 }
             }
-	    LOG.fine("Returning effectivePolicy for null incoming"); // Liberty Change
+
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                LOG.fine("Returning effectivePolicy for null incoming"); // Liberty Change
+            }
             return effectivePolicy;
         }
         EffectivePolicyImpl epi = createOutPolicyInfo();
@@ -319,7 +330,9 @@ public class PolicyEngineImpl implements PolicyEngine, BusExtension {
             boi = boi.getWrappedOperation();
             for (BindingFaultInfo bf2 : boi.getFaults()) {
                 if (bf2.getFaultInfo().getName().equals(bfi.getFaultInfo().getName())) {
-		    LOG.fine("bf1 and bf2 faultinfo is same, returning bf2");  // Liberty Change
+                    if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                        LOG.fine("bf1 and bf2 faultinfo is same, returning bf2");  // Liberty Change
+                    }
                     return bf2;
                 }
             }
@@ -461,7 +474,9 @@ public class PolicyEngineImpl implements PolicyEngine, BusExtension {
         if (ignoreUnknownAssertions != null) {
             AssertionBuilderRegistry abr = bus.getExtension(AssertionBuilderRegistry.class);
             if (null != abr) {
-		LOG.fine("Setting ignoreUnknownAssertions to: " + ignoreUnknownAssertions);  // Liberty Change
+                if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                    LOG.fine("Setting ignoreUnknownAssertions to: " + ignoreUnknownAssertions);  // Liberty Change
+                }
                 abr.setIgnoreUnknownAssertions(ignoreUnknownAssertions);
             }
         }
@@ -558,11 +573,15 @@ public class PolicyEngineImpl implements PolicyEngine, BusExtension {
         if (Constants.TYPE_ASSERTION == pc.getType()) {
             Assertion a = (Assertion)pc;
             if (includeOptional || !a.isOptional()) {
-		LOG.finest("Adding required assertions 1: " + a.getName()); // Liberty Change
+                if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("Adding required assertions 1: " + a.getName()); // Liberty Change
+                }
                 assertions.add(a);
             }
         } else {
-	    LOG.finest("Adding optional assertions 1: " + includeOptional); // Liberty Change
+            if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest("Adding optional assertions 1: " + includeOptional); // Liberty Change
+            }
             addAssertions(pc, includeOptional, assertions);
         }
         return assertions;
@@ -590,7 +609,9 @@ public class PolicyEngineImpl implements PolicyEngine, BusExtension {
         if (Constants.TYPE_ASSERTION == pc.getType()) {
             Assertion a = (Assertion)pc;
             if (includeOptional || !a.isOptional()) {
-		LOG.finest("Adding required assertions 2: " + a.getName()); // Liberty Change
+                if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("Adding required assertions 2: " + a.getName()); // Liberty Change
+                }
                 assertions.add((Assertion)pc);
             }
             return;
@@ -605,7 +626,9 @@ public class PolicyEngineImpl implements PolicyEngine, BusExtension {
 
         List<PolicyComponent> pcs = CastUtils.cast(po.getPolicyComponents(), PolicyComponent.class);
         for (PolicyComponent child : pcs) {
-	    LOG.finest("Adding optional assertions 2: " + includeOptional); // Liberty Change
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                LOG.finest("Adding optional assertions 2: " + includeOptional); // Liberty Change
+            }
             addAssertions(child, includeOptional, assertions);
         }
     }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/PolicyInInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/PolicyInInterceptor.java
@@ -57,14 +57,18 @@ public class PolicyInInterceptor extends AbstractPolicyInterceptor {
         Bus bus = exchange.getBus();
         Endpoint e = exchange.getEndpoint();
         if (null == e) {
-            LOG.fine("No endpoint.");
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                LOG.fine("No endpoint.");
+            }
             return;
         }
         EndpointInfo ei = e.getEndpointInfo();
 
         PolicyEngine pe = bus.getExtension(PolicyEngine.class);
         if (null == pe) {
-	    LOG.fine("No PolicyEngine.");  // Liberty Change
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                LOG.fine("No PolicyEngine.");  // Liberty Change
+            }
             return;
         }
 
@@ -84,7 +88,9 @@ public class PolicyInInterceptor extends AbstractPolicyInterceptor {
             interceptors.addAll(effectivePolicy.getInterceptors());
             assertions.addAll(effectivePolicy.getChosenAlternative());
         } else if (MessageUtils.isRequestor(msg)) {
-	    LOG.finest("Processing client policy.");  // Liberty Change
+            if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest("Processing client policy.");  // Liberty Change
+            }
             // 2. Process client policy
             BindingOperationInfo boi = exchange.getBindingOperationInfo();
             if (boi == null) {
@@ -98,8 +104,10 @@ public class PolicyInInterceptor extends AbstractPolicyInterceptor {
                 // We do not know the underlying message type yet - so we pre-emptively add interceptors
                 // that can deal with any resposes or faults returned to this client endpoint.
 
-		LOG.finest("getEffectiveClientResponsePolicy for boi: " + boi.getName() + " and EI: " + 
+                if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("getEffectiveClientResponsePolicy for boi: " + boi.getName() + " and EI: " + 
 				(ei != null ? ei.getAddress() : "null") ); // Liberty Change
+                }
                 EffectivePolicy ep = pe.getEffectiveClientResponsePolicy(ei, boi, msg);
                 if (ep != null) {
                     interceptors.addAll(ep.getInterceptors());
@@ -112,7 +120,9 @@ public class PolicyInInterceptor extends AbstractPolicyInterceptor {
             }
         } else {
             // 3. Process server policy
-	    LOG.finest("Processing server policy.");  // Liberty Change
+            if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                LOG.finest("Processing server policy.");  // Liberty Change
+            }
             Destination destination = exchange.getDestination();
 
             // We do not know the underlying message type yet - so we pre-emptively add interceptors

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/PolicyOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/PolicyOutInterceptor.java
@@ -60,20 +60,26 @@ public class PolicyOutInterceptor extends AbstractPolicyInterceptor {
 
         BindingOperationInfo boi = exchange.getBindingOperationInfo();
         if (null == boi) {
-            LOG.fine("No binding operation info.");
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                LOG.fine("No binding operation info.");
+            }
             return;
         }
 
         Endpoint e = exchange.getEndpoint();
         if (null == e) {
-            LOG.fine("No endpoint.");
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                LOG.fine("No endpoint.");
+            }
             return;
         }
         EndpointInfo ei = e.getEndpointInfo();
 
         PolicyEngine pe = bus.getExtension(PolicyEngine.class);
         if (null == pe) {
-            LOG.fine("No PolicyEngine.");  // Liberty Change
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                LOG.fine("No PolicyEngine.");  // Liberty Change
+            }
             return;
         }
 
@@ -92,7 +98,9 @@ public class PolicyOutInterceptor extends AbstractPolicyInterceptor {
             addInterceptors(effectivePolicy.getInterceptors(), msg);
             assertions.addAll(effectivePolicy.getChosenAlternative());
         } else if (MessageUtils.isRequestor(msg)) {
-	    LOG.fine("Processing client policy");  // Liberty Change
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                LOG.fine("Processing client policy");  // Liberty Change
+            }
             // 2. Process client policy
             Conduit conduit = exchange.getConduit(msg);
 
@@ -108,7 +116,9 @@ public class PolicyOutInterceptor extends AbstractPolicyInterceptor {
             }
         } else {
             // 3. Process server policy
-	    LOG.fine("Processing server policy");  // Liberty Change
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                LOG.fine("Processing server policy");  // Liberty Change
+            }
             Destination destination = exchange.getDestination();
             List<List<Assertion>> incoming
                 = CastUtils.cast((List<?>)exchange.get("ws-policy.validated.alternatives"));
@@ -134,7 +144,7 @@ public class PolicyOutInterceptor extends AbstractPolicyInterceptor {
                 for (Assertion a : assertions) {
                     PolicyUtils.printPolicyComponent(a, buf, 1);
                 }
-                LOG.finest(buf.toString());
+				LOG.finest(buf.toString());
             }
             msg.put(AssertionInfoMap.class, new AssertionInfoMap(assertions));
             msg.getInterceptorChain().add(PolicyVerificationOutInterceptor.INSTANCE);
@@ -144,7 +154,9 @@ public class PolicyOutInterceptor extends AbstractPolicyInterceptor {
     private static void addInterceptors(List<Interceptor<? extends Message>> interceptors, Message msg) {
         for (Interceptor<? extends Message> oi : interceptors) {
             msg.getInterceptorChain().add(oi);
-            LOG.log(Level.FINE, "Added interceptor of type {0}", oi.getClass().getSimpleName());
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change 
+                LOG.log(Level.FINE, "Added interceptor of type {0}", oi.getClass().getSimpleName());
+            }
         }
     }
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/PolicyVerificationInInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/PolicyVerificationInInterceptor.java
@@ -73,22 +73,31 @@ public class PolicyVerificationInInterceptor extends AbstractPolicyInterceptor {
      */
     protected void handle(Message message) {
 
+        boolean isFineEnabled = LOG.isLoggable(Level.FINE); // Liberty Change
+            
         AssertionInfoMap aim = message.get(AssertionInfoMap.class);
         if (null == aim) {
-            LOG.fine("No AssertionInfoMap.");  // Liberty Change
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("No AssertionInfoMap.");  // Liberty Change
+            }
             return;
         }
 
         Exchange exchange = message.getExchange();
         BindingOperationInfo boi = exchange.getBindingOperationInfo();
         if (null == boi) {
-            LOG.fine("No binding operation info.");
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("No binding operation info.");
+            }
+            
             return;
         }
 
         Endpoint e = exchange.getEndpoint();
         if (null == e) {
-            LOG.fine("No endpoint.");
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("No endpoint.");
+            }
             return;
         }
 
@@ -99,7 +108,9 @@ public class PolicyVerificationInInterceptor extends AbstractPolicyInterceptor {
         }
 
         if (MessageUtils.isPartialResponse(message)) {
-            LOG.fine("Not verifying policies on inbound partial response.");
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("Not verifying policies on inbound partial response.");
+            }
             return;
         }
 
@@ -109,10 +120,14 @@ public class PolicyVerificationInInterceptor extends AbstractPolicyInterceptor {
         if (effectivePolicy == null) {
             EndpointInfo ei = e.getEndpointInfo();
             if (MessageUtils.isRequestor(message)) {
-                LOG.fine("Getting response effectivePolicy for client.");  // Liberty Change
+                if(isFineEnabled) { // Liberty Change
+                    LOG.fine("Getting response effectivePolicy for client.");  // Liberty Change
+                }
                 effectivePolicy = pe.getEffectiveClientResponsePolicy(ei, boi, message);
             } else {
-                LOG.fine("Getting request effectivePolicy for server .");  // Liberty Change
+                if(isFineEnabled) { // Liberty Change
+                    LOG.fine("Getting request effectivePolicy for server .");  // Liberty Change
+                }
                 effectivePolicy = pe.getEffectiveServerRequestPolicy(ei, boi, message);
             }
         }
@@ -122,8 +137,10 @@ public class PolicyVerificationInInterceptor extends AbstractPolicyInterceptor {
             
             if (ignoreUnsupportedPolicy) {
                 // Please do not modify log message below, it's been used in PropertySettingTest
-                LOG.fine("WARNING: checkEffectivePolicy will not be called because "
+                if(isFineEnabled) { // Liberty Change
+                    LOG.fine("WARNING: checkEffectivePolicy will not be called because "
                                 + "property cxf.ignore.unsupported.policy is set to true.");
+                }
             } else {
                 usedAlternatives = aim.checkEffectivePolicy(effectivePolicy.getPolicy());
             } // Liberty Change End
@@ -143,7 +160,9 @@ public class PolicyVerificationInInterceptor extends AbstractPolicyInterceptor {
             }
             throw ex;
         }
-        LOG.fine("Verified policies for inbound message.");
+        if(isFineEnabled) { // Liberty Change
+            LOG.fine("Verified policies for inbound message.");
+        }
     }
 
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/PolicyVerificationOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/PolicyVerificationOutInterceptor.java
@@ -19,6 +19,7 @@
 
 package org.apache.cxf.ws.policy;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.cxf.common.logging.LogUtils;
@@ -47,14 +48,20 @@ public class PolicyVerificationOutInterceptor extends AbstractPolicyInterceptor 
      * @throws PolicyException if none of the alternatives is supported
      */
     protected void handle(Message message) {
+        boolean isFineEnabled = LOG.isLoggable(Level.FINE); // Liberty Change
+        
         if (MessageUtils.isPartialResponse(message)) {
-            LOG.fine("Not verifying policies on outbound partial response.");
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("Not verifying policies on outbound partial response.");
+            }
             return;
         }
 
         AssertionInfoMap aim = message.get(AssertionInfoMap.class);
         if (null == aim) {
-            LOG.fine("AssertionInfoMap is null.");  // Liberty Change
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("AssertionInfoMap is null.");  // Liberty Change
+            }
             return;
         }
 
@@ -62,7 +69,9 @@ public class PolicyVerificationOutInterceptor extends AbstractPolicyInterceptor 
 
         EffectivePolicy policy = message.get(EffectivePolicy.class);
         if (policy == null) {
-            LOG.fine("EffectivePolicy is null.");  // Liberty Change
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("EffectivePolicy is null.");  // Liberty Change
+            }
             return;
         }
 
@@ -71,12 +80,16 @@ public class PolicyVerificationOutInterceptor extends AbstractPolicyInterceptor 
         try {
             aim.checkEffectivePolicy(policy.getPolicy());
         } catch (PolicyException e) {
-            LOG.fine("An exception was thrown when verifying that the effective policy for "
+            if(isFineEnabled) { // Liberty Change
+                LOG.fine("An exception was thrown when verifying that the effective policy for "
                      + "this request was satisfied.  However, this exception will not result in "
                      + "a fault.  The exception raised is: "
                      + e.toString());
+            }
             return;
         }
-        LOG.fine("Verified policies for outbound message.");
+        if(isFineEnabled) { // Liberty Change
+            LOG.fine("Verified policies for outbound message.");
+        }
     }
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/mtom/MTOMPolicyInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/mtom/MTOMPolicyInterceptor.java
@@ -21,6 +21,8 @@ package org.apache.cxf.ws.policy.mtom;
 
 import java.util.Collection;
 import org.apache.cxf.common.logging.LogUtils;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.cxf.interceptor.Fault;
@@ -56,17 +58,23 @@ public class MTOMPolicyInterceptor extends AbstractPhaseInterceptor<Message> {
             for (AssertionInfo ai : ais) {
                 if (MessageUtils.isRequestor(message)) {
                     //just turn on MTOM
-		    LOG.fine("Enable MTOM on client side");  // Liberty Change start
+                    if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                        LOG.fine("Enable MTOM on client side");  // Liberty Change start
+                    }
                     message.put(Message.MTOM_ENABLED, Boolean.TRUE);
                     ai.setAsserted(true);
                 } else {
                     // set mtom enabled and assert the policy if we find an mtom request
                     String contentType = (String)message.getExchange().getInMessage()
                         .get(Message.CONTENT_TYPE);
-		    LOG.fine("ContentType is " + contentType);
+                    if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                        LOG.fine("ContentType is " + contentType);
+                    }
                     if (contentType != null && contentType.contains("type=\"application/xop+xml\"")) {
                         ai.setAsserted(true);
-		        LOG.fine("Enable MTOM on provider side");  // Liberty Change end
+                        if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                            LOG.fine("Enable MTOM on provider side");  // Liberty Change end
+                        }
                         message.put(Message.MTOM_ENABLED, Boolean.TRUE);
                     }
                 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/selector/MinimalAlternativeSelector.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/src/org/apache/cxf/ws/policy/selector/MinimalAlternativeSelector.java
@@ -23,6 +23,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.cxf.common.logging.LogUtils;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.cxf.message.Message;
@@ -51,13 +53,17 @@ public class MinimalAlternativeSelector extends BaseAlternativeSelector {
             if (engine.supportsAlternative(alternative, assertor, msg)
                 && isCompatibleWithRequest(alternative, request)
                 && (null == choice || alternative.size() < choice.size())) {
-		LOG.fine("Engine supports alternative (CXF 2.6.2)");
+                if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                    LOG.fine("Engine supports alternative (CXF 2.6.2)");
+                }
                 choice = alternative;
             }
 	    // Liberty Change End
         }
         if (choice == null) {
-	    LOG.fine("Getting minimal alternatives");  // Liberty Change
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                LOG.fine("Getting minimal alternatives");  // Liberty Change
+            }
             // didn't find one completely compatible with the incoming, just get the minimal
             alternatives = policy.getAlternatives();
             while (alternatives.hasNext()) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/src/org/apache/cxf/wsdl/interceptors/BareOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/src/org/apache/cxf/wsdl/interceptors/BareOutInterceptor.java
@@ -46,13 +46,17 @@ public class BareOutInterceptor extends AbstractOutDatabindingInterceptor {
         BindingOperationInfo operation = exchange.getBindingOperationInfo();
 
         if (operation == null) {
-	    LOG.finest("BareOutInterceptor: Operation is NULL, returning..."); // Liberty Change start
+            if(LOG.isLoggable(Level.FINEST)) { // Liberty Change 
+                LOG.finest("BareOutInterceptor: Operation is NULL, returning..."); // Liberty Change start
+            }
             return;
         }
 
         MessageContentsList objs = MessageContentsList.getContentsList(message);
         if (objs == null || objs.isEmpty()) {
-	    LOG.finest("BareOutInterceptor: MessageContentsList is empty, returning...");
+            if(LOG.isLoggable(Level.FINEST)) { // Liberty Change 
+                LOG.finest("BareOutInterceptor: MessageContentsList is empty, returning...");
+            }
             return;
         }
 
@@ -62,16 +66,22 @@ public class BareOutInterceptor extends AbstractOutDatabindingInterceptor {
 
         if (!client) {
             if (operation.getOutput() != null) {
-		LOG.fine("BareOutInterceptor: Getoutput for operation: " + operation.getName());
+                if(LOG.isLoggable(Level.FINE)) { // Liberty Change 
+                    LOG.fine("BareOutInterceptor: Getoutput for operation: " + operation.getName());
+                }
                 bmsg = operation.getOutput();
                 parts = bmsg.getMessageParts();
             } else {
                 // partial response to oneway
-		LOG.finest("BareOutInterceptor: Operation output is NULL, returning");
+                if(LOG.isLoggable(Level.FINEST)) { // Liberty Change 
+                    LOG.finest("BareOutInterceptor: Operation output is NULL, returning");
+                }
                 return;
             }
         } else {
-	    LOG.fine("BareOutInterceptor: Get input message parts...");
+            if(LOG.isLoggable(Level.FINE)) { // Liberty Change 
+                LOG.fine("BareOutInterceptor: Get input message parts...");
+            }
             bmsg = operation.getInput();
             parts = bmsg.getMessageParts();
         }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/src/org/apache/cxf/wsdl/interceptors/DocLiteralInInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/src/org/apache/cxf/wsdl/interceptors/DocLiteralInInterceptor.java
@@ -66,7 +66,9 @@ public class DocLiteralInInterceptor extends AbstractInDatabindingInterceptor {
 
     public void handleMessage(Message message) {
         if (isGET(message) && message.getContent(List.class) != null) {
-            LOG.finest("DocLiteralInInterceptor: HTTP GET method, returning");
+            if(LOG.isLoggable(Level.FINEST)) { // Liberty Change 
+                LOG.finest("DocLiteralInInterceptor: HTTP GET method, returning");
+            }
             return;
         }
 
@@ -82,7 +84,9 @@ public class DocLiteralInInterceptor extends AbstractInDatabindingInterceptor {
         //operation anymore, just return
         if (bop != null && !StaxUtils.toNextElement(xmlReader)) {
             // body may be empty for partial response to decoupled request
-            LOG.finest("DocLiteralInInterceptor: Soap Body may be empty, returning"); // Liberty Change
+            if(LOG.isLoggable(Level.FINEST)) { // Liberty Change 
+                LOG.finest("DocLiteralInInterceptor: Soap Body may be empty, returning"); // Liberty Change
+            }
             return;
         }
 
@@ -105,7 +109,9 @@ public class DocLiteralInInterceptor extends AbstractInDatabindingInterceptor {
                 if (shouldWrapParameters(msgInfo, message)) {
                     QName startQName = xmlReader.getName();
                     MessagePartInfo mpi = msgInfo.getFirstMessagePart();
-		    LOG.fine("Should wrap parameters for Message part: " + mpi); // Liberty Change
+                    if(LOG.isLoggable(Level.FINE)) { // Liberty Change 
+                        LOG.fine("Should wrap parameters for Message part: " + mpi); // Liberty Change
+                    }
                     if (!mpi.getConcreteName().equals(startQName)) {
                         throw new Fault("UNEXPECTED_WRAPPER_ELEMENT", LOG, null, startQName,
                                         mpi.getConcreteName());
@@ -113,7 +119,9 @@ public class DocLiteralInInterceptor extends AbstractInDatabindingInterceptor {
                     Object wrappedObject = dr.read(mpi, xmlReader);
                     parameters.put(mpi, wrappedObject);
                 } else {
-		    LOG.fine("No wrapper, unwrap each part individually"); // Liberty Change
+                    if(LOG.isLoggable(Level.FINE)) { // Liberty Change 
+                        LOG.fine("No wrapper, unwrap each part individually"); // Liberty Change
+                    }
                     // Unwrap each part individually if we don't have a wrapper
 
                     bop = bop.getUnwrappedOperation();
@@ -133,7 +141,9 @@ public class DocLiteralInInterceptor extends AbstractInDatabindingInterceptor {
                 }
 
             } else {
-		LOG.finest("This is Bare style");  // Liberty Change
+                if(LOG.isLoggable(Level.FINEST)) { // Liberty Change 
+                    LOG.finest("This is Bare style");  // Liberty Change
+                }
                 //Bare style
                 BindingMessageInfo msgInfo = null;
 
@@ -149,7 +159,9 @@ public class DocLiteralInInterceptor extends AbstractInDatabindingInterceptor {
                         }
                     }
                     if (msgInfo == null) {
-		        LOG.finest("MsgInfo is null, returning");  // Liberty Change
+                        if(LOG.isLoggable(Level.FINEST)) { // Liberty Change 
+                            LOG.finest("MsgInfo is null, returning");  // Liberty Change
+                        }
                         return;
                     }
                     setMessage(message, bop, client, si, msgInfo.getMessageInfo());
@@ -160,7 +172,9 @@ public class DocLiteralInInterceptor extends AbstractInDatabindingInterceptor {
 
                 if (xmlReader == null || !StaxUtils.toNextElement(xmlReader)) {
                     // empty input
-		    LOG.finest("No input, returning");  // Liberty Change
+                    if(LOG.isLoggable(Level.FINEST)) { // Liberty Change 
+                        LOG.finest("No input, returning");  // Liberty Change
+                    }
                     getBindingOperationForEmptyBody(operations, ep, exchange);
                     return;
                 }
@@ -176,7 +190,9 @@ public class DocLiteralInInterceptor extends AbstractInDatabindingInterceptor {
                     if (!client && msgInfo != null && msgInfo.getMessageParts() != null
                         && msgInfo.getMessageParts().isEmpty()) {
                         //no input messagePartInfo
-		        LOG.finest("MessageParts empty, returning");  // Liberty Change
+                        if(LOG.isLoggable(Level.FINEST)) { // Liberty Change 
+                            LOG.finest("MessageParts empty, returning");  // Liberty Change
+                        }
                         return;
                     }
 
@@ -194,17 +210,23 @@ public class DocLiteralInInterceptor extends AbstractInDatabindingInterceptor {
                     if (!forceDocLitBare) {
                         //Make sure the elName found on the wire is actually OK for
                         //the purpose we need it
-		        LOG.finest("Validating elName: " + elName); // Liberty Change
+                        if(LOG.isLoggable(Level.FINEST)) { // Liberty Change 
+                            LOG.finest("Validating elName: " + elName); // Liberty Change
+                        }
                         validatePart(p, elName, message);
                     }
 
                     final Object o = dr.read(p, xmlReader);
                     if (forceDocLitBare && parameters.isEmpty()) {
                         // webservice provider does not need to ensure size
-			LOG.finest("No parameters to add!");  // Liberty Change
+                        if(LOG.isLoggable(Level.FINEST)) { // Liberty Change 
+                            LOG.finest("No parameters to add!");  // Liberty Change
+                        }
                         parameters.add(o);
                     } else {
-			LOG.finest("Add parameters to msgpart: " + p);  // Liberty Change
+                        if(LOG.isLoggable(Level.FINEST)) { // Liberty Change 
+                            LOG.finest("Add parameters to msgpart: " + p);  // Liberty Change
+                        }
                         parameters.put(p, o);
                     }
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/src/org/apache/cxf/wsdl/service/factory/ReflectionServiceFactoryBean.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/src/org/apache/cxf/wsdl/service/factory/ReflectionServiceFactoryBean.java
@@ -228,7 +228,9 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
                 return cls.getConstructor(Boolean.TYPE, Map.class)
                     .newInstance(this.isQualifyWrapperSchema(), this.getProperties());
             } catch (NoSuchMethodException nsme) {
-		LOG.fine("Ignoring NoSuchMethodException: " + nsme);  // Liberty Change
+                if(LOG.isLoggable(Level.FINE)) {
+                    LOG.fine("Ignoring NoSuchMethodException: " + nsme);  // Liberty Change
+                }
                 //ignore, use the no-arg constructor
             }
             return cls.newInstance();
@@ -648,10 +650,14 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
         Map<QName, Method> validMethods = new HashMap<>();
         for (Method m : methods) {
 	    // Liberty Change start
-	    LOG.finest("initializeWSDLOperations: for Method: " + m.getName());
+            if(LOG.isLoggable(Level.FINEST)) {
+                LOG.finest("initializeWSDLOperations: for Method: " +  (m != null ? m.getName() : "null"));
+            }
             if (isValidMethod(m)) {
                 QName opName = getOperationName(intf, m);
-		LOG.finest("initializeWSDLOperations: Operation name: " + opName);
+                if(LOG.isLoggable(Level.FINEST)) {
+                    LOG.finest("initializeWSDLOperations: Operation name: " + opName);
+                }
 	    // Liberty Change end
                 validMethods.put(opName, m);
             }
@@ -665,7 +671,9 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
                 if (o.getName().getNamespaceURI().equals(opName.getNamespaceURI())
                     && isMatchOperation(o.getName().getLocalPart(), opName.getLocalPart())) {
                     selected = m.getValue();
-		    LOG.finest("Method selected: " + (selected != null ? selected.getName() : "null")); // Liberty Change
+                    if(LOG.isLoggable(Level.FINEST)) {
+                        LOG.finest("Method selected: " + (selected != null ? selected.getName() : "null")); // Liberty Change
+                    }
                     break;
                 }
             }
@@ -725,17 +733,19 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
         OperationInfo origOp = o;
 
 	// Liberty Change start
-	if (LOG.isLoggable(Level.FINEST)) {
+        if (LOG.isLoggable(Level.FINEST)) {
             if (paramOrder != null && !paramOrder.isEmpty()) {
                 for (String p1 : paramOrder) {
                     LOG.finest("initializeClassInfo: paramOrder: " + p1);
                 }
             }
-	}
+        }
 	// Liberty Change end
 
         if (isWrapped(method)) {
-	    LOG.finest("initializeClassInfo: Method is wrapped");   // Liberty Change
+            if(LOG.isLoggable(Level.FINEST)) {
+                LOG.finest("initializeClassInfo: Method is wrapped");   // Liberty Change
+            }
             if (o.getUnwrappedOperation() == null) {
                 //the "normal" algorithm didn't allow for unwrapping,
                 //but the annotations say unwrap this.   We'll need to
@@ -743,7 +753,9 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
                 WSDLServiceBuilder.checkForWrapped(o, true);
             }
             if (o.getUnwrappedOperation() != null) {
-		LOG.finest("initializeClassInfo: Operation is Unwrapped");  // Liberty Change
+                if(LOG.isLoggable(Level.FINEST)) {
+                    LOG.finest("initializeClassInfo: Operation is Unwrapped");  // Liberty Change
+                }
                 if (o.hasInput()) {
                     MessageInfo input = o.getInput();
                     MessagePartInfo part = input.getFirstMessagePart();
@@ -766,7 +778,9 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
                 setFaultClassInfo(o, method);
             }
         } else if (o.isUnwrappedCapable()) {
-	    LOG.finest("initializeClassInfo: Operation is Unwrapped Capable");  // Liberty Change
+            if(LOG.isLoggable(Level.FINEST)) {
+                LOG.finest("initializeClassInfo: Operation is Unwrapped Capable");  // Liberty Change
+            }
             // remove the unwrapped operation because it will break the
             // the WrapperClassOutInterceptor, and in general makes
             // life more confusing
@@ -794,7 +808,9 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
             Class<?> paramType = paramTypes[i];
             Type genericType = genericTypes[i];
             if (!initializeParameter(o, method, i, paramType, genericType)) {
-		LOG.finest("initializeClassInfo: initializeParameter 1 returning false.");  // Liberty Change
+                if(LOG.isLoggable(Level.FINEST)) {
+                    LOG.finest("initializeClassInfo: initializeParameter 1 returning false.");  // Liberty Change
+                }
                 return false;
             }
         }
@@ -803,7 +819,9 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
         // Initialize return type
         if (o.hasOutput()
             && !initializeParameter(o, method, -1, method.getReturnType(), method.getGenericReturnType())) {
-	    LOG.finest("initializeClassInfo: initializeParameter 2 returning false.");  // Liberty Change
+            if(LOG.isLoggable(Level.FINEST)) {
+                LOG.finest("initializeClassInfo: initializeParameter 2 returning false.");  // Liberty Change
+            }
             return false;
         }
         if (o.hasOutput()) {
@@ -837,11 +855,15 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
         boolean isHeader = isHeader(method, i);
         Annotation[] paraAnnos = null;
         if (i != -1 && o.getProperty(METHOD_PARAM_ANNOTATIONS) != null) {
-	    LOG.fine("initializeParameter : Param Annotations"); // Liberty Change
+            if(LOG.isLoggable(Level.FINE)) {
+                LOG.fine("initializeParameter : Param Annotations"); // Liberty Change
+            }
             Annotation[][] anns = (Annotation[][])o.getProperty(METHOD_PARAM_ANNOTATIONS);
             paraAnnos = anns[i];
         } else if (i == -1 && o.getProperty(METHOD_ANNOTATIONS) != null) {
-	    LOG.fine("initializeParameter : Method Annotations"); // Liberty Change
+            if(LOG.isLoggable(Level.FINE)) {
+                LOG.fine("initializeParameter : Method Annotations"); // Liberty Change
+            }
             paraAnnos = (Annotation[])o.getProperty(METHOD_ANNOTATIONS);
         }
 
@@ -1849,14 +1871,20 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
 
 
     protected void initializeParameter(MessagePartInfo part, Class<?> rawClass, Type type) {
+        
+        boolean isFineEnabled = LOG.isLoggable(Level.FINE);
         if (isHolder(rawClass, type)) {
             Type c = getHolderType(rawClass, type);
             if (c != null) {
                 type = c;
 		// Liberty Change start
-		LOG.fine("initializeParameter: Holder type: " + c.getTypeName()); 
+                if(isFineEnabled) {
+                    LOG.fine("initializeParameter: Holder type: " + c.getTypeName()); 
+                }
                 rawClass = getClass(type);
-		LOG.fine("initializeParameter: Holder rawClass: " + (rawClass != null ? rawClass.getCanonicalName() : "NULL") );
+                if(isFineEnabled) {
+                    LOG.fine("initializeParameter: Holder rawClass: " + (rawClass != null ? rawClass.getCanonicalName() : "NULL") );
+                }
 		// Liberty Change end
             }
         }
@@ -1882,7 +1910,9 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
         if (Collection.class.isAssignableFrom(rawClass)) {
             part.setProperty(RAW_CLASS, rawClass);
         }
-	LOG.fine("Calling setTypeClass 1 for : " + rawClass.getCanonicalName()); // Liberty Change
+        if(isFineEnabled) {
+            LOG.fine("Calling setTypeClass 1 for : " + rawClass.getCanonicalName()); // Liberty Change
+        }
         part.setTypeClass(rawClass);
 
         if (part.getMessageInfo().getOperation().isUnwrapped()
@@ -1896,7 +1926,9 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
                 || Boolean.TRUE.equals(part.getProperty(ReflectionServiceFactoryBean.MODE_INOUT))) {
                 MessagePartInfo mpi = o.getOutput().getMessagePart(part.getName());
                 if (mpi != null) {
-	            LOG.fine("Calling setTypeClass 2 for : " + rawClass.getCanonicalName()); // Liberty Change
+                    if(isFineEnabled) {
+                        LOG.fine("Calling setTypeClass 2 for : " + rawClass.getCanonicalName()); // Liberty Change
+                    }
                     mpi.setTypeClass(rawClass);
                     mpi.setProperty(GENERIC_TYPE, type);
                     if (Collection.class.isAssignableFrom(rawClass)) {
@@ -1907,7 +1939,9 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
             if (!Boolean.TRUE.equals(part.getProperty(ReflectionServiceFactoryBean.MODE_OUT))) {
                 MessagePartInfo mpi = o.getInput().getMessagePart(part.getName());
                 if (mpi != null) {
-	            LOG.fine("Calling setTypeClass 3 for : " + rawClass.getCanonicalName()); // Liberty Change
+                    if(isFineEnabled) {
+                        LOG.fine("Calling setTypeClass 3 for : " + rawClass.getCanonicalName()); // Liberty Change
+                    }
                     mpi.setTypeClass(rawClass);
                     mpi.setProperty(GENERIC_TYPE, type);
                     if (Collection.class.isAssignableFrom(rawClass)) {
@@ -2125,11 +2159,14 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
             // Ignore XFireFaults because they don't need to be declared
             if (Fault.class.isAssignableFrom(exClazz)
                 || exClazz.equals(RuntimeException.class) || exClazz.equals(Throwable.class)) {
-		LOG.finest("initializeFaults: Ignoring fault class: " + exClazz.getCanonicalName()); // Liberty Change
+                if(LOG.isLoggable(Level.FINEST)) {
+                    LOG.finest("initializeFaults: Ignoring fault class: " + exClazz.getCanonicalName()); // Liberty Change
+                }
                 continue;
             }
-
-	    LOG.finest("initializeFaults: Adding fault class: " + exClazz.getCanonicalName()); // Liberty Change
+            if(LOG.isLoggable(Level.FINEST)) {
+                LOG.finest("initializeFaults: Adding fault class: " + exClazz.getCanonicalName()); // Liberty Change
+            }
             addFault(service, op, exClazz);
         }
     }
@@ -2571,7 +2608,9 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
             for (AbstractServiceConfiguration c : serviceConfigurations) {
                 defWrappedCache = c.isWrapped();
                 if (defWrappedCache != null) {
-		    LOG.finest("isWrapped: Returning defWrappedCache");  // Liberty Change
+                    if(LOG.isLoggable(Level.FINEST)) {
+                        LOG.finest("isWrapped: Returning defWrappedCache");  // Liberty Change
+                    }
                     return defWrappedCache;
                 }
             }
@@ -2585,7 +2624,9 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
             for (AbstractServiceConfiguration c : serviceConfigurations) {
                 styleCache = c.getStyle();
                 if (styleCache != null) {
-		    LOG.finest("Returning styleCache");	 // Liberty Change
+                    if(LOG.isLoggable(Level.FINEST)) {
+                        LOG.finest("Returning styleCache");	 // Liberty Change
+                    }
                     return styleCache;
                 }
             }
@@ -2600,7 +2641,9 @@ public class ReflectionServiceFactoryBean extends org.apache.cxf.service.factory
             for (AbstractServiceConfiguration c : serviceConfigurations) {
                 b = c.isRPC(method);
                 if (b != null) {
-		    LOG.finest("isRPC: Adding method to RPC Cache: " + method.getName());  // Liberty Change
+                    if(LOG.isLoggable(Level.FINEST)) {
+                        LOG.finest("isRPC: Adding method to RPC Cache: " + method.getName());  // Liberty Change
+                    }
                     isRpcCache.put(method, b);
                     return b.booleanValue();
                 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/src/org/apache/cxf/wsdl11/WSDLServiceBuilder.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/src/org/apache/cxf/wsdl11/WSDLServiceBuilder.java
@@ -135,13 +135,17 @@ public class WSDLServiceBuilder {
     private void copyExtensors(AbstractPropertiesHolder info, List<?> extList) {
         if (info != null) {
             for (ExtensibilityElement ext : cast(extList, ExtensibilityElement.class)) {
-		LOG.finest("copyExtensors: Ext element: " + ext.getElementType()); // Liberty Change
+                if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                    LOG.finest("copyExtensors: Ext element: " + ext.getElementType()); // Liberty Change
+                }
                 Object o = ext;
                 if (ext instanceof JAXBExtensibilityElement) {
                     o = ((JAXBExtensibilityElement)ext).getValue();
                 }
                 if (!info.containsExtensor(o)) {
-		    LOG.finest("copyExtensors: Adding ext: " + o);  // Liberty Change
+                    if(LOG.isLoggable(Level.FINEST)) { // Liberty Change
+                        LOG.finest("copyExtensors: Adding ext: " + o);  // Liberty Change
+                    }
                     info.addExtensor(o);
                 }
             }
@@ -448,7 +452,9 @@ public class WSDLServiceBuilder {
             }
             if (ns == null) {
                 if (ignoreUnknownBindings) {
-		    LOG.fine("Ignoring UnknownBindings, return null");  // Liberty Change
+                    if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                        LOG.fine("Ignoring UnknownBindings, return null");  // Liberty Change
+                    }
                     return null;
                 }
                 org.apache.cxf.common.i18n.Message msg = new
@@ -460,7 +466,9 @@ public class WSDLServiceBuilder {
             try {
                 factory = bus.getExtension(DestinationFactoryManager.class).getDestinationFactory(ns);
             } catch (BusException e) {
-		LOG.fine("Ignoring BusException: " + e);  // Liberty Change
+                if(LOG.isLoggable(Level.FINE)) { // Liberty Change
+                    LOG.fine("Ignoring BusException: " + e);  // Liberty Change
+                }
                 // do nothing
             }
         }
@@ -488,12 +496,15 @@ public class WSDLServiceBuilder {
     }
 
     public BindingInfo buildBinding(ServiceInfo service, Binding binding) {
+        boolean isFineEnabled = LOG.isLoggable(Level.FINE); // Liberty Change
         BindingInfo bi = null;
         StringBuilder ns = new StringBuilder(100);
         BindingFactory factory = WSDLServiceUtils.getBindingFactory(binding, bus, ns);
         if (factory instanceof WSDLBindingFactory) {
             WSDLBindingFactory wFactory = (WSDLBindingFactory)factory;
-	    LOG.fine("buildBinding: Calling createBindingInfo for NS: " + ns.toString() + " and QName: " + binding.getQName());  // Liberty Change
+            if(isFineEnabled) {
+                LOG.fine("buildBinding: Calling createBindingInfo for NS: " + ns.toString() + " and QName: " + binding.getQName());  // Liberty Change
+            }
             bi = wFactory.createBindingInfo(service, binding, ns.toString());
             copyExtensors(bi, binding.getExtensibilityElements());
             copyExtensionAttributes(bi, binding);
@@ -518,11 +529,15 @@ public class WSDLServiceBuilder {
                 String outName = null;
                 if (bop.getBindingInput() != null) {
                     inName = bop.getBindingInput().getName();
-		    LOG.fine("buildBinding: Binding input: " + inName);  // Liberty Change
+                    if(isFineEnabled) {
+                        LOG.fine("buildBinding: Binding input: " + inName);  // Liberty Change
+                    }
                 }
                 if (bop.getBindingOutput() != null) {
                     outName = bop.getBindingOutput().getName();
-		    LOG.fine("buildBinding: Binding output: " + outName);  // Liberty Change
+                    if(isFineEnabled) {
+                        LOG.fine("buildBinding: Binding output: " + outName);  // Liberty Change
+                    }
                 }
                 final BindingOperationInfo bop2;
                 if (onlyExtensors) {
@@ -532,12 +547,16 @@ public class WSDLServiceBuilder {
                     bop2 = bi.buildOperation(new QName(binding.getQName().getNamespaceURI(),
                                                        bop.getName()), inName, outName);
                     if (bop2 != null) {
-		        LOG.fine("buildBinding: Adding bop2 to BI..." + bop2.getName()); // Liberty Change
+                        if(isFineEnabled) {
+                            LOG.fine("buildBinding: Adding bop2 to BI..." + bop2.getName()); // Liberty Change
+                        }
                         bi.addOperation(bop2);
                     }
                 }
                 if (bop2 != null) {
-		    LOG.fine("buildBinding: bop2 is not NULL" + bop2.getName());  // Liberty Change
+                    if(isFineEnabled) {
+                        LOG.fine("buildBinding: bop2 is not NULL" + bop2.getName());  // Liberty Change
+                    }
                     copyExtensors(bop2, bop.getExtensibilityElements());
                     copyExtensionAttributes(bop2, bop);
                     if (bop.getBindingInput() != null) {
@@ -575,7 +594,9 @@ public class WSDLServiceBuilder {
             .getExtensors(ExtensibilityElement.class);
         // for non-soap binding, the extensiblilityElement could be null
         if (extensiblilityElement == null) {
-	    LOG.fine("handleHeader: extensiblilityElement is null, returning");  // Liberty Change
+            if(LOG.isLoggable(Level.FINE)) {
+                LOG.fine("handleHeader: extensiblilityElement is null, returning");  // Liberty Change
+            }
             return;
         }
         // for (ExtensibilityElement element : extensiblilityElement) {


### PR DESCRIPTION
This PR adds guard statements to the recently added trace improvements in CXF. 