### PR TITLE
decouple Sort from PageRequest

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -47,13 +47,13 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
 
     private final Object[] args;
     private final boolean isForward;
-    private final PageRequest<T> pageRequest;
+    private final PageRequest pageRequest;
     private final QueryInfo queryInfo;
     private final List<T> results;
     private long totalElements = -1;
 
     @FFDCIgnore(Exception.class)
-    CursoredPageImpl(QueryInfo queryInfo, PageRequest<T> pageRequest, Object[] args) {
+    CursoredPageImpl(QueryInfo queryInfo, PageRequest pageRequest, Object[] args) {
 
         this.args = args;
         this.queryInfo = queryInfo;
@@ -185,15 +185,8 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
     }
 
     @Override
-    public PageRequest<T> pageRequest() {
+    public PageRequest pageRequest() {
         return pageRequest;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <E> PageRequest<E> pageRequest(Class<E> entityClass) {
-        // KeysetAwareSlice/Page must always have the same type result as sort criteria per the API.
-        return (PageRequest<E>) pageRequest;
     }
 
     @Override
@@ -223,37 +216,24 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
     }
 
     @Override
-    public PageRequest<T> nextPageRequest() {
+    public PageRequest nextPageRequest() {
         if (!hasNext())
             throw new NoSuchElementException("Cannot request a next page. To avoid this error, check for a " +
                                              "true result of CursoredPage.hasNext before attempting this method."); // TODO NLS
 
-        PageRequest<T> p = pageRequest.page() == Long.MAX_VALUE ? pageRequest : pageRequest.page(pageRequest.page() + 1);
+        PageRequest p = pageRequest.page() == Long.MAX_VALUE ? pageRequest : pageRequest.page(pageRequest.page() + 1);
         return p.afterKey(queryInfo.getKeysetValues(results.get(Math.min(results.size(), pageRequest.size()) - 1)));
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public <E> PageRequest<E> nextPageRequest(Class<E> entityClass) {
-        // CursoredPage must always have the same type result as sort criteria per the API.
-        return (PageRequest<E>) nextPageRequest();
-    }
-
-    @Override
-    public PageRequest<T> previousPageRequest() {
+    public PageRequest previousPageRequest() {
         if (!hasPrevious())
             throw new NoSuchElementException("Cannot request a previous page. To avoid this error, check for a " +
                                              "true result of CursoredPage.hasPrevious before attempting this method."); // TODO NLS
 
         // Decrement page number by 1 unless it would go below 1.
-        PageRequest<T> p = pageRequest.page() == 1 ? pageRequest : pageRequest.page(pageRequest.page() - 1);
+        PageRequest p = pageRequest.page() == 1 ? pageRequest : pageRequest.page(pageRequest.page() - 1);
         return p.beforeKey(queryInfo.getKeysetValues(results.get(0)));
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <E> PageRequest<E> previousPageRequest(Class<E> entityClass) {
-        return (PageRequest<E>) previousPageRequest();
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -35,20 +35,20 @@ public class PageImpl<T> implements Page<T> {
     private static final TraceComponent tc = Tr.register(PageImpl.class);
 
     private final Object[] args;
-    private final PageRequest<?> pageRequest;
+    private final PageRequest pageRequest;
     private final QueryInfo queryInfo;
     private final List<T> results;
     private long totalElements = -1;
 
     @FFDCIgnore(Exception.class)
-    PageImpl(QueryInfo queryInfo, PageRequest<T> pageRequest, Object[] args) {
+    PageImpl(QueryInfo queryInfo, PageRequest pageRequest, Object[] args) {
         this.queryInfo = queryInfo;
         this.pageRequest = pageRequest == null ? PageRequest.ofSize(100) : pageRequest;
         this.args = args;
 
-        // BasicRepository.findAll(PageRequest) requires NullPointerException when PageRequest is null.
+        // BasicRepository.findAll(PageRequest, Order) requires NullPointerException when PageRequest is null.
         // TODO Should this apply in general?
-        if (pageRequest == null && queryInfo.paramCount == 0 && queryInfo.method.getParameterCount() == 1
+        if (pageRequest == null && queryInfo.paramCount == 0 && queryInfo.method.getParameterCount() == 2
             && PageRequest.class.equals(queryInfo.method.getParameterTypes()[0]))
             throw new NullPointerException("PageRequest: null");
 
@@ -145,53 +145,23 @@ public class PageImpl<T> implements Page<T> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public PageRequest<T> pageRequest() {
-        return (PageRequest<T>) pageRequest;
+    public PageRequest pageRequest() {
+        return pageRequest;
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public <E> PageRequest<E> pageRequest(Class<E> entityClass) {
-        return (PageRequest<E>) pageRequest;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public PageRequest<T> nextPageRequest() {
+    public PageRequest nextPageRequest() {
         if (hasNext())
-            return (PageRequest<T>) pageRequest.next();
+            return pageRequest.next();
         else
             throw new NoSuchElementException("Cannot request a next page. To avoid this error, check for a " +
                                              "true result of Page.hasNext before attempting this method."); // TODO NLS
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public <E> PageRequest<E> nextPageRequest(Class<E> entityClass) {
-        if (hasNext())
-            return (PageRequest<E>) pageRequest.next();
-        else
-            throw new NoSuchElementException("Cannot request a next page. To avoid this error, check for a " +
-                                             "true result of Page.hasNext before attempting this method."); // TODO NLS
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public PageRequest<T> previousPageRequest() {
+    public PageRequest previousPageRequest() {
         if (pageRequest.page() > 1)
-            return (PageRequest<T>) pageRequest.previous();
-        else
-            throw new NoSuchElementException("Cannot request a page number prior to " + pageRequest.page() +
-                                             ". To avoid this error, check for a true result of Page.hasPrevious " +
-                                             "before attempting this method."); // TODO NLS
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <E> PageRequest<E> previousPageRequest(Class<E> entityClass) {
-        if (pageRequest.page() > 1)
-            return (PageRequest<E>) pageRequest.previous();
+            return pageRequest.previous();
         else
             throw new NoSuchElementException("Cannot request a page number prior to " + pageRequest.page() +
                                              ". To avoid this error, check for a true result of Page.hasPrevious " +

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import jakarta.data.Limit;
+import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.PageRequest;
@@ -84,9 +85,9 @@ public interface Packages extends BasicRepository<Package, Integer> {
     @OrderBy(value = "width", descending = true)
     @OrderBy(value = "height")
     @OrderBy(value = "id", descending = true)
-    CursoredPage<Package> findByHeightGreaterThan(float minHeight, PageRequest<?> pagination);
+    CursoredPage<Package> findByHeightGreaterThan(float minHeight, PageRequest pagination);
 
-    CursoredPage<Package> findByHeightGreaterThanOrderByLengthAscWidthDescHeightDescIdAsc(float minHeight, PageRequest<?> pagination);
+    CursoredPage<Package> findByHeightGreaterThanOrderByLengthAscWidthDescHeightDescIdAsc(float minHeight, PageRequest pagination);
 
     @OrderBy(value = "id")
     List<Integer> findIdByHeightRoundedDown(int height);
@@ -136,13 +137,14 @@ public interface Packages extends BasicRepository<Package, Integer> {
     @Find
     CursoredPage<Package> whereHeightNotWithin(@By("height") @LessThan float minToExclude,
                                                @Or @By("height") @GreaterThan float maxToExclude,
-                                               PageRequest<?> pagination);
+                                               Order<Package> order,
+                                               PageRequest pagination);
 
     @Query("SELECT p FROM Package p WHERE (p.length * p.width * p.height >= ?1 AND p.length * p.width * p.height <= ?2)")
     @OrderBy(value = "width", descending = true)
     @OrderBy(value = "length")
     @OrderBy(value = "id")
-    CursoredPage<Package> whereVolumeWithin(float minVolume, float maxVolume, PageRequest<?> pagination);
+    CursoredPage<Package> whereVolumeWithin(float minVolume, float maxVolume, PageRequest pagination);
 
     @Find
     @OrderBy(value = "id")

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
@@ -119,7 +119,7 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
     @Select({ "start", "stop" })
     Stream<ReservedTimeSlot> findByStopOrStopOrStop(OffsetDateTime stop1, OffsetDateTime stop2, OffsetDateTime stop3);
 
-    Page<Reservation> findByHostStartsWith(String hostPrefix, PageRequest<?> pagination, Sort<Reservation> sort);
+    Page<Reservation> findByHostStartsWith(String hostPrefix, PageRequest pagination, Sort<Reservation> sort);
 
     LinkedHashSet<Reservation> findByInviteesContainsOrderByMeetingID(String invitee);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
@@ -57,7 +57,7 @@ public interface Businesses extends BasicRepository<Business, Integer> {
     @OrderBy("location.address.zip")
     @OrderBy("houseNum")
     @OrderBy("id")
-    CursoredPage<Business> findByZipIn(Iterable<Integer> zipCodes, PageRequest<?> pagination);
+    CursoredPage<Business> findByZipIn(Iterable<Integer> zipCodes, PageRequest pagination);
 
     // embeddable 3 levels deep as result type
     @OrderBy("street")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -112,7 +112,7 @@ public interface Cities {
     @OrderBy("stateName")
     CityId[] findByStateNameEndsWith(String ending);
 
-    CursoredPage<City> findByStateNameGreaterThan(String stateNameAfter, PageRequest<City> pagination);
+    CursoredPage<City> findByStateNameGreaterThan(String stateNameAfter, PageRequest pagination, Order<City> order);
 
     Stream<City> findByStateNameLessThan(String stateNameBefore, Sort<?>... sorts);
 
@@ -120,13 +120,13 @@ public interface Cities {
     Stream<City> findByStateNameNot(String exclude);
 
     @OrderBy(ID)
-    CursoredPage<City> findByStateNameNotEndsWith(String postfix, PageRequest<?> pagination);
+    CursoredPage<City> findByStateNameNotEndsWith(String postfix, PageRequest pagination);
 
     @OrderBy(ID)
-    CursoredPage<City> findByStateNameNotNull(PageRequest<City> pagination);
+    CursoredPage<City> findByStateNameNotNull(PageRequest pagination, Order<City> order);
 
     @OrderBy(value = ID, descending = true)
-    CursoredPage<City> findByStateNameNotStartsWith(String prefix, PageRequest<?> pagination);
+    CursoredPage<City> findByStateNameNotStartsWith(String prefix, PageRequest pagination);
 
     CityId findFirstByNameOrderByPopulationDesc(String name);
 
@@ -169,7 +169,7 @@ public interface Cities {
     @OrderBy(value = ID, descending = true)
     CursoredPage<City> sizedWithin(@By("population") @GreaterThanEqual int minPopulation,
                                    @By("population") @LessThanEqual int maxPopulation,
-                                   PageRequest<City> pagination);
+                                   PageRequest pagination);
 
     @Save
     City save(City c);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -243,7 +243,7 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testCountQueryWithFromClauseOnly() {
-        Page<Business> page1 = mixed.findAll(PageRequest.of(Business.class).size(5).desc("name"));
+        Page<Business> page1 = mixed.findAll(PageRequest.ofSize(5), Order.by(Sort.desc("name")));
 
         assertEquals(5L, page1.numberOfElements());
         assertEquals(15L, page1.totalElements());
@@ -255,7 +255,7 @@ public class DataJPATestServlet extends FATServlet {
                                      .map(b -> b.name)
                                      .collect(Collectors.toList()));
 
-        Page<Business> page2 = mixed.findAll(page1.nextPageRequest());
+        Page<Business> page2 = mixed.findAll(page1.nextPageRequest(), Order.by(Sort.desc("name")));
 
         assertEquals(List.of("Metafile", "Mayo Clinic", "IBM", "Home Federal Savings Bank", "HALCON"),
                      page2.stream()
@@ -264,7 +264,7 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, page2.hasNext());
 
-        Page<Business> page3 = mixed.findAll(page2.nextPageRequest());
+        Page<Business> page3 = mixed.findAll(page2.nextPageRequest(), Order.by(Sort.desc("name")));
 
         assertEquals(List.of("Geotek", "Custom Alarm", "Crenlo", "Cardinal", "Benike Construction"),
                      page3.stream()
@@ -278,7 +278,8 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testCountQueryWithFromAndWhereClausesOnly() {
-        Page<Business> page1 = mixed.locatedIn("Rochester", PageRequest.of(Business.class).size(6).asc("name"));
+        Order<Business> order = Order.by(Sort.asc("name"));
+        Page<Business> page1 = mixed.locatedIn("Rochester", PageRequest.ofSize(6), order);
 
         assertEquals(6L, page1.numberOfElements());
         assertEquals(13L, page1.totalElements());
@@ -290,7 +291,7 @@ public class DataJPATestServlet extends FATServlet {
                                      .map(b -> b.name)
                                      .collect(Collectors.toList()));
 
-        Page<Business> page2 = mixed.locatedIn("Rochester", page1.nextPageRequest());
+        Page<Business> page2 = mixed.locatedIn("Rochester", page1.nextPageRequest(), order);
 
         assertEquals(List.of("Mayo Clinic", "Metafile", "Olmsted Medical", "RAC", "Reichel Foods", "Silver Lake Foods"),
                      page2.stream()
@@ -299,7 +300,7 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, page2.hasNext());
 
-        Page<Business> page3 = mixed.locatedIn("Rochester", page2.nextPageRequest());
+        Page<Business> page3 = mixed.locatedIn("Rochester", page2.nextPageRequest(), order);
 
         assertEquals(List.of("Think Bank"),
                      page3.stream()
@@ -1343,7 +1344,7 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testFromAndWhereClausesOnly() {
-        CursoredPage<Business> page1 = mixed.locatedIn("Rochester", "MN", PageRequest.of(Business.class).size(4).asc("name"));
+        CursoredPage<Business> page1 = mixed.locatedIn("Rochester", "MN", PageRequest.ofSize(4), Order.by(Sort.asc("name")));
 
         assertEquals(4L, page1.numberOfElements());
         assertEquals(13L, page1.totalElements());
@@ -1355,7 +1356,7 @@ public class DataJPATestServlet extends FATServlet {
                                      .map(b -> b.name)
                                      .collect(Collectors.toList()));
 
-        CursoredPage<Business> page2 = mixed.locatedIn("Rochester", "MN", page1.nextPageRequest());
+        CursoredPage<Business> page2 = mixed.locatedIn("Rochester", "MN", page1.nextPageRequest(), Order.by(Sort.asc("name")));
 
         assertEquals(List.of("Home Federal Savings Bank", "IBM", "Mayo Clinic", "Metafile"),
                      page2.stream()
@@ -1364,7 +1365,7 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, page2.hasNext());
 
-        CursoredPage<Business> page3 = mixed.locatedIn("Rochester", "MN", page2.nextPageRequest());
+        CursoredPage<Business> page3 = mixed.locatedIn("Rochester", "MN", page2.nextPageRequest(), Order.by(Sort.asc("name")));
 
         assertEquals(List.of("Olmsted Medical", "RAC", "Reichel Foods", "Silver Lake Foods"),
                      page3.stream()
@@ -1373,7 +1374,7 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, page3.hasNext());
 
-        CursoredPage<Business> page4 = mixed.locatedIn("Rochester", "MN", page3.nextPageRequest());
+        CursoredPage<Business> page4 = mixed.locatedIn("Rochester", "MN", page3.nextPageRequest(), Order.by(Sort.asc("name")));
 
         assertEquals(List.of("Think Bank"),
                      page4.stream()
@@ -1579,7 +1580,7 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testIdClassOrderByAnnotationWithKeysetPagination() {
-        PageRequest<?> pagination = PageRequest
+        PageRequest pagination = PageRequest
                         .ofSize(3)
                         .withoutTotal()
                         .afterKey(CityId.of("Rochester", "Minnesota"));
@@ -1612,7 +1613,7 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testIdClassOrderByAnnotationWithKeysetPaginationAndNamedParameters() {
-        PageRequest<City> pagination = PageRequest.ofSize(2);
+        PageRequest pagination = PageRequest.ofSize(2);
 
         CursoredPage<City> page1 = cities.sizedWithin(100000, 1000000, pagination);
         assertIterableEquals(List.of("Springfield Missouri",
@@ -1644,9 +1645,9 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testIdClassOrderByNamePatternWithKeysetPagination() {
-        PageRequest<City> pagination = PageRequest.of(City.class).size(5).withoutTotal();
+        PageRequest pagination = PageRequest.ofSize(5).withoutTotal();
 
-        CursoredPage<City> slice1 = cities.findByStateNameNotNull(pagination);
+        CursoredPage<City> slice1 = cities.findByStateNameNotNull(pagination, Order.by());
         assertIterableEquals(List.of("Kansas City Kansas",
                                      "Kansas City Missouri",
                                      "Rochester Minnesota",
@@ -1654,7 +1655,7 @@ public class DataJPATestServlet extends FATServlet {
                                      "Springfield Illinois"),
                              slice1.stream().map(c -> c.name + ' ' + c.stateName).collect(Collectors.toList()));
 
-        CursoredPage<City> slice2 = cities.findByStateNameNotNull(slice1.nextPageRequest());
+        CursoredPage<City> slice2 = cities.findByStateNameNotNull(slice1.nextPageRequest(), Order.by());
         assertIterableEquals(List.of("Springfield Massachusetts",
                                      "Springfield Missouri",
                                      "Springfield Ohio",
@@ -1666,13 +1667,14 @@ public class DataJPATestServlet extends FATServlet {
         Cursor springfieldMO = slice2.cursor(1);
         pagination = pagination.size(3).beforeCursor(springfieldMO);
 
-        CursoredPage<City> beforeSpringfieldMO = cities.findByStateNameNotNull(pagination);
+        CursoredPage<City> beforeSpringfieldMO = cities.findByStateNameNotNull(pagination, Order.by());
         assertIterableEquals(List.of("Rochester New York",
                                      "Springfield Illinois",
                                      "Springfield Massachusetts"),
                              beforeSpringfieldMO.stream().map(c -> c.name + ' ' + c.stateName).collect(Collectors.toList()));
 
-        CursoredPage<City> beforeRochesterNY = cities.findByStateNameNotNull(beforeSpringfieldMO.previousPageRequest());
+        CursoredPage<City> beforeRochesterNY = cities.findByStateNameNotNull(beforeSpringfieldMO.previousPageRequest(),
+                                                                             Order.by());
         assertIterableEquals(List.of("Kansas City Kansas",
                                      "Kansas City Missouri",
                                      "Rochester Minnesota"),
@@ -1687,7 +1689,7 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testIdClassOrderByNamePatternWithKeysetPaginationDescending() {
-        PageRequest<?> pagination = PageRequest.ofSize(3).withTotal().afterKey(CityId.of("Springfield", "Tennessee"));
+        PageRequest pagination = PageRequest.ofSize(3).withTotal().afterKey(CityId.of("Springfield", "Tennessee"));
 
         CursoredPage<City> page1 = cities.findByStateNameNotStartsWith("Ma", pagination);
         assertIterableEquals(List.of("Springfield Oregon",
@@ -1722,9 +1724,10 @@ public class DataJPATestServlet extends FATServlet {
     @Test
     public void testIdClassOrderByPaginationWithKeyset() {
         // ascending:
-        PageRequest<City> pagination = PageRequest.of(City.class).size(5).sortBy(Sort.asc(ID));
+        Order<City> asc = Order.by(Sort.asc(ID));
+        PageRequest pagination = PageRequest.ofSize(5);
 
-        CursoredPage<City> page1 = cities.findByStateNameGreaterThan("Iowa", pagination);
+        CursoredPage<City> page1 = cities.findByStateNameGreaterThan("Iowa", pagination, asc);
         assertIterableEquals(List.of("Kansas City Kansas",
                                      "Kansas City Missouri",
                                      "Rochester Minnesota",
@@ -1732,7 +1735,7 @@ public class DataJPATestServlet extends FATServlet {
                                      "Springfield Massachusetts"),
                              page1.stream().map(c -> c.name + ' ' + c.stateName).collect(Collectors.toList()));
 
-        CursoredPage<City> page2 = cities.findByStateNameGreaterThan("Iowa", page1.nextPageRequest());
+        CursoredPage<City> page2 = cities.findByStateNameGreaterThan("Iowa", page1.nextPageRequest(), asc);
         assertIterableEquals(List.of("Springfield Missouri",
                                      "Springfield Ohio",
                                      "Springfield Oregon"),
@@ -1741,22 +1744,23 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals(false, page2.hasNext());
 
         // descending:
-        pagination = PageRequest.of(City.class).size(4).sortBy(Sort.descIgnoreCase(ID));
-        page1 = cities.findByStateNameGreaterThan("Idaho", pagination);
+        Order<City> desc = Order.by(Sort.descIgnoreCase(ID));
+        pagination = PageRequest.ofSize(4);
+        page1 = cities.findByStateNameGreaterThan("Idaho", pagination, desc);
         assertIterableEquals(List.of("Springfield Oregon",
                                      "Springfield Ohio",
                                      "Springfield Missouri",
                                      "Springfield Massachusetts"),
                              page1.stream().map(c -> c.name + ' ' + c.stateName).collect(Collectors.toList()));
 
-        page2 = cities.findByStateNameGreaterThan("Idaho", page1.nextPageRequest());
+        page2 = cities.findByStateNameGreaterThan("Idaho", page1.nextPageRequest(), desc);
         assertIterableEquals(List.of("Springfield Illinois",
                                      "Rochester New York",
                                      "Rochester Minnesota",
                                      "Kansas City Missouri"),
                              page2.stream().map(c -> c.name + ' ' + c.stateName).collect(Collectors.toList()));
 
-        CursoredPage<City> page3 = cities.findByStateNameGreaterThan("Idaho", page2.nextPageRequest());
+        CursoredPage<City> page3 = cities.findByStateNameGreaterThan("Idaho", page2.nextPageRequest(), desc);
         assertIterableEquals(List.of("Kansas City Kansas"),
                              page3.stream().map(c -> c.name + ' ' + c.stateName).collect(Collectors.toList()));
 
@@ -2560,8 +2564,8 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testParenthesisInsertionForCursorPagination() {
-        PageRequest<?> page1Request = PageRequest.ofSize(3).asc("name").asc(ID);
-        CursoredPage<Business> page1 = mixed.withZipCodeIn(55901, 55904, page1Request);
+        PageRequest page1Request = PageRequest.ofSize(3);
+        CursoredPage<Business> page1 = mixed.withZipCodeIn(55901, 55904, page1Request, Sort.asc("name"), Sort.asc(ID));
 
         assertEquals(List.of("Benike Construction", "Crenlo", "Home Federal Savings Bank"),
                      page1.stream()
@@ -2570,7 +2574,7 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, page1.hasNext());
 
-        CursoredPage<Business> page2 = mixed.withZipCodeIn(55901, 55904, page1.nextPageRequest());
+        CursoredPage<Business> page2 = mixed.withZipCodeIn(55901, 55904, page1.nextPageRequest(), Sort.asc("name"), Sort.asc(ID));
 
         assertEquals(List.of("IBM", "Metafile", "Olmsted Medical"),
                      page2.stream()
@@ -2579,7 +2583,7 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, page1.hasNext());
 
-        CursoredPage<Business> page3 = mixed.withZipCodeIn(55901, 55904, page2.nextPageRequest());
+        CursoredPage<Business> page3 = mixed.withZipCodeIn(55901, 55904, page2.nextPageRequest(), Sort.asc("name"), Sort.asc(ID));
 
         assertEquals(List.of("RAC", "Think Bank"),
                      page3.stream()

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import jakarta.data.Order;
+import jakarta.data.Sort;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
@@ -38,7 +39,7 @@ public interface MixedRepository { // Do not inherit from a supertype
     List<City> all(Order<City> sortBy);
 
     @Query(value = "FROM Business WHERE location.address.zip = location.address.zip")
-    Page<Business> findAll(PageRequest<Business> pageRequest);
+    Page<Business> findAll(PageRequest pageRequest, Order<Business> order);
 
     @OrderBy("name")
     Business[] findByLocationAddressCity(String cityName);
@@ -49,11 +50,11 @@ public interface MixedRepository { // Do not inherit from a supertype
     LinkedList<Unpopulated> findBySomethingStartsWith(String prefix);
 
     @Query(value = "WHERE location.address.city=?1")
-    Page<Business> locatedIn(String city, PageRequest<Business> pageRequest);
+    Page<Business> locatedIn(String city, PageRequest pageRequest, Order<Business> order);
 
     @Query("FROM Business WHERE location.address.city=:city AND location.address.state=:state")
-    CursoredPage<Business> locatedIn(String city, String state, PageRequest<Business> pageRequest);
+    CursoredPage<Business> locatedIn(String city, String state, PageRequest pageRequest, Order<Business> order);
 
     @Query("FROM Business WHERE location.address.zip=?1 OR location.address.zip=?2")
-    CursoredPage<Business> withZipCodeIn(int zip1, int zip2, PageRequest<?> pageRequest);
+    CursoredPage<Business> withZipCodeIn(int zip1, int zip2, PageRequest pageRequest, Sort<?>... sorts);
 }

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/Order.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/Order.java
@@ -15,8 +15,6 @@ package jakarta.data;
 import java.util.Iterator;
 import java.util.List;
 
-import jakarta.data.page.PageRequest;
-
 /**
  * Method signatures copied from jakarta.data.Order from the Jakarta Data repo.
  */
@@ -26,6 +24,10 @@ public class Order<T> implements Iterable<Sort<? super T>> {
 
     private Order(List<Sort<? super T>> sortBy) {
         this.sortBy = sortBy;
+    }
+
+    public static <T> Order<T> by(List<Sort<? super T>> sorts) {
+        return new Order<T>(List.copyOf(sorts));
     }
 
     @SafeVarargs
@@ -51,14 +53,6 @@ public class Order<T> implements Iterable<Sort<? super T>> {
     @Override
     public Iterator<Sort<? super T>> iterator() {
         return sortBy.iterator();
-    }
-
-    public PageRequest<T> page(long pageNumber) {
-        return PageRequest.<T> ofPage(pageNumber).sortBy(sortBy);
-    }
-
-    public PageRequest<T> pageSize(int size) {
-        return PageRequest.<T> ofSize(size).sortBy(sortBy);
     }
 
     @Override

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/CursoredPage.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/CursoredPage.java
@@ -22,8 +22,8 @@ public interface CursoredPage<T> extends Page<T> {
     boolean hasPrevious();
 
     @Override
-    PageRequest<T> nextPageRequest();
+    PageRequest nextPageRequest();
 
     @Override
-    PageRequest<T> previousPageRequest();
+    PageRequest previousPageRequest();
 }

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Page.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Page.java
@@ -31,19 +31,13 @@ public interface Page<T> extends Iterable<T> {
 
     boolean hasPrevious();
 
-    PageRequest<T> nextPageRequest();
-
-    <E> PageRequest<E> nextPageRequest(Class<E> entityClass);
+    PageRequest nextPageRequest();
 
     int numberOfElements();
 
-    PageRequest<T> pageRequest();
+    PageRequest pageRequest();
 
-    <E> PageRequest<E> pageRequest(Class<E> entityClass);
-
-    PageRequest<T> previousPageRequest();
-
-    <E> PageRequest<E> previousPageRequest(Class<E> entityClass);
+    PageRequest previousPageRequest();
 
     default Stream<T> stream() {
         return StreamSupport.stream(spliterator(), false);

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/PageRequest.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/PageRequest.java
@@ -12,16 +12,13 @@
  *******************************************************************************/
 package jakarta.data.page;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
-import jakarta.data.Sort;
 
 /**
  * Method signatures are copied from jakarta.data.repository.PageRequest from the Jakarta Data repo.
  */
-public interface PageRequest<T> {
+public interface PageRequest {
     public static enum Mode {
         CURSOR_NEXT, CURSOR_PREVIOUS, OFFSET
     }
@@ -38,39 +35,27 @@ public interface PageRequest<T> {
         public int size();
     }
 
-    public static <T> PageRequest<T> of(Class<T> entityClass) {
-        return new Pagination<T>(1, 10, Collections.emptyList(), Mode.OFFSET, null, true);
+    public static PageRequest ofPage(long page) {
+        return new Pagination(page, 10, Mode.OFFSET, null, true);
     }
 
-    public static <T> PageRequest<T> ofPage(long page) {
-        return new Pagination<T>(page, 10, Collections.emptyList(), Mode.OFFSET, null, true);
+    public static PageRequest ofSize(int size) {
+        return new Pagination(1, size, Mode.OFFSET, null, true);
     }
 
-    public static <T> PageRequest<T> ofSize(int size) {
-        return new Pagination<T>(1, size, Collections.emptyList(), Mode.OFFSET, null, true);
-    }
+    public PageRequest afterCursor(PageRequest.Cursor cursor);
 
-    public PageRequest<T> afterCursor(PageRequest.Cursor cursor);
+    public PageRequest afterKey(Object... componentsOfKey);
 
-    public PageRequest<T> afterKey(Object... componentsOfKey);
+    public PageRequest beforeCursor(PageRequest.Cursor cursor);
 
-    public PageRequest<T> asc(String property);
-
-    public PageRequest<T> ascIgnoreCase(String property);
-
-    public PageRequest<T> beforeCursor(PageRequest.Cursor cursor);
-
-    public PageRequest<T> beforeKey(Object... componentsOfKey);
+    public PageRequest beforeKey(Object... componentsOfKey);
 
     public Optional<Cursor> cursor();
 
-    public PageRequest<T> desc(String property);
-
-    public PageRequest<T> descIgnoreCase(String property);
-
     public Mode mode();
 
-    public PageRequest<T> next();
+    public PageRequest next();
 
     public long page();
 
@@ -78,30 +63,14 @@ public interface PageRequest<T> {
 
     public int size();
 
-    public List<Sort<? super T>> sorts();
+    public PageRequest page(long page);
 
-    public PageRequest<T> page(long page);
+    public PageRequest previous();
 
-    public PageRequest<T> previous();
+    public PageRequest size(int size);
 
-    public PageRequest<T> size(int size);
+    public PageRequest withoutTotal();
 
-    public PageRequest<T> sortBy(Iterable<Sort<? super T>> sorts);
-
-    public PageRequest<T> sortBy(Sort<? super T> sort);
-
-    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2);
-
-    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3);
-
-    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3,
-                                 Sort<? super T> sort4);
-
-    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3,
-                                 Sort<? super T> sort4, Sort<? super T> sort5);
-
-    public PageRequest<T> withoutTotal();
-
-    public PageRequest<T> withTotal();
+    public PageRequest withTotal();
 
 }

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Pagination.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/Pagination.java
@@ -12,25 +12,17 @@
  *******************************************************************************/
 package jakarta.data.page;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
-import jakarta.data.Sort;
 
 /**
  * Method signatures are copied from jakarta.data.repository.PageRequest from the Jakarta Data repo.
  */
-record Pagination<T>(long page,
+record Pagination(long page,
                 int size,
-                List<Sort<? super T>> sorts,
                 Mode mode,
                 Cursor type,
                 boolean requestTotal)
-                implements PageRequest<T> {
+                implements PageRequest {
 
     Pagination {
         if (page < 1)
@@ -42,46 +34,23 @@ record Pagination<T>(long page,
     }
 
     @Override
-    public PageRequest<T> afterKey(Object... componentsOfKey) {
-        return new Pagination<T>(page, size, sorts, Mode.CURSOR_NEXT, new PageRequestCursor(componentsOfKey), requestTotal);
+    public PageRequest afterKey(Object... componentsOfKey) {
+        return new Pagination(page, size, Mode.CURSOR_NEXT, new PageRequestCursor(componentsOfKey), requestTotal);
     }
 
     @Override
-    public PageRequest<T> afterCursor(PageRequest.Cursor cursor) {
-        return new Pagination<T>(page, size, sorts, Mode.CURSOR_NEXT, cursor, requestTotal);
-    }
-
-    private static final <E> List<E> append(List<E> list, E element) {
-        int size = list.size();
-        if (size == 0) {
-            return List.of(element);
-        } else {
-            Object[] array = list.toArray(new Object[size + 1]);
-            array[size] = element;
-            @SuppressWarnings("unchecked")
-            List<E> newList = (List<E>) Collections.unmodifiableList(Arrays.asList(array));
-            return newList;
-        }
+    public PageRequest afterCursor(PageRequest.Cursor cursor) {
+        return new Pagination(page, size, Mode.CURSOR_NEXT, cursor, requestTotal);
     }
 
     @Override
-    public PageRequest<T> asc(String property) {
-        return new Pagination<T>(page, size, append(sorts, Sort.asc(property)), mode, type, requestTotal);
+    public PageRequest beforeKey(Object... componentsOfKey) {
+        return new Pagination(page, size, Mode.CURSOR_PREVIOUS, new PageRequestCursor(componentsOfKey), requestTotal);
     }
 
     @Override
-    public PageRequest<T> ascIgnoreCase(String attribute) {
-        return new Pagination<T>(page, size, append(sorts, Sort.ascIgnoreCase(attribute)), mode, type, requestTotal);
-    }
-
-    @Override
-    public PageRequest<T> beforeKey(Object... componentsOfKey) {
-        return new Pagination<T>(page, size, sorts, Mode.CURSOR_PREVIOUS, new PageRequestCursor(componentsOfKey), requestTotal);
-    }
-
-    @Override
-    public PageRequest<T> beforeCursor(PageRequest.Cursor cursor) {
-        return new Pagination<T>(page, size, sorts, Mode.CURSOR_PREVIOUS, cursor, requestTotal);
+    public PageRequest beforeCursor(PageRequest.Cursor cursor) {
+        return new Pagination(page, size, Mode.CURSOR_PREVIOUS, cursor, requestTotal);
     }
 
     @Override
@@ -90,33 +59,23 @@ record Pagination<T>(long page,
     }
 
     @Override
-    public PageRequest<T> desc(String attribute) {
-        return new Pagination<T>(page, size, append(sorts, Sort.desc(attribute)), mode, type, requestTotal);
-    }
-
-    @Override
-    public PageRequest<T> descIgnoreCase(String attribute) {
-        return new Pagination<T>(page, size, append(sorts, Sort.descIgnoreCase(attribute)), mode, type, requestTotal);
-    }
-
-    @Override
-    public Pagination<T> next() {
+    public Pagination next() {
         if (mode == Mode.OFFSET)
-            return new Pagination<T>(page + 1, size, sorts, mode, null, requestTotal);
+            return new Pagination(page + 1, size, mode, null, requestTotal);
         else
             throw new UnsupportedOperationException("Not supported for cursor-based pagination. Instead use afterKey or afterCursor to provide a cursor or obtain the nextPageRequest from a CursoredPage.");
     }
 
     @Override
-    public Pagination<T> page(long pageNumber) {
-        return new Pagination<T>(pageNumber, size, sorts, mode, type, requestTotal);
+    public Pagination page(long pageNumber) {
+        return new Pagination(pageNumber, size, mode, type, requestTotal);
     }
 
     @Override
-    public PageRequest<T> previous() {
+    public PageRequest previous() {
         if (mode == Mode.OFFSET)
             if (page > 1)
-                return new Pagination<T>(page - 1, size, sorts, mode, null, requestTotal);
+                return new Pagination(page - 1, size, mode, null, requestTotal);
             else
                 return null;
         else
@@ -124,58 +83,18 @@ record Pagination<T>(long page,
     }
 
     @Override
-    public Pagination<T> size(int maxPageSize) {
-        return new Pagination<T>(page, maxPageSize, sorts, mode, type, requestTotal);
-    }
-
-    @Override
-    public Pagination<T> sortBy(Iterable<Sort<? super T>> sorts) {
-        List<Sort<? super T>> sortList = sorts instanceof List //
-                        ? List.copyOf((List<Sort<? super T>>) sorts) //
-                        : sorts == null //
-                                        ? Collections.emptyList() //
-                                        : StreamSupport.stream(sorts.spliterator(), false) //
-                                                        .collect(Collectors.toUnmodifiableList());
-        return new Pagination<T>(page, size, sortList, mode, type, requestTotal);
-    }
-
-    @Override
-    public PageRequest<T> sortBy(Sort<? super T> sort) {
-        return new Pagination<T>(page, size, List.of(sort), mode, type, requestTotal);
-    }
-
-    @Override
-    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2) {
-        return new Pagination<T>(page, size, List.of(sort1, sort2), mode, type, requestTotal);
-    }
-
-    @Override
-    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3) {
-        return new Pagination<T>(page, size, List.of(sort1, sort2, sort3), mode, type, requestTotal);
-    }
-
-    @Override
-    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3,
-                                 Sort<? super T> sort4) {
-        return new Pagination<T>(page, size, List.of(sort1, sort2, sort3, sort4), mode, type, requestTotal);
-    }
-
-    @Override
-    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3,
-                                 Sort<? super T> sort4, Sort<? super T> sort5) {
-        return new Pagination<T>(page, size, List.of(sort1, sort2, sort3, sort4, sort5), mode, type, requestTotal);
+    public Pagination size(int maxPageSize) {
+        return new Pagination(page, maxPageSize, mode, type, requestTotal);
     }
 
     @Override
     public String toString() {
-        StringBuilder b = new StringBuilder("PageRequest{page=").append(page).append(", size=").append(size);
+        StringBuilder b = new StringBuilder("PageRequest{page=").append(page) //
+                        .append(", size=").append(size) //
+                        .append(", mode=").append(mode);
 
         if (type != null)
-            b.append(", mode=").append(mode).append(", ").append(type.size()).append(" keys");
-
-        for (Sort<? super T> o : sorts) {
-            b.append(", ").append(o.property()).append(o.ignoreCase() ? " IGNORE CASE" : "").append(o.isDescending() ? " DESC" : " ASC");
-        }
+            b.append(", ").append(type.size()).append(" keys");
 
         b.append("}");
 
@@ -183,12 +102,12 @@ record Pagination<T>(long page,
     }
 
     @Override
-    public PageRequest<T> withoutTotal() {
-        return new Pagination<T>(page, size, sorts, mode, type, false);
+    public PageRequest withoutTotal() {
+        return new Pagination(page, size, mode, type, false);
     }
 
     @Override
-    public PageRequest<T> withTotal() {
-        return new Pagination<T>(page, size, sorts, mode, type, true);
+    public PageRequest withTotal() {
+        return new Pagination(page, size, mode, type, true);
     }
 }

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/CursoredPageRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/CursoredPageRecord.java
@@ -27,10 +27,23 @@ public record CursoredPageRecord<T>(
                 List<T> content,
                 List<Cursor> cursors,
                 long totalElements,
-                PageRequest<T> pageRequest,
-                PageRequest<T> nextPageRequest,
-                PageRequest<T> previousPageRequest)
+                PageRequest pageRequest,
+                PageRequest nextPageRequest,
+                PageRequest previousPageRequest)
                 implements CursoredPage<T> {
+
+    public CursoredPageRecord(List<T> content,
+                              List<PageRequest.Cursor> cursors,
+                              long totalElements,
+                              PageRequest pageRequest,
+                              boolean first,
+                              boolean last) {
+        this(content, //
+             cursors, //
+             totalElements, //
+             pageRequest, last ? null : pageRequest.page(1 + pageRequest.page()).afterCursor(cursors.get(cursors.size() - 1)), //
+             first ? null : pageRequest.page(pageRequest.page() == 1 ? 1 : pageRequest.page() - 1).beforeCursor(cursors.get(0)));
+    }
 
     @Override
     public Cursor cursor(int i) {
@@ -63,17 +76,11 @@ public record CursoredPageRecord<T>(
     }
 
     @Override
-    public PageRequest<T> nextPageRequest() {
+    public PageRequest nextPageRequest() {
         if (nextPageRequest == null)
             throw new NoSuchElementException();
         else
             return nextPageRequest;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <E> PageRequest<E> nextPageRequest(Class<E> entityClass) {
-        return (PageRequest<E>) nextPageRequest();
     }
 
     @Override
@@ -81,24 +88,12 @@ public record CursoredPageRecord<T>(
         return content.size();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public <E> PageRequest<E> pageRequest(Class<E> entityClass) {
-        return (PageRequest<E>) pageRequest;
-    }
-
-    @Override
-    public PageRequest<T> previousPageRequest() {
+    public PageRequest previousPageRequest() {
         if (previousPageRequest == null)
             throw new NoSuchElementException();
         else
             return previousPageRequest;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <E> PageRequest<E> previousPageRequest(Class<E> entityClass) {
-        return (PageRequest<E>) previousPageRequest();
     }
 
     @Override

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/PageRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/page/impl/PageRecord.java
@@ -22,13 +22,13 @@ import jakarta.data.page.PageRequest;
 /**
  * Method signatures are copied from Jakarta Data.
  */
-public record PageRecord<T>(PageRequest<T> pageRequest,
+public record PageRecord<T>(PageRequest pageRequest,
                 List<T> content,
                 long totalElements,
                 boolean moreResults)
                 implements Page<T> {
 
-    public PageRecord(PageRequest<T> req,
+    public PageRecord(PageRequest req,
                       List<T> content,
                       long total) {
         this(req, //
@@ -63,17 +63,11 @@ public record PageRecord<T>(PageRequest<T> pageRequest,
     }
 
     @Override
-    public PageRequest<T> nextPageRequest() {
+    public PageRequest nextPageRequest() {
         if (hasNext())
             return pageRequest.next();
         else
             throw new NoSuchElementException();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <E> PageRequest<E> nextPageRequest(Class<E> entityClass) {
-        return (PageRequest<E>) nextPageRequest();
     }
 
     @Override
@@ -81,24 +75,12 @@ public record PageRecord<T>(PageRequest<T> pageRequest,
         return content.size();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public <E> PageRequest<E> pageRequest(Class<E> entityClass) {
-        return (PageRequest<E>) pageRequest;
-    }
-
-    @Override
-    public PageRequest<T> previousPageRequest() {
+    public PageRequest previousPageRequest() {
         if (hasPrevious())
             return pageRequest.previous();
         else
             throw new NoSuchElementException();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <E> PageRequest<E> previousPageRequest(Class<E> entityClass) {
-        return (PageRequest<E>) previousPageRequest();
     }
 
     @Override

--- a/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/BasicRepository.java
+++ b/dev/io.openliberty.jakarta.data.1.0/src/jakarta/data/repository/BasicRepository.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import jakarta.data.Order;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 
@@ -39,7 +40,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     Stream<T> findAll();
 
     @Find
-    Page<T> findAll(PageRequest<T> pageRequest);
+    Page<T> findAll(PageRequest pageRequest, Order<T> sortBy);
 
     @Find
     Optional<T> findById(@By(ID) K id);

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
@@ -55,6 +55,7 @@ public class DataCoreTckLauncher {
     }
 
     @Test
+    @Ignore("Broken by PageRequest/Sort decoupling") // TODO enable when we have RC1
     @AllowedFFDC // The tested exceptions cause FFDC so we have to allow for this.
     public void launchDataTckCorePersistence() throws Exception {
 

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataFullTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataFullTckLauncher.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -58,6 +59,7 @@ public class DataFullTckLauncher {
      * Run the TCK (controlled by autoFVT/publish/tckRunner/tck/*)
      */
     @Test
+    @Ignore("Broken by PageRequest/Sort decoupling") // TODO enable when we have RC1
     @AllowedFFDC // The tested exceptions cause FFDC so we have to allow for this.
     public void launchDataTckFullPersistence() throws Exception {
         // Test groups to run

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -56,6 +57,7 @@ public class DataWebTckLauncher {
      * Run the TCK (controlled by autoFVT/publish/tckRunner/tck/*)
      */
     @Test
+    @Ignore("Broken by PageRequest/Sort decoupling") // TODO enable when we have RC1
     @AllowedFFDC // The tested exceptions cause FFDC so we have to allow for this.
     public void launchDataTckWebPersistence() throws Exception {
         // Test groups to run


### PR DESCRIPTION
This contains the spec updates to decouple Sort from PageRequest, along with code and test updates.
This is a breaking change to the M4 TCK, which is temporarily disabled until we get the TCK for RC1 with these updates.

Do not merge this until after the 24.0.0.5-beta release is made because it breaks compatibility with Jakarta Data 1.0 M4.