### PR TITLE
Only check SAF if user's length is less than 8 characters

### DIFF
--- a/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/adapter/urbridge/URBridge.java
+++ b/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/adapter/urbridge/URBridge.java
@@ -163,6 +163,8 @@ public class URBridge implements Repository {
      */
     private static Map<String, String[]> defaultRDNProperties = null;
 
+    private static final int RACF_MAX_USER_LENGTH = 8;
+
     /*******************************************************************************************/
 
     private static void initializeSupportedEntities() {
@@ -1004,7 +1006,7 @@ public class URBridge implements Repository {
                     boolean isValidUser = false;
                     if (isSafRegistry()) {
                         try {
-                            isValidUser = userRegistry.isValidUser(pname);
+                            isValidUser = isValidSafUser(pname);
                         } catch (RegistryException e) {
                             if (tc.isDebugEnabled()) {
                                 Tr.debug(tc, SPI_PREFIX + METHODNAME, " principal, " + pname + ", not found in " + reposId);
@@ -1291,7 +1293,7 @@ public class URBridge implements Repository {
 
         if (isSafRegistry()) {
             try {
-                if (userRegistry.isValidUser(uniqueName)) {
+                if (isValidSafUser(uniqueName)) {
                     return true;
                 }
             } catch (Exception e) {
@@ -1340,7 +1342,7 @@ public class URBridge implements Repository {
 
         if (isSafRegistry()) {
             try {
-                if (userRegistry.isValidUser(entity)) {
+                if (isValidSafUser(entity)) {
                     List<String> returnValue = new ArrayList<String>();
                     returnValue.add(SchemaConstants.DO_PERSON_ACCOUNT);
                     returnValue.add(userRegistry.getUserSecurityName(entity)); // Handle SAF tokens.
@@ -1426,5 +1428,16 @@ public class URBridge implements Repository {
      */
     private boolean isSafRegistry() {
         return SAFRegistryImplClass.equalsIgnoreCase(userRegistry.getClass().getName());
+    }
+
+    private boolean isValidSafUser(String userSecurityName) throws RegistryException {
+        if(userSecurityName == null){
+            return false;
+        }
+        if (userSecurityName.trim().length() > RACF_MAX_USER_LENGTH){
+            Tr.debug(tc, "The user " + userSecurityName + " could not be checked in RACF because the username exceeds the maximun length of characters allowed by RACF.");
+            return false;
+        }
+        return userRegistry.isValidUser(userSecurityName);
     }
 }


### PR DESCRIPTION
Currently `isValidUser` checks if user is valid all the time. However this shouldn't be the case because SAF only supports users that are less than 8 characters. [https://www.ibm.com/docs/en/zos/2.4.0?topic=users-user-naming-conventions](https://www.ibm.com/docs/en/zos/2.4.0?topic=users-user-naming-conventions)

Checking for users that are longer than 8 characters causes this RACF exception and ffdc:

```
    [7/13/23 8:32:38:113 GMT] 0000003e id=00000000 com.ibm.ws.logging.internal.impl.IncidentImpl                I FFDC1015I: An FFDC Incident has been created: "com.ibm.ws.security.registry.RegistryException: CWWKS2910E: SAF service WAS_INTERNAL did not succeed. SAF return code 0xffffffff. RACF return code 0xffffffff. RACF reason code 0xffffffff. Internal error code 0x00000001. com.ibm.ws.security.wim.adapter.urbridge.URBridge 1008" at ffdc_23.07.13_08.32.38.0.log

```

In a single SAF UR environment, this can be acceptable since customers will not be able to create users longer than 8 characters without SAF Complaining. However in a VMM setup where LDAP and other UR are used that don't have this restriction, this can lead to the creation of hundreds if not thousands of ffdcs. This is because the VMM checks if a user exist in the Realm.

This MR will only check SAF if the user is less than 8 characters long.

OpenLiberty Pull Requester,

ATTENTION, READ THIS: Updated 4/11/2018 - Read and understand this completely,
then delete this entire template. If a reviewer or merger sees this template,
they should fail the review or merge.

If this code change is fixing a user-visible bug in previously released code, it MUST
have an associated issue mentioned in the PR text or description. That Issue also
MUST be labelled “release bug”

This directs automation to scrape this fix for inclusion in the next release's
list of bugs fixed.

If this code is NOT for fixing a released bug, for example new function, fixing
a bug in unreleased function, or other improvements that do not affect the
user-space, no label is needed. An issue could or could not be used based
on the developer’s discretion, but do still delete this text block.

For full details, please see this wiki page:

https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions

