### PR TITLE
JAX-WS: beta webServiceClient config processing

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
@@ -224,7 +224,7 @@ instrument.classesExcludes: com/ibm/ws/jaxws/internal/resources/*.class
 	com.ibm.websphere.appserver.spi.threading;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.jaxws.tools.2.2.10,\
-	javax.activation:activation;version='1.1',\
+	javax.activation:activation;version=1.1,\
 	com.ibm.ws.kernel.service;version=latest, \
 	com.ibm.ws.kernel.boot.core;version=latest
 

--- a/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2023 IBM Corporation and others.
+# Copyright (c) 2019, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -78,8 +78,13 @@ DynamicImport-Package: com.sun.xml.bind.v2, \
   com.ibm.ws.jaxws.metadata.builder.WebServicesBndEndpointInfoConfigurator,\
   com.ibm.ws.jaxws.threading.LibertyThreadPoolAdapter,\
   com.ibm.ws.jaxws.client.injection.ServiceRefObjectFactory,\
-  com.ibm.ws.jaxws.JaxwsConduitConfigActivator
-
+  com.ibm.ws.jaxws.JaxwsConduitConfigActivator, \
+  com.ibm.ws.jaxws.client.WebServiceClientConfigImpl
+  
+# include the service providers and metatype
+Include-Resource: \
+  OSGI-INF=resources/OSGI-INF, \
+  OSGI-INF/metatype/metatype.xml=resources/OSGI-INF/metatype/metatype.xml
 
 Service-Component: \
   com.ibm.wsspi.jaxws.JaxWsService; \
@@ -216,11 +221,12 @@ instrument.classesExcludes: com/ibm/ws/jaxws/internal/resources/*.class
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.webservices.handler;version=latest,\
 	com.ibm.ws.org.apache.neethi.3.1.1;version=latest,\
-	com.ibm.websphere.appserver.spi.threading;version=latest, \
+	com.ibm.websphere.appserver.spi.threading;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.ws.jaxws.tools.2.2.10, \
-	javax.activation:activation;version=1.1, \
-	com.ibm.ws.kernel.service;version=latest
+	com.ibm.ws.jaxws.tools.2.2.10,\
+	javax.activation:activation;version='1.1',\
+	com.ibm.ws.kernel.service;version=latest, \
+	com.ibm.ws.kernel.boot.core;version=latest
 
 -testpath: \
 	org.hamcrest:hamcrest-all;version=1.3, \

--- a/dev/com.ibm.ws.jaxws.2.3.common/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jaxws.2.3.common/resources/OSGI-INF/metatype/metatype.xml
@@ -12,10 +12,10 @@
                    xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
                    localization="OSGI-INF/l10n/metatype">
 
-    <OCD id="com.ibm.ws.jaxws.clientConfig.metatype" description="%webserviceClient.desc" name="%webserviceClient.name" ibm:alias="webServiceClient" ibm:beta="true" >
+    <OCD id="com.ibm.ws.jaxws.clientConfig.metatype" description="%webserviceClient.desc" name="%webserviceClient" ibm:alias="webServiceClient" ibm:beta="true" >
          <AD id="serviceName" name="%serviceName" description="%serviceName.desc" required="false" type="String" />
-         <AD id="ignoreUnexpectedElements" name="%ignoreUnexpectedElements" description="%ignoreUnexpectedElements.desc" required="false" type="boolean" default="false" />
-         <AD id="enableSchemaValidation" name="%enableSchemaValidation" description="%enableSchemaValidation.desc" required="false" type="boolean" default="true" />
+         <AD id="ignoreUnexpectedElements" name="%ignoreUnexpectedElements" description="%ignoreUnexpectedElements.desc" required="false" type="Boolean" default="false" />
+         <AD id="enableSchemaValidation" name="%enableSchemaValidation" description="%enableSchemaValidation.desc" required="false" type="Boolean" default="true" />
     </OCD>
 
     <Designate factoryPid="com.ibm.ws.jaxws.clientConfig">

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyServiceImpl.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Map.Entry;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.namespace.QName;
@@ -45,6 +46,7 @@ import org.apache.cxf.feature.Feature;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.jaxws.JaxWsConstants;
+import com.ibm.ws.jaxws.internal.WebServiceConfigConstants;
 import com.ibm.ws.jaxws.metadata.ConfigProperties;
 import com.ibm.ws.jaxws.metadata.PortComponentRefInfo;
 import com.ibm.ws.jaxws.metadata.WebServiceFeatureInfo;
@@ -53,6 +55,7 @@ import com.ibm.ws.jaxws.security.JaxWsSecurityConfigurationService;
 import com.ibm.ws.jaxws.support.LibertyLoggingInInterceptor;
 import com.ibm.ws.jaxws.support.LibertyLoggingOutInterceptor;
 import com.ibm.ws.jaxws23.client.security.LibertyJaxWsClientSecurityOutInterceptor;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 
 /**
  * All the Web Service ports and dispatches are created via the class
@@ -69,7 +72,7 @@ public class LibertyServiceImpl extends ServiceImpl {
     private final WebServiceRefInfo wsrInfo;
 
     private final JaxWsSecurityConfigurationService securityConfigService;
-
+   
     /**
      * The map contains the port QName to port properties entry
      */
@@ -79,6 +82,10 @@ public class LibertyServiceImpl extends ServiceImpl {
         // Add more if need other service pid to property prefix
         servicePidToPropertyPrefixMap.put(JaxWsConstants.HTTP_CONDUITS_SERVICE_FACTORY_PID, JaxWsConstants.HTTP_CONDUIT_PREFIX);
     }
