### PR TITLE
Appended Health Check name to CWMMH0052W message

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/fat/src/com/ibm/ws/microprofile/health/tck/HealthTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/fat/src/com/ibm/ws/microprofile/health/tck/HealthTCKLauncher.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019,2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -46,7 +46,7 @@ public class HealthTCKLauncher {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWMH0051W", "CWWKZ0002E", "SRVE0190E", "CWWKZ0014W");
+        server.stopServer("CWMH0052W", "CWWKZ0002E", "SRVE0190E", "CWWKZ0014W");
     }
 
     @Test

--- a/dev/com.ibm.ws.microprofile.health.2.0/src/com/ibm/ws/microprofile/health20/services/impl/HealthCheck20ExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0/src/com/ibm/ws/microprofile/health20/services/impl/HealthCheck20ExecutorImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -113,6 +113,7 @@ public class HealthCheck20ExecutorImpl implements HealthCheck20Executor {
                                                                                                    appName,
                                                                                                    moduleName,
                                                                                                    hcr.getState().toString(),
+                                                                                                   hcr.getName(),
                                                                                                    hcr.getData() != null ? hcr.getData().toString() : "{NO DATA}" });
             }
         }

--- a/dev/com.ibm.ws.microprofile.health/resources/com/ibm/ws/microprofile/health/resources/Health.nlsprops
+++ b/dev/com.ibm.ws.microprofile.health/resources/com/ibm/ws/microprofile/health/resources/Health.nlsprops
@@ -6,7 +6,7 @@
 #ISMESSAGEFILE true
 # #########################################################################
 ###############################################################################
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -47,8 +47,8 @@ healthcheck.bean.call.exception.CWMH0050E.explanation=The specified call method 
 healthcheck.bean.call.exception.CWMH0050E.useraction=Review your call method within the HealthCheck bean to identify the exception that occurred.
 
 # The HealthCheck bean call method had a DOWN outcome
-healthcheck.application.down.CWMH0052W=CWMH0052W: The {0} implementing HealthCheckResponse in the {1} application in module {2}, reported a {3} status with data {4}.
-healthcheck.application.down.CWMH0052W.explanation=The DOWN status might cause a monitoring service to take action on this server.
+healthcheck.application.down.CWMH0052W=CWMH0052W: The {0} implementing HealthCheckResponse in the {1} application in the module, {2}, reported a {3} status for the health check, {4}, and with the data {5}.
+healthcheck.application.down.CWMH0052W.explanation=The DOWN status might cause a monitoring service to act on this server.
 healthcheck.application.down.CWMH0052W.useraction=No user action is required.  This warning is a record of the DOWN status.
 
 # The Readiness HealthCheck had a DOWN outcome, when applications are not started yet

--- a/dev/com.ibm.ws.microprofile.health/src/com/ibm/ws/microprofile/health/services/impl/HealthExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.health/src/com/ibm/ws/microprofile/health/services/impl/HealthExecutorImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -107,10 +107,11 @@ public class HealthExecutorImpl implements HealthExecutor {
 
         for (HealthCheckResponse hcr : retval) {
             if (HealthCheckResponse.State.DOWN == hcr.getState()) {
-                logger.log(Level.WARNING, "healthcheck.application.down.CWMH0051W", new Object[] { hcr.getClass().toString(),
+                logger.log(Level.WARNING, "healthcheck.application.down.CWMH0052W", new Object[] { hcr.getClass().toString(),
                                                                                                    appName,
                                                                                                    moduleName,
                                                                                                    hcr.getState().toString(),
+                                                                                                   hcr.getName(),
                                                                                                    hcr.getData() != null ? hcr.getData().toString() : "{NO DATA}" });
             }
         }

--- a/dev/com.ibm.ws.microprofile.health_fat/fat/src/com/ibm/ws/microprofile/health/fat/CDIHealthCheckTest.java
+++ b/dev/com.ibm.ws.microprofile.health_fat/fat/src/com/ibm/ws/microprofile/health/fat/CDIHealthCheckTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -60,7 +60,7 @@ public class CDIHealthCheckTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.stopServer("CWMH0051W");
+        server1.stopServer("CWMH0052W");
     }
 
     public void testJsonReceived() throws Exception {

--- a/dev/com.ibm.ws.microprofile.health_fat/fat/src/com/ibm/ws/microprofile/health/fat/MultipleChecksTest.java
+++ b/dev/com.ibm.ws.microprofile.health_fat/fat/src/com/ibm/ws/microprofile/health/fat/MultipleChecksTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -78,7 +78,7 @@ public class MultipleChecksTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.stopServer("CWMH0051W");
+        server1.stopServer("CWMH0052W");
     }
 
     @Test

--- a/dev/io.openliberty.microprofile.health.3.0.internal/src/io/openliberty/microprofile/health30/services/impl/HealthCheck30ExecutorImpl.java
+++ b/dev/io.openliberty.microprofile.health.3.0.internal/src/io/openliberty/microprofile/health30/services/impl/HealthCheck30ExecutorImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -102,6 +102,7 @@ public class HealthCheck30ExecutorImpl implements HealthCheck30Executor {
                                                                                                     appName,
                                                                                                     moduleName,
                                                                                                     hcr.getStatus().toString(),
+                                                                                                    hcr.getName(),
                                                                                                     hcr.getData() != null ? hcr.getData().toString() : "{NO DATA}" });
             }
         }

--- a/dev/io.openliberty.microprofile.health.3.1.internal/src/io/openliberty/microprofile/health31/services/impl/HealthCheck31ExecutorImpl.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal/src/io/openliberty/microprofile/health31/services/impl/HealthCheck31ExecutorImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -117,6 +117,7 @@ public class HealthCheck31ExecutorImpl implements HealthCheck31Executor {
                                                                                                     appName,
                                                                                                     moduleName,
                                                                                                     hcr.getStatus().toString(),
+                                                                                                    hcr.getName(),
                                                                                                     hcr.getData() != null ? hcr.getData().toString() : "{NO DATA}" });
             }
         }

--- a/dev/io.openliberty.microprofile.health.internal.common/resources/io/openliberty/microprofile/health/resources/Health.nlsprops
+++ b/dev/io.openliberty.microprofile.health.internal.common/resources/io/openliberty/microprofile/health/resources/Health.nlsprops
@@ -6,7 +6,7 @@
 #ISMESSAGEFILE true
 # #########################################################################
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -42,8 +42,8 @@ healthcheck.bean.call.exception.CWMMH0050E.explanation=The specified call method
 healthcheck.bean.call.exception.CWMMH0050E.useraction=Review your call method within the HealthCheck bean to identify the exception that occurred.
 
 # The HealthCheck bean call method had a DOWN outcome
-healthcheck.application.down.CWMMH0052W=CWMMH0052W: The {0} implementing HealthCheckResponse in the {1} application in module {2}, reported a {3} status with data {4}.
-healthcheck.application.down.CWMMH0052W.explanation=The DOWN status might cause a monitoring service to take action on this server.
+healthcheck.application.down.CWMMH0052W=CWMMH0052W: The {0} implementing HealthCheckResponse in the {1} application in the module, {2}, reported a {3} status for the health check, {4}, and with the data {5}.
+healthcheck.application.down.CWMMH0052W.explanation=The DOWN status might cause a monitoring service to act on this server.
 healthcheck.application.down.CWMMH0052W.useraction=No user action is required.  This warning is a record of the DOWN status.
 
 # The Readiness HealthCheck had a DOWN outcome, when applications are not started yet


### PR DESCRIPTION
fixes #28048 
- Added the Health Check attribute name to the CWMMH0052W warning message, for it to be more informative to the users.