### PR TITLE
JDQL FROM clause

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -643,7 +643,7 @@ public class QueryInfo {
             case 'F':
             case 'f': // FROM
                 boolean continueToWhereClause = false;
-                if (length > startAt + 5
+                if (startAt + 5 < length
                     && countQL.regionMatches(true, startAt + 1, "ROM", 0, 3)
                     && Character.isWhitespace(countQL.charAt(startAt + 4))) {
 
@@ -671,7 +671,7 @@ public class QueryInfo {
                     break;
             case 'W':
             case 'w': // WHERE
-                if (length > startAt + 5
+                if (startAt + 5 < length
                     && countQL.regionMatches(true, startAt + 1, "HERE", 0, 4)
                     && !Character.isLetterOrDigit(countQL.charAt(startAt + 5))) {
 
@@ -702,47 +702,46 @@ public class QueryInfo {
      */
     void initForQuery(String ql, String countQL, boolean countPages) {
 
+        StringBuilder q = null; // main query
+        StringBuilder c = null; // count query
+
         int length = ql.length();
         int startAt = 0;
         char firstChar = ' ';
         for (; startAt < length && Character.isWhitespace(firstChar = ql.charAt(startAt)); startAt++);
 
         switch (firstChar) {
-            case 'S':
-            case 's': // SELECT
-                // TODO
-                break;
             case 'D':
             case 'd': // DELETE FROM EntityName[ WHERE ...]
                 // Temporarily simulate optional identifier names by inserting them.
                 // TODO remove when switched to Jakarta Persistence 3.2.
-                if (length > startAt + 12
+                if (startAt + 12 < length
                     && ql.regionMatches(true, startAt + 1, "ELETE", 0, 5)
                     && Character.isWhitespace(ql.charAt(startAt + 6))) {
-                    int f = startAt + 7; // start of FROM
-                    for (; f < length && Character.isWhitespace(ql.charAt(f)); f++);
-                    if (length > f + 6
-                        && ql.regionMatches(true, f, "FROM", 0, 4)
-                        && Character.isWhitespace(ql.charAt(f + 4))) {
-                        int e = f + 5; // start of EntityName
-                        for (; e < length && Character.isWhitespace(ql.charAt(e)); e++);
+                    startAt += 7; // start of FROM
+                    for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
+                    if (startAt + 6 < length
+                        && ql.regionMatches(true, startAt, "FROM", 0, 4)
+                        && Character.isWhitespace(ql.charAt(startAt + 4))) {
+                        startAt += 5; // start of EntityName
+                        for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
                         StringBuilder entityName = new StringBuilder();
-                        for (char ch; e < length && Character.isLetterOrDigit(ch = ql.charAt(e)); e++)
+                        for (char ch; startAt < length && Character.isLetterOrDigit(ch = ql.charAt(startAt)); startAt++)
                             entityName.append(ch);
-                        if (e < length - 1 && entityName.length() > 0 && Character.isWhitespace(ql.charAt(e))) {
+                        if (startAt + 1 < length && entityName.length() > 0 && Character.isWhitespace(ql.charAt(startAt))) {
                             // EntityName followed by whitespace and at least one more character
-                            int w = e + 1; // start of WHERE
-                            for (; w < length && Character.isWhitespace(ql.charAt(w)); w++);
-                            if (length > w + 6
-                                && ql.regionMatches(true, w, "WHERE", 0, 5)
-                                && !Character.isLetterOrDigit(ql.charAt(w + 5))) {
+                            startAt++; // start of WHERE
+                            for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
+                            if (startAt + 6 < length
+                                && ql.regionMatches(true, startAt, "WHERE", 0, 5)
+                                && !Character.isLetterOrDigit(ql.charAt(startAt + 5))) {
                                 type = Type.DELETE;
                                 hasWhere = true;
                                 entityVar = "o";
                                 entityVar_ = "o.";
-                                StringBuilder q = new StringBuilder(ql.length() * 3 / 2) //
+                                q = new StringBuilder(ql.length() * 3 / 2) //
                                                 .append("DELETE FROM ").append(entityName).append(" o WHERE");
-                                jpql = appendWithIdentifierName(entityVar_, ql, w + 5, q, null).toString();
+                                jpql = appendWithIdentifierName(entityVar_, ql, startAt + 5, q, null).toString();
                             }
                         }
                     }
@@ -752,48 +751,99 @@ public class QueryInfo {
             case 'u': // UPDATE EntityName[ SET ... WHERE ...]
                 // Temporarily simulate optional identifier names by inserting them.
                 // TODO remove when switched to Jakarta Persistence 3.2.
-                if (length > startAt + 13
+                if (startAt + 13 < length
                     && ql.regionMatches(true, startAt + 1, "PDATE", 0, 5)
                     && Character.isWhitespace(ql.charAt(startAt + 6))) {
-                    int e = startAt + 7; // start of EntityName
-                    for (; e < length && Character.isWhitespace(ql.charAt(e)); e++);
+                    startAt += 7; // start of EntityName
+                    for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
                     StringBuilder entityName = new StringBuilder();
-                    for (char ch; e < length && Character.isLetterOrDigit(ch = ql.charAt(e)); e++)
+                    for (char ch; startAt < length && Character.isLetterOrDigit(ch = ql.charAt(startAt)); startAt++)
                         entityName.append(ch);
-                    if (e < length - 1 && entityName.length() > 0 && Character.isWhitespace(ql.charAt(e))) {
+                    if (startAt + 1 < length && entityName.length() > 0 && Character.isWhitespace(ql.charAt(startAt))) {
                         // EntityName followed by whitespace and at least one more character
-                        int s = e + 1; // start of SET
-                        for (; s < length && Character.isWhitespace(ql.charAt(s)); s++);
-                        if (length > s + 4
-                            && ql.regionMatches(true, s, "SET", 0, 3)
-                            && !Character.isLetterOrDigit(ql.charAt(s + 3))) {
+                        startAt++; // start of SET
+                        for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
+                        if (startAt + 4 < length
+                            && ql.regionMatches(true, startAt, "SET", 0, 3)
+                            && !Character.isLetterOrDigit(ql.charAt(startAt + 3))) {
                             type = Type.UPDATE;
                             entityVar = "o";
                             entityVar_ = "o.";
-                            StringBuilder q = new StringBuilder(ql.length() * 3 / 2) //
+                            q = new StringBuilder(ql.length() * 3 / 2) //
                                             .append("UPDATE ").append(entityName).append(" o SET");
-                            jpql = appendWithIdentifierName(entityVar_, ql, s + 3, q, null).toString();
+                            jpql = appendWithIdentifierName(entityVar_, ql, startAt + 3, q, null).toString();
                         }
                     }
                 }
                 break;
+            case 'S':
+            case 's': // SELECT
+                // TODO
+                break;
+            case 'F':
+            case 'f': // FROM
+                if (startAt + 5 < length
+                    && ql.regionMatches(true, startAt, "FROM", 0, 4)
+                    && Character.isWhitespace(ql.charAt(startAt + 4))) {
+
+                    startAt += 5; // EntityName optionally preceded by whitespace
+                    for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
+                    StringBuilder entityName = new StringBuilder();
+                    for (char ch; startAt < length && Character.isLetterOrDigit(ch = ql.charAt(startAt)); startAt++)
+                        entityName.append(ch);
+
+                    if (entityName.length() > 0) {
+                        if (q == null) {
+                            type = Type.FIND;
+                            entityVar = "o";
+                            entityVar_ = "o.";
+                            q = new StringBuilder(ql.length() * 5 / 4 + 20).append("SELECT o");
+                        }
+                        q.append(" FROM ").append(entityName).append(' ').append(entityVar);
+
+                        if (countPages && countQL.length() == 0) {
+                            if (c == null)
+                                c = new StringBuilder(ql.length() * 5 / 4 + 20).append("SELECT COUNT(").append(entityVar).append(")");
+                            c.append(" FROM ").append(entityName).append(' ').append(entityVar);
+                        }
+
+                        // EntityName might be followed by whitespace and a WHERE clause or ORDER BY clause
+                        for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
+                    } else {
+                        throw new UnsupportedOperationException("The query supplied to the " + method.getName() + " method of the " +
+                                                                method.getDeclaringClass().getName() + " repository does not apear to be " +
+                                                                "valid JDQL (Jakarta Data Query Language) or " +
+                                                                "valid JPQL (Jakarta Persistence Query Language) because its FROM clause " +
+                                                                "does not specify the entity name. The query is " + ql); // TODO NLS
+                    }
+                }
+                // continue
             case 'W':
             case 'w': // WHERE
-                if (length > startAt + 5
-                    && ql.regionMatches(true, startAt + 1, "HERE", 0, 4)
+                if (startAt + 5 < length
+                    && ql.regionMatches(true, startAt, "WHERE", 0, 5)
                     && !Character.isLetterOrDigit(ql.charAt(startAt + 5))) {
-                    type = Type.FIND;
                     hasWhere = true;
-                    entityVar = "o";
-                    entityVar_ = "o.";
-                    StringBuilder q = new StringBuilder(ql.length() * 5 / 4 + 20) // add 25% for identifier variable use
-                                    .append("SELECT o FROM ").append(entityInfo.name).append(" o WHERE");
-                    StringBuilder c = countPages && countQL.length() == 0 //
-                                    ? new StringBuilder(q.length()) //
-                                                    .append("SELECT COUNT(o) FROM ") //
-                                                    .append(entityInfo.name).append(" o WHERE") //
-                                    : null;
+
+                    if (q == null) {
+                        type = Type.FIND;
+                        entityVar = "o";
+                        entityVar_ = "o.";
+                        q = new StringBuilder(ql.length() * 5 / 4 + 20) // add 25% for identifier variable use
+                                        .append("SELECT o FROM ").append(entityInfo.name).append(" o");
+                    }
+                    q.append(" WHERE");
+
+                    if (countPages && countQL.length() == 0) {
+                        if (c == null)
+                            c = new StringBuilder(ql.length() * 5 / 4 + 20) // add 25% for identifier variable use
+                                            .append("SELECT COUNT(").append(entityVar) //
+                                            .append(") FROM ").append(entityInfo.name).append(' ').append(entityVar);
+                        c.append(" WHERE");
+                    }
+
                     jpql = appendWithIdentifierName(entityVar_, ql, startAt + 5, q, c).toString();
+
                     if (countPages)
                         if (c == null)
                             jpqlCount = assembleCountQuery(countQL);
@@ -801,16 +851,14 @@ public class QueryInfo {
                             jpqlCount = c.toString();
                     else
                         jpqlCount = null;
+
+                    break;
                 }
-                break;
-            case 'F':
-            case 'f': // FROM
-                // TOOD
-                break;
+                // continue
             case 'O':
             case 'o': // ORDER BY
-                // TODO
-                break;
+                throw new UnsupportedOperationException(); // TODO
+            // break;
             default:
                 break;
         }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -4468,7 +4468,7 @@ public class DataTestServlet extends FATServlet {
         assertIterableEquals(List.of(990002, 990004, 990005),
                              packages.findAll().map(pack -> pack.id).sorted().collect(Collectors.toList()));
 
-        packages.deleteAll();
+        assertEquals(3l, packages.deleteAll());
 
         assertEquals(0, packages.countAll());
     }
@@ -4578,7 +4578,7 @@ public class DataTestServlet extends FATServlet {
         assertIterableEquals(List.of(601, 603),
                              packages.withHeightAbout(5.0f));
 
-        packages.deleteAll();
+        assertEquals(4, packages.deleteEverything());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -59,6 +59,9 @@ public interface Packages extends BasicRepository<Package, Integer> {
 
     Package[] deleteByDescriptionEndsWith(String ending, Sort<?>... sorts);
 
+    @Query("DELETE FROM Package")
+    int deleteEverything();
+
     Optional<Integer> deleteFirstBy(Sort<Package> sort);
 
     int[] deleteFirst2By(Sort<?>... sorts);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -254,7 +254,7 @@ public class DataJPATestServlet extends FATServlet {
                                      .map(b -> b.name)
                                      .collect(Collectors.toList()));
 
-        assertEquals(true, page1.hasNext());
+        assertEquals(true, page2.hasNext());
 
         Page<Business> page3 = mixed.findAll(page2.nextPageRequest());
 
@@ -289,7 +289,7 @@ public class DataJPATestServlet extends FATServlet {
                                      .map(b -> b.name)
                                      .collect(Collectors.toList()));
 
-        assertEquals(true, page1.hasNext());
+        assertEquals(true, page2.hasNext());
 
         Page<Business> page3 = mixed.locatedIn("Rochester", page2.nextPageRequest());
 
@@ -566,6 +566,50 @@ public class DataJPATestServlet extends FATServlet {
 
         // Ensure non-matching entities remain in the database
         assertEquals(true, cities.existsById(CityId.of("Rochester", "Minnesota")));
+    }
+
+    /**
+     * Use a repository method with JDQL query language that includes only the FROM and WHERE clauses.
+     * Omit the count query and let it be inferred from the main query.
+     */
+    @Test
+    public void testFromAndWhereClausesOnly() {
+        CursoredPage<Business> page1 = mixed.locatedIn("Rochester", "MN", PageRequest.of(Business.class).size(4).asc("name"));
+
+        assertEquals(4L, page1.numberOfElements());
+        assertEquals(13L, page1.totalElements());
+        assertEquals(4L, page1.totalPages());
+        assertEquals(true, page1.hasNext());
+
+        assertEquals(List.of("Benike Construction", "Cardinal", "Crenlo", "Custom Alarm"),
+                     page1.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        CursoredPage<Business> page2 = mixed.locatedIn("Rochester", "MN", page1.nextPageRequest());
+
+        assertEquals(List.of("Home Federal Savings Bank", "IBM", "Mayo Clinic", "Metafile"),
+                     page2.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(true, page2.hasNext());
+
+        CursoredPage<Business> page3 = mixed.locatedIn("Rochester", "MN", page2.nextPageRequest());
+
+        assertEquals(List.of("Olmsted Medical", "RAC", "Reichel Foods", "Silver Lake Foods"),
+                     page3.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(true, page3.hasNext());
+
+        CursoredPage<Business> page4 = mixed.locatedIn("Rochester", "MN", page3.nextPageRequest());
+
+        assertEquals(List.of("Think Bank"),
+                     page4.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -569,50 +569,6 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Use a repository method with JDQL query language that includes only the FROM and WHERE clauses.
-     * Omit the count query and let it be inferred from the main query.
-     */
-    @Test
-    public void testFromAndWhereClausesOnly() {
-        CursoredPage<Business> page1 = mixed.locatedIn("Rochester", "MN", PageRequest.of(Business.class).size(4).asc("name"));
-
-        assertEquals(4L, page1.numberOfElements());
-        assertEquals(13L, page1.totalElements());
-        assertEquals(4L, page1.totalPages());
-        assertEquals(true, page1.hasNext());
-
-        assertEquals(List.of("Benike Construction", "Cardinal", "Crenlo", "Custom Alarm"),
-                     page1.stream()
-                                     .map(b -> b.name)
-                                     .collect(Collectors.toList()));
-
-        CursoredPage<Business> page2 = mixed.locatedIn("Rochester", "MN", page1.nextPageRequest());
-
-        assertEquals(List.of("Home Federal Savings Bank", "IBM", "Mayo Clinic", "Metafile"),
-                     page2.stream()
-                                     .map(b -> b.name)
-                                     .collect(Collectors.toList()));
-
-        assertEquals(true, page2.hasNext());
-
-        CursoredPage<Business> page3 = mixed.locatedIn("Rochester", "MN", page2.nextPageRequest());
-
-        assertEquals(List.of("Olmsted Medical", "RAC", "Reichel Foods", "Silver Lake Foods"),
-                     page3.stream()
-                                     .map(b -> b.name)
-                                     .collect(Collectors.toList()));
-
-        assertEquals(true, page3.hasNext());
-
-        CursoredPage<Business> page4 = mixed.locatedIn("Rochester", "MN", page3.nextPageRequest());
-
-        assertEquals(List.of("Think Bank"),
-                     page4.stream()
-                                     .map(b -> b.name)
-                                     .collect(Collectors.toList()));
-    }
-
-    /**
      * Add, search, and remove entities with Embeddable fields.
      */
     @Test
@@ -1278,6 +1234,93 @@ public class DataJPATestServlet extends FATServlet {
         // WithWeek
         assertEquals(List.of(4000921042220002L),
                      creditCards.findByExpiresOnWithWeek(17));
+    }
+
+    /**
+     * Use a repository method with JDQL query language that includes only the FROM and ORDER BY clauses.
+     */
+    @Test
+    public void testFromAndOrderByClausesOnly() {
+        List<City> list = mixed.all(); // ORDER BY name DESC, stateName ASC
+
+        assertEquals(List.of("Springfield:Illinois",
+                             "Springfield:Massachusetts",
+                             "Springfield:Missouri",
+                             "Springfield:Ohio",
+                             "Springfield:Oregon",
+                             "Rochester:Minnesota",
+                             "Rochester:New York",
+                             "Kansas City:Kansas",
+                             "Kansas City:Missouri"),
+                     list.stream()
+                                     .map(c -> c.name + ":" + c.stateName)
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
+     * Use a repository method with JDQL query language that includes only the FROM and WHERE clauses.
+     * Omit the count query and let it be inferred from the main query.
+     */
+    @Test
+    public void testFromAndWhereClausesOnly() {
+        CursoredPage<Business> page1 = mixed.locatedIn("Rochester", "MN", PageRequest.of(Business.class).size(4).asc("name"));
+
+        assertEquals(4L, page1.numberOfElements());
+        assertEquals(13L, page1.totalElements());
+        assertEquals(4L, page1.totalPages());
+        assertEquals(true, page1.hasNext());
+
+        assertEquals(List.of("Benike Construction", "Cardinal", "Crenlo", "Custom Alarm"),
+                     page1.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        CursoredPage<Business> page2 = mixed.locatedIn("Rochester", "MN", page1.nextPageRequest());
+
+        assertEquals(List.of("Home Federal Savings Bank", "IBM", "Mayo Clinic", "Metafile"),
+                     page2.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(true, page2.hasNext());
+
+        CursoredPage<Business> page3 = mixed.locatedIn("Rochester", "MN", page2.nextPageRequest());
+
+        assertEquals(List.of("Olmsted Medical", "RAC", "Reichel Foods", "Silver Lake Foods"),
+                     page3.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(true, page3.hasNext());
+
+        CursoredPage<Business> page4 = mixed.locatedIn("Rochester", "MN", page3.nextPageRequest());
+
+        assertEquals(List.of("Think Bank"),
+                     page4.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
+     * Use a repository method with JDQL query language that includes only the FROM clause.
+     */
+    @Test
+    public void testFromClauseOnly() {
+        List<City> list = mixed.all(Order.by(Sort.asc("stateName"),
+                                             Sort.desc("name")));
+
+        assertEquals(List.of("Illinois:Springfield",
+                             "Kansas:Kansas City",
+                             "Massachusetts:Springfield",
+                             "Minnesota:Rochester",
+                             "Missouri:Springfield",
+                             "Missouri:Kansas City",
+                             "New York:Rochester",
+                             "Ohio:Springfield",
+                             "Oregon:Springfield"),
+                     list.stream()
+                                     .map(c -> c.stateName + ":" + c.name)
+                                     .collect(Collectors.toList()));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,10 @@ package test.jakarta.data.jpa.web;
 import java.util.LinkedList;
 import java.util.stream.Stream;
 
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 
 /**
@@ -25,6 +28,10 @@ import jakarta.data.repository.Repository;
 @Repository
 public interface MixedRepository { // Do not inherit from a supertype
 
+    @Query(value = "WHERE location.address.zip = location.address.zip", // TODO use different JDQL without WHERE
+           count = "FROM Business")
+    Page<Business> findAll(PageRequest<Business> pageRequest);
+
     @OrderBy("name")
     Business[] findByLocationAddressCity(String cityName);
 
@@ -32,4 +39,8 @@ public interface MixedRepository { // Do not inherit from a supertype
     Stream<City> findByName(String name);
 
     LinkedList<Unpopulated> findBySomethingStartsWith(String prefix);
+
+    @Query(value = "WHERE location.address.city=?1",
+           count = "FROM Business WHERE location.address.city=?1")
+    Page<Business> locatedIn(String name, PageRequest<Business> pageRequest);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
@@ -13,8 +13,10 @@
 package test.jakarta.data.jpa.web;
 
 import java.util.LinkedList;
+import java.util.List;
 import java.util.stream.Stream;
 
+import jakarta.data.Order;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
@@ -28,6 +30,12 @@ import jakarta.data.repository.Repository;
  */
 @Repository
 public interface MixedRepository { // Do not inherit from a supertype
+
+    @Query("FROM City ORDER BY name DESC, stateName ASC")
+    List<City> all();
+
+    @Query("FROM City")
+    List<City> all(Order<City> sortBy);
 
     @Query(value = "FROM Business WHERE location.address.zip = location.address.zip",
            count = "FROM Business")
@@ -45,6 +53,6 @@ public interface MixedRepository { // Do not inherit from a supertype
            count = "FROM Business WHERE location.address.city=?1")
     Page<Business> locatedIn(String city, PageRequest<Business> pageRequest);
 
-    @Query(value = "FROM Business WHERE location.address.city=:city AND location.address.state=:state")
+    @Query("FROM Business WHERE location.address.city=:city AND location.address.state=:state")
     CursoredPage<Business> locatedIn(String city, String state, PageRequest<Business> pageRequest);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
@@ -15,6 +15,7 @@ package test.jakarta.data.jpa.web;
 import java.util.LinkedList;
 import java.util.stream.Stream;
 
+import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.OrderBy;
@@ -28,7 +29,7 @@ import jakarta.data.repository.Repository;
 @Repository
 public interface MixedRepository { // Do not inherit from a supertype
 
-    @Query(value = "WHERE location.address.zip = location.address.zip", // TODO use different JDQL without WHERE
+    @Query(value = "FROM Business WHERE location.address.zip = location.address.zip",
            count = "FROM Business")
     Page<Business> findAll(PageRequest<Business> pageRequest);
 
@@ -42,5 +43,8 @@ public interface MixedRepository { // Do not inherit from a supertype
 
     @Query(value = "WHERE location.address.city=?1",
            count = "FROM Business WHERE location.address.city=?1")
-    Page<Business> locatedIn(String name, PageRequest<Business> pageRequest);
+    Page<Business> locatedIn(String city, PageRequest<Business> pageRequest);
+
+    @Query(value = "FROM Business WHERE location.address.city=:city AND location.address.state=:state")
+    CursoredPage<Business> locatedIn(String city, String state, PageRequest<Business> pageRequest);
 }


### PR DESCRIPTION
Add the JDQL FROM clause, either on its own, or in combination with WHERE, or ORDER BY, or with both WHERE and ORDER BY.  Be able to use it in both the main query and the count query.  Add tests.  Temporarily, the JDQL is simulated by inserting the entity identifier variable. That will be removed when we have JPA 3.2.