### PR TITLE
JDQL WHERE clause only or with ORDER BY

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -299,7 +299,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                                                              count, exists, select);
 
         if (query != null) { // @Query annotation
-            queryInfo.initForQuery(query.value(), query.count(), countPages, entityInfo);
+            queryInfo.initForQuery(query.value(), query.count(), countPages);
         } else if (save != null) { // @Save annotation
             queryInfo.init(Save.class, QueryInfo.Type.SAVE);
         } else if (insert != null) { // @Insert annotation

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
@@ -36,7 +36,7 @@ import io.openliberty.data.repository.update.Assign;
 @Repository
 @Transactional(TxType.SUPPORTS)
 public interface PersonRepo {
-    @Query("SELECT o FROM Person o WHERE o.lastName=?1")
+    @Query("WHERE lastName=?1")
     List<Person> find(String lastName);
 
     @Find

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -235,6 +235,11 @@ public interface Primes {
     @Exists
     boolean isFoundWith(long id, String hex);
 
+    // TODO after JDQL SELECT is added: "Select name Where length(romanNumeral) * 2 >= length(name) Order By name Asc",
+    @Query(value = "Where numberId < 50 and romanNumeral is not null and length(romanNumeral) * 2 >= length(name) Order By name Desc",
+           count = "WHERE numberId < 50 and romanNumeral is not null and length ( name ) \r\n\t\t <= length(romanNumeral)*2")
+    Page<Prime> lengthBasedQuery(PageRequest<Prime> pageRequest);
+
     @Find
     @OrderBy(value = "numberId", descending = true)
     Stream<Prime> lessThanWithSuffixOrBetweenWithSuffix(@By("id") @LessThan long numLessThan,
@@ -329,6 +334,19 @@ public interface Primes {
 
     @Find
     Optional<Prime> withAnyCaseName(@By("name") @Trimmed @IgnoreCase String name);
+
+    @Query("where numberId <= ?2 and numberId>=?1")
+    Page<Prime> within(long minimum, long maximum, PageRequest<Prime> pageRequest);
+
+    @Query("where (numberId <= :maximum) and numberId>=10 order by name asc")
+    Page<Prime> within10toXAndSortedByName(long maximum, PageRequest<Prime> pageRequest);
+
+    @OrderBy(value = "even", descending = true)
+    @OrderBy(value = "name", descending = false)
+    @Query(" WHERE( numberId<=:max AND UPPER(romanNumeral) NOT LIKE '%VII' AND (numberId-(numberId/10)* 10)<>3 AND\tnumberId\t>= :min)")
+    CursoredPage<Prime> withinButNotEndingIn7or3(@Param("min") long minimum,
+                                                 @Param("max") long maximum,
+                                                 PageRequest<Prime> pageRequest);
 
     @Find
     List<Prime> withNameLengthAndWithin(@By("name") @Trimmed @CharCount int length,

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
@@ -54,7 +54,7 @@ public interface Products {
 
     Product[] findByVersionGreaterThanEqualOrderByPrice(long minVersion);
 
-    @Query("SELECT o FROM Product o WHERE o.pk=:productId")
+    @Query("WHERE pk=:productId")
     Product findItem(@Param("productId") UUID id);
 
     Optional<Product> findById(UUID id);


### PR DESCRIPTION
Simulate JDQL query language optimization to allow a WHERE clause without SELECT and FROM.
Temporarily, we need to add in an entity identifier variable in order for the JPQL to be valid.