### PR TITLE
Allow InternalLogException in batch lease deletion test

### DIFF
--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/fat/src/tests/FailoverTestLease.java
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/fat/src/tests/FailoverTestLease.java
@@ -437,6 +437,8 @@ public class FailoverTestLease extends FATServletClient {
     }
 
     @Test
+    // Can get a benign InternalLogException if heartbeat happens at same time as lease claim
+    @AllowedFFDC(value = { "com.ibm.ws.recoverylog.spi.InternalLogException" })
     public void testBatchLeaseDeletion() throws Exception {
         final String method = "testBatchLeaseDeletion";
         if (!TxTestContainerSuite.isDerby()) { // Exclude Derby


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.lease