### PR TITLE
Add checkpoint as testedfeature

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/bnd.bnd
@@ -32,7 +32,7 @@ tested.features: mpReactiveMessaging-1.0, \
                  cdi-4.0, \
                  jsonp-2.0, \
                  jsonp-2.1, \
-				 checkpoint
+                 checkpoint
                  
 
 fat.project: true

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/bnd.bnd
@@ -31,7 +31,8 @@ tested.features: mpReactiveMessaging-1.0, \
                  cdi-3.0, \
                  cdi-4.0, \
                  jsonp-2.0, \
-                 jsonp-2.1
+                 jsonp-2.1, \
+				 checkpoint
                  
 
 fat.project: true

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -62,6 +62,7 @@ tested.features: \
         appsecurity-6.0,\
         beanvalidation-3.1,\
         cdi-4.1,\
+		checkpoint,\
         concurrent-3.1,\
         connectors-2.0,\
         connectors-2.1,\
@@ -103,7 +104,7 @@ tested.features: \
         websocket-2.2,\
         xmlbinding-4.0,\
         xmlWS-3.0,\
-        xmlws-4.0
+        xmlws-4.0,\
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -104,7 +104,7 @@ tested.features: \
         websocket-2.2,\
         xmlbinding-4.0,\
         xmlWS-3.0,\
-        xmlws-4.0,\
+        xmlws-4.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -62,7 +62,7 @@ tested.features: \
         appsecurity-6.0,\
         beanvalidation-3.1,\
         cdi-4.1,\
-		checkpoint,\
+        checkpoint,\
         concurrent-3.1,\
         connectors-2.0,\
         connectors-2.1,\

--- a/dev/io.openliberty.checkpoint_fat_beanvalidation/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_beanvalidation/bnd.bnd
@@ -37,7 +37,8 @@ tested.features: \
     cdi-4.0,\
     servlet-6.0,\
     expressionlanguage-5.0,\
-    enterprisebeanslite-4.0
+    enterprisebeanslite-4.0,\
+    checkpoint
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.checkpoint_fat_crac/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_crac/bnd.bnd
@@ -18,7 +18,7 @@ src: \
 
 fat.project: true
 
-tested.features: servlet-5.0, servlet-6.0
+tested.features: servlet-5.0, servlet-6.0, checkpoint
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.checkpoint_fat_jms/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_jms/bnd.bnd
@@ -26,6 +26,7 @@ test.project: true
 tested.features:\
   wasJmsServer-1.0,\
   wasJmsClient-2.0,\
+  checkpoint
 
 
 # To define a global minimum java level for the FAT, use the following property.

--- a/dev/io.openliberty.checkpoint_fat_mail/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_mail/bnd.bnd
@@ -24,7 +24,8 @@ tested.features: \
 	servlet-5.0,\
 	mail-2.0,\
 	servlet-6.0,\
-	mail-2.1
+	mail-2.1,\
+  checkpoint
 
 
 # To define a global minimum java level for the FAT, use the following property.

--- a/dev/io.openliberty.checkpoint_fat_mail/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_mail/bnd.bnd
@@ -25,7 +25,7 @@ tested.features: \
 	mail-2.0,\
 	servlet-6.0,\
 	mail-2.1,\
-  checkpoint
+	checkpoint
 
 
 # To define a global minimum java level for the FAT, use the following property.

--- a/dev/io.openliberty.checkpoint_fat_mpconfig/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_mpconfig/bnd.bnd
@@ -25,7 +25,8 @@ tested.features: \
 	servlet-5.0,\
 	servlet-6.0,\
 	cdi-3.0,\
-	cdi-4.0
+	cdi-4.0,\
+	checkpoint
 
 
 # To define a global minimum java level for the FAT, use the following property.

--- a/dev/io.openliberty.checkpoint_fat_persistence/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_persistence/bnd.bnd
@@ -21,6 +21,8 @@ src: \
 
 fat.project: true
 
+
+
 fat.test.container.images: kyleaure/db2-ssl:3.0
 
 # To define a global minimum java level for the FAT, use the following property.
@@ -43,4 +45,4 @@ fat.test.container.images: kyleaure/db2-ssl:3.0
 	com.ibm.websphere.javaee.jaxrs.2.1,\
 	com.ibm.websphere.javaee.transaction.1.2
 
-tested.features=jdbc-4.3,jdbc-4.2,jdbc-4.1
+tested.features=checkpoint,jdbc-4.3,jdbc-4.2,jdbc-4.1

--- a/dev/io.openliberty.checkpoint_fat_security_oidc_social/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_security_oidc_social/bnd.bnd
@@ -21,7 +21,7 @@ src: \
 fat.project: true
 
 tested.features: jaxrs-2.0, el-3.0, restfulwsclient-3.0, restfulws-3.0, appsecurity-4.0, cdi-2.0, expressionlanguage-4.0, pages-3.0, \
