### PR TITLE
Don't rollback on closed connections

### DIFF
--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/test-bundles/ifxlib/src/com/informix/jdbcx/IfxConnection.java
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/test-bundles/ifxlib/src/com/informix/jdbcx/IfxConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -494,7 +494,13 @@ public class IfxConnection implements Connection {
      */
     @Override
     public void rollback() throws SQLException {
-        wrappedConn.rollback();
+        // FFDCs on SQL Server if we're shutting down
+        final String dbname = getMetaData().getDatabaseProductName();
+        if (wrappedConn.isClosed() && dbname.toLowerCase().contains("microsoft sql")) {
+            System.out.println("IfxConnection(" + wrappedConn + "): Not rolling back because the connection is closed and the db is " + dbname);
+        } else {
+            wrappedConn.rollback();
+        }
     }
 
     /*


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.transaction.hadb_fat.db2.1,com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.db2.retriablecodes,com.ibm.ws.transaction.hadb_fat.derby.1,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.derby.retriablecodes,com.ibm.ws.transaction.hadb_fat.oracle.1,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.oracle.retriablecodes,com.ibm.ws.transaction.hadb_fat.postgresql.1,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.postgresql.retriablecodes,com.ibm.ws.transaction.hadb_fat.sqlserver.1,com.ibm.ws.transaction.hadb_fat.sqlserver.2,com.ibm.ws.transaction.hadb_fat.sqlserver.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes