### PR TITLE
Fix Oracle property decoding bug

### DIFF
--- a/dev/com.ibm.ws.crypto.passwordutil/test/com/ibm/websphere/crypto/PasswordUtilTest.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/test/com/ibm/websphere/crypto/PasswordUtilTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -35,7 +35,7 @@ public class PasswordUtilTest {
 
     /**
      * Capture stdout/stderr output to the manager.
-     * 
+     *
      * @throws Exception
      */
     @BeforeClass
@@ -46,7 +46,7 @@ public class PasswordUtilTest {
 
     /**
      * Final teardown work when class is exiting.
-     * 
+     *
      * @throws Exception
      */
     @AfterClass
@@ -57,7 +57,7 @@ public class PasswordUtilTest {
 
     /**
      * Individual teardown after each test.
-     * 
+     *
      * @throws Exception
      */
     @After
@@ -103,6 +103,9 @@ public class PasswordUtilTest {
                 // expected exception
             }
             assertEquals("WebAS", PasswordUtil.decode("{xor}CDo9Hgw="));
+
+            assertEquals("{xor}Lz4sLCgwLTsINis3exYxFis=", PasswordUtil.encode("passwordWith$InIt"));
+            assertEquals("passwordWith$InIt", PasswordUtil.decode("{xor}Lz4sLCgwLTsINis3exYxFis="));
 
             try {
                 PasswordUtil.encode(null);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -1358,7 +1358,8 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
             password = PasswordUtil.getCryptoAlgorithm(password) == null ? password : PasswordUtil.decode(matcher.group(1));
             
             //This appends a replacement for group(0), so we want to just replace group(1) with [decoded password]
-            matcher.appendReplacement(sb, matcher.group(0).replace(matcher.group(1), password));
+            //  Escape '$' in a password otherwise the matcher will attempt to replace based on group number
+            matcher.appendReplacement(sb, matcher.group(0).replace(matcher.group(1), password).replace("$", "\\$"));
         }
         
         //Append any trailing characters after matches

--- a/dev/com.ibm.ws.jdbc/test/com/ibm/ws/jdbc/internal/InternalTest.java
+++ b/dev/com.ibm.ws.jdbc/test/com/ibm/ws/jdbc/internal/InternalTest.java
@@ -200,6 +200,8 @@ public class InternalTest {
                      PropertyService.filterURL("this_is_a_very_non_complient_jdbc_url;password=12jsadf")); 
     }
     static String[] expectedConnProps = {
+                                  "javax.net.ssl.trustStorePassword=passwordWith$In$It;",
+                                  "javax.net.ssl.trustStorePassword=passwordWith$InIt;",
                                   "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=unencPassword1;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password",
                                   "javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword =unencPassword2;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password",
                                   "javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword= unencPassword3;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password",
@@ -220,6 +222,8 @@ public class InternalTest {
                                   "oracle.net.ssl_version=1.2;"
     };
     static String[] expectedObfuscatedConnProps = {
+                                 "javax.net.ssl.trustStorePassword=*****;",
+                                 "javax.net.ssl.trustStorePassword=*****;",
                                  "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=*****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
                                  "javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword =*****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
                                  "javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword= *****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
@@ -240,6 +244,8 @@ public class InternalTest {
                                  "oracle.net.ssl_version=1.2;"
    };
     static String[] connProps = {
+                                  "javax.net.ssl.trustStorePassword={xor}Lz4sLCgwLTsINis3exYxexYr;",
+                                  "javax.net.ssl.trustStorePassword={xor}Lz4sLCgwLTsINis3exYxFis=;",
                                   "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=unencPassword1;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password",
                                   "javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword ={xor}KjE6MTwPPiwsKDAtO20=;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password",
                                   "javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword= {aes}AGSgzua84RvVKvqP/N1FhMMbhdoFoht03A+T02KrDZ4QAJngbba3jDbVUVnhGTZ0Ig==;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password",


### PR DESCRIPTION
## Issue resolution
The matcher used to replace encoded passwords with decoded passwords did not account for the fact that the matcher.appendReplacement method automatically attempts to replace substrings in the form `${---}` and `$---` with the next group. It is fairly common for passwords to have a `$` within them so we need to escape these characters.

## Breaking change
No chance of this being a breaking change since today no one is able to use an encoded password with `$` as it will result in the following error: 
```
java.lang.IllegalArgumentException: Illegal group reference
	at java.base/java.util.regex.Matcher.appendExpandedReplacement(Matcher.java:1067)
	at java.base/java.util.regex.Matcher.appendReplacement(Matcher.java:907)
	at com.ibm.ws.jdbc.internal.JDBCDriverService.decodeOracleConnectionPropertiesPwds(JDBCDriverService.java:1361)
```

