### PR TITLE
use the entity specified in JDQL FROM clause

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -37,6 +37,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import io.openliberty.data.internal.persistence.model.Model;
+import jakarta.data.repository.Query;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.Attribute.PersistentAttributeType;
@@ -153,15 +154,16 @@ public abstract class EntityManagerBuilder implements Runnable {
      * @param staticMetamodels static metamodel class(es) per entity class.
      */
     public void populateStaticMetamodelClasses(Map<Class<?>, List<Class<?>>> staticMetamodels) {
-        for (Class<?> entityClass : entities) {
-            List<Class<?>> metamodelClasses = staticMetamodels.get(entityClass);
-            if (metamodelClasses != null) {
-                CompletableFuture<EntityInfo> entityInfoFuture = entityInfoMap.computeIfAbsent(entityClass, EntityInfo::newFuture);
-                EntityInfo entityInfo = entityInfoFuture.join();
-                for (Class<?> metamodelClass : metamodelClasses)
-                    Model.initialize(metamodelClass, entityInfo.attributeNames);
+        for (Class<?> entityClass : entities)
+            if (!Query.class.equals(entityClass)) {
+                List<Class<?>> metamodelClasses = staticMetamodels.get(entityClass);
+                if (metamodelClasses != null) {
+                    CompletableFuture<EntityInfo> entityInfoFuture = entityInfoMap.computeIfAbsent(entityClass, EntityInfo::newFuture);
+                    EntityInfo entityInfo = entityInfoFuture.join();
+                    for (Class<?> metamodelClass : metamodelClasses)
+                        Model.initialize(metamodelClass, entityInfo.attributeNames);
+                }
             }
-        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1817,6 +1817,45 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Repository methods where the FROM clause identifies the entity.
+     */
+    @Test
+    public void testFromClauseIdentifiesEntity() {
+        products.clear();
+
+        Product prod1 = new Product();
+        prod1.pk = UUID.nameUUIDFromBytes("TestFromClauseIdentifiesEntity-1".getBytes());
+        prod1.name = "TestFromClauseIdentifiesEntity-Product-1";
+        prod1.price = 8.99f;
+        prod1 = multi.create(prod1);
+
+        Product prod2 = new Product();
+        prod2.pk = UUID.nameUUIDFromBytes("TestFromClauseIdentifiesEntity-2".getBytes());
+        prod2.name = "TestFromClauseIdentifiesEntity-Product-2";
+        prod2.price = 12.99f;
+        prod2 = multi.create(prod2);
+
+        Product prod3 = new Product();
+        prod3.pk = UUID.nameUUIDFromBytes("TestFromClauseIdentifiesEntity-3".getBytes());
+        prod3.name = "TestFromClauseIdentifiesEntity-Product-3";
+        prod3.price = 16.99f;
+        prod3 = multi.create(prod3);
+
+        assertEquals(3L, multi.countEverything());
+
+        assertEquals(1L, multi.discount("TestFromClauseIdentifiesEntity-Product-3", 0.30f));
+        assertEquals(3L, multi.discount("TestFromClauseIdentifiesEntity-Product-_", 0.20f));
+
+        assertEquals(8.79f, products.findByPK(prod1.pk).orElseThrow().price, 0.001f);
+        assertEquals(12.79f, products.findByPK(prod2.pk).orElseThrow().price, 0.001f);
+        assertEquals(16.49f, products.findByPK(prod3.pk).orElseThrow().price, 0.001f);
+
+        assertEquals(3L, multi.destroy("TestFromClauseIdentifiesEntity-%"));
+
+        assertEquals(0L, multi.countEverything());
+    }
+
+    /**
      * Verify that ORDER BY can be generated, taking into account the entity variable name of a custom query.
      * The custom query in this case has no WHERE clause.
      * Other tests cover similar scenarios in which a WHERE clause is present.

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/MultiRepository.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/MultiRepository.java
@@ -20,13 +20,14 @@ import java.util.Optional;
 import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 
 /**
  * Repository with multiple entity classes,
- * and where this is no primary enitty class.
+ * and where this is no primary entity class.
  */
 @Repository
 public interface MultiRepository {
@@ -34,11 +35,20 @@ public interface MultiRepository {
     @Insert
     List<Person> add(Person... people);
 
+    @Query("SELECT COUNT(THIS) FROM Product")
+    long countEverything();
+
     @Insert
     Product create(Product prod);
 
     @Delete
     Optional<Person> deleteById(@By(ID) Long id);
+
+    @Query("DELETE FROM Product WHERE name LIKE ?1")
+    long destroy(String namePattern);
+
+    @Query("UPDATE Product SET price = price - :amount WHERE name LIKE :namePattern")
+    long discount(String namePattern, float amount);
 
     Optional<Package> findById(Number id);
 


### PR DESCRIPTION
The entity that is listed in the JDQL FROM clause, if present, needs to be used as the entity type for the query.  This allows Query methods to be used on repositories where there is no primary entity type as well as repositories where there is a primary entity type but it differs from the entity in the FROM clause.