### PR TITLE
Fix formatting and create common fat.properties file

### DIFF
--- a/.ci-orchestrator/fat.properties
+++ b/.ci-orchestrator/fat.properties
@@ -1,0 +1,27 @@
+aggregationId: ${Compile Liberty Images:execution_id}
+bucket_image_artifact_execution_id: ${Compile FATs:execution_id}
+buildType: personal
+changes_summary_artifact_execution_id: ${Compile Liberty Images:execution_id}
+command: ant -f build-test.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
+# asyncArchive.zip is 6 directories up from the wlp-embeddable-full image.
+dependenciesRelativePath: ../../../../../..
+fat_uploads_to_expect: ${Compile Liberty Images:fat_uploads_to_expect},${Compile FATs:fat_uploads_to_expect}
+fat.buckets.to.run: ${PR Changes:fat.buckets.to.run}
+fat.test.mode: lite
+# Omit the FATs prefixed with build.featureStart because those run in separate steps. Omit intelligent management FATs because those require complex topologies to execute.
+fats_to_omit: "build.featureStart.part1_fat, build.featureStart.part2_fat, build.featureStart.part3_fat, build.featureStart.part4_fat, build.featureStart.part1.was_fat, build.featureStart.part2.was_fat, build.featureStart.part3.was_fat, build.featureStart.part4.was_fat, com.ibm.ws.collective.controller.deploy_fat, com.ibm.ws.health.manager.odrlib_fat, com.ibm.ws.dynamic.routing_ihs_fat, com.ibm.ws.node.scaling_fat, com.ibm.ws.scaling.member_fat_multinode, com.ibm.ws.node.health_fat"
+outputPath: /liberty/personal/2/ciorchestrator
+outputServer: libertyfs.hursley.ibm.com
+product_image_artifact_execution_id: ${Compile Liberty Images:execution_id}
+product_image_type_under_test: wlp-embeddable-full
+# If there are fewer than x fat buckets then we will run each fat multiple times.
+repeat_if_few_fats: true
+reportingOS: ubuntu22_x86
+retry_failing_fats: true
+runner_minimum_total: 10
+runner_max_total: 80
+runner_projectName: ebcTestRunner
+runner_threshold: 5
+runner_workType: Jenkins
+# We want to 50% of the time run buckets in order of predicted failures.
+testBucketPriorityStrategy: 50%|ci-bucket-failure-predictor-v1

--- a/.ci-orchestrator/pb.yml
+++ b/.ci-orchestrator/pb.yml
@@ -1,107 +1,112 @@
 type: pipeline_definition
 product: Liberty
-name: Open Liberty Personal Build
-description: "Run a Personal build against an Open Liberty PR."
+name: Open Liberty - Personal
+description: "Run a Personal Pipeline against an Open Liberty PR."
+
 triggers:
 - type: github
-  description: "Runs an optimised Open Liberty personal build, running FATs using the CIOrchestrator/Jenkins."
+  description: "Runs an optimised Personal Pipeline against an Open Liberty PR, running FATs using the CI Orchestrator and Jenkins."
   triggerName: "ol-pbbeta"
   triggerRank: 50
   groups: ["LibertyDev"]
-  keyword: "!pbbeta"
+  keyword: "!build"
   aliasKeywords:
-  - "#build"
-  - "!build"
-  - "#pbbeta"
+    - "!pbbeta"
+    - "#pbbeta"
+    - "#build"
+    - "#personal"
+    - "!personal"
   propertyDefinitions:
