### PR TITLE
Update fattest.simplicity for changes in WebSphere Liberty

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE6FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE6FeatureReplacementAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2023 IBM Corporation and others.
+ * Copyright (c) 2018,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,6 @@ public class EE6FeatureReplacementAction extends FeatureReplacementAction {
     public static final String ID = "EE6_FEATURES";
 
     static final String[] EE6_FEATURES_ARRAY = { "webProfile-6.0",
-                                                 "javaeeClient-6.0",
                                                  "cdi-1.0",
                                                  "appSecurity-2.0",
                                                  "jsf-2.0",


### PR DESCRIPTION
- Remove non-existent feature from EE6FetaureReplacementAction
- Add wmqJmsClient to wmqMessagingClient mapping for EE8 to EE9+
- Add max Java level logic to FeatureReplacementAction
- Add updateServerConfig logic to FeatureReplacementAction and an implementation in JakartaEEAction
- Add additional methods to JakartaEEAction for additional transformation scenarios when running with Jakarta EE 9+.
