### PR TITLE
updates to lifecycle method return types

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -133,7 +133,7 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
     }
 
     @Override
-    public PageRequest.Cursor getCursor(int index) {
+    public PageRequest.Cursor cursor(int index) {
         if (index < 0 || index >= pageRequest.size())
             throw new IllegalArgumentException("index: " + index);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -2643,7 +2643,7 @@ public class DataTestServlet extends FATServlet {
         assertIterableEquals(List.of(29L, 43L, 7L, 11L, 13L, 19L, 37L, 41L),
                              page2.stream().map(p -> p.numberId).collect(Collectors.toList()));
 
-        PageRequest.Cursor cursor7 = page2.getCursor(2);
+        PageRequest.Cursor cursor7 = page2.cursor(2);
         PageRequest<?> paginationBefore7 = PageRequest.ofSize(8).beforeCursor(cursor7);
 
         CursoredPage<Prime> page1 = primes.findByNumberIdBetweenOrderByEvenDescSumOfBitsDescIdAsc(0L, 45L, paginationBefore7);
@@ -2651,7 +2651,7 @@ public class DataTestServlet extends FATServlet {
         assertIterableEquals(List.of(2L, 31L, 23L, 29L, 43L),
                              page1.stream().map(p -> p.numberId).collect(Collectors.toList()));
 
-        PageRequest.Cursor cursor13 = page2.getCursor(4);
+        PageRequest.Cursor cursor13 = page2.cursor(4);
         PageRequest<?> paginationAfter13 = PageRequest.ofPage(3).afterCursor(cursor13);
 
         CursoredPage<Prime> page3 = primes.findByNumberIdBetweenOrderByEvenDescSumOfBitsDescIdAsc(0L, 45, paginationAfter13);
@@ -2661,7 +2661,7 @@ public class DataTestServlet extends FATServlet {
 
         // test .equals method
         assertEquals(cursor13, cursor13);
-        assertEquals(cursor13, page2.getCursor(4));
+        assertEquals(cursor13, page2.cursor(4));
         assertEquals(false, cursor13.equals(cursor7));
 
         // test .hashCode method
@@ -5156,7 +5156,7 @@ public class DataTestServlet extends FATServlet {
         pagination = PageRequest.ofSize(6)
                         .sortBy(Sort.desc("binaryDigits"))
                         .withoutTotal()
-                        .beforeCursor(page3.getCursor(1)); // before the middle element of page 3
+                        .beforeCursor(page3.cursor(1)); // before the middle element of page 3
 
         CursoredPage<Prime> page = primes.findByNumberIdLessThanOrderByEvenAscSumOfBitsAsc(52L, pagination);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -970,8 +970,15 @@ public class DataJPATestServlet extends FATServlet {
         o3.purchasedBy = "testEntitiesAsParameters-Customer3";
         o3.purchasedOn = OffsetDateTime.now();
         o3.total = 30.99f;
-        orders.insert(o3);
+        o3 = orders.insert(o3);
+
+        assertNotNull(o3.id);
+        assertEquals("testEntitiesAsParameters-Customer3", o3.purchasedBy);
+        assertEquals(30.99f, o3.total, 0.001f);
+        int o3_v1 = o3.versionNum;
+
         o3 = orders.findFirstByPurchasedBy("testEntitiesAsParameters-Customer3").orElseThrow();
+        assertEquals(o3_v1, o3.versionNum);
 
         PurchaseOrder o4 = new PurchaseOrder();
         o4.purchasedBy = "testEntitiesAsParameters-Customer4";
@@ -1089,10 +1096,25 @@ public class DataJPATestServlet extends FATServlet {
         o8.purchasedOn = OffsetDateTime.now();
         o8.total = 80.99f;
 
-        orders.insertAll(Set.of(o7, o8));
+        List<PurchaseOrder> inserted = orders.insertAll(List.of(o7, o8));
+
+        assertEquals(2, inserted.size());
+        assertNotNull(o7 = inserted.get(0));
+        assertNotNull(o7.id);
+        assertEquals("testEntitiesAsParameters-Customer7", o7.purchasedBy);
+        assertEquals(70.99f, o7.total, 0.001f);
+        int o7_v1 = o7.versionNum;
+        assertNotNull(o8 = inserted.get(1));
+        assertNotNull(o8.id);
+        assertEquals("testEntitiesAsParameters-Customer8", o8.purchasedBy);
+        assertEquals(80.99f, o8.total, 0.001f);
+        int o8_v1 = o8.versionNum;
 
         o7 = orders.findFirstByPurchasedBy("testEntitiesAsParameters-Customer7").orElseThrow();
         o8 = orders.findFirstByPurchasedBy("testEntitiesAsParameters-Customer8").orElseThrow();
+
+        assertEquals(o7_v1, o7.versionNum);
+        assertEquals(o8_v1, o8.versionNum);
 
         o7.total = 77.99f;
         o8.total = 88.99f;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1605,7 +1605,7 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(false, slice2.hasNext());
 
-        Cursor springfieldMO = slice2.getCursor(1);
+        Cursor springfieldMO = slice2.cursor(1);
         pagination = pagination.size(3).beforeCursor(springfieldMO);
 
         CursoredPage<City> beforeSpringfieldMO = cities.findByStateNameNotNullOrderById(pagination);

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -511,7 +511,7 @@ public class DataValidationTestServlet extends FATServlet {
         c1.weight = 5.7f;
         c3.latitude = BigDecimal.valueOf(44040337, 6);
         try {
-            creatures.saveAll(Set.of(c1, c3));
+            creatures.saveAll(List.of(c1, c3));
         } catch (ConstraintViolationException x) {
             violations = x.getConstraintViolations();
             if (violations.isEmpty())

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/CursoredPage.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/CursoredPage.java
@@ -16,7 +16,7 @@ package jakarta.data.page;
  * Methods are copied from proposed interfaces in the Jakarta Data repo.
  */
 public interface CursoredPage<T> extends Page<T> {
-    PageRequest.Cursor getCursor(int index);
+    PageRequest.Cursor cursor(int index);
 
     @Override
     boolean hasPrevious();

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/CursoredPageRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/CursoredPageRecord.java
@@ -33,7 +33,7 @@ public record CursoredPageRecord<T>(
                 implements CursoredPage<T> {
 
     @Override
-    public Cursor getCursor(int i) {
+    public Cursor cursor(int i) {
         return cursors.get(i);
     }
 

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/BasicRepository.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/BasicRepository.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package jakarta.data.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -27,7 +28,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     void delete(T entity);
 
     @Delete
-    void deleteAll(Iterable<? extends T> entities);
+    void deleteAll(List<? extends T> entities);
 
     void deleteByIdIn(Iterable<K> ids);
 
@@ -49,5 +50,5 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     <S extends T> S save(S entity);
 
     @Save
-    <S extends T> Iterable<S> saveAll(Iterable<S> entities);
+    <S extends T> List<S> saveAll(List<S> entities);
 }

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/CrudRepository.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/CrudRepository.java
@@ -12,19 +12,21 @@
  *******************************************************************************/
 package jakarta.data.repository;
 
+import java.util.List;
+
 /**
  * Interface methods copied from Jakarta Data.
  */
 public interface CrudRepository<T, K> extends BasicRepository<T, K> {
     @Insert
-    void insert(T entity);
+    <S extends T> S insert(S entity);
 
     @Insert
-    void insertAll(Iterable<T> entities);
+    <S extends T> List<S> insertAll(List<S> entities);
 
     @Update
-    T update(T entity);
+    <S extends T> S update(S entity);
 
     @Update
-    Iterable<T> updateAll(Iterable<T> entities);
+    <S extends T> List<S> updateAll(List<S> entities);
 }


### PR DESCRIPTION
Align with changes that were recently made to the Jakarta Data spec:
Life cycle method parameters return and accept List rather than Iterable.
getCursor(index) was renamed to cursor(index)
