### PR TITLE
spaces allowed in verbosegc log filepath

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1136,7 +1136,7 @@ serverCmd()
   # if [ ! jvmargs, javaoptions, jvmoptionsquoted contains verbose:gc, verbosegc, etc] then SERVER_IBM_JAVA_OPTIONS += -Xverbosegclog:verbosegc.%seq.log,10,1024
   if [ -n "${JVM_OPTIONS_QUOTED##*"verbosegc"*}" ] && [ -n "${JVM_OPTIONS_QUOTED##*"verbose:gc"*}"  ] && [ ! "${VERBOSEGC}" = "false" ]
   then
-    OPENJ9_JAVA_OPTIONS="-Xverbosegclog:${X_LOG_DIR}/verbosegc.%seq.log,10,1024 ${OPENJ9_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="\"-Xverbosegclog:${X_LOG_DIR}/verbosegc.%seq.log,10,1024\" ${OPENJ9_JAVA_OPTIONS}"
   fi
 
   if $os400lib; then

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -734,7 +734,7 @@ goto:eof
       goto:eof
     )
 
-    set OPENJ9_JAVA_OPTIONS=-Xverbosegclog:!X_LOG_DIR!\verbosegc.%%seq.log,10,1024 !OPENJ9_JAVA_OPTIONS!
+    set OPENJ9_JAVA_OPTIONS="-Xverbosegclog:!X_LOG_DIR!\verbosegc.%%seq.log,10,1024" !OPENJ9_JAVA_OPTIONS!
 goto:eof
 
 @REM


### PR DESCRIPTION
spaces can appear in the filepath of verbosegc logs, this should not cause the server to not start.

Fixes #28083