### PR TITLE
3 methods removed from BasicRepository

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -59,6 +59,8 @@ public interface Packages extends BasicRepository<Package, Integer> {
 
     Package[] deleteByDescriptionEndsWith(String ending, Sort<?>... sorts);
 
+    void deleteByIdIn(Iterable<Integer> ids);
+
     @Query("DELETE FROM Package")
     int deleteEverything();
 

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/BasicRepository.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/BasicRepository.java
@@ -32,20 +32,14 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     @Delete
     void deleteAll(List<? extends T> entities);
 
-    void deleteByIdIn(Iterable<K> ids);
-
     @Delete
     void deleteById(@By(ID) K id);
-
-    boolean existsById(K id);
 
     @Find
     Stream<T> findAll();
 
     @Find
     Page<T> findAll(PageRequest<T> pageRequest);
-
-    Stream<T> findByIdIn(Iterable<K> ids);
 
     @Find
     Optional<T> findById(@By(ID) K id);


### PR DESCRIPTION
Align with latest Jakarta Data which removes the following from BasicRepository:
existsById
findByIdIn
deleteByIdIn