### PR TITLE
more complete simulation of JDQL

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -276,36 +276,26 @@ public class QueryInfo {
      * This method does not cover all scenarios but should be sufficient for simulating.
      * TODO remove this method once we have Jakarta Persistence 3.2.
      *
-     * @oaram o_ entity identifier variable followed by the . character.
-     * @param ql             Jakarta Data Query Language
-     * @param startAt        position in query language to start at.
-     * @param q              simulated JPQL to which to append.
-     * @param c              simulated JPQL count query to which to append unless null. The ORDER BY clause is not appended.
-     * @param isCursoredPage indicates if the return type is CursoredPage.
+     * @param ql        Jakarta Data Query Language
+     * @param startAt   position in query language to start at.
+     * @param endBefore position in query language before which to end.
+     * @param q         simulated JPQL to which to append.
      * @return simulated JPQL.
      */
-    private StringBuilder appendWithIdentifierName(String o_, String ql, int startAt, StringBuilder q, StringBuilder c, boolean isCursoredPage) {
-        boolean appendToCountQuery = c != null;
+    private StringBuilder appendWithIdentifierName(String ql, int startAt, int endBefore, StringBuilder q) {
         boolean isLiteral = false;
         boolean isNamedParamOrEmbedded = false;
-        int length = ql.length();
-        for (int i = startAt; i < length; i++) {
+        for (int i = startAt; i < endBefore; i++) {
             char ch = ql.charAt(i);
             if (!isLiteral && (ch == ':' || ch == '.')) {
                 q.append(ch);
-                if (appendToCountQuery)
-                    c.append(ch);
                 isNamedParamOrEmbedded = true;
             } else if (ch == '\'') {
                 q.append(ch);
-                if (appendToCountQuery)
-                    c.append(ch);
                 if (isLiteral) {
-                    if (i + 1 < length && ql.charAt(i + 1) == '\'') {
+                    if (i + 1 < endBefore && ql.charAt(i + 1) == '\'') {
                         // escaped ' within a literal
                         q.append('\'');
-                        if (appendToCountQuery)
-                            c.append('\'');
                         i++;
                     } else {
                         isLiteral = false;
@@ -317,63 +307,32 @@ public class QueryInfo {
             } else if (Character.isLetter(ch)) {
                 if (isNamedParamOrEmbedded || isLiteral) {
                     q.append(ch);
-                    if (appendToCountQuery)
-                        c.append(ch);
                 } else {
                     StringBuilder s = new StringBuilder();
                     s.append(ch);
-                    for (int j = i + 1; j < length; j++) {
+                    for (int j = i + 1; j < endBefore; j++) {
                         ch = ql.charAt(j);
-                        if (Character.isLetterOrDigit(ch))
+                        if (Character.isJavaIdentifierPart(ch))
                             s.append(ch);
                         else
                             break;
                     }
                     i += s.length();
                     String str = s.toString();
-                    int by = -1;
-                    if ("ORDER".equalsIgnoreCase(str)
-                        && i + 3 < length
-                        && (by = indexOfAfterWhitespace("BY", ql, i + 1)) > 0) {
-                        if (isCursoredPage)
-                            throw new UnsupportedOperationException("The " + ql + " query that is supplied to the " + method.getName() +
-                                                                    " method of the " + method.getDeclaringClass().getName() +
-                                                                    " repository cannot include an ORDER BY clause because" +
-                                                                    " the method returns a " + "CursoredPage" + ". Remove the ORDER BY" +
-                                                                    " clause and instead use the " + "OrderBy" +
-                                                                    " annotation to specify static sort criteria."); // TODO NLS
-                        for (; i < by + 2; i++)
-                            s.append(ql.charAt(i));
-                        str = s.toString();
-                    }
                     i--; // adjust for separate loop increment
 
-                    if (by > 0) {
-                        appendToCountQuery = false;
-                        q.append(str);
-                    } else if ("WHERE".equalsIgnoreCase(str)) {
-                        hasWhere = true;
-                        q.append(str);
-                        if (appendToCountQuery)
-                            c.append(str);
+                    if ("this".equalsIgnoreCase(str)) {
+                        q.append(entityVar);
                     } else if (entityInfo.getAttributeName(str, false) == null) {
                         q.append(str);
-                        if (appendToCountQuery)
-                            c.append(str);
                     } else {
-                        q.append(o_).append(str);
-                        if (appendToCountQuery)
-                            c.append(o_).append(str);
+                        q.append(entityVar_).append(str);
                     }
                 }
             } else if (Character.isDigit(ch)) {
                 q.append(ch);
-                if (appendToCountQuery)
-                    c.append(ch);
             } else {
                 q.append(ch);
-                if (appendToCountQuery)
-                    c.append(ch);
                 if (!isLiteral)
                     isNamedParamOrEmbedded = false;
             }
@@ -436,60 +395,6 @@ public class QueryInfo {
                 combined.add(entityInfo.getWithAttributeName(sort.property(), sort));
         }
         return combined;
-    }
-
-    /**
-     * Finds the first occurrence of the text followed by a non-alphanumeric/non-underscore character.
-     *
-     * @param lookFor text to find.
-     * @param findIn  where to look for it.
-     * @param startAt starting position.
-     * @return index where found, otherwise -1.
-     */
-    private static int find(String lookFor, String findIn, int startAt) {
-        int totalLength = findIn.length();
-        for (int foundAt; startAt < totalLength && (foundAt = findIn.indexOf(lookFor, startAt)) > 0; startAt = foundAt + 1) {
-            int nextPosition = foundAt + lookFor.length();
-            if (nextPosition >= totalLength)
-                break;
-            char ch = findIn.charAt(nextPosition);
-            if (!Character.isLowerCase(ch) && !Character.isUpperCase(ch) && !Character.isDigit(ch) && ch != '_')
-                return foundAt;
-        }
-        return -1;
-    }
-
-    /**
-     * Finds the entity variable name after the start of the entity name.
-     * Examples of JPQL:
-     * ... FROM Order o, Product p ...
-     * ... FROM Product AS p ...
-     *
-     * @param findIn  where to look for it.
-     * @param startAt position after the end of the entity name.
-     * @return entity variable name. Null if none is found.
-     */
-    private static String findEntityVariable(String findIn, int startAt) {
-        int length = findIn.length();
-        boolean foundStart = false;
-        for (int c = startAt; c < length; c++) {
-            char ch = findIn.charAt(c);
-            if (Character.isLowerCase(ch) || Character.isUpperCase(ch) || Character.isDigit(ch) || ch == '_') {
-                if (!foundStart) {
-                    startAt = c;
-                    foundStart = true;
-                }
-            } else { // not part of the entity variable name
-                if (foundStart) {
-                    String found = findIn.substring(startAt, c);
-                    if ("AS".equalsIgnoreCase(found))
-                        foundStart = false;
-                    else
-                        return found;
-                }
-            }
-        }
-        return foundStart ? findIn.substring(startAt) : null;
     }
 
     /**
@@ -636,283 +541,312 @@ public class QueryInfo {
      * @param multiType the type of data structure that returns multiple results for this query. Otherwise null.
      */
     void initForQuery(String ql, Class<?> multiType) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
         boolean isCursoredPage = CursoredPage.class.equals(multiType);
         boolean countPages = isCursoredPage || Page.class.equals(multiType);
-
-        StringBuilder q = null; // main query
-        StringBuilder c = null; // count query
 
         int length = ql.length();
         int startAt = 0;
         char firstChar = ' ';
         for (; startAt < length && Character.isWhitespace(firstChar = ql.charAt(startAt)); startAt++);
 
-        switch (firstChar) {
-            case 'D':
-            case 'd': // DELETE FROM EntityName[ WHERE ...]
-                // Temporarily simulate optional identifier names by inserting them.
-                // TODO remove when switched to Jakarta Persistence 3.2.
-                if (startAt + 12 < length
-                    && ql.regionMatches(true, startAt + 1, "ELETE", 0, 5)
-                    && Character.isWhitespace(ql.charAt(startAt + 6))) {
-                    startAt += 7; // start of FROM
+        if (firstChar == 'D' || firstChar == 'd') { // DELETE FROM EntityName[ WHERE ...]
+            // Temporarily simulate optional identifier names by inserting them.
+            // TODO remove when switched to Jakarta Persistence 3.2.
+            if (startAt + 12 < length
+                && ql.regionMatches(true, startAt + 1, "ELETE", 0, 5)
+                && Character.isWhitespace(ql.charAt(startAt + 6))) {
+                type = Type.DELETE;
+                jpql = ql;
+                startAt += 7; // start of FROM
+                for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
+                if (startAt + 6 < length
+                    && ql.regionMatches(true, startAt, "FROM", 0, 4)
+                    && Character.isWhitespace(ql.charAt(startAt + 4))) {
+                    startAt += 5; // start of EntityName
                     for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
-                    if (startAt + 6 < length
-                        && ql.regionMatches(true, startAt, "FROM", 0, 4)
-                        && Character.isWhitespace(ql.charAt(startAt + 4))) {
-                        startAt += 5; // start of EntityName
+                    StringBuilder entityName = new StringBuilder();
+                    for (char ch; startAt < length && Character.isJavaIdentifierPart(ch = ql.charAt(startAt)); startAt++)
+                        entityName.append(ch);
+                    if (entityName.length() > 0) {
+                        // skip whitespace
                         for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
-                        StringBuilder entityName = new StringBuilder();
-                        for (char ch; startAt < length && Character.isLetterOrDigit(ch = ql.charAt(startAt)); startAt++)
-                            entityName.append(ch);
-                        if (startAt + 1 < length && entityName.length() > 0 && Character.isWhitespace(ql.charAt(startAt))) {
-                            // EntityName followed by whitespace and at least one more character
-                            startAt++; // start of WHERE
-                            for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
-                            if (startAt + 6 < length
-                                && ql.regionMatches(true, startAt, "WHERE", 0, 5)
-                                && !Character.isLetterOrDigit(ql.charAt(startAt + 5))) {
-                                type = Type.DELETE;
-                                hasWhere = true;
-                                entityVar = "o";
-                                entityVar_ = "o.";
-                                q = new StringBuilder(ql.length() * 3 / 2) //
-                                                .append("DELETE FROM ").append(entityName).append(" o WHERE");
-                                jpql = appendWithIdentifierName(entityVar_, ql, startAt + 5, q, null, false).toString();
+                        if (startAt >= length) {
+                            // Entity identifier variable is not present. Add it.
+                            entityVar = "o";
+                            entityVar_ = "o.";
+                            jpql = new StringBuilder(entityName.length() + 14) //
+                                            .append("DELETE FROM ").append(entityName).append(" o").toString();
+                        } else if (startAt + 6 < length
+                                   && ql.regionMatches(true, startAt, "WHERE", 0, 5)
+                                   && !Character.isJavaIdentifierPart(ql.charAt(startAt + 5))) {
+                            hasWhere = true;
+                            entityVar = "o";
+                            entityVar_ = "o.";
+                            StringBuilder q = new StringBuilder(ql.length() * 3 / 2) //
+                                            .append("DELETE FROM ").append(entityName).append(" o WHERE");
+                            jpql = appendWithIdentifierName(ql, startAt + 5, ql.length(), q).toString();
+                        }
+                    }
+                }
+            }
+        } else if (firstChar == 'U' || firstChar == 'u') { // UPDATE EntityName[ SET ... WHERE ...]
+            // Temporarily simulate optional identifier names by inserting them.
+            // TODO remove when switched to Jakarta Persistence 3.2.
+            if (startAt + 13 < length
+                && ql.regionMatches(true, startAt + 1, "PDATE", 0, 5)
+                && Character.isWhitespace(ql.charAt(startAt + 6))) {
+                type = Type.UPDATE;
+                jpql = ql;
+                startAt += 7; // start of EntityName
+                for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
+                StringBuilder entityName = new StringBuilder();
+                for (char ch; startAt < length && Character.isJavaIdentifierPart(ch = ql.charAt(startAt)); startAt++)
+                    entityName.append(ch);
+                if (startAt + 1 < length && entityName.length() > 0 && Character.isWhitespace(ql.charAt(startAt))) {
+                    for (startAt++; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
+                    if (startAt + 4 < length
+                        && ql.regionMatches(true, startAt, "SET", 0, 3)
+                        && !Character.isJavaIdentifierPart(ql.charAt(startAt + 3))) {
+                        entityVar = "o";
+                        entityVar_ = "o.";
+                        StringBuilder q = new StringBuilder(ql.length() * 3 / 2) //
+                                        .append("UPDATE ").append(entityName).append(" o SET");
+                        jpql = appendWithIdentifierName(ql, startAt + 3, ql.length(), q).toString();
+                    }
+                }
+            }
+        } else { // SELECT ... or FROM ... or WHERE ... or ORDER BY ...
+            int select0 = -1, selectLen = 0; // starts after SELECT
+            int from0 = -1, fromLen = 0; // starts after FROM
+            int where0 = -1, whereLen = 0; // starts after WHERE
+            int order0 = -1, orderLen = 0; // starts at ORDER BY
+
+            if (length > startAt + 6
+                && ql.regionMatches(true, startAt, "SELECT", 0, 6)
+                && !Character.isJavaIdentifierPart(ql.charAt(startAt + 6))) {
+                select0 = startAt += 6;
+                // The end of the SELECT clause is a FROM, WHERE, GROUP BY, HAVING, or ORDER BY clause, or the end of the query
+            }
+
+            boolean isLiteral = false;
+            boolean isNamedParamOrEmbedded = false;
+            for (; startAt < length; startAt++) {
+                char ch = ql.charAt(startAt);
+                if (!isLiteral && (ch == ':' || ch == '.')) {
+                    isNamedParamOrEmbedded = true;
+                } else if (ch == '\'') {
+                    if (isLiteral) {
+                        if (startAt + 1 < length && ql.charAt(startAt + 1) == '\'')
+                            startAt++; // escaped ' within a literal
+                        else
+                            isLiteral = false;
+                    } else {
+                        isLiteral = true;
+                        isNamedParamOrEmbedded = false;
+                    }
+                } else if (Character.isLetter(ch)) {
+                    if (!isNamedParamOrEmbedded && !isLiteral) {
+                        int by;
+                        if (from0 < 0 && where0 < 0 && length > startAt + 4
+                            && ql.regionMatches(true, startAt, "FROM", 0, 4)
+                            && !Character.isJavaIdentifierPart(ql.charAt(startAt + 4))) {
+                            if (select0 >= 0 && selectLen == 0)
+                                selectLen = startAt - select0;
+                            from0 = startAt + 4;
+                            startAt = from0 - 1; // -1 to allow for loop increment
+                        } else if (length > startAt + 5
+                                   && ql.regionMatches(true, startAt, "WHERE", 0, 5)
+                                   && !Character.isJavaIdentifierPart(ql.charAt(startAt + 5))) {
+                            if (select0 >= 0 && selectLen == 0)
+                                selectLen = startAt - select0;
+                            else if (from0 >= 0 && fromLen == 0)
+                                fromLen = startAt - from0;
+                            where0 = startAt + 5;
+                            startAt = where0 - 1; // -1 to allow for loop increment
+                            whereLen = 0;
+                        } else if (length > startAt + 8
+                                   && ql.regionMatches(true, startAt, "GROUP", 0, 5)
+                                   && (by = indexOfAfterWhitespace("BY", ql, startAt + 5)) > 0) {
+                            if (select0 >= 0 && selectLen == 0)
+                                selectLen = startAt - select0;
+                            else if (from0 >= 0 && fromLen == 0)
+                                fromLen = startAt - from0;
+                            else if (where0 >= 0 && whereLen == 0)
+                                whereLen = startAt - where0;
+                            startAt = by + 2 - 1; // -1 to allow for loop increment
+                        } else if (length > startAt + 6
+                                   && ql.regionMatches(true, startAt, "HAVING", 0, 6)
+                                   && !Character.isJavaIdentifierPart(ql.charAt(startAt + 6))) {
+                            if (select0 >= 0 && selectLen == 0)
+                                selectLen = startAt - select0;
+                            else if (from0 >= 0 && fromLen == 0)
+                                fromLen = startAt - from0;
+                            else if (where0 >= 0 && whereLen == 0)
+                                whereLen = startAt - where0;
+                            startAt += 6 - 1; // -1 to allow for loop increment
+                        } else if (length > startAt + 8
+                                   && ql.regionMatches(true, startAt, "ORDER", 0, 5)
+                                   && (by = indexOfAfterWhitespace("BY", ql, startAt + 5)) > 0) {
+                            if (select0 >= 0 && selectLen == 0)
+                                selectLen = startAt - select0;
+                            else if (from0 >= 0 && fromLen == 0)
+                                fromLen = startAt - from0;
+                            else if (where0 >= 0 && whereLen == 0)
+                                whereLen = startAt - where0;
+                            order0 = startAt; // include the ORDER BY unlike the other clauses
+                            startAt = by + 2 - 1; // -1 to allow for loop increment
+                        } else {
+                            while (length > startAt + 1 && Character.isJavaIdentifierPart(ql.charAt(startAt + 1)))
+                                startAt++;
+                        }
+                    }
+                } else if (Character.isDigit(ch)) {
+                } else if (!isLiteral) {
+                    isNamedParamOrEmbedded = false;
+                }
+            }
+
+            if (select0 >= 0 && selectLen == 0)
+                selectLen = length - select0;
+            else if (from0 >= 0 && fromLen == 0)
+                fromLen = length - from0;
+            else if (where0 >= 0 && whereLen == 0)
+                whereLen = length - where0;
+            else if (order0 >= 0 && orderLen == 0)
+                orderLen = length - order0;
+
+            type = Type.FIND;
+            entityVar = "this";
+            entityVar_ = "";
+            hasWhere = whereLen > 0;
+            String entityName = entityInfo.name;
+
+            // Locate the entity identifier variable (if present). Examples of FROM clause:
+            // FROM EntityName
+            // FROM EntityName e
+            // FROM EntityName AS e
+            for (startAt = from0; startAt < from0 + fromLen && Character.isWhitespace(ql.charAt(startAt)); startAt++);
+            if (startAt < from0 + fromLen) {
+                int entityName0 = startAt, entityNameLen = 0; // starts at EntityName
+                for (; startAt < from0 + fromLen && Character.isJavaIdentifierPart(ql.charAt(startAt)); startAt++);
+                if ((entityNameLen = startAt - entityName0) > 0 && startAt < from0 + fromLen) {
+                    entityName = ql.substring(entityName0, entityName0 + entityNameLen);
+                    for (; startAt < from0 + fromLen && Character.isWhitespace(ql.charAt(startAt)); startAt++);
+                    if (startAt < from0 + fromLen) {
+                        int idVar0 = startAt, idVarLen = 0; // starts at the entity identifier variable
+                        for (; startAt < from0 + fromLen && Character.isJavaIdentifierPart(ql.charAt(startAt)); startAt++);
+                        if ((idVarLen = startAt - idVar0) > 0) {
+                            if (idVarLen == 2
+                                && (ql.charAt(idVar0) == 'A' || ql.charAt(idVar0) == 'a')
+                                && (ql.charAt(idVar0 + 1) == 'S' || ql.charAt(idVar0 + 1) == 's')) {
+                                // skip over the AS keyword
+                                for (; startAt < from0 + fromLen && Character.isWhitespace(ql.charAt(startAt)); startAt++);
+                                idVar0 = startAt;
+                                for (; startAt < from0 + fromLen && Character.isJavaIdentifierPart(ql.charAt(startAt)); startAt++);
+                            }
+                            if (startAt > idVar0) {
+                                entityVar = ql.substring(idVar0, startAt);
+                                entityVar_ = entityVar + '.';
                             }
                         }
                     }
                 }
-                break;
-            case 'U':
-            case 'u': // UPDATE EntityName[ SET ... WHERE ...]
-                // Temporarily simulate optional identifier names by inserting them.
-                // TODO remove when switched to Jakarta Persistence 3.2.
-                if (startAt + 13 < length
-                    && ql.regionMatches(true, startAt + 1, "PDATE", 0, 5)
-                    && Character.isWhitespace(ql.charAt(startAt + 6))) {
-                    startAt += 7; // start of EntityName
-                    for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
-                    StringBuilder entityName = new StringBuilder();
-                    for (char ch; startAt < length && Character.isLetterOrDigit(ch = ql.charAt(startAt)); startAt++)
-                        entityName.append(ch);
-                    if (startAt + 1 < length && entityName.length() > 0 && Character.isWhitespace(ql.charAt(startAt))) {
-                        // EntityName followed by whitespace and at least one more character
-                        startAt++; // start of SET
-                        for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
-                        if (startAt + 4 < length
-                            && ql.regionMatches(true, startAt, "SET", 0, 3)
-                            && !Character.isLetterOrDigit(ql.charAt(startAt + 3))) {
-                            type = Type.UPDATE;
-                            entityVar = "o";
-                            entityVar_ = "o.";
-                            q = new StringBuilder(ql.length() * 3 / 2) //
-                                            .append("UPDATE ").append(entityName).append(" o SET");
-                            jpql = appendWithIdentifierName(entityVar_, ql, startAt + 3, q, null, false).toString();
-                        }
-                    }
-                }
-                break;
-            case 'S':
-            case 's': // SELECT
-                // TODO
-                break;
-            case 'F':
-            case 'f': // FROM
-                if (startAt + 5 < length
-                    && ql.regionMatches(true, startAt, "FROM", 0, 4)
-                    && Character.isWhitespace(ql.charAt(startAt + 4))) {
-
-                    startAt += 5; // EntityName optionally preceded by whitespace
-                    for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
-                    StringBuilder entityName = new StringBuilder();
-                    for (char ch; startAt < length && Character.isLetterOrDigit(ch = ql.charAt(startAt)); startAt++)
-                        entityName.append(ch);
-
-                    if (entityName.length() > 0) {
-                        if (q == null) {
-                            type = Type.FIND;
-                            entityVar = "o";
-                            entityVar_ = "o.";
-                            q = new StringBuilder(ql.length() * 5 / 4 + 20).append("SELECT o");
-                        }
-                        q.append(" FROM ").append(entityName).append(' ').append(entityVar);
-
-                        if (countPages) {
-                            if (c == null)
-                                c = new StringBuilder(ql.length() * 5 / 4 + 20).append("SELECT COUNT(").append(entityVar).append(")");
-                            c.append(" FROM ").append(entityName).append(' ').append(entityVar);
-                        }
-
-                        // EntityName might be followed by whitespace and a WHERE clause or ORDER BY clause
-                        for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
-                    } else {
-                        throw new UnsupportedOperationException("The query supplied to the " + method.getName() + " method of the " +
-                                                                method.getDeclaringClass().getName() + " repository does not apear to be " +
-                                                                "valid JDQL (Jakarta Data Query Language) or " +
-                                                                "valid JPQL (Jakarta Persistence Query Language) because its FROM clause " +
-                                                                "does not specify the entity name. The query is " + ql); // TODO NLS
-                    }
-                }
-                // continue
-            case 'W':
-            case 'w': // WHERE
-                if (startAt + 5 < length
-                    && ql.regionMatches(true, startAt, "WHERE", 0, 5)
-                    && !Character.isLetterOrDigit(ql.charAt(startAt + 5))) {
-                    hasWhere = true;
-                    startAt += 5;
-
-                    if (q == null) {
-                        type = Type.FIND;
-                        entityVar = "o";
-                        entityVar_ = "o.";
-                        q = new StringBuilder(ql.length() * 5 / 4 + 20) // add 25% for identifier variable use
-                                        .append("SELECT o FROM ").append(entityInfo.name).append(" o");
-                    }
-                    q.append(" WHERE");
-
-                    if (countPages) {
-                        if (c == null)
-                            c = new StringBuilder(ql.length() * 5 / 4 + 20) // add 25% for identifier variable use
-                                            .append("SELECT COUNT(").append(entityVar) //
-                                            .append(") FROM ").append(entityInfo.name).append(' ').append(entityVar);
-                        c.append(" WHERE");
-                    }
-
-                    // Cursor-based pagination queries must end with the WHERE clause, per the spec.
-                    // Insert parenthesis to allow later appending conditions.
-                    if (isCursoredPage)
-                        q.append(" (");
-
-                    appendWithIdentifierName(entityVar_, ql, startAt, q, c, isCursoredPage);
-
-                    if (isCursoredPage)
-                        q.append(')');
-
-                    jpql = q.toString();
-
-                    if (countPages)
-                        jpqlCount = c.toString();
-
-                    break;
-                }
-                // continue
-            case 'O':
-            case 'o': // ORDER BY
-                if (startAt + 10 < length
-                    && ql.regionMatches(true, startAt, "ORDER", 0, 5)
-                    && Character.isWhitespace(ql.charAt(startAt + 5))) {
-                    startAt += 6; // Order followed by whitespace
-                    for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
-                    if (startAt + 4 < length
-                        && ql.regionMatches(true, startAt, "BY", 0, 2)
-                        && !Character.isLetterOrDigit(ql.charAt(startAt + 2))) {
-                        startAt += 2;
-
-                        if (q == null) {
-                            type = Type.FIND;
-                            entityVar = "o";
-                            entityVar_ = "o.";
-                            q = new StringBuilder(ql.length() * 5 / 4 + 20) // add 25% for identifier variable use
-                                            .append("SELECT o FROM ").append(entityInfo.name).append(" o");
-                        }
-                        q.append(" ORDER BY");
-
-                        if (countPages && c == null)
-                            c = new StringBuilder(q.length()).append("SELECT COUNT(").append(entityVar) //
-                                            .append(") FROM ").append(entityInfo.name).append(' ').append(entityVar);
-
-                        jpql = appendWithIdentifierName(entityVar_, ql, startAt, q, null, false).toString();
-
-                        if (countPages)
-                            jpqlCount = c.toString();
-
-                        break;
-                    }
-                }
-                // continue
-            default:
-                if (Character.isLetterOrDigit(firstChar)) {
-                    if (q != null && (firstChar == 'F' || firstChar == 'f')) {
-                        // FROM clause without WHERE and without ORDER BY
-                        jpql = q.toString();
-                        if (countPages)
-                            jpqlCount = c.toString();
-                    }
-                } else { // empty query
-                    type = Type.FIND;
-                    entityVar = "o";
-                    entityVar_ = "o.";
-
-                    jpql = new StringBuilder(entityInfo.name.length() + 16) //
-                                    .append("SELECT o FROM ").append(entityInfo.name).append(" o") //
-                                    .toString();
-
-                    if (countPages)
-                        jpqlCount = new StringBuilder(entityInfo.name.length() + 23) //
-                                        .append("SELECT COUNT(o) FROM ").append(entityInfo.name).append(" o") //
-                                        .toString();
-                }
-        }
-
-        if (jpql == null) {
-            // TODO replace old logic
-            jpql = ql;
-            String upper = ql.toUpperCase();
-            String upperTrimmed = upper.stripLeading();
-            // TODO JDQL queries can omit SELECT and/or FROM
-            if (upperTrimmed.startsWith("SELECT")) {
-                int order = upper.lastIndexOf("ORDER BY");
-                type = Type.FIND;
-                sorts = sorts == null ? new ArrayList<>() : sorts;
-                jpqlCount = null; // TODO JDQL
-
-                int selectIndex = upper.length() - upperTrimmed.length();
-                int from = find("FROM", upper, selectIndex + 9);
-                if (from > 0) {
-                    // TODO support for multiple entity types
-                    int entityName = find(entityInfo.name.toUpperCase(), upper, from + 5);
-                    if (entityName > 0) {
-                        entityVar = findEntityVariable(ql, entityName + entityInfo.name.length() + 1);
-                        if (entityVar == null) {
-                            entityVar = "*";
-                            entityVar_ = "";
-                        } else {
-                            entityVar_ = entityVar + '.';
-                        }
-                    }
-
-                    if (countPages && jpqlCount == null) {
-                        // Attempt to infer from provided query
-                        String s = ql.substring(selectIndex + 6, from);
-                        int comma = s.indexOf(',');
-                        if (comma > 0)
-                            s = s.substring(0, comma);
-                        jpqlCount = new StringBuilder(ql.length() + 7) //
-                                        .append("SELECT COUNT(").append(s.trim()).append(") ") //
-                                        .append(order > from ? ql.substring(from, order) : ql.substring(from)) //
-                                        .toString();
-                    }
-                }
-            } else if (upperTrimmed.startsWith("UPDATE")) {
-                type = Type.UPDATE;
-            } else if (upperTrimmed.startsWith("DELETE")) {
-                type = Type.DELETE;
-            } else {
-                throw new UnsupportedOperationException("The query supplied to the " + method.getName() + " method of the " +
-                                                        method.getDeclaringClass().getName() + " repository does not apear to be " +
-                                                        "valid JDQL (Jakarta Data Query Language) or " +
-                                                        "valid JPQL (Jakarta Persistence Query Language). The query is " + ql); // TODO NLS
             }
-            hasWhere = upperTrimmed.contains("WHERE");
-        }
 
-        if (isCursoredPage && !hasWhere)
-            throw new UnsupportedOperationException("The " + ql + " query that is supplied to the " + method.getName() +
-                                                    " method of the " + method.getDeclaringClass().getName() +
-                                                    " repository must end with a WHERE clause because the method returns a " +
-                                                    "CursoredPage" + "."); // TODO NLS
+            if (trace && tc.isDebugEnabled()) {
+                Tr.debug(tc, ql, "JDQL query parts", // does not include GROUP BY, HAVING, or address subqueries or other complex JPQL
+                         "  SELECT [" + (selectLen > 0 ? ql.substring(select0, select0 + selectLen) : "") + "]",
+                         "    FROM [" + (fromLen > 0 ? ql.substring(from0, from0 + fromLen) : "") + "]",
+                         "   WHERE [" + (whereLen > 0 ? ql.substring(where0, where0 + whereLen) : "") + "]",
+                         "  [" + (orderLen > 0 ? ql.substring(order0, order0 + orderLen) : "") + "]",
+                         "  entity [" + entityName + "] [" + entityVar + "]");
+            }
+
+            // TODO remove this once we have JPA 3.2
+            boolean lacksEntityVar;
+            if (lacksEntityVar = "this".equals(entityVar)) {
+                entityVar = "o";
+                entityVar_ = "o.";
+            }
+
+            if (countPages) {
+                // TODO count query cannot always be accurately inferred if Query value is JPQL
+                StringBuilder c = new StringBuilder("SELECT COUNT(");
+                if (lacksEntityVar
+                    || selectLen <= 0
+                    || ql.substring(select0, select0 + selectLen).indexOf(',') >= 0) // comma delimited multiple return values
+                    c.append(entityVar);
+                else // allows for COUNT(DISTINCT o.name)
+                    appendWithIdentifierName(ql, select0, select0 + selectLen, c);
+
+                c.append(") FROM");
+                if (from0 >= 0 && !lacksEntityVar)
+                    c.append(ql.substring(from0, from0 + fromLen));
+                else
+                    c.append(' ').append(entityName).append(' ').append(entityVar).append(' ');
+
+                if (whereLen > 0) {
+                    c.append("WHERE");
+                    appendWithIdentifierName(ql, where0, where0 + whereLen, c);
+                }
+
+                jpqlCount = c.toString();
+            }
+
+            if (isCursoredPage) {
+                if (order0 >= 0)
+                    throw new UnsupportedOperationException("The " + ql + " query that is supplied to the " + method.getName() +
+                                                            " method of the " + method.getDeclaringClass().getName() +
+                                                            " repository cannot include an ORDER BY clause because" +
+                                                            " the method returns a " + "CursoredPage" + ". Remove the ORDER BY" +
+                                                            " clause and instead use the " + "OrderBy" +
+                                                            " annotation to specify static sort criteria."); // TODO NLS
+
+                if (where0 + whereLen != length)
+                    throw new UnsupportedOperationException("The " + ql + " query that is supplied to the " + method.getName() +
+                                                            " method of the " + method.getDeclaringClass().getName() +
+                                                            " repository must end in a WHERE clause because" +
+                                                            " the method returns a " + "CursoredPage" + ". There WHERE clause" +
+                                                            " ends at position " + (where0 + whereLen) + " but the length of the" +
+                                                            " query is " + length + "."); // TODO NLS
+
+                // Enclose the WHERE clause in parenthesis so that conditions can be appended.
+                boolean addSpace = ql.charAt(where0) != ' ';
+                ql = new StringBuilder(ql.length() + 2) //
+                                .append(ql.substring(0, where0)) //
+                                .append(" (") //
+                                .append(ql.substring(where0 + (addSpace ? 0 : 1), where0 + whereLen)) //
+                                .append(")") //
+                                .toString();
+                whereLen += 2 + (addSpace ? 1 : 0);
+            }
+
+            StringBuilder q = new StringBuilder(ql.length() + (selectLen >= 0 ? 0 : 50) + (fromLen >= 0 ? 0 : 50) + 2);
+            q.append("SELECT");
+            if (selectLen > 0)
+                appendWithIdentifierName(ql, select0, select0 + selectLen, q);
+            else
+                q.append(' ').append(entityVar).append(' ');
+
+            q.append("FROM");
+            if (fromLen > 0 && !lacksEntityVar)
+                q.append(ql.substring(from0, from0 + fromLen));
+            else
+                q.append(' ').append(entityName).append(' ').append(entityVar).append(' ');
+
+            if (whereLen > 0) {
+                q.append("WHERE");
+                appendWithIdentifierName(ql, where0, where0 + whereLen, q);
+            }
+
+            if (orderLen > 0) {
+                appendWithIdentifierName(ql, order0, order0 + orderLen, q);
+            }
+
+            jpql = q.toString();
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -266,173 +266,188 @@ public class RepositoryImpl<R> implements InvocationHandler {
      * @param queryInfo  partially populated query information
      * @return information about the query.
      */
+    @FFDCIgnore(Throwable.class) // TODO look into these failures and decide if FFDC should be enabled
+    @Trivial
     private QueryInfo completeQueryInfo(EntityInfo entityInfo, QueryInfo queryInfo) {
-        queryInfo.entityInfo = entityInfo;
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "completeQueryInfo", entityInfo, queryInfo);
 
-        if (validator != null) {
-            boolean[] v = validator.isValidatable(queryInfo.method);
-            queryInfo.validateParams = v[0];
-            queryInfo.validateResult = v[1];
-        }
+        try {
+            queryInfo.entityInfo = entityInfo;
 
-        Method method = queryInfo.method;
-        Class<?> multiType = queryInfo.getMultipleResultType();
-        boolean countPages = Page.class.equals(multiType) || CursoredPage.class.equals(multiType);
-        StringBuilder q = null;
-
-        // TODO would it be more efficient to invoke method.getAnnotations() once?
-
-        // spec-defined annotation types
-        Delete delete = method.getAnnotation(Delete.class);
-        Find find = method.getAnnotation(Find.class);
-        Insert insert = method.getAnnotation(Insert.class);
-        Update update = method.getAnnotation(Update.class);
-        Save save = method.getAnnotation(Save.class);
-        Query query = method.getAnnotation(Query.class);
-        OrderBy[] orderBy = method.getAnnotationsByType(OrderBy.class);
-
-        // experimental annotation types
-        Count count = method.getAnnotation(Count.class);
-        Exists exists = method.getAnnotation(Exists.class);
-        Select select = method.getAnnotation(Select.class);
-
-        Annotation methodTypeAnno = queryInfo.validateAnnotationCombinations(delete, insert, update, save,
-                                                                             find, query, orderBy,
-                                                                             count, exists, select);
-
-        if (query != null) { // @Query annotation
-            queryInfo.initForQuery(query.value(), multiType);
-        } else if (save != null) { // @Save annotation
-            queryInfo.init(Save.class, QueryInfo.Type.SAVE);
-        } else if (insert != null) { // @Insert annotation
-            queryInfo.init(Insert.class, QueryInfo.Type.INSERT);
-        } else if (queryInfo.entityParamType != null) {
-            if (update != null) { // @Update annotation
-                q = generateUpdateEntity(queryInfo);
-            } else if (delete != null) { // @Delete annotation
-                q = generateDeleteEntity(queryInfo);
-            } else { // should be unreachable
-                throw new UnsupportedOperationException("The " + method.getName() + " method of the " + repositoryInterface.getName() +
-                                                        " repository interface must be annotated with one of " +
-                                                        "(Delete, Insert, Save, Update)" +
-                                                        " because the method's parameter accepts entity instances. The following" +
-                                                        " annotations were found: " + Arrays.toString(method.getAnnotations()));
+            if (validator != null) {
+                boolean[] v = validator.isValidatable(queryInfo.method);
+                queryInfo.validateParams = v[0];
+                queryInfo.validateResult = v[1];
             }
-        } else {
-            if (methodTypeAnno != null) {
-                // Query by Parameters
-                q = generateQueryFromMethodParams(queryInfo, methodTypeAnno, countPages);//keyset queries before orderby
+
+            Method method = queryInfo.method;
+            Class<?> multiType = queryInfo.getMultipleResultType();
+            boolean countPages = Page.class.equals(multiType) || CursoredPage.class.equals(multiType);
+            StringBuilder q = null;
+
+            // TODO would it be more efficient to invoke method.getAnnotations() once?
+
+            // spec-defined annotation types
+            Delete delete = method.getAnnotation(Delete.class);
+            Find find = method.getAnnotation(Find.class);
+            Insert insert = method.getAnnotation(Insert.class);
+            Update update = method.getAnnotation(Update.class);
+            Save save = method.getAnnotation(Save.class);
+            Query query = method.getAnnotation(Query.class);
+            OrderBy[] orderBy = method.getAnnotationsByType(OrderBy.class);
+
+            // experimental annotation types
+            Count count = method.getAnnotation(Count.class);
+            Exists exists = method.getAnnotation(Exists.class);
+            Select select = method.getAnnotation(Select.class);
+
+            Annotation methodTypeAnno = queryInfo.validateAnnotationCombinations(delete, insert, update, save,
+                                                                                 find, query, orderBy,
+                                                                                 count, exists, select);
+
+            if (query != null) { // @Query annotation
+                queryInfo.initForQuery(query.value(), multiType);
+            } else if (save != null) { // @Save annotation
+                queryInfo.init(Save.class, QueryInfo.Type.SAVE);
+            } else if (insert != null) { // @Insert annotation
+                queryInfo.init(Insert.class, QueryInfo.Type.INSERT);
+            } else if (queryInfo.entityParamType != null) {
+                if (update != null) { // @Update annotation
+                    q = generateUpdateEntity(queryInfo);
+                } else if (delete != null) { // @Delete annotation
+                    q = generateDeleteEntity(queryInfo);
+                } else { // should be unreachable
+                    throw new UnsupportedOperationException("The " + method.getName() + " method of the " + repositoryInterface.getName() +
+                                                            " repository interface must be annotated with one of " +
+                                                            "(Delete, Insert, Save, Update)" +
+                                                            " because the method's parameter accepts entity instances. The following" +
+                                                            " annotations were found: " + Arrays.toString(method.getAnnotations()));
+                }
             } else {
-                // Query by Method Name
-                q = generateQueryFromMethodName(queryInfo, countPages);
-            }
-
-            // TODO did we break the following? Maybe move this into the above methods?
-            // @Select annotation only
-            if (q == null && queryInfo.type == null && select != null) {
-                queryInfo.type = QueryInfo.Type.FIND;
-                q = generateSelectClause(queryInfo, select);
-                if (countPages)
-                    generateCount(queryInfo, null);
-            } else if (queryInfo.type == QueryInfo.Type.FIND_AND_DELETE
-                       && multiType != null
-                       && Stream.class.isAssignableFrom(multiType)) {
-                throw new UnsupportedOperationException("The " + method.getName() + " method of the " + repositoryInterface.getName() +
-                                                        " repository interface cannot use the " +
-                                                        method.getReturnType().getName() + " return type for a delete operation.");
-            }
-        }
-
-        // If we don't already know from generating the JPQL, find out how many
-        // parameters the JPQL takes and which parameters are named parameters.
-        if (query != null || queryInfo.paramNames != null) {
-            int initialParamCount = queryInfo.paramCount;
-            Parameter[] params = method.getParameters();
-            List<Integer> paramPositions = null;
-            Class<?> paramType;
-            boolean hasParamAnnotation = false;
-            for (int i = 0; i < params.length && !SPECIAL_PARAM_TYPES.contains(paramType = params[i].getType()); i++) {
-                Param param = params[i].getAnnotation(Param.class);
-                hasParamAnnotation |= param != null;
-                String paramName = param == null ? null : param.value();
-                if (param == null && queryInfo.jpql != null && params[i].isNamePresent()) {
-                    String name = params[i].getName();
-                    if (paramPositions == null)
-                        paramPositions = getParameterPositions(queryInfo.jpql);
-                    for (int p = 0; p < paramPositions.size() && paramName == null; p++) {
-                        int pos = paramPositions.get(p); // position at which the named parameter name must appear
-                        int next = pos + name.length(); // the next character must not be alphanumeric for the name to be a match
-                        if (queryInfo.jpql.regionMatches(paramPositions.get(p), name, 0, name.length())
-                            && (next >= queryInfo.jpql.length() || !Character.isLetterOrDigit(queryInfo.jpql.charAt(next)))) {
-                            paramName = name;
-                            paramPositions.remove(p);
-                        }
-                    }
+                if (methodTypeAnno != null) {
+                    // Query by Parameters
+                    q = generateQueryFromMethodParams(queryInfo, methodTypeAnno, countPages);//keyset queries before orderby
+                } else {
+                    // Query by Method Name
+                    q = generateQueryFromMethodName(queryInfo, countPages);
                 }
-                if (paramName != null) {
-                    if (queryInfo.paramNames == null)
-                        queryInfo.paramNames = new ArrayList<>();
-                    if (entityInfo.idClassAttributeAccessors != null && paramType.equals(entityInfo.idType))
-                        // TODO is this correct to do when @Query has a named parameter with type of the IdClass?
-                        // It seems like the JPQL would not be consistent.
-                        for (int p = 1, numIdClassParams = entityInfo.idClassAttributeAccessors.size(); p <= numIdClassParams; p++) {
-                            queryInfo.paramNames.add(new StringBuilder(paramName).append('_').append(p).toString());
-                            if (p > 1) {
-                                queryInfo.paramCount++;
-                                queryInfo.paramAddedCount++;
-                            }
-                        }
-                    else
-                        queryInfo.paramNames.add(paramName);
-                }
-                queryInfo.paramCount++;
 
-                if (initialParamCount != 0)
-                    throw new MappingException("Cannot mix positional and named parameters on repository method " +
-                                               method.getDeclaringClass().getName() + '.' + method.getName()); // TODO NLS
-
-                int numParamNames = queryInfo.paramNames == null ? 0 : queryInfo.paramNames.size();
-                if (numParamNames > 0 && numParamNames != queryInfo.paramCount)
-                    if (hasParamAnnotation) {
-                        throw new MappingException("Cannot mix positional and named parameters on repository method " +
-                                                   method.getDeclaringClass().getName() + '.' + method.getName()); // TODO NLS
-                    } else { // we might have mistaken a literal value for a named parameter
-                        queryInfo.paramNames = null;
-                        queryInfo.paramCount -= queryInfo.paramAddedCount;
-                        queryInfo.paramAddedCount = 0;
-                    }
-            }
-        }
-
-        // The @OrderBy annotation from Jakarta Data provides sort criteria statically
-        if (orderBy.length > 0) {
-            //queryInfo.type = queryInfo.type == null ? QueryInfo.Type.FIND : queryInfo.type;
-            queryInfo.sorts = queryInfo.sorts == null ? new ArrayList<>(orderBy.length + 2) : queryInfo.sorts;
-            if (q == null)
-                if (queryInfo.jpql == null) {
-                    q = generateSelectClause(queryInfo, select); // TODO can select ever be present here and not already handled by other code path?
+                // TODO did we break the following? Maybe move this into the above methods?
+                // @Select annotation only
+                if (q == null && queryInfo.type == null && select != null) {
+                    queryInfo.type = QueryInfo.Type.FIND;
+                    q = generateSelectClause(queryInfo, select);
                     if (countPages)
                         generateCount(queryInfo, null);
-                } else {
-                    q = new StringBuilder(queryInfo.jpql);
+                } else if (queryInfo.type == QueryInfo.Type.FIND_AND_DELETE
+                           && multiType != null
+                           && Stream.class.isAssignableFrom(multiType)) {
+                    throw new UnsupportedOperationException("The " + method.getName() + " method of the " + repositoryInterface.getName() +
+                                                            " repository interface cannot use the " +
+                                                            method.getReturnType().getName() + " return type for a delete operation.");
                 }
+            }
 
-            for (int i = 0; i < orderBy.length; i++)
-                queryInfo.addSort(orderBy[i].ignoreCase(), orderBy[i].value(), orderBy[i].descending());
+            // If we don't already know from generating the JPQL, find out how many
+            // parameters the JPQL takes and which parameters are named parameters.
+            if (query != null || queryInfo.paramNames != null) {
+                int initialParamCount = queryInfo.paramCount;
+                Parameter[] params = method.getParameters();
+                List<Integer> paramPositions = null;
+                Class<?> paramType;
+                boolean hasParamAnnotation = false;
+                for (int i = 0; i < params.length && !SPECIAL_PARAM_TYPES.contains(paramType = params[i].getType()); i++) {
+                    Param param = params[i].getAnnotation(Param.class);
+                    hasParamAnnotation |= param != null;
+                    String paramName = param == null ? null : param.value();
+                    if (param == null && queryInfo.jpql != null && params[i].isNamePresent()) {
+                        String name = params[i].getName();
+                        if (paramPositions == null)
+                            paramPositions = getParameterPositions(queryInfo.jpql);
+                        for (int p = 0; p < paramPositions.size() && paramName == null; p++) {
+                            int pos = paramPositions.get(p); // position at which the named parameter name must appear
+                            int next = pos + name.length(); // the next character must not be alphanumeric for the name to be a match
+                            if (queryInfo.jpql.regionMatches(paramPositions.get(p), name, 0, name.length())
+                                && (next >= queryInfo.jpql.length() || !Character.isLetterOrDigit(queryInfo.jpql.charAt(next)))) {
+                                paramName = name;
+                                paramPositions.remove(p);
+                            }
+                        }
+                    }
+                    if (paramName != null) {
+                        if (queryInfo.paramNames == null)
+                            queryInfo.paramNames = new ArrayList<>();
+                        if (entityInfo.idClassAttributeAccessors != null && paramType.equals(entityInfo.idType))
+                            // TODO is this correct to do when @Query has a named parameter with type of the IdClass?
+                            // It seems like the JPQL would not be consistent.
+                            for (int p = 1, numIdClassParams = entityInfo.idClassAttributeAccessors.size(); p <= numIdClassParams; p++) {
+                                queryInfo.paramNames.add(new StringBuilder(paramName).append('_').append(p).toString());
+                                if (p > 1) {
+                                    queryInfo.paramCount++;
+                                    queryInfo.paramAddedCount++;
+                                }
+                            }
+                        else
+                            queryInfo.paramNames.add(paramName);
+                    }
+                    queryInfo.paramCount++;
 
-            if (!queryInfo.hasDynamicSortCriteria())
-                generateOrderBy(queryInfo, q);
+                    if (initialParamCount != 0)
+                        throw new MappingException("Cannot mix positional and named parameters on repository method " +
+                                                   method.getDeclaringClass().getName() + '.' + method.getName()); // TODO NLS
+
+                    int numParamNames = queryInfo.paramNames == null ? 0 : queryInfo.paramNames.size();
+                    if (numParamNames > 0 && numParamNames != queryInfo.paramCount)
+                        if (hasParamAnnotation) {
+                            throw new MappingException("Cannot mix positional and named parameters on repository method " +
+                                                       method.getDeclaringClass().getName() + '.' + method.getName()); // TODO NLS
+                        } else { // we might have mistaken a literal value for a named parameter
+                            queryInfo.paramNames = null;
+                            queryInfo.paramCount -= queryInfo.paramAddedCount;
+                            queryInfo.paramAddedCount = 0;
+                        }
+                }
+            }
+
+            // The @OrderBy annotation from Jakarta Data provides sort criteria statically
+            if (orderBy.length > 0) {
+                //queryInfo.type = queryInfo.type == null ? QueryInfo.Type.FIND : queryInfo.type;
+                queryInfo.sorts = queryInfo.sorts == null ? new ArrayList<>(orderBy.length + 2) : queryInfo.sorts;
+                if (q == null)
+                    if (queryInfo.jpql == null) {
+                        q = generateSelectClause(queryInfo, select); // TODO can select ever be present here and not already handled by other code path?
+                        if (countPages)
+                            generateCount(queryInfo, null);
+                    } else {
+                        q = new StringBuilder(queryInfo.jpql);
+                    }
+
+                for (int i = 0; i < orderBy.length; i++)
+                    queryInfo.addSort(orderBy[i].ignoreCase(), orderBy[i].value(), orderBy[i].descending());
+
+                if (!queryInfo.hasDynamicSortCriteria())
+                    generateOrderBy(queryInfo, q);
+            }
+
+            queryInfo.jpql = q == null ? queryInfo.jpql : q.toString();
+
+            if (queryInfo.type == null)
+                throw new MappingException("Repository method name " + method.getName() +
+                                           " does not map to a valid query. Some examples of valid method names are:" +
+                                           " save(entity), findById(id), findByPriceLessThanEqual(maxPrice), deleteById(id)," +
+                                           " existsById(id), countByPriceBetween(min, max), updateByIdSetPrice(id, newPrice)"); // TODO NLS
+
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "completeQueryInfo", queryInfo);
+            return queryInfo;
+        } catch (Throwable x) {
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "completeQueryInfo", x);
+            throw x;
         }
 
-        queryInfo.jpql = q == null ? queryInfo.jpql : q.toString();
-
-        if (queryInfo.type == null)
-            throw new MappingException("Repository method name " + method.getName() +
-                                       " does not map to a valid query. Some examples of valid method names are:" +
-                                       " save(entity), findById(id), findByPriceLessThanEqual(maxPrice), deleteById(id)," +
-                                       " existsById(id), countByPriceBetween(min, max), updateByIdSetPrice(id, newPrice)"); // TODO NLS
-
-        return queryInfo;
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -4835,6 +4835,16 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Repository method with a SELECT clause but no FROM clause.
+     */
+    @Test
+    public void testSelectClauseWithoutFromClause() {
+        assertEquals("1D", primes.toHexadecimal(29).orElseThrow());
+        assertEquals("2B", primes.toHexadecimal(43).orElseThrow());
+        assertEquals(false, primes.toHexadecimal(18).isPresent());
+    }
+
+    /**
      * Repository method returns a single result or raises the specification-defined exceptions for none or too many.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -322,6 +322,9 @@ public interface Primes {
     @Query("SELECT DISTINCT LENGTH(p.romanNumeral) FROM Prime p WHERE p.numberId <= ?1 ORDER BY LENGTH(p.romanNumeral) DESC")
     Page<Integer> romanNumeralLengths(long maxNumber, PageRequest<?> pagination);
 
+    @Query("SELECT hex WHERE numberId=?1")
+    Optional<String> toHexadecimal(long num);
+
     @Query("SELECT prime_ FROM Prime AS prime_ WHERE (prime_.numberId <= ?1)")
     @OrderBy(value = "even", descending = true)
     @OrderBy(value = "sumOfBits", descending = true)


### PR DESCRIPTION
Refactor the simulation of JDQL to get SELECT working and align it more closely with usage of JPA 3.2, so that some core sections can be preserved and remaining sections for identifier variable insertion removed entirely.  For now, this will be less efficient than what we were doing before because the insertion gets duplicated for primary and count queries but all of that will go away.  I also added some debug info to capture failures processing repository methods when they happen.