### PR TITLE
Update CDI API to 4.1.0.RC1, fix weld version refs

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1324,12 +1324,12 @@
     <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
-      <version>4.1.0.Beta2</version>
+      <version>4.1.0.RC1</version>
     </dependency>
     <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
-      <version>4.1.0.Beta2</version>
+      <version>4.1.0.RC1</version>
     </dependency>
     <dependency>
       <groupId>jakarta.enterprise</groupId>
@@ -1339,7 +1339,7 @@
     <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.lang-model</artifactId>
-      <version>4.1.0.Beta2</version>
+      <version>4.1.0.RC1</version>
     </dependency>
     <dependency>
       <groupId>jakarta.inject</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -260,10 +260,10 @@ jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.0.3
 jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:3.1.0-M1
 jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.1
 jakarta.enterprise:jakarta.enterprise.cdi-api:4.0.1
-jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0.Beta2
-jakarta.enterprise:jakarta.enterprise.cdi-el-api:4.1.0.Beta2
+jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0.RC1
+jakarta.enterprise:jakarta.enterprise.cdi-el-api:4.1.0.RC1
 jakarta.enterprise:jakarta.enterprise.lang-model:4.0.1
-jakarta.enterprise:jakarta.enterprise.lang-model:4.1.0.Beta2
+jakarta.enterprise:jakarta.enterprise.lang-model:4.1.0.RC1
 jakarta.inject:jakarta.inject-api:2.0.1
 jakarta.interceptor:jakarta.interceptor-api:2.0.1
 jakarta.interceptor:jakarta.interceptor-api:2.1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.cdi-4.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.cdi-4.1.feature
@@ -5,7 +5,7 @@ singleton=true
   com.ibm.websphere.appserver.eeCompatible-11.0, \
   io.openliberty.jakarta.interceptor-2.2, \
   io.openliberty.noShip-1.0
--bundles=io.openliberty.jakarta.cdi.4.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0.Alpha1"
+-bundles=io.openliberty.jakarta.cdi.4.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0.RC1"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-4.1/io.openliberty.cdi-4.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-4.1/io.openliberty.cdi-4.1.feature
@@ -64,7 +64,7 @@ Subsystem-Name: Jakarta Contexts and Dependency Injection 4.1
  com.ibm.ws.cdi.interfaces.jakarta, \
  io.openliberty.cdi.4.0.internal.interfaces, \
  io.openliberty.cdi.spi; location:="dev/spi/ibm/,lib/"
--jars=io.openliberty.cdi.4.1.thirdparty; location:="dev/api/third-party/,lib/"; mavenCoordinates="org.jboss.weld:weld-osgi-bundle:6.0.0.Alpha1"
+-jars=io.openliberty.cdi.4.1.thirdparty; location:="dev/api/third-party/,lib/"; mavenCoordinates="org.jboss.weld:weld-osgi-bundle:6.0.0.Beta1"
 -files=dev/api/ibm/schema/ibm-managed-bean-bnd_1_0.xsd, \
  dev/api/ibm/schema/ibm-managed-bean-bnd_1_1.xsd, \
  dev/spi/ibm/javadoc/io.openliberty.cdi.spi_1.1-javadoc.zip

--- a/dev/io.openliberty.cdi.4.1.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.cdi.4.1.thirdparty/bnd.bnd
@@ -20,8 +20,8 @@ Bundle-SymbolicName: io.openliberty.cdi.4.1.thirdparty
 Bundle-Description: WebSphere CDI 4.1 Weld Third Party API
 
 Export-Package:\
- org.jboss.weld.context;version=6.0.0.Alpha1, \
- org.jboss.weld.context.*;version=6.0.0.Alpha1
+ org.jboss.weld.context;version=6.0.0.Beta1, \
+ org.jboss.weld.context.*;version=6.0.0.Beta1
 
 Import-Package:*
 

--- a/dev/io.openliberty.jakarta/cdi.4.1.bnd
+++ b/dev/io.openliberty.jakarta/cdi.4.1.bnd
@@ -61,14 +61,14 @@ publish.wlp.jar.suffix: dev/api/spec
 
 -includeresource: \
    @${repo;jakarta.inject:jakarta.inject-api;2.0.1;EXACT}!/!(META-INF/maven/*|module-info.class),\
-   @${repo;jakarta.enterprise:jakarta.enterprise.cdi-api;4.1.0.Beta2;EXACT}!/!(META-INF/maven/*|module-info.class),\
-   @${repo;jakarta.enterprise:jakarta.enterprise.cdi-el-api;4.1.0.Beta2;EXACT}!/!(META-INF/maven/*|module-info.class),\
-   @${repo;jakarta.enterprise:jakarta.enterprise.lang-model;4.1.0.Beta2;EXACT}!/!(META-INF/maven/*|module-info.class)
+   @${repo;jakarta.enterprise:jakarta.enterprise.cdi-api;4.1.0.RC1;EXACT}!/!(META-INF/maven/*|module-info.class),\
+   @${repo;jakarta.enterprise:jakarta.enterprise.cdi-el-api;4.1.0.RC1;EXACT}!/!(META-INF/maven/*|module-info.class),\
+   @${repo;jakarta.enterprise:jakarta.enterprise.lang-model;4.1.0.RC1;EXACT}!/!(META-INF/maven/*|module-info.class)
 
 -maven-dependencies: \
    dep1;groupId=jakarta.inject;artifactId=jakarta.inject-api;version=2.0.1;scope=runtime,\
-   dep2;groupId=jakarta.enterprise;artifactId=jakarta.enterprise.cdi-api;version=4.1.0.Beta2;scope=runtime,\
-   dep3;groupId=jakarta.enterprise;artifactId=jakarta.enterprise.cdi-el-api;version=4.1.0.Beta2;scope=runtime,\
-   dep4;groupId=jakarta.enterprise;artifactId=jakarta.enterprise.lang-model;version=4.1.0.Beta2;scope=runtime
+   dep2;groupId=jakarta.enterprise;artifactId=jakarta.enterprise.cdi-api;version=4.1.0.RC1;scope=runtime,\
+   dep3;groupId=jakarta.enterprise;artifactId=jakarta.enterprise.cdi-el-api;version=4.1.0.RC1;scope=runtime,\
+   dep4;groupId=jakarta.enterprise;artifactId=jakarta.enterprise.lang-model;version=4.1.0.RC1;scope=runtime
 
 


### PR DESCRIPTION
* Update the CDI API jars to the latest version
* Fix some references to the Weld version which were missed in the last update (the correct version of weld was being included, but some manifests listed the wrong version)
