### PR TITLE
Test Oracle UCP Application Continuity

### DIFF
--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2023 IBM Corporation and others.
+    Copyright (c) 2011, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -1295,9 +1295,15 @@
  
   <OCD id="com.ibm.ws.jdbc.dataSource.properties.oracle.ucp" name="%properties.oracle.ucp" description="%properties.oracle.ucp.desc" ibm:extendsAlias="oracle.ucp" ibm:extends="com.ibm.ws.jdbc.dataSource.properties.supertype" ibmui:extraProperties="true" ibmui:localization="OSGI-INF/l10n/metatype">
   <AD id="connectionFactoryClassName"         required="false" type="String" name="%connectionFactoryClassName" description="%connectionFactoryClassName.desc">
+   <!-- Traditional DataSource classes from the ojdbc driver -->
    <Option value="oracle.jdbc.pool.OracleDataSource"               label="oracle.jdbc.pool.OracleDataSource"/>
    <Option value="oracle.jdbc.pool.OracleConnectionPoolDataSource" label="oracle.jdbc.pool.OracleConnectionPoolDataSource"/>
    <Option value="oracle.jdbc.xa.client.OracleXADataSource"        label="oracle.jdbc.xa.client.OracleXADataSource"/>
+   
+   <!-- Replay DataSource classes from the ojdbc driver used for Application Continuity -->
+   <Option value="oracle.jdbc.replay.OracleDataSourceImpl"           	 label="oracle.jdbc.replay.OracleDataSourceImpl"/>
+   <Option value="oracle.jdbc.replay.OracleConnectionPoolDataSourceImpl" label="oracle.jdbc.replay.OracleConnectionPoolDataSourceImpl"/>
+   <Option value="oracle.jdbc.replay.OracleXADataSourceImpl"             label="oracle.jdbc.replay.OracleXADataSourceImpl"/>
   </AD>
   <AD id="connectionPoolName"                 required="false" type="String"  name="%connectionPoolName" description="%connectionPoolName.desc"/>
   <AD id="databaseName"                       required="false" type="String"  name="%databaseName" description="%databaseNameIgnored.desc"/>

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2016, 2023 IBM Corporation and others.
+    Copyright (c) 2016, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@
     </application>
     
     <library id="UCPDBLib">
-    	<fileset dir="${shared.resource.dir}/ucp"/>
+        <fileset dir="${shared.resource.dir}/ucp"/>
     </library>
     
     <connectionManager id="conMgr" maxPoolSize="2" enableSharingForDirectLookups="false"/> 
@@ -36,53 +36,68 @@
     
     <!-- This DataSource intentionally uses a connectionManagerRef -->
     <dataSource id="ucpDS" jndiName="jdbc/ucpDS" connectionManagerRef="conMgr" validationTimeout="20" >
-    	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp maxStatements="5"  maxPoolSize="3" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" connectionWaitTimeout="30" URL="${env.ORACLE_URL}" />
+        <jdbcDriver libraryRef="UCPDBLib" />
+        <properties.oracle.ucp maxStatements="5"  maxPoolSize="3" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" connectionWaitTimeout="30" URL="${env.ORACLE_URL}" />
     </dataSource>
     
     <dataSource id="ucpDSSameConMgr" jndiName="jdbc/ucpDSSameConMgr" connectionManagerRef="sharedConMgr" validationTimeout="20" >
-    	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
+        <jdbcDriver libraryRef="UCPDBLib" />
+        <properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
     </dataSource>
     
     <dataSource id="ucpXADS" jndiName="jdbc/ucpXADS" type="javax.sql.XADataSource">
-    	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
+        <jdbcDriver libraryRef="UCPDBLib" />
+        <properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
     </dataSource>
     
     <dataSource id="ucpXADS2" jndiName="jdbc/ucpXADS2" type="javax.sql.XADataSource">
-    	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
+        <jdbcDriver libraryRef="UCPDBLib" />
+        <properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
     </dataSource>
     
     <dataSource id="ucpConnectionPoolDS" jndiName="jdbc/ucpConnectionPoolDS" type="javax.sql.ConnectionPoolDataSource" >
-    	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
+        <jdbcDriver libraryRef="UCPDBLib" />
+        <properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
     </dataSource>
     
     <dataSource id="ucpDriverDS" jndiName="jdbc/ucpDriverDS" type="java.sql.Driver" >
-    	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
+        <jdbcDriver libraryRef="UCPDBLib" />
+        <properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
     </dataSource>
     
     <dataSource id="ucpDSAuthData" jndiName="jdbc/ucpDSAuthData">
