### PR TITLE
Use the staged API artifacts for annotations-3.0

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1252,11 +1252,6 @@
       <version>2.1.1</version>
     </dependency>
     <dependency>
-      <groupId>jakarta.annotation</groupId>
-      <artifactId>jakarta.annotation-api</artifactId>
-      <version>3.0.0-M1</version>
-    </dependency>
-    <dependency>
       <groupId>jakarta.authentication</groupId>
       <artifactId>jakarta.authentication-api</artifactId>
       <version>2.0.0</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -246,7 +246,6 @@ jakarta.activation:jakarta.activation-api:2.0.1
 jakarta.activation:jakarta.activation-api:2.1.1
 jakarta.annotation:jakarta.annotation-api:2.0.0
 jakarta.annotation:jakarta.annotation-api:2.1.1
-jakarta.annotation:jakarta.annotation-api:3.0.0-M1
 jakarta.authentication:jakarta.authentication-api:2.0.0
 jakarta.authentication:jakarta.authentication-api:3.0.0
 jakarta.authentication:jakarta.authentication-api:3.1.0-M1

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -63,6 +63,7 @@ io.openliberty:java-apps:19.0.0
 io.openliberty:java-apps:20.0.0
 io.openliberty:java-apps:21.0.0
 io.openliberty:java-apps:22.1.0
+jakarta.annotation:jakarta.annotation-api:3.0.0-staged
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.annotation-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.annotation-3.0.feature
@@ -5,7 +5,7 @@ IBM-Process-Types: server, \
  client
 -features=com.ibm.websphere.appserver.eeCompatible-11.0, \
   io.openliberty.noShip-1.0
--bundles=io.openliberty.jakarta.annotation.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.annotation:jakarta.annotation-api:3.0.0-M1"
+-bundles=io.openliberty.jakarta.annotation.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.annotation:jakarta.annotation-api:3.0.0-staged"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.jakarta/annotation.3.0.bnd
+++ b/dev/io.openliberty.jakarta/annotation.3.0.bnd
@@ -23,9 +23,9 @@ Export-Package: \
   jakarta.annotation.sql;version="3.0.0"
 
 -includeresource: \
-  @${repo;jakarta.annotation:jakarta.annotation-api;3.0.0.M1;EXACT}!/!(META-INF/maven/*|module-info.class)
+  @${repo;jakarta.annotation:jakarta.annotation-api;3.0.0.staged;EXACT}!/!(META-INF/maven/*|module-info.class)
 
 -maven-dependencies: \
-   dep1;groupId=jakarta.annotation;artifactId=jakarta.annotation-api;version=3.0.0-M1;scope=runtime
+   dep1;groupId=jakarta.annotation;artifactId=jakarta.annotation-api;version=3.0.0-staged;scope=runtime
 
    


### PR DESCRIPTION
The proposed final API jars for annotations 3.0 have been staged. Use those artifacts (renamed so that the build is reproducible if the staged artifacts are removed).