### PR TITLE
InstallFeature test change version in CL prop

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
@@ -344,11 +344,18 @@ public abstract class FeatureUtilityToolTest {
             os = rf.openForWriting(false);
             wlpVersionProps.setProperty("com.ibm.websphere.productVersion", version);
             Log.info(c, "replaceWlpProperties", "Set the version to : " + version);
-	    // beta
-	    wlpVersionProps.setProperty("com.ibm.websphere.productPublicKeyId", "0xBD9FD5BE9E68CA00");
-	    Log.info(c, "replaceWlpProperties", "Set product Key ID to : " + "0xBD9FD5BE9E68CA00");
             wlpVersionProps.store(os, null);
             os.close();
+            
+	    rf = new RemoteFile(server.getMachine(),
+		    minifiedRoot + "/lib/versions/WebSphereApplicationServer.properties");
+	    if (rf.exists()) {
+		os = rf.openForWriting(false);
+		wlpVersionProps.setProperty("com.ibm.websphere.productVersion", version);
+		Log.info(c, "replaceWlpProperties - closed ", "Set the version to : " + version);
+		wlpVersionProps.store(os, null);
+		os.close();
+	    }
         } finally {
             try {
                 os.close();


### PR DESCRIPTION
Currently we hardcode liberty version to 23.0.0.2 for testing because we are using a local maven repo to remove external dependencies. If the edition is closed, we also need to update the version in WebSphereApplicationServer.properties so that the resolver can resolve the correct version of the features