### PR TITLE
Use correct path to delete lease file

### DIFF
--- a/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/FileSharedServerLeaseLog.java
+++ b/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/FileSharedServerLeaseLog.java
@@ -331,8 +331,7 @@ public class FileSharedServerLeaseLog extends LeaseLogImpl implements SharedServ
 
                         boolean success = false;
                         try {
-                            Path path = FileSystems.getDefault().getPath(System.getenv("WLP_USER_DIR"), "shared",
-                                                                         "leases", _recoveryGroup, recoveryIdentity);
+                            Path path = FileSystems.getDefault().getPath(_serverInstallLeaseLogDir, recoveryIdentity);
                             fileExists = Files.exists(path);
                             if (tc.isDebugEnabled())
                                 Tr.debug(tc, "Does nio path exist? " + fileExists);


### PR DESCRIPTION
If the transaction manager is configured for peer recovery as the following:
```xml
<transaction recoveryGroup="peer-group-name" recoveryIdentity="${HOSTNAME}" transactionLogDirectory="${server.output.dir}/tranlog/${HOSTNAME}"/>
```
The leases files will never be deleted and it will try to recover transactions from old instances again and again.