### PR TITLE
Adding Validation test for behavior between Hibernate Validator 6.1 and 7.0

### DIFF
--- a/dev/com.ibm.ws.beanvalidation.v20_fat/.classpath
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/.classpath
@@ -9,7 +9,12 @@
 	<classpathentry kind="src" path="test-applications/MultipleValidationXmlEjb2.jar/src"/>
 	<classpathentry kind="src" path="test-applications/MultipleValidationXmlWeb.war/src"/>
 	<classpathentry kind="src" path="test-applications/HibernateConfig.war/src"/>
+	<classpathentry kind="src" path="test-applications/bvalELApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/bnd.bnd
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/bnd.bnd
@@ -37,5 +37,4 @@ tested.features: \
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.websphere.javaee.validation.2.0;version=latest,\
-	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
-	javax.validation.api
+	com.ibm.websphere.javaee.ejb.3.2;version=latest

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/bnd.bnd
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/bnd.bnd
@@ -18,6 +18,7 @@ src: \
 	fat/src,\
 	test-applications/bvalApp/src,\
 	test-applications/bvalCDIApp/src,\
+	test-applications/bvalELApp/src,\
 	test-applications/bvalValueExtractorApp/src,\
 	test-applications/customBvalProviderApp/src,\
 	test-applications/HibernateConfig.war/src,\
@@ -36,4 +37,5 @@ tested.features: \
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.websphere.javaee.validation.2.0;version=latest,\
-	com.ibm.websphere.javaee.ejb.3.2;version=latest
+	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
+	javax.validation.api

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/fat/src/com/ibm/ws/bval/v20/fat/BeanVal20Test.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/fat/src/com/ibm/ws/bval/v20/fat/BeanVal20Test.java
@@ -31,6 +31,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import bval.v20.cdi.web.BeanValCDIServlet;
 import bval.v20.customprovider.CustomProviderTestServlet;
+import bval.v20.el.web.BeanValELServlet;
 import bval.v20.hibernateconfig.web.BeanValidationServlet;
 import bval.v20.multixml.web.BeanValidationTestServlet;
 import bval.v20.valueextractor.web.ValueExtractorServlet;
