### PR TITLE
Update kernel and app classloader to be more efficient

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -474,7 +474,7 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
                     String sealedString = null;
 
                     if (manifestEntryAttributes != null) {
-                        String unixName = packageName.replaceAll("\\.", "/") + "/"; //replace all dots with slash and add trailing slash
+                        String unixName = packageName.replace('.', '/') + "/"; //replace all dots with slash and add trailing slash
                         Map<Name, String> entryAttributes = manifestEntryAttributes.get(unixName);
                         if (entryAttributes != null) {
                             specTitle = entryAttributes.get(Name.SPECIFICATION_TITLE);

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/DirectoryResourceHandler.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/DirectoryResourceHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,6 +17,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.jar.Manifest;
 
 /**
@@ -35,7 +37,8 @@ public class DirectoryResourceHandler implements ResourceHandler {
     }
 
     @Override
-    public void close() throws IOException {}
+    public void close() throws IOException {
+    }
 
     @Override
     public ResourceEntry getEntry(String name) {
@@ -71,6 +74,33 @@ public class DirectoryResourceHandler implements ResourceHandler {
             manifestLoaded = true;
         }
         return manifest;
+    }
+
+    @Override
+    public Set<String> getClassPackages() {
+        Set<String> packages = new HashSet<>();
+        StringBuilder sb = new StringBuilder();
+        getPackages(directory, packages, sb);
+        return packages;
+    }
+
+    private static void getPackages(File directory, Set<String> packages, StringBuilder sb) {
+        File[] files = directory.listFiles();
+        int builderLength = sb.length();
+        String packageName = null;
+        for (File file : files) {
+            if (file.isDirectory()) {
+                if (builderLength != 0) {
+                    sb.append('.');
+                }
+                sb.append(file.getName());
+                getPackages(file, packages, sb);
+                sb.setLength(builderLength);
+            } else if (packageName == null && file.getName().endsWith(".class")) {
+                packageName = sb.toString();
+                packages.add(packageName);
+            }
+        }
     }
 
     private static String getCanonicalPath(File file) {

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/ResourceHandler.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/ResourceHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,6 +15,7 @@ package com.ibm.ws.kernel.internal.classloader;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Set;
 import java.util.jar.Manifest;
 
 /**
@@ -26,4 +27,6 @@ public interface ResourceHandler extends Closeable {
     URL toURL();
 
     Manifest getManifest() throws IOException;
+
+    Set<String> getClassPackages();
 }


### PR DESCRIPTION
- Update to not create locks for classes that will not be found by the boot classloader.  This reduces the amount of garbage created and reduces the amount of work that GC does since we use weak references to the classloader locks.
- Update loadClass to only lock around loading of the class from this loader.  In ParentLast load don't hold the classloader lock when calling the parent.  Also when calling the class generator don't hold the classloader lock.  It is not needed.
- Update to use replace(char, char) instead of replaceAll(String, String)