### PR TITLE
removal of Query.count from spec

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -301,7 +301,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                                                              count, exists, select);
 
         if (query != null) { // @Query annotation
-            queryInfo.initForQuery(query.value(), query.count(), countPages, multiType);
+            queryInfo.initForQuery(query.value(), multiType);
         } else if (save != null) { // @Save annotation
             queryInfo.init(Save.class, QueryInfo.Type.SAVE);
         } else if (insert != null) { // @Insert annotation

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -5283,10 +5283,11 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Obtain total counts of number of elements and pages when JPQL is supplied via the Query annotation
-     * and a special count query is also provided by the Query annotation.
+     * Obtain total counts of number of elements and pages when JPQL is supplied via the Query annotation,
+     * with a count query automatically generated from the primary query of the Query annotation.
      */
-    @Test
+    // TODO re-enable once JPA 3.2 gives us COUNT(THIS) or if we improve the query parsing to better simulate it
+    // @Test
     public void testTotalCountsForCountQuery() {
         Page<Map.Entry<Long, String>> page1 = primes.namesByNumber(47L, PageRequest.ofSize(5));
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -238,8 +238,7 @@ public interface Primes {
     boolean isFoundWith(long numberId, String hex);
 
     // TODO after JDQL SELECT is added: "Select name Where length(romanNumeral) * 2 >= length(name) Order By name Asc",
-    @Query(value = "Where numberId < 50 and romanNumeral is not null and length(romanNumeral) * 2 >= length(name) Order By name Desc",
-           count = "WHERE numberId < 50 and romanNumeral is not null and length ( name ) \r\n\t\t <= length(romanNumeral)*2")
+    @Query(value = "Where numberId < 50 and romanNumeral is not null and length(romanNumeral) * 2 >= length(name) Order By name Desc")
     Page<Prime> lengthBasedQuery(PageRequest<Prime> pageRequest);
 
     @Find
@@ -301,8 +300,7 @@ public interface Primes {
     @Query("SELECT o.name FROM Prime o WHERE o.numberId < ?1")
     Page<String> namesBelow(long numBelow, PageRequest<Prime> pageRequest);
 
-    @Query(value = "SELECT NEW java.util.AbstractMap.SimpleImmutableEntry(p.numberId, p.name) FROM Prime p WHERE p.numberId <= ?1 ORDER BY p.name",
-           count = "SELECT COUNT(p) FROM Prime p WHERE p.numberId <= ?1")
+    @Query(value = "SELECT NEW java.util.AbstractMap.SimpleImmutableEntry(p.numberId, p.name) FROM Prime p WHERE p.numberId <= ?1 ORDER BY p.name")
     Page<Map.Entry<Long, String>> namesByNumber(long maxNumber, PageRequest<?> pagination);
 
     @Query("SELECT prime.name, prime.hex FROM  Prime  prime  WHERE prime.numberId <= ?1")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
@@ -37,8 +37,7 @@ public interface MixedRepository { // Do not inherit from a supertype
     @Query("FROM City")
     List<City> all(Order<City> sortBy);
 
-    @Query(value = "FROM Business WHERE location.address.zip = location.address.zip",
-           count = "FROM Business")
+    @Query(value = "FROM Business WHERE location.address.zip = location.address.zip")
     Page<Business> findAll(PageRequest<Business> pageRequest);
 
     @OrderBy("name")
@@ -49,8 +48,7 @@ public interface MixedRepository { // Do not inherit from a supertype
 
     LinkedList<Unpopulated> findBySomethingStartsWith(String prefix);
 
-    @Query(value = "WHERE location.address.city=?1",
-           count = "FROM Business WHERE location.address.city=?1")
+    @Query(value = "WHERE location.address.city=?1")
     Page<Business> locatedIn(String city, PageRequest<Business> pageRequest);
 
     @Query("FROM Business WHERE location.address.city=:city AND location.address.state=:state")

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/Query.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/Query.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,7 +23,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Query {
-    String count() default "";
 
     String value();
 }


### PR DESCRIPTION
Aligns with the change to Jakarta Data that removes the count query from the Query annotation.
This will now rely on inferring the query from the main query, which we already have partial logic for.
I commented out one test that will either require JPA 3.2 which will let you do SELECT COUNT(this) ...
or some enhancements to the simulation logic that I'll look into separately.