-  # If a user defines this property, set it for all steps that use it except the "Distributed Full FATs" step
-  # because those steps are set to use a value calculated by the PR Changes step.
-  - name: fat.buckets.to.run
-    defaultValue: ${PR Changes:fat.buckets.to.run}
-    steps:
-    - stepName: Compile Liberty Images
-    - stepName: Compile FATs
-    - stepName: Determine FATs Needed
-    - stepName: Distributed Lite FATs
-  # Disable IM buckets.
-  - name: create.im.repo
-    defaultValue: false
-    steps:
-    - stepName: Compile Liberty Images
-  # Disable z/OS buckets.
-  - name: spawn.zos
-    defaultValue: false
-    steps:
-    - stepName: Compile Liberty Images
-    - stepName: Compile FATs
-    - stepName: z/OS FATs
-    - stepName: z/OS Unittests
-  # Enable the testing of the checkpoint feature, running the FATs (if any) in lite mode where only @CheckpointTest annotated test cases will be run.
-  - name: spawn.checkpoint
-    defaultValue: "true"
-    steps:
-    - stepName: Checkpoint FATs (Lite)
+    # If a user defines this property, set it for all steps that use it except the "Distributed Full FATs" step.
+    - name: fat.buckets.to.run
+      defaultValue: ${PR Changes:fat.buckets.to.run}
+      steps:
+        - stepName: Compile Liberty Images
+        - stepName: Compile FATs
+        - stepName: Determine FATs Needed
+        - stepName: Distributed Lite FATs
+    # Disable IM buckets.
+    - name: create.im.repo
+      defaultValue: false
+      steps:
+        - stepName: Compile Liberty Images
+    # Disable z/OS buckets.
+    - name: spawn.zos
+      defaultValue: false
+      steps:
+        - stepName: Compile Liberty Images
+        - stepName: Compile FATs
+        - stepName: z/OS FATs
+        - stepName: z/OS Unittests
+    # Enable the testing of the checkpoint feature, running the FATs (if any) in lite mode where only @CheckpointTest annotated test cases will be run.
+    - name: spawn.checkpoint
+      defaultValue: "true"
+      steps:
+        - stepName: Checkpoint FATs (Lite)
 
 - type: manual
   triggerName: "ol-pbbeta-manual"
-  description: "Runs an optimised Open Liberty personal build, running FATs using the CIOrchestrator/Jenkins."
+  description: "Runs an optimised Personal Pipeline against an Open Liberty PR, running FATs using the CI Orchestrator and Jenkins."
   triggerRank: 50
   groups: ["LibertyDev"]
   propertyDefinitions:
-  - name: github_pr_user
-    isRequired: true
-    defaultValue: "Name of Open Liberty user or organization for checkout."
-    description: "Name of Open Liberty user or organization for checkout."
-  - name: github_pr_branch
-    isRequired: true
-    defaultValue: "Name of Open Liberty branch to checkout."
-    description: "Name of Open Liberty branch to checkout."
-  - name: github_pr_number
-    isRequired: true
-    defaultValue: "PR number in Open Liberty to checkout."
-    description: "PR number in Open Liberty to checkout."
-  - name: github_pr_api
-    defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/${github_pr_number}"
-  # Enable the testing of the checkpoint feature, running the FATs (if any) in lite mode where only @CheckpointTest annotated test cases will be run.
-  - name: spawn.checkpoint
-    defaultValue: "true"
-    steps:
-    - stepName: Checkpoint FATs (Lite)
+    - name: github_pr_user
+      isRequired: true
+      defaultValue: "username"
+      description: "Name of Open Liberty user/org to checkout."
+    - name: github_pr_branch
+      isRequired: true
+      defaultValue: "branch"
+      description: "Name of Open Liberty branch to checkout."
+    - name: github_pr_number
+      isRequired: true
+      defaultValue: "PR"
+      description: "PR number in Open Liberty to checkout."
+    - name: github_pr_api
+      defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/${github_pr_number}"
+      description: "URL to PR in Open Liberty."
+    # Enable the testing of the checkpoint feature, running the FATs (if any) in lite mode where only @CheckpointTest annotated test cases will be run.
+    - name: spawn.checkpoint
+      defaultValue: "true"
+      steps:
+        - stepName: Checkpoint FATs (Lite)
 
 - type: github
   triggerName: "ol-fullpbbeta"