+    
+    // Flag tells us if the message for a call to a beta method has been issued
+    private static boolean issuedBetaMessage = false;
+    
 
     /**
      * @param bus
@@ -92,15 +99,17 @@ public class LibertyServiceImpl extends ServiceImpl {
         super(bus, url, name, clazz, features);
         this.securityConfigService = securityConfigService;
         this.wsrInfo = wsrInfo;
-
-        if (null != wsrInfo) {
+        
+        if (null != wsrInfo) { 
             try {
                 //Configure each port's properties defined in the custom binding files.
                 configureClientProperties();
+                
             } catch (IOException e) {
                 throw new Fault(e);
             }
-        }
+        } 
+        
     }
 
     @Override
@@ -116,6 +125,23 @@ public class LibertyServiceImpl extends ServiceImpl {
         Client client = ClientProxy.getClient(clientProxy);
 
         configureCustomizeBinding(client, portName);
+        
+        if (!ProductInfo.getBetaEdition()) {           
+
+            // Because we have to apply webService and webServiceClient configuration to existing code
+            // we need to not apply it when not in beta. That means
+            // we can't throw the normal UnsupportedOperationException when not in beta
+            // so we just return the clientProxy as was done originally at this point in the code.
+            return clientProxy;
+        } else {
+            // Running beta exception, issue message if we haven't already issued one for this class
+            if (!issuedBetaMessage) {
+                Tr.info(tc, "BETA: A webServiceClient configuration beta method has been invoked for the class " + this.getClass().getName() + " for the first time.");
+                issuedBetaMessage = !issuedBetaMessage;
+            }
+        }
+		
+        configureWebServiceClientProperties(client);
 
         return clientProxy;
     }
@@ -128,9 +154,43 @@ public class LibertyServiceImpl extends ServiceImpl {
         Client client = dispatch.getClient();
 
         configureCustomizeBinding(client, portName);
+		
+		if (!ProductInfo.getBetaEdition()) {           
 
+            // Because we have to apply webService and webServiceClient configuration to existing code
+            // we need to not apply it when not in beta. That means
+            // we can't throw the normal UnsupportedOperationException when not in beta
+            // so we just return the clientProxy as was done originally at this point in the code.
+            return dispatch;
+        } else {
+            // Running beta exception, issue message if we haven't already issued one for this class
+            if (!issuedBetaMessage) {
+                Tr.info(tc, "BETA: A webServiceClient configuration beta method has been invoked for the class " + this.getClass().getName() + " for the first time.");
+                issuedBetaMessage = !issuedBetaMessage;
+            }
+        }
+		
+        configureWebServiceClientProperties(client); 
+		
         return dispatch;
     }
+    
+    /**
+     *  This method is used to apply webServiceClient configuration to the Client instance
+     *  Given that all of the current configuration is meant to be applied to inbound response processing
+     *  This method simply sets a new instances of the LibertyWebServiceClientInInterceptor to the InterceptorChain.
+     * @param client
+     * @param map
+     */
+    private void configureWebServiceClientProperties(Client client) {
+        // add the a new instance of LibertyWebServiceClientInInterceptor
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Adding the LibertyWebServiceClintInInterceptor ");
+        }
+        client.getInInterceptors().add(new LibertyWebServiceClientInInterceptor());
+        
+    }
+
 
     /**
      * Add the LibertyCustomizeBindingOutInterceptor in the out interceptor chain.

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyServiceImpl.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyServiceImpl.java
@@ -96,7 +96,9 @@ public class LibertyServiceImpl extends ServiceImpl {
      */
     public LibertyServiceImpl(JaxWsSecurityConfigurationService securityConfigService, WebServiceRefInfo wsrInfo,
                               Bus bus, URL url, QName name, Class<?> clazz, WebServiceFeature... features) {
+        
         super(bus, url, name, clazz, features);
+
         this.securityConfigService = securityConfigService;
         this.wsrInfo = wsrInfo;
         

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
@@ -63,20 +63,12 @@ public class LibertyWebServiceClientInInterceptor  extends AbstractPhaseIntercep
         
         // if messageServiceName != null, try to get the values from configuration using it
         if(messageServiceName != null) {
-            enableSchemaValidation = WebServicesClientConfigHolder.getEnableSchemaValidation(messageServiceName);
-            // if enableSchemaValidation is still null, then we need to try it to get the default setting if its set
-            if(enableSchemaValidation == null) {
-                WebServicesClientConfigHolder.getEnableSchemaValidation(WebServiceConfigConstants.DEFAULT_PROP);
-            }
+            // if messageServiceName != null, try to get enableSchemaValidation value from configuration, if it's == null try it to get the default configuration value
+            enableSchemaValidation = (WebServicesClientConfigHolder.getEnableSchemaValidation(messageServiceName) != null) ? WebServicesClientConfigHolder.getEnableSchemaValidation(messageServiceName): WebServicesClientConfigHolder.getEnableSchemaValidation(WebServiceConfigConstants.DEFAULT_PROP);         
             
-            // if messageServiceName != null, try to get ignoreUnexpectedElements value from configuration, if messageSevice == null then try to get the default configuration value
-            ignoreUnexpectedElements = WebServicesClientConfigHolder.getIgnoreUnexpectedElements(messageServiceName);
-            
-            
-            // if ignoreUnexpectedElements is still null then we need to try it to get the default setting if its set
-            if(ignoreUnexpectedElements == null) {
-                WebServicesClientConfigHolder.getIgnoreUnexpectedElements(WebServiceConfigConstants.DEFAULT_PROP);
-            }
+            // if messageServiceName != null, try to get ignoreUnexpectedElements value from configuration, if it's == null try to get the default configuration value
+            ignoreUnexpectedElements = (WebServicesClientConfigHolder.getIgnoreUnexpectedElements(messageServiceName) != null) ? WebServicesClientConfigHolder.getIgnoreUnexpectedElements(messageServiceName) : WebServicesClientConfigHolder.getIgnoreUnexpectedElements(WebServiceConfigConstants.DEFAULT_PROP);         
+                                                                                                                                                                                                                                                      
         } else {
             // if messageSevice == null then try to get the default configuration values
             enableSchemaValidation = WebServicesClientConfigHolder.getEnableSchemaValidation(WebServiceConfigConstants.DEFAULT_PROP);
@@ -103,15 +95,15 @@ public class LibertyWebServiceClientInInterceptor  extends AbstractPhaseIntercep
         boolean enableSchemaValidationValue = (boolean) enableSchemaValidation;
         boolean ignoreUnexpectedElementsValue = (boolean) ignoreUnexpectedElements;
         
-        // If both values are set to true, these are the default behaviors and we can just return. 
+        // If both values are set like this, these are the default behaviors and we can just no-op return. 
         if(enableSchemaValidationValue == true && ignoreUnexpectedElementsValue == false) {
             if (debug) {
-                Tr.debug(tc, "No webServiceClient configuration found. returning.");
+                Tr.debug(tc, "The webServiceClient configuration found matches the default behavior, returning.");
             }
             return;
         }
         
-        if(enableSchemaValidationValue == false) { // since the existing behavior already has a true value, no need to do anything unless its non-default
+        if(enableSchemaValidationValue == false) { // since the existing behavior already sets this with a true value, only change it when value is false
             // Set the CXF property for enabling schema validation based on the value from our config
             MessageUtils.getContextualBoolean(message, "schema-validation-enabled", (boolean) enableSchemaValidation);
             
@@ -121,7 +113,7 @@ public class LibertyWebServiceClientInInterceptor  extends AbstractPhaseIntercep
             }
         }
             
-        if(ignoreUnexpectedElementsValue == true) { // since the existing behavior already has a true value, no need to do anything unless its non-default
+        if(ignoreUnexpectedElementsValue == true) { // existing behavior sets this to true, but since we have to invert to match the property, only set it when our property is true
             // Set the CXF property for enabling schema validation based on the value from our config
             // TODO implement custom Validation Event Handler to ignore only UnexpectedElementExceptions
             MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER, !ignoreUnexpectedElementsValue); // Since we are using our internal property to set a CXF property, we must invert the value

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.Map.Entry;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.interceptor.Interceptor;
+import org.apache.cxf.jaxb.JAXBDataBinding;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.jaxws.internal.WebServiceConfigConstants;
+
+/**
+ *
+ */
+public class LibertyWebServiceClientInInterceptor  extends AbstractPhaseInterceptor<Message>  {
+    
+
+    private static final TraceComponent tc = Tr.register(LibertyWebServiceClientInInterceptor.class);
+    
+    /**
+     * @param serviceName
+     */
+    public LibertyWebServiceClientInInterceptor() {
+        super(Phase.RECEIVE);
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "The LibertyWebServiceClientInInterceptor has been registered to the Interceptor chain.");
+        }
+    }
+
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        boolean debug = TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled();
+        // Get the serviceName from the message
+        String messageServiceName = message.getExchange().getService().getName().getLocalPart();
+
+        if (debug) {
+            Tr.debug(tc, "Obtained name of the Service from the message - messageServiceName = " + messageServiceName);
+        }
+        
+        Object enableSchemaValidation;
+        
+        Object ignoreUnexpectedElements;
+        
+        // if messageServiceName != null, try to get the values from configuration using it
+        if(messageServiceName != null) {
+            enableSchemaValidation = WebServicesClientConfigHolder.getEnableSchemaValidation(messageServiceName);
+            // if enableSchemaValidation is still null, then we need to try it to get the default setting if its set
+            if(enableSchemaValidation == null) {
+                WebServicesClientConfigHolder.getEnableSchemaValidation(WebServiceConfigConstants.DEFAULT_PROP);
+            }
+            
+            // if messageServiceName != null, try to get ignoreUnexpectedElements value from configuration, if messageSevice == null then try to get the default configuration value
+            ignoreUnexpectedElements = WebServicesClientConfigHolder.getIgnoreUnexpectedElements(messageServiceName);
+            
+            
+            // if ignoreUnexpectedElements is still null then we need to try it to get the default setting if its set
+            if(ignoreUnexpectedElements == null) {
+                WebServicesClientConfigHolder.getIgnoreUnexpectedElements(WebServiceConfigConstants.DEFAULT_PROP);
+            }
+        } else {
+            // if messageSevice == null then try to get the default configuration values
+            enableSchemaValidation = WebServicesClientConfigHolder.getEnableSchemaValidation(WebServiceConfigConstants.DEFAULT_PROP);
+            
+            ignoreUnexpectedElements = WebServicesClientConfigHolder.getIgnoreUnexpectedElements(WebServiceConfigConstants.DEFAULT_PROP);
+        }
+        
+        // If both values are null, then we can just skip the rest of this interceptor and return
+        if(enableSchemaValidation == null && ignoreUnexpectedElements == null) {
+            if (debug) {
+                Tr.debug(tc, "No webServiceClient configuration found. returning.");
+            }
+            return;
+        }
+        
+
+        
+        if (debug) {
+            Tr.debug(tc, "Found webServiceClient configuration - enableSchemaValidation = " + enableSchemaValidation + ", ignoreUnexpectedElements = " + ignoreUnexpectedElements);
+            
+        }
+        
+        // now that we've done pulled the config, we can cast the Objects to proper booleans
+        boolean enableSchemaValidationValue = (boolean) enableSchemaValidation;
+        boolean ignoreUnexpectedElementsValue = (boolean) ignoreUnexpectedElements;
+        
+        // If both values are set to true, these are the default behaviors and we can just return. 
+        if(enableSchemaValidationValue == true && ignoreUnexpectedElementsValue == false) {
+            if (debug) {
+                Tr.debug(tc, "No webServiceClient configuration found. returning.");
+            }
+            return;
+        }
+        
+        if(enableSchemaValidationValue == false) { // since the existing behavior already has a true value, no need to do anything unless its non-default
+            // Set the CXF property for enabling schema validation based on the value from our config
+            MessageUtils.getContextualBoolean(message, "schema-validation-enabled", (boolean) enableSchemaValidation);
+            
+            if (debug) {
+                Tr.debug(tc, "Set schema-validation-enabled to " + enableSchemaValidation);
+                
+            }
+        }
+            
+        if(ignoreUnexpectedElementsValue == true) { // since the existing behavior already has a true value, no need to do anything unless its non-default
+            // Set the CXF property for enabling schema validation based on the value from our config
+            // TODO implement custom Validation Event Handler to ignore only UnexpectedElementExceptions
+            MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER, !ignoreUnexpectedElementsValue); // Since we are using our internal property to set a CXF property, we must invert the value
+            
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Set JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER to  " + !ignoreUnexpectedElementsValue);
+            } 
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/WebServiceClientConfigImpl.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/WebServiceClientConfigImpl.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.client;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.jaxws.internal.ConfigValidation;
+import com.ibm.ws.jaxws.internal.WebServiceConfig;
+import com.ibm.ws.jaxws.internal.WebServiceConfigConstants;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
+
+/**
+ * The declarative service responsible for processing a given
+ * Adapted from com.ibm.ws.jaxrs20.clientconfig.JAXRSClientConfig
+ */
+@Component(configurationPid = "com.ibm.ws.jaxws.clientConfig",
+           configurationPolicy = ConfigurationPolicy.REQUIRE, // Must be ConfigurationPolicy.REQUIRE to prevent the DS being activated without the configuration present. 
+           service = { WebServiceConfig.class },
+           immediate = true,
+           property = { "service.vendor=IBM" })
+public class WebServiceClientConfigImpl extends WebServiceConfig {
+    private static final TraceComponent tc = Tr.register(WebServiceClientConfigImpl.class);
+
+    static {
+        // remove the serviceName from the properties to be checked, since we use the serviceName as a key
+        propertiesToRemove.add(WebServiceConfigConstants.SERVICE_NAME_PROP);
+    }
+    
+    // Flag tells us if the message for a call to a beta method has been issued
+    private static boolean issuedBetaMessage = false;
+    
+    private void betaFenceCheck() throws UnsupportedOperationException {
+        // Not running beta edition, throw exception
+        if (!ProductInfo.getBetaEdition()) { 
+            throw new UnsupportedOperationException("The webServiceClient configuration is in beta and is not available.");
+        } else {
+        // Running beta exception, issue message if we haven't already issued one for this class
+            if (!issuedBetaMessage) {
+                Tr.info(tc, "BETA: A webServiceClient configuration beta method has been invoked for the class " + this.getClass().getName() + " for the first time.");
+                issuedBetaMessage = !issuedBetaMessage;
+           }
+        }
+    }
+
+    
+    
+    @Deprecated
+    @Activate
+    public WebServiceClientConfigImpl(Map<String, Object> properties) {
+        betaFenceCheck();
+        
+        if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
+            Tr.debug(tc, "WebServiceClientConfigImpl activate - " + properties);
+        }
+        
+        if (properties == null) {
+            
+            if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
+                Tr.debug(tc, "properites are null returning");
+            }
+            
+            return;
+        }
+        
+        String serviceName = getServiceName(properties); // find serviceName
+        
+        // Add config for serviceName
+        WebServicesClientConfigHolder.addConfig(this.toString(), serviceName,
+                                                filterProps(properties));
+    }
+    
+    @Deprecated
+    @Modified
+    protected void modified(Map<String, Object> properties) {        
+
+        betaFenceCheck();
+        
+        if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
+            Tr.debug(tc, "entering modified - " + properties);
+        }
+        
+        if (properties == null) {
+            
+            if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
+                Tr.debug(tc, "properites are null returning");
+            }
+            
+            return;
+        }
+        
+
+        
+        // Clear existing config
+        WebServicesClientConfigHolder.removeConfig(this.toString());
+        
+        // Re-add modfied config
+        String serviceName = getServiceName(properties);
+        WebServicesClientConfigHolder.addConfig(this.toString(), serviceName,
+                                                filterProps(properties));
+    }
+
+    @Deprecated
+    @Deactivate
+    protected void deactivate() {
+        
+
+        betaFenceCheck();
+        
+        if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
+            Tr.debug(tc, "entering deactivate");
+        }
+        WebServicesClientConfigHolder.removeConfig(this.toString());
+    }
+
+    /**
+     * given the map of properties, remove ones we don't care about, and translate
+     * some others. If it's not one we're familiar with, transfer it unaltered
+     *
+     * @param props - input list of properties
+     * @return - a new Map of the filtered properties.
+     */
+    protected Map<String, Object> filterProps(Map<String, Object> props) {
+        HashMap<String, Object> filteredProps = new HashMap<>();
+        Iterator<String> it = props.keySet().iterator();
+
+        while (it.hasNext()) {
+            String key = it.next();
+
+            if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
+                Tr.debug(tc, "key: " + key + " value: " + props.get(key) + " of type " + props.get(key).getClass());
+            }
+            // skip stuff we don't care about
+            if (propertiesToRemove.contains(key)) {
+                continue;
+            }
+            if (key.compareTo(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP) == 0) {
+                if (!ConfigValidation.validateEnableSchemaValidation((boolean) props.get(key)))
+                    continue;
+            }
+            if (key.compareTo(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP) == 0) {
+                if (!ConfigValidation.validateIgnoreUnexpectedElements((boolean) props.get(key)))
+                    continue;
+            }
+            filteredProps.put(key, props.get(key));
+
+        }
+        return filteredProps;
+    }
+
+    /**
+     * find the serviceName parameter which we will key off of
+     *
+     * @param props
+     * @return value of serviceName param within props, or null if no serviceName param
+     */
+    private String getServiceName(Map<String, Object> props) {
+        if (props == null)
+            return null;
+        if (props.keySet().contains(WebServiceConfigConstants.SERVICE_NAME_PROP)) {
+            return (props.get(WebServiceConfigConstants.SERVICE_NAME_PROP).toString());
+        } else {
+            return WebServiceConfigConstants.DEFAULT_PROP;
+        }
+    }
+}

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/WebServiceClientConfigImpl.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/WebServiceClientConfigImpl.java
@@ -27,7 +27,7 @@ import com.ibm.ws.jaxws.internal.WebServiceConfigConstants;
 import com.ibm.ws.kernel.productinfo.ProductInfo;
 
 /**
- * The declarative service responsible for processing a given
+ * The declarative service responsible for processing a given <webServiceClient> element in the server.xml
  * Adapted from com.ibm.ws.jaxrs20.clientconfig.JAXRSClientConfig
  */
 @Component(configurationPid = "com.ibm.ws.jaxws.clientConfig",
@@ -142,6 +142,10 @@ public class WebServiceClientConfigImpl extends WebServiceConfig {
 
         while (it.hasNext()) {
             String key = it.next();
+            
+            if(key == null) {
+                continue;
+            }
 
             if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
                 Tr.debug(tc, "key: " + key + " value: " + props.get(key) + " of type " + props.get(key).getClass());

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/WebServicesClientConfigHolder.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/WebServicesClientConfigHolder.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.client;
+
+import com.ibm.ws.jaxws.internal.ConfigHolder;
+
+/**
+ * The webServiceClient configuration holder, currently since 
+ * configuration is identical with webService this just extends the
+ * ConfigHolder class. Any client unqiue configuration to be held should be 
+ * added here.
+ */
+public class WebServicesClientConfigHolder extends ConfigHolder {
+
+}

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/ConfigHolder.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/ConfigHolder.java
@@ -1,0 +1,256 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.internal;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ *  This class holds all of the config property maps and processing code that is common between
+ *  WebServiceClientConfigHolder and WebServiceConfigHolder
+ *  
+ *  It maintains a map of all of the maps provided by each instance of WebServiceConfigImpl or WebServiceClientImpl
+ *  
+ *  It maintains a map of all of the known serviceNames or portNames
+ *  
+ *  It maintains a cache of already associated maps by their serviceName and portName
+ *  
+ *  If the configuration in common between the two configurations it can be processed  here, if not, then the 
+ *  unique configuration should be processed in either WebServiceClientConfigHolder or WebServiceConfigHolder
+ *  
+ *  It's used to return obtain configuration values for integration code.
+ *  
+ */
+public class ConfigHolder {
+
+    private static final TraceComponent tc = Tr.register(ConfigHolder.class);
+
+    private static boolean debug = getDebugEnabled();
+
+    // a map of configuration properties keyed on serviceName/portName.
+    private static volatile Map<String, Map<String, Object>> configInfo = new HashMap<>();
+
+    // a map of declarative service object id's to serviceName or portName, so we can track which service added
+    // which serviceName/portName.
+    private static volatile Map<String, String> nameMap = new HashMap<>();
+
+    // a cached map of search results
+    // that have been processed to look up the best match for the serviceName or portName strings
+    private static volatile Map<String, Map<String, Object>> resolvedConfigInfoCacheByName = new HashMap<>();
+
+    /**
+     * add a configuration for a name (serviceName/portName). We'd like a set of hashmaps keyed by name,
+     * however when osgi calls deactivate, we have no arguments, so we have to
+     * associate a name with the object id of the service. That allows us to remove
+     * the right one.
+     *
+     * @param id     - the object id of the service instance that added this.
+     * @param name   - either the serviceName or portName depending on the record being added.
+     * @param params - the properties applicable to this serviceName/portName.
+     */
+    public static synchronized void addConfig(String id, String name, Map<String, Object> params) {
+        if(getDebugEnabled()) {
+            Tr.debug(tc, "addConfig addConfig is id: " + id + " name = " + name + " params : " + params);
+        }
+        nameMap.put(id, name);
+        if (name != null) {
+            configInfo.put(name, params);
+        }
+        resolvedConfigInfoCacheByName.clear();
+    }
+
+    
+    /**
+    * remove a configuration (we'll look up the name (serviceName/portName) from the objectId)
+    *
+    * @param id - the object id of the service that called us
+    */
+    public static synchronized void removeConfig(String objectId) {
+
+        if(getDebugEnabled()) {
+            Tr.debug(tc, "addConfig removeConfig is objectId: " + objectId );
+        }
+        String serviceName = nameMap.get(objectId);
+        if (serviceName != null) {
+            configInfo.remove(serviceName);
+        }
+        nameMap.remove(objectId);
+        resolvedConfigInfoCacheByName.clear();
+    }
+    
+    /**
+     * Get the value of enableSchemaValidation from all know property maps using the name (serviceName/portName) provided.
+     *
+     * @param name - either the serviceName or portName depending on which config is being used to get the enableSchemaValidation
+     * 
+     * @return value of enableSchemaValidation if set, or null if the configuration doesn't contain the property
+     */
+    public static Object getEnableSchemaValidation(String name) {
+        
+        Map<String, Object> props = getNameProps(name);
+        
+        if (props != null) {
+
+            Object enableSchemaValidation = props.get(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP);
+            
+            if(getDebugEnabled()) {
+                Tr.debug(tc, "getEnableSchemaValidation is returning: " + enableSchemaValidation);
+            }
+            return enableSchemaValidation;
+        } else {
+            // return the default value
+            return null;
+        }
+    }
+
+    /**
+     * Get the value of ignoreUnexpectedElements from all know property maps using the name (serviceName/portName) provided.
+     *
+     * @param name - either the serviceName or portName depending on which config is being used to get the ignoreUnexpectedElements
+     * 
+     * @return value of ignoreUnexpectedElements if set, or null if the configuration doesn't contain the property
+     */
+    public static Object getIgnoreUnexpectedElements(String name) {
+        Map<String, Object> props = getNameProps(name);
+        
+        if (props != null) {
+
+            Object ignoreUnexpectedElements = props.get(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP);
+            if(getDebugEnabled()) {
+                Tr.debug(tc, "getIgnoreUnexpectedElements is returning: " + ignoreUnexpectedElements);
+            }
+            
+            return ignoreUnexpectedElements;
+            
+        } else {
+            
+            if(getDebugEnabled()) {
+                Tr.debug(tc, "getIgnoreUnexpectedElements is returning null because no properties exist for name - " + name);
+            }
+            return null; // No properties exist so return null
+            
+        }
+    }
+
+    /**
+     * This method uses the prpvided name (serviceName/portName) to find the associated property map
+     * It will first check if the configInfo map is empty, if it is then we return null because there 
+     * are no known configuration properties known to this class. Then if name is null, it will see if 
+     * @param name - either the portName/serviceName used to look up the property map
+     * @return A Map<String, Object> Properties object based on portName/serviceName
+     */
+    public static Map<String, Object> getNameProps(String name) {
+        boolean debug = getDebugEnabled();
+        if (configInfo.isEmpty()) {
+            if (debug) {
+                Tr.debug(tc, "getNameProps is empty, return null");
+            }
+            return null;
+        }
+
+        // look in the cache in case we've resolved this before
+        if (name != null) {
+            synchronized (resolvedConfigInfoCacheByName) {
+                Map<String, Object> props = resolvedConfigInfoCacheByName.get(name);
+                if (props != null) {
+                    if (debug) {
+                        Tr.debug(tc, "resolvedConfigInfoCacheByName cache hit, name: " + name + " props: " + props);
+                    }
+                    return (props.isEmpty() ? null : props);
+                }
+            }
+        }
+
+        // at this point we might have to merge something, set up a new hashmap to hold
+        // the results
+        HashMap<String, Object> mergedProps = new HashMap<>();
+
+        if (debug) {
+            Tr.debug(tc, "begin name search - configInfo = " + configInfo);
+        }
+        
+        String foundName = ""; 
+        // try to find a match from name of serviceName/portName or default if exists
+        synchronized (ConfigHolder.class) {
+            Iterator<String> it = configInfo.keySet().iterator();
+            while (it.hasNext()) {
+                String key = it.next();
+                if (key.equals(name)) {
+
+                    if (debug) {
+                        Tr.debug(tc, "name found - " + name + " adding associated props");
+                    } 
+
+                    Map<String, Object> props = configInfo.get(key);
+
+                    mergedProps.putAll(props); // merge props for this name.
+
+                    foundName = key; // assign the foundName to the key name.
+                } else if (key.equals(WebServiceConfigConstants.DEFAULT_PROP)) {
+
+                    if (debug) {
+                        Tr.debug(tc, "default found - " + name + " adding default props");
+                    }
+                    
+                    Map<String, Object> props = configInfo.get(key);
+
+                    // Merge all key value pairs from props if they don't already exist in the merged map
+                    // This should allow a named config to override the default and inherit the default if it's not specified for the named config
+                    for (Map.Entry<String, Object> entry : props.entrySet()) {
+                        String propsKey = entry.getKey();
+                        Object propsValue = entry.getValue();
+                        mergedProps.putIfAbsent(propsKey, propsValue);
+                        
+                        if (debug) {
+                            Tr.debug(tc, "default prop to be added if absent - propsKey " + propsKey + " propsValue " + propsValue);
+                        }
+                    }
+
+                    if(foundName.isEmpty()) { // Only set it to default if default exists and the key hasn't already matched the name
+                        foundName = key;
+                    }
+                }
+            }
+            
+            if (foundName.contains(name)) { // We found a properties map for this serviceName/portName store it in cache
+                
+                resolvedConfigInfoCacheByName.put(name, mergedProps);
+                
+            } else if (foundName.contains(WebServiceConfigConstants.DEFAULT_PROP)) { // We found the default properties map so store it in the cache
+                
+                resolvedConfigInfoCacheByName.put(WebServiceConfigConstants.DEFAULT_PROP, mergedProps);
+                
+            } else {
+
+                if (debug) {
+                    Tr.debug(tc, "No properties found for: " + name );
+                }
+                return null; // We found neither properties for the serviceName/portName or any default properties
+                
+            }
+            if (debug) {
+                Tr.debug(tc, "getNameProps final result for nameame: " + name + " values: " + mergedProps);
+            }
+
+            return (mergedProps.isEmpty() ? null : mergedProps);
+        } // end sync block
+    }
+
+    // Method to ensure dynamic tracing is honored while still using a class variable
+    // Call directly if only one debug statement is needed in the method
+    // Set debug = getDebugEnabled() if multiple checks are needed per method
+    private static boolean getDebugEnabled() {
+        return tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled();
+    }
+}

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/ConfigHolder.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/ConfigHolder.java
@@ -90,7 +90,7 @@ public class ConfigHolder {
     }
     
     /**
-     * Get the value of enableSchemaValidation from all know property maps using the name (serviceName/portName) provided.
+     * Get the value of enableSchemaValidation from all known property maps using the name (serviceName/portName) provided.
      *
      * @param name - either the serviceName or portName depending on which config is being used to get the enableSchemaValidation
      * 
@@ -115,7 +115,7 @@ public class ConfigHolder {
     }
 
     /**
-     * Get the value of ignoreUnexpectedElements from all know property maps using the name (serviceName/portName) provided.
+     * Get the value of ignoreUnexpectedElements from all known property maps using the name (serviceName/portName) provided.
      *
      * @param name - either the serviceName or portName depending on which config is being used to get the ignoreUnexpectedElements
      * 
@@ -154,7 +154,7 @@ public class ConfigHolder {
         boolean debug = getDebugEnabled();
         if (configInfo.isEmpty()) {
             if (debug) {
-                Tr.debug(tc, "getNameProps is empty, return null");
+                Tr.debug(tc, "configInfo is empty, returning null");
             }
             return null;
         }
@@ -189,7 +189,7 @@ public class ConfigHolder {
                 if (key.equals(name)) {
 
                     if (debug) {
-                        Tr.debug(tc, "name found - " + name + " adding associated props");
+                        Tr.debug(tc, "key found - " + key + " adding associated props");
                     } 
 
                     Map<String, Object> props = configInfo.get(key);
@@ -197,10 +197,11 @@ public class ConfigHolder {
                     mergedProps.putAll(props); // merge props for this name.
 
                     foundName = key; // assign the foundName to the key name.
+                    continue;
                 } else if (key.equals(WebServiceConfigConstants.DEFAULT_PROP)) {
 
                     if (debug) {
-                        Tr.debug(tc, "default found - " + name + " adding default props");
+                        Tr.debug(tc, "default found - " + key + " adding default props");
                     }
                     
                     Map<String, Object> props = configInfo.get(key);
@@ -237,13 +238,12 @@ public class ConfigHolder {
                     Tr.debug(tc, "No properties found for: " + name );
                 }
                 return null; // We found neither properties for the serviceName/portName or any default properties
-                
             }
             if (debug) {
                 Tr.debug(tc, "getNameProps final result for nameame: " + name + " values: " + mergedProps);
             }
 
-            return (mergedProps.isEmpty() ? null : mergedProps);
+            return mergedProps;
         } // end sync block
     }
 

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/ConfigValidation.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/ConfigValidation.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.internal;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+// Validating isn't necessary for booleans, but for future config values it will be
+// TODO: add validation of serviceName and portName strings - want to prevent wildcards and duplicates
+public class ConfigValidation {
+
+	private static final TraceComponent tc = Tr.register(ConfigValidation.class);
+
+
+        /**
+         * @param value - key name
+         * @return true since no need to validate booleans
+         */
+        public static boolean validateEnableSchemaValidation(boolean value) {
+            return true;
+        }
+
+        /**
+         * @param value - key name
+         * @return true since no need to validate booleans
+         */
+        public static boolean validateIgnoreUnexpectedElements(boolean value) {
+            return true;
+        }
+}

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/WebServiceConfig.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/WebServiceConfig.java
@@ -59,8 +59,11 @@ public abstract class WebServiceConfig {
             while (it.hasNext()) {
                     String key = it.next();
 
+                    if(key == null) {
+                        continue;
+                    }
                     if (debug) {
-                            Tr.info(tc, "key: " + key + " value: " + props.get(key) + " of type " + props.get(key).getClass());
+                            Tr.debug(tc, "key: " + key + " value: " + props.get(key) + " of type " + props.get(key).getClass());
                     }
                     // skip stuff we don't care about
                     if (propertiesToRemove.contains(key)) {

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/WebServiceConfig.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/WebServiceConfig.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.internal;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * The abstract class of the WebServiceConfig which is used to process the
+ * common parts of webService and webServiceClient config.
+ * 
+ * Each Declarative Service for the two configurations should use this class
+ */
+public abstract class WebServiceConfig {
+
+    private static final TraceComponent tc = Tr.register(WebServiceConfig.class);
+    
+    protected static final HashSet<String> propertiesToRemove = new HashSet<>();
+
+    static {
+            // this is stuff the framework always adds, we don't need it so we'll filter it
+            // out.
+            propertiesToRemove.add("config.overrides");
+            propertiesToRemove.add("config.id");
+            propertiesToRemove.add("component.id");
+            propertiesToRemove.add("config.displayId");
+            propertiesToRemove.add("component.name");
+            propertiesToRemove.add("config.source");
+            propertiesToRemove.add("service.pid");
+            propertiesToRemove.add("service.vendor");
+            propertiesToRemove.add("service.factoryPid");
+    }
+
+    /**
+     * given the map of properties, remove ones we don't care about, and translate
+     * some others. If it's not one we're familiar with, transfer it unaltered
+     *
+     * @param props - input list of properties
+     * @return - a new Map of the filtered properties.
+     */
+    protected Map<String, Object> filterProps(Map<String, Object> props) {
+            HashMap<String, Object> filteredProps = new HashMap<>();
+            Iterator<String> it = props.keySet().iterator();
+            boolean debug = tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled();
+
+            while (it.hasNext()) {
+                    String key = it.next();
+
+                    if (debug) {
+                            Tr.info(tc, "key: " + key + " value: " + props.get(key) + " of type " + props.get(key).getClass());
+                    }
+                    // skip stuff we don't care about
+                    if (propertiesToRemove.contains(key)) {
+                            continue;
+                    }
+                    if (key.compareTo(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP) == 0) {
+                            if (!ConfigValidation.validateEnableSchemaValidation((boolean) props.get(key)))
+                                    continue;
+                    }
+                    if (key.compareTo(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP) == 0) {
+                            if (!ConfigValidation.validateIgnoreUnexpectedElements((boolean) props.get(key)))
+                                    continue;
+                    }
+                    filteredProps.put(key, props.get(key));
+
+            }
+            return filteredProps;
+    }
+
+    protected abstract void modified(Map<String, Object> properties);
+    
+
+    protected abstract void deactivate();
+    
+}

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/WebServiceConfigConstants.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/WebServiceConfigConstants.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.internal;
+
+public class WebServiceConfigConstants {
+    
+    // config related constants
+    public static final String ENABLE_SCHEMA_VALIDATION_PROP = "enableSchemaValidation";
+    public static final String IGNORE_UNEXPECTED_ELEMENTS_PROP = "ignoreUnexpectedElements";
+    public static final String SERVICE_NAME_PROP = "serviceName";
+    public static final String PORT_NAME_PROP = "portName";
+    public static final String DEFAULT_PROP = "default";
+}

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/jaxb/IgnoreUnknownElementValidationEventHandler.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/jaxb/IgnoreUnknownElementValidationEventHandler.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.jaxb;
+
+import javax.xml.bind.ValidationEvent;
+import javax.xml.bind.ValidationEventHandler;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * This is just a skeleton class for now -
+ *
+ * This class will allow us to set a custom ValidationEventHandler on the JAXB Unmashaller
+ * which allow a user to ignore unknown elements in their inboound resonses.
+ *
+ * TODO: Complete Implementation
+ */
+public class IgnoreUnknownElementValidationEventHandler implements ValidationEventHandler {
+
+    private static final TraceComponent tc = Tr.register(IgnoreUnknownElementValidationEventHandler.class);
+    
+    public boolean handleEvent(ValidationEvent event) {
+        boolean debug = TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled();
+        
+        if(debug) {
+            Tr.debug(tc, "handling event - " + event);
+        }
+        
+        if(event.getMessage().contains("unexpected element")) {
+            if(debug) {
+                Tr.debug(tc, "The event contains an unexpected element, returning true to allow unmarshaller to continue. ");
+            }
+            return true;
+        } else {
+
+            if(debug) {
+                Tr.debug(tc, "The event doesn't contain an unexpected element, will return false stopping the unmarshaller. ");
+            }
+            return false;
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.jaxws.2.3.common/test/com/ibm/ws/jaxws/client/WebServiceClientConfigTest.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/test/com/ibm/ws/jaxws/client/WebServiceClientConfigTest.java
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+
+import com.ibm.ws.jaxws.internal.WebServiceConfigConstants;
+
+import test.common.SharedOutputManager;
+
+/**
+ * Basic unit tests for the webServiceClient configuration
+ */
+public class WebServiceClientConfigTest {
+    
+    static {
+        // Since the webServiceClient configuration is in beta, need to set the system property to pass tests
+        System.getProperties().setProperty("com.ibm.ws.beta.edition", "true");
+    }
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    @Rule
+    public TestRule rule = outputMgr;
+
+    @Rule
+    public TestName name = new TestName();
+
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * verify a basic default webServiceClient configuration
+     */
+    @Test
+    public void testSimpleClientConfig() {
+        Map<String, Object> basicProps = new HashMap<String, Object>();
+
+        // this properties map should map to all serviceNames 
+        basicProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, "default");
+        basicProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, true);
+        basicProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, true);
+        
+        WebServiceClientConfigImpl config = new WebServiceClientConfigImpl(basicProps);
+        
+        List<String> serviceNamesToTest = new ArrayList<String>();
+        serviceNamesToTest.add("SimpleService");
+        serviceNamesToTest.add("SimpleService2");
+        serviceNamesToTest.add("SimpleService3");
+
+        for (String serviceName : serviceNamesToTest) {
+            Assert.assertTrue((boolean) WebServicesClientConfigHolder.getIgnoreUnexpectedElements(serviceName));
+            Assert.assertTrue((boolean) WebServicesClientConfigHolder.getEnableSchemaValidation(serviceName));
+
+        }
+        config.deactivate();
+    }
+
+    /**
+     * verify updating a single webServiceClient configuration
+     */
+    @Test
+    public void testConfigUpdate() {
+
+        Map<String, Object> basicProps1 = new HashMap<String, Object>();
+        Map<String, Object> basicProps2 = new HashMap<String, Object>();
+        Map<String, Object> basicProps3 = new HashMap<String, Object>();
+        String serviceName = "default";
+        String serviceName1 = "SimpleService";
+        String serviceName2 = "SimpleService1";
+
+        basicProps2.put(WebServiceConfigConstants.SERVICE_NAME_PROP, serviceName);
+        basicProps2.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, true);
+        WebServiceClientConfigImpl config = new WebServiceClientConfigImpl(basicProps2);
+
+        Assert.assertTrue((boolean) WebServicesClientConfigHolder.getEnableSchemaValidation(serviceName));
+
+        basicProps1.put(WebServiceConfigConstants.SERVICE_NAME_PROP, serviceName1);
+        basicProps1.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, true);
+        config.modified(basicProps1);
+
+
+        Assert.assertTrue((boolean) WebServicesClientConfigHolder.getIgnoreUnexpectedElements(serviceName1));
+
+        basicProps3.put(WebServiceConfigConstants.SERVICE_NAME_PROP, serviceName2);
+        basicProps3.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, false);
+        basicProps3.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, false);
+        config.modified(basicProps3);
+
+        Assert.assertFalse((boolean) WebServicesClientConfigHolder.getEnableSchemaValidation(serviceName2));
+        Assert.assertFalse((boolean) WebServicesClientConfigHolder.getIgnoreUnexpectedElements(serviceName2));
+
+        config.deactivate();
+
+        Assert.assertNull(WebServicesClientConfigHolder.getNameProps(serviceName2));
+    }
+
+    /**
+     * verify with multiple webServiceClient configuration
+     */
+    @Test
+    public void testMultipleElements() {
+
+
+        Map<String, Object> basicProps = new HashMap<String, Object>();
+        Map<String, Object> basicProps1 = new HashMap<String, Object>();
+        Map<String, Object> basicProps2 = new HashMap<String, Object>();
+
+        String serviceName = "default";
+        String serviceName1 = "SimpleService";
+        String serviceName2 = "SimpleService1";
+
+        basicProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, serviceName);
+        basicProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, true);
+        
+        WebServiceClientConfigImpl config = new WebServiceClientConfigImpl(basicProps);
+        
+        Assert.assertTrue((boolean) WebServicesClientConfigHolder.getIgnoreUnexpectedElements(serviceName));
+
+        basicProps1.put(WebServiceConfigConstants.SERVICE_NAME_PROP, serviceName1);
+        basicProps1.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, true);
+        basicProps1.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, true);
+        
+        WebServiceClientConfigImpl config1 = new WebServiceClientConfigImpl(basicProps1);
+        basicProps2.put(WebServiceConfigConstants.SERVICE_NAME_PROP, serviceName2);
+        
+        basicProps2.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, false);
+        basicProps2.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, false);
+        
+        WebServiceClientConfigImpl config2 = new WebServiceClientConfigImpl(basicProps2);
+
+        Assert.assertTrue((boolean) WebServicesClientConfigHolder.getIgnoreUnexpectedElements(serviceName));
+        Assert.assertTrue((boolean) WebServicesClientConfigHolder.getIgnoreUnexpectedElements(serviceName1));
+        Assert.assertFalse((boolean) WebServicesClientConfigHolder.getEnableSchemaValidation(serviceName2));
+
+        config.deactivate();
+        config1.deactivate();
+        config2.deactivate();
+    }
+
+}


### PR DESCRIPTION
This pull request adds the `webServiceClient` server.xml configuration with support for `ignoreUnexpectedElements` and `enableSchemaValidation` to the `com.ibm.ws.jaxws.2.3.common` code.

It adds a new DS `WebServiceClientConfigImpl` that is beta-guarded, that is extended from `WebServiceConfig`.

It adds new inbound interceptor, LibertyWebServiceClientInInterceptor,  for applying configuration to the `MessageContext`.

Also included is the new `WebServiceClientConfigTest` unit tests that validates config processing. 