### PR TITLE
Update Jakarta EE 11 test to use minimum Java of 17 instead of 21

### DIFF
--- a/dev/com.ibm.ws.javaee.ddmodel_fat/fat/src/com/ibm/ws/javaee/ddmodel/suite/core/DDValidAppTests_J11.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/fat/src/com/ibm/ws/javaee/ddmodel/suite/core/DDValidAppTests_J11.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,7 +23,7 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 21)
+@MinimumJavaLevel(javaLevel = 17)
 @Mode(TestMode.LITE)
 public class DDValidAppTests_J11 extends CommonTests_Core {
     public static final Class<?> TEST_CLASS = DDValidAppTests_J11.class;

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/fat/src/com/ibm/ws/javaee/ddmodel/suite/core/DDValidModTests_J11.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/fat/src/com/ibm/ws/javaee/ddmodel/suite/core/DDValidModTests_J11.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,7 +23,7 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 21)
+@MinimumJavaLevel(javaLevel = 17)
 @Mode(TestMode.LITE)
 public class DDValidModTests_J11 extends CommonTests_Core {
     public static final Class<?> TEST_CLASS = DDValidModTests_J11.class;


### PR DESCRIPTION
- When PR #27349 was created, Jakarta EE 11 features required Java 21. As such it set the minimum Java to be 21 for the tests added.  In parallel, PR #27335 was being done to switch to Java 17 for all Jakarta EE 11 features and tests.  Both were merged on the same day so the new tests were not converted.  This PR fixes the missed tests to be Java 17 minimum.