-  description: "Runs an optimised Open Liberty personal build, including building the IM and z/OS images, then running all FATs using the CIOrchestrator/Jenkins."
+  description: "Runs an optimised Personal Pipeline against an Open Liberty PR, including building the IM and z/OS images, then running all FATs using the CI Orchestrator and Jenkins."
   triggerRank: 50
   groups: ["LibertyDev"]
   keyword: "!fullpbbeta"
   aliasKeywords:
-  - "#fullpbbeta"
+    - "#fullpbbeta"
+    - "!fullbuild"
+    - "#fullbuild"
   propertyDefinitions:
-  # Run all buckets in full mode.
-  - name: fat.buckets.to.run
-    defaultValue: all
-    steps:
-    - stepName: Compile Liberty Images
-    - stepName: Compile FATs
-    - stepName: Distributed Full FATs
-  # Run IM buckets.
-  - name: create.im.repo
-    defaultValue: true
-    steps:
-    - stepName: Compile Liberty Images
-  # Run z/OS buckets.
-  - name: spawn.zos
-    defaultValue: true
-    steps:
-    - stepName: Compile Liberty Images
-    - stepName: Compile FATs
-    - stepName: z/OS FATs
-    - stepName: z/OS Unittests
-  # Enable the testing of the checkpoint feature, running the FATs (if any) in lite mode where only @CheckpointTest annotated test cases will be run.
-  - name: spawn.checkpoint
-    defaultValue: "true"
-    steps:
-    - stepName: Checkpoint FATs (Lite)
+    # Run all buckets in full mode.
+    - name: fat.buckets.to.run
+      defaultValue: all
+      steps:
+        - stepName: Compile Liberty Images
+        - stepName: Compile FATs
+        - stepName: Distributed Full FATs
+    # Run IM buckets.
+    - name: create.im.repo
+      defaultValue: true
+      steps:
+        - stepName: Compile Liberty Images
+    # Run z/OS buckets.
+    - name: spawn.zos
+      defaultValue: true
+      steps:
+        - stepName: Compile Liberty Images
+        - stepName: Compile FATs
+        - stepName: z/OS FATs
+        - stepName: z/OS Unittests
+    # Enable the testing of the checkpoint feature, running the FATs (if any) in lite mode where only @CheckpointTest annotated test cases will be run.
+    - name: spawn.checkpoint
+      defaultValue: "true"
+      steps:
+        - stepName: Checkpoint FATs (Lite)
 
 steps:
 - stepName: PR Changes
@@ -116,10 +121,10 @@ steps:
   workType: RTC
   projectName: "Open Liberty Personal Build CI Orchestrator - EBC"
   dependsOn:
-  - stepName: PR Changes
-    awaitOutputProperties: true
-  - stepName: Compile FATs
-    awaitOutputProperties: true
+    - stepName: PR Changes
+      awaitOutputProperties: true
+    - stepName: Compile FATs
+      awaitOutputProperties: true
   timeoutInMinutes: 1440
   properties:
     build.stub.target: build.CachedWSCD.CompileImageOnly
@@ -140,25 +145,25 @@ steps:
     skip.fat.tests: true
     upload.buckets.with.uuid: ${Compile FATs:execution_id}
   includeProperties:
-  - file: compilePersonal.properties
-  - file: compile.properties
+    - file: compilePersonal.properties
+    - file: compile.properties
 
 - stepName: Unittest Open Liberty
   workType: RTC
   projectName: "Open Liberty Personal Build CI Orchestrator - EBC"
-  dependsOn:
-  - stepName: PR Changes
-    awaitOutputProperties: true
   conditionalRun:
     - type: ifFalse
       value: ${disable.run.runUnitTests}
+  dependsOn:
+    - stepName: PR Changes
+      awaitOutputProperties: true
   timeoutInMinutes: 1440
   properties:
     build.stub.target: build.CachedWSCD.OLTest
     disable.run.runUnitTests: ${PR Changes:disable.run.runUnitTests}
   includeProperties:
-  - file: compilePersonal.properties
-  - file: compile.properties
+    - file: compilePersonal.properties
+    - file: compile.properties
 
 - stepName: Compile FATs
   workType: RTC
