### PR TITLE
Install tools update feature product match logic

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ExceptionUtils.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ExceptionUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -438,6 +438,7 @@ public class ExceptionUtils {
 
         MissingRequirement missingRequirementWithMaxVersion = null;
         String newestVersion = null;
+        List productMatchers = new ArrayList<>();
         for (MissingRequirement mr : allRequirementsNotFound) {
             if (missingRequirementWithMaxVersion == null)
                 missingRequirementWithMaxVersion = mr;
@@ -449,25 +450,14 @@ public class ExceptionUtils {
                 Pattern validNumericVersionOrRange = Pattern.compile("\\d+\\.\\d+\\.\\d+\\.\\d+");
                 Matcher matcher = validNumericVersionOrRange.matcher(r);
                 String version = null;
+                String currentEdition = "";
                 while (matcher.find()) {
                     version = matcher.group();
                     break;
                 }
-                List productMatchers = SelfExtractor.parseAppliesTo(mr.getRequirementName());
-                wlp.lib.extract.ReturnCode validInstallRC = SelfExtractor.validateProductMatches(installDir, productMatchers);
-                String currentEdition = "";
-                String messageKey = validInstallRC.getMessageKey();
+                productMatchers.addAll(SelfExtractor.parseAppliesTo(mr.getRequirementName()));
 
-                if (messageKey != null) {
-                    if (messageKey.equals("invalidVersion") || messageKey.equals("invalidEdition")) {
-                        int productEdition = 2;
-                        if (messageKey.equals("invalidEdition")) {
-                            productEdition = 0;
-                        }
-                        currentEdition = (String) validInstallRC.getParameters()[productEdition];
-                    }
-                }
-                if (!!!currentEdition.equals("Liberty Early Access")) {
+                if (!r.contains("Liberty Early Access")) {
                     if (isNewerVersion(version, newestVersion, false)) {
                         missingRequirementWithMaxVersion = mr;
                         newestVersion = version;
@@ -478,7 +468,6 @@ public class ExceptionUtils {
                         newestVersion = version;
                     }
                 }
-
             }
         }
 
@@ -520,7 +509,6 @@ public class ExceptionUtils {
             missingRequirementWithMaxVersion.getRequirementName().contains("productEdition") ||
             missingRequirementWithMaxVersion.getRequirementName().contains("productVersion")) {
             @SuppressWarnings("rawtypes")
-            List productMatchers = SelfExtractor.parseAppliesTo(missingRequirementWithMaxVersion.getRequirementName());
             String feature = RepositoryDownloadUtil.getAssetNameFromMassiveResource(missingRequirementWithMaxVersion.getOwningResource());
             String errMsg = "";
             if (InstallUtils.containsIgnoreCase(assetNames, feature)) {
@@ -788,6 +776,7 @@ public class ExceptionUtils {
                     }
                     String version = (String) params[productVersion];
                     String appliesToVersion = (String) params[matchVersion];
+
                     if (appliesToVersion == null || version.equals(appliesToVersion))
                         appliesToVersion = "";
 
@@ -814,7 +803,14 @@ public class ExceptionUtils {
                         String editionName = "";
                         editionName = InstallUtils.getEditionName(e);
                         if (!productMap.containsKey(editionName)) {
-                            String product = "- " + productName + (editionName.isEmpty() ? "" : " ") + editionName + " " + appliesToVersion;
+                            String product;
+                            if (editionName.equalsIgnoreCase("open") && !isFeatureUtil) { //InstallUtility and featureManager are not available in Open Liberty so don't list it.
+                                continue;
+                            } else if (editionName.equalsIgnoreCase("open") && isFeatureUtil) {
+                                product = "- IBM Open Liberty " + appliesToVersion;
+                            } else {
+                                product = "- " + productName + (editionName.isEmpty() ? "" : " ") + editionName + " " + appliesToVersion;
+                            }
                             productMap.put(editionName, product);
                             applicableProducts.append(product);
                             applicableProducts.append(InstallUtils.NEWLINE);
@@ -825,20 +821,19 @@ public class ExceptionUtils {
                     if (dependency == null || dependency.isEmpty()) {
                         if (appliesToVersion.equals("")) { //installing asset has invalid product edition only
 
-                            if (((String) params[productEdition]).equalsIgnoreCase("Open_Web") && productName.equalsIgnoreCase("IBM WebSphere Application Server Liberty")) {
-                                errMsg = Messages.INSTALL_KERNEL_MESSAGES.getLogMessage(installingAsset ? "ERROR_ASSET_INVALID_PRODUCT_EDITION" : "ERROR_INVALID_PRODUCT_EDITION_FOR_OPEN_LIBERTY_FEATURE",
-                                                                                        new Object[] { feature });
-                            } else {
-
-                                errMsg = Messages.INSTALL_KERNEL_MESSAGES.getLogMessage(installingAsset ? "ERROR_ASSET_INVALID_PRODUCT_EDITION" : "ERROR_INVALID_PRODUCT_EDITION",
+                            if (installingAsset) {//print installUtility error message
+                                errMsg = Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_ASSET_INVALID_PRODUCT_EDITION",
+                                                                                        new Object[] { feature, productName, edition, applicableProducts.toString(),
+                                                                                                       productName,
+                                                                                                       edition });
+                            } else if (isFeatureUtil) {
+                                errMsg = Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_INVALID_PRODUCT_EDITION_FEATURE_UTILITY",
+                                                                                        new Object[] { feature, productName, edition, applicableProducts.toString() });
+                            } else {//print featureManager error message
+                                errMsg = Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_INVALID_PRODUCT_EDITION",
                                                                                         new Object[] { feature, productName, edition, applicableProducts.toString(), productName,
                                                                                                        edition });
-                                if (isFeatureUtil) {
-                                    errMsg = Messages.INSTALL_KERNEL_MESSAGES.getLogMessage(installingAsset ? "ERROR_ASSET_INVALID_PRODUCT_EDITION" : "ERROR_INVALID_PRODUCT_EDITION_FEATURE_UTILITY",
-                                                                                            new Object[] { feature, productName, edition, applicableProducts.toString() });
-                                }
                             }
-
                         } else {
                             errMsg = Messages.INSTALL_KERNEL_MESSAGES.getLogMessage(installingAsset ? "ERROR_ASSET_INVALID_PRODUCT_EDITION_VERSION" : "ERROR_INVALID_PRODUCT_EDITION_VERSION",
                                                                                     new Object[] { feature, productName, edition, version, applicableProducts.toString() });

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -48,6 +48,7 @@ import com.ibm.ws.repository.resources.ApplicableToProduct;
 import com.ibm.ws.repository.resources.EsaResource;
 import com.ibm.ws.repository.resources.RepositoryResource;
 import com.ibm.ws.repository.resources.SampleResource;
+import com.ibm.ws.repository.transport.model.AppliesToFilterInfo;
 
 /**
  * Resolves a list of names into lists of {@link RepositoryResource} to be installed
@@ -906,7 +907,21 @@ public class RepositoryResolver {
         Set<ProductRequirementInformation> missingProductInformation = new HashSet<>();
 
         for (ApplicableToProduct esa : resourcesWrongProduct) {
-            missingRequirements.add(new MissingRequirement(esa.getAppliesTo(), (RepositoryResource) esa));
+            String appliesTo = esa.getAppliesTo();
+            if (appliesTo.contains("productEdition=Open")) { //Check if there are WebSphere editions and add
+                if (esa instanceof EsaResource && ((EsaResource) esa).getAppliesToFilterInfo() != null) {
+                    for (AppliesToFilterInfo atfi : ((EsaResource) esa).getAppliesToFilterInfo()) {
+                        if (!atfi.getEditions().toString().isEmpty()) {
+                            StringBuffer sb = new StringBuffer("; editions=\"");
+                            sb.append(atfi.getEditions().toString().replace("[", "").replace("]", "").replace(" ", ""));
+                            sb.append("\"");
+                            appliesTo = appliesTo.concat(sb.toString());
+                        }
+                    }
+                }
+            }
+
+            missingRequirements.add(new MissingRequirement(appliesTo, (RepositoryResource) esa));
             missingProductInformation.addAll(ProductRequirementInformation.createFromAppliesTo(esa.getAppliesTo()));
         }
 

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/EsaResource.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/EsaResource.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import com.ibm.ws.repository.common.enums.InstallPolicy;
 import com.ibm.ws.repository.common.enums.Visibility;
+import com.ibm.ws.repository.transport.model.AppliesToFilterInfo;
 
 /**
  * Represents a Feature Resource in a repository.
@@ -124,4 +125,11 @@ public interface EsaResource extends RepositoryResource, ApplicableToProduct {
      * @return The IBM-InstallTo header property
      */
     public String getIBMInstallTo();
+
+    /**
+     * Gets the IBM getAppliesToFilterInfo property from the feature.
+     *
+     * @return The AppliesToFilter header property
+     */
+    public Collection<AppliesToFilterInfo> getAppliesToFilterInfo();
 }

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
@@ -365,7 +365,8 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
         addVersionDisplayString();
     }
 
-    protected Collection<AppliesToFilterInfo> getAppliesToFilterInfo() {
+    @Override
+    public Collection<AppliesToFilterInfo> getAppliesToFilterInfo() {
         return _asset.getWlpInformation().getAppliesToFilterInfo();
     }
 

--- a/dev/wlp.lib.extract/src/wlp/lib/extract/ProductMatch.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/ProductMatch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2017 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -43,6 +43,8 @@ public final class ProductMatch {
     public static final int INVALID_EDITION = -3;
     public static final int INVALID_INSTALL_TYPE = -4;
     public static final int INVALID_LICENSE = -5;
+    public static final String NOT_OPENLIBERTY_PRODUCTID = "com.ibm.websphere.appserver";
+    public static final String OPENLIBERTY_PRODUCTID = "io.openliberty";
 
     /**
      * @param substring
@@ -61,6 +63,17 @@ public final class ProductMatch {
                     break;
                 }
             }
+        } else if (substring.startsWith("edition")) {
+            //If editions contains Open, add supported WebSphere editions.
+            if (!editions.isEmpty() && editions.contains("Open")) {
+                String editionStr = getValue(substring);
+                for (int startIndex = 0, endIndex = editionStr.indexOf(',');; startIndex = endIndex, endIndex = editionStr.indexOf(',', ++startIndex)) {
+                    editions.add(editionStr.substring(startIndex, endIndex == -1 ? editionStr.length() : endIndex));
+                    if (endIndex == -1) {
+                        break;
+                    }
+                }
+            }
         } else if (substring.startsWith("productInstallType")) {
             installType = getValue(substring);
         } else if (substring.startsWith("productLicenseType")) {
@@ -69,7 +82,7 @@ public final class ProductMatch {
     }
 
     public int matches(Properties props) {
-        if (productId.equals(props.getProperty("com.ibm.websphere.productId"))) {
+        if (!(productId.equals(NOT_OPENLIBERTY_PRODUCTID) && props.getProperty("com.ibm.websphere.productId").equals(OPENLIBERTY_PRODUCTID))) {
             if (version != null) {
                 String productVersion = props.getProperty("com.ibm.websphere.productVersion");
                 Matcher appliesToMatcher = validNumericVersionOrRange.matcher(version);

--- a/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractor.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -546,28 +546,17 @@ public class SelfExtractor implements LicenseProvider {
     }
 
     /**
-     * TODO move this to ReturnCode class
      *
-     * @param rc
-     * @return
-     */
-    private static boolean isReturnCodeOK(ReturnCode rc) {
-        return rc.getCode() == ReturnCode.OK.getCode();
-    }
-
-    /**
      * @param productMatches
      * @param props
      */
     protected static ReturnCode matchLibertyProperties(List productMatches, Properties props) {
-        Iterator<ProductMatch> matches = productMatches.iterator();
-        ReturnCode rc = ReturnCode.OK;
-        while (matches.hasNext() && ReturnCode.isReturnCodeOK(rc)) {
-            ProductMatch match = matches.next();
-            int result = match.matches(props);
-            rc = getReturnCode(props, match, result);
+        if (productMatches.isEmpty()) {
+            return ReturnCode.OK;
         }
-        return rc;
+        //Returns the ProductMatch object from productMatches with the lowest value returned from ProductMatch.matches(props)
+        ProductMatch match = (ProductMatch) productMatches.stream().min((o1, o2) -> ((ProductMatch) o1).matches(props) - ((ProductMatch) o2).matches(props)).get();
+        return getReturnCode(props, match, match.matches(props));
     }
 
     /**

--- a/dev/wlp.lib.extract/test/wlp/lib/extract/SelfExtractorTest.java
+++ b/dev/wlp.lib.extract/test/wlp/lib/extract/SelfExtractorTest.java
@@ -30,9 +30,31 @@ public class SelfExtractorTest {
      */
     @Test
     public void testmatchLibertyPropertiesInvalidEdition() {
-        String appliesTo = "com.ibm.websphere.appserver; productVersion=24.0.0.1; productEdition=Open; editions=\"BASE, DEVELOPER\"";
+        String appliesTo = "com.ibm.websphere.appserver; productVersion=24.0.0.2; productEdition=Open; editions=\"BASE, DEVELOPER\"";
         List productMatches = SelfExtractor.parseAppliesTo(appliesTo);
-        appliesTo = "com.ibm.websphere.appserver; productVersion=24.0.0.2; productEdition=Open; editions=\"BASE, DEVELOPER\"";
+        appliesTo = "com.ibm.websphere.appserver; productVersion=24.0.0.1; productEdition=Open; editions=\"BASE, DEVELOPER\"";
+        productMatches.addAll(SelfExtractor.parseAppliesTo(appliesTo));
+        Properties props = new Properties();
+        props.put("com.ibm.websphere.productId", "com.ibm.websphere.appserver");
+        props.put("com.ibm.websphere.productVersion", "24.0.0.2");
+        props.put("com.ibm.websphere.productEdition", "LIBERTY_CORE");
+        props.put("com.ibm.websphere.productLicenseType", "IPLA");
+        props.put("com.ibm.websphere.productInstallType", "Archive");
+
+        ReturnCode rc = SelfExtractor.matchLibertyProperties(productMatches, props);
+        assertTrue("Message key should be invalidEdition but it was '" + rc.getMessageKey() + "'", rc.getMessageKey().equals("invalidEdition"));
+
+    }
+
+    /**
+     *
+     * Test method for {@link wlp.lib.extract.SelfExtractor#validateProductMatches(java.io.File, java.util.List)}.
+     */
+    @Test
+    public void testmatchLibertyPropertiesInvalidEditionWithOlderVersion() {
+        String appliesTo = "com.ibm.websphere.appserver; productVersion=24.0.0.2; productEdition=Open; editions=\"BASE, DEVELOPER\"";
+        List productMatches = SelfExtractor.parseAppliesTo(appliesTo);
+        appliesTo = "com.ibm.websphere.appserver; productVersion=24.0.0.1; productEdition=Open; editions=\"BASE, DEVELOPER\"";
         productMatches.addAll(SelfExtractor.parseAppliesTo(appliesTo));
         Properties props = new Properties();
         props.put("com.ibm.websphere.productId", "com.ibm.websphere.appserver");
@@ -43,6 +65,25 @@ public class SelfExtractorTest {
 
         ReturnCode rc = SelfExtractor.matchLibertyProperties(productMatches, props);
         assertTrue("Message key should be invalidEdition but it was '" + rc.getMessageKey() + "'", rc.getMessageKey().equals("invalidEdition"));
+
+    }
+
+    /**
+     * User feature or local ESA install does not have "appliesTo" String. Therefore, productMatches list is empty.
+     */
+    @Test
+    public void testmatchLibertyPropertiesEmptyProductMatch() {
+        String appliesTo = null;
+        List productMatches = SelfExtractor.parseAppliesTo(appliesTo);
+        Properties props = new Properties();
+        props.put("com.ibm.websphere.productId", "com.ibm.websphere.appserver");
+        props.put("com.ibm.websphere.productVersion", "24.0.0.1");
+        props.put("com.ibm.websphere.productEdition", "LIBERTY_CORE");
+        props.put("com.ibm.websphere.productLicenseType", "IPLA");
+        props.put("com.ibm.websphere.productInstallType", "Archive");
+
+        ReturnCode rc = SelfExtractor.matchLibertyProperties(productMatches, props);
+        assertTrue("Should return OK '", rc.getCode() == 0);
 
     }
 


### PR DESCRIPTION
Fixes an error message when users try to install a feature that is available on all Liberty editions except Core to Core edition. 

