### PR TITLE
Add social instance of OIDC_CLIENT_BAD_REQUEST_NO_COOKIE

### DIFF
--- a/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
+++ b/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
@@ -658,6 +658,6 @@ CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD.useraction=Configure a c
 
 # do not translate hostname, sameSiteCookie, webAppSecurity, Strict, Lax, None
 # used by client
-OIDC_CLIENT_BAD_REQUEST_NO_COOKIE=CWWKS2352E: A request to [{0}] is not valid. A required cookie with a name that begins with WASReqURLOidc is missing. The host name that is used to access the client might not match the name that is registered at the provider.
-OIDC_CLIENT_BAD_REQUEST_NO_COOKIE.explanation=A request was received that did not include a required cookie.
-OIDC_CLIENT_BAD_REQUEST_NO_COOKIE.useraction=Verify the OpenID Connect provider and client configurations. The missing cookie can be caused by accessing the client with a host name that differs from the host name of the redirect that is registered with the provider. If the sameSiteCookie attribute in the webAppSecurity element in the server configuration is set to Strict, try setting the value to Lax or None.
+OIDC_CLIENT_BAD_REQUEST_NO_COOKIE=CWWKS2352E: A request to [{0}] is not valid. A required cookie with a name that begins with WASReqURLOidc is missing. The hostname that is used to access the client might not match the name that is registered at the provider.
+OIDC_CLIENT_BAD_REQUEST_NO_COOKIE.explanation=The client received a request that did not include a required cookie.
+OIDC_CLIENT_BAD_REQUEST_NO_COOKIE.useraction=Verify the OpenID Connect provider and client configurations. The missing cookie might be caused by accessing the client with a hostname that differs from the hostname of the redirect that is registered with the provider. If the sameSiteCookie attribute in the webAppSecurity element in the server configuration is set to Strict, try setting the value to Lax or None.

--- a/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
+++ b/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2023 IBM Corporation and others.
+# Copyright (c) 2016, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -655,3 +655,9 @@ BACKCHANNEL_REQUEST_NOT_SUPPORTED_CONFIG.useraction=Use the logout endpoint that
 CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD=CWWKS2351E: The {0} OpenID Connect client uses the {1} token endpoint authentication method. This authentication method requires a client secret, but a client secret is not configured.
 CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD.explanation=The token endpoint authentication method that is specified in the message requires a client secret to authenticate with the token endpoint of the OpenID Connect provider.
 CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD.useraction=Configure a client secret for the OpenID Connect client, or switch the token endpoint authentication method of the client to one that does not require a client secret.
+
+# do not translate hostname, sameSiteCookie, webAppSecurity, Strict, Lax, None
+# used by client
+OIDC_CLIENT_BAD_REQUEST_NO_COOKIE=CWWKS2352E: A request to [{0}] is not valid. A required cookie with a name that begins with WASReqURLOidc is missing. The host name that is used to access the client might not match the name that is registered at the provider. A response code of 500 is returned.
+OIDC_CLIENT_BAD_REQUEST_NO_COOKIE.explanation=A request was received that did not include a required cookie.
+OIDC_CLIENT_BAD_REQUEST_NO_COOKIE.useraction=Verify the OpenID Connect provider and client configurations. The missing cookie can be caused by accessing the client with a host name that differs from the host name of the redirect that is registered with the provider. If the sameSiteCookie attribute in the webAppSecurity element in the server configuration is set to Strict, try setting the value to Lax or None.

--- a/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
+++ b/dev/com.ibm.ws.security.social/resources/com/ibm/ws/security/social/resources/SocialMessages.nlsprops
@@ -658,6 +658,6 @@ CLIENT_SECRET_MISSING_BUT_REQUIRED_BY_TOKEN_AUTH_METHOD.useraction=Configure a c
 
 # do not translate hostname, sameSiteCookie, webAppSecurity, Strict, Lax, None
 # used by client
-OIDC_CLIENT_BAD_REQUEST_NO_COOKIE=CWWKS2352E: A request to [{0}] is not valid. A required cookie with a name that begins with WASReqURLOidc is missing. The host name that is used to access the client might not match the name that is registered at the provider. A response code of 500 is returned.
+OIDC_CLIENT_BAD_REQUEST_NO_COOKIE=CWWKS2352E: A request to [{0}] is not valid. A required cookie with a name that begins with WASReqURLOidc is missing. The host name that is used to access the client might not match the name that is registered at the provider.
 OIDC_CLIENT_BAD_REQUEST_NO_COOKIE.explanation=A request was received that did not include a required cookie.
 OIDC_CLIENT_BAD_REQUEST_NO_COOKIE.useraction=Verify the OpenID Connect provider and client configurations. The missing cookie can be caused by accessing the client with a host name that differs from the host name of the redirect that is registered with the provider. If the sameSiteCookie attribute in the webAppSecurity element in the server configuration is set to Strict, try setting the value to Lax or None.


### PR DESCRIPTION

Tried to use a local instance of tr to point to the common message instance, but that just wouldn't work.
I created an instance of the  OIDC_CLIENT_BAD_REQUEST_NO_COOKIE message in the social nlsprops.
I updated the social tests (that haven't been delivered yet to look for the new message id)