@@ -184,6 +189,9 @@ steps:
 - stepName: Determine FATs Needed
   workType: Jenkins
   projectName: dependencyMapper
+  conditionalRun:
+    - type: ifSet
+      value: ${fat.buckets.to.run}
   dependsOn:
     - stepName: PR Changes
       awaitOutputProperties: true
@@ -191,9 +199,6 @@ steps:
       awaitOutputProperties: true
     - stepName: Compile FATs
       awaitOutputProperties: true
-  conditionalRun:
-    - type: ifSet
-      value: ${fat.buckets.to.run}
   timeoutInMinutes: 120
   properties:
     fat.buckets.to.run: ${PR Changes:fat.buckets.to.run}
@@ -207,6 +212,9 @@ steps:
 
 - stepName: Distributed Lite FATs
   workType: FAT
+  conditionalRun:
+    - type: ifSet
+      value: ${fat.buckets.to.run}
   dependsOn:
     - stepName: PR Changes
       awaitOutputProperties: true
@@ -217,44 +225,20 @@ steps:
       awaitOutputProperties: true
     - stepName: Determine FATs Needed
       allowFailures: true
-  conditionalRun:
-    - type: ifSet
-      value: ${fat.buckets.to.run}
   timeoutInMinutes: 1920
   properties:
-    product_image_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    bucket_image_artifact_execution_id: ${Compile FATs:execution_id}
-    changes_summary_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    runner_projectName: ebcTestRunner
-    runner_workType: Jenkins
-    runner_threshold: 5
-    runner_minimum_total: 10
-    fat.buckets.to.run: ${PR Changes:fat.buckets.to.run}
-    fat.test.mode: lite
-    fats_to_omit: "build.featureStart.part1_fat, build.featureStart.part2_fat, build.featureStart.part3_fat, build.featureStart.part4_fat, build.featureStart.part1.was_fat, build.featureStart.part2.was_fat, build.featureStart.part3.was_fat, build.featureStart.part4.was_fat, com.ibm.ws.collective.controller.deploy_fat, com.ibm.ws.health.manager.odrlib_fat, com.ibm.ws.dynamic.routing_ihs_fat, com.ibm.ws.node.scaling_fat, com.ibm.ws.scaling.member_fat_multinode, com.ibm.ws.node.health_fat"
-    fat_uploads_to_expect: ${Compile Liberty Images:fat_uploads_to_expect},${Compile FATs:fat_uploads_to_expect}
-    # asyncArchive.zip is 6 directories up from the wlp-embeddable-full image.
-    dependenciesRelativePath: ../../../../../..
-    outputServer: libertyfs.hursley.ibm.com
-    outputPath: /liberty/personal/2/ciorchestrator
-    command: ant -f build-test.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
-    aggregationId: ${Compile Liberty Images:execution_id}
-    buildType: personal
-    reportingOS: ubuntu22_x86
-    ebcPlan: See Shortlist 
+    ebcPlan: See Shortlist
     ebcShortlist: jenkins-child.yml
-    retry_failing_fats: true
-    repeat_if_few_fats: true  #If there are fewer than x fat buckets then we will run each fat multiple times
-    testBucketPriorityStrategy: 50%|ci-bucket-failure-predictor-v1 #We want to 50% of the time run buckets in order of predicted failures
   includeProperties:
-  - file: fatMaxDurationOverrides.properties
-  - file: jvms/dev/linux_x86_64.properties
+    - file: fat.properties
+    - file: fatMaxDurationOverrides.properties
+    - file: jvms/dev/linux_x86_64.properties
 
 - stepName: Distributed Full FATs
+  workType: FAT
   conditionalRun:
     - type: ifSet
       value: ${fat.buckets.to.run}
-  workType: FAT
   dependsOn:
     - stepName: PR Changes
       awaitOutputProperties: true
@@ -267,36 +251,20 @@ steps:
       allowFailures: true
   timeoutInMinutes: 1920
   properties:
