### PR TITLE
Remove container verification step from shared library tests.

### DIFF
--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATSuite.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2023 IBM Corporation and others.
+ * Copyright (c) 2018,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,13 +18,14 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-        FATTest.class,
-        AutoExtractTest.class,
-        AppOrderTests.class,
-        DropinsTests.class,
-        AppPrereqTest.class,
-        SharedLibUpdateConfigTest.class,
-        SharedLibUpdateJarTest.class
+                FATTest.class,
+                AutoExtractTest.class,
+                AppOrderTests.class,
+                DropinsTests.class,
+                AppPrereqTest.class,
+                SharedLibParseTest.class,
+                SharedLibUpdateConfigTest.class,
+                SharedLibUpdateJarTest.class
 })
 public class FATSuite {
     // EMPTY

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/SharedLibParseTest.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/SharedLibParseTest.java
@@ -1,0 +1,358 @@
+/*******************************************************************************
+ * Copyright (c) 2020,2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.application.manager.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.application.manager.test.SharedLibTestUtils.ContainerAction;
+import componenttest.application.manager.test.SharedLibTestUtils.OrderedAction;
+import componenttest.custom.junit.runner.FATRunner;
+
+//@formatter:off
+@RunWith(FATRunner.class)
+public class SharedLibParseTest {
+
+    public static void main(String[] args) {
+        SharedLibParseTest tester = new SharedLibParseTest();
+        tester.parseTest();
+    }
+
+    public static void fail(String message) {
+        SharedLibTestUtils.fail(message);
+    }
+
+    public static final String[] SAMPLE_UNIX = {
+        "[3/2/24, 17:54:10:176 PST] 0000003f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 1 ] [ 7 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:178 PST] 0000003f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ /sharedLibConfigServer/snoopLib/test2.jar ] [ 1 ] [ 3 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@e071c466 ]",
+        "[3/2/24, 17:54:10:179 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 2 ] [ 6 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:179 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ /sharedLibConfigServer/snoopLib/test2.jar ] [ 2 ] [ 2 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@e071c466 ]",
+        "[3/2/24, 17:54:10:182 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 3 ] [ 5 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:182 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ /sharedLibConfigServer/snoopLib/test1.jar ] [ 1 ] [ 3 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@8b509485 ]",
+        "[3/2/24, 17:54:10:217 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 4 ] [ 4 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:217 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ /sharedLibConfigServer/snoopLib/test2.jar ] [ 3 ] [ 1 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@e071c466 ]",
+        "[3/2/24, 17:54:10:231 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 5 ] [ 3 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:231 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ /sharedLibConfigServer/snoopLib/test1.jar ] [ 2 ] [ 2 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@8b509485 ]",
+        "[3/2/24, 17:54:10:239 PST] 0000003f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 6 ] [ 2 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:239 PST] 0000003f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ /sharedLibConfigServer/snoopLib/test2.jar ] [ 4 ] [ 0 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@e071c466 ]",
+        "[3/2/24, 17:54:10:261 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 7 ] [ 3 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:262 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test1.jar ] [ 3 ] [ 3 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@8b509485 ]",
+        "[3/2/24, 17:54:10:268 PST] 0000004a id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 8 ] [ 4 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:268 PST] 0000004a id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test3.jar ] [ 1 ] [ 1 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@c3bac697 ]",
+        "[3/2/24, 17:54:10:306 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 9 ] [ 5 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:306 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test3.jar ] [ 2 ] [ 2 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@c3bac697 ]",
+        "[3/2/24, 17:54:10:307 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 10 ] [ 6 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:309 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test3.jar ] [ 3 ] [ 3 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@c3bac697 ]",
+        "[3/2/24, 17:54:10:314 PST] 0000003f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 11 ] [ 7 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:314 PST] 0000003f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test3.jar ] [ 4 ] [ 4 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@c3bac697 ]",
+        "[3/2/24, 17:54:10:342 PST] 0000004a id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 12 ] [ 8 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:344 PST] 0000004a id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test3.jar ] [ 5 ] [ 5 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@c3bac697 ]",
+        "[3/2/24, 17:54:10:372 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 13 ] [ 9 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:373 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test3.jar ] [ 6 ] [ 6 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@c3bac697 ]",
+        "[3/2/24, 17:54:10:373 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 14 ] [ 10 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:374 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test1.jar ] [ 4 ] [ 4 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@8b509485 ]",
+        "[3/2/24, 17:54:10:383 PST] 0000003f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 15 ] [ 11 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:385 PST] 0000003f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test3.jar ] [ 7 ] [ 7 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@c3bac697 ]",
+        "[3/2/24, 17:54:10:426 PST] 0000004a id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 16 ] [ 12 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:429 PST] 0000004a id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test3.jar ] [ 8 ] [ 8 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@c3bac697 ]",
+        "[3/2/24, 17:54:10:446 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 17 ] [ 13 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:447 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test3.jar ] [ 9 ] [ 9 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@c3bac697 ]",
+        "[3/2/24, 17:54:10:456 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 18 ] [ 14 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:456 PST] 0000003f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 19 ] [ 15 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:457 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test3.jar ] [ 10 ] [ 10 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@c3bac697 ]",
+        "[3/2/24, 17:54:10:457 PST] 0000003f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test3.jar ] [ 11 ] [ 11 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@c3bac697 ]",
+        "[3/2/24, 17:54:10:503 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 20 ] [ 16 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+        "[3/2/24, 17:54:10:503 PST] 0000002c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ /sharedLibConfigServer/snoopLib/test3.jar ] [ 12 ] [ 12 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@c3bac697 ]"
+    };
+
+    public static final String[] SAMPLE_WINDOWS = {
+        "[3/4/24, 21:17:16:211 EST] 0000016f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 1 ] [ 7 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:211 EST] 0000016f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ \\sharedLibConfigServer\\snoopLib\\test2.jar ] [ 1 ] [ 3 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@53b335c8 ]",
+        "[3/4/24, 21:17:16:213 EST] 00000167 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 2 ] [ 6 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:213 EST] 00000170 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 3 ] [ 5 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:213 EST] 00000167 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ \\sharedLibConfigServer\\snoopLib\\test1.jar ] [ 1 ] [ 3 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@876989c8 ]",
+        "[3/4/24, 21:17:16:213 EST] 00000170 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ \\sharedLibConfigServer\\snoopLib\\test2.jar ] [ 2 ] [ 2 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@53b335c8 ]",
+        "[3/4/24, 21:17:16:261 EST] 00000168 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 4 ] [ 4 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:261 EST] 00000168 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ \\sharedLibConfigServer\\snoopLib\\test2.jar ] [ 2 ] [ 1 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@53b335c8 ]",
+        "[3/4/24, 21:17:16:263 EST] 0000016c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 5 ] [ 3 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:263 EST] 0000016c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ \\sharedLibConfigServer\\snoopLib\\test1.jar ] [ 2 ] [ 2 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@876989c8 ]",
+        "[3/4/24, 21:17:16:271 EST] 00000172 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 6 ] [ 2 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:271 EST] 00000172 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].release: [ \\sharedLibConfigServer\\snoopLib\\test2.jar ] [ 2 ] [ 0 ]: [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@53b335c8 ]",
+        "[3/4/24, 21:17:16:348 EST] 0000016a id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test3.jar ] [ 1 ] [ 1 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@2c937585 ]",
+        "[3/4/24, 21:17:16:349 EST] 00000169 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test3.jar ] [ 2 ] [ 2 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@2c937585 ]",
+        "[3/4/24, 21:17:16:355 EST] 00000168 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test3.jar ] [ 3 ] [ 3 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@2c937585 ]",
+        "[3/4/24, 21:17:16:357 EST] 0000016f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test3.jar ] [ 4 ] [ 4 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@2c937585 ]",
+        "[3/4/24, 21:17:16:366 EST] 0000016c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test3.jar ] [ 5 ] [ 5 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@2c937585 ]",
+        "[3/4/24, 21:17:16:366 EST] 00000168 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 7 ] [ 3 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:367 EST] 00000170 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test3.jar ] [ 6 ] [ 6 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@2c937585 ]",
+        "[3/4/24, 21:17:16:367 EST] 0000016f id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 8 ] [ 4 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:369 EST] 0000016a id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 9 ] [ 5 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:370 EST] 0000016c id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 10 ] [ 6 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:371 EST] 00000170 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 11 ] [ 7 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:374 EST] 00000169 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 12 ] [ 8 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:376 EST] 0000016e id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test3.jar ] [ 7 ] [ 7 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@2c937585 ]",
+        "[3/4/24, 21:17:16:377 EST] 00000167 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test3.jar ] [ 8 ] [ 8 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@2c937585 ]",
+        "[3/4/24, 21:17:16:378 EST] 0000016d id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test3.jar ] [ 9 ] [ 9 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@2c937585 ]",
+        "[3/4/24, 21:17:16:379 EST] 0000016e id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 13 ] [ 9 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:380 EST] 00000167 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 14 ] [ 10 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:383 EST] 0000016d id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 15 ] [ 11 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:401 EST] 00000172 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test3.jar ] [ 10 ] [ 10 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@2c937585 ]",
+        "[3/4/24, 21:17:16:401 EST] 00000171 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test3.jar ] [ 11 ] [ 11 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@2c937585 ]",
+        "[3/4/24, 21:17:16:403 EST] 00000172 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 16 ] [ 12 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:408 EST] 00000171 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 17 ] [ 13 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:591 EST] 00000172 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 18 ] [ 14 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:595 EST] 00000172 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test1.jar ] [ 3 ] [ 3 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@876989c8 ]",
+        "[3/4/24, 21:17:16:648 EST] 0000016a id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test3.jar ] [ 12 ] [ 12 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@2c937585 ]",
+        "[3/4/24, 21:17:16:648 EST] 00000170 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 19 ] [ 15 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]",
+        "[3/4/24, 21:17:16:651 EST] 00000170 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test1.jar ] [ 4 ] [ 4 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@876989c8 ]",
+        "[3/4/24, 21:17:16:651 EST] 0000016a id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+            "[container].capture: [ \\sharedLibConfigServer\\snoopLib\\test0.jar ] [ 20 ] [ 16 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@f682bcb1 ]"
+    };
+
+    public static List<ContainerAction> parseActions(String[] actionText) {
+        List<ContainerAction> actions = new ArrayList<>(actionText.length);
+        for ( int actionNo = 0; actionNo < actionText.length; actionNo++ ) {
+            actions.add( new ContainerAction(actionNo, actionText[actionNo]) );
+        }
+        return actions;
+    }
+
+    public static ContainerAction[] parseActions(OrderedAction[] orderedActions) {
+        ContainerAction[] actions = new ContainerAction[ orderedActions.length ];
+        for ( int actionNo = 0; actionNo < orderedActions.length; actionNo++ ) {
+            OrderedAction orderedAction = orderedActions[actionNo];
+            actions[actionNo] = new ContainerAction(orderedAction.offset, orderedAction.actionText);
+        }
+        return actions;
+    }
+
+    @Test
+    public void parseTest() {
+        OrderedAction[] orderedUnix = SharedLibTestUtils.order(SAMPLE_UNIX);
+        ContainerAction[] unixActions = parseActions(orderedUnix);
+        display(unixActions, "Unix sample data");
+
+        OrderedAction[] orderedWin = SharedLibTestUtils.order(SAMPLE_WINDOWS);
+        ContainerAction[] winActions = parseActions(orderedWin);
+        display(winActions, "Unix sample data");
+
+        compare(unixActions, "Unix sample data", winActions, "Windows sample data");
+    }
+
+    public void compare(ContainerAction[] actions0, String title0, ContainerAction[] actions1, String title1) {
+        List<String> failures = new ArrayList<>();
+
+        int num0 = actions0.length;
+        int num1 = actions1.length;
+        if ( num0 != num1 ) {
+            failures.add("Length error: " + title0 + " [ " + num0 + " ]; " + title1 + " [ " + num1 + " ]");
+        }
+
+        int minLength = (num0 < num1) ? num0 : num1;
+
+        for ( int actionNo = 0; actionNo < minLength; actionNo++ ) {
+            ContainerAction action0 = actions0[actionNo];
+            ContainerAction action1 = actions1[actionNo];
+
+            boolean sameAs = action0.sameAs(action1, failures, !ContainerAction.COMPARE_INSTANCES);
+        }
+
+        if ( failures.isEmpty() ) {
+            System.out.println("Verified [ " + num0 + " ] actions");
+        } else {
+            System.out.println("Verification failures [ " + failures.size() + " ]");
+            for ( String failure : failures ) {
+                System.out.println("  [ " + failure + " ]");
+            }
+            fail("Verification failures [ " + failures.size() + " ]");
+        }
+    }
+
+    public static void display(ContainerAction[] actions, String title) {
+        System.out.println(title);
+        System.out.println("==========");
+        for ( ContainerAction action : actions ) {
+            System.out.println("  [ " + action + " ]");
+        }
+        System.out.println("==========");
+    }
+
+    // Container verification is disabled due to problems of event ordering.
+    // Logging does not guarantee that log events from different threads will
+    // be written in the order in which logging was requested.
+
+//  public static final String[] IN_ORDER_UNIX = {
+//  "[3/2/24, 17:51:05:690 PST] 0000002d id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+//      "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 1 ] [ 1 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+//  "[3/2/24, 17:51:05:687 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+//      "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 2 ] [ 2 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+//  "[3/2/24, 17:51:05:690 PST] 00000039 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+//      "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 3 ] [ 3 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]"
+// };
+//
+// public static final String[] OUT_OF_ORDER_UNIX = {
+//  "[3/2/24, 17:51:05:687 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+//      "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 2 ] [ 2 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+//  "[3/2/24, 17:51:05:690 PST] 00000039 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+//      "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 3 ] [ 3 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]",
+//  "[3/2/24, 17:51:05:690 PST] 0000002d id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3 " +
+//      "[container].capture: [ /sharedLibConfigServer/snoopLib/test0.jar ] [ 1 ] [ 1 ] [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]"
+// };
+//
+//    private List<ContainerAction> inOrderActions;
+//
+//    public List<ContainerAction> getInOrderActions() {
+//        if ( inOrderActions == null ) {
+//            inOrderActions = parseActions(IN_ORDER_UNIX);
+//        }
+//        return inOrderActions;
+//    }
+//
+//    private List<ContainerAction> outOfOrderActions;
+//
+//    public List<ContainerAction> getOutOfOrderActions() {
+//        if ( outOfOrderActions == null ) {
+//            outOfOrderActions = parseActions(OUT_OF_ORDER_UNIX);
+//        }
+//        return outOfOrderActions;
+//    }
+//
+//    @Test
+//    public void validateInOrderTest() {
+//        List<ContainerAction> actions = getInOrderActions();
+//        display(actions, "In-order actions");
+//        SharedLibTestUtils.verifyContainers(actions);
+//    }
+//
+//    @Test
+//    public void validateOutOfOrderTest() {
+//        List<ContainerAction> actions = getOutOfOrderActions();
+//        display(actions, "Out-of-order actions");
+//        SharedLibTestUtils.verifyContainers(actions);
+//    }
+//
+//    @Test
+//    public void verifyOrderDataTest() {
+//        List<ContainerAction> useInOrderActions = getInOrderActions();
+//        display(useInOrderActions, "In-order actions");
+//        useInOrderActions.sort(ContainerAction::compareTo);
+//        display(useInOrderActions, "In-order actions (sorted)");
+//
+//        List<ContainerAction> useOutOfOrderActions = getOutOfOrderActions();
+//        display(useOutOfOrderActions, "Out-of-order actions");
+//        useOutOfOrderActions.sort(ContainerAction::compareTo);
+//        display(useInOrderActions, "Out-of-order actions (sorted)");
+//
+//        ContainerAction[] inOrder = asArray(useInOrderActions, ContainerAction.class);
+//        ContainerAction[] outOfOrder = asArray(useOutOfOrderActions, ContainerAction.class);
+//
+//        compare(inOrder, "In-Order actions", outOfOrder, "Out-Of-Order actions");
+//    }
+//
+//    @SuppressWarnings("unchecked")
+//    public static <T> T[] asArray(List<T> elements, Class<T> tClass) {
+//        return elements.toArray( (T[]) Array.newInstance(tClass, elements.size()) );
+//    }
+//
+//    public static void display(List<ContainerAction> actions, String title) {
+//        System.out.println(title);
+//        System.out.println("==========");
+//        for ( ContainerAction action : actions ) {
+//            System.out.println("  [ " + action + " ]");
+//        }
+//        System.out.println("==========");
+//    }
+}
+//@formatter:on

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/SharedLibServerUtils.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/SharedLibServerUtils.java
@@ -1,0 +1,488 @@
+/*******************************************************************************
+ * Copyright (c) 2020,2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.application.manager.test;
+
+import java.io.BufferedReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+/**
+ * Test of shared libraries when there are many applications.
+ */
+public class SharedLibServerUtils {
+    public static void assertNotNull(Object value) {
+        SharedLibTestUtils.assertNotNull(value);
+    }
+
+    public static void fail(String message) {
+        SharedLibTestUtils.fail(message);
+    }
+
+    //
+
+    public static final int SNOOP_TIMEOUT = 10;
+
+    public static List<String> captureURL(URL url) throws Exception {
+        System.out.println("URL [ " + url + " ]");
+        System.out.println("============================================================");
+
+        List<String> lines = new ArrayList<>();
+
+        HttpURLConnection con = HttpUtils.getHttpConnection(url, HttpURLConnection.HTTP_OK, SNOOP_TIMEOUT);
+        try {
+            try (BufferedReader br = HttpUtils.getConnectionStream(con)) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    lines.add(line);
+                    System.out.println(line);
+                }
+            }
+        } finally {
+            con.disconnect();
+        }
+
+        System.out.println("============================================================");
+
+        return lines;
+    }
+
+    public static String getSnoopUrlPrefix(LibertyServer server) {
+        return "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/snoop";
+    }
+
+    //
+
+    public static void setup(String serverName, LibertyServer server, String serverConfig) throws Exception {
+        setupServer(server);
+        startServer(serverName, server, serverConfig);
+    }
+
+    public static void setupServer(LibertyServer server) throws Exception {
+        setupLibs();
+        installLibs(server);
+
+        setupApp();
+        installApp(server);
+    }
+
+    public final static String PUBLISH_FILES = "publish/files";
+    public final static String PUBLISH_FILES_ALT = "publish/files_alt";
+
+    public static final int LIB_COUNT = 4;
+    public static final String SHARED_LIB_DIR = "snoopLib";
+
+    public static volatile boolean setupLibs;
+
+    public static final String LIB_NAME_0 = "test0.jar";
+    public static final String LIB_NAME_1 = "test1.jar";
+    public static final String LIB_NAME_2 = "test2.jar";
+    public static final String LIB_NAME_3 = "test3.jar";
+
+    // alt0 and alt1 reuse LIB_NAME_0 and LIB_NAME_1
+    public static final String LIB_NAMES[] = { LIB_NAME_0, LIB_NAME_1, LIB_NAME_2, LIB_NAME_3 };
+
+    public static volatile JavaArchive[] sharedLibs;
+    public static volatile JavaArchive sharedLib_alt0;
+    public static volatile JavaArchive sharedLib_alt1;
+
+    public static Object sharedLibLock = new Object();
+
+    public static void setupLibs() throws Exception {
+        if (setupLibs) {
+            return;
+        }
+
+        synchronized (sharedLibLock) {
+            if (setupLibs) {
+                return;
+            }
+
+            JavaArchive[] libs = new JavaArchive[LIB_COUNT];
+
+            for (int libNo = 0; libNo < LIB_COUNT; libNo++) {
+                String libName = "test" + libNo + ".jar";
+                String libPackage = "com.ibm.ws.test" + libNo + "_base.*"; // Reused packages
+                JavaArchive lib = ShrinkHelper.buildJavaArchive(libName, libPackage);
+                ShrinkHelper.exportArtifact(lib, PUBLISH_FILES, true, true);
+
+                libs[libNo] = lib;
+            }
+
+            // Reusing the names forces the archives to be put in a different directory.
+
+            String libName_alt0 = LIB_NAME_0;
+            String libPackage_alt0 = "com.ibm.ws.test0_alt.*";
+            JavaArchive lib_alt0 = ShrinkHelper.buildJavaArchive(libName_alt0, libPackage_alt0);
+            ShrinkHelper.exportArtifact(lib_alt0, PUBLISH_FILES_ALT, true, true);
+
+            String libName_alt1 = LIB_NAME_1;
+            String libPackage_alt1 = "com.ibm.ws.test1_alt.*";
+            JavaArchive lib_alt1 = ShrinkHelper.buildJavaArchive(libName_alt1, libPackage_alt1);
+            ShrinkHelper.exportArtifact(lib_alt1, PUBLISH_FILES_ALT, true, true);
+
+            sharedLibs = libs;
+
+            sharedLib_alt0 = lib_alt0;
+            sharedLib_alt1 = lib_alt1;
+
+            setupLibs = true;
+        }
+    }
+
+    public static void installLibs(LibertyServer server) throws Exception {
+        for (int libNo = 0; libNo < LIB_COUNT; libNo++) {
+            String libName = "test" + libNo + ".jar";
+            server.copyFileToLibertyServerRoot(PUBLISH_FILES, SHARED_LIB_DIR, libName);
+        }
+    }
+
+    public static final boolean FROM_ALT = true;
+
+    public static void installLib(LibertyServer server, boolean fromAlt, String libName) throws Exception {
+        String publishDir = (fromAlt ? PUBLISH_FILES_ALT : PUBLISH_FILES);
+        server.copyFileToLibertyServerRoot(publishDir, SHARED_LIB_DIR, libName);
+    }
+
+    public static final String WAR_NAME = "sharedLibSnoop.war";
+    public static final String WAR_PACKAGE_NAME = "com.ibm.ws.test.sharedlib";
+
+    public static final String APPS_DIR = "apps";
+
+    public static volatile boolean setupSnoop;
+    public static volatile WebArchive sharedLibSnoop;
+    public static Object sharedLibSnoopAppLock = new Object();
+
+    public static void setupApp() throws Exception {
+        if (!setupSnoop) {
+            synchronized (sharedLibSnoopAppLock) {
+                if (!setupSnoop) {
+                    // Recreate snoop, even though other tests use the same WAR.
+                    // We don't know the test order: We cannot rely on this
+                    // test running after the test that creates snoop.
+                    WebArchive snoop = ShrinkHelper.buildDefaultApp(WAR_NAME, WAR_PACKAGE_NAME);
+
+                    ShrinkHelper.addDirectory(snoop, "test-applications/sharedLibSnoop.war/resources");
+                    ShrinkHelper.exportArtifact(snoop, PUBLISH_FILES, true, true);
+
+                    // Do not put in the server configuration ... the test will do this
+
+                    sharedLibSnoop = snoop;
+                    setupSnoop = true;
+                }
+            }
+        }
+    }
+
+    public static void installApp(LibertyServer server) throws Exception {
+        server.copyFileToLibertyServerRoot(PUBLISH_FILES, APPS_DIR, WAR_NAME);
+    }
+
+    public static void startServer(String serverName,
+                                   LibertyServer server,
+                                   String serverConfig) throws Exception {
+
+        server.setServerConfigurationFile(serverName + '/' + serverConfig);
+        server.startServer(serverName + ".log");
+        assertNotNull(server.waitForStringInLog("TE9900A"));
+    }
+
+    public static void verifyServer(LibertyServer server,
+                                    int[] activity,
+                                    int[] runningRange,
+                                    int[][] expectedValues) throws Exception {
+
+        assertActivity(server, activity);
+        assertSnoop(server, runningRange, expectedValues);
+    }
+
+    public static void stopServer(LibertyServer server) throws Exception {
+        if (server.isStarted()) {
+            server.stopServer();
+            // assertActivity(server, FINAL_ACTIVITY_RANGE);
+        }
+    }
+
+    //
+
+    // [11/28/23, 17:24:58:244 EST] 00000037 id=00000000 com.ibm.ws.app.manager.AppMessageHelper
+    // A CWWKZ0001I: Application snoop0 started in 3.385 seconds.
+
+    // [11/28/23, 17:25:01:416 EST] 00000034 id=00000000 com.ibm.ws.app.manager.AppMessageHelper
+    // A CWWKZ0003I: The application snoop0 updated in 0.099 seconds.
+
+    // [11/28/23, 17:25:01:292 EST] 0000003b id=00000000 com.ibm.ws.app.manager.AppMessageHelper
+    // A CWWKZ0009I: The application snoop0 has stopped successfully.
+
+    public static final String START_CODE = "CWWKZ0001I:.*";
+    public static final String UPDATE_CODE = "CWWKZ0003I:.*";
+    public static final String STOP_CODE = "CWWKZ0009I:.*";
+
+    public static enum AppStateChange {
+        STARTED(START_CODE), UPDATED(UPDATE_CODE), STOPPED(STOP_CODE);
+
+        public final String code;
+
+        private AppStateChange(String code) {
+            this.code = code;
+        }
+    }
+
+    public static void assertRestarted(LibertyServer server, int appNo) {
+        assertStopped(server, appNo);
+        assertUpdated(server, appNo);
+    }
+
+    public static void assertStarted(LibertyServer server, int appNo) {
+        assertActivity(server, new int[] { appNo, appNo + 1 }, AppStateChange.STARTED);
+    }
+
+    public static void assertStopped(LibertyServer server, int appNo) {
+        assertActivity(server, new int[] { appNo, appNo + 1 }, AppStateChange.STOPPED);
+    }
+
+    public static void assertUpdated(LibertyServer server, int appNo) {
+        assertActivity(server, new int[] { appNo, appNo + 1 }, AppStateChange.UPDATED);
+    }
+
+    public static void assertActivity(LibertyServer server, int[] range) {
+        // [ 0,   16 ] ==> // START 0 .. 15
+
+        // [ 0,    1 ] ==> // START 0 ..  0
+        // [ 1,   16 ] ==> // START 1 .. 15
+
+        // [ -1, -18 ] ==> // STOP  0 .. 15
+        // [ -2, -18 ] ==> // STOP  1 .. 15
+        // [ -1,  -2 ] ==> // STOP  0 ..  1
+
+        int min = range[0];
+        int max = range[1];
+        AppStateChange change;
+        if (min < 0) {
+            min = -(min + 1);
+            max = -(max + 1);
+            range = new int[] { min, max };
+            change = AppStateChange.STOPPED;
+        } else {
+            change = AppStateChange.STARTED;
+        }
+
+        assertActivity(server, range, change);
+    }
+
+    public static void assertActivity(LibertyServer server, int[] range, AppStateChange change) {
+        System.out.println("Verifying activity ...");
+        System.out.println("Min [ " + range[0] + " ] Max [ " + range[1] + " ]" +
+                           " Code [ " + change + " ] ( " + change.code + " )");
+
+        verifyActivity(range, getActivity(server, range, change));
+    }
+
+    public static List<String> getActivity(LibertyServer server, int[] range, AppStateChange change) {
+        int count = range[1] - range[0];
+
+        List<String> activity = new ArrayList<>(count);
+
+        for (int actionNo = 0; actionNo < count; actionNo++) {
+            String nextAction = server.waitForStringInLogUsingLastOffset(change.code);
+            if (nextAction == null) {
+                fail("Null action [ " + actionNo + " ] of [ " + count + " ]");
+            }
+            System.out.println("Action [ " + nextAction + " ]");
+            activity.add(nextAction);
+        }
+
+        return activity;
+    }
+
+    public static void verifyActivity(int[] range, List<String> activity) {
+        int min = range[0];
+        int max = range[1];
+        int count = max - min;
+
+        Set<Integer> expected = new HashSet<>(count);
+
+        for (int appNo = min; appNo < max; appNo++) {
+            expected.add(Integer.valueOf(appNo));
+        }
+
+        for (String action : activity) {
+            int appNo = getAppNo(action);
+
+            Integer actualApp = Integer.valueOf(appNo);
+            boolean removed = expected.remove(actualApp);
+            if (!removed) {
+                fail("Unexpected app [ " + actualApp + " ]");
+                return;
+            }
+        }
+
+        if (!expected.isEmpty()) {
+            fail("Missing apps [ " + expected + " ]");
+            return;
+        }
+    }
+
+    // 11/14/23, 16:32:35:584 EST] 0000003b
+    //  com.ibm.ws.app.manager.AppMessageHelper
+    // A CWWKZ0001I: Application snoop11 started in 0.763 seconds.
+
+    public static int getAppNo(String action) {
+        int appLoc = action.indexOf("snoop");
+        if (appLoc == -1) {
+            fail("No app location [ " + action + " ]");
+            return -1;
+        }
+        appLoc += "snoop".length();
+
+        int actionLength = action.length();
+
+        boolean failed;
+        if (appLoc >= actionLength) {
+            failed = true;
+        } else {
+            char c1 = action.charAt(appLoc);
+            if (!Character.isDigit(c1)) {
+                failed = true;
+
+            } else {
+                int appNo = c1 - '0';
+
+                if (appLoc >= actionLength - 1) {
+                    failed = true;
+                } else {
+                    char c2 = action.charAt(appLoc + 1);
+                    if (c2 != ' ') {
+                        if (!Character.isDigit(c2)) {
+                            failed = true;
+
+                        } else {
+                            appNo *= 10;
+                            appNo += (c2 - '0');
+
+                            if (appLoc >= actionLength - 2) {
+                                failed = true;
+                            } else {
+                                char c3 = action.charAt(appLoc + 2);
+                                if (c3 != ' ') {
+                                    failed = true;
+                                } else {
+                                    failed = false;
+                                }
+                            }
+                        }
+                    } else {
+                        failed = false;
+                    }
+
+                    if (!failed) {
+                        return appNo;
+                    }
+                }
+            }
+        }
+
+        fail("Bad app number [ " + action + " ]");
+        return -1;
+    }
+
+    //
+
+    public static final int NUM_VALUES = 6;
+
+    public static final String PRESENT_VALUE_0_BASE = "<tr><td>com.ibm.ws.test0_base.Test0_Base</td><td>interface com.ibm.ws.test0_base.Test0_Base</td><td>TEST_VALUE</td><td>Test0</td></tr>";
+    public static final String PRESENT_VALUE_0_ALT = "<tr><td>com.ibm.ws.test0_alt.Test0_Alt</td><td>interface com.ibm.ws.test0_alt.Test0_Alt</td><td>TEST_VALUE</td><td>Test0_Alt</td></tr>";
+    public static final String PRESENT_VALUE_1_BASE = "<tr><td>com.ibm.ws.test1_base.Test1_Base</td><td>interface com.ibm.ws.test1_base.Test1_Base</td><td>TEST_VALUE</td><td>Test1</td></tr>";
+    public static final String PRESENT_VALUE_1_ALT = "<tr><td>com.ibm.ws.test1_alt.Test1_Alt</td><td>interface com.ibm.ws.test1_alt.Test1_Alt</td><td>TEST_VALUE</td><td>Test1_Alt</td></tr>";
+    public static final String PRESENT_VALUE_2_BASE = "<tr><td>com.ibm.ws.test2_base.Test2_Base</td><td>interface com.ibm.ws.test2_base.Test2_Base</td><td>TEST_VALUE</td><td>Test2</td></tr>";
+    public static final String PRESENT_VALUE_3_BASE = "<tr><td>com.ibm.ws.test3_base.Test3_Base</td><td>interface com.ibm.ws.test3_base.Test3_Base</td><td>TEST_VALUE</td><td>Test3</td></tr>";
+
+    public static final String[] PRESENT_VALUES = { PRESENT_VALUE_0_BASE, PRESENT_VALUE_0_ALT,
+                                                    PRESENT_VALUE_1_BASE, PRESENT_VALUE_1_ALT,
+                                                    PRESENT_VALUE_2_BASE,
+                                                    PRESENT_VALUE_3_BASE };
+
+    public static final String ABSENT_VALUE_0_BASE = "<tr><td>com.ibm.ws.test0_base.Test0_Base</td><td>null</td><td>TEST_VALUE</td><td>null</td></tr>";
+    public static final String ABSENT_VALUE_0_ALT = "<tr><td>com.ibm.ws.test0_alt.Test0_Alt</td><td>null</td><td>TEST_VALUE</td><td>null</td></tr>";
+    public static final String ABSENT_VALUE_1_BASE = "<tr><td>com.ibm.ws.test1_base.Test1_Base</td><td>null</td><td>TEST_VALUE</td><td>null</td></tr>";
+    public static final String ABSENT_VALUE_1_ALT = "<tr><td>com.ibm.ws.test1_alt.Test1_Alt</td><td>null</td><td>TEST_VALUE</td><td>null</td></tr>";
+    public static final String ABSENT_VALUE_2_BASE = "<tr><td>com.ibm.ws.test2_base.Test2_Base</td><td>null</td><td>TEST_VALUE</td><td>null</td></tr>";
+    public static final String ABSENT_VALUE_3_BASE = "<tr><td>com.ibm.ws.test3_base.Test3_Base</td><td>null</td><td>TEST_VALUE</td><td>null</td></tr>";
+
+    public static final String[] ABSENT_VALUES = { ABSENT_VALUE_0_BASE, ABSENT_VALUE_0_ALT,
+                                                   ABSENT_VALUE_1_BASE, ABSENT_VALUE_1_ALT,
+                                                   ABSENT_VALUE_2_BASE,
+                                                   ABSENT_VALUE_3_BASE };
+
+    public static final String SNOOP_RESPONSE = "Shared Library Test Servlet";
+
+    public static void assertSnoop(LibertyServer server,
+                                   int[] range, int[][] expectedValues) throws Exception {
+        int min = range[0];
+        int max = range[1] - 1;
+
+        System.out.println("Verifying snoop [ " + min + " ] to [ " + max + " ]");
+
+        for (int appNo = min; appNo <= max; appNo++) {
+            assertSnoop(server, appNo, expectedValues[appNo]);
+        }
+    }
+
+    public static void assertSnoop(LibertyServer server,
+                                   int snoopNo, int[] expectedValues) throws Exception {
+        System.out.println("Invoke snoop [ " + snoopNo + " ]");
+
+        URL url = new URL(getSnoopUrlPrefix(server) + snoopNo);
+        List<String> lines = captureURL(url);
+
+        boolean foundResponse = false;
+        boolean[] foundValues = new boolean[NUM_VALUES];
+
+        for (String line : lines) {
+            if (line.contains(SNOOP_RESPONSE)) {
+                foundResponse = true;
+            } else {
+                for (int valueNo = 0; valueNo < NUM_VALUES; valueNo++) {
+                    if (line.equals(PRESENT_VALUES[valueNo])) {
+                        foundValues[valueNo] = true;
+                    }
+                }
+            }
+        }
+
+        String responseMessage = "Snoop URL [ " + url + " ] " + (foundResponse ? "contains" : "missing") + " [ " + SNOOP_RESPONSE + " ]";
+        System.out.println(responseMessage);
+        if (!foundResponse) {
+            fail(responseMessage);
+        }
+
+        for (int valueNo = 0; valueNo < NUM_VALUES; valueNo++) {
+            String message = "Probe value [ " + valueNo + " ] is [ " + (foundValues[valueNo] ? "present" : "missing") + " ]";
+            System.out.println(message);
+            if ((expectedValues[valueNo] > 0) != foundValues[valueNo]) {
+                fail(message);
+            }
+        }
+    }
+}

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/SharedLibTestUtils.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/SharedLibTestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020,2023 IBM Corporation and others.
+ * Copyright (c) 2020,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,32 +12,16 @@
  *******************************************************************************/
 package componenttest.application.manager.test;
 
