### PR TITLE
fix invalid proxy format error message

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -1976,13 +1976,13 @@ public class InstallKernelMap implements Map {
 
         String[] proxyEnvVarSplit = proxyEnvVar.split("@");
         if (proxyEnvVarSplit.length != 1 && proxyEnvVarSplit.length != 2) {
-            throw new InstallException(Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_IMPROPER_" + protocol + "PROXY_FORMAT", proxyEnvVar));
+            throw new InstallException(Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_IMPROPER_" + protocol.toUpperCase() + "PROXY_FORMAT", proxyEnvVar));
         }
 
         if (proxyEnvVarSplit.length == 1) { //without username and password
             String[] proxyHttpSplit = proxyEnvVar.split(":");
             if (proxyHttpSplit.length != 3) {
-                throw new InstallException(Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_IMPROPER_" + protocol + "PROXY_FORMAT", proxyEnvVar));
+                throw new InstallException(Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_IMPROPER_" + protocol.toUpperCase() + "PROXY_FORMAT", proxyEnvVar));
             }
             result.put(protocol + ".proxyHost", proxyHttpSplit[1].replace("/", "")); //proxy-server
             result.put(protocol + ".proxyPort", proxyHttpSplit[2]); ////3128


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/open-liberty/issues/26512 and https://github.com/OpenLiberty/ci.maven/issues/1808
When users provide the invalid proxy format using the environment variable, they get 
`Can't find resource for bundle com.ibm.ws.install.internal.resources.InstallKernel, key ERROR_IMPROPER_httpPROXY_FORMAT`.
The expected output is
`CWWKF1400E: The format of the proxy-server:3128 http_proxy environment variable is invalid. Ensure that the http_proxy variable is in the http_proxy=http://<proxy-host>:<proxy-port> format.`

The issue became more noticeable with feature signature verification on Liberty 23.0.0.10 because it tries to validate proxy format before downloading the public key to verify signature
