### PR TITLE
Fix NullPointerException in JarFileClassLoader

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarFileClassLoader.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarFileClassLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2023 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -162,7 +162,7 @@ public class JarFileClassLoader extends SecureClassLoader implements Closeable {
             manifest = resourceHandler.getManifest();
         } catch (IOException e) {
             if (returnNull) {
-                throw null;
+                return null;
             }
             throw new ClassNotFoundException(className, e);
         }


### PR DESCRIPTION
- The code erroneously was throwing null instead of returning null.

The change that caused this problem was #5808.

Fixes #27886 
Fixes #PH60659