### PR TITLE
Add Checkpoint PB support (on via test-trigger)

### DIFF
--- a/.ci-orchestrator/jvms/dev/checkpoint_linux_x86_64.properties
+++ b/.ci-orchestrator/jvms/dev/checkpoint_linux_x86_64.properties
@@ -1,0 +1,3 @@
+reportingJVM=IBM_SEMERU_OPEN_JDK_17
+jvmUnderTestPath=/liberty/jvms/linux_x86_64/ibm-semerujdk-17.0.9+9_openj9-0.41.0/jdk-17.0.9+9.tar.gz
+jvmFrameworkPath=/liberty/jvms/linux_x86_64/ibm-semerujdk-21.0.2+13_openj9-0.43.0/jdk-21.0.2+13.tar.gz

--- a/.ci-orchestrator/pb.yml
+++ b/.ci-orchestrator/pb.yml
@@ -289,7 +289,7 @@ triggers:
   triggerName: "Test: Feature (Checkpoint) Lite."
   triggerRank: 50
   groups: ["CSD"]
-  keyword: "!test_pb_with_checkpoint"
+  keyword: "!test_ol_pb_with_checkpoint"
   propertyDefinitions:
   - name: fat.buckets.to.run
     defaultValue: ${PR Changes:fat.buckets.to.run}

--- a/.ci-orchestrator/pb.yml
+++ b/.ci-orchestrator/pb.yml
@@ -1,9 +1,10 @@
 type: pipeline_definition
 product: Liberty
 name: Open Liberty Personal Build
-description: A build run against Open Liberty Pull Requests
+description: "Run a Personal build against an Open Liberty PR."
 triggers:
 - type: github
+  description: "Runs an optimised Open Liberty personal build, running FATs using the CIOrchestrator/Jenkins."
   triggerName: "ol-pbbeta"
   triggerRank: 50
   groups: ["LibertyDev"]
@@ -38,23 +39,28 @@ triggers:
 
 - type: manual
   triggerName: "ol-pbbeta-manual"
+  description: "Runs an optimised Open Liberty personal build, running FATs using the CIOrchestrator/Jenkins."
   triggerRank: 50
   groups: ["LibertyDev"]
   propertyDefinitions:
   - name: github_pr_user
     isRequired: true
-    defaultValue: "Name of org to checkout"
+    defaultValue: "Name of Open Liberty user or organization for checkout."
+    description: "Name of Open Liberty user or organization for checkout."
   - name: github_pr_branch
     isRequired: true
-    defaultValue: "Name of branch to checkout"
+    defaultValue: "Name of Open Liberty branch to checkout."
+    description: "Name of Open Liberty branch to checkout."
   - name: github_pr_number
     isRequired: true
-    defaultValue: "PR number in open-liberty"
+    defaultValue: "PR number in Open Liberty to checkout."
+    description: "PR number in Open Liberty to checkout."
   - name: github_pr_api
     defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/${github_pr_number}"
 
 - type: github
   triggerName: "ol-fullpbbeta"
+  description: "Runs an optimised Open Liberty personal build, including building the IM and z/OS images, then running all FATs using the CIOrchestrator/Jenkins."
   triggerRank: 50
   groups: ["LibertyDev"]
   keyword: "!fullpbbeta"
@@ -83,44 +89,52 @@ triggers:
     - stepName: z/OS Unittests
 
 - type: manual
-  triggerName: "Open Liberty Personal product only change"
+  description: "Runs a test Personal build which simulates an Open Liberty product-only change."
+  triggerName: "Test: Product-only change."
   triggerRank: 50
   groups: ["CSD"]
   propertyDefinitions:
   - name: git.laos.clone.repository.username
     defaultValue: "fritze2"
+    description: "Name of Open Liberty user or organization for checkout."
     steps:
     - stepName: Compile Liberty Images
     - stepName: Unittest Open Liberty
     - stepName: Compile FATs
   - name: git.laos.clone.checkout.branch
     defaultValue: "test-change-com.ibm.ws.jca"
