### PR TITLE
Id is no longer an alias for the unique identifier

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
+import static jakarta.data.repository.By.ID;
+
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -122,7 +124,7 @@ class EntityInfo {
         String lowerName = name.toLowerCase();
         String attributeName = attributeNames.get(lowerName);
         if (attributeName == null)
-            if ("id".equals(lowerName))
+            if (ID.equals(lowerName))
                 if (idClassAttributeAccessors == null && failIfNotFound)
                     throw new MappingException("Entity class " + getType().getName() + " does not have a property named " + name +
                                                " or which is designated as the @Id."); // TODO NLS
@@ -172,8 +174,8 @@ class EntityInfo {
         for (String name : attributeTypes.keySet())
             names.add(name);
 
-        names.remove("id");
-        names.remove(attributeNames.get("id"));
+        names.remove(ID);
+        names.remove(attributeNames.get(ID));
         names.remove(versionAttributeName);
 
         for (String name : attributeTypes.keySet()) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
+import static jakarta.data.repository.By.ID;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.util.ArrayList;
@@ -216,7 +218,7 @@ public abstract class EntityManagerBuilder implements Runnable {
                     } else {
                         SingularAttribute<?, ?> singleAttr = attr instanceof SingularAttribute ? (SingularAttribute<?, ?>) attr : null;
                         if (singleAttr != null && singleAttr.isId()) {
-                            attributeNames.put("id", attributeName);
+                            attributeNames.put(ID, attributeName);
                             idType = singleAttr.getJavaType();
                         } else if (singleAttr != null && singleAttr.isVersion()) {
                             versionAttrName = attributeName;
@@ -280,7 +282,7 @@ public abstract class EntityManagerBuilder implements Runnable {
                                 collectionElementTypes.put(fullAttributeName, ((PluralAttribute<?, ?, ?>) relAttr).getElementType().getJavaType());
                         } else if (relAttr instanceof SingularAttribute) {
                             SingularAttribute<?, ?> singleAttr = ((SingularAttribute<?, ?>) relAttr);
-                            if (singleAttr.isId() && attributeNames.putIfAbsent("id", fullAttributeName) == null) {
+                            if (singleAttr.isId() && attributeNames.putIfAbsent(ID, fullAttributeName) == null) {
                                 idType = singleAttr.getJavaType();
                             } else if (singleAttr.isVersion()) {
                                 versionAttrName = relationAttributeName_; // to be suitable for query-by-method
@@ -298,7 +300,7 @@ public abstract class EntityManagerBuilder implements Runnable {
                         @SuppressWarnings("unchecked")
                         Set<SingularAttribute<?, ?>> idClassAttributes = (Set<SingularAttribute<?, ?>>) (Set<?>) entityType.getIdClassAttributes();
                         if (idClassAttributes != null) {
-                            attributeNames.remove("id");
+                            attributeNames.remove(ID);
                             idType = idClassType.getJavaType();
                             idClassAttributeAccessors = new TreeMap<>();
                             for (SingularAttribute<?, ?> attr : idClassAttributes) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -280,8 +280,7 @@ public abstract class EntityManagerBuilder implements Runnable {
                                 collectionElementTypes.put(fullAttributeName, ((PluralAttribute<?, ?, ?>) relAttr).getElementType().getJavaType());
                         } else if (relAttr instanceof SingularAttribute) {
                             SingularAttribute<?, ?> singleAttr = ((SingularAttribute<?, ?>) relAttr);
-                            if (singleAttr.isId()) {
-                                attributeNames.put("id", fullAttributeName);
+                            if (singleAttr.isId() && attributeNames.putIfAbsent("id", fullAttributeName) == null) {
                                 idType = singleAttr.getJavaType();
                             } else if (singleAttr.isVersion()) {
                                 versionAttrName = relationAttributeName_; // to be suitable for query-by-method

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
+import static jakarta.data.repository.By.ID;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -249,7 +251,7 @@ public class QueryInfo {
      */
     @Trivial
     void addSort(boolean ignoreCase, String attribute, boolean descending) {
-        Set<String> names = entityInfo.idClassAttributeAccessors != null && "id".equalsIgnoreCase(attribute) //
+        Set<String> names = entityInfo.idClassAttributeAccessors != null && ID.equalsIgnoreCase(attribute) //
                         ? entityInfo.idClassAttributeAccessors.keySet() //
                         : Set.of(attribute);
 
@@ -391,7 +393,7 @@ public class QueryInfo {
             Sort<Object> sort = addIt.next();
             if (sort == null)
                 throw new IllegalArgumentException("Sort: null");
-            else if (hasIdClass && sort.property().equalsIgnoreCase("id"))
+            else if (hasIdClass && ID.equals(sort.property()))
                 for (String name : entityInfo.idClassAttributeAccessors.keySet())
                     combined.add(entityInfo.getWithAttributeName(entityInfo.getAttributeName(name, true), sort));
             else
@@ -417,7 +419,7 @@ public class QueryInfo {
         for (Sort<Object> sort : additional) {
             if (sort == null)
                 throw new IllegalArgumentException("Sort: null");
-            else if (hasIdClass && sort.property().equalsIgnoreCase("id"))
+            else if (hasIdClass && ID.equals(sort.property()))
                 for (String name : entityInfo.idClassAttributeAccessors.keySet())
                     combined.add(entityInfo.getWithAttributeName(entityInfo.getAttributeName(name, true), sort));
             else

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
+import static jakarta.data.repository.By.ID;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
@@ -695,7 +697,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 jpql = jpql.replace("=?" + versionParamIndex, " IS NULL");
         }
 
-        Object id = entityInfo.getAttribute(e, entityInfo.getAttributeName("id", true));
+        Object id = entityInfo.getAttribute(e, entityInfo.getAttributeName(ID, true));
         if (id == null) {
             jpql = jpql.replace("=?" + (versionParamIndex - 1), " IS NULL");
             if (version != null)
@@ -748,7 +750,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
         String o_ = queryInfo.entityVar_;
         StringBuilder q;
         if (entityInfo.idClassAttributeAccessors == null) {
-            String idAttrName = entityInfo.attributeNames.get("id");
+            String idAttrName = entityInfo.attributeNames.get(ID);
             q = new StringBuilder(24 + entityInfo.name.length() + o.length() * 2 + idAttrName.length()) //
                             .append("DELETE FROM ").append(entityInfo.name).append(' ').append(o).append(" WHERE ") //
                             .append(o_).append(idAttrName).append("=?1");
@@ -785,7 +787,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
             q.append(" WHERE (");
 
-            String idName = entityInfo.getAttributeName("id", true);
+            String idName = entityInfo.getAttributeName(ID, true);
             if (idName == null && entityInfo.idClassAttributeAccessors != null) {
                 boolean first = true;
                 for (String name : entityInfo.idClassAttributeAccessors.keySet()) {
@@ -981,7 +983,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 if (where + 8 == len)
                     q.delete(where, len); // Remove " WHERE " because there are no conditions
                 queryInfo.hasWhere = false;
-            } else if (queryInfo.entityInfo.idClassAttributeAccessors != null && attribute.equalsIgnoreCase("id")) {
+            } else if (queryInfo.entityInfo.idClassAttributeAccessors != null && ID.equals(attribute)) {
                 generateConditionsForIdClass(queryInfo, condition, ignoreCase, negated, q);
             }
             return;
@@ -1609,7 +1611,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
             queryInfo.type = QueryInfo.Type.COUNT;
         } else if (methodName.startsWith("exists")) {
             int c = by < 0 ? 6 : (by + 2);
-            String name = entityInfo.idClassAttributeAccessors == null ? "id" : entityInfo.idClassAttributeAccessors.firstKey();
+            String name = entityInfo.idClassAttributeAccessors == null ? ID : entityInfo.idClassAttributeAccessors.firstKey();
             String attrName = entityInfo.getAttributeName(name, true);
             q = new StringBuilder(200).append("SELECT ").append(o).append('.').append(attrName) //
                             .append(" FROM ").append(entityInfo.name).append(' ').append(o);
@@ -1734,7 +1736,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 generateFromParameters(queryInfo, q, methodTypeAnno, countPages, hasUpdateParam, allParamInfo);
         } else if (methodTypeAnno instanceof Exists) {
             queryInfo.type = QueryInfo.Type.EXISTS;
-            String name = entityInfo.idClassAttributeAccessors == null ? "id" : entityInfo.idClassAttributeAccessors.firstKey();
+            String name = entityInfo.idClassAttributeAccessors == null ? ID : entityInfo.idClassAttributeAccessors.firstKey();
             String attrName = entityInfo.getAttributeName(name, true);
             q = new StringBuilder(200).append("SELECT ").append(o_).append(attrName) //
                             .append(" FROM ").append(entityInfo.name).append(' ').append(o);
@@ -1988,7 +1990,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
         String o_ = queryInfo.entityVar_;
         StringBuilder q;
 
-        String idName = queryInfo.entityInfo.getAttributeName("id", true);
+        String idName = queryInfo.entityInfo.getAttributeName(ID, true);
         if (idName == null && queryInfo.entityInfo.idClassAttributeAccessors != null) {
             // TODO support this similar to what generateDeleteEntity does
             throw new MappingException("Update operations cannot be used on entities with composite IDs."); // TODO NLS
@@ -2517,7 +2519,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                             Object value = result;
                                             if (entityInfo.entityClass.isInstance(result) ||
                                                 entityInfo.recordClass != null && entityInfo.recordClass.isInstance(result)) {
-                                                List<Member> accessors = entityInfo.attributeAccessors.get(entityInfo.attributeNames.get("id"));
+                                                List<Member> accessors = entityInfo.attributeAccessors.get(entityInfo.attributeNames.get(ID));
                                                 if (accessors == null || accessors.isEmpty())
                                                     throw new MappingException("Unable to find the id attribute on the " + entityInfo.name + " entity."); // TODO NLS
                                                 for (Member accessor : accessors)
@@ -2973,7 +2975,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
         Object id = null;
         if (entityInfo.idClassAttributeAccessors == null) {
-            id = entityInfo.getAttribute(e, entityInfo.getAttributeName("id", true));
+            id = entityInfo.getAttribute(e, entityInfo.getAttributeName(ID, true));
             if (id == null) {
                 jpql = jpql.replace("=?" + (versionParamIndex - 1), " IS NULL");
                 if (version != null)
@@ -3328,7 +3330,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 jpql = jpql.replace("=?" + versionParamIndex, " IS NULL");
         }
 
-        Object id = entityInfo.getAttribute(e, entityInfo.getAttributeName("id", true));
+        Object id = entityInfo.getAttribute(e, entityInfo.getAttributeName(ID, true));
         if (id == null) {
             jpql = jpql.replace("=?" + (versionParamIndex - 1), " IS NULL");
             if (version != null)

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -60,6 +60,7 @@ import io.openliberty.data.internal.persistence.service.DBStoreEMBuilder;
 import jakarta.annotation.Generated;
 import jakarta.data.exceptions.MappingException;
 import jakarta.data.metamodel.StaticMetamodel;
+import jakarta.data.repository.By;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
@@ -439,8 +440,15 @@ public class DataExtension implements Extension, PrivilegedAction<DataExtensionP
                 } else if (c.isArray()) {
                     c = c.getComponentType();
                 }
-                if (Object.class.equals(c)) { // generic parameter like BasicRepository.save(S entity)
-                    entityParamType = method.getParameterTypes()[0];
+                if (Object.class.equals(c)) {
+                    // generic parameter like BasicRepository.save(S entity) or BasicRepository.deleteById(@By(ID) K id)
+                    boolean isEntity = true;
+                    for (Annotation anno : method.getParameterAnnotations()[0])
+                        if (By.class.equals(anno.annotationType()))
+                            isEntity = false;
+                    if (isEntity)
+                        entityParamType = c;
+                    // TODO is there any way to distinguish @Delete deleteById(K key) when @By is not present?
                 } else if (c != null &&
                            !c.isPrimitive() &&
                            !c.isInterface()) {

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/CustomRepository.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/CustomRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import static jakarta.data.repository.By.ID;
+
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Save;
 
@@ -19,12 +21,12 @@ import jakarta.data.repository.Save;
  * Custom repository interface that provides entity and key type parameters.
  */
 public interface CustomRepository<T, K> {
-    long countByIdBetween(K minId, K maxId);
+    long countBySSN_IdBetween(K minId, K maxId);
 
-    long deleteByIdBetween(K minId, K maxId);
+    long deleteBySSN_IdBetween(K minId, K maxId);
 
     @OrderBy("firstName")
-    @OrderBy("id")
+    @OrderBy(ID)
     T[] findByLastName(String lastName);
 
     @Save

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import static jakarta.data.repository.By.ID;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -482,25 +483,25 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testBooleanConditions() {
         assertIterableEquals(List.of(3L, 5L, 7L),
-                             primes.findByEvenFalseAndIdLessThan(10L)
+                             primes.findByEvenFalseAndNumberIdLessThan(10L)
                                              .stream()
                                              .map(p -> p.numberId)
                                              .collect(Collectors.toList()));
 
         assertIterableEquals(List.of(7L, 5L, 3L),
-                             primes.findByEvenNotTrueAndIdLessThan(10L)
+                             primes.findByEvenNotTrueAndNumberIdLessThan(10L)
                                              .stream()
                                              .map(p -> p.numberId)
                                              .collect(Collectors.toList()));
 
         assertIterableEquals(List.of(2L),
-                             primes.findByEvenTrueAndIdLessThan(10L)
+                             primes.findByEvenTrueAndNumberIdLessThan(10L)
                                              .stream()
                                              .map(p -> p.numberId)
                                              .collect(Collectors.toList()));
 
         assertIterableEquals(List.of(2L),
-                             primes.findByEvenNotFalseAndIdLessThan(10L)
+                             primes.findByEvenNotFalseAndNumberIdLessThan(10L)
                                              .stream()
                                              .map(p -> p.numberId)
                                              .collect(Collectors.toList()));
@@ -535,12 +536,12 @@ public class DataTestServlet extends FATServlet {
     public void testCompletionStageOfPage() throws ExecutionException, InterruptedException, TimeoutException {
         LinkedBlockingQueue<Long> sums = new LinkedBlockingQueue<Long>();
 
-        primes.findByNumberIdLessThanOrderByIdDesc(42L, PageRequest.ofSize(6)).thenCompose(page1 -> {
+        primes.findByNumberIdLessThanOrderByNumberIdDesc(42L, PageRequest.ofSize(6)).thenCompose(page1 -> {
             sums.add(page1.stream().mapToLong(p -> p.numberId).sum());
-            return primes.findByNumberIdLessThanOrderByIdDesc(42L, page1.nextPageRequest());
+            return primes.findByNumberIdLessThanOrderByNumberIdDesc(42L, page1.nextPageRequest());
         }).thenCompose(page2 -> {
             sums.add(page2.stream().mapToLong(p -> p.numberId).sum());
-            return primes.findByNumberIdLessThanOrderByIdDesc(42L, page2.nextPageRequest());
+            return primes.findByNumberIdLessThanOrderByNumberIdDesc(42L, page2.nextPageRequest());
         }).thenAccept(page3 -> {
             sums.add(page3.stream().mapToLong(p -> p.numberId).sum());
         }).toCompletableFuture().get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
@@ -562,13 +563,13 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testCount() throws ExecutionException, InterruptedException, TimeoutException {
 
-        assertEquals(15, primes.countByIdLessThan(50));
+        assertEquals(15, primes.countByNumberIdLessThan(50));
 
         assertEquals(Integer.valueOf(0), primes.countByNumberIdBetween(32, 36));
 
         assertEquals(Integer.valueOf(3), primes.countByNumberIdBetween(40, 50));
 
-        assertEquals(Short.valueOf((short) 14), primes.countByIdBetweenAndEvenNot(0, 50, true).get(TIMEOUT_MINUTES, TimeUnit.MINUTES));
+        assertEquals(Short.valueOf((short) 14), primes.countByNumberIdBetweenAndEvenNot(0, 50, true).get(TIMEOUT_MINUTES, TimeUnit.MINUTES));
     }
 
     /**
@@ -632,7 +633,7 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testCustomRepositoryInterface() {
-        people.deleteByIdBetween(400000000L, 499999999L);
+        people.deleteBySSN_IdBetween(400000000L, 499999999L);
 
         Person p1 = new Person();
         p1.firstName = "Catherine";
@@ -651,7 +652,7 @@ public class DataTestServlet extends FATServlet {
 
         people.updateOrAdd(Set.of(p1, p2, p3));
 
-        assertEquals(3L, people.countByIdBetween(400000000L, 499999999L));
+        assertEquals(3L, people.countBySSN_IdBetween(400000000L, 499999999L));
 
         Person p4 = new Person();
         p4.firstName = "Cathy";
@@ -664,9 +665,9 @@ public class DataTestServlet extends FATServlet {
                                      .map(p -> p.firstName)
                                      .collect(Collectors.toList()));
 
-        assertEquals(1L, people.deleteByIdBetween(400000000L, 449999999L));
+        assertEquals(1L, people.deleteBySSN_IdBetween(400000000L, 449999999L));
 
-        assertEquals(2L, people.deleteByIdBetween(400000000L, 499999999L));
+        assertEquals(2L, people.deleteBySSN_IdBetween(400000000L, 499999999L));
     }
 
     /**
@@ -713,8 +714,8 @@ public class DataTestServlet extends FATServlet {
             Product removed = products.remove(prod1.pk);
             assertEquals("TestDefaultRepositoryMethod Standard Edition", removed.name);
 
-            assertEquals(false, products.findById(prod1.pk).isPresent());
-            assertEquals(true, products.findById(prod3.pk).isPresent());
+            assertEquals(false, products.findByPK(prod1.pk).isPresent());
+            assertEquals(true, products.findByPK(prod3.pk).isPresent());
         }
 
         products.clear();
@@ -1139,7 +1140,7 @@ public class DataTestServlet extends FATServlet {
                              "TestEmbeddable-304-3655-30",
                              "TestEmbeddable-404-4418-40"),
                      houses.findByAreaGreaterThan(1200,
-                                                  Order.by(_House.id.ascIgnoreCase()))
+                                                  Order.by(_House.parcelid.ascIgnoreCase()))
                                      .map(house -> house.parcelId)
                                      .collect(Collectors.toList()));
 
@@ -1161,7 +1162,7 @@ public class DataTestServlet extends FATServlet {
 
         // Find a subset of attributes
 
-        Object[] tuple = houses.findGarageDoorAndKitchenLengthAndKitchenWidthById("TestEmbeddable-304-3655-30").orElseThrow();
+        Object[] tuple = houses.findGarageDoorAndKitchenLengthAndKitchenWidthByParcelId("TestEmbeddable-304-3655-30").orElseThrow();
         GarageDoor door = (GarageDoor) tuple[0];
         assertEquals(8, door.getHeight());
         assertEquals(9, door.getWidth());
@@ -1175,7 +1176,7 @@ public class DataTestServlet extends FATServlet {
 
         // Update embeddable attributes
 
-        assertEquals(true, houses.updateByIdSetGarageAddAreaAddKitchenLengthSetNumBedrooms("TestEmbeddable-304-3655-30", null, 180, 2, 4));
+        assertEquals(true, houses.updateByParcelIdSetGarageAddAreaAddKitchenLengthSetNumBedrooms("TestEmbeddable-304-3655-30", null, 180, 2, 4));
 
         h = houses.findById("TestEmbeddable-304-3655-30");
         assertEquals("TestEmbeddable-304-3655-30", h.parcelId);
@@ -1239,8 +1240,8 @@ public class DataTestServlet extends FATServlet {
         assertEquals(true, primes.existsByNumberId(19));
         assertEquals(false, primes.existsByNumberId(9));
 
-        assertEquals(Boolean.TRUE, primes.existsByIdBetween(Long.valueOf(14), Long.valueOf(18)));
-        assertEquals(Boolean.FALSE, primes.existsByIdBetween(Long.valueOf(24), Long.valueOf(28)));
+        assertEquals(Boolean.TRUE, primes.existsByNumberIdBetween(Long.valueOf(14), Long.valueOf(18)));
+        assertEquals(Boolean.FALSE, primes.existsByNumberIdBetween(Long.valueOf(24), Long.valueOf(28)));
     }
 
     /**
@@ -1640,7 +1641,7 @@ public class DataTestServlet extends FATServlet {
         assertNotNull(prime);
         assertEquals(7, prime.numberId);
 
-        Prime[] p = primes.findFirst5ByIdLessThanEqual(25); // descending order by name
+        Prime[] p = primes.findFirst5ByNumberIdLessThanEqual(25); // descending order by name
         assertNotNull(p);
         assertEquals(Arrays.toString(p), 5, p.length);
         assertEquals("two", p[0].name);
@@ -1804,7 +1805,7 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testFindSubsetOfAttributes() {
-        List<Object[]> all = primes.findIdAndNameBy(Sort.asc("numberId"));
+        List<Object[]> all = primes.findNumberIdAndNameBy(Sort.asc("numberId"));
 
         Object[] idAndName = all.get(5);
         assertEquals(13L, idAndName[0]);
@@ -1836,7 +1837,7 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testGenericArrayReturnType() {
-        people.deleteByIdBetween(100101001l, 100101004l);
+        people.deleteBySSN_IdBetween(100101001l, 100101004l);
 
         Person p1 = new Person();
         p1.firstName = "George";
@@ -1867,7 +1868,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals("Gerald", found[1].firstName);
         assertEquals("Gordon", found[2].firstName);
 
-        assertEquals(4l, people.deleteByIdBetween(100101001l, 100101004l));
+        assertEquals(4l, people.deleteBySSN_IdBetween(100101001l, 100101004l));
     }
 
     /**
@@ -1970,42 +1971,42 @@ public class DataTestServlet extends FATServlet {
 
         // Not
         assertIterableEquals(List.of("two", "five", "seven"),
-                             primes.findByNameIgnoreCaseNotAndIdLessThanOrderByIdAsc("Three", 10)
+                             primes.findByNameIgnoreCaseNotAndNumberIdLessThanOrderByNumberIdAsc("Three", 10)
                                              .stream()
                                              .map(p -> p.name)
                                              .collect(Collectors.toList()));
 
         // StartsWith
         assertIterableEquals(List.of("thirteen", "thirty-one", "thirty-seven"),
-                             primes.findByNameIgnoreCaseStartsWithAndIdLessThanOrderByIdAsc("Thirt%n", 1000)
+                             primes.findByNameIgnoreCaseStartsWithAndNumberIdLessThanOrderByNumberIdAsc("Thirt%n", 1000)
                                              .stream()
                                              .map(p -> p.name)
                                              .collect(Collectors.toList()));
 
         // Like
         assertIterableEquals(List.of("thirteen", "thirty-seven"),
-                             primes.findByNameIgnoreCaseLikeAndIdLessThanOrderByIdAsc("Thirt%n", 1000)
+                             primes.findByNameIgnoreCaseLikeAndNumberIdLessThanOrderByNumberIdAsc("Thirt%n", 1000)
                                              .stream()
                                              .map(p -> p.name)
                                              .collect(Collectors.toList()));
 
         // Contains
         assertIterableEquals(List.of("twenty-three", "seventeen"),
-                             primes.findByNameIgnoreCaseContainsAndIdLessThanOrderByIdDesc("ent%ee", 1000)
+                             primes.findByNameIgnoreCaseContainsAndNumberIdLessThanOrderByNumberIdDesc("ent%ee", 1000)
                                              .stream()
                                              .map(p -> p.name)
                                              .collect(Collectors.toList()));
 
         // Between
         assertIterableEquals(List.of("nineteen", "seventeen", "seven"),
-                             primes.findByNameIgnoreCaseBetweenAndIdLessThanOrderByIdDesc("Nine", "SEVENTEEN", 50)
+                             primes.findByNameIgnoreCaseBetweenAndNumberIdLessThanOrderByNumberIdDesc("Nine", "SEVENTEEN", 50)
                                              .stream()
                                              .map(p -> p.name)
                                              .collect(Collectors.toList()));
 
         // GreaterThan, LessThanEqual
         assertIterableEquals(List.of("XLVII", "XLIII", "XIII", "XI", "VII", "V", "III"),
-                             primes.findByHexIgnoreCaseGreaterThanAndRomanNumeralIgnoreCaseLessThanEqualAndIdLessThan("2a", "xlvII", 50)
+                             primes.findByHexIgnoreCaseGreaterThanAndRomanNumeralIgnoreCaseLessThanEqualAndNumberIdLessThan("2a", "xlvII", 50)
                                              .stream()
                                              .map(p -> p.romanNumeral)
                                              .collect(Collectors.toList()));
@@ -2035,7 +2036,7 @@ public class DataTestServlet extends FATServlet {
     @AllowedFFDC("jakarta.data.exceptions.EntityExistsException")
     @Test
     public void testInsert() throws Exception {
-        people.deleteByIdBetween(0L, 999999999L);
+        people.deleteBySSN_IdBetween(0L, 999999999L);
 
         // insert single:
 
@@ -2131,7 +2132,7 @@ public class DataTestServlet extends FATServlet {
                 tran.commit();
         }
 
-        assertEquals(5, people.deleteByIdBetween(0L, 999999999L));
+        assertEquals(5, people.deleteBySSN_IdBetween(0L, 999999999L));
     }
 
     /**
@@ -2140,7 +2141,7 @@ public class DataTestServlet extends FATServlet {
     // @AllowedFFDC("jakarta.data.exceptions.EntityExistsException")
     @Test
     public void testInsertAndDeleteMultiple() throws Exception {
-        people.deleteByIdBetween(0L, 999999999L);
+        people.deleteBySSN_IdBetween(0L, 999999999L);
 
         // insert multiple:
 
@@ -2234,7 +2235,7 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testIntStreamResult() {
         assertIterableEquals(List.of(5, 4, 3, 3, 5, 4, 4),
-                             primes.findSumOfBitsByIdBetween(20, 49)
+                             primes.findSumOfBitsByNumberIdBetween(20, 49)
                                              .mapToObj(i -> Integer.valueOf(i))
                                              .collect(Collectors.toList()));
     }
@@ -2287,7 +2288,7 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testIteratorWithKeysetPagination_OrderBy() {
         PageRequest<?> p = PageRequest.ofSize(5).afterKey(false, 2, 3);
-        Iterator<Prime> it = primes.findByNameStartsWithAndIdLessThanOrNameContainsAndIdLessThan("t", 50L, "n", 50L, p);
+        Iterator<Prime> it = primes.findByNameStartsWithAndNumberIdLessThanOrNameContainsAndNumberIdLessThan("t", 50L, "n", 50L, p);
 
         assertEquals("seventeen", it.next().name);
         assertEquals("seven", it.next().name);
@@ -2306,7 +2307,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals(false, it.hasNext());
 
         p = PageRequest.ofSize(4).beforeKey(true, 1, 2);
-        it = primes.findByNameStartsWithAndIdLessThanOrNameContainsAndIdLessThan("t", 45L, "n", 45L, p);
+        it = primes.findByNameStartsWithAndNumberIdLessThanOrNameContainsAndNumberIdLessThan("t", 45L, "n", 45L, p);
 
         assertEquals("forty-one", it.next().name);
         assertEquals("twenty-three", it.next().name);
@@ -2638,7 +2639,7 @@ public class DataTestServlet extends FATServlet {
         // 17, 10001,  2, false
 
         PageRequest<?> initialPagination = PageRequest.ofPage(2).size(8).afterKey(false, 4, 23L);
-        CursoredPage<Prime> page2 = primes.findByNumberIdBetweenOrderByEvenDescSumOfBitsDescIdAsc(0L, 45L, initialPagination);
+        CursoredPage<Prime> page2 = primes.findByNumberIdBetweenOrderByEvenDescSumOfBitsDescNumberIdAsc(0L, 45L, initialPagination);
 
         assertIterableEquals(List.of(29L, 43L, 7L, 11L, 13L, 19L, 37L, 41L),
                              page2.stream().map(p -> p.numberId).collect(Collectors.toList()));
@@ -2646,7 +2647,7 @@ public class DataTestServlet extends FATServlet {
         PageRequest.Cursor cursor7 = page2.cursor(2);
         PageRequest<?> paginationBefore7 = PageRequest.ofSize(8).beforeCursor(cursor7);
 
-        CursoredPage<Prime> page1 = primes.findByNumberIdBetweenOrderByEvenDescSumOfBitsDescIdAsc(0L, 45L, paginationBefore7);
+        CursoredPage<Prime> page1 = primes.findByNumberIdBetweenOrderByEvenDescSumOfBitsDescNumberIdAsc(0L, 45L, paginationBefore7);
 
         assertIterableEquals(List.of(2L, 31L, 23L, 29L, 43L),
                              page1.stream().map(p -> p.numberId).collect(Collectors.toList()));
@@ -2654,7 +2655,7 @@ public class DataTestServlet extends FATServlet {
         PageRequest.Cursor cursor13 = page2.cursor(4);
         PageRequest<?> paginationAfter13 = PageRequest.ofPage(3).afterCursor(cursor13);
 
-        CursoredPage<Prime> page3 = primes.findByNumberIdBetweenOrderByEvenDescSumOfBitsDescIdAsc(0L, 45, paginationAfter13);
+        CursoredPage<Prime> page3 = primes.findByNumberIdBetweenOrderByEvenDescSumOfBitsDescNumberIdAsc(0L, 45, paginationAfter13);
 
         assertIterableEquals(List.of(19L, 37L, 41L, 3L, 5L, 17L),
                              page3.stream().map(p -> p.numberId).collect(Collectors.toList()));
@@ -3058,7 +3059,7 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testKeysetWithoutPageRequest() {
         // This is not a recommended pattern. Testing to see how it is handled.
-        CursoredPage<Prime> page = primes.findByNumberIdBetweenAndBinaryDigitsNotNull(30L, 40L, Sort.asc("id"));
+        CursoredPage<Prime> page = primes.findByNumberIdBetweenAndBinaryDigitsNotNull(30L, 40L, Sort.asc(ID));
         assertEquals(31L, page.content().get(0).numberId);
 
         // Obtain PageRequest for previous entries from the CursoredPage
@@ -3122,14 +3123,14 @@ public class DataTestServlet extends FATServlet {
             h1.purchasePrice = 222000f;
             h1.sold = Year.of(2020);
             houses.save(h1);
-            assertEquals(true, vehicles.updateByIdAddPrice("TME09876543210001", 200f));
+            assertEquals(true, vehicles.updateByVinIdAddPrice("TME09876543210001", 200f));
         } finally {
             tran.rollback();
         }
 
         // Ensure all updates were rolled back
         h = houses.findById("111-222-333");
-        v = vehicles.findById("TME09876543210001").get();
+        v = vehicles.findByVinId("TME09876543210001").get();
 
         assertEquals(219000f, h.purchasePrice, 0.001f);
         assertEquals(Year.of(2019), h.sold);
@@ -3141,14 +3142,14 @@ public class DataTestServlet extends FATServlet {
             h1.purchasePrice = 241000f;
             h1.sold = Year.of(2021);
             houses.save(h1);
-            assertEquals(true, vehicles.updateByIdAddPrice("TME09876543210001", 2000f));
+            assertEquals(true, vehicles.updateByVinIdAddPrice("TME09876543210001", 2000f));
         } finally {
             tran.commit();
         }
 
         // Ensure all updates were committed
         h = houses.findById("111-222-333");
-        v = vehicles.findById("TME09876543210001").get();
+        v = vehicles.findByVinId("TME09876543210001").get();
 
         assertEquals(241000f, h.purchasePrice, 0.001f);
         assertEquals(Year.of(2021), h.sold);
@@ -3164,9 +3165,9 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testMixSortParamsAndPageRequestSorts() {
-        PageRequest<?> pageRequest = PageRequest.ofSize(30).sortBy(Sort.asc("id"));
+        PageRequest<?> pageRequest = PageRequest.ofSize(30).sortBy(Sort.asc(ID));
         try {
-            Page<Prime> page = primes.findByRomanNumeralEndsWithAndIdLessThan("I", 300L, pageRequest, Sort.desc("id"));
+            Page<Prime> page = primes.findByRomanNumeralEndsWithAndNumberIdLessThan("I", 300L, pageRequest, Sort.desc(ID));
             fail("Must raise IllegalArgumentException when Sort parameters are " +
                  "intermixed with PageRequest with Sort parameters. Instead: " + page);
         } catch (IllegalArgumentException x) {
@@ -3253,7 +3254,7 @@ public class DataTestServlet extends FATServlet {
         // Remove any pre-existing data that could interfere with the test:
         products.clear();
         packages.deleteAll();
-        multi.deleteByIdIn(List.of(908070605l, 807060504l, 706050403l));
+        personnel.removeAll().join();
 
         Product prod = new Product();
         prod.pk = UUID.nameUUIDFromBytes("TestMultipleEntitiesInARepository".getBytes());
@@ -3305,8 +3306,9 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(true, multi.remove(added.get(2)));
 
-        Person[] deleted = multi.deleteByIdIn(List.of(908070605l, 807060504l, 706050403l));
-        assertEquals(2, deleted.length);
+        assertEquals(true, multi.deleteById(908070605l).isPresent());
+        assertEquals(true, multi.deleteById(807060504l).isPresent());
+        assertEquals(false, multi.deleteById(706050403l).isPresent());
 
         prod.name = "Test-Multiple-Entities-In-A-Repository-Product";
         assertEquals(1, multi.modify(prod));
@@ -3412,7 +3414,7 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testOrderedSet() {
         assertIterableEquals(List.of(47L, 43L, 41L, 37L, 31L, 29L, 23L),
-                             primes.findIdByIdBetween(20, 49));
+                             primes.findNumberIdByNumberIdBetween(20, 49));
     }
 
     /**
@@ -3422,14 +3424,14 @@ public class DataTestServlet extends FATServlet {
     public void testOverflow() {
         Limit range = Limit.range(Integer.MAX_VALUE + 5L, Integer.MAX_VALUE + 10L);
         try {
-            List<Prime> found = primes.findByNumberIdLessThanEqualOrderByIdDesc(9L, range);
+            List<Prime> found = primes.findByNumberIdLessThanEqualOrderByNumberIdDesc(9L, range);
             fail("Expected an error because starting position of range exceeds Integer.MAX_VALUE. Found: " + found);
         } catch (IllegalArgumentException x) {
             // expected
         }
 
         try {
-            Stream<Prime> found = primes.findFirst2147483648ByIdGreaterThan(1L);
+            Stream<Prime> found = primes.findFirst2147483648ByNumberIdGreaterThan(1L);
             fail("Expected an error because limit exceeds Integer.MAX_VALUE. Found: " + found);
         } catch (UnsupportedOperationException x) {
             // expected
@@ -3492,7 +3494,7 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testPageRequestTypeMatchesResultType() {
-        PageRequest<Prime> page1Request = Order.by(_Prime.id.desc()).pageSize(5).withoutTotal();
+        PageRequest<Prime> page1Request = Order.by(_Prime.numberId.desc()).pageSize(5).withoutTotal();
         CursoredPage<Prime> page1 = primes.findByNumberIdBetweenAndEvenFalse(20, 50, page1Request);
 
         assertEquals(List.of(47L, 43L, 41L, 37L, 31L),
@@ -3652,19 +3654,19 @@ public class DataTestServlet extends FATServlet {
                                  new Receipt(400L, "C0045-00-054", 44.49f),
                                  new Receipt(500L, "C0045-00-054", 155.00f)));
 
-        assertEquals(true, receipts.existsById(300L));
+        assertEquals(true, receipts.existsByPurchaseId(300L));
         assertEquals(5L, receipts.count());
 
         Receipt receipt = receipts.findById(200L).orElseThrow();
         assertEquals(202.40f, receipt.total(), 0.001f);
 
         assertIterableEquals(List.of("C0013-00-031:300", "C0022-00-022:200", "C0045-00-054:500"),
-                             receipts.findByIdIn(List.of(200L, 300L, 500L))
+                             receipts.findByPurchaseIdIn(List.of(200L, 300L, 500L))
                                              .map(r -> r.customer() + ":" + r.purchaseId())
                                              .sorted()
                                              .collect(Collectors.toList()));
 
-        receipts.deleteByIdIn(List.of(200L, 500L));
+        receipts.deleteByPurchaseIdIn(List.of(200L, 500L));
 
         assertIterableEquals(List.of("C0013-00-031:100", "C0013-00-031:300", "C0045-00-054:400"),
                              receipts.findAll()
@@ -3678,7 +3680,7 @@ public class DataTestServlet extends FATServlet {
 
         receipts.delete(new Receipt(400L, "C0045-00-054", 44.49f));
 
-        assertEquals(false, receipts.existsById(400L));
+        assertEquals(false, receipts.existsByPurchaseId(400L));
 
         receipts.saveAll(List.of(new Receipt(600L, "C0067-00-076", 266.80f),
                                  new Receipt(700L, "C0067-00-076", 17.99f),
@@ -3830,7 +3832,7 @@ public class DataTestServlet extends FATServlet {
         r1.stop = OffsetDateTime.of(2022, 5, 23, 10, 0, 0, 0, CDT);
         r1.setLengthInMinutes(60);
 
-        assertEquals(false, reservations.existsById(r1.meetingID));
+        assertEquals(Boolean.FALSE, reservations.existsByMeetingId(r1.meetingID));
 
         Reservation inserted = reservations.save(r1);
         assertEquals(r1.host, inserted.host);
@@ -3840,7 +3842,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals(r1.start, inserted.start);
         assertEquals(r1.stop, inserted.stop);
 
-        assertEquals(true, reservations.existsById(r1.meetingID));
+        assertEquals(Boolean.TRUE, reservations.existsByMeetingId(r1.meetingID));
 
         assertEquals(1, reservations.countBy());
 
@@ -3908,11 +3910,11 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(false, it.hasNext());
 
-        assertEquals(true, reservations.existsById(r3.meetingID));
+        assertEquals(true, reservations.existsByMeetingId(r3.meetingID));
 
         assertEquals(4, reservations.count());
 
-        Map<Long, Reservation> found = reservations.findByIdIn(List.of(r4.meetingID, r2.meetingID))
+        Map<Long, Reservation> found = reservations.findByMeetingIdIn(List.of(r4.meetingID, r2.meetingID))
                         .collect(Collectors.toMap(rr -> rr.meetingID, Function.identity()));
         assertEquals(found.toString(), 2, found.size());
         assertEquals(true, found.containsKey(r2.meetingID));
@@ -3930,9 +3932,9 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(3, reservations.count());
 
-        reservations.deleteByIdIn(Set.of(r1.meetingID, r4.meetingID));
+        reservations.deleteByMeetingIdIn(Set.of(r1.meetingID, r4.meetingID));
 
-        assertEquals(false, reservations.existsById(r4.meetingID));
+        assertEquals(Boolean.FALSE, reservations.existsByMeetingId(r4.meetingID));
 
         assertEquals(1, reservations.count());
 
@@ -4572,7 +4574,7 @@ public class DataTestServlet extends FATServlet {
 
         // TODO is "Desc" allowed in an entity property name in the OrderBy clause?
         assertIterableEquals(List.of("A101", "android", "apple"),
-                             things.findByIdGreaterThan(3L)
+                             things.findByThingIdGreaterThan(3L)
                                              .map(o -> o.a)
                                              .sorted()
                                              .collect(Collectors.toList()));
@@ -4618,7 +4620,7 @@ public class DataTestServlet extends FATServlet {
     public void testSaveAndUpdateMultiple() {
         // find none
         houses.dropAll();
-        assertEquals(false, houses.existsById("001-203-401"));
+        assertEquals(false, houses.existsByParcelId("001-203-401"));
 
         // insert
         House h1 = new House();
@@ -4705,7 +4707,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals(1L, houses.deleteById(h1.parcelId));
 
         // find none
-        assertEquals(false, houses.existsById(h1.parcelId));
+        assertEquals(false, houses.existsByParcelId(h1.parcelId));
 
         // delete nothing
         assertEquals(0L, houses.deleteById(h1.parcelId));
@@ -4753,17 +4755,17 @@ public class DataTestServlet extends FATServlet {
         assertEquals(false, i.hasNext());
 
         // delete
-        assertEquals(true, vehicles.removeById(v1.vinId));
+        assertEquals(true, vehicles.removeByVinId(v1.vinId));
 
         // find none
-        Optional<Vehicle> found = vehicles.findById(v1.vinId);
+        Optional<Vehicle> found = vehicles.findByVinId(v1.vinId);
         assertEquals(false, found.isPresent());
 
         // update
-        assertEquals(true, vehicles.updateByIdAddPrice("TE201234567890003", 500.0f));
+        assertEquals(true, vehicles.updateByVinIdAddPrice("TE201234567890003", 500.0f));
 
         // find
-        found = vehicles.findById("TE201234567890003");
+        found = vehicles.findByVinId("TE201234567890003");
         assertEquals(true, found.isPresent());
         assertEquals(25500f, found.get().price, 0.001f);
 
@@ -4888,7 +4890,7 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testSliceWithLimit() {
         // This is not a recommended pattern. Testing to see how it is handled.
-        Page<Prime> slice = primes.findByRomanNumeralEndsWithAndIdLessThan("II", 50L, Limit.of(4), Sort.desc("id"));
+        Page<Prime> slice = primes.findByRomanNumeralEndsWithAndNumberIdLessThan("II", 50L, Limit.of(4), Sort.desc(ID));
 
         assertEquals(1L, slice.pageRequest().page());
         assertEquals(4L, slice.numberOfElements());
@@ -4900,7 +4902,7 @@ public class DataTestServlet extends FATServlet {
                                              .map(p -> p.romanNumeral)
                                              .collect(Collectors.toList()));
 
-        slice = primes.findByRomanNumeralEndsWithAndIdLessThan("II", 50L, slice.nextPageRequest(), Sort.desc("id"));
+        slice = primes.findByRomanNumeralEndsWithAndNumberIdLessThan("II", 50L, slice.nextPageRequest(), Sort.desc(ID));
 
         assertEquals(2L, slice.pageRequest().page());
         assertEquals(4L, slice.numberOfElements());
@@ -4912,7 +4914,7 @@ public class DataTestServlet extends FATServlet {
                                              .map(p -> p.romanNumeral)
                                              .collect(Collectors.toList()));
 
-        slice = primes.findByRomanNumeralEndsWithAndIdLessThan("II", 50L, slice.nextPageRequest(), Sort.desc("id"));
+        slice = primes.findByRomanNumeralEndsWithAndNumberIdLessThan("II", 50L, slice.nextPageRequest(), Sort.desc(ID));
 
         assertEquals(3L, slice.pageRequest().page());
         assertEquals(1L, slice.numberOfElements());
@@ -4931,9 +4933,9 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testSliceWithSortCriteriaAsSortParameters() {
-        Page<Prime> slice = primes.findByRomanNumeralEndsWithAndIdLessThan("I", 50L,
-                                                                           PageRequest.of(Prime.class).withoutTotal().size(5),
-                                                                           Sort.asc("sumOfBits"), Sort.desc("id"));
+        Page<Prime> slice = primes.findByRomanNumeralEndsWithAndNumberIdLessThan("I", 50L,
+                                                                                 PageRequest.of(Prime.class).withoutTotal().size(5),
+                                                                                 Sort.asc("sumOfBits"), Sort.desc(ID));
         assertEquals(1L, slice.pageRequest().page());
         assertEquals(5, slice.numberOfElements());
         assertEquals(1L, slice.pageRequest().page());
@@ -4942,9 +4944,9 @@ public class DataTestServlet extends FATServlet {
         assertIterableEquals(List.of(2L, 17L, 3L, 41L, 37L),
                              slice.stream().map(p -> p.numberId).collect(Collectors.toList()));
 
-        slice = primes.findByRomanNumeralEndsWithAndIdLessThan("I", 50L,
-                                                               slice.nextPageRequest(),
-                                                               Sort.asc("sumOfBits"), Sort.desc("id"));
+        slice = primes.findByRomanNumeralEndsWithAndNumberIdLessThan("I", 50L,
+                                                                     slice.nextPageRequest(),
+                                                                     Sort.asc("sumOfBits"), Sort.desc(ID));
         assertEquals(2L, slice.pageRequest().page());
         assertEquals(5, slice.numberOfElements());
         assertEquals(2L, slice.pageRequest().page());
@@ -4953,9 +4955,9 @@ public class DataTestServlet extends FATServlet {
         assertIterableEquals(List.of(13L, 11L, 7L, 43L, 23L),
                              slice.stream().map(p -> p.numberId).collect(Collectors.toList()));
 
-        slice = primes.findByRomanNumeralEndsWithAndIdLessThan("I", 50L,
-                                                               slice.nextPageRequest(),
-                                                               Sort.asc("sumOfBits"), Sort.desc("id"));
+        slice = primes.findByRomanNumeralEndsWithAndNumberIdLessThan("I", 50L,
+                                                                     slice.nextPageRequest(),
+                                                                     Sort.asc("sumOfBits"), Sort.desc(ID));
         assertEquals(3L, slice.pageRequest().page());
         assertEquals(2, slice.numberOfElements());
         assertEquals(3L, slice.pageRequest().page());
@@ -4972,10 +4974,10 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testSliceWithSortCriteriaInOrderByAnnotation() {
-        Page<Prime> slice = primes.findByRomanNumeralStartsWithAndIdLessThan("X", 50L,
-                                                                             PageRequest.of(Prime.class)
-                                                                                             .size(4)
-                                                                                             .withoutTotal());
+        Page<Prime> slice = primes.findByRomanNumeralStartsWithAndNumberIdLessThan("X", 50L,
+                                                                                   PageRequest.of(Prime.class)
+                                                                                                   .size(4)
+                                                                                                   .withoutTotal());
         assertEquals(1L, slice.pageRequest().page());
         assertEquals(4, slice.numberOfElements());
         assertEquals(1L, slice.pageRequest().page());
@@ -4985,7 +4987,7 @@ public class DataTestServlet extends FATServlet {
                              slice.stream().map(p -> p.name).collect(Collectors.toList()));
 
         assertEquals(true, slice.hasNext());
-        slice = primes.findByRomanNumeralStartsWithAndIdLessThan("X", 50L, slice.nextPageRequest());
+        slice = primes.findByRomanNumeralStartsWithAndNumberIdLessThan("X", 50L, slice.nextPageRequest());
         assertEquals(2L, slice.pageRequest().page());
         assertEquals(4, slice.numberOfElements());
         assertEquals(2L, slice.pageRequest().page());
@@ -4995,7 +4997,7 @@ public class DataTestServlet extends FATServlet {
                              slice.stream().map(p -> p.name).collect(Collectors.toList()));
 
         assertEquals(true, slice.hasNext());
-        slice = primes.findByRomanNumeralStartsWithAndIdLessThan("X", 50L, slice.nextPageRequest());
+        slice = primes.findByRomanNumeralStartsWithAndNumberIdLessThan("X", 50L, slice.nextPageRequest());
         assertEquals(3L, slice.pageRequest().page());
         assertEquals(3, slice.numberOfElements());
         assertEquals(3L, slice.pageRequest().page());
@@ -5012,10 +5014,10 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testSliceWithSortCriteriaInPageRequest() {
-        Page<Prime> slice = primes.findByRomanNumeralEndsWithAndIdLessThan("II", 50L,
-                                                                           PageRequest.ofSize(6)
-                                                                                           .withoutTotal()
-                                                                                           .sortBy(Sort.desc("numberId")));
+        Page<Prime> slice = primes.findByRomanNumeralEndsWithAndNumberIdLessThan("II", 50L,
+                                                                                 PageRequest.ofSize(6)
+                                                                                                 .withoutTotal()
+                                                                                                 .sortBy(Sort.desc("numberId")));
         assertEquals(1L, slice.pageRequest().page());
         assertEquals(6, slice.numberOfElements());
         assertEquals(1L, slice.pageRequest().page());
@@ -5024,8 +5026,8 @@ public class DataTestServlet extends FATServlet {
         assertIterableEquals(List.of(47L, 43L, 37L, 23L, 17L, 13L),
                              slice.stream().map(p -> p.numberId).collect(Collectors.toList()));
 
-        slice = primes.findByRomanNumeralEndsWithAndIdLessThan("II", 50L,
-                                                               slice.nextPageRequest());
+        slice = primes.findByRomanNumeralEndsWithAndNumberIdLessThan("II", 50L,
+                                                                     slice.nextPageRequest());
         assertEquals(2L, slice.pageRequest().page());
         assertEquals(3, slice.numberOfElements());
         assertEquals(2L, slice.pageRequest().page());
@@ -5196,7 +5198,7 @@ public class DataTestServlet extends FATServlet {
                                      "23(4)", "29(4)", "43(4)",
                                      "31(5)", "47(5)",
                                      "2(1)"),
-                             primes.findByNumberIdLessThanOrderByEven(50L, Sort.asc("sumOfBits"), Sort.asc("id"))
+                             primes.findByNumberIdLessThanOrderByEven(50L, Sort.asc("sumOfBits"), Sort.asc(ID))
                                              .map(p -> p.numberId + "(" + p.sumOfBits + ")")
                                              .collect(Collectors.toList()));
     }
@@ -5216,7 +5218,7 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testStreamable() {
-        List<Prime> streamable = primes.findByNumberIdLessThanEqualOrderByIdDesc(49L, Limit.of(14));
+        List<Prime> streamable = primes.findByNumberIdLessThanEqualOrderByNumberIdDesc(49L, Limit.of(14));
         Long total = streamable.stream().parallel().reduce(0L, (sum, p) -> sum + p.numberId, (sum1, sum2) -> sum1 + sum2);
         assertEquals(Long.valueOf(326), total);
 
@@ -5234,13 +5236,13 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testStreamableWithPagination() {
         PageRequest<?> p1 = PageRequest.ofSize(9);
-        List<Prime> list1 = primes.findByNumberIdLessThanEqualOrderByIdAsc(44L, p1);
+        List<Prime> list1 = primes.findByNumberIdLessThanEqualOrderByNumberIdAsc(44L, p1);
 
         assertIterableEquals(List.of(2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L),
                              list1.stream().map(p -> p.numberId).collect(Collectors.toList()));
 
         PageRequest<?> p2 = p1.next();
-        List<Prime> list2 = primes.findByNumberIdLessThanEqualOrderByIdAsc(44L, p2);
+        List<Prime> list2 = primes.findByNumberIdLessThanEqualOrderByNumberIdAsc(44L, p2);
 
         assertIterableEquals(List.of(29L, 31L, 37L, 41L, 43L),
                              list2.stream().map(p -> p.numberId).collect(Collectors.toList()));
@@ -5610,7 +5612,7 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testTrimmedKeyword() {
-        List<Prime> found = primes.findByNameTrimmedCharCountAndIdBetween(24, 4000L, 4025L);
+        List<Prime> found = primes.findByNameTrimmedCharCountAndNumberIdBetween(24, 4000L, 4025L);
         assertNotNull(found);
         assertEquals("Found: " + found, 1, found.size());
         assertEquals(4021L, found.get(0).numberId);
@@ -5780,7 +5782,7 @@ public class DataTestServlet extends FATServlet {
     @AllowedFFDC("jakarta.data.exceptions.OptimisticLockingFailureException")
     @Test
     public void testUpdateWithEntityParameter() {
-        people.deleteByIdBetween(0L, 999999999L);
+        people.deleteBySSN_IdBetween(0L, 999999999L);
 
         Person ursula = new Person();
         ursula.firstName = "Ursula";
@@ -5838,7 +5840,7 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(0, persons.updateSome());
 
-        assertEquals(4, people.deleteByIdBetween(0L, 999999999L));
+        assertEquals(4, people.deleteBySSN_IdBetween(0L, 999999999L));
     }
 
     /**
@@ -6003,7 +6005,7 @@ public class DataTestServlet extends FATServlet {
     public void testWhereClauseOnly() {
         // The prime numbers between 6 and 36:
         // 7, 11, 13, 17, 19, 23, 29, 31
-        Page<Prime> page1 = primes.within(6, 36, PageRequest.of(Prime.class).size(3).desc("id"));
+        Page<Prime> page1 = primes.within(6, 36, PageRequest.of(Prime.class).size(3).desc(ID));
 
         assertEquals(List.of(31L, 29L, 23L),
                      page1.stream()

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
@@ -12,12 +12,15 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import static jakarta.data.repository.By.ID;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 
 import jakarta.data.Order;
+import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
@@ -32,7 +35,8 @@ import jakarta.data.repository.Save;
 @Repository
 public interface Houses {
 
-    long deleteById(String parcel);
+    @Delete
+    long deleteById(@By(ID) String parcel);
 
     long deleteByKitchenWidthGreaterThan(int widthAbove);
 
@@ -42,18 +46,19 @@ public interface Houses {
     @Delete
     long dropAll();
 
-    boolean existsById(String parcel);
+    boolean existsByParcelId(String parcel);
 
     Stream<House> findByAreaGreaterThan(int minArea, Order<House> sorts);
 
     List<House> findByGarageTypeOrderByGarageDoorWidthDesc(Garage.Type type);
 
-    House findById(String parcel);
+    @Find
+    House findById(@By(ID) String parcel);
 
     @OrderBy("purchasePrice")
     int[] findGarageAreaByGarageNotNull();
 
-    Optional<Object[]> findGarageDoorAndKitchenLengthAndKitchenWidthById(String parcel);
+    Optional<Object[]> findGarageDoorAndKitchenLengthAndKitchenWidthByParcelId(String parcel);
 
     @OrderBy("lotSize")
     Stream<Object[]> findKitchenLengthAndKitchenWidthAndGarageAreaAndAreaByAreaLessThan(int maxArea);
@@ -73,5 +78,5 @@ public interface Houses {
     @Save
     List<House> save(House... h);
 
-    boolean updateByIdSetGarageAddAreaAddKitchenLengthSetNumBedrooms(String parcel, Garage updatedGarage, int addedArea, int addedKitchenLength, int newNumBedrooms);
+    boolean updateByParcelIdSetGarageAddAreaAddKitchenLengthSetNumBedrooms(String parcel, Garage updatedGarage, int addedArea, int addedKitchenLength, int newNumBedrooms);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/MultiRepository.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/MultiRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,9 +12,12 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import static jakarta.data.repository.By.ID;
+
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Repository;
@@ -34,7 +37,8 @@ public interface MultiRepository {
     @Insert
     Product create(Product prod);
 
-    Person[] deleteByIdIn(Iterable<Long> ids);
+    @Delete
+    Optional<Person> deleteById(@By(ID) Long id);
 
     Optional<Package> findById(Number id);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import static jakarta.data.repository.By.ID;
+
 import java.util.List;
 
 import jakarta.data.repository.By;
@@ -68,7 +70,7 @@ public interface PersonRepo {
 
     @Update
     @Transactional(TxType.MANDATORY)
-    boolean setFirstNameInCurrentTransaction(@By("id") Long ssn,
+    boolean setFirstNameInCurrentTransaction(@By(ID) Long ssn,
                                              @Assign("firstName") String newFirstName);
 
     @Update
@@ -78,12 +80,12 @@ public interface PersonRepo {
 
     @Update
     @Transactional(TxType.NEVER)
-    boolean setFirstNameWhenNoTransactionIsPresent(Long id,
+    boolean setFirstNameWhenNoTransactionIsPresent(@By(ID) Long id,
                                                    @Assign("FIRSTNAME") String newFirstName);
 
     @Update
     @Transactional(TxType.NOT_SUPPORTED)
-    boolean setFirstNameWithCurrentTransactionSuspended(Long id,
+    boolean setFirstNameWithCurrentTransactionSuspended(@By(ID) Long id,
                                                         @Assign("firstname") String newFirstName);
 
     @Update

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Personnel.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import static jakarta.data.repository.By.ID;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -53,7 +55,8 @@ public interface Personnel {
     void deleteByFirstName(String firstName);
 
     @Asynchronous
-    CompletableFuture<Void> deleteById(long ssn);
+    @Delete
+    CompletableFuture<Void> deleteById(@By(ID) long ssn);
 
     @Asynchronous
     @Delete

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import static jakarta.data.repository.By.ID;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
@@ -69,12 +71,12 @@ public interface Primes {
     boolean anyLessThanEndingWithBitPattern(@By("numberId") @LessThan long upperLimit,
                                             @By("binaryDigits") @EndsWith String pattern);
 
-    long countByIdLessThan(long number);
+    Integer countByNumberIdBetween(long first, long last);
 
     @Asynchronous
-    CompletableFuture<Short> countByIdBetweenAndEvenNot(long first, long last, boolean isOdd);
+    CompletableFuture<Short> countByNumberIdBetweenAndEvenNot(long first, long last, boolean isOdd);
 
-    Integer countByNumberIdBetween(long first, long last);
+    long countByNumberIdLessThan(long number);
 
     @Find
     Stream<Prime> find(boolean even, int sumOfBits, Limit limit, Sort<?>... sorts);
@@ -85,41 +87,41 @@ public interface Primes {
     @Find
     Optional<Prime> findByBinary(@By("binaryDigits") String binary);
 
-    @OrderBy("id")
-    List<Prime> findByEvenFalseAndIdLessThan(long max);
+    @OrderBy(ID)
+    List<Prime> findByEvenFalseAndNumberIdLessThan(long max);
 
-    List<Prime> findByEvenNotFalseAndIdLessThan(long max);
+    List<Prime> findByEvenNotFalseAndNumberIdLessThan(long max);
 
-    @OrderBy(value = "id", descending = true)
-    List<Prime> findByEvenNotTrueAndIdLessThan(long max);
+    @OrderBy(value = ID, descending = true)
+    List<Prime> findByEvenNotTrueAndNumberIdLessThan(long max);
 
-    List<Prime> findByEvenTrueAndIdLessThan(long max);
+    List<Prime> findByEvenTrueAndNumberIdLessThan(long max);
 
     @OrderBy(value = "romanNumeral", descending = true)
-    List<Prime> findByHexIgnoreCaseGreaterThanAndRomanNumeralIgnoreCaseLessThanEqualAndIdLessThan(String hexAbove, String maxNumeral, long numBelow);
+    List<Prime> findByHexIgnoreCaseGreaterThanAndRomanNumeralIgnoreCaseLessThanEqualAndNumberIdLessThan(String hexAbove, String maxNumeral, long numBelow);
 
     @OrderBy("name")
     Stream<Prime> findByNameCharCountBetween(int minLength, int maxLength);
 
     Prime findByNameIgnoreCase(String name);
 
-    List<Prime> findByNameIgnoreCaseBetweenAndIdLessThanOrderByIdDesc(String first, String last, long max);
+    List<Prime> findByNameIgnoreCaseBetweenAndNumberIdLessThanOrderByNumberIdDesc(String first, String last, long max);
 
-    List<Prime> findByNameIgnoreCaseContainsAndIdLessThanOrderByIdDesc(String pattern, long max);
+    List<Prime> findByNameIgnoreCaseContainsAndNumberIdLessThanOrderByNumberIdDesc(String pattern, long max);
 
-    List<Prime> findByNameIgnoreCaseLikeAndIdLessThanOrderByIdAsc(String pattern, long max);
+    List<Prime> findByNameIgnoreCaseLikeAndNumberIdLessThanOrderByNumberIdAsc(String pattern, long max);
 
-    List<Prime> findByNameIgnoreCaseNotAndIdLessThanOrderByIdAsc(String name, long max);
+    List<Prime> findByNameIgnoreCaseNotAndNumberIdLessThanOrderByNumberIdAsc(String name, long max);
 
-    List<Prime> findByNameIgnoreCaseStartsWithAndIdLessThanOrderByIdAsc(String pattern, long max);
+    List<Prime> findByNameIgnoreCaseStartsWithAndNumberIdLessThanOrderByNumberIdAsc(String pattern, long max);
 
     @OrderBy("even")
     @OrderBy("sumOfBits")
-    @OrderBy("id")
-    Iterator<Prime> findByNameStartsWithAndIdLessThanOrNameContainsAndIdLessThan(String prefix, long max1, String contains, long max2,
-                                                                                 PageRequest<?> pagination);
+    @OrderBy(ID)
+    Iterator<Prime> findByNameStartsWithAndNumberIdLessThanOrNameContainsAndNumberIdLessThan(String prefix, long max1, String contains, long max2,
+                                                                                             PageRequest<?> pagination);
 
-    List<Prime> findByNameTrimmedCharCountAndIdBetween(int length, long min, long max);
+    List<Prime> findByNameTrimmedCharCountAndNumberIdBetween(int length, long min, long max);
 
     Optional<Prime> findByNameTrimmedIgnoreCase(String name);
 
@@ -128,7 +130,7 @@ public interface Primes {
     @OrderBy("numberId")
     CursoredPage<Prime> findByNumberIdBetween(long min, long max, Limit limit);
 
-    @OrderBy("id")
+    @OrderBy(ID)
     CursoredPage<Prime> findByNumberIdBetween(long min, long max, PageRequest<?> pagination);
 
     List<Prime> findByNumberIdBetween(long min, long max, Sort<?>... orderBy);
@@ -139,7 +141,7 @@ public interface Primes {
 
     Page<Prime> findByNumberIdBetweenAndSumOfBitsNotNull(long min, long max, PageRequest<?> pagination);
 
-    CursoredPage<Prime> findByNumberIdBetweenOrderByEvenDescSumOfBitsDescIdAsc(long min, long max, PageRequest<?> pagination);
+    CursoredPage<Prime> findByNumberIdBetweenOrderByEvenDescSumOfBitsDescNumberIdAsc(long min, long max, PageRequest<?> pagination);
 
     List<Prime> findByNumberIdBetweenOrderByNameIgnoreCaseDesc(long min, long max);
 
@@ -149,16 +151,16 @@ public interface Primes {
     @OrderBy("numberId")
     List<Prime> findByNumberIdInAndRomanNumeralNotEmpty(List<Long> nums);
 
-    @OrderBy("id")
+    @OrderBy(ID)
     List<Prime> findByNumberIdInAndRomanNumeralNull(Iterable<Long> nums);
 
-    @OrderBy("id")
+    @OrderBy(ID)
     List<Prime> findByNumberIdInAndRomanNumeralNotNull(Set<Long> nums);
 
     @OrderBy("numberId")
     List<Prime> findByNumberIdInAndRomanNumeralSymbolsEmpty(Collection<Long> nums);
 
-    @OrderBy("id")
+    @OrderBy(ID)
     List<Prime> findByNumberIdInAndRomanNumeralSymbolsNotEmpty(Stack<Long> nums);
 
     Stream<Prime> findByNumberIdLessThan(long max);
@@ -167,9 +169,9 @@ public interface Primes {
     @OrderBy("sumOfBits")
     Page<Prime> findByNumberIdLessThan(long max, PageRequest<?> pagination);
 
-    List<Prime> findByNumberIdLessThanEqualOrderByIdAsc(long max, PageRequest<?> pagination);
+    List<Prime> findByNumberIdLessThanEqualOrderByNumberIdAsc(long max, PageRequest<?> pagination);
 
-    List<Prime> findByNumberIdLessThanEqualOrderByIdDesc(long max, Limit limit);
+    List<Prime> findByNumberIdLessThanEqualOrderByNumberIdDesc(long max, Limit limit);
 
     Page<Prime> findByNumberIdLessThanEqualOrderByNumberIdDesc(long max, PageRequest<?> pagination);
 
@@ -178,62 +180,62 @@ public interface Primes {
     CursoredPage<Prime> findByNumberIdLessThanOrderByEvenAscSumOfBitsAsc(long max, PageRequest<?> pagination);
 
     @Asynchronous
-    CompletionStage<CursoredPage<Prime>> findByNumberIdLessThanOrderByIdDesc(long max, PageRequest<?> pagination);
+    CompletionStage<CursoredPage<Prime>> findByNumberIdLessThanOrderByNumberIdDesc(long max, PageRequest<?> pagination);
 
     Iterator<Prime> findByNumberIdNotGreaterThan(long max, PageRequest<?> pagination);
 
     Iterator<Prime> findByNumberIdNotGreaterThan(long max, Sort<?>... order);
 
-    Page<Prime> findByRomanNumeralEndsWithAndIdLessThan(String ending, long max, Limit limit, Sort<?>... orderBy);
+    Page<Prime> findByRomanNumeralEndsWithAndNumberIdLessThan(String ending, long max, Limit limit, Sort<?>... orderBy);
 
-    Page<Prime> findByRomanNumeralEndsWithAndIdLessThan(String ending, long max, PageRequest<?> pagination, Sort<?>... orderBy);
+    Page<Prime> findByRomanNumeralEndsWithAndNumberIdLessThan(String ending, long max, PageRequest<?> pagination, Sort<?>... orderBy);
 
     @OrderBy(value = "sumOfBits", descending = true)
     @OrderBy("name")
-    Page<Prime> findByRomanNumeralStartsWithAndIdLessThan(String prefix, long max, PageRequest<?> pagination);
+    Page<Prime> findByRomanNumeralStartsWithAndNumberIdLessThan(String prefix, long max, PageRequest<?> pagination);
 
     @Find
     Prime findFirst(Sort<Prime> sort, Limit limitOf1);
 
-    Stream<Prime> findFirst2147483648ByIdGreaterThan(long min); // Exceeds Integer.MAX_VALUE by 1
+    Stream<Prime> findFirst2147483648ByNumberIdGreaterThan(long min); // Exceeds Integer.MAX_VALUE by 1
 
     @OrderBy(value = "name", descending = true)
-    Prime[] findFirst5ByIdLessThanEqual(long maxNumber);
+    Prime[] findFirst5ByNumberIdLessThanEqual(long maxNumber);
 
     Prime findFirstByNameLikeOrderByNumberId(String namePattern);
 
     @Find
     Optional<Prime> findHexadecimal(String hex);
 
-    List<Object[]> findIdAndNameBy(Sort<?>... sort);
+    List<Object[]> findNumberIdAndNameBy(Sort<?>... sort);
 
-    @OrderBy(value = "id", descending = true)
-    Set<Long> findIdByIdBetween(long min, long max);
+    @OrderBy(value = ID, descending = true)
+    Set<Long> findNumberIdByNumberIdBetween(long min, long max);
 
-    @OrderBy(value = "id", descending = true)
-    IntStream findSumOfBitsByIdBetween(long min, long max);
+    @OrderBy(value = ID, descending = true)
+    IntStream findSumOfBitsByNumberIdBetween(long min, long max);
 
     boolean existsByNumberId(long number);
 
-    Boolean existsByIdBetween(Long first, Long last);
+    Boolean existsByNumberIdBetween(Long first, Long last);
 
     @Count
-    long howManyIn(@By("id") @GreaterThanEqual long min,
-                   @By("id") @LessThanEqual long max);
+    long howManyIn(@By(ID) @GreaterThanEqual long min,
+                   @By(ID) @LessThanEqual long max);
 
     @Count
     Long howManyBetweenExclusive(@By("NumberId") @GreaterThan long exclusiveMin,
                                  @By("NumberId") @LessThan long exclusiveMax);
 
     @Find
-    @OrderBy(value = "id", descending = true)
-    List<Long> inRangeHavingNumeralLikeAndSubstringOfName(@By("id") @GreaterThanEqual long min,
-                                                          @By("id") @LessThanEqual long max,
+    @OrderBy(value = ID, descending = true)
+    List<Long> inRangeHavingNumeralLikeAndSubstringOfName(@By(ID) @GreaterThanEqual long min,
+                                                          @By(ID) @LessThanEqual long max,
                                                           @By("romanNumeral") @IgnoreCase @Like String pattern,
                                                           @By("name") @Contains String nameSuffix);
 
     @Exists
-    boolean isFoundWith(long id, String hex);
+    boolean isFoundWith(long numberId, String hex);
 
     // TODO after JDQL SELECT is added: "Select name Where length(romanNumeral) * 2 >= length(name) Order By name Asc",
     @Query(value = "Where numberId < 50 and romanNumeral is not null and length(romanNumeral) * 2 >= length(name) Order By name Desc",
@@ -242,17 +244,17 @@ public interface Primes {
 
     @Find
     @OrderBy(value = "numberId", descending = true)
-    Stream<Prime> lessThanWithSuffixOrBetweenWithSuffix(@By("id") @LessThan long numLessThan,
+    Stream<Prime> lessThanWithSuffixOrBetweenWithSuffix(@By(ID) @LessThan long numLessThan,
                                                         @By("name") @EndsWith String firstSuffix,
-                                                        @Or @By("id") @GreaterThanEqual long lowerLimit,
-                                                        @By("id") @LessThanEqual long upperLimit,
+                                                        @Or @By(ID) @GreaterThanEqual long lowerLimit,
+                                                        @By(ID) @LessThanEqual long upperLimit,
                                                         @By("name") @EndsWith String secondSuffix);
 
-    @OrderBy("id")
+    @OrderBy(ID)
     @Query("SELECT o.numberId FROM Prime o WHERE (o.name = :numberName OR :numeral=o.romanNumeral OR o.hex =:hex OR o.numberId=:num)")
     long[] matchAny(long num, String numeral, String hex, String numberName);
 
-    @OrderBy("id")
+    @OrderBy(ID)
     @Query("SELECT o.name FROM Prime o WHERE (o.name <> ':name' AND (o.numberId=?1 OR o.name=?2))")
     List<String> matchAnyExceptLiteralValueThatLooksLikeANamedParameter(long num, String name);
 
@@ -308,10 +310,10 @@ public interface Primes {
     Page<Object[]> namesWithHex(long maxNumber, PageRequest<?> pagination);
 
     @Find
-    @OrderBy("id")
-    List<Long> notWithinButBelow(@By("id") @LessThan int rangeMin,
-                                 @Or @By("id") @GreaterThan int rangeMax,
-                                 @By("id") @LessThan int below);
+    @OrderBy(ID)
+    List<Long> notWithinButBelow(@By(ID) @LessThan int rangeMin,
+                                 @Or @By(ID) @GreaterThan int rangeMax,
+                                 @By(ID) @LessThan int below);
 
     @Count
     int numEvenWithSumOfBits(int sumOfBits, boolean even);
@@ -350,12 +352,12 @@ public interface Primes {
 
     @Find
     List<Prime> withNameLengthAndWithin(@By("name") @Trimmed @CharCount int length,
-                                        @By("id") @GreaterThanEqual long min,
-                                        @By("id") @LessThanEqual long max);
+                                        @By(ID) @GreaterThanEqual long min,
+                                        @By(ID) @LessThanEqual long max);
 
     @Find
     @Select("name")
     List<String> withRomanNumeralSuffixAndWithoutNameSuffix(@By("romanNumeral") @EndsWith String numeralSuffix,
                                                             @By("name") @Not @EndsWith String nameSuffixToExclude,
-                                                            @By("id") @LessThanEqual long max);
+                                                            @By(ID) @LessThanEqual long max);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
@@ -57,7 +57,7 @@ public interface Products {
     @Query("WHERE pk=:productId")
     Product findItem(@Param("productId") UUID id);
 
-    Optional<Product> findById(UUID id);
+    Optional<Product> findByPK(UUID id);
 
     @Find
     @Select(function = Aggregate.MAXIMUM, value = "price")
@@ -87,7 +87,7 @@ public interface Products {
     // Custom repository method that combines multiple operations into a single transaction
     @Transactional
     default Product remove(UUID id) {
-        for (Optional<Product> product; (product = findById(id)).isPresent();)
+        for (Optional<Product> product; (product = findByPK(id)).isPresent();)
             if (discontinueProducts(Set.of(id)) == 1)
                 return product.get();
         return null;
@@ -100,7 +100,7 @@ public interface Products {
     Product[] saveMultiple(Product... p);
 
     @Update
-    boolean setPrice(UUID id,
+    boolean setPrice(UUID pk,
                      long version,
                      @Assign("price") float newPrice);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
@@ -14,6 +14,7 @@ package test.jakarta.data.web;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Delete;
@@ -32,6 +33,12 @@ public interface Receipts extends CrudRepository<Receipt, Long> {
 
     Optional<Receipt> deleteByPurchaseId(long purchaseId);
 
+    int deleteByPurchaseIdIn(Iterable<Long> ids);
+
     @Delete
     Collection<Receipt> discardFor(String customer);
+
+    boolean existsByPurchaseId(long id);
+
+    Stream<Receipt> findByPurchaseIdIn(Iterable<Long> ids);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
@@ -15,6 +15,7 @@ package test.jakarta.data.web;
 import static io.openliberty.data.repository.function.Extract.Field.HOUR;
 import static io.openliberty.data.repository.function.Extract.Field.MINUTE;
 import static io.openliberty.data.repository.function.Extract.Field.SECOND;
+import static jakarta.data.repository.By.ID;
 
 import java.time.OffsetDateTime;
 import java.util.AbstractCollection;
@@ -64,17 +65,23 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
 
     long deleteByHostNot(String host);
 
+    void deleteByMeetingIdIn(Iterable<Long> ids);
+
     @Find
     @Select("meetingId")
-    @OrderBy("id")
+    @OrderBy(ID)
     List<Long> endsAtSecond(@By("stop") @Extract(SECOND) int second);
+
+    Boolean existsByMeetingId(long meetingID);
 
     Iterable<Reservation> findByHost(String host);
 
-    @OrderBy("id")
+    @OrderBy(ID)
     Stream<Reservation> findByInviteesElementCount(int size);
 
     Collection<Reservation> findByLocationContainsOrderByMeetingID(String locationSubstring);
+
+    Stream<Reservation> findByMeetingIdIn(Iterable<Long> ids);
 
     List<Reservation> findByMeetingIDOrLocationLikeAndStartAndStopOrHost(long meetingID,
                                                                          String location,
@@ -144,6 +151,6 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
     boolean updateByMeetingIDSetHost(long meetingID, String newHost);
 
     @Find
-    @OrderBy("id")
+    @OrderBy(ID)
     Stream<Reservation> withInviteeCount(@By("invitees") @ElementCount int size);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Things.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Things.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,9 +12,13 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import static jakarta.data.repository.By.ID;
+
 import java.util.stream.Stream;
 
+import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
@@ -47,19 +51,20 @@ public interface Things {
      */
     Stream<Thing> findByFloorNotAndInfoLikeAndOrderNumberLessThan(Integer floor, String infoPattern, long orderNumBelow);
 
-    Thing findById(long id);
+    @Find
+    Thing findById(@By(ID) long id);
+
+    /**
+     * The "Or" in "OrderNumber" should not be treated as a keyword because it immediately follows "findBy".
+     */
+    Stream<Thing> findByOrderNumber(long orderNum);
 
     /**
      * "Desc" within OrderByDescription would be treated as a keyword,
      * but @OrderBy can be used instead.
      */
     @OrderBy("description")
-    Stream<Thing> findByIdGreaterThan(long idAbove);
-
-    /**
-     * The "Or" in "OrderNumber" should not be treated as a keyword because it immediately follows "findBy".
-     */
-    Stream<Thing> findByOrderNumber(long orderNum);
+    Stream<Thing> findByThingIdGreaterThan(long exclusiveMin);
 
     /**
      * "Or" within findBy...PurchaseOrder... would be treated as a keyword,

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
@@ -26,15 +26,15 @@ import jakarta.data.repository.Save;
 @Repository(dataStore = "java:module/jdbc/env/DerbyDataSourceRef")
 public interface Vehicles {
 
-    Optional<Vehicle> findById(String vin);
+    Optional<Vehicle> findByVinId(String vin);
 
     @Delete
     long removeAll();
 
-    boolean removeById(String vin);
+    boolean removeByVinId(String vin);
 
     @Save
     Iterable<Vehicle> save(Iterable<Vehicle> v);
 
-    boolean updateByIdAddPrice(String vin, float priceIncrease);
+    boolean updateByVinIdAddPrice(String vin, float priceIncrease);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/_House.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/_House.java
@@ -40,8 +40,6 @@ public class _House {
 
     public static volatile SortableAttribute<House> kitchen_width;
 
-    public static volatile TextAttribute<House> id;
-
     public static volatile SortableAttribute<House> LotSize;
 
     public static final String NUM_BEDROOMS = "numBedrooms";

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/_Prime.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/_Prime.java
@@ -25,7 +25,6 @@ public class _Prime {
     public static final String BINARYDIGITS = "binaryDigits";
     public static final String EVEN = "even";
     public static final String HEX = "hex";
-    public static final String ID = "id";
     public static final String NAME = "name";
     public static final String NUMBERID = "numberId";
     public static final String ROMANNUMERAL = "romanNumeral";
@@ -37,8 +36,6 @@ public class _Prime {
     public static volatile SortableAttribute<Prime> even;
 
     public static volatile TextAttribute<Prime> hex;
-
-    public static volatile SortableAttribute<Prime> id;
 
     public static volatile TextAttribute<Prime> name;
 

--- a/dev/io.openliberty.data.internal_fat_config/test-applications/DataConfigTestApp/src/test/jakarta/data/config/web/DataConfigTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_config/test-applications/DataConfigTestApp/src/test/jakarta/data/config/web/DataConfigTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@
 package test.jakarta.data.config.web;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -85,10 +84,10 @@ public class DataConfigTestServlet extends FATServlet {
      * Adds new data to tables. The data must not already exist.
      */
     public void testEntitiesCanBeAdded(HttpServletRequest request, PrintWriter response) {
-        assertEquals(false, employees.existsById(111222));
+        assertEquals(false, employees.findById(111222).isPresent());
         employees.save(new Employee(111222, "Dan", "TestDropCreateTables", 52));
 
-        assertEquals(false, students.existsById(1234));
+        assertEquals(false, students.findById(1234).isPresent());
         students.save(new Student(1234, "Dylan", "TestDropCreateTables", 12));
     }
 
@@ -97,8 +96,8 @@ public class DataConfigTestServlet extends FATServlet {
      */
     public void testEntitiesDoNotHaveTables(HttpServletRequest request, PrintWriter response) {
         try {
-            boolean foundEntry = employees.existsById(111222);
-            fail("Employee table should not be found. Contains entry? " + foundEntry);
+            Employee found = employees.findById(111222).orElseGet(() -> null);
+            assertEquals("Employee table should not be found.", null, found);
         } catch (DataException x) {
             boolean expectedException = false;
             for (Throwable cause = x.getCause(); cause != null && !expectedException; cause = cause.getCause())
@@ -108,8 +107,8 @@ public class DataConfigTestServlet extends FATServlet {
         }
 
         try {
-            boolean foundEntry = students.existsById(1234);
-            fail("Student table should not be found. Contains entry? " + foundEntry);
+            Student found = students.findById(1234).orElseGet(() -> null);
+            assertEquals("Student table should not be found", null, found);
         } catch (DataException x) {
             boolean expectedException = false;
             for (Throwable cause = x.getCause(); cause != null && !expectedException; cause = cause.getCause())
@@ -123,16 +122,16 @@ public class DataConfigTestServlet extends FATServlet {
      * Verifies that entities are found in the database.
      */
     public void testEntitiesFound(HttpServletRequest request, PrintWriter response) {
-        assertEquals(true, employees.existsById(111222));
-        assertEquals(true, students.existsById(1234));
+        assertEquals(true, employees.findById(111222).isPresent());
+        assertEquals(true, students.findById(1234).isPresent());
     }
 
     /**
      * Verifies that entities are not found in the database.
      */
     public void testEntitiesNotFound(HttpServletRequest request, PrintWriter response) {
-        assertEquals(false, employees.existsById(111222));
-        assertEquals(false, students.existsById(1234));
+        assertEquals(false, employees.findById(111222).isPresent());
+        assertEquals(false, students.findById(1234).isPresent());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Accounts.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Accounts.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,10 +10,14 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import static jakarta.data.repository.By.ID;
+
 import java.util.List;
 import java.util.stream.Stream;
 
+import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Repository;
@@ -52,19 +56,20 @@ public interface Accounts {
     @OrderBy("accountId")
     Stream<AccountId> findByBankName(String bank);
 
-    Account findById(AccountId id);
+    @Find
+    Account findById(@By(ID) AccountId id);
 
     // EclipseLink IllegalArgumentException:
     // Problem compiling [SELECT o FROM Account o WHERE (o.accountId BETWEEN ?1 AND ?2)].
     // [31, 42] The association field 'o.accountId' cannot be used as a state field path.
-    List<Account> findByIdBetween(AccountId minId, AccountId maxId);
+    List<Account> findByAccountIdBetween(AccountId minId, AccountId maxId);
 
-    List<Account> findByIdEmpty();
+    List<Account> findByAccountIdEmpty();
 
     // EclipseLink IllegalArgumentException:
     // Problem compiling [SELECT o FROM Account o WHERE (o.accountId>?1)].
     // The relationship mapping 'o.accountId' cannot be used in conjunction with the > operator
-    Stream<Account> findByIdGreaterThan(AccountId id);
+    Stream<Account> findByAccountIdGreaterThan(AccountId id);
 
     // EclipseLink org.eclipse.persistence.exceptions.DatabaseException
     // java.sql.SQLSyntaxErrorException: Syntax error: Encountered "," at line 1, column 102. Error Code: 30000
@@ -72,16 +77,16 @@ public interface Accounts {
     // WHERE (((ACCOUNTNUM, ROUTINGNUM) IN (AccountId:1004470:30372, AccountId:1006380:22158)) OR (OWNER = ...)) ORDER BY OWNER DESC
     // ** position 102 is ^ **
     @OrderBy(value = "owner", descending = true)
-    Stream<Account> findByIdInOrOwner(List<AccountId> id, String owner);
+    Stream<Account> findByAccountIdInOrOwner(List<AccountId> id, String owner);
 
     @OrderBy("accountId")
-    Stream<Account> findByIdNotNull();
+    Stream<Account> findByAccountIdNotNull();
 
     // EclipseLink org.eclipse.persistence.exceptions.DescriptorException
     // No subclass matches this class [class java.lang.Boolean] for this Aggregate mapping with inheritance.
     // Mapping: org.eclipse.persistence.mappings.AggregateObjectMapping[accountId]
     // Descriptor: RelationalDescriptor(test.jakarta.data.jpa.web.Account --> [DatabaseTable(WLPAccount)])
-    List<Account> findByIdTrue();
+    List<Account> findByAccountIdTrue();
 
     @Delete
     void remove(Account account);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Badge.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Badge.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,10 +12,9 @@ package test.jakarta.data.jpa.web;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.Id;
 
 /**
- *
+ * Embeddable object for the Employee entity.
  */
 @Embeddable
 public class Badge {
@@ -23,7 +22,6 @@ public class Badge {
     public char accessLevel;
 
     @Column(name = "BADGENUM")
-    @Id
     public short number;
 
     public Badge() {

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
@@ -51,9 +51,9 @@ public interface Counties {
 
     Timestamp findLastUpdatedByName(String name);
 
-    int[] findZipCodesById(String name);
-
     Optional<int[]> findZipCodesByName(String name);
+
+    int[] findZipCodesByNameContains(String substring);
 
     @OrderBy("population")
     Stream<int[]> findZipCodesByNameEndsWith(String ending);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
@@ -17,6 +17,7 @@ import static io.openliberty.data.repository.function.Extract.Field.MONTH;
 import static io.openliberty.data.repository.function.Extract.Field.QUARTER;
 import static io.openliberty.data.repository.function.Extract.Field.WEEK;
 import static io.openliberty.data.repository.function.Extract.Field.YEAR;
+import static jakarta.data.repository.By.ID;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -79,7 +80,7 @@ public interface CreditCards extends DataRepository<CreditCard, CardId> {
     @OrderBy("debtor_email")
     Stream<Customer> findByIssuer(Issuer cardIssuer);
 
-    @OrderBy("id")
+    @OrderBy(ID)
     Stream<CardId> findBySecurityCode(int code);
 
     @OrderBy("number")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -1937,9 +1938,25 @@ public class DataJPATestServlet extends FATServlet {
                                              .map(Badge::toString)
                                              .collect(Collectors.toList()));
 
-        // TODO add tests that query on Id once we add support Id not being the unique identifier
+        // Use @OrderBy to sort by the id attribute which is not a unique identifier:
+        assertEquals(List.of("Irene", "Isaac", "Isabella", "Ivan"),
+                     employees.findByFirstNameStartsWith("I")
+                                     .map(e -> e.firstName)
+                                     .collect(Collectors.toList()));
+
+        // Use the OrderBy keyword to sort by the id attribute which is not a unique identifier:
+        assertEquals(List.of("Ivan", "Isabella", "Isaac", "Irene"),
+                     employees.findByFirstNameStartsWithOrderByIdDesc("I")
+                                     .map(e -> e.firstName)
+                                     .collect(Collectors.toList()));
+
+        Optional<Employee> found = employees.withId("Ivan testIdThatIsNotTheUniqueIdentifier");
+        assertEquals(true, found.isPresent());
+        assertEquals(1004948, found.get().empNum);
 
         employees.deleteByLastName("testIdThatIsNotTheUniqueIdentifier");
+
+        assertEquals(false, employees.withId("Ivan testIdThatIsNotTheUniqueIdentifier").isPresent());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employee.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employee.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,33 +13,40 @@ package test.jakarta.data.jpa.web;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 
 /**
- *
+ * Employee entity for tests.
  */
 @Entity
 public class Employee {
+    @Embedded
+    public Badge badge;
+
+    @Id
+    public int empNum;
 
     @Column(name = "LNAME")
     public String firstName;
 
+    public String id;
+
     @Column(name = "FNAME")
     public String lastName;
-
-    @Embedded
-    public Badge badge;
 
     public Employee() {
     }
 
-    Employee(String firstName, String lastName, short badgeNum, char accessLevel) {
+    Employee(int empNum, String firstName, String lastName, short badgeNum, char accessLevel) {
+        this.empNum = empNum;
         this.firstName = firstName;
         this.lastName = lastName;
+        this.id = firstName + " " + lastName;
         this.badge = new Badge(badgeNum, accessLevel);
     }
 
     @Override
     public String toString() {
-        return "Employee " + firstName + " " + lastName + " " + badge;
+        return "Employee #" + empNum + " " + firstName + " " + lastName + " " + badge;
     }
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -29,14 +29,15 @@ public interface Employees {
 
     Employee findByBadgeNumber(long badgeNumber);
 
+    Employee findByEmpNum(long employeeNumber);
+
     @OrderBy("badge.number")
     Stream<Employee> findByFirstNameLike(String pattern);
 
-    List<Employee> findByFirstNameStartsWithOrderByIdDesc(String prefix);
+    List<Employee> findByFirstNameStartsWithOrderByEmpNumDesc(String prefix);
 
-    Employee findById(long badgeNumber);
-
-    @OrderBy("badge")
+    @OrderBy("badge.number")
+    @OrderBy("badge.accessLevel")
     Stream<Badge> findByLastName(String lastName);
 
     // "IN" is not supported for embeddables, but EclipseLink generates SQL that leads to an SQLDataException rather than rejecting outright

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
@@ -11,8 +11,11 @@
 package test.jakarta.data.jpa.web;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
+import jakarta.data.repository.By;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
@@ -34,7 +37,12 @@ public interface Employees {
     @OrderBy("badge.number")
     Stream<Employee> findByFirstNameLike(String pattern);
 
+    @OrderBy("id")
+    Stream<Employee> findByFirstNameStartsWith(String prefix);
+
     List<Employee> findByFirstNameStartsWithOrderByEmpNumDesc(String prefix);
+
+    Stream<Employee> findByFirstNameStartsWithOrderByIdDesc(String prefix);
 
     @OrderBy("badge.number")
     @OrderBy("badge.accessLevel")
@@ -43,4 +51,7 @@ public interface Employees {
     // "IN" is not supported for embeddables, but EclipseLink generates SQL that leads to an SQLDataException rather than rejecting outright
     @Query("SELECT e FROM Employee e WHERE e.badge IN ?1")
     List<Employee> withBadge(Iterable<Badge> badges);
+
+    @Find
+    Optional<Employee> withId(@By("id") String id);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Manufacturer.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Manufacturer.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+
+/**
+ * This entity has a OneToMany relationship with Model.
+ */
+@Entity
+public class Manufacturer {
+
+    @Id
+    private UUID id;
+
+    @OneToMany(cascade = CascadeType.ALL,
+               mappedBy = "manufacturer")
+    private Set<Model> models;
+
+    private String name;
+
+    private String notes;
+
+    public Manufacturer() {
+        id = UUID.randomUUID();
+        models = new LinkedHashSet<>();
+    }
+
+    public void addModel(Model model) {
+        models.add(model);
+        model.setManufacturer(this);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Set<Model> getModels() {
+        return models;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public void setModels(Set<Model> models) {
+        for (Model model : this.models) {
+            model.setManufacturer(null);
+        }
+
+        this.models.clear();
+
+        for (Model model : models) {
+            addModel(model);
+        }
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    @Override
+    public String toString() {
+        return "Manufacturer " + name + " " + id + ": " + notes;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Manufacturers.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Manufacturers.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.UUID;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for the Manufacturer entity.
+ */
+@Repository
+public interface Manufacturers extends CrudRepository<Manufacturer, UUID> {
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Model.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Model.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+/**
+ * This entity has a ManyToOne relationship with Manufacturer.
+ */
+@Entity
+public class Model {
+
+    @Id
+    private UUID id;
+
+    @JoinColumn(name = "manufacturer_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Manufacturer manufacturer;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "intro_year")
+    private Integer yearIntroduced;
+
+    public Model() {
+        id = UUID.randomUUID();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Manufacturer getManufacturer() {
+        return manufacturer;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getYearIntroduced() {
+        return yearIntroduced;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public void setManufacturer(Manufacturer manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setYearIntroduced(Integer yearIntroduced) {
+        this.yearIntroduced = yearIntroduced;
+    }
+
+    @Override
+    public String toString() {
+        return "Model " + name + " " + yearIntroduced + " " + id;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Models.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Models.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.UUID;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for the Model entity.
+ */
+@Repository
+public interface Models extends CrudRepository<Model, UUID> {
+}

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/BasicRepository.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/BasicRepository.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package jakarta.data.repository;
 
+import static jakarta.data.repository.By.ID;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -32,7 +34,8 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
 
     void deleteByIdIn(Iterable<K> ids);
 
-    void deleteById(K id);
+    @Delete
+    void deleteById(@By(ID) K id);
 
     boolean existsById(K id);
 
@@ -44,7 +47,8 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
 
     Stream<T> findByIdIn(Iterable<K> ids);
 
-    Optional<T> findById(K id);
+    @Find
+    Optional<T> findById(@By(ID) K id);
 
     @Save
     <S extends T> S save(S entity);

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/By.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/By.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,5 +23,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
 public @interface By {
+    String ID = "#id";
+
     String value();
 }


### PR DESCRIPTION
Align with changes to the specification that Id is no longer considered an alias for the unique identifier.
This also fixes a bug with overwriting the id.