### PR TITLE
return all config files with fetchConfigurationFiles

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ServerXMLConfiguration.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ServerXMLConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -248,6 +248,48 @@ class ServerXMLConfiguration {
 
         if (configDropinOverrides != null) {
             files.add(configDropinOverrides.toRepositoryPath());
+        }
+
+        return files;
+    }
+
+    /**
+     * Gets all monitored config files, this contains the server.xml, all files within <include> tags
+     * and all files within configDropins/defaults and configDropins/overrides
+     * 
+     * @return
+     */
+    public Collection<String> getAllMonitoredConfigFiles(){
+        Collection<String> files = new HashSet<String>();
+
+        if (configDropinDefaults != null) {
+            File[] defaultFiles = getChildXMLFiles(configDropinDefaults);
+            if (defaultFiles != null) {
+                for (File f : defaultFiles) {
+                    String name = f.getName();
+                    WsResource resource = configDropinDefaults.resolveRelative(name);
+                    String path = resource.toRepositoryPath();
+                    if (path != null) {
+                        files.add(path);
+                    }
+                }
+            }
+        }
+
+        files.addAll(getFilesToMonitor());
+
+        if (configDropinOverrides != null) {
+            File[] overrideFiles = getChildXMLFiles(configDropinOverrides);
+            if (overrideFiles != null) {
+                for (File f : overrideFiles) {
+                    String name = f.getName();
+                    WsResource resource = configDropinOverrides.resolveRelative(name);
+                    String path = resource.toRepositoryPath();
+                    if (path != null) {
+                        files.add(path);
+                    }
+                }
+            }
         }
 
         return files;

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/SystemConfiguration.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/SystemConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -243,7 +243,7 @@ class SystemConfiguration implements CheckpointHook {
     }
 
     Collection<String> fetchConfigurationFilePaths() {
-        return this.serverXMLConfig.getFilesToMonitor();
+        return this.serverXMLConfig.getAllMonitoredConfigFiles();
     }
 
     BaseConfiguration loadDefaultConfiguration(Bundle bundle) throws ConfigUpdateException, ConfigValidationException {

--- a/dev/com.ibm.ws.config_fat/fat/src/test/server/config/ServerXMLConfigurationMBeanTest.java
+++ b/dev/com.ibm.ws.config_fat/fat/src/test/server/config/ServerXMLConfigurationMBeanTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -164,13 +164,17 @@ public class ServerXMLConfigurationMBeanTest {
         assertNotNull("Configuration file path collection should not be null.", configFilePaths);
 
         // Check that the collection contains the expected file paths.
-        assertEquals("Config file path collection size is not 3.", 3, configFilePaths.size());
+        assertEquals("Config file path collection size is not 5.", 5, configFilePaths.size());
         assertTrue("server.xml is missing from the collection.",
                    configFilePaths.contains("${server.config.dir}/server.xml"));
         assertTrue("fatTestPorts.xml is missing from the collection.",
                    configFilePaths.contains("${wlp.user.dir}/servers/fatTestPorts.xml"));
         assertTrue("fatTestCommon.xml is missing from the collection.",
                    configFilePaths.contains("${wlp.user.dir}/servers/fatTestCommon.xml"));
+        assertTrue("configDropins/defaults/a.xml is missing from the collection.",
+                   configFilePaths.contains("${server.config.dir}/configDropins/defaults/a.xml"));
+        assertTrue("configDropins/overrides/b.xml is missing from the collection.",
+                   configFilePaths.contains("${server.config.dir}/configDropins/overrides/b.xml"));
     }
 
     private static int getSSLPort() {

--- a/dev/com.ibm.ws.config_fat/publish/servers/com.ibm.ws.config.schemaGen.mbean/configDropins/defaults/a.xml
+++ b/dev/com.ibm.ws.config_fat/publish/servers/com.ibm.ws.config.schemaGen.mbean/configDropins/defaults/a.xml
@@ -1,0 +1,15 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server> 
+    
+</server>

--- a/dev/com.ibm.ws.config_fat/publish/servers/com.ibm.ws.config.schemaGen.mbean/configDropins/overrides/b.xml
+++ b/dev/com.ibm.ws.config_fat/publish/servers/com.ibm.ws.config.schemaGen.mbean/configDropins/overrides/b.xml
@@ -1,0 +1,15 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server> 
+    
+</server>


### PR DESCRIPTION
`ServerXMLConfigurationMBean.fetchConfigurationFilePaths()` previously would only return the server.xml and any files listed in `<include>` tags. Now it returns those files along with all files within `configDropins/defaults` and `configDropins/overrides`.