-    product_image_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    bucket_image_artifact_execution_id: ${Compile FATs:execution_id}
-    changes_summary_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    runner_projectName: ebcTestRunner
-    runner_workType: Jenkins
-    runner_threshold: 5
-    runner_minimum_total: 10
+    ebcPlan: See Shortlist
+    ebcShortlist: jenkins-child.yml
     fat.buckets.to.run: ${PR Changes:spawn.fullfat.buckets}
     fat.test.mode: full
-    fats_to_omit: "build.featureStart.part1_fat, build.featureStart.part2_fat, build.featureStart.part3_fat, build.featureStart.part4_fat, build.featureStart.part1.was_fat, build.featureStart.part2.was_fat, build.featureStart.part3.was_fat, build.featureStart.part4.was_fat, com.ibm.ws.collective.controller.deploy_fat, com.ibm.ws.health.manager.odrlib_fat, com.ibm.ws.dynamic.routing_ihs_fat, com.ibm.ws.node.scaling_fat, com.ibm.ws.scaling.member_fat_multinode, com.ibm.ws.node.health_fat"
-    fat_uploads_to_expect: ${Compile Liberty Images:fat_uploads_to_expect},${Compile FATs:fat_uploads_to_expect}
-    # asyncArchive.zip is 6 directories up from the wlp-embeddable-full image.
-    dependenciesRelativePath: ../../../../../..
-    outputServer: libertyfs.hursley.ibm.com
-    outputPath: /liberty/personal/2/ciorchestrator
-    command: ant -f build-test.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
-    aggregationId: ${Compile Liberty Images:execution_id}
-    buildType: personal
-    reportingOS: ubuntu22_x86
-    ebcPlan: See Shortlist 
-    ebcShortlist: jenkins-child.yml
-    retry_failing_fats: true
-    repeat_if_few_fats: true  #If there are fewer than x fat buckets then we will run each fat multiple times
-    testBucketPriorityStrategy: 50%|ci-bucket-failure-predictor-v1 #We want to 50% of the time run buckets in order of predicted failures    
   includeProperties:
-  - file: fatMaxDurationOverrides.properties
-  - file: jvms/dev/linux_x86_64.properties
+    - file: fat.properties
+    - file: fatMaxDurationOverrides.properties
+    - file: jvms/dev/linux_x86_64.properties
 
 - stepName: Open Liberty Feature Start FATs
   workType: FAT
+  conditionalRun:
+    - type: ifSet
+      value: ${fat.buckets.to.run}
   dependsOn:
     - stepName: PR Changes
       awaitOutputProperties: true
@@ -307,89 +275,27 @@ steps:
       awaitOutputProperties: true
     - stepName: Determine FATs Needed
       allowFailures: true
-  conditionalRun:
-    - type: ifSet
-      value: ${fat.buckets.to.run}
   timeoutInMinutes: 1920
   properties:
-    aggregationId: ${Compile Liberty Images:execution_id}
-    bucket_image_artifact_execution_id: ${Compile FATs:execution_id}
-    buildType: personal
-    changes_summary_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    command: ant -f build-test.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
-    ebcPlan: See Shortlist 
+    ebcPlan: See Shortlist
     ebcShortlist: jenkins-child.yml
-    fat_uploads_to_expect: ${Compile Liberty Images:fat_uploads_to_expect},${Compile FATs:fat_uploads_to_expect}
-    fat.buckets.to.run: ${PR Changes:fat.buckets.to.run}
     fat.test.mode: full
-    fatPatternToMatch: build.featureStart.part\d*_fat
-    outputPath: /liberty/personal/2/ciorchestrator
-    outputServer: libertyfs.hursley.ibm.com
-    product_image_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    product_image_type_under_test: wlp-embeddable-full
-    # asyncArchive.zip is 6 directories up from the wlp-embeddable-full image.
-    dependenciesRelativePath: ../../../../../..
-    reportingOS: ubuntu22_x86
-    retry_failing_fats: true
+    fatPatternToMatch: build.featureStart.part\d*_fat # Pattern causes us to only execute the Open Liberty build.featureStart FATs.
+    fats_to_omit: ""
+    repeat_if_few_fats: false
     runner_minimum_total: 1
