### PR TITLE
JAX-WS: Add beta metatype for webServiceClient

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.common/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jaxws.2.3.common/resources/OSGI-INF/l10n/metatype.properties
@@ -1,0 +1,26 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+# -------------------------------------------------------------------------------------------------
+#CMVCPATHNAME com.ibm.ws.build.example.project/resources/OSGI-INF/l10n/metatype.properties
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+webserviceClient=JAX-WS web service client configuration
+webserviceClient.desc=Configuration for JAX-WS clients.
+
+serviceName=Web service client name
+serviceName.desc=The name property defined in the @WebServiceClient annotation.
+
+ignoreUnexpectedElements=Ignore unexpected elements
+ignoreUnexpectedElements.desc=Ignore unexpected elements in the SOAPMessage object. The default value for ignoring unexpected elements is false for the webServiceClient configuration element and true for the webService configuration element.
+
+enableSchemaValidation=Enable schema validation
+enableSchemaValidation.desc=Enable schema validation in the SOAPMessage object. The default value for enabling schema validation is true for the webServiceClient configuration element and false for the webService configuration element.

--- a/dev/com.ibm.ws.jaxws.2.3.common/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jaxws.2.3.common/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+-->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0"
+                   xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
+                   localization="OSGI-INF/l10n/metatype">
+
+    <OCD id="com.ibm.ws.jaxws.clientConfig.metatype" description="%webserviceClient.desc" name="%webserviceClient.name" ibm:alias="webServiceClient" ibm:beta="true" >
+         <AD id="serviceName" name="%serviceName" description="%serviceName.desc" required="false" type="String" />
+         <AD id="ignoreUnexpectedElements" name="%ignoreUnexpectedElements" description="%ignoreUnexpectedElements.desc" required="false" type="boolean" default="false" />
+         <AD id="enableSchemaValidation" name="%enableSchemaValidation" description="%enableSchemaValidation.desc" required="false" type="boolean" default="true" />
+    </OCD>
+
+    <Designate factoryPid="com.ibm.ws.jaxws.clientConfig">
+        <Object ocdref="com.ibm.ws.jaxws.clientConfig.metatype" />
+    </Designate>
+   
+</metatype:MetaData>


### PR DESCRIPTION
This PR adds the initial metatype definitions for the `webServiceClient` server.xml configuration to `com.ibm.ws.jaxws.2.3.common` 