### PR TITLE
Move unregister hook service to prepare while in multi-thread mode

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/test-bundles/test.checkpoint.config.bundle/src/test/checkpoint/config/bundle/TestStaticHookRegister.java
+++ b/dev/io.openliberty.checkpoint_fat/test-bundles/test.checkpoint.config.bundle/src/test/checkpoint/config/bundle/TestStaticHookRegister.java
@@ -136,7 +136,7 @@ public class TestStaticHookRegister {
             if (priorHook >= rank) {
                 System.out.println(testPrepareMsgPrefix + rank + " " + hookCallIndex.addAndGet(1) + " SUCCESS");
             } else {
-                System.out.println(testPrepareMsgPrefix + rank + " " + hookCallIndex.addAndGet(1) + " FAILED");
+                System.out.println(testPrepareMsgPrefix + rank + " " + hookCallIndex.addAndGet(1) + " FAILED - " + priorHook);
             }
         }
 
@@ -146,7 +146,7 @@ public class TestStaticHookRegister {
             if (priorHook <= rank) {
                 System.out.println(testRestoreMsgPrefix + rank + " " + hookCallIndex.addAndGet(1) + " SUCCESS");
             } else {
-                System.out.println(testRestoreMsgPrefix + rank + " " + hookCallIndex.addAndGet(1) + " FAILED");
+                System.out.println(testRestoreMsgPrefix + rank + " " + hookCallIndex.addAndGet(1) + " FAILED - " + priorHook);
             }
         }
 


### PR DESCRIPTION
To avoid a blocking call on ServiceRegistration.unregister while the JVM is in single-thread mode this change moves all the static hook service unregistering to happen from a single multi-thread hook with the highest rank so it happens early in prepare while the JVM is still in multi-thread mode.