-    runner_projectName: ebcTestRunner
+    runner_max_total: 4
     runner_threshold: 4
-    runner_workType: Jenkins
-    testBucketPriorityStrategy: 50%|ci-bucket-failure-predictor-v1 #We want to 50% of the time run buckets in order of predicted failures
   includeProperties:
-  - file: fatMaxDurationOverrides.properties
-  - file: jvms/dev/linux_x86_64.properties
+    - file: fat.properties
+    - file: fatMaxDurationOverrides.properties
+    - file: jvms/dev/linux_x86_64.properties
 
 - stepName: Liberty Feature Start FATs
   workType: FAT
-  dependsOn:
-    - stepName: PR Changes
-      awaitOutputProperties: true
-    - stepName: Compile Liberty Images
-      awaitOutputProperties: true
-    - stepName: Compile FATs
-      allowFailures: false
-      awaitOutputProperties: true
-    - stepName: Determine FATs Needed
-      allowFailures: true
   conditionalRun:
     - type: ifSet
       value: ${fat.buckets.to.run}
-  timeoutInMinutes: 1920
-  properties:
-    aggregationId: ${Compile Liberty Images:execution_id}
-    bucket_image_artifact_execution_id: ${Compile FATs:execution_id}
-    buildType: personal
-    changes_summary_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    command: ant -f build-test.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
-    ebcPlan: See Shortlist 
-    ebcShortlist: jenkins-child.yml
-    fat_uploads_to_expect: ${Compile Liberty Images:fat_uploads_to_expect},${Compile FATs:fat_uploads_to_expect}
-    fat.buckets.to.run: ${PR Changes:fat.buckets.to.run}
-    fat.test.mode: full
-    fatPatternToMatch: build.featureStart.part\d*.was_fat
-    outputPath: /liberty/personal/2/ciorchestrator
-    outputServer: libertyfs.hursley.ibm.com
-    product_image_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    product_image_type_under_test: wlp-embeddable-full
-    # asyncArchive.zip is 6 directories up from the wlp-embeddable-full image.
-    dependenciesRelativePath: ../../../../../..
-    reportingOS: ubuntu22_x86
-    retry_failing_fats: true
-    runner_minimum_total: 1
-    runner_projectName: ebcTestRunner
-    runner_threshold: 4
-    runner_workType: Jenkins
-    testBucketPriorityStrategy: 50%|ci-bucket-failure-predictor-v1 #We want to 50% of the time run buckets in order of predicted failures
-  includeProperties:
-  - file: fatMaxDurationOverrides.properties
-  - file: jvms/dev/linux_x86_64.properties
-
-- stepName: z/OS FATs
-  conditionalRun:
-    - type: ifTrue
-      value: ${spawn.zos}
-  workType: FAT
   dependsOn:
     - stepName: PR Changes
       awaitOutputProperties: true
@@ -402,35 +308,57 @@ steps:
       allowFailures: true
   timeoutInMinutes: 1920
   properties:
-    aggregationId: ${Compile Liberty Images:execution_id}
-    product_image_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    bucket_image_artifact_execution_id: ${Compile FATs:execution_id}
-    changes_summary_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    buildType: personal
+    ebcPlan: See Shortlist
+    ebcShortlist: jenkins-child.yml
+    fat.test.mode: full
+    fatPatternToMatch: build.featureStart.part\d*.was_fat # Pattern causes us to only execute the WebSphere Liberty build.featureStart FATs.
+    repeat_if_few_fats: false
+    runner_minimum_total: 1
+    runner_max_total: 4
+    runner_threshold: 4
+  includeProperties:
+    - file: fat.properties
+    - file: fatMaxDurationOverrides.properties
+    - file: jvms/dev/linux_x86_64.properties
+
+- stepName: z/OS FATs
+  workType: FAT
+  conditionalRun:
+    - type: ifTrue
+      value: ${spawn.zos}
+  dependsOn:
+    - stepName: PR Changes
+      awaitOutputProperties: true
+    - stepName: Compile Liberty Images
+      awaitOutputProperties: true
+    - stepName: Compile FATs
+      allowFailures: false
+      awaitOutputProperties: true
+    - stepName: Determine FATs Needed
+      allowFailures: true
+  timeoutInMinutes: 1920
+  properties:
     command: ant -f build-ztest.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