-                 jsonp-1.1, jaxrsclient-2.1, restfulws-3.1, appsecurity-5.0, pages-3.1, jaspic-1.1, appauthentication-2.0, appauthentication-3.0, xmlbinding-3.0 
+                 jsonp-1.1, jaxrsclient-2.1, restfulws-3.1, appsecurity-5.0, pages-3.1, jaspic-1.1, appauthentication-2.0, appauthentication-3.0, xmlbinding-3.0, checkpoint
 
 -buildpath: \
     com.ibm.json4j;version=latest,\

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/bnd.bnd
@@ -24,7 +24,8 @@ tested.features: \
   mpConfig-3.1, \
   servlet-6.0, \
   mpMetrics-5.1, \
-  cdi-4.0
+  cdi-4.0, \
+  checkpoint
 
 
 -buildpath: \

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan_container/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan_container/bnd.bnd
@@ -29,7 +29,8 @@ tested.features: \
   servlet-6.0,\
   componenttest-2.0,\
   cdi-3.0,\
-  cdi-4.0
+  cdi-4.0,\
+  checkpoint
 
 
 -buildpath: \

--- a/dev/io.openliberty.checkpoint_fat_springboot/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_springboot/bnd.bnd
@@ -17,7 +17,7 @@ javac.source: 17
 javac.target: 17
 
 tested.features: \
-	checkpoint
+  checkpoint
 
 src: \
         fat/src

--- a/dev/io.openliberty.checkpoint_fat_springboot/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_springboot/bnd.bnd
@@ -16,6 +16,9 @@ bVersion=1.0
 javac.source: 17
 javac.target: 17
 
+tested.features: \
+	checkpoint
+
 src: \
         fat/src
 

--- a/dev/io.openliberty.checkpoint_fat_transaction/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_transaction/bnd.bnd
@@ -31,7 +31,8 @@ tested.features: \
 	osgiConsole-1.0,\
 	webProfile-8.0,\
 	webProfile-9.1,\
-	webProfile-10.0
+	webProfile-10.0 \
+	checkpoint
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.checkpoint_fat_xmlws/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_xmlws/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 fat.project: true
 
 tested.features: servlet-5.0, servlet-6.0, xmlws-3.0, xmlbinding-3.0, enterprisebeansLite-4.0, appSecurity-4.0, expressionlanguage-4.0,\
-				 cdi-3.0, xmlws-4.0, expressionlanguage-5.0, appSecurity-5.0, jsonp-2.1, cdi-4.0
+				 cdi-3.0, xmlws-4.0, expressionlanguage-5.0, appSecurity-5.0, jsonp-2.1, cdi-4.0, checkpoint
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.data.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat/bnd.bnd
@@ -25,6 +25,9 @@ fat.minimum.java.level: 17
 fat.project: true
 fat.test.databases: true
 
+tested.features: \
+  checkpoint
+
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true
 

--- a/dev/io.openliberty.data.internal_fat_jpa/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat_jpa/bnd.bnd
@@ -24,6 +24,9 @@ fat.minimum.java.level: 17
 fat.project: true
 fat.test.databases: true
 
+tested.features: \
+  checkpoint
+
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true
 

--- a/dev/io.openliberty.data/bnd.bnd
+++ b/dev/io.openliberty.data/bnd.bnd
@@ -16,9 +16,6 @@ bVersion=1.0
 javac.source: 17
 javac.target: 17
 
-tested.features: \
-  checkpoint
-
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=17))"
 
 Bundle-Name: Open Liberty API for Jakarta Data

--- a/dev/io.openliberty.data/bnd.bnd
+++ b/dev/io.openliberty.data/bnd.bnd
@@ -16,6 +16,9 @@ bVersion=1.0
 javac.source: 17
 javac.target: 17
 
+tested.features: \
+	checkpoint
+
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=17))"
 
 Bundle-Name: Open Liberty API for Jakarta Data

--- a/dev/io.openliberty.data/bnd.bnd
+++ b/dev/io.openliberty.data/bnd.bnd
@@ -17,7 +17,7 @@ javac.source: 17
 javac.target: 17
 
 tested.features: \
-	checkpoint
+  checkpoint
 
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=17))"
 

--- a/dev/io.openliberty.ejbcontainer.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.ejbcontainer.checkpoint_fat/bnd.bnd
@@ -28,7 +28,8 @@ tested.features: \
 	servlet-3.1,\
 	servlet-4.0,\
 	servlet-5.0,\
-	servlet-6.0
+	servlet-6.0,\
+	checkpoint
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\


### PR DESCRIPTION
Add 'checkpoint' to the tested.features (in bnd.bnd) for FATs containing a CheckpointTest annotation to enable them to be automatically run in supporting environments where enabled on builds.