@@ -48,6 +49,7 @@ public class BeanVal20Test extends FATServletClient {
 
     public static final String REG_APP = "bvalApp";
     public static final String CDI_APP = "bvalCDIApp";
+    public static final String EL_APP = "bvalELApp";
     public static final String MULTI_VAL_APP = "MultipleValidationXmlWeb";
     public static final String VAL_EXT_APP = "bvalValueExtractorApp";
     public static final String HIBERNATE_DEFAULT_APP = "HibernateConfig";
@@ -59,6 +61,7 @@ public class BeanVal20Test extends FATServletClient {
     @TestServlets({
                     @TestServlet(servlet = BeanVal20TestServlet.class, contextRoot = REG_APP),
                     @TestServlet(servlet = BeanValCDIServlet.class, contextRoot = CDI_APP),
+                    @TestServlet(servlet = BeanValELServlet.class, contextRoot = EL_APP),
                     @TestServlet(servlet = BeanValidationTestServlet.class, contextRoot = MULTI_VAL_APP),
                     @TestServlet(servlet = ValueExtractorServlet.class, contextRoot = VAL_EXT_APP),
                     @TestServlet(servlet = BeanValidationServlet.class, contextRoot = HIBERNATE_DEFAULT_APP),
@@ -86,6 +89,7 @@ public class BeanVal20Test extends FATServletClient {
         exportDropinAppToServer(server, multiValXmlEar);
 
         defaultDropinApp(server, REG_APP, "bval.v20.web");
+        defaultDropinApp(server, EL_APP, "bval.v20.el.web");
         defaultDropinApp(server, CDI_APP, "bval.v20.cdi.web");
         defaultDropinApp(server, VAL_EXT_APP, "bval.v20.valueextractor.web");
         defaultDropinApp(server, HIBERNATE_DEFAULT_APP, "bval.v20.hibernateconfig.web");

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/BeanValELServlet.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/BeanValELServlet.java
@@ -1,0 +1,38 @@
+/**
+ *
+ */
+package bval.v20.el.web;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+/**
+ * Bean Validation App to test Expression Language
+ */
+@SuppressWarnings("serial")
+@WebServlet("/BeanValELServlet")
+public class BeanValELServlet extends FATServlet {
+
+    @Inject
+    Validator validator;
+
+    @Inject
+    ELBean bean;
+
+    @Test
+    public void testELEvaluation() {
+        Set<ConstraintViolation<ELBean>> violations = validator.validate(bean);
+        violations.iterator().forEachRemaining(v -> {
+            System.out.println(v.getMessage());
+        });
+    }
+
+}

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/BeanValELServlet.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/BeanValELServlet.java
@@ -1,6 +1,15 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package bval.v20.el.web;
 
 import static componenttest.annotation.SkipForRepeat.EE9_OR_LATER_FEATURES;

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/BeanValELServlet.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/BeanValELServlet.java
@@ -3,6 +3,10 @@
  */
 package bval.v20.el.web;
 
+import static componenttest.annotation.SkipForRepeat.EE9_OR_LATER_FEATURES;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
+import static org.junit.Assert.assertEquals;
+
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -12,10 +16,12 @@ import javax.validation.Validator;
 
 import org.junit.Test;
 
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
- * Bean Validation App to test Expression Language
+ * Bean Validation App to test Expression Language. There is behavior change with EL evaluation
+ * between EE8 and EE9+, so this Servlet confirms the difference in behavior.
  */
 @SuppressWarnings("serial")
 @WebServlet("/BeanValELServlet")
@@ -27,11 +33,29 @@ public class BeanValELServlet extends FATServlet {
     @Inject
     ELBean bean;
 
+    /**
+     * Test that Expression Language can be evaluated in a validation method. This was changed
+     * in Hibernate Validator 7.0, so it should only occur on EE8 (NO_MODIFICATION).
+     */
+    @SkipForRepeat(EE9_OR_LATER_FEATURES)
     @Test
-    public void testELEvaluation() {
+    public void testELEvaluationEE8() {
         Set<ConstraintViolation<ELBean>> violations = validator.validate(bean);
         violations.iterator().forEachRemaining(v -> {
-            System.out.println(v.getMessage());
+            assertEquals("Expression Language String should have evaluated to 3", "3", v.getMessage());
+        });
+    }
+
+    /**
+     * Test that Expression Language can not be evaluated in a validation method. This was changed
+     * in Hibernate Validator 7.0, so it should not work on EE8 (NO_MODIFICATION).
+     */
+    @SkipForRepeat(NO_MODIFICATION)
+    @Test
+    public void testELEvaluationEE9plus() {
+        Set<ConstraintViolation<ELBean>> violations = validator.validate(bean);
+        violations.iterator().forEachRemaining(v -> {
+            assertEquals("Expression Language String should not have been evaluated", "${1+2}", v.getMessage());
         });
     }
 

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELBean.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELBean.java
@@ -6,7 +6,7 @@ package bval.v20.el.web;
 import javax.enterprise.context.ApplicationScoped;
 
 /**
- * Bean with Expression Language features
+ * CDI Bean with a single string for Expression language testing
  */
 @ApplicationScoped
 public class ELBean {

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELBean.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELBean.java
@@ -1,0 +1,17 @@
+/**
+ *
+ */
+package bval.v20.el.web;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * Bean with Expression Language features
+ */
+@ApplicationScoped
+public class ELBean {
+
+    @ELInvalid
+    String testString = "test";
+
+}

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELBean.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELBean.java
@@ -1,6 +1,15 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package bval.v20.el.web;
 
 import javax.enterprise.context.ApplicationScoped;

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELInvalid.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELInvalid.java
@@ -1,0 +1,30 @@
+/**
+ *
+ */
+package bval.v20.el.web;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Always invalid constraint to test EL features in a violation message
+ */
+@Target({ FIELD, METHOD, PARAMETER, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+@Constraint(validatedBy = ELInvalidValidator.class)
+public @interface ELInvalid {
+    String message() default "Should have invalid message";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELInvalid.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELInvalid.java
@@ -1,6 +1,15 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package bval.v20.el.web;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELInvalidValidator.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELInvalidValidator.java
@@ -14,7 +14,7 @@ public class ELInvalidValidator implements ConstraintValidator<ELInvalid, String
     @Override
     public boolean isValid(String s, ConstraintValidatorContext context) {
         context.disableDefaultConstraintViolation();
-        context.buildConstraintViolationWithTemplate("${1+2} <-- EL should be 3").addConstraintViolation();
+        context.buildConstraintViolationWithTemplate("${1+2}").addConstraintViolation();
         return false;
     }
 

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELInvalidValidator.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELInvalidValidator.java
@@ -1,0 +1,21 @@
+/**
+ *
+ */
+package bval.v20.el.web;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Always finds the String invalid to test EL features in a violation message
+ */
+public class ELInvalidValidator implements ConstraintValidator<ELInvalid, String> {
+
+    @Override
+    public boolean isValid(String s, ConstraintValidatorContext context) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate("${1+2} <-- EL should be 3").addConstraintViolation();
+        return false;
+    }
+
+}

--- a/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELInvalidValidator.java
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/test-applications/bvalELApp/src/bval/v20/el/web/ELInvalidValidator.java
@@ -1,6 +1,15 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package bval.v20.el.web;
 
 import javax.validation.ConstraintValidator;


### PR DESCRIPTION
Adding tests to cover the difference in behavior between the EE8 and EE9+ versions of the Jakarta Bean Validation implementation.