+    description: "Name of Open Liberty branch to checkout."
     steps:
     - stepName: Compile Liberty Images
     - stepName: Unittest Open Liberty
     - stepName: Compile FATs
   - name: buildLabelPrefix
     defaultValue: "fritze2-23250-"
+    description: "RTC build label prefix."
     steps:
     - stepName: Compile Liberty Images
     - stepName: Unittest Open Liberty
     - stepName: Compile FATs
   - name: githubPRApi
     defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/23250"
+    description: "API URL to PR in Open Liberty."
     steps:
     - stepName: PR Changes
     - stepName: Determine FATs Needed
   - name: githubPRNumber
     defaultValue: "23250"
+    description: "PR number in Open Liberty to checkout."
     steps:
     - stepName: PR Changes
 
 - type: manual
-  triggerName: "Open Liberty Personal unittest only change"
+  description: "Runs a test personal build which simulates an Open Liberty unit test-only change."
+  triggerName: "Test: Unit test-only change."
   triggerRank: 50
   groups: ["CSD"]
   propertyDefinitions:
   - name: git.laos.clone.repository.username
+    description: "Name of Open Liberty user or organization for checkout."
     defaultValue: "fritze2"
     steps:
     - stepName: Compile Liberty Images
@@ -128,32 +142,38 @@ triggers:
     - stepName: Compile FATs
   - name: git.laos.clone.checkout.branch
     defaultValue: "test-change-com.ibm.ws.jmx-unittest"
+    description: "Name of Open Liberty branch to checkout."
     steps:
     - stepName: Compile Liberty Images
     - stepName: Unittest Open Liberty
     - stepName: Compile FATs
   - name: buildLabelPrefix
     defaultValue: "fritze2-23738-"
+    description: "RTC build label prefix."
     steps:
     - stepName: Compile Liberty Images
     - stepName: Unittest Open Liberty
     - stepName: Compile FATs
   - name: githubPRApi
     defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/23738"
+    description: "API URL to PR in Open Liberty."
     steps:
     - stepName: PR Changes
     - stepName: Determine FATs Needed
   - name: githubPRNumber
     defaultValue: "23738"
+    description: "PR number in Open Liberty to checkout."
     steps:
     - stepName: PR Changes
 
 - type: manual
-  triggerName: "Open Liberty Personal FAT only change"
+  description: "Runs a test personal build which simulates an Open Liberty FAT-only change."
+  triggerName: "Test: FAT-only change."
   triggerRank: 50
   groups: ["CSD"]
   propertyDefinitions:
   - name: git.laos.clone.repository.username
+    description: "Name of Open Liberty user or organization for checkout."
     defaultValue: "fritze2"
     steps:
     - stepName: Compile Liberty Images
@@ -161,32 +181,38 @@ triggers:
     - stepName: Compile FATs
   - name: git.laos.clone.checkout.branch
     defaultValue: "test-change-com.ibm.ws.jca_fat"
+    description: "Name of Open Liberty branch to checkout."
     steps:
     - stepName: Compile Liberty Images
     - stepName: Unittest Open Liberty
     - stepName: Compile FATs
   - name: buildLabelPrefix
     defaultValue: "fritze2-23249-"
+    description: "RTC build label prefix."
     steps:
     - stepName: Compile Liberty Images
     - stepName: Unittest Open Liberty
     - stepName: Compile FATs
   - name: githubPRApi
     defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/23249"
+    description: "API URL to PR in Open Liberty."
     steps:
     - stepName: PR Changes
     - stepName: Determine FATs Needed
   - name: githubPRNumber
     defaultValue: "23249"
+    description: "PR number in Open Liberty to checkout."
     steps:
     - stepName: PR Changes
 
 - type: manual
