### PR TITLE
Removing unncessary assert

### DIFF
--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/ConfigAdminHealthCheckTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/ConfigAdminHealthCheckTest.java
@@ -400,10 +400,8 @@ public class ConfigAdminHealthCheckTest {
                                 assertNotNull("The CWWKZ0001I Application started message did not appear in messages.log", line);
 
                                 String configAdminLine = server1.waitForStringInTrace("configAdminAppName = MultiWarApps");
-                                String stateMapLine = server1.waitForStringInTrace(": appName = MultiWarApps,");
 
                                 assertNotNull("App was not detected by ConfigAdmin.", configAdminLine);
-                                assertNotNull("App was not detected by appTracker.", stateMapLine);
                             } else {
                                 log("testReadinessEndpointOnServerStart", "Application started but timeout still reached.");
                                 throw new TimeoutException("Timed out waiting for server and app to be ready. Timeout set to " + time_out + "ms.");


### PR DESCRIPTION
Fixes: #27876

This is a test bug caused by an assert that may fail if the server is too slow. As long as the previous assert passes, this test is performing as expected and meeting the expectations of the feature.