### PR TITLE
Update microprofile tck servers to avoid server reconfigs 

### DIFF
--- a/dev/com.ibm.ws.microprofile.mpjwt.1.0_fat_tck/publish/servers/mpjwt_roles/server.xml
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.0_fat_tck/publish/servers/mpjwt_roles/server.xml
@@ -36,22 +36,5 @@
 	<javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
 
    <!-- needed for roles mapping -->
-     <webApplication id="RolesAllowedTest" location="${server.config.dir}/apps/RolesAllowedTest.war" name="RolesAllowedTest">
-       <application-bnd>
-           <security-role name="Token2Role">
-              <group access-id="group:https://server.example.com/group1.2" name="group1.2"/>  
-           </security-role>
-           <security-role name="Group1MappedRole">
-              <group access-id="group:https://server.example.com/group1" name="group1"/>            
-           </security-role>
-           <security-role name="Tester">              
-            <group access-id="group:https://server.example.com/Tester" name="Tester"/>  
-            </security-role>
-            <security-role name="Echoer">
-                <group access-id="group:https://server.example.com/Echoer" name="Echoer"/> 
-            </security-role>
-       </application-bnd> 
-    </webApplication> 
-    
 
 </server>

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/publish/servers/tckAudEnv/server.xml
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/publish/servers/tckAudEnv/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2018 IBM Corporation and others.
+    Copyright (c) 2018, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -38,25 +38,4 @@
  
     <keyStore id="defaultKeyStore" password="keyspass"/>
 	
-   
-     <webApplication id="RolesAllowedTest" location="${server.config.dir}/apps/RolesAllowedTest.war" name="RolesAllowedTest">
-       <application-bnd>
-           <security-role name="Token2Role">
-              <group access-id="group:https://server.example.com/group1.2" name="group1.2"/>  
-               <group access-id="group:https://server.example.com/group1.2" name="Token2Role"/>   <!--  new  -->     
-           </security-role>
-           <security-role name="Group1MappedRole">
-              <group access-id="group:https://server.example.com/group1" name="group1"/>   
-              <group access-id="group:https://server.example.com/group1" name="group1MappedRole"/>       <!--  new  -->    
-           </security-role>
-           <security-role name="Tester">              
-               <group access-id="group:https://server.example.com/Tester" name="Tester"/>  
-            </security-role>
-            <security-role name="Echoer">
-                <group access-id="group:https://server.example.com/Echoer" name="Echoer"/> 
-            </security-role>
-       </application-bnd> 
-    </webApplication> 
-    
-
 </server>

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/publish/tckRunner/tck/tck_suite_aud_env.xml
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/publish/tckRunner/tck/tck_suite_aud_env.xml
@@ -36,14 +36,7 @@
 	          <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" />
 	          <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" />
 	          <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" />
-	          
-	          <!-- 
-	          removing this for now as it fails intermittently with a 404.  Something to do with the harness 
-	          starting the app twice.  Similar coverage is available in the mpjwt 1.0 tck bucket
-	   
-              <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" />  
-              --> 
-                         
+	          <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" />  
               <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest" /> 
         </classes>
     </test>


### PR DESCRIPTION
Update microprofile tck servers to avoid server reconfigs during run.
The server.xml's contained a config entry for the RolesAllowedTest application, but the project did not include the app - we expect to get it when the tck is downloaded.
The test wrapper starts our server - we get an error message about the missing app, but, the server starts up.  Then the tck is downloaded and the app is unpacked into the dropins folder.  This causes the app to be loaded and started, but, it also results in a config update which restarts the app.  In many cases, it's back up and ready for the tests to use, but in others, it's not and we get a 404.
There are also some other intermittent failures with the tests using this war that are most likely caused by the app being in the server.xml.
I'm fixing our 1.0 bucket as well as the 1.2 bucket (and re-enabling the RolesAllowedTest).