-  triggerName: "Open Liberty Personal BVT only change"
+  description: "Runs a test personal build which simulates an Open Liberty BVT-only change."
+  triggerName: "Test: BVT-only change."
   triggerRank: 50
   groups: ["CSD"]
   propertyDefinitions:
   - name: git.laos.clone.repository.username
+    description: "Name of Open Liberty user or organization for checkout."
     defaultValue: "fritze2"
     steps:
     - stepName: Compile Liberty Images
@@ -194,32 +220,38 @@ triggers:
     - stepName: Compile FATs
   - name: git.laos.clone.checkout.branch
     defaultValue: "test-change-com.ibm.ws.jca_fat_bvt"
+    description: "Name of Open Liberty branch to checkout."
     steps:
     - stepName: Compile Liberty Images
     - stepName: Unittest Open Liberty
     - stepName: Compile FATs
   - name: buildLabelPrefix
     defaultValue: "fritze2-23248-"
+    description: "RTC build label prefix."
     steps:
     - stepName: Compile Liberty Images
     - stepName: Unittest Open Liberty
     - stepName: Compile FATs
   - name: githubPRApi
     defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/23248"
+    description: "API URL to PR in Open Liberty."
     steps:
     - stepName: PR Changes
     - stepName: Determine FATs Needed
   - name: githubPRNumber
     defaultValue: "23248"
+    description: "PR number in Open Liberty to checkout."
     steps:
     - stepName: PR Changes
 
 - type: manual
-  triggerName: "Open Liberty Personal infrastructure only change"
+  description: "Runs a test personal build which simulates an Open Liberty infrastructure only change."
+  triggerName: "Test: Infrastructure only change."
   triggerRank: 50
   groups: ["CSD"]
   propertyDefinitions:
   - name: git.laos.clone.repository.username
+    description: "Name of Open Liberty user or organization for checkout."
     defaultValue: "fritze2"
     steps:
     - stepName: Compile Liberty Images
@@ -227,25 +259,50 @@ triggers:
     - stepName: Compile FATs
   - name: git.laos.clone.checkout.branch
     defaultValue: "test-change-infra"
+    description: "Name of Open Liberty branch to checkout."
     steps:
     - stepName: Compile Liberty Images
     - stepName: Unittest Open Liberty
     - stepName: Compile FATs
   - name: buildLabelPrefix
     defaultValue: "fritze2-23739-"
+    description: "RTC build label prefix."
     steps:
     - stepName: Compile Liberty Images
     - stepName: Unittest Open Liberty
     - stepName: Compile FATs
   - name: githubPRApi
     defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/23739"
+    description: "API URL to PR in Open Liberty."
     steps:
     - stepName: PR Changes
     - stepName: Determine FATs Needed
   - name: githubPRNumber
     defaultValue: "23739"
+    description: "PR number in Open Liberty to checkout."
     steps:
     - stepName: PR Changes
+
+# Trigger to be deleted once confirmed to be working. 
+- type: github
+  description: "Runs a test personal build which also runs the Checkpoint feature FATs."
+  triggerName: "Test: Feature (Checkpoint) Lite."
+  triggerRank: 50
+  groups: ["CSD"]
+  keyword: "!test_pb_with_checkpoint"
+  propertyDefinitions:
+  - name: fat.buckets.to.run
+    defaultValue: ${PR Changes:fat.buckets.to.run}
+    steps:
+    - stepName: Compile Liberty Images
+    - stepName: Compile FATs
+    - stepName: Determine FATs Needed
+    - stepName: Distributed Lite FATs
+  # Enable the testing of the checkpoint feature, running the FATs (if any) in lite mode where only @CheckpointTest annotated test cases will be run.
+  - name: spawn.checkpoint
+    defaultValue: "true"
+    steps:
+    - stepName: Checkpoint FATs (Lite)
 
 steps:
 - stepName: PR Changes
