### PR TITLE
Test bug Fix: java console hanging on jdk22 and update jks expectation to p12

### DIFF
--- a/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/CommonTest.java
+++ b/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/CommonTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -266,7 +266,7 @@ public class CommonTest {
         if (waitTime > 0) {
             startParms.add(Integer.toString(waitTime));
             String clientRoot = testClient.getClientRoot();
-            String keyLocation = clientRoot + "/resources/security/key.jks";
+            String keyLocation = clientRoot + "/resources/security/key.p12";
             Log.info(c, thisMethod, "wait Time is " + waitTime + " seconds. keyLocation is" + keyLocation);
             startParms.add(keyLocation);
         }

--- a/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/CommonTest.java
+++ b/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/CommonTest.java
@@ -213,7 +213,7 @@ public class CommonTest {
      * @param pause          the maximum wait time in seconds prior to invoke init() method of the ORB object.
      *                           This can be used in order to make sure that a SSL certificate is being genereated.
      *                           At the worst case, it took more than 20 seconds to generate. So putting 30 seconds.
-     *                           When this value is set, the calc application will check whether key.jks file exists
+     *                           When this value is set, the calc application will check whether key.p12 file exists
      *                           in the default location for every two seconds, and if it's not there, wait up to specified wait time.
      *                           When it reaches the maximum wait time, the program resumes.
      * @param ignoreErrors
@@ -232,7 +232,7 @@ public class CommonTest {
      * @param pause          the maximum wait time in seconds prior to invoke init() method of the ORB object.
      *                           This can be used in order to make sure that a SSL certificate is being genereated.
      *                           At the worst case, it took more than 20 seconds to genereate. So putting 30 seconds.
-     *                           When this value is set, the calc application will check whether key.jks file exists
+     *                           When this value is set, the calc application will check whether key.p12 file exists
      *                           in the default location for every two seconds, and if it's not there, wait up to specified wait time.
      *                           When it reaches the maximum wait time, the program resumes.
      * @param ignoreErrors
@@ -333,11 +333,11 @@ public class CommonTest {
         // the file location of the current client keystore
         //String clientRoot = testClient.getInstallRoot();
         String clientRoot = testClient.getClientRoot();
-        String keyLocation = clientRoot + "/resources/security/key.jks";
+        String keyLocation = clientRoot + "/resources/security/key.p12";
         Log.info(c, thisMethod, "keyLocation is" + keyLocation);
         startParms.add(keyLocation);
         // the file location of the new client keystore
-        String newKeyLocation = clientRoot + "/resources/security/newkey.jks";
+        String newKeyLocation = clientRoot + "/resources/security/newkey.p12";
         Log.info(c, thisMethod, "newKeyLocation is" + newKeyLocation);
         startParms.add(newKeyLocation);
 

--- a/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/CommonTest.java
+++ b/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/CommonTest.java
@@ -333,11 +333,11 @@ public class CommonTest {
         // the file location of the current client keystore
         //String clientRoot = testClient.getInstallRoot();
         String clientRoot = testClient.getClientRoot();
-        String keyLocation = clientRoot + "/resources/security/key.p12";
+        String keyLocation = clientRoot + "/resources/security/key.jks";
         Log.info(c, thisMethod, "keyLocation is" + keyLocation);
         startParms.add(keyLocation);
         // the file location of the new client keystore
-        String newKeyLocation = clientRoot + "/resources/security/newkey.p12";
+        String newKeyLocation = clientRoot + "/resources/security/newkey.jks";
         Log.info(c, thisMethod, "newKeyLocation is" + newKeyLocation);
         startParms.add(newKeyLocation);
 

--- a/dev/com.ibm.ws.security.client_fat/publish/clients/noDefaultKeyClient/bootstrap.properties
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/noDefaultKeyClient/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -21,3 +21,7 @@ logService=all
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
+
+#In JDK22, the console no longer returns null when there is no console
+#Using java.base restores the existing console behavior from previous JDK versions. 
+jdk.console=java.base

--- a/dev/com.ibm.ws.security.client_fat/test-applications/BasicCalculatorClient.jar/src/com/ibm/websphere/samples/technologysamples/basiccalcclient/BasicCalculatorClientJ2EEMain.java
+++ b/dev/com.ibm.ws.security.client_fat/test-applications/BasicCalculatorClient.jar/src/com/ibm/websphere/samples/technologysamples/basiccalcclient/BasicCalculatorClientJ2EEMain.java
@@ -158,9 +158,9 @@ public class BasicCalculatorClientJ2EEMain {
         // .p12 is the default for Liberty, but some tests still have .jks files specified.
         String keyLocationOtherEnding = "notSet";
 
-        if (keyLocation.contains(".jks")) {
+        if (keyLocation.endsWith(".jks")) {
             keyLocationOtherEnding = keyLocation.replace(".jks", ".p12");
-        } else if (keyLocation.contains(".p12")) {
+        } else if (keyLocation.endsWith(".p12")) {
             keyLocationOtherEnding = keyLocation.replace(".p12", ".jks");
         }
 


### PR DESCRIPTION
Fixes: https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=298672

Fixed 2 issues:
1. On JDK22, java Console class no longer returns null when there is no real console for user input. Using `jdk.console=java.base` as a workaround to restore previous JDK behavior. See https://www.oracle.com/java/technologies/javase/22-relnote-issues.html
2. Update wait expectation from looking for the `.jks` file to `.p12` instead