### PR TITLE
Remove noship-1.0 from tested.features in com.ibm.ws.javaee.ddmodel_fat

### DIFF
--- a/dev/com.ibm.ws.javaee.ddmodel_fat/bnd.bnd
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/bnd.bnd
@@ -38,7 +38,7 @@ test.project: true
 # has dependencies on these features, they must be be explicitly added to
 # the tested features list.
 
-tested.features: connectors-2.1, xmlbinding-4.0, noship-1.0
+tested.features: connectors-2.1, xmlbinding-4.0
 
 -sub: *.bnd
 


### PR DESCRIPTION
for #27410

Now that cdi-4.1 is beta we should be able to remove the `noship-1.0` feature from `tested.features`.