@@ -516,3 +573,56 @@ steps:
     testBucketPriorityStrategy: 50%|ci-bucket-failure-predictor-v1 #We want to 50% of the time run buckets in order of predicted failures
   includeProperties:
   - file: jvms/dev/zOS_s390_64_java11.properties
+
+# This step runs any FATs which test the 'checkpoint' feature in an environment with CRIU installed.
+# Checkpoint FATs therefore run twice in builds but the @CheckpointTest annotation and use of the fat.test.run.checkpoint.only property mean that in standard CRIU
+# environments they only run the test cases with @CheckpointTest (skipping the others) and in non-CRIU environments they only run the unannotated test cases. Hence,
+# there's no duplication of testing. 
+- stepName: Checkpoint FATs (Lite)
+  workType: FAT
+  dependsOn:
+    - stepName: PR Changes
+      awaitOutputProperties: true
+    - stepName: Compile Liberty Images
+      awaitOutputProperties: true
+    - stepName: Compile FATs
+      allowFailures: false
+      awaitOutputProperties: true
+    - stepName: Determine FATs Needed
+      allowFailures: true
+  conditionalRun:
+    - type: ifTrue
+      value: ${spawn.checkpoint}
+  timeoutInMinutes: 1920
+  properties:
+    product_image_artifact_execution_id: ${Compile Liberty Images:execution_id}
+    bucket_image_artifact_execution_id: ${Compile FATs:execution_id}
+    changes_summary_artifact_execution_id: ${Compile Liberty Images:execution_id}
+    runner_projectName: ebcTestRunner
+    runner_workType: Jenkins
+    runner_threshold: 5
+    runner_minimum_total: 10
+    fat.buckets.to.run: ${PR Changes:fat.buckets.to.run}
+    # Limit the FATs to only those supporting the checkpoint feature.
+    limit.fat.buckets.to.feature: checkpoint
+    # Only run test cases with the @CheckpointTest annotation.
+    fat.test.run.checkpoint.only: true
+    fat.test.mode: lite
+    fats_to_omit: "com.ibm.ws.collective.controller.deploy_fat, com.ibm.ws.health.manager.odrlib_fat, com.ibm.ws.dynamic.routing_ihs_fat, com.ibm.ws.node.scaling_fat, com.ibm.ws.scaling.member_fat_multinode, com.ibm.ws.node.health_fat"
+    fat_uploads_to_expect: ${Compile Liberty Images:fat_uploads_to_expect},${Compile FATs:fat_uploads_to_expect}
+    outputServer: libertyfs.hursley.ibm.com
+    outputPath: /liberty/personal/2/ciorchestrator
+    command: ant -f build-test.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
+    aggregationId: ${Compile Liberty Images:execution_id}
+    buildType: personal
+    reportingOS: ubuntu22_x86
+    ebcPlan: See Shortlist 
+    ebcShortlist: jenkinsbuild-checkpoint-ubuntu22_x86.yml
+    retry_failing_fats: true
+    # Only a small number of FATs exercise the checkpoint feature and so we should not repeat them by default otherwise they'll run 10 times.
+    repeat_if_few_fats: false
+    testBucketPriorityStrategy: 50%|ci-bucket-failure-predictor-v1 #We want to 50% of the time run buckets in order of predicted failures
+  includeProperties:
+  - file: fatMaxDurationOverrides.properties
+  # Custom JVM properties as Checkpoint is only supported on specific JVMs/levels.
+  - file: jvms/dev/checkpoint_linux_x86_64.properties


### PR DESCRIPTION
Adds the "Checkpoint FATs (Lite)" step for Checkpoint testing.
Adds the associated JVM properties for the platform (Checkpoint requires CRIU supporting OSes/JDKs).
Improves descriptions/values with clearer context and poor spelling/grammar.
Adds missing descriptions.

The above unifies descriptions between this OL pb.yml and the CL pb.yml (PR to follow).

The new step is duplicated from the CL version which has been tested. Even so, I've not added it to any of the default triggers and will only do so once tested via my test trigger.