### PR TITLE
Update Java 22 specific FAT with GA build

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -62,7 +62,7 @@ io.openliberty:java-apps:18.0.0
 io.openliberty:java-apps:19.0.0
 io.openliberty:java-apps:20.0.0
 io.openliberty:java-apps:21.0.0
-io.openliberty:java-apps:22.0.0
+io.openliberty:java-apps:22.1.0
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0

--- a/dev/io.openliberty.java.internal_fat/build.gradle
+++ b/dev/io.openliberty.java.internal_fat/build.gradle
@@ -26,7 +26,7 @@ configurations {
     app19 'io.openliberty:java-apps:19.0.0'
     app20 'io.openliberty:java-apps:20.0.0'
     app21 'io.openliberty:java-apps:21.0.0'
-    app22 'io.openliberty:java-apps:22.0.0'
+    app22 'io.openliberty:java-apps:22.1.0'
  }
 
 task copyKernelService(type: Copy) {


### PR DESCRIPTION
The Java 22 [specific FAT that we use](https://github.com/OpenLiberty/open-liberty/pull/27515) was compiled against the EA version of Java 22.  Now that Java 22 has GAed, we have recompiled the FAT with the version and need to update it in our repositories.