+    dependenciesRelativePath: "" # asyncArchive.zip is in the same directory as the wlp-zosimage image.
     ebcPlan: managed-pool-zos-fat-test-jenkins-middleware.yml
-    fat.buckets.to.run: ${PR Changes:fat.buckets.to.run}
-    fatPatternToMatch: .*_zfat
-    fat.test.mode: lite
-    outputPath: /liberty/personal/2/ciorchestrator
-    outputServer: libertyfs.hursley.ibm.com
+    fatPatternToMatch: .*_zfat # Pattern causes us to only execute the z/OS FATs.
+    fats_to_omit: ""
     product_image_type_under_test: wlp-zosimage
     reportingOS: zOS
-    retry_failing_fats: true
-    runner_projectName: ebcTestRunner
-    runner_workType: Jenkins
+    runner_minimum_total: 1
+    runner_max_total: 4
     runner_threshold: 27
     runZosTests: true
     spawn.zos: ${PR Changes:spawn.zos}
-    testBucketPriorityStrategy: 50%|ci-bucket-failure-predictor-v1 #We want to 50% of the time run buckets in order of predicted failures
   includeProperties:
-  - file: jvms/dev/zOS_s390_64.properties
+    - file: fat.properties
+    - file: jvms/dev/zOS_s390_64.properties
 
 - stepName: z/OS Unittests
+  workType: FAT
   conditionalRun:
     - type: ifTrue
       value: ${spawn.zos}
-  workType: FAT
   dependsOn:
     - stepName: PR Changes
       awaitOutputProperties: true
@@ -443,35 +371,29 @@ steps:
       allowFailures: true
   timeoutInMinutes: 1920
   properties:
-    aggregationId: ${Compile Liberty Images:execution_id}
-    product_image_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    bucket_image_artifact_execution_id: ${Compile FATs:execution_id}
-    changes_summary_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    buildType: personal
     command: ant -f build-zunittest.xml unittest -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath -lib ../prereq.published/lib -lib ../ant_build/lib/biz.aQute.bnd-3.3.0.jar -lib ../ant_build/lib/jsoup-1.7.2.jar
+    dependenciesRelativePath: "" # asyncArchive.zip is in the same directory as the wlp-zosimage image.
     ebcPlan: managed-pool-zos-fat-test-jenkins-middleware.yml
-    fat.buckets.to.run: ${PR Changes:fat.buckets.to.run}
-    fatPatternToMatch: .*_ztest
-    fat.test.mode: lite
-    outputPath: /liberty/personal/2/ciorchestrator
-    outputServer: libertyfs.hursley.ibm.com
+    fatPatternToMatch: .*_ztest # Pattern causes us to only execute the z/OS unittests.
+    fats_to_omit: ""
     product_image_type_under_test: wlp-zosimage
     reportingOS: zOS
-    retry_failing_fats: true
-    runner_projectName: ebcTestRunner
-    runner_workType: Jenkins
-    runner_threshold: 5
+    runner_minimum_total: 1
+    runner_max_total: 2
     runZosTests: true
     spawn.zos: ${PR Changes:spawn.zos}
-    testBucketPriorityStrategy: 50%|ci-bucket-failure-predictor-v1 #We want to 50% of the time run buckets in order of predicted failures
   includeProperties:
