### PR TITLE
The By clause is now optional for Query by Method Name

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
@@ -25,6 +25,7 @@ import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 
@@ -55,14 +56,18 @@ public interface Houses {
     @Find
     House findById(@By(ID) String parcel);
 
+    @Query("SELECT garage.area WHERE garage IS NOT NULL")
     @OrderBy("purchasePrice")
-    int[] findGarageAreaByGarageNotNull();
+    int[] findGarageAreas();
 
+    @Query("SELECT garage.door, kitchen.length, kitchen.width WHERE parcelId = ?1")
     Optional<Object[]> findGarageDoorAndKitchenLengthAndKitchenWidthByParcelId(String parcel);
 
+    @Query("SELECT kitchen.length, kitchen.width, garage.area, area WHERE area < :maxArea")
     @OrderBy("lotSize")
     Stream<Object[]> findKitchenLengthAndKitchenWidthAndGarageAreaAndAreaByAreaLessThan(int maxArea);
 
+    @Query("SELECT purchasePrice WHERE lotSize > ?1")
     @OrderBy("area")
     DoubleStream findPurchasePriceByLotSizeGreaterThan(float minLotSize);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -65,17 +65,17 @@ public interface Packages extends BasicRepository<Package, Integer> {
     @Query("DELETE FROM Package")
     int deleteEverything();
 
-    Optional<Integer> deleteFirstBy(Sort<Package> sort);
+    Optional<Integer> deleteFirst(Sort<Package> sort);
 
-    int[] deleteFirst2By(Sort<?>... sorts);
+    int[] deleteFirst2(Sort<?>... sorts);
 
     LinkedList<?> deleteFirst2ByHeightLessThan(float maxHeight, Sort<?>... sorts);
 
-    long[] deleteFirst3By(Sort<Package> sort); // invalid return type is not the entity or id
+    long[] deleteFirst3(Sort<Package> sort); // invalid return type is not the entity or id
 
-    List<String> deleteFirst4By(Sort<Package> sort); // invalid return type is not the entity or id
+    List<String> deleteFirst4(Sort<Package> sort); // invalid return type is not the entity or id
 
-    Collection<Number> deleteFirst5By(Sort<Package> sort); // invalid return type is not the entity or id
+    Collection<Number> deleteFirst5(Sort<Package> sort); // invalid return type is not the entity or id
 
     @Delete
     Object[] destroy(Limit limit, Sort<Package> sort);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -211,7 +211,8 @@ public interface Primes {
     @Find
     Optional<Prime> findHexadecimal(String hex);
 
-    List<Object[]> findNumberIdAndNameBy(Sort<?>... sort);
+    @Query("SELECT o.numberId, o.name FROM Prime o")
+    List<Object[]> findNumberIdAndName(Sort<?>... sort);
 
     @OrderBy(value = ID, descending = true)
     Set<Long> findNumberIdByNumberIdBetween(long min, long max);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Reservations.java
@@ -59,7 +59,7 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
     @Query("SELECT COUNT(o) FROM Reservation o") // JPQL
     int count();
 
-    int countBy();
+    int countAll();
 
     boolean deleteByHostIn(List<String> hosts);
 
@@ -131,7 +131,8 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
     List<Long> findMeetingIdByStopWithSecond(int second);
 
     // Use a record as the return type
-    ReservedTimeSlot[] findStartAndStopByLocationAndStartBetweenOrderByStart(String location, OffsetDateTime startAfter, OffsetDateTime startBefore);
+    @Select({ "start", "stop" })
+    ReservedTimeSlot[] findTimeSlotByLocationAndStartBetweenOrderByStart(String location, OffsetDateTime startAfter, OffsetDateTime startBefore);
 
     ArrayDeque<Reservation> findByLocationStartsWith(String locationPrefix);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Repository;
@@ -25,6 +27,30 @@ import jakarta.data.repository.Save;
  */
 @Repository(dataStore = "java:module/jdbc/env/DerbyDataSourceRef")
 public interface Vehicles {
+
+    long count();
+
+    long countEverything();
+
+    long delete();
+
+    List<Vehicle> deleteAll();
+
+    List<Vehicle> deleteFirst2FoundOrderByPriceAscVinIdAsc();
+
+    boolean exists();
+
+    boolean existsAny();
+
+    Stream<Vehicle> find();
+
+    Stream<Vehicle> findAll();
+
+    Optional<Vehicle> findFirstOrderByVinId();
+
+    List<Vehicle> findAllOrderByPriceDescVinIdAsc();
+
+    List<Vehicle> findOrderByMakeAscModelAscVinIdAsc();
 
     Optional<Vehicle> findByVinId(String vin);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
@@ -21,6 +21,7 @@ import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 import jakarta.persistence.EntityManager;
@@ -46,25 +47,32 @@ public interface Counties {
 
     Optional<County> findByZipCodes(int... zipcodes);
 
+    @Query("SELECT cities WHERE name LIKE CONCAT(?1, '%')")
     @OrderBy("name")
     List<Set<CityId>> findCitiesByNameStartsWith(String beginning);
 
     Timestamp findLastUpdatedByName(String name);
 
+    @Query("SELECT zipcodes WHERE name = ?1")
     Optional<int[]> findZipCodesByName(String name);
 
+    @Query("SELECT zipcodes WHERE name LIKE CONCAT('%', ?1, '%')")
     int[] findZipCodesByNameContains(String substring);
 
+    @Query("SELECT zipcodes WHERE name LIKE CONCAT('%', ?1)")
     @OrderBy("population")
     Stream<int[]> findZipCodesByNameEndsWith(String ending);
 
+    @Query("SELECT zipcodes WHERE name NOT LIKE CONCAT(?1, '%')")
     @OrderBy("name")
     List<int[]> findZipCodesByNameNotStartsWith(String beginning);
 
+    @Query("SELECT zipcodes WHERE name LIKE CONCAT(?1, '%')")
     @OrderBy("population")
     @OrderBy("name")
     Page<int[]> findZipCodesByNameStartsWith(String beginning, PageRequest pagination);
 
+    @Query("SELECT zipcodes WHERE population <= ?1")
     @OrderBy("population")
     Optional<Iterator<int[]>> findZipCodesByPopulationLessThanEqual(int maxPopulation);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
@@ -27,6 +27,7 @@ import jakarta.data.repository.By;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 
@@ -83,6 +84,7 @@ public interface CreditCards extends DataRepository<CreditCard, CardId> {
     @OrderBy(ID)
     Stream<CardId> findBySecurityCode(int code);
 
+    @Query("SELECT number WHERE EXTRACT (YEAR FROM expiresOn) <= ?1")
     @OrderBy("number")
     List<Long> findNumberByExpiresOnWithYearLessThanEqual(int maxYearOfExpiry);
 

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
@@ -460,7 +460,7 @@ public class DataValidationTestServlet extends FATServlet {
         assertEquals(violations.toString(), 1, violations.size());
 
         // The violation on r6 must prevent the valid update to r7:
-        assertEquals(17, rectangles.findWidthById("R7"));
+        assertEquals(17, rectangles.getWidth("R7"));
 
         // First valid, second not valid:
         r6 = new Rectangle("R6", 600l, 660l, 6, 60);
@@ -475,7 +475,7 @@ public class DataValidationTestServlet extends FATServlet {
         assertEquals(violations.toString(), 1, violations.size());
 
         // The violation on r7 must prevent the valid update to r6:
-        assertEquals(16, rectangles.findWidthById("R6"));
+        assertEquals(16, rectangles.getWidth("R6"));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Rectangles.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Rectangles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ package test.jakarta.data.validation.web;
 
 import java.util.List;
 
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 import jakarta.validation.Valid;
@@ -31,7 +32,8 @@ public interface Rectangles {
 
     List<Rectangle> findByWidth(@Positive int width);
 
-    int findWidthById(String id);
+    @Query("SELECT width WHERE id=?1")
+    int getWidth(String id);
 
     @Save
     void save(@Valid Rectangle r);


### PR DESCRIPTION
Query by Method Name was changed in Jakarta Data to make the By clause optional for delete, count, exists, and find operations.  This pull updates Liberty to align with that, and adds testing.  Also, a By clause without conditions is no longer expected to be supported, so I have switched some tests from that to having no By clause.  Other tests were specifying names of entity fields to return within the find clause, which is not supported by the spec, so I have switched those tests to achieve this with `@Query` instead, and in doing so ran into a bug with `@Query` where it isn't defaulting to the primary entity type. This pull also fixes that issue.