### PR TITLE
Update PackageRunnableTest to allow for ShutdownHook to finish on all platforms. 

### DIFF
--- a/dev/wlp.lib.extract/src/wlp/lib/extract/ShutdownHook.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/ShutdownHook.java
@@ -154,12 +154,16 @@ public class ShutdownHook implements Runnable {
 
     }
 
+    private void waitAndCloseStreams(Process proc) throws IOException, InterruptedException {
+        waitAndCloseStreams(proc, false, true);
+    }
+
     /**
      * @param proc
      * @throws Exception
      * @throws InterruptedException
      */
-    private void waitAndCloseStreams(Process proc) throws IOException, InterruptedException {
+    private void waitAndCloseStreams(Process proc, boolean writeStdoutToHookLog, boolean writeStderrToHookLog) throws IOException, InterruptedException {
         StringBuilder stdOut = new StringBuilder();
         StringBuilder stdErr = new StringBuilder();
         StringBuilder output = new StringBuilder();
@@ -183,10 +187,10 @@ public class ShutdownHook implements Runnable {
 
         proc.waitFor();
 
-        if (!stdoutEmpty) {
+        if (writeStdoutToHookLog && !stdoutEmpty) {
             output.append(stdOut.toString());
         }
-        if (!stderrEmpty) {
+        if (writeStderrToHookLog && !stderrEmpty) {
             if (!stdoutEmpty) {
                 output.append("\nStderr:\n");
             }

--- a/dev/wlp.lib.extract/src/wlp/lib/extract/ShutdownHook.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/ShutdownHook.java
@@ -17,11 +17,16 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.ResourceBundle;
 
 /**
@@ -31,6 +36,7 @@ import java.util.ResourceBundle;
 public class ShutdownHook implements Runnable {
 
     private static final ResourceBundle resourceBundle = ResourceBundle.getBundle(SelfExtract.class.getName() + "Messages");
+    private static final String hookLog = "shutdownHook.log";
 
     final int platformType;
     final String dir;
@@ -106,7 +112,7 @@ public class ShutdownHook implements Runnable {
 
         Process stopProcess = Runtime.getRuntime().exec(cmd, SelfExtractUtils.runEnv(dir), null); // stop server
         try {
-            stopProcess.waitFor();
+            waitAndCloseStreams(stopProcess);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
@@ -117,18 +123,23 @@ public class ShutdownHook implements Runnable {
      *
      * @throws IOException
      */
-    private void startAsyncDelete() throws IOException {
+    private void startAsyncDelete() throws IOException, InterruptedException {
 
         Runtime rt = Runtime.getRuntime();
         File scriptFile = null;
+
         if (platformType == SelfExtractUtils.PlatformType_UNIX) {
             scriptFile = writeCleanupFile(SelfExtractUtils.PlatformType_UNIX);
-            rt.exec("chmod 750 " + scriptFile.getAbsolutePath());
-            rt.exec("sh -c " + scriptFile.getAbsolutePath() + " &");
+            Process proc = rt.exec("chmod 750 " + scriptFile.getAbsolutePath());
+            waitAndCloseStreams(proc);
+            ProcessBuilder job = new ProcessBuilder().command("sh", "-c", scriptFile.getAbsolutePath());
+            job.redirectErrorStream(true);
+            proc = job.start();
+            waitAndCloseStreams(proc);
         } else if (platformType == SelfExtractUtils.PlatformType_OS400) {
             scriptFile = writeCleanupFile(SelfExtractUtils.PlatformType_OS400);
             rt.exec("chmod 750 " + scriptFile.getAbsolutePath());
-            rt.exec("/usr/bin/qsh -c " + scriptFile.getAbsolutePath() + " &");
+            rt.exec("/usr/bin/qsh -c " + scriptFile.getAbsolutePath());
         } else if (platformType == SelfExtractUtils.PlatformType_WINDOWS) {
             scriptFile = writeCleanupFile(SelfExtractUtils.PlatformType_WINDOWS);
             // Note: must redirect output in order for script to run on windows.
@@ -140,6 +151,62 @@ public class ShutdownHook implements Runnable {
             // convert to Unix type path and run under bash
             rt.exec("bash -c " + scriptFile.getAbsolutePath().replace('\\', '/') + " &");
         }
+
+    }
+
+    private void waitAndCloseStreams(Process proc) throws IOException, InterruptedException {
+        waitAndCloseStreams(proc, false, true);
+    }
+
+    /**
+     * @param proc
+     * @throws Exception
+     * @throws InterruptedException
+     */
+    private void waitAndCloseStreams(Process proc, boolean writeStdoutToHookLog, boolean writeStderrToHookLog) throws IOException, InterruptedException {
+        StringBuilder stdOut = new StringBuilder();
+        StringBuilder stdErr = new StringBuilder();
+        StringBuilder output = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                stdOut.append(line + "\n");
+            }
+        }
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getErrorStream()))) {
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                stdErr.append(line + "\n");
+            }
+        }
+
+        boolean stdoutEmpty = stdOut.toString().isEmpty();
+        boolean stderrEmpty = stdErr.toString().isEmpty();
+
+        proc.waitFor();
+
+        if (writeStdoutToHookLog && !stdoutEmpty) {
+            output.append(stdOut.toString());
+        }
+        if (writeStderrToHookLog && !stderrEmpty) {
+            if (!stdoutEmpty) {
+                output.append("\nStderr:\n");
+            }
+            output.append(stdErr.toString());
+        }
+        File outputFile = getHookLog().toFile();
+
+        if (!output.toString().isEmpty()) {
+            try (FileWriter writer = new FileWriter(outputFile, true); BufferedWriter bufferedWriter = new BufferedWriter(writer)) {
+                bufferedWriter.write(output.toString());
+            }
+        }
+
+        proc.getInputStream().close();
+        proc.getOutputStream().close();
+        proc.getErrorStream().close();
     }
 
     /**
@@ -191,22 +258,28 @@ public class ShutdownHook implements Runnable {
         String serverDir = dir + File.separator + "wlp" + File.separator + "usr" + File.separator + "servers" + File.separator + serverName + File.separator;
         File tempDir = Files.createTempDirectory("logs").toFile();
 
+        String logDirNormalized = logDir.replace('\\', '/');
+        String dirNormalized = dir.replace('\\', '/');
+        String tempDirNormalized = tempDir.getAbsolutePath().replace('\\', '/');
+        String fileNormalized = file.getAbsolutePath().replace('\\', '/');
+
         bw.write("echo begin delete" + "\n");
         bw.write("n=0" + "\n");
         bw.write("while [ $n -ne 1 ]; do" + "\n");
-        bw.write("  if [ -e " + dir.replace('\\', '/') + "/wlp ]; then" + "\n");
-        bw.write("    cp -r " + logDir.replace('\\', '/') + " " + tempDir.getAbsolutePath().replace('\\', '/') + "\n");
-        bw.write("    rm -rf " + dir.replace('\\', '/') + "/wlp/ \n");
+        bw.write("  if [ -e " + dirNormalized + "/wlp ]; then" + "\n");
+        bw.write("    cp -r " + logDirNormalized + " " + tempDirNormalized + "\n");
+        bw.write("    rm -rf " + dirNormalized + "/wlp/ \n");
         bw.write("  else" + "\n");
-        bw.write("    echo file not found - n=$n" + "\n");
+        bw.write("    echo file " + dirNormalized + "/wlp was deleted. Exiting loop." + "\n");
         bw.write("    n=1" + "\n");
         bw.write("  fi" + "\n");
         bw.write("done" + "\n");
-        bw.write("mkdir -p " + logDir.replace('\\', '/') + "\n");
-        bw.write("cp -r " + tempDir.getAbsolutePath().replace('\\', '/') + "/logs/ " + serverDir.replace('\\', '/') + "\n");
-        bw.write("chmod -R 755 " + dir.replace('\\', '/') + "\n");
-        bw.write("rm -rf " + file.getAbsolutePath().replace('\\', '/') + "\n");
-        bw.write("rm -rf " + tempDir.getAbsolutePath().replace('\\', '/') + "\n");
+        bw.write("mkdir -p " + logDirNormalized + "\n");
+        bw.write("cp -r " + tempDirNormalized + "/logs/ " + serverDir.replace('\\', '/') + "\n");
+        bw.write("echo log directory restored to: " + logDirNormalized + "\n");
+        bw.write("chmod -R 755 " + dirNormalized + "\n");
+        bw.write("rm -rf " + fileNormalized + "\n");
+        bw.write("rm -rf " + tempDirNormalized + "\n");
         bw.write("echo end delete" + "\n");
     }
 
@@ -286,22 +359,32 @@ public class ShutdownHook implements Runnable {
     @Override
     public void run() {
         try {
-
             stopServer(); // first, stop server
-
             // When the server is launched with java -jar, delete the server on exit minus
             // the /logs folder, unless WLP_JAR_EXTRACT_DIR is set at which point don't delete
             // anything.
-
             if (extractDirPredefined != true) {
                 startAsyncDelete(); // now launch async process to cleanup extraction directory
             }
 
         } catch (Exception e) {
+            try {
+                Files.write(getHookLog(), (e.getMessage() + "\n" + Arrays.toString(e.getStackTrace())).getBytes(), StandardOpenOption.APPEND);
+            } catch (IOException e1) {
+                e1.printStackTrace();
+            }
             e.printStackTrace();
             throw new RuntimeException("Shutdown hook failed with exception " + e.getMessage());
         }
 
+    }
+
+    /**
+     * @return
+     */
+    private Path getHookLog() {
+        String logDir = dir + File.separator + "wlp" + File.separator + "usr" + File.separator + "servers" + File.separator + serverName + File.separator + "logs";
+        return Paths.get(logDir, hookLog);
     }
 
 }

--- a/dev/wlp.lib.extract_fat/fat/src/wlp/lib/extract/PackageRunnableTest.java
+++ b/dev/wlp.lib.extract_fat/fat/src/wlp/lib/extract/PackageRunnableTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,20 +20,24 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.stream.Collectors;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -87,7 +91,6 @@ public class PackageRunnableTest {
 
     @Before
     public void setup() throws Exception {
-        String method = "setup";
 
         // Verify that /lib/extract exits, and the manifest.mf is valid
         validateWLPLibExtractAndManifest();
@@ -253,8 +256,12 @@ public class PackageRunnableTest {
         assertNotNull("The server did not show that it had stopped after executing the jar.",
                       server.waitForStringInLog("CWWKE0036I:.*"));
 
-        // wait 30s to give the shutdown script time to run in the shutdown hook
-        Thread.sleep(30000);
+        File templateDir = getTemplateDir(extractLocation);
+        // wait up to 3 minutes to give the shutdown script time to run in the shutdown hook
+        Instant start = Instant.now();
+        while (templateDir.exists() && Duration.between(start, Instant.now()).toMinutes() < 3) {
+            Thread.sleep(5000);
+        }
 
         Log.info(c, method, "The value of extractLocation is: " + extractLocation);
         Log.info(c, method, "extractLocation is a directory: " + extractLocation.isDirectory());
@@ -263,7 +270,7 @@ public class PackageRunnableTest {
     }
 
     /**
-     * Checks that the /logs and optionally the /bin folder exist within the /wlp folder structure.
+     * Checks that the /logs and optionally the /templates folder exist within the /wlp folder structure.
      *
      * @param extractDir
      * @param shouldBinFolderExist
@@ -280,18 +287,8 @@ public class PackageRunnableTest {
             sb.append(files[i] + "\n");
         }
 
-        File logDir = null;
-        File templateDir = null;
-
-        if (extractDir.getAbsolutePath().endsWith("wlp")) {
-            logDir = new File(extractDir.getAbsolutePath() + File.separator + "usr" + File.separator + "servers" + File.separator + serverName
-                              + File.separator + "logs");
-            templateDir = new File(extractDir.getAbsolutePath() + File.separator + "templates");
-        } else {
-            logDir = new File(extractDir.getAbsolutePath() + File.separator + "wlp" + File.separator + "usr" + File.separator + "servers" + File.separator + serverName
-                              + File.separator + "logs");
-            templateDir = new File(extractDir.getAbsolutePath() + File.separator + "wlp" + File.separator + "templates");
-        }
+        File logDir = getLogsDir(extractDir);
+        File templateDir = getTemplateDir(extractDir);
 
         // Logs should always exist regardless
         assertTrue(File.separator + "logs folder at " + logDir.getAbsolutePath() + " does not exist, but should. " + sb.toString(), logDir.exists());
@@ -300,10 +297,44 @@ public class PackageRunnableTest {
             assertTrue(File.separator + "templates folder at " + templateDir.getAbsolutePath() + " does not exist, but should. Contents =" + sb.toString(),
                        templateDir.exists());
         } else {
-            Log.info(c, method, "Contents at " + templateDir.getAbsolutePath() + " are : " + sb.toString());
-            assumeTrue(!templateDir.exists());
+            Log.info(c, method, "Contents at " + extractDir.getAbsolutePath() + " are :\n" + sb.toString());
+            assertFalse(File.separator + "templates folder at " + templateDir.getAbsolutePath() + " exists, but should not. Contents =" + sb.toString(), templateDir.exists());
         }
 
+    }
+
+    /**
+     * @param extractDir
+     * @return
+     */
+    private File getLogsDir(File extractDir) {
+        File logDir = null;
+
+        if (extractDir.getAbsolutePath().endsWith("wlp")) {
+            logDir = new File(extractDir.getAbsolutePath() + File.separator + "usr" + File.separator + "servers" + File.separator + serverName
+                              + File.separator + "logs");
+        } else {
+
+            logDir = new File(extractDir.getAbsolutePath() + File.separator + "wlp" + File.separator + "usr" + File.separator + "servers" + File.separator + serverName
+                              + File.separator + "logs");
+        }
+        return logDir;
+    }
+
+    /**
+     * @param extractDir
+     * @return
+     */
+    private File getTemplateDir(File extractDir) {
+        File templateDir = null;
+
+        if (extractDir.getAbsolutePath().endsWith("wlp")) {
+            templateDir = new File(extractDir.getAbsolutePath() + File.separator + "templates");
+        } else {
+
+            templateDir = new File(extractDir.getAbsolutePath() + File.separator + "wlp" + File.separator + "templates");
+        }
+        return templateDir;
     }
 
     /**
@@ -432,6 +463,19 @@ public class PackageRunnableTest {
             } else {
                 // stop normally so shutdown hook is called
                 stopServer(extractLoc);
+                Instant start = Instant.now();
+                // wait for process to die gracefully before landing in the finally block where it will be destroyed forcefully.
+                while (proc.isAlive() && Duration.between(start, Instant.now()).toMinutes() < 3) {
+                    Thread.sleep(1000);
+                }
+                File shutdownHookLog = new File(getLogsDir(new File(extractLoc)), "shutdownHook.log");
+                if (shutdownHookLog.exists()) {
+                    List<String> logStrings = Files.readAllLines(shutdownHookLog.toPath(), StandardCharsets.UTF_8);
+                    Log.info(c, method, "shutdown log found in " + shutdownHookLog.getAbsolutePath() + ", contents:\n" + logStrings.stream().collect(Collectors.joining("\n")));
+                } else {
+                    Log.info(c, method, "shutdown hook log doesn't exist in: " + shutdownHookLog.getAbsolutePath());
+
+                }
             }
 
             if (os != null) {
@@ -636,13 +680,19 @@ public class PackageRunnableTest {
      */
     private void stopServer(String extractLocation) throws Exception {
         String method = "stopServer";
+        // LibertyServer framework doesn't work here. It always detects the server as not started even though it is started.
+        // When forcing it to started using `setStarted` this causes the stop command to hang indefinitely.
+        Runtime rt = Runtime.getRuntime();
+        String serverCmd;
+        if (System.getProperty("os.name").startsWith("Win")) {
+            serverCmd = "server.bat";
+        } else {
+            serverCmd = "server";
+        }
+        String stopCmd = extractLocation + File.separator + "bin" + File.separator + serverCmd + " stop " + serverName;
+        Log.info(c, method, "Stopping server with the following command: '" + stopCmd + "'");
+        rt.exec(stopCmd);
 
-        Log.info(c, method, "Getting existing liberty server");
-        LibertyServer server = LibertyServerFactory.getExistingLibertyServer(extractLocation + File.separator + "usr" + File.separator + "servers" + File.separator
-                                                                             + serverName);
-        Log.info(c, method, "Attempting to stop server = " + server.getServerName() + " with status = " + server.isStarted());
-
-        server.stopServer();
     }
 
     /**
@@ -834,28 +884,6 @@ public class PackageRunnableTest {
                     fos.write(buffer, 0, read);
                 }
             }
-        }
-    }
-
-    /**
-     * Writes a file out to the output log
-     *
-     * @param f
-     * @throws FileNotFoundException
-     * @throws IOException
-     */
-    private static void dumpFileToLog(File f) throws FileNotFoundException, IOException {
-        BufferedReader reader = null;
-        String method = "dumpFileToLog";
-        try {
-            reader = new BufferedReader(new FileReader(f));
-            String s = null;
-            Log.info(c, method, "\t Contents of " + f.getAbsolutePath() + " : ");
-            while ((s = reader.readLine()) != null) {
-                Log.info(c, method, "\t\t" + s);
-            }
-        } finally {
-            reader.close();
         }
     }
 

--- a/dev/wlp.lib.extract_fat/fat/src/wlp/lib/extract/PackageRunnableTest.java
+++ b/dev/wlp.lib.extract_fat/fat/src/wlp/lib/extract/PackageRunnableTest.java
@@ -468,10 +468,10 @@ public class PackageRunnableTest {
                 while (proc.isAlive() && Duration.between(start, Instant.now()).toMinutes() < 3) {
                     Thread.sleep(1000);
                 }
-                File shutdownHookLog = new File(getLogsDir(extractDirectory), "shutdownHook.log");
+                File shutdownHookLog = new File(getLogsDir(new File(extractLoc)), "shutdownHook.log");
                 if (shutdownHookLog.exists()) {
                     List<String> logStrings = Files.readAllLines(shutdownHookLog.toPath(), StandardCharsets.UTF_8);
-                    Log.info(c, method, "shutdown log found, contents:\n" + logStrings.stream().collect(Collectors.joining("\n")));
+                    Log.info(c, method, "shutdown log found in " + shutdownHookLog.getAbsolutePath() + ", contents:\n" + logStrings.stream().collect(Collectors.joining("\n")));
                 } else {
                     Log.info(c, method, "shutdown hook log doesn't exist in: " + shutdownHookLog.getAbsolutePath());
 


### PR DESCRIPTION
Sometimes our test pipeline fails with the following:

```
testRunnableDeleteServerMinusLogsFolder:junit.framework.AssertionFailedError: 2023-05-01-12:51:11:439 extractDir:/home/jazz_build/wlpExtract/runnableTestServer_32153121321335/wlp is not a directory.
at wlp.lib.extract.PackageRunnableTest.checkDirStructure(PackageRunnableTest.java:277)
at wlp.lib.extract.PackageRunnableTest.testRunnableDeleteServerMinusLogsFolder(PackageRunnableTest.java:262)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:204)
at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:364)
at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:178)
```

This is likely because the shutdown hook hadn't completed or because the JVM was terminated by the test prematurely.