-import java.io.BufferedReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import static componenttest.application.manager.test.SharedLibServerUtils.LIB_COUNT;
 
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Assert;
 
-import com.ibm.websphere.simplicity.ShrinkHelper;
-
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.HttpUtils;
 
-/**
- * Test of shared libraries when there are many applications.
- */
 public class SharedLibTestUtils {
-    public Class<?> getLogClass() {
-        return SharedLibTestUtils.class;
-    }
 
     public static void assertNotNull(Object value) {
         Assert.assertNotNull(value);
@@ -47,210 +31,26 @@ public class SharedLibTestUtils {
         Assert.fail(message);
     }
 
-    //
-
-    public static final int SNOOP_TIMEOUT = 10;
-
-    public static List<String> captureURL(URL url) throws Exception {
-        System.out.println("URL [ " + url + " ]");
-        System.out.println("============================================================");
-
-        List<String> lines = new ArrayList<>();
-
-        HttpURLConnection con = HttpUtils.getHttpConnection(url, HttpURLConnection.HTTP_OK, SNOOP_TIMEOUT);
-        try {
-            try (BufferedReader br = HttpUtils.getConnectionStream(con)) {
-                String line;
-                while ((line = br.readLine()) != null) {
-                    lines.add(line);
-                    System.out.println(line);
-                }
-            }
-        } finally {
-            con.disconnect();
+    public static String concat(String... values) {
+        int len = 0;
+        for (String value : values) {
+            len += value.length();
         }
 
-        System.out.println("============================================================");
-
-        return lines;
-    }
-
-    public static String getSnoopUrlPrefix(LibertyServer server) {
-        return "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/snoop";
-    }
-
-    //
-
-    public static void setup(String serverName, LibertyServer server, String serverConfig) throws Exception {
-        setupServer(server);
-        startServer(serverName, server, serverConfig);
-    }
-
-    public static void setupServer(LibertyServer server) throws Exception {
-        setupLibs();
-        installLibs(server);
-
-        setupApp();
-        installApp(server);
-    }
-
-    public final static String PUBLISH_FILES = "publish/files";
-    public final static String PUBLISH_FILES_ALT = "publish/files_alt";
-
-    public static final int LIB_COUNT = 4;
-    public static final String SHARED_LIB_DIR = "snoopLib";
-
-    public static volatile boolean setupLibs;
-
-    public static final String LIB_NAME_0 = "test0.jar";
-    public static final String LIB_NAME_1 = "test1.jar";
-    public static final String LIB_NAME_2 = "test2.jar";
-    public static final String LIB_NAME_3 = "test3.jar";
-
-    // alt0 and alt1 reuse LIB_NAME_0 and LIB_NAME_1
-    public static final String LIB_NAMES[] = { LIB_NAME_0, LIB_NAME_1, LIB_NAME_2, LIB_NAME_3 };
-
-    public static volatile JavaArchive[] sharedLibs;
-    public static volatile JavaArchive sharedLib_alt0;
-    public static volatile JavaArchive sharedLib_alt1;
-
-    public static Object sharedLibLock = new Object();
-
-    public static void setupLibs() throws Exception {
-        if ( setupLibs ) {
-            return;
+        StringBuilder builder = new StringBuilder(len);
+        for (String value : values) {
+            builder.append(value);
         }
-
-        synchronized( sharedLibLock ) {
-            if ( setupLibs) {
-                return;
-            }
-
-            JavaArchive[] libs = new JavaArchive[LIB_COUNT];
-
-            for ( int libNo = 0; libNo < LIB_COUNT; libNo++ ) {
-                String libName = "test" + libNo + ".jar";
-                String libPackage = "com.ibm.ws.test" + libNo + "_base.*"; // Reused packages
-                JavaArchive lib = ShrinkHelper.buildJavaArchive(libName, libPackage);
-                ShrinkHelper.exportArtifact(lib, PUBLISH_FILES, true, true);
-
-                libs[libNo] = lib;
-            }
-
-            // Reusing the names forces the archives to be put in a different directory.
-
-            String libName_alt0 = LIB_NAME_0;
-            String libPackage_alt0 = "com.ibm.ws.test0_alt.*";
-            JavaArchive lib_alt0 = ShrinkHelper.buildJavaArchive(libName_alt0, libPackage_alt0);
-            ShrinkHelper.exportArtifact(lib_alt0, PUBLISH_FILES_ALT, true, true);
-
-            String libName_alt1 = LIB_NAME_1;
-            String libPackage_alt1 = "com.ibm.ws.test1_alt.*";
-            JavaArchive lib_alt1 = ShrinkHelper.buildJavaArchive(libName_alt1, libPackage_alt1);
-            ShrinkHelper.exportArtifact(lib_alt1, PUBLISH_FILES_ALT, true, true);
-
-            sharedLibs = libs;
-
-            sharedLib_alt0 = lib_alt0;
-            sharedLib_alt1 = lib_alt1;
-
-            setupLibs = true;
-        }
+        return builder.toString();
     }
-
-    public static void installLibs(LibertyServer server) throws Exception {
-        for ( int libNo = 0; libNo < LIB_COUNT; libNo++ ) {
-            String libName = "test" + libNo + ".jar";
-            server.copyFileToLibertyServerRoot(PUBLISH_FILES, SHARED_LIB_DIR, libName);
-        }
-    }
-
-    public static final boolean FROM_ALT = true;
-
-    public static void installLib(LibertyServer server, boolean fromAlt, String libName) throws Exception {
-        String publishDir = ( fromAlt ? PUBLISH_FILES_ALT : PUBLISH_FILES );
-        server.copyFileToLibertyServerRoot(publishDir, SHARED_LIB_DIR, libName);
-    }
-
-    public static final String WAR_NAME = "sharedLibSnoop.war";
-    public static final String WAR_PACKAGE_NAME = "com.ibm.ws.test.sharedlib";
-
-    public static final String APPS_DIR = "apps";
-
-    public static volatile boolean setupSnoop;
-    public static volatile WebArchive sharedLibSnoop;
-    public static Object sharedLibSnoopAppLock = new Object();
-
-    public static void setupApp() throws Exception {
-        if ( !setupSnoop ) {
-            synchronized(sharedLibSnoopAppLock) {
-                if ( !setupSnoop ) {
-                    // Recreate snoop, even though other tests use the same WAR.
-                    // We don't know the test order: We cannot rely on this
-                    // test running after the test that creates snoop.
-                    WebArchive snoop = ShrinkHelper.buildDefaultApp(WAR_NAME, WAR_PACKAGE_NAME);
-
-                    ShrinkHelper.addDirectory(snoop, "test-applications/sharedLibSnoop.war/resources");
-                    ShrinkHelper.exportArtifact(snoop, PUBLISH_FILES, true, true);
-
-                    // Do not put in the server configuration ... the test will do this
-
-                    sharedLibSnoop = snoop;
-                    setupSnoop = true;
-                }
-            }
-        }
-    }
-
-    public static void installApp(LibertyServer server) throws Exception {
-        server.copyFileToLibertyServerRoot(PUBLISH_FILES, APPS_DIR, WAR_NAME);
-    }
-
-    public static void startServer(String serverName,
-                                   LibertyServer server,
-                                   String serverConfig) throws Exception {
-
-        server.setServerConfigurationFile(serverName + '/' + serverConfig);
-        server.startServer(serverName + ".log");
-        assertNotNull(server.waitForStringInLog("TE9900A"));
-    }
-
-    public static void verifyServer(LibertyServer server,
-                                    int[] activity,
-                                    int[] runningRange,
-                                    int[][] expectedValues) throws Exception {
-        assertActivity(server, activity);
-        assertSnoop(server, runningRange, expectedValues);
-    }
-
-    public static void stopServer(LibertyServer server) throws Exception {
-        if (server.isStarted()) {
-            server.stopServer();
-            // assertActivity(server, FINAL_ACTIVITY_RANGE);
-        }
-    }
-
-    // [11/17/23, 13:17:42:930 EST] 00000035 id=00000000
-    // com.ibm.ws.app.manager.module.internal.CaptureCache 3
-    // [container].capture:
-    // [ C:\\dev\\repos-pub\\ol-baw\\dev\\build.image\\wlp\\usr\\servers\\sharedLibServer\\snoopLib\\test0.jar ]
-    // [ 1 ]
-
-    // [11/16/23, 16:59:39:253 EST] 0000004d id=00000000
-    // com.ibm.ws.app.manager.module.internal.CaptureCache          3
-    // [container].release:
-    // [ C:\\dev\\repos-pub\\ol-baw\\dev\\build.image\\wlp\\usr\\servers\\sharedLibServer\\snoopLib\\test0.jar ]
-    // [ 15 ]:
-    // [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@45ea83a8 ]
 
     public static final String CONTAINER_ACTIVITY = "\\[container\\]\\.";
 
-    public static final CacheTransitions INITIAL_CAPTURES =
-        new CacheTransitions( new int[] { 0, 0, 0, 0 }, 0, 0, 0 );
+    public static final CacheTransitions INITIAL_CAPTURES = new CacheTransitions(new int[] { 0, 0, 0, 0 }, 0, 0, 0);
 
     public static CacheTransitions assertContainerActions(LibertyServer server,
-                                                        int iter, int configNo, CacheTransitions expectedCapture,
-                                                        CacheTransitions priorCapture, List<ContainerAction> actions) throws Exception {
+                                                          int iter, int configNo, CacheTransitions expectedCapture,
+                                                          CacheTransitions priorCapture, List<ContainerAction> actions) throws Exception {
         int oldActionCount = actions.size();
 
         List<String> allActionLines = server.findStringsInTrace(CONTAINER_ACTIVITY);
@@ -260,11 +60,11 @@ public class SharedLibTestUtils {
         System.out.println("  [ " + CONTAINER_ACTIVITY + " ]");
         System.out.println("================================================================================");
 
-        for ( int actionNo = oldActionCount; actionNo < newActionCount; actionNo++ ) {
+        for (int actionNo = oldActionCount; actionNo < newActionCount; actionNo++) {
             String actionLine = allActionLines.get(actionNo);
             System.out.printf("[%8d][ %s ]\n", actionNo, actionLine);
 
-            ContainerAction action = new ContainerAction(actionLine);
+            ContainerAction action = new ContainerAction(actionNo, actionLine);
             actions.add(action);
             System.out.println(action);
         }
@@ -277,205 +77,80 @@ public class SharedLibTestUtils {
         System.out.println("================================================================================");
 
         String error = newCapture.compare(expectedCapture);
-        if ( error != null ) {
+        if (error != null) {
             fail(error);
         }
 
         return newCapture;
     }
 
+    //
 
-    // [11/28/23, 17:24:58:244 EST] 00000037 id=00000000 com.ibm.ws.app.manager.AppMessageHelper
-    // A CWWKZ0001I: Application snoop0 started in 3.385 seconds.
+    public static class OrderedAction implements Comparable<OrderedAction> {
+        public final String actionText;
+        public final String archive;
+        public final int offset;
 
-    // [11/28/23, 17:25:01:416 EST] 00000034 id=00000000 com.ibm.ws.app.manager.AppMessageHelper
-    // A CWWKZ0003I: The application snoop0 updated in 0.099 seconds.
+        public OrderedAction(String actionText, int offset) {
+            this.actionText = actionText;
+            this.offset = offset;
 
-    // [11/28/23, 17:25:01:292 EST] 0000003b id=00000000 com.ibm.ws.app.manager.AppMessageHelper
-    // A CWWKZ0009I: The application snoop0 has stopped successfully.
-
-    public static final String START_CODE  = "CWWKZ0001I:.*";
-    public static final String UPDATE_CODE = "CWWKZ0003I:.*";
-    public static final String STOP_CODE   = "CWWKZ0009I:.*";
-
-    public static enum AppStateChange {
-        STARTED(START_CODE), UPDATED(UPDATE_CODE), STOPPED(STOP_CODE);
-
-        public final String code;
-
-        private AppStateChange(String code) {
-            this.code = code;
-        }
-    }
-
-    public static void assertRestarted(LibertyServer server, int appNo) {
-        assertStopped(server, appNo);
-        assertUpdated(server, appNo);
-    }
-
-    public static void assertStarted(LibertyServer server, int appNo) {
-        assertActivity(server, new int[] { appNo, appNo + 1 }, AppStateChange.STARTED);
-    }
-
-    public static void assertStopped(LibertyServer server, int appNo) {
-        assertActivity(server, new int[] { appNo, appNo + 1 }, AppStateChange.STOPPED);
-    }
-
-    public static void assertUpdated(LibertyServer server, int appNo) {
-        assertActivity(server, new int[] { appNo, appNo + 1 }, AppStateChange.UPDATED);
-    }
-
-    public static void assertActivity(LibertyServer server, int[] range) {
-        // [ 0,   16 ] ==> // START 0 .. 15
-
-        // [ 0,    1 ] ==> // START 0 ..  0
-        // [ 1,   16 ] ==> // START 1 .. 15
-
-        // [ -1, -18 ] ==> // STOP  0 .. 15
-        // [ -2, -18 ] ==> // STOP  1 .. 15
-        // [ -1,  -2 ] ==> // STOP  0 ..  1
-
-        int min = range[0];
-        int max = range[1];
-        AppStateChange change;
-        if (min < 0) {
-            min = -(min + 1);
-            max = -(max + 1);
-            range = new int[] { min, max };
-            change = AppStateChange.STOPPED;
-        } else {
-            change = AppStateChange.STARTED;
-        }
-
-        assertActivity(server, range, change);
-    }
-
-    public static void assertActivity(LibertyServer server, int[] range, AppStateChange change) {
-        System.out.println("Verifying activity ...");
-        System.out.println("Min [ " + range[0] + " ] Max [ " + range[1] + " ]" +
-                           " Code [ " + change + " ] ( " + change.code + " )");
-
-        verifyActivity( range, getActivity(server, range, change) );
-    }
-
-    public static List<String> getActivity(LibertyServer server, int[] range, AppStateChange change) {
-        int count = range[1] - range[0];
-
-        List<String> activity = new ArrayList<>(count);
-
-        for (int actionNo = 0; actionNo < count; actionNo++) {
-            String nextAction = server.waitForStringInLogUsingLastOffset(change.code);
-            if (nextAction == null) {
-                fail("Null action [ " + actionNo + " ] of [ " + count + " ]");
+            int jarLoc = actionText.indexOf(".jar");
+            if (jarLoc == -1) {
+                throw new IllegalArgumentException("No archive [ " + actionText + " ]");
             }
-            System.out.println("Action [ " + nextAction + " ]");
-            activity.add(nextAction);
-        }
 
-        return activity;
-    }
-
-    public static void verifyActivity(int[] range, List<String> activity) {
-        int min = range[0];
-        int max = range[1];
-        int count = max - min;
-
-        Set<Integer> expected = new HashSet<>(count);
-
-        for (int appNo = min; appNo < max; appNo++) {
-            expected.add(Integer.valueOf(appNo));
-        }
-
-        for (String action : activity) {
-            int appNo = getAppNo(action);
-
-            Integer actualApp = Integer.valueOf(appNo);
-            boolean removed = expected.remove(actualApp);
-            if (!removed) {
-                fail("Unexpected app [ " + actualApp + " ]");
-                return;
-            }
-        }
-
-        if (!expected.isEmpty()) {
-            fail("Missing apps [ " + expected + " ]");
-            return;
-        }
-    }
-
-    // 11/14/23, 16:32:35:584 EST] 0000003b
-    //  com.ibm.ws.app.manager.AppMessageHelper
-    // A CWWKZ0001I: Application snoop11 started in 0.763 seconds.
-
-    public static int getAppNo(String action) {
-        int appLoc = action.indexOf("snoop");
-        if (appLoc == -1) {
-            fail("No app location [ " + action + " ]");
-            return -1;
-        }
-        appLoc += "snoop".length();
-
-        int actionLength = action.length();
-
-        boolean failed;
-        if (appLoc >= actionLength) {
-            failed = true;
-        } else {
-            char c1 = action.charAt(appLoc);
-            if (!Character.isDigit(c1)) {
-                failed = true;
-
-            } else {
-                int appNo = c1 - '0';
-
-                if (appLoc >= actionLength - 1) {
-                    failed = true;
-                } else {
-                    char c2 = action.charAt(appLoc + 1);
-                    if (c2 != ' ') {
-                        if (!Character.isDigit(c2)) {
-                            failed = true;
-
-                        } else {
-                            appNo *= 10;
-                            appNo += (c2 - '0');
-
-                            if (appLoc >= actionLength - 2) {
-                                failed = true;
-                            } else {
-                                char c3 = action.charAt(appLoc + 2);
-                                if (c3 != ' ') {
-                                    failed = true;
-                                } else {
-                                    failed = false;
-                                }
-                            }
-                        }
-                    } else {
-                        failed = false;
-                    }
-
-                    if (!failed) {
-                        return appNo;
-                    }
+            int start = -1;
+            for (int charNo = 0; charNo < jarLoc; charNo++) {
+                char c = actionText.charAt(charNo);
+                if ((c == '/') || (c == '\\')) {
+                    start = charNo;
                 }
             }
+
+            if (start == -1) {
+                start = 0;
+            }
+
+            this.archive = actionText.substring(start, jarLoc);
         }
 
-        fail("Bad app number [ " + action + " ]");
-        return -1;
+        @Override
+        public int compareTo(OrderedAction other) {
+            if (other == null) {
+                throw new IllegalArgumentException("Null other");
+            }
+
+            int jarResult = archive.compareToIgnoreCase(other.archive);
+            if (jarResult != 0) {
+                return jarResult;
+            } else {
+                return offset - other.offset;
+            }
+        }
     }
 
-    //
+    public static OrderedAction[] order(String[] actionText) {
+        OrderedAction[] ordered = new OrderedAction[actionText.length];
+        for (int actionNo = 0; actionNo < actionText.length; actionNo++) {
+            ordered[actionNo] = new OrderedAction(actionText[actionNo], actionNo);
+        }
+        Arrays.sort(ordered);
+        return ordered;
+    }
 
     public static final String ACTION_TAG = "[container].";
     public static final String CAPTURE_TAG = "capture";
     public static final String RELEASE_TAG = "release";
 
-    public static class ContainerAction {
+    public static class ContainerAction implements Comparable<ContainerAction> {
+        public final int offset;
+
         public final boolean isCapture;
         public final String archive;
+        public final int activity;
         public final int references;
+        public final String supplierInstance;
         public final String supplierClass;
 
         public final String asString;
@@ -485,7 +160,9 @@ public class SharedLibTestUtils {
             return asString;
         }
 
-        public ContainerAction(String line) {
+        public ContainerAction(int offset, String line) {
+            this.offset = offset;
+
             // [container].release:
             // [ C:\\dev\\repos-pub\\ol-baw\\dev\\build.image\\wlp\\usr\\servers\\sharedLibServer\\snoopLib\\test0.jar ]
             // [ 15 ]:
@@ -493,79 +170,120 @@ public class SharedLibTestUtils {
 
             int lineLen = line.length();
 
-            int actionOffset = line.indexOf(ACTION_TAG);
-            if ( actionOffset == -1 ) {
+            // Parse action ...
+
+            int regionEnd = line.indexOf(ACTION_TAG);
+            if (regionEnd == -1) {
                 throw new IllegalArgumentException("No action tag [ " + line + " ]");
             }
+            regionEnd += ACTION_TAG.length();
 
-            actionOffset += ACTION_TAG.length();
-            if ( line.regionMatches(actionOffset, CAPTURE_TAG, 0, CAPTURE_TAG.length()) ) {
+            int regionLen;
+            if (line.regionMatches(regionEnd, CAPTURE_TAG, 0, regionLen = CAPTURE_TAG.length())) {
                 this.isCapture = true;
-            } else if ( line.regionMatches(actionOffset, RELEASE_TAG, 0, RELEASE_TAG.length()) ) {
+            } else if (line.regionMatches(regionEnd, RELEASE_TAG, 0, regionLen = RELEASE_TAG.length())) {
                 this.isCapture = false;
             } else {
-                throw new IllegalArgumentException("Bad action [ " + line + " ]");
+                throw new IllegalArgumentException("Unknown action [ " + line + " ]");
             }
+            regionEnd += regionLen;
 
-            actionOffset += (this.isCapture ? CAPTURE_TAG : RELEASE_TAG).length();
+            // Parse archive ...
 
             int firstBrace = -1;
             int lastBrace = -1;
 
             int lastSlash = -1;
 
-            while ( (lastBrace == -1) && (actionOffset < lineLen) ) {
-                char c = line.charAt(actionOffset);
-                if ( firstBrace == -1 ) {
-                    if ( c == '[' ) {
-                        firstBrace = actionOffset;
+            while ((lastBrace == -1) && (regionEnd < lineLen)) {
+                char c = line.charAt(regionEnd);
+                if (firstBrace == -1) {
+                    if (c == '[') {
+                        firstBrace = regionEnd;
                     }
                 } else {
-                    if ( c == '[' ) {
+                    if (c == '[') {
                         throw new IllegalArgumentException("Misplaced open brace [ " + line + " ]");
-                    } else if ( (c == '/') || (c == '\\') ) {
-                        lastSlash = actionOffset;
-                    } else if ( c == ']' ) {
-                        lastBrace = actionOffset;
+                    } else if ((c == '/') || (c == '\\')) {
+                        lastSlash = regionEnd;
+                    } else if (c == ']') {
+                        lastBrace = regionEnd;
                     }
                 }
-                actionOffset++;
+                regionEnd++;
             }
 
-            if ( firstBrace == -1 ) {
+            if (firstBrace == -1) {
                 throw new IllegalArgumentException("Missing open brace [ " + line + " ]");
-            } else if ( lastBrace == -1 ) {
+            } else if (lastBrace == -1) {
                 throw new IllegalArgumentException("Missing close brace [ " + line + " ]");
-            } else if ( (lastBrace - firstBrace) < 4 ) { // [ x ] // need at least 4
+            } else if ((lastBrace - firstBrace) < 4) { // [ x ] // need at least 4
                 throw new IllegalArgumentException("Incomplete archive [ " + line + " ]");
             } else {
                 firstBrace++; // remove space
                 lastBrace--; // remove space
             }
 
-            int archiveStart = ( (lastSlash == -1) ? firstBrace : lastSlash );
+            int archiveStart = ((lastSlash == -1) ? firstBrace : lastSlash);
             this.archive = line.substring(archiveStart + 1, lastBrace);
+
+            // Parse activity ...
 
             firstBrace = -1;
             lastBrace = -1;
 
-            while ( (lastBrace == -1) && (actionOffset < lineLen) ) {
-                char c = line.charAt(actionOffset);
-                if ( firstBrace == -1 ) {
-                    if ( c == '[' ) {
-                        firstBrace = actionOffset;
+            while ((lastBrace == -1) && (regionEnd < lineLen)) {
+                char c = line.charAt(regionEnd);
+                if (firstBrace == -1) {
+                    if (c == '[') {
+                        firstBrace = regionEnd;
                     }
                 } else {
-                    if ( c == '[' ) {
+                    if (c == '[') {
                         throw new IllegalArgumentException("Misplaced open brace [ " + line + " ]");
-                    } else if ( c == ']' ) {
-                        lastBrace = actionOffset;
+                    } else if (c == ']') {
+                        lastBrace = regionEnd;
                     }
                 }
-                actionOffset++;
+                regionEnd++;
             }
 
-            if ( (lastBrace - firstBrace) < 4 ) { // [ x ] // need at least 4
+            if ((lastBrace - firstBrace) < 4) { // [ x ] // need at least 4
+                throw new IllegalArgumentException("Incomplete references [ " + line + " ]");
+            } else {
+                firstBrace++; // remove space
+                lastBrace--; // remove space
+            }
+
+            String activityText = line.substring(firstBrace + 1, lastBrace);
+            try {
+                this.activity = Integer.parseInt(activityText);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Non-numeric activity [ " + line + " ]", e);
+            }
+
+            // Parse references ...
+
+            firstBrace = -1;
+            lastBrace = -1;
+
+            while ((lastBrace == -1) && (regionEnd < lineLen)) {
+                char c = line.charAt(regionEnd);
+                if (firstBrace == -1) {
+                    if (c == '[') {
+                        firstBrace = regionEnd;
+                    }
+                } else {
+                    if (c == '[') {
+                        throw new IllegalArgumentException("Misplaced open brace [ " + line + " ]");
+                    } else if (c == ']') {
+                        lastBrace = regionEnd;
+                    }
+                }
+                regionEnd++;
+            }
+
+            if ((lastBrace - firstBrace) < 4) { // [ x ] // need at least 4
                 throw new IllegalArgumentException("Incomplete references [ " + line + " ]");
             } else {
                 firstBrace++; // remove space
@@ -575,57 +293,128 @@ public class SharedLibTestUtils {
             String referencesText = line.substring(firstBrace + 1, lastBrace);
             try {
                 this.references = Integer.parseInt(referencesText);
-            } catch ( NumberFormatException e ) {
+            } catch (NumberFormatException e) {
                 throw new IllegalArgumentException("Non-numeric references [ " + line + " ]", e);
             }
+
+            // Parser supplier ...
 
             firstBrace = -1;
             lastBrace = -1;
 
             int lastDot = -1;
 
-            while ( (lastBrace == -1) && (actionOffset < lineLen) ) {
-                char c = line.charAt(actionOffset);
-                if ( firstBrace == -1 ) {
-                    if ( c == '[' ) {
-                        firstBrace = actionOffset;
+            while ((lastBrace == -1) && (regionEnd < lineLen)) {
+                char c = line.charAt(regionEnd);
+                if (firstBrace == -1) {
+                    if (c == '[') {
+                        firstBrace = regionEnd;
                     }
                 } else {
-                    if ( c == '[' ) {
+                    if (c == '[') {
                         throw new IllegalArgumentException("Misplaced open brace [ " + line + " ]");
-                    } else if ( c == '.' ) {
-                        lastDot = actionOffset;
-                    } else if ( c == ']' ) {
-                        lastBrace = actionOffset;
+                    } else if (c == '.') {
+                        lastDot = regionEnd;
+                    } else if (c == ']') {
+                        lastBrace = regionEnd;
                     }
                 }
-                actionOffset++;
+                regionEnd++;
             }
 
-            if ( firstBrace == -1 ) {
+            if (firstBrace == -1) {
                 throw new IllegalArgumentException("Missing open brace [ " + line + " ]");
-            } else if ( lastBrace == -1 ) {
+            } else if (lastBrace == -1) {
                 throw new IllegalArgumentException("Missing close brace [ " + line + " ]");
-            } else if ( (lastBrace - firstBrace) < 4 ) { // [ x ] // need at least 4
+            } else if ((lastBrace - firstBrace) < 4) { // [ x ] // need at least 4
                 throw new IllegalArgumentException("Incomplete supplier class [ " + line + " ]");
             } else {
                 firstBrace++; // remove space
                 lastBrace--; // remove space
             }
 
-            int supplierStart = ( (lastDot == -1) ? firstBrace : lastDot );
+            int supplierStart = ((lastDot == -1) ? firstBrace : lastDot);
 
-            String useClass = line.substring(supplierStart + 1, lastBrace);
-            if ( useClass.isEmpty() ) {
-                throw new IllegalArgumentException("Empty archive [ " + line + " ]");
+            String useInstance = line.substring(supplierStart + 1, lastBrace);
+            if (useInstance.isEmpty()) {
+                throw new IllegalArgumentException("Empty supplier [ " + line + " ]");
             } else {
-                this.supplierClass = useClass;
+                this.supplierInstance = useInstance;
+                this.supplierClass = stripInstance(useInstance);
             }
 
-            this.asString = "[" + (isCapture ? "capture" : "release") + "]" +
-                            "[" + String.format("%3d", references) + "]" +
-                            "[" + archive + "]" +
-                            "[" + supplierClass + "]";
+            this.asString = concat("[", String.format("%3d", offset), "]",
+                                   "[", isCapture ? "capture" : "release", "]",
+                                   "[", String.format("%3d", activity), "]",
+                                   "[", String.format("%3d", references), "]",
+                                   "[", archive, "]",
+                                   "[", supplierInstance, "]");
+        }
+
+        public static String stripInstance(String className) {
+            int atOffset = className.lastIndexOf('@');
+            return ((atOffset == -1) ? className : className.substring(0, atOffset));
+        }
+
+        public static final boolean COMPARE_INSTANCES = true;
+
+        public boolean sameAs(ContainerAction other, List<String> differences, boolean compareInstances) {
+            boolean isSame = true;
+
+            if (isCapture != other.isCapture) {
+                differences.add("This capture [ " + isCapture + " ] Other capture [ " + other.isCapture + " ]");
+                isSame = false;
+            }
+
+            if (!archive.equals(other.archive)) {
+                differences.add("This archive [ " + archive + " ] Other archive [ " + other.archive + " ]");
+                isSame = false;
+            }
+
+            if (references != other.references) {
+                differences.add("This references [ " + references + " ] Other references [ " + other.references + " ]");
+                isSame = false;
+            }
+
+            if (compareInstances) {
+                if (!supplierInstance.equals(other.supplierInstance)) {
+                    differences.add("This supplier instance [ " + supplierInstance + " ] Other supplier instance [ " + other.supplierInstance + " ]");
+                    isSame = false;
+                }
+            } else {
+                if (!supplierClass.equals(other.supplierClass)) {
+                    differences.add("This supplier class [ " + supplierClass + " ] Other supplier class [ " + other.supplierClass + " ]");
+                    isSame = false;
+                }
+            }
+
+            return isSame;
+        }
+
+        /**
+         * Compare two container actions.
+         *
+         * Compare first by archive, then by supplier, then by activity.
+         *
+         * @return The result of comparing this container action with another container action.
+         */
+        @Override
+        public int compareTo(ContainerAction other) {
+            if (other == null) {
+                throw new IllegalArgumentException("Null other action");
+            }
+
+            int archiveCmp = archive.compareTo(other.archive);
+            if (archiveCmp != 0) {
+                return archiveCmp;
+            }
+
+            int supplierCmp = this.supplierInstance.compareTo(other.supplierInstance);
+            if (supplierCmp != 0) {
+                return supplierCmp;
+            }
+
+            return activity - other.activity;
         }
     }
 
@@ -644,26 +433,26 @@ public class SharedLibTestUtils {
 
         int remaining = width;
 
-        if ( value == 0 ) {
-            valueChars[ --remaining ] = '0';
+        if (value == 0) {
+            valueChars[--remaining] = '0';
 
         } else {
             int initialValue = value;
 
-            while ( (value > 0) && (remaining > 0) ) {
+            while ((value > 0) && (remaining > 0)) {
                 int nextDigit = value % 10;
                 value = value / 10;
 
-                valueChars[ --remaining ] = (char) ('0' + nextDigit);
+                valueChars[--remaining] = (char) ('0' + nextDigit);
             }
 
-            if ( value > 0 ) {
+            if (value > 0) {
                 return Integer.toString(initialValue);
             }
         }
 
-        while ( remaining > 0 ) {
-            valueChars[ --remaining ] = fillChar;
+        while (remaining > 0) {
+            valueChars[--remaining] = fillChar;
         }
 
         return new String(valueChars);
@@ -684,23 +473,22 @@ public class SharedLibTestUtils {
         }
 
         public static String asString(int[] refs, int capture, int release, int total) {
-            return "[" + fill_3(refs[0]) +
-                            ", " + fill_3(refs[1]) +
-                            ", " + fill_3(refs[2]) +
-                            ", " + fill_3(refs[3]) + "]" +
-                   " c[" + fill_4(capture) + "]" +
-                   " r[" + fill_4(release) + "]: " +
-                   fill_4(total);
+            return concat("[", fill_3(refs[0]), ", ",
+                          fill_3(refs[1]), ", ",
+                          fill_3(refs[2]), ", ",
+                          fill_3(refs[3]), "]",
+                          " c[", fill_4(capture), "]",
+                          " r[", fill_4(release), "]: ", fill_4(total));
         }
 
         public CacheTransitions(int[] referenceCounts,
                                 int actionsCapture, int actionsRelease, int actionsTotal) {
 
             int captured = 0;
-            for ( int refNo = 0; refNo < referenceCounts.length; refNo++ ) {
+            for (int refNo = 0; refNo < referenceCounts.length; refNo++) {
                 captured += referenceCounts[refNo];
             }
-            if ( captured != actionsTotal ) {
+            if (captured != actionsTotal) {
                 throw new IllegalArgumentException("Inconsistent capture total [ " + actionsTotal + " ]");
             }
 
@@ -717,23 +505,21 @@ public class SharedLibTestUtils {
 
         public CacheTransitions(int[] referenceCounts,
                                 int actionsCapture, int actionsRelease, CacheTransitions priorTransitions) {
-            this(referenceCounts,
-                 actionsCapture, actionsRelease,
-                 priorTransitions.actionsTotal + actionsCapture + actionsRelease);
+            this(referenceCounts, actionsCapture, actionsRelease, priorTransitions.actionsTotal + actionsCapture + actionsRelease);
         }
 
         public static int archiveNo(String archiveName) {
             int archiveLen = archiveName.length();
-            if ( archiveLen < 5 ) {
+            if (archiveLen < 5) {
                 throw new IllegalArgumentException("Unexpected archive [ " + archiveName + " ]");
             }
-            if ( archiveName.charAt(archiveLen - 4) != '.' ) {
+            if (archiveName.charAt(archiveLen - 4) != '.') {
                 throw new IllegalArgumentException("Non-valid archive [ " + archiveName + " ]");
             }
 
             char archiveChar = archiveName.charAt(archiveLen - 5);
             int archiveNo = archiveChar - '0';
-            if ( (archiveNo < 0) || (archiveNo > 3) ) {
+            if ((archiveNo < 0) || (archiveNo > 3)) {
                 throw new IllegalArgumentException("Archive out of range [ " + archiveName + " ]");
             }
             return archiveNo;
@@ -747,8 +533,8 @@ public class SharedLibTestUtils {
 
             int useCaptureTotal;
 
-            if ( priorTransitions != null ) {
-                for ( int archiveNo = 0; archiveNo < LIB_COUNT; archiveNo++ ) {
+            if (priorTransitions != null) {
+                for (int archiveNo = 0; archiveNo < LIB_COUNT; archiveNo++) {
                     useReferenceCounts[archiveNo] = priorTransitions.referenceCounts[archiveNo];
                 }
                 useCaptureTotal = priorTransitions.actionsTotal;
@@ -759,11 +545,11 @@ public class SharedLibTestUtils {
             int useCaptureActions = 0;
             int useReleaseActions = 0;
 
-            for ( int actionNo = firstTransitionNo; actionNo < lastTransitionNo; actionNo++ ) {
+            for (int actionNo = firstTransitionNo; actionNo < lastTransitionNo; actionNo++) {
                 ContainerAction action = allActions.get(actionNo);
 
                 int adj;
-                if ( action.isCapture ) {
+                if (action.isCapture) {
                     useCaptureActions++;
                     adj = +1;
                 } else {
@@ -789,7 +575,7 @@ public class SharedLibTestUtils {
                 // The write could be performed inside of the cache lock, at a cost
                 // to performance.
 
-                useReferenceCounts[ archiveNo(action.archive) ] += adj;
+                useReferenceCounts[archiveNo(action.archive)] += adj;
                 useCaptureTotal += adj;
             }
 
@@ -805,26 +591,26 @@ public class SharedLibTestUtils {
         public String compare(CacheTransitions expected) {
             String error;
 
-            for ( int archiveNo = 0; archiveNo < LIB_COUNT; archiveNo++ ) {
-                error = compare( referenceCounts[archiveNo], expected.referenceCounts[archiveNo],
-                                 "Incorrect references to archive [ " + archiveNo + " ]");
-                if ( error != null ) {
+            for (int archiveNo = 0; archiveNo < LIB_COUNT; archiveNo++) {
+                error = compare(referenceCounts[archiveNo], expected.referenceCounts[archiveNo],
+                                "Incorrect references to archive [ " + archiveNo + " ]");
+                if (error != null) {
                     return error;
                 }
             }
 
-            error = compare( actionsCapture, expected.actionsCapture, "Incorrect capture actions");
-            if ( error != null ) {
+            error = compare(actionsCapture, expected.actionsCapture, "Incorrect capture actions");
+            if (error != null) {
                 return error;
             }
 
-            error = compare( actionsRelease, expected.actionsRelease, "Incorrect release actions");
-            if ( error != null ) {
+            error = compare(actionsRelease, expected.actionsRelease, "Incorrect release actions");
+            if (error != null) {
                 return error;
             }
 
-            error = compare( actionsTotal, expected.actionsTotal, "Incorrect capture total");
-            if ( error != null ) {
+            error = compare(actionsTotal, expected.actionsTotal, "Incorrect capture total");
+            if (error != null) {
                 return error;
             }
 
@@ -832,180 +618,124 @@ public class SharedLibTestUtils {
         }
 
         public String compare(int actual, int expected, String message) {
-            if ( actual == expected ) {
+            if (actual == expected) {
                 return null;
             }
-            return ( message + "; expected [ " + expected + " ] actual [ " + actual + " ]" );
+            return (message + "; expected [ " + expected + " ] actual [ " + actual + " ]");
         }
     }
 
-    public static void verifyContainers(List<ContainerAction> containerActions) {
-        Map<String, String> allSuppliers = new HashMap<>();
-        Map<String, int[]> allTransitions = new HashMap<>();
-
-        for ( ContainerAction action : containerActions ) {
-            boolean isCapture = action.isCapture;
-            String archive = action.archive;
-            int references = action.references;
-            String supplier = action.supplierClass;
-
-            String priorSupplier = allSuppliers.get(archive);
-
-            // Transitions shows the amount of activity there is between
-            // the each initial capture of an archive and each final release
-            // of that archive.  For now, the value is only being displayed.
-            // No tests are done on the value.
-
-            int[] transitions = allTransitions.computeIfAbsent(archive, (String useArchive) -> new int[1]);
-
-            String failure;
-            String success;
-            int adjustment;
-
-            if ( isCapture && (references == 1) ) { // Should add a supplier.
-                if ( priorSupplier != null ) {
-                    failure = "found prior supplier [ " + priorSupplier + " ]";
-                    success = null;
-                } else {
-                    failure = null;
-                    success = "adds supplier [ " + supplier + " ]";
-                    allSuppliers.put(archive, supplier);
-                    transitions[0]++;
-                }
-
-            } else if ( !isCapture && (references == 0) ) { // Should remove a supplier.
-                if ( priorSupplier == null ) {
-                    failure = "found no prior supplier";
-                    success = null;
-                } else if ( !priorSupplier.equals(supplier) ) {
-                    failure = "changed supplier from [ " + priorSupplier + " ] to [ " + supplier + " ]";
-                    success = null;
-                } else {
-                    failure = null;
-                    success = "removed supplier [ " + priorSupplier + " ]";
-                    allSuppliers.remove(archive);
-                    transitions[0]++;
-                }
-
-            } else { // Should leave the supplier unchanged.
-                if ( priorSupplier == null ) {
-                    failure = "found no prior supplier";
-                    success = null;
-                } else if ( !priorSupplier.equals(supplier) ) {
-                    failure = "changed supplier from [ " + priorSupplier + " ] to [ " + supplier + " ]";
-                    success = null;
-                } else {
-                    failure = null; // The correct supplier is associated with the archive.
-                    success = null; // "leaves supplier as [ " + activeSupplier + " ]";
-                    transitions[0]++;
-                }
-            }
-
-            if ( (failure != null) || (success != null) ) {
-                String actionTag = ( isCapture ? "Capture" : "Release" );
-                String prefix = "Action [ " + actionTag + " ] references [ " + references + " ] archive [ " + archive + " ]: ";
-                if ( failure != null ) {
-                    fail(prefix + failure);
-                } else {
-                    System.out.println(prefix + success + ": transitions [ " + transitions[0] + " ]");
-                    if ( !isCapture && (references == 0) ) {
-                        transitions[0] = 0;
-                    }
-                }
-            }
-        }
-    }
-
+    // CAUTION!
     //
+    // Logging may place captured actions in an order that does not match changes to reference counts.
+    //
+    // For example, the following raw log text (a subset selected from a test failure)
+    // is in the relative order as it appears in the trace log.
+    //
+    // This causes failures of the supplier validation, since the capture with reference count of 2 detects
+    // as not following a capture with reference count of 1.
 
-    public static final int NUM_VALUES = 6;
+    // [3/2/24, 17:51:05:687 PST] 00000037 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3
+    // [container].capture: [ /home/ci/Build/workspace/ebcTestRunner/dev/autoFVT/image/output/wlp/usr/servers/sharedLibConfigServer/snoopLib/test0.jar ]
+    // [ 2 ]
+    // [ 2 ]
+    // [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]
+    //
+    // [3/2/24, 17:51:05:690 PST] 00000039 id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3
+    // [container].capture: [ /home/ci/Build/workspace/ebcTestRunner/dev/autoFVT/image/output/wlp/usr/servers/sharedLibConfigServer/snoopLib/test0.jar ]
+    // [ 3 ]
+    // [ 3 ]
+    // [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]
+    //
+    // [3/2/24, 17:51:05:690 PST] 0000002d id=00000000 com.ibm.ws.app.manager.module.internal.CaptureCache          3
+    // [container].capture: [ /home/ci/Build/workspace/ebcTestRunner/dev/autoFVT/image/output/wlp/usr/servers/sharedLibConfigServer/snoopLib/test0.jar ]
+    // [ 1 ]
+    // [ 1 ]
+    // [ com.ibm.ws.app.manager.module.internal.CaptureCache$CaptureSupplier@12bde948 ]
 
-    public static final String PRESENT_VALUE_0_BASE =
-        "<tr><td>com.ibm.ws.test0_base.Test0_Base</td><td>interface com.ibm.ws.test0_base.Test0_Base</td><td>TEST_VALUE</td><td>Test0</td></tr>";
-    public static final String PRESENT_VALUE_0_ALT =
-        "<tr><td>com.ibm.ws.test0_alt.Test0_Alt</td><td>interface com.ibm.ws.test0_alt.Test0_Alt</td><td>TEST_VALUE</td><td>Test0_Alt</td></tr>";
-    public static final String PRESENT_VALUE_1_BASE =
-        "<tr><td>com.ibm.ws.test1_base.Test1_Base</td><td>interface com.ibm.ws.test1_base.Test1_Base</td><td>TEST_VALUE</td><td>Test1</td></tr>";
-    public static final String PRESENT_VALUE_1_ALT =
-        "<tr><td>com.ibm.ws.test1_alt.Test1_Alt</td><td>interface com.ibm.ws.test1_alt.Test1_Alt</td><td>TEST_VALUE</td><td>Test1_Alt</td></tr>";
-    public static final String PRESENT_VALUE_2_BASE =
-        "<tr><td>com.ibm.ws.test2_base.Test2_Base</td><td>interface com.ibm.ws.test2_base.Test2_Base</td><td>TEST_VALUE</td><td>Test2</td></tr>";
-    public static final String PRESENT_VALUE_3_BASE =
-        "<tr><td>com.ibm.ws.test3_base.Test3_Base</td><td>interface com.ibm.ws.test3_base.Test3_Base</td><td>TEST_VALUE</td><td>Test3</td></tr>";
+    // Container verification is disabled due to problems of event ordering.
+    // Logging does not guarantee that log events from different threads will
+    // be written in the order in which logging was requested.
 
-    public static final String[] PRESENT_VALUES =
-        { PRESENT_VALUE_0_BASE, PRESENT_VALUE_0_ALT,
-          PRESENT_VALUE_1_BASE, PRESENT_VALUE_1_ALT,
-          PRESENT_VALUE_2_BASE,
-          PRESENT_VALUE_3_BASE };
-
-    public static final String ABSENT_VALUE_0_BASE =
-        "<tr><td>com.ibm.ws.test0_base.Test0_Base</td><td>null</td><td>TEST_VALUE</td><td>null</td></tr>";
-    public static final String ABSENT_VALUE_0_ALT =
-        "<tr><td>com.ibm.ws.test0_alt.Test0_Alt</td><td>null</td><td>TEST_VALUE</td><td>null</td></tr>";
-    public static final String ABSENT_VALUE_1_BASE =
-        "<tr><td>com.ibm.ws.test1_base.Test1_Base</td><td>null</td><td>TEST_VALUE</td><td>null</td></tr>";
-    public static final String ABSENT_VALUE_1_ALT =
-        "<tr><td>com.ibm.ws.test1_alt.Test1_Alt</td><td>null</td><td>TEST_VALUE</td><td>null</td></tr>";
-    public static final String ABSENT_VALUE_2_BASE =
-        "<tr><td>com.ibm.ws.test2_base.Test2_Base</td><td>null</td><td>TEST_VALUE</td><td>null</td></tr>";
-    public static final String ABSENT_VALUE_3_BASE =
-        "<tr><td>com.ibm.ws.test3_base.Test3_Base</td><td>null</td><td>TEST_VALUE</td><td>null</td></tr>";
-
-    public static final String[] ABSENT_VALUES =
-        { ABSENT_VALUE_0_BASE, ABSENT_VALUE_0_ALT,
-          ABSENT_VALUE_1_BASE, ABSENT_VALUE_1_ALT,
-          ABSENT_VALUE_2_BASE,
-          ABSENT_VALUE_3_BASE };
-
-    public static final String SNOOP_RESPONSE = "Shared Library Test Servlet";
-
-    public static void assertSnoop(LibertyServer server,
-                                   int[] range, int[][] expectedValues) throws Exception {
-        int min = range[0];
-        int max = range[1] - 1;
-
-        System.out.println("Verifying snoop [ " + min + " ] to [ " + max + " ]");
-
-        for (int appNo = min; appNo <= max; appNo++) {
-            assertSnoop(server, appNo, expectedValues[appNo]);
-        }
-    }
-
-    public static void assertSnoop(LibertyServer server,
-                                   int snoopNo, int[] expectedValues) throws Exception {
-        System.out.println("Invoke snoop [ " + snoopNo + " ]");
-
-        URL url = new URL( getSnoopUrlPrefix(server) + snoopNo);
-        List<String> lines = captureURL(url);
-
-        boolean foundResponse = false;
-        boolean[] foundValues = new boolean[NUM_VALUES];
-
-        for (String line : lines) {
-            if (line.contains(SNOOP_RESPONSE)) {
-                foundResponse = true;
-            } else {
-                for (int valueNo = 0; valueNo < NUM_VALUES; valueNo++) {
-                    if (line.equals(PRESENT_VALUES[valueNo])) {
-                        foundValues[valueNo] = true;
-                    }
-                }
-            }
-        }
-
-        String responseMessage = "Snoop URL [ " + url + " ] " + (foundResponse ? "contains" : "missing") + " [ " + SNOOP_RESPONSE + " ]";
-        System.out.println(responseMessage);
-        if (!foundResponse) {
-            fail(responseMessage);
-        }
-
-        for (int valueNo = 0; valueNo < NUM_VALUES; valueNo++) {
-            String message = "Probe value [ " + valueNo + " ] is [ " + (foundValues[valueNo] ? "present" : "missing") + " ]";
-            System.out.println(message);
-            if ((expectedValues[valueNo] > 0) != foundValues[valueNo]) {
-                fail(message);
-            }
-        }
-    }
+//    public static void verifyContainers(List<ContainerAction> containerActions) {
+//        List<ContainerAction> sortedActions = new ArrayList<>(containerActions);
+//        sortedActions.sort(ContainerAction::compareTo);
+//
+//        Map<String, String> allSuppliers = new HashMap<>();
+//        Map<String, int[]> allTransitions = new HashMap<>();
+//
+//        for (ContainerAction action : sortedActions) {
+//            boolean isCapture = action.isCapture;
+//            int activity = action.activity;
+//            String archive = action.archive;
+//            int references = action.references;
+//            String supplier = action.supplierInstance;
+//
+//            String priorSupplier = allSuppliers.get(archive);
+//
+//            // Transitions shows the amount of activity there is between
+//            // the each initial capture of an archive and each final release
+//            // of that archive.  For now, the value is only being displayed.
+//            // No tests are done on the value.
+//
+//            int[] transitions = allTransitions.computeIfAbsent(archive, (String useArchive) -> new int[1]);
+//
+//            String failure;
+//            String success;
+//
+//            if (isCapture && (references == 1)) { // Should add a supplier.
+//                if (priorSupplier != null) {
+//                    failure = "found prior supplier [ " + priorSupplier + " ]";
+//                    success = null;
+//                } else {
+//                    failure = null;
+//                    success = "adds supplier [ " + supplier + " ]";
+//                    allSuppliers.put(archive, supplier);
+//                    transitions[0]++;
+//                }
+//
+//            } else if (!isCapture && (references == 0)) { // Should remove a supplier.
+//                if (priorSupplier == null) {
+//                    failure = "found no prior supplier";
+//                    success = null;
+//                } else if (!priorSupplier.equals(supplier)) {
+//                    failure = "changed supplier from [ " + priorSupplier + " ] to [ " + supplier + " ]";
+//                    success = null;
+//                } else {
+//                    failure = null;
+//                    success = "removed supplier [ " + priorSupplier + " ]";
+//                    allSuppliers.remove(archive);
+//                    transitions[0]++;
+//                }
+//
+//            } else { // Should leave the supplier unchanged.
+//                // 2024-03-02-17:54:20:124 Action [ Capture ] references [ 2 ] archive [ test0.jar ]: found no prior supplier
+//
+//                if (priorSupplier == null) {
+//                    failure = "found no prior supplier";
+//                    success = null;
+//                } else if (!priorSupplier.equals(supplier)) {
+//                    failure = "changed supplier from [ " + priorSupplier + " ] to [ " + supplier + " ]";
+//                    success = null;
+//                } else {
+//                    failure = null; // The correct supplier is associated with the archive.
+//                    success = null; // "leaves supplier as [ " + activeSupplier + " ]";
+//                    transitions[0]++;
+//                }
+//            }
+//
+//            if ((failure != null) || (success != null)) {
+//                String actionTag = (isCapture ? "Capture" : "Release");
+//                String prefix = "Action [ " + actionTag + " ] activity [ " + activity + " ] references [ " + references + " ] archive [ " + archive + " ]: ";
+//                if (failure != null) {
+//                    fail(prefix + failure);
+//                } else {
+//                    System.out.println(prefix + success + ": transitions [ " + transitions[0] + " ]");
+//                    if (!isCapture && (references == 0)) {
+//                        transitions[0] = 0;
+//                    }
+//                }
+//            }
+//        }
+//    }
 }

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/SharedLibUpdateConfigTest.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/SharedLibUpdateConfigTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020,2023 IBM Corporation and others.
+ * Copyright (c) 2020,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,13 +12,12 @@
  *******************************************************************************/
 package componenttest.application.manager.test;
 
-import static componenttest.application.manager.test.SharedLibTestUtils.assertActivity;
+import static componenttest.application.manager.test.SharedLibServerUtils.assertActivity;
+import static componenttest.application.manager.test.SharedLibServerUtils.assertSnoop;
+import static componenttest.application.manager.test.SharedLibServerUtils.setupServer;
+import static componenttest.application.manager.test.SharedLibServerUtils.startServer;
+import static componenttest.application.manager.test.SharedLibServerUtils.verifyServer;
 import static componenttest.application.manager.test.SharedLibTestUtils.assertContainerActions;
-import static componenttest.application.manager.test.SharedLibTestUtils.assertSnoop;
-import static componenttest.application.manager.test.SharedLibTestUtils.setupServer;
-import static componenttest.application.manager.test.SharedLibTestUtils.startServer;
-import static componenttest.application.manager.test.SharedLibTestUtils.verifyContainers;
-import static componenttest.application.manager.test.SharedLibTestUtils.verifyServer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,16 +61,14 @@ public class SharedLibUpdateConfigTest {
     public static final String SERVER_08_XML = "server08.xml";
     public static final String SERVER_16_XML = "server16.xml";
 
-    public static final String[] SERVER_XMLS =
-        { SERVER_01_XML, SERVER_04_XML, SERVER_08_XML, SERVER_16_XML };
+    public static final String[] SERVER_XMLS = { SERVER_01_XML, SERVER_04_XML, SERVER_08_XML, SERVER_16_XML };
 
     //
 
-    public static final String[] APP_NAMES =
-        { "snoop0",  "snoop1",  "snoop2",  "snoop3",
-          "snoop4",  "snoop5",  "snoop6",  "snoop7",
-          "snoop8",  "snoop9",  "snoop10", "snoop11",
-          "snoop12", "snoop13", "snoop14", "snoop15" };
+    public static final String[] APP_NAMES = { "snoop0", "snoop1", "snoop2", "snoop3",
+                                               "snoop4", "snoop5", "snoop6", "snoop7",
+                                               "snoop8", "snoop9", "snoop10", "snoop11",
+                                               "snoop12", "snoop13", "snoop14", "snoop15" };
 
     public static final int APP_COUNT = APP_NAMES.length;
 
@@ -79,17 +76,13 @@ public class SharedLibUpdateConfigTest {
 
     // min -> max + 1: 0..15 -> [ 0, 16 ]
     // -(min + 1) -> -((max + 1) + 1): 0..15 -> [ -1, -17 ]
-    public static final int[] APP_ACTIVITY_INITIAL =
-        { 0, APP_COUNT }; // Start 0 .. 15
-    public static final int[][] APP_ACTIVITY =
-        { { -2, -17 }, { 1, 4 }, { 4, 8 }, { 8, APP_COUNT } };
-                // Stop 1 .. 15, Start 1 .. 3, Start 4 .. 7, Start 8 .. 15
+    public static final int[] APP_ACTIVITY_INITIAL = { 0, APP_COUNT }; // Start 0 .. 15
+    public static final int[][] APP_ACTIVITY = { { -2, -17 }, { 1, 4 }, { 4, 8 }, { 8, APP_COUNT } };
+    // Stop 1 .. 15, Start 1 .. 3, Start 4 .. 7, Start 8 .. 15
 
     // min -> max + 1
-    public static final int[] APPS_RUNNING_INITIAL =
-        { 0, APP_COUNT };
-    public static final int[][] APPS_RUNNING =
-        { { 0, 1 }, { 0, 4 }, { 0, 8 }, { 0, APP_COUNT } };
+    public static final int[] APPS_RUNNING_INITIAL = { 0, APP_COUNT };
+    public static final int[][] APPS_RUNNING = { { 0, 1 }, { 0, 4 }, { 0, 8 }, { 0, APP_COUNT } };
 
     // Capture history:
     //
@@ -165,30 +158,25 @@ public class SharedLibUpdateConfigTest {
     // test2(0)  [snoop2: y/y/n/n] [snoop6: y/n/n/y] [snoop10: y/n/n/y] [snoop14: y/n/n/y]
     // test3(12) [snoop3: y/y/n/n] [snoop7: y/n/n/y] [snoop11: y/n/n/y] [snoop15: y/n/n/y]
 
-    public static final int NUM_VALUES = SharedLibTestUtils.NUM_VALUES;
+    public static final int NUM_VALUES = SharedLibServerUtils.NUM_VALUES;
 
     public static final int[] VALUES_0_1 = { 1, 0, 1, 0, 0, 0 }; // 0-Y 0Alt-N 1-Y 1Alt-N 2-N 3-N
     public static final int[] VALUES_0_2 = { 1, 0, 0, 0, 1, 0 }; // 0-Y 0Alt-N 1-N 1Alt-N 2-Y 3-N
     public static final int[] VALUES_0_3 = { 1, 0, 0, 0, 0, 1 }; // 0-Y 0Alt-N 1-N 1Alt-N 2-N 3-Y
 
-    public static final int[][] EXPECTED_VALUES_1 =
-        { VALUES_0_1 };
+    public static final int[][] EXPECTED_VALUES_1 = { VALUES_0_1 };
 
-    public static final int[][] EXPECTED_VALUES_4 =
-        { VALUES_0_1, VALUES_0_1, VALUES_0_1, VALUES_0_1 };
+    public static final int[][] EXPECTED_VALUES_4 = { VALUES_0_1, VALUES_0_1, VALUES_0_1, VALUES_0_1 };
 
-    public static final int[][] EXPECTED_VALUES_8 =
-        { VALUES_0_1, VALUES_0_1, VALUES_0_1, VALUES_0_1,
-          VALUES_0_2, VALUES_0_2, VALUES_0_2, VALUES_0_2 };
+    public static final int[][] EXPECTED_VALUES_8 = { VALUES_0_1, VALUES_0_1, VALUES_0_1, VALUES_0_1,
+                                                      VALUES_0_2, VALUES_0_2, VALUES_0_2, VALUES_0_2 };
 
-    public static final int[][] EXPECTED_VALUES_16 =
-        { VALUES_0_1, VALUES_0_1, VALUES_0_1, VALUES_0_1,
-          VALUES_0_3, VALUES_0_3, VALUES_0_3, VALUES_0_3,
-          VALUES_0_3, VALUES_0_3, VALUES_0_3, VALUES_0_3,
-          VALUES_0_3, VALUES_0_3, VALUES_0_3, VALUES_0_3 };
+    public static final int[][] EXPECTED_VALUES_16 = { VALUES_0_1, VALUES_0_1, VALUES_0_1, VALUES_0_1,
+                                                       VALUES_0_3, VALUES_0_3, VALUES_0_3, VALUES_0_3,
+                                                       VALUES_0_3, VALUES_0_3, VALUES_0_3, VALUES_0_3,
+                                                       VALUES_0_3, VALUES_0_3, VALUES_0_3, VALUES_0_3 };
 
-    public static final int[][][] ALL_EXPECTED_VALUES =
-        { EXPECTED_VALUES_1, EXPECTED_VALUES_4, EXPECTED_VALUES_8, EXPECTED_VALUES_16 };
+    public static final int[][][] ALL_EXPECTED_VALUES = { EXPECTED_VALUES_1, EXPECTED_VALUES_4, EXPECTED_VALUES_8, EXPECTED_VALUES_16 };
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -205,10 +193,9 @@ public class SharedLibUpdateConfigTest {
 
         List<ContainerAction> containerActions = new ArrayList<>();
 
-        CacheTransitions priorData =
-            assertContainerActions(server,
-                                                      0, 0, EXPECTED_CAPTURES_0_16,
-                                                      INITIAL_CAPTURES, containerActions);
+        CacheTransitions priorData = assertContainerActions(server,
+                                                            0, 0, EXPECTED_CAPTURES_0_16,
+                                                            INITIAL_CAPTURES, containerActions);
 
         for (int iter = 0; iter < TEST_ITERATIONS; iter++) {
             int configNo = iter % 4;
@@ -226,7 +213,11 @@ public class SharedLibUpdateConfigTest {
                                                priorData, containerActions);
         }
 
-        verifyContainers(containerActions);
+        // Container verification is disabled due to problems of event ordering.
+        // Logging does not guarantee that log events from different threads will
+        // be written in the order in which logging was requested.
+
+        // verifyContainers(containerActions);
     }
 
     //
@@ -237,34 +228,27 @@ public class SharedLibUpdateConfigTest {
     // update[2-3] last: [8,  4, 4,  0] c[8]  r[0]:  16
     // update[3-4] last: [16, 4, 0, 12] c[20] r[4]:  32
 
-    public static final CacheTransitions INITIAL_CAPTURES =
-        new CacheTransitions( new int[] { 0, 0, 0, 0 }, 0, 0, 0 );
+    public static final CacheTransitions INITIAL_CAPTURES = new CacheTransitions(new int[] { 0, 0, 0, 0 }, 0, 0, 0);
 
-    public static final CacheTransitions EXPECTED_CAPTURES_0_16 =
-        new CacheTransitions( new int[] { 16, 4, 0, 12 }, 32, 0, 32 );
+    public static final CacheTransitions EXPECTED_CAPTURES_0_16 = new CacheTransitions(new int[] { 16, 4, 0, 12 }, 32, 0, 32);
 
-    public static final CacheTransitions EXPECTED_CAPTURES_16_1 =
-        new CacheTransitions( new int[] { 1, 1, 0, 0 }, 0, 30, 2 );
+    public static final CacheTransitions EXPECTED_CAPTURES_16_1 = new CacheTransitions(new int[] { 1, 1, 0, 0 }, 0, 30, 2);
 
-    public static final CacheTransitions EXPECTED_CAPTURES_1_4 =
-        new CacheTransitions( new int[] { 4, 4, 0, 0 }, 6, 0, 8 );
+    public static final CacheTransitions EXPECTED_CAPTURES_1_4 = new CacheTransitions(new int[] { 4, 4, 0, 0 }, 6, 0, 8);
 
-    public static final CacheTransitions EXPECTED_CAPTURES_4_8 =
-        new CacheTransitions( new int[] { 8, 4, 4, 0 }, 8 + 4, 0 + 4, 16 );
+    public static final CacheTransitions EXPECTED_CAPTURES_4_8 = new CacheTransitions(new int[] { 8, 4, 4, 0 }, 8 + 4, 0 + 4, 16);
 
     // The releases and captures for (4 -> 8) are 4 higher because
     // the configuration changes for apps 2 and 3, from A: { test0, test1 } to B: { test0, test1 }.
     // the comparison evidently doesn't compare the actual shared libraries: the comparison
     // only sees that a different shared library has been set.
     // similarly for the captures (8 -> 16).
-    public static final CacheTransitions EXPECTED_CAPTURES_8_16 =
-        new CacheTransitions( new int[] { 16, 4, 0, 12 }, 24 + 4, 8 + 4, 32 );
+    public static final CacheTransitions EXPECTED_CAPTURES_8_16 = new CacheTransitions(new int[] { 16, 4, 0, 12 }, 24 + 4, 8 + 4, 32);
     // The releases and captures for (8 -> 16) are 4 higher; see the comment
     // for the captures (4 -> 8).
 
-    public static final CacheTransitions[] EXPECTED_CAPTURES =
-        { EXPECTED_CAPTURES_16_1,
-          EXPECTED_CAPTURES_1_4,
-          EXPECTED_CAPTURES_4_8,
-          EXPECTED_CAPTURES_8_16 };
+    public static final CacheTransitions[] EXPECTED_CAPTURES = { EXPECTED_CAPTURES_16_1,
+                                                                 EXPECTED_CAPTURES_1_4,
+                                                                 EXPECTED_CAPTURES_4_8,
+                                                                 EXPECTED_CAPTURES_8_16 };
 }


### PR DESCRIPTION
This step cannot be performed because log output is not guaranteed to be in the order of the base events.  Event sequencing could be provided, but would require synchronizing shared library key steps.  That would have too much of a runtime impact and was not done. Some sequence numbers were added, and new event parsing tests were added.
