### PR TITLE
prepare for Jakarta Data Query Language

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -91,9 +91,16 @@ public class QueryInfo {
     final Class<?> entityParamType;
 
     /**
-     * Entity variable name. "o" is used as the default in generated queries.
+     * Entity identifier variable name if an identifier variable is used.
+     * Otherwise "*". "o" is used as the default in generated queries.
      */
     String entityVar = "o";
+
+    /**
+     * Entity identifier variable name and . character if an identifier variable is used.
+     * Otherwise the empty string. "o." is used as the default in generated queries.
+     */
+    String entityVar_ = "o.";
 
     /**
      * Indicates if the query has a WHERE clause.
@@ -503,6 +510,7 @@ public class QueryInfo {
 
         String upper = jpql.toUpperCase();
         String upperTrimmed = upper.stripLeading();
+        // TODO JDQL queries can omit SELECT and/or FROM
         if (upperTrimmed.startsWith("SELECT")) {
             int order = upper.lastIndexOf("ORDER BY");
             type = Type.FIND;
@@ -514,8 +522,15 @@ public class QueryInfo {
             if (from > 0) {
                 // TODO support for multiple entity types
                 int entityName = find(entityInfo.name.toUpperCase(), upper, from + 5);
-                if (entityName > 0)
+                if (entityName > 0) {
                     entityVar = findEntityVariable(jpql, entityName + entityInfo.name.length() + 1);
+                    if (entityVar == null) {
+                        entityVar = "*";
+                        entityVar_ = "";
+                    } else {
+                        entityVar_ = entityVar + '.';
+                    }
+                }
 
                 if (countPages && jpqlCount == null) {
                     // Attempt to infer from provided query
@@ -845,6 +860,7 @@ public class QueryInfo {
         QueryInfo q = new QueryInfo(method, entityParamType, returnArrayType, returnTypeAtDepth);
         q.entityInfo = entityInfo;
         q.entityVar = entityVar;
+        q.entityVar_ = entityVar_;
         q.hasWhere = hasWhere;
         q.jpql = jpql;
         q.jpqlAfterKeyset = jpqlAfterKeyset;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -303,7 +303,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                                                              count, exists, select);
 
         if (query != null) { // @Query annotation
-            queryInfo.initForQuery(query.value(), query.count(), countPages);
+            queryInfo.initForQuery(query.value(), query.count(), countPages, entityInfo);
         } else if (save != null) { // @Save annotation
             queryInfo.init(Save.class, QueryInfo.Type.SAVE);
         } else if (insert != null) { // @Insert annotation

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
@@ -45,7 +45,7 @@ public interface Products {
     @Delete
     void clear();
 
-    @Query("DELETE FROM Product o WHERE o.pk IN ?1")
+    @Query("DELETE FROM Product WHERE pk IN ?1")
     int discontinueProducts(Set<UUID> ids);
 
     @Select(value = "name", distinct = true)

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
@@ -81,7 +81,7 @@ public interface Products {
     @Select(function = Aggregate.AVERAGE, value = "price")
     float meanPrice();
 
-    @Query("UPDATE Product o SET o.price = o.price - (?2 * o.price) WHERE o.name LIKE CONCAT('%', ?1, '%')")
+    @Query("UPDATE Product SET price = price - (?2 * price) WHERE name LIKE CONCAT('%', ?1, '%')")
     long putOnSale(String nameContains, float discount);
 
     // Custom repository method that combines multiple operations into a single transaction
@@ -115,7 +115,7 @@ public interface Products {
     @Select(function = Aggregate.SUM, distinct = true, value = "price")
     float totalOfDistinctPrices();
 
-    @Query("UPDATE Product o SET o.price=o.price/?2, o.version=o.version-1 WHERE (o.pk IN ?1)")
+    @Query("UPDATE Product SET price=price/?2, version=version-1 WHERE (pk IN ?1)")
     // TODO switch to annotated parameters once available for conditions
     //@Filter(by = "pk", op = Compare.In)
     //@Update(attr = "price", op = Operation.Divide)


### PR DESCRIPTION
This pull takes the first steps to prepare for Jakarta Data Query Language,
specifically where the entity identifier variable becomes optional.
The first portion of this pull prepares for JDQL queries that lack the identifier variable, which will only be possible when the capability goes into Jakarta Persistence 3.2 and is implemented by the Jakarta Persistence provider.
In the meantime, I'm adding some temporary code to convert from JDQL to JPQL.  At first, I'm adding it for DELETE and UPDATE, and even then, it should be mostly correct but not in all situations.  This is okay because the code will ultimately be replaced by sending the JDQL directly to the Jakarta Persistence provider.