### PR TITLE
insert parenthesis around WHERE clause for cursor pagination

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -301,7 +301,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                                                              count, exists, select);
 
         if (query != null) { // @Query annotation
-            queryInfo.initForQuery(query.value(), query.count(), countPages);
+            queryInfo.initForQuery(query.value(), query.count(), countPages, multiType);
         } else if (save != null) { // @Save annotation
             queryInfo.init(Save.class, QueryInfo.Type.SAVE);
         } else if (insert != null) { // @Insert annotation

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2527,6 +2527,41 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Use a repository method with cursor-based pagination that does not specify parenthesis
+     * in the WHERE clause.
+     */
+    @Test
+    public void testParenthesisInsertionForCursorPagination() {
+        PageRequest<?> page1Request = PageRequest.ofSize(3).asc("name").asc(ID);
+        CursoredPage<Business> page1 = mixed.withZipCodeIn(55901, 55904, page1Request);
+
+        assertEquals(List.of("Benike Construction", "Crenlo", "Home Federal Savings Bank"),
+                     page1.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(true, page1.hasNext());
+
+        CursoredPage<Business> page2 = mixed.withZipCodeIn(55901, 55904, page1.nextPageRequest());
+
+        assertEquals(List.of("IBM", "Metafile", "Olmsted Medical"),
+                     page2.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(true, page1.hasNext());
+
+        CursoredPage<Business> page3 = mixed.withZipCodeIn(55901, 55904, page2.nextPageRequest());
+
+        assertEquals(List.of("RAC", "Think Bank"),
+                     page3.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(false, page3.hasNext());
+    }
+
+    /**
      * Tests lifecycle methods returning a single record.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
@@ -55,4 +55,7 @@ public interface MixedRepository { // Do not inherit from a supertype
 
     @Query("FROM Business WHERE location.address.city=:city AND location.address.state=:state")
     CursoredPage<Business> locatedIn(String city, String state, PageRequest<Business> pageRequest);
+
+    @Query("FROM Business WHERE location.address.zip=?1 OR location.address.zip=?2")
+    CursoredPage<Business> withZipCodeIn(int zip1, int zip2, PageRequest<?> pageRequest);
 }


### PR DESCRIPTION
The Jakarta Data spec removed a requirement for the user to enclose their WHERE clause in parenthesis, and now we need to cover that if needing to append conditions for cursor-based pagination.