### PR TITLE
Give applications 60s to start before launching checkpoint

### DIFF
--- a/dev/io.openliberty.checkpoint_fat_persistence/publish/servers/checkpointfat.jpa/server.xml
+++ b/dev/io.openliberty.checkpoint_fat_persistence/publish/servers/checkpointfat.jpa/server.xml
@@ -9,10 +9,10 @@
     <feature>osgiConsole-1.0</feature>
   </featureManager>
 
-  
   <include location="../fatTestPorts.xml"/>
 
-  
+  <applicationManager startTimeout="60s"/>
+
   <application location="jpafat.war" type="war" context-root="/"></application>
 
   <library id="DB2Lib">
@@ -29,5 +29,5 @@
   </dataSource>
 
   <javaPermission codebase="${shared.resource.dir}db2/jcc-11.1.4.4.jar" className="java.security.AllPermission"/>
-  
+
 </server>

--- a/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.checkpoint.fat.jpa/server.xml
+++ b/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.checkpoint.fat.jpa/server.xml
@@ -22,6 +22,8 @@
 
   <include location="../fatTestPorts.xml"/>
 
+  <applicationManager startTimeout="60s"/>
+
   <application location="DataJPATestApp.war">
     <classloader commonLibraryRef="DerbyLib"/>
   </application>


### PR DESCRIPTION
Fixes RTC-299382, RTC-299270

Allow the test application 60s to start before the server begins a checkpoint.  This will reduce breaks due to slow running test environments.