-  - file: jvms/dev/zOS_s390_64_java11.properties
+    - file: fat.properties
+    - file: jvms/dev/zOS_s390_64_java11.properties
 
 # This step runs any FATs which declare that they test the 'checkpoint' feature in an environment with CRIU installed.
 # Checkpoint FATs therefore run twice in builds but the @CheckpointTest annotation and use of the fat.test.run.checkpoint.only property mean that in CRIU environments
 # they only run the test cases with @CheckpointTest (skipping the others) and in non-CRIU environments they only run the unannotated test cases. Hence, there's no duplication of testing.
 - stepName: Checkpoint FATs (Lite)
   workType: FAT
+  conditionalRun:
+    - type: ifTrue
+      value: ${spawn.checkpoint}
   dependsOn:
     - stepName: PR Changes
       awaitOutputProperties: true
@@ -482,41 +404,14 @@ steps:
       awaitOutputProperties: true
     - stepName: Determine FATs Needed
       allowFailures: true
-  conditionalRun:
-    - type: ifTrue
-      value: ${spawn.checkpoint}
   timeoutInMinutes: 1920
   properties:
-    product_image_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    bucket_image_artifact_execution_id: ${Compile FATs:execution_id}
-    changes_summary_artifact_execution_id: ${Compile Liberty Images:execution_id}
-    runner_projectName: ebcTestRunner
-    runner_workType: Jenkins
-    runner_threshold: 5
-    runner_minimum_total: 10
-    fat.buckets.to.run: ${PR Changes:fat.buckets.to.run}
-    # Limit the FATs to only those supporting the checkpoint feature.
-    limit.fat.buckets.to.feature: checkpoint
-    # Only run test cases with the @CheckpointTest annotation.
-    fat.test.run.checkpoint.only: true
-    fat.test.mode: lite
-    fats_to_omit: "com.ibm.ws.collective.controller.deploy_fat, com.ibm.ws.health.manager.odrlib_fat, com.ibm.ws.dynamic.routing_ihs_fat, com.ibm.ws.node.scaling_fat, com.ibm.ws.scaling.member_fat_multinode, com.ibm.ws.node.health_fat"
-    fat_uploads_to_expect: ${Compile Liberty Images:fat_uploads_to_expect},${Compile FATs:fat_uploads_to_expect}
-    # asyncArchive.zip is 6 directories up from the wlp-embeddable-full image.
-    dependenciesRelativePath: ../../../../../..
-    outputServer: libertyfs.hursley.ibm.com
-    outputPath: /liberty/personal/2/ciorchestrator
-    command: ant -f build-test.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
-    aggregationId: ${Compile Liberty Images:execution_id}
-    buildType: personal
-    reportingOS: ubuntu22_x86
     ebcPlan: See Shortlist 
     ebcShortlist: jenkinsbuild-checkpoint-ubuntu22_x86.yml
-    retry_failing_fats: true
-    # Only a small number of FATs exercise the checkpoint feature and so we should not repeat them by default otherwise they'll run 10 times.
-    repeat_if_few_fats: false
-    testBucketPriorityStrategy: 50%|ci-bucket-failure-predictor-v1 #We want to 50% of the time run buckets in order of predicted failures
+    fat.test.run.checkpoint.only: true # Only run test cases with the @CheckpointTest annotation.
+    limit.fat.buckets.to.feature: checkpoint # Limit the FATs to only those supporting the checkpoint feature.
+    repeat_if_few_fats: false # Only a small number of FATs exercise the checkpoint feature and so we should not repeat them by default otherwise they'll run 10 times.
   includeProperties:
-  - file: fatMaxDurationOverrides.properties
-  # Custom JVM properties as Checkpoint is only supported on specific JVMs/levels.
-  - file: jvms/dev/checkpoint_linux_x86_64.properties
+    - file: fat.properties
+    - file: fatMaxDurationOverrides.properties
+    - file: jvms/dev/checkpoint_linux_x86_64.properties # Custom JVM properties as Checkpoint is only supported on specific JVMs/levels.


### PR DESCRIPTION
- Create fat.properties for common properties used in FAT workType steps.
- Rename `Open Liberty Personal Build` pipeline to `Open Liberty - Personal`.
- Change formatting and wording of descriptions.