### PR TITLE
Revert "use long instead of integer in SipApplicationSession"

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/appqueue/NativeMessageDispatchingHandler.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/appqueue/NativeMessageDispatchingHandler.java
@@ -172,7 +172,7 @@ public class NativeMessageDispatchingHandler implements MessageDispatchingHandle
 			c_logger.traceEntry(this, "dispatch message = " + msg +" blockTime="+blockTimeout);
 		}
 
-		long index = msg.getQueueIndex();
+		int index = msg.getQueueIndex();
 		if(index < 0){
 			//this should never happen.
 			if (c_logger.isTraceDebugEnabled()) {
@@ -196,13 +196,13 @@ public class NativeMessageDispatchingHandler implements MessageDispatchingHandle
 	 * @param index
 	 * @return
 	 */
-	protected AppQueueHandler getQueueToProcess(long index, Queueable msg){
-		int daIndex = (int) index % s_dispatchers;
+	protected AppQueueHandler getQueueToProcess(int index, Queueable msg){
+		index = index % s_dispatchers;
 		if (c_logger.isTraceDebugEnabled()) {
-			c_logger.traceDebug(this, "getQueueToProcess", "sending msg to queue no:"+daIndex + " msg="+msg +
-					" handler Q:"+_dispatchersArray[daIndex].getClass().getName());
+			c_logger.traceDebug(this, "getQueueToProcess", "sending msg to queue no:"+index + " msg="+msg +
+					" handler Q:"+_dispatchersArray[index].getClass().getName());
 		}
-		return _dispatchersArray[daIndex];
+		return _dispatchersArray[index];
 	}
 
 	/**

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/asynch/AsynchronousWorkListenerWrapper.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/asynch/AsynchronousWorkListenerWrapper.java
@@ -97,7 +97,7 @@ public class AsynchronousWorkListenerWrapper extends RoutedTask{
 	 * 
 	 * @param asynchWorkListener
 	 */
-	public AsynchronousWorkListenerWrapper(AsynchronousWorkListener asynchWorkListener, long queueIndex) {
+	public AsynchronousWorkListenerWrapper(AsynchronousWorkListener asynchWorkListener, int queueIndex) {
 		_appAsynchWorkListener = asynchWorkListener;
 		_index = queueIndex;
 	}

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/asynch/AsynchronousWorkTask.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/asynch/AsynchronousWorkTask.java
@@ -139,7 +139,7 @@ public class AsynchronousWorkTask extends RoutedTask implements AsynchronousWork
     /**
 	 * @see com.ibm.ws.sip.container.util.Queueable#getQueueIndex()
 	 */
-	public long getQueueIndex() {
+	public int getQueueIndex() {
 		if (_index < 0){
 			throw new RuntimeException("Dispatching error, transaction-user not found!");
 		}		
@@ -281,9 +281,9 @@ public class AsynchronousWorkTask extends RoutedTask implements AsynchronousWork
 				}
 				
 				//calculate the queue id of the async work
-				long asyncQueueId = this.getQueueIndex() % NativeMessageDispatchingHandler.s_dispatchers;
+				int asyncQueueId = this.getQueueIndex() % NativeMessageDispatchingHandler.s_dispatchers;
 				
-				if (asyncQueueId == currentQueueId.longValue()){
+				if (asyncQueueId == currentQueueId.intValue()){
 					//the async work should run on the same queue as the current thread, run it now
 					setForDispatching(false);
 					

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/events/EventsDispatcher.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/events/EventsDispatcher.java
@@ -269,7 +269,7 @@ public class EventsDispatcher {
      * @param context
      * @param appQueueIndex
      */
-    public static void sipServletInitiated(SipAppDesc appDescriptor, SipServlet sipServlet, ServletContext context, long appQueueIndex) {
+    public static void sipServletInitiated(SipAppDesc appDescriptor, SipServlet sipServlet, ServletContext context, int appQueueIndex) {
 		if ( appDescriptor.getSipServletListeners().isEmpty()) {
 			if (c_logger.isTraceDebugEnabled()) {
 	    		c_logger.traceExit(null, "dispatchSipServletListeners, no listeners to call");
@@ -649,7 +649,7 @@ public class EventsDispatcher {
      * @param taskNum task type
      * @param appQueueIndex queue number (when possible)
      */
-    private static void dispatchTasksOnCurrentThread( Iterator<? extends EventListener> listenerIter, EventObject evt, SipAppDesc appDesc, int taskNum, long appQueueIndex){
+    private static void dispatchTasksOnCurrentThread( Iterator<? extends EventListener> listenerIter, EventObject evt, SipAppDesc appDesc, int taskNum, int appQueueIndex){
     	for ( ;listenerIter.hasNext();) {
     		EventListener listener = listenerIter.next();
     		    		

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/events/ListenerTask.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/events/ListenerTask.java
@@ -115,7 +115,7 @@ public class ListenerTask implements Queueable {
 	/**
 	 * default queue to send, this keeps a counter that would round robin all the app queues 
 	 */
-	private long _appQueueIndex = -1;
+	private int _appQueueIndex = -1;
 	
 	/**
 	 * which app queue to use
@@ -157,7 +157,7 @@ public class ListenerTask implements Queueable {
 					  EventObject event,
 					  int taskNum,
 					  SipAppDesc appDesc,
-					  long appQueueIndex){
+					  int appQueueIndex){
 		init(listener, event, taskNum);
 		this._appDesc = appDesc;
 		this._appQueueIndex = appQueueIndex;
@@ -356,9 +356,9 @@ public class ListenerTask implements Queueable {
 	/**
 	 *  @see com.ibm.ws.sip.container.util.QueueIndex#getQueueIndex()
 	 */
-	public long getQueueIndex() {
+	public int getQueueIndex() {
 		
-		long index = -1;
+		int index = -1;
 		// will try to get queue index for following well known type of events
 		// otherwise index 0 will be returned.
 		if (_event instanceof SipApplicationSessionBindingEvent) {

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/osgi/ServletInstanceHolderInterface.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/osgi/ServletInstanceHolderInterface.java
@@ -38,7 +38,7 @@ public interface ServletInstanceHolderInterface {
 	/**
 	 * Trigger listener
 	 */
-	public void triggerSipletInitServlet(long appQueueIndex);
+	public void triggerSipletInitServlet(int appQueueIndex);
 	
 	
 	/**

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/parser/ServletsInstanceHolder.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/parser/ServletsInstanceHolder.java
@@ -250,7 +250,7 @@ public class ServletsInstanceHolder implements ServletInstanceHolderInterface{
 	/**
 	 * @see ServletsInstanceHolder#triggerSipletInitServlet()
 	 */
-	public void triggerSipletInitServlet(long appQueueIndex) {
+	public void triggerSipletInitServlet(int appQueueIndex) {
 		InitMembers members = sipServletThreadLocal.get();
 		sipServletThreadLocal.set(null);
 		

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/proxy/ProxyBranchTimer.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/proxy/ProxyBranchTimer.java
@@ -64,8 +64,8 @@ public class ProxyBranchTimer extends BaseTimer{
     /**
 	 * Extracts queue index from the related application session.
 	 */
-	protected long extractQueueIndex() {
-		long result = -1;
+	protected int extractQueueIndex() {
+		int result = -1;
 		if(_origReqImp != null){
 			TransactionUserWrapper tuImpl = _origReqImp.getTransactionUser();
 			if(tuImpl != null){

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/proxy/ProxyTimer.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/proxy/ProxyTimer.java
@@ -104,8 +104,8 @@ public class ProxyTimer extends BaseTimer{
 	/**
 	 * Extracts queue index from the related application session.
 	 */
-	protected long extractQueueIndex() {
-		long result = -1;
+	protected int extractQueueIndex() {
+		int result = -1;
 		if(_origReqImp != null){
 			TransactionUserWrapper tuImpl = _origReqImp.getTransactionUser();
 			if(tuImpl != null){

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/router/tasks/RoutedTask.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/router/tasks/RoutedTask.java
@@ -28,7 +28,7 @@ import com.ibm.ws.sip.container.util.Queueable;
  */
 public abstract class RoutedTask implements Queueable {
 
-	protected long _index = -1;
+	protected int _index = -1;
 	protected TransactionUserWrapper _transactionUser;
 	private boolean _forDispatching = true;
 	
@@ -78,7 +78,7 @@ public abstract class RoutedTask implements Queueable {
 	/**
 	 * @see com.ibm.ws.sip.container.util.Queueable#getQueueIndex()
 	 */
-	public long getQueueIndex() {
+	public int getQueueIndex() {
 		return _index;
 	}
 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipApplicationSessionImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/SipApplicationSessionImpl.java
@@ -173,7 +173,7 @@ implements SipApplicationSession {
 	 * We use this counter for queuing a message into SIP container's queues.
 	 * look at Queueable#getQueueIndex() 
 	 */
-	private transient long  m_extractedAppSessionSeqCounter = -1;
+	private transient int  m_extractedAppSessionSeqCounter = -1;
 
 	/**
 	 * Member that Developer can set to define that this ApplicationSession
@@ -516,9 +516,7 @@ implements SipApplicationSession {
 	 * @see javax.servlet.sip.SipApplicationSession#invalidate()
 	 */
 	public void invalidate() {
-		//remove synchronized as it has caused deadlocks
-		//see open-liberty issue #27282
-		//synchronized (getSynchronizer()) {
+		synchronized (getSynchronizer()) {
 			if(m_duringInvalidate) {
 				checkIsSessionValid();
 				return;
@@ -605,7 +603,7 @@ implements SipApplicationSession {
 			if (c_logger.isTraceEntryExitEnabled()) {
 				c_logger.traceExit(this, "invalidate", "AppSessionId: " + getId());
 			}
-		//}
+		}
 	}
 
 	/**
@@ -707,9 +705,6 @@ implements SipApplicationSession {
 		}
 		checkIsSessionValid();
 		if (protocol.equalsIgnoreCase("SIP")) {
-			if (c_logger.isTraceDebugEnabled()) {
-				c_logger.traceDebug("SipApplicationSessionImpl","getSessions", "getSessions(SIP) detected");
-			}
 			//Moti 24/Sep: here is a bug in PMR 46156,033,00 : should call getAllSipSessions
 			// if we call  return getSessions() here we might accidently activate derived class' method
 			// defect PK54754
@@ -1523,7 +1518,7 @@ implements SipApplicationSession {
 	 * @param AppSessionId - full sip application session ID
 	 * @return - the last two digits of the SipApplicationSession ID.
 	 */
-	public long extractAppSessionCounter()
+	public int extractAppSessionCounter()
 	{
 		if (m_extractedAppSessionSeqCounter < 0) {
 			m_extractedAppSessionSeqCounter = extractAppSessionCounter(getSharedId());
@@ -1542,7 +1537,7 @@ implements SipApplicationSession {
 	 * 6 is the internal Transaction user ID
 	 * @return - the last two digits of the SAS ID.
 	 */
-	public static long extractAppSessionCounter(String AppSessionId)
+	public static int extractAppSessionCounter(String AppSessionId)
 	{
 		StringTokenizer tokenizer = new StringTokenizer(AppSessionId,Replicatable.ID_INTERNAL_SEPERATOR);
 		tokenizer.nextToken(); // skip the serverid
@@ -1550,7 +1545,7 @@ implements SipApplicationSession {
 		if (c_logger.isTraceDebugEnabled()) {
 			c_logger.traceDebug("SipApplicationSessionImpl", "extractAppSessionCounter","found App session counter:"+appCounterAsString);
 		}
-		long result = Long.parseLong(appCounterAsString);
+		int result = Integer.parseInt(appCounterAsString);
 		//Moti: fix for defect 487485: apprantly getAppSession().getID().hashcode()
 		// is not univormly distributed (prefix is always the same:logical name).
 		// so we will extract the only thing that actually changes: 
@@ -1811,10 +1806,6 @@ implements SipApplicationSession {
 	}
 	
 	public Iterator getSessions(String protocol, boolean create){
-		if (c_logger.isTraceDebugEnabled()) {
-			c_logger.traceDebug("getSessions(" + protocol + ", " + create + " detected.");
-		}
-
 		if (protocol.equalsIgnoreCase("SIP"))  {  //get SIP application sessions  
 			if (create) {  //boolean is true	
 					return (Iterator)getAllSIPSessions(true).iterator();

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/timer/BaseTimer.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/timer/BaseTimer.java
@@ -100,7 +100,7 @@ public abstract class BaseTimer extends ReplicatableImpl implements Runnable, Qu
      * Holds queue index which is used for the invocation on the 
      * application thread.
      */
-    protected long m_queueIndex = 0;
+    protected int m_queueIndex = 0;
     
     /**
      * Used to schedule timer actions
@@ -132,7 +132,7 @@ public abstract class BaseTimer extends ReplicatableImpl implements Runnable, Qu
      * Set queue index for this timer
      * @param timerId
      */
-    public void setQueueIndex(long queueIndex) {
+    public void setQueueIndex(int queueIndex) {
     	m_queueIndex = queueIndex;
     }
       
@@ -141,12 +141,12 @@ public abstract class BaseTimer extends ReplicatableImpl implements Runnable, Qu
      * It allows the 
      * @return the appropriate queue index where this timer should be run.
      */
-    abstract protected long extractQueueIndex() ;
+    abstract protected int extractQueueIndex() ;
     
     /**
 	 *  @see com.ibm.ws.sip.container.util.Queueable#getQueueIndex()
 	 */
-	public long getQueueIndex() {
+	public int getQueueIndex() {
 		return m_queueIndex;
 	}
     

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/timer/ExpirationTimer.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/timer/ExpirationTimer.java
@@ -135,10 +135,10 @@ public class ExpirationTimer extends BaseTimer {
 	/**
 	 * Extracts queue index from the related application session.
 	 */
-	protected long extractQueueIndex(){
+	protected int extractQueueIndex(){
 		if(m_expInvoker!= null){
 			String sessId = m_expInvoker.getApplicationId();
-	    	long result = SipApplicationSessionImpl.extractAppSessionCounter(sessId);
+	    	int result = SipApplicationSessionImpl.extractAppSessionCounter(sessId);
 			return result;
 		}
 		return 0;

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/timer/Invite2xxRetransmitTimer.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/timer/Invite2xxRetransmitTimer.java
@@ -74,8 +74,8 @@ public class Invite2xxRetransmitTimer extends BaseTimer {
     /**
 	 * Extracts queue index from the related application session.
 	 */
-	protected long extractQueueIndex() {
-		long result = -1;
+	protected int extractQueueIndex() {
+		int result = -1;
 			if(_response != null){
 				TransactionUserWrapper tuImpl = _response.getTransactionUser();
 				if(tuImpl != null){

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/timer/ReliabeResponseRetransmitTimer.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/timer/ReliabeResponseRetransmitTimer.java
@@ -67,8 +67,8 @@ public class ReliabeResponseRetransmitTimer extends BaseTimer {
     /**
 	 * Extracts queue index from the related application session.
 	 */
-	protected long extractQueueIndex(){
-   		long result = -1;
+	protected int extractQueueIndex(){
+   		int result = -1;
    		
    			if(_responseObj != null){
    				TransactionUserWrapper tuImpl = _responseObj.getServletResponse().getTransactionUser();

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/timer/ServletTimerImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/timer/ServletTimerImpl.java
@@ -262,7 +262,7 @@ public class ServletTimerImpl extends BaseTimer implements ServletTimer,
     /**
      * Returns the hash code of the applicationId 
      */
-    protected long extractQueueIndex() {
+    protected int extractQueueIndex() {
 		if(m_appSession != null){
 			//Moti: fix for defect 487485
 			return m_appSession.extractAppSessionCounter();

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/util/Queueable.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/util/Queueable.java
@@ -39,7 +39,7 @@ public interface Queueable extends Runnable {
 	 * object belongs to.
 	 * @return
 	 */
-	public long getQueueIndex();
+	public int getQueueIndex();
 	
 	/**
 	 * Returns the priority level of the queueable element

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/was/SignalingEndOfTask.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/was/SignalingEndOfTask.java
@@ -67,7 +67,7 @@ class SignalingEndOfTask  implements Runnable
 		boolean hangedDetected = false;
 		try{
 			//store the queue id on the current thread
-			ThreadLocalStorage.setQueueId((int)m_msg.getQueueIndex() % NativeMessageDispatchingHandler.s_dispatchers);
+			ThreadLocalStorage.setQueueId(m_msg.getQueueIndex() % NativeMessageDispatchingHandler.s_dispatchers);
 			setLogExtOnThread();
 			
 			m_parent.reportToFailoverServiceStart();

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/was/ThreadLocalStorage.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/was/ThreadLocalStorage.java
@@ -100,7 +100,7 @@ public class ThreadLocalStorage
 		
 		if (c_logger.isTraceFailureEnabled()) {
 			try {
-				long tuQueueIndex = SipApplicationSessionImpl.extractAppSessionCounter(tu.getApplicationId()) % NativeMessageDispatchingHandler.s_dispatchers;
+				int tuQueueIndex = SipApplicationSessionImpl.extractAppSessionCounter(tu.getApplicationId()) % NativeMessageDispatchingHandler.s_dispatchers;
 				
 				if(ThreadLocalStorage.getQueueId() == null || ! ThreadLocalStorage.getQueueId().equals(tuQueueIndex)) {
 					c_logger.traceFailure(tu, "traceThreadModelValidity", "Threading model violation! " +

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/was/filters/SipServletListener.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/was/filters/SipServletListener.java
@@ -59,7 +59,7 @@ public class SipServletListener implements ServletListener {
 		
 		SipServletRequestImpl sipRequest = null;
     	SipServletResponseImpl sipResponse = null;
-    	long index = -1;
+    	int index = -1;
     	
 		 //Read back the servlet request\response which we stored locally for 
         // this thread before entering the web-container.

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/was/message/SipMessage.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/was/message/SipMessage.java
@@ -1485,7 +1485,7 @@ public class SipMessage implements IRequestExtended, IResponse, Queueable
 	/**
 	 *  @see com.ibm.ws.sip.container.util.Queueable#getQueueIndex()
 	 */
-    public long getQueueIndex() {
+    public int getQueueIndex() {
 		TransactionUserWrapper tu = null;
     	if(_request != null){
 			tu = ((SipServletMessageImpl)_request).getTransactionUser();


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#27806. This commit has introduced a traceThreadModelValidity exception in the sipcontainer traces, like the one shown below:

[4/1/24, 12:29:11:339 EDT] 00000073 id=00000000 com.ibm.ws.sip.container.was.ThreadLocalStorage              1 traceThreadModelValidity  Threading model violation! current thread queue_id = 5 violation on access to SAS_id = wlp_5 violated SAS_id queue index = 5The TU is wlp_5_4 
                                                                                                               null
                                                                                                               [com.ibm.ws.sip.container.was.ThreadLocalStorage.traceThreadModelValidity(ThreadLocalStorage.java:110), com.ibm.ws.sip.container.was.ThreadLocalStorage.setTuForInvalidate(ThreadLocalStorage.java:86), com.ibm.ws.sip.container.tu.TransactionUserWrapper.invalidateIfReady(TransactionUserWrapper.java:628), com.ibm.ws.sip.container.tu.TransactionUserWrapper.tryToInvalidate(TransactionUserWrapper.java:592), com.ibm.ws.sip.container.tu.TransactionUserWrapper.transactionTerminated(TransactionUserWrapper.java:565), com.ibm.ws.sip.container.tu.TransactionUserWrapper.serverTransactionTerminated(TransactionUserWrapper.java:2205), com.ibm.ws.sip.container.transaction.ServerTransaction.transactionTerminated(ServerTransaction.java:162), com.ibm.ws.sip.container.transaction.SipTransaction.removeFromTransactionTable(SipTransaction.java:200), com.ibm.ws.sip.container.transaction.SipTransaction.onFinalResponse(SipTransaction.java:172), com.ibm.ws.sip.container.transaction.ServerTransaction.sendResponse(ServerTransaction.java:143), com.ibm.ws.sip.container.servlets.OutgoingSipServletResponse.continueToSend(OutgoingSipServletResponse.java:381), com.ibm.ws.sip.container.servlets.OutgoingSipServletResponse.send(OutgoingSipServletResponse.java:158), jsr289.test.sipp.test.ErrorOnreINVITE.doOptions(ErrorOnreINVITE.java:70), javax.servlet.sip.SipServlet.doRequest(SipServlet.java:491), javax.servlet.sip.SipServlet.doRequestWrapper(SipServlet.java:553), javax.servlet.sip.SipServlet.service(SipServlet.java:909), com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1260), com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:748), com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:445), com.ibm.ws.webcontainer.filter.WebAppFilterChain.invokeTarget(WebAppFilterChain.java:197), com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:100), com.ibm.ws.sip.container.was.filters.SipFilter.doFilter(SipFilter.java:99), com.ibm.ws.webcontainer.filter.FilterInstanceWrapper.doFilter(FilterInstanceWrapper.java:203), com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:93), com.ibm.ws.webcontainer.filter.WebAppFilterManager.doFilter(WebAppFilterManager.java:1068), com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1259), com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1077), com.ibm.ws.webcontainer.webapp.WebAppRequestDispatcher.dispatch(WebAppRequestDispatcher.java:1413), com.ibm.ws.webcontainer.webapp.WebAppRequestDispatcher.forward(WebAppRequestDispatcher.java:174), com.ibm.ws.sip.container.servlets.RequestDispatcherWrapper.forward(RequestDispatcherWrapper.java:97), jsr289.test.sipp.MainServlet.doRequest(MainServlet.java:41), javax.servlet.sip.SipServlet.doRequestWrapper(SipServlet.java:553), javax.servlet.sip.SipServlet.service(SipServlet.java:909), com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1260), com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:748), com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:445), com.ibm.ws.webcontainer.filter.WebAppFilterChain.invokeTarget(WebAppFilterChain.java:197), com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:100), com.ibm.ws.sip.container.was.filters.SipFilter.doFilter(SipFilter.java:99), com.ibm.ws.webcontainer.filter.FilterInstanceWrapper.doFilter(FilterInstanceWrapper.java:203), com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:93), com.ibm.ws.webcontainer.filter.WebAppFilterManager.doFilter(WebAppFilterManager.java:1068), com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1259), com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1077), com.ibm.ws.webcontainer.servlet.CacheServletWrapper.handleRequest(CacheServletWrapper.java:77), com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:969), com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:293), com.ibm.ws.sip.container.was.message.SipMessage.dispatch(SipMessage.java:1437), com.ibm.ws.sip.container.was.message.SipMessage.run(SipMessage.java:1392), com.ibm.ws.sip.container.was.WebsphereInvoker.invokeSipServlet(WebsphereInvoker.java:144), com.ibm.ws.sip.container.router.SipRouter.invokeSipServlet(SipRouter.java:1742), com.ibm.ws.sip.container.tu.TransactionUserImpl.handleUASRequest(TransactionUserImpl.java:1800), com.ibm.ws.sip.container.tu.TransactionUserImpl.processRequestUASMode(TransactionUserImpl.java:1893), com.ibm.ws.sip.container.tu.TransactionUserImpl.processRequest(TransactionUserImpl.java:1625), com.ibm.ws.sip.container.tu.TransactionUserWrapper.processRequest(TransactionUserWrapper.java:912), com.ibm.ws.sip.container.transaction.ServerTransaction.processRequest(ServerTransaction.java:100), com.ibm.ws.sip.container.router.tasks.RequestRoutedTask.doTask(RequestRoutedTask.java:95), com.ibm.ws.sip.container.router.tasks.InitialRequestRoutedTask.doTask(InitialRequestRoutedTask.java:60), com.ibm.ws.sip.container.router.tasks.RoutedTask.run(RoutedTask.java:94), com.ibm.ws.sip.container.was.SignalingEndOfTask.run(SignalingEndOfTask.java:78), com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:280), java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136), java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635), java.base/java.lang.Thread.run(Thread.java:857)]


[4/1/24, 12:29:11:340 EDT] 00000073 id=00000000 com.ibm.ws.sip.container.was.ThreadLocalStorage              1 traceThreadModelValidity  Violated SAS's message = OPTIONS sip:service@192.168.86.20:5060;transport=UDP SIP/2.0