-   	    <jdbcDriver libraryRef="UCPDBLib" />
-   		<properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
-   		<containerAuthData user="wrong" password="wrong" />
+        <jdbcDriver libraryRef="UCPDBLib" />
+        <properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
+        <containerAuthData user="wrong" password="wrong" />
     </dataSource>
     
     <!-- This DataSource intentionally uses the generic properties element and embedded connection manager -->
     <dataSource id="ucpDSEmbeddedConMgr" jndiName="jdbc/ucpDSEmbeddedConMgr" internalDevNonshipFunctionDoNotUseProduction="true" type="javax.sql.DataSource" validationTimeout="20" >
-    	<connectionManager maxPoolSize="2" minPoolSize="1"/> 
-    	<jdbcDriver libraryRef="UCPDBLib" javax.sql.DataSource="oracle.ucp.jdbc.PoolDataSourceImpl"/>
-    	<!-- TODO remove noship guard -->
-    	<properties maxPoolSize="3" connectionWaitTimeout="30" URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" connectionFactoryClassName="oracle.jdbc.pool.OracleDataSource"/>
+        <connectionManager maxPoolSize="2" minPoolSize="1"/> 
+        <jdbcDriver libraryRef="UCPDBLib" javax.sql.DataSource="oracle.ucp.jdbc.PoolDataSourceImpl"/>
+        <!-- TODO remove noship guard -->
+        <properties maxPoolSize="3" connectionWaitTimeout="30" URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" connectionFactoryClassName="oracle.jdbc.pool.OracleDataSource"/>
     </dataSource>
     
     <!-- This Oracle DataSource uses Liberty connection pooling rather than UCP -->
     <dataSource id="oracleDS" jndiName="jdbc/oracleDS" connectionManagerRef="sharedConMgr" type="javax.sql.DataSource">
-    	<jdbcDriver libraryRef="UCPDBLib"/>
-    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
+        <jdbcDriver libraryRef="UCPDBLib"/>
+        <properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
+    </dataSource>
+    
+    <!-- 
+      Verify behavior or oracle.jdbc.replay datasource classes
+    -->
+    <dataSource id="ds-replay" jndiName="jdbc/ds-replay" type="javax.sql.DataSource">
+        <jdbcDriver libraryRef="UCPDBLib"/>
+        <properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"
+                               connectionFactoryClassName="oracle.jdbc.replay.OracleDataSourceImpl" />
+    </dataSource>
+    
+    <dataSource id="ds-replay-xa" jndiName="jdbc/ds-replay-xa" type="javax.sql.XADataSource">
+        <jdbcDriver libraryRef="UCPDBLib"/>
+        <properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"
+                               connectionFactoryClassName="oracle.jdbc.replay.OracleXADataSourceImpl" />
     </dataSource>
     
     <javaPermission codebase="${shared.resource.dir}/ucp/ojdbc8_g.jar" className="java.security.AllPermission"/>

--- a/dev/io.openliberty.org.testcontainers/cache/projects
+++ b/dev/io.openliberty.org.testcontainers/cache/projects
@@ -168,12 +168,15 @@ com.ibm.ws.wsat.migration_fat.6
 com.ibm.ws.wsat.recovery_fat.multi.6
 fattest.simplicity
 io.openliberty.checkpoint_fat_persistence
+io.openliberty.checkpoint_fat_session_cache_infinispan_container
 io.openliberty.data.internal_fat
 io.openliberty.data.internal_fat_jpa
 io.openliberty.data.internal_fat_nosql
 io.openliberty.jakarta.data.1.0_fat_tck
 io.openliberty.jcache.internal_fat.hazelcast
 io.openliberty.jcache.internal_fat.infinispan
+io.openliberty.microprofile.health.3.1.internal_fat
 io.openliberty.microprofile.openapi.ui.internal_fat
 io.openliberty.microprofile.reactive.messaging.internal_fat
 io.openliberty.microprofile.telemetry.1.0.internal.container_fat
+io.openliberty.org.apache.myfaces.4.1_fat


### PR DESCRIPTION
Testing the validity of using the Application Continuity oracle feature in Liberty backed by the Universal Connection Pool (UCP) from Oracle.

Needed to update our Metatype to allow for the new DataSource factories.
We are able to create connections using these new DataSources but when a connection is created within a local transaction we see: 
```
[3/19/24 11:24:16:469 CDT] 00000025 oracle.jdbc.internal.replay                                  W AC is disabled on oracle.jdbc.driver.T4CConnection@62432b06, because FAILOVER_TYPE service attribute is not set to TRANSACTION in server
```

Because our Database was not configured correctly to use Application Continuity as described here: https://docs.oracle.com/en/database/oracle/oracle-database/21/jjdbc/application-continuity.html#GUID-79858AAD-BDC4-4CFA-91C2-0F515316E069