### PR TITLE
Update to ASM 9.7 for Java 23

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -4209,27 +4209,27 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-analysis</artifactId>
-      <version>9.6</version>
+      <version>9.7</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-commons</artifactId>
-      <version>9.6</version>
+      <version>9.7</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-tree</artifactId>
-      <version>9.6</version>
+      <version>9.7</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-util</artifactId>
-      <version>9.6</version>
+      <version>9.7</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>9.6</version>
+      <version>9.7</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -837,11 +837,11 @@ org.osgi:org.osgi.util.function:1.1.0
 org.osgi:org.osgi.util.promise:1.1.1
 org.osgi:osgi.core:7.0.0
 org.osgi:osgi.core:8.0.0
-org.ow2.asm:asm-analysis:9.6
-org.ow2.asm:asm-commons:9.6
-org.ow2.asm:asm-tree:9.6
-org.ow2.asm:asm-util:9.6
-org.ow2.asm:asm:9.6
+org.ow2.asm:asm-analysis:9.7
+org.ow2.asm:asm-commons:9.7
+org.ow2.asm:asm-tree:9.7
+org.ow2.asm:asm-util:9.7
+org.ow2.asm:asm:9.7
 org.postgresql:postgresql:42.7.2
 org.powermock:powermock-core:1.5
 org.quartz-scheduler:quartz:2.3.2

--- a/dev/com.ibm.ws.org.objectweb.asm/bnd.bnd
+++ b/dev/com.ibm.ws.org.objectweb.asm/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2023 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -10,16 +10,16 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.ow2.asm:asm;9.6}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.ow2.asm:asm-analysis;9.6}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.ow2.asm:asm-commons;9.6}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.ow2.asm:asm-tree;9.6}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.ow2.asm:asm-util;9.6}}!/META-INF/MANIFEST.MF,\
+-include= jar:${fileuri;${repo;org.ow2.asm:asm;9.7}}!/META-INF/MANIFEST.MF,\
+          jar:${fileuri;${repo;org.ow2.asm:asm-analysis;9.7}}!/META-INF/MANIFEST.MF,\
+          jar:${fileuri;${repo;org.ow2.asm:asm-commons;9.7}}!/META-INF/MANIFEST.MF,\
+          jar:${fileuri;${repo;org.ow2.asm:asm-tree;9.7}}!/META-INF/MANIFEST.MF,\
+          jar:${fileuri;${repo;org.ow2.asm:asm-util;9.7}}!/META-INF/MANIFEST.MF,\
           bnd.overrides
 
 instrument.disabled: true
 
-asmVersion=9.6
+asmVersion=9.7
 
 -buildpath: \
 	org.ow2.asm:asm;version=${asmVersion},\

--- a/dev/com.ibm.ws.org.objectweb.asm/bnd.overrides
+++ b/dev/com.ibm.ws.org.objectweb.asm/bnd.overrides
@@ -10,5 +10,5 @@ DynamicImport-Package: *
 # IMPORTANT: Remember to update io.openliberty.asm.ASMHelper.CURRENT_ASM to the value of the most current
 # org.objectweb.asm.Opcodes.ASM## constant when updating the ASM dependency.
 Export-Package: \
-  org.objectweb.asm.*;version="9.6",\
+  org.objectweb.asm.*;version="9.7",\
   io.openliberty.asm;version="1.0"

--- a/dev/com.ibm.ws.org.objectweb.asm/src/io/openliberty/asm/ASMHelper.java
+++ b/dev/com.ibm.ws.org.objectweb.asm/src/io/openliberty/asm/ASMHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2023 IBM Corporation and others.
+ * Copyright (c) 2022,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ import org.objectweb.asm.Opcodes;
  */
 public class ASMHelper {
     private static final int CURRENT_ASM = Opcodes.ASM9; // Update this when an ASM update introduces a new constant
-    private static final int CURRENT_MAX_JAVA_LEVEL = Opcodes.V22; // Update this to show the maximum version of Java we can run with
+    private static final int CURRENT_MAX_JAVA_LEVEL = Opcodes.V23; // Update this to show the maximum version of Java we can run with
 
     /**
      * Returns the constant representing the current version of ASM.

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceConfigClassVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceConfigClassVisitor.java
@@ -52,7 +52,7 @@ public class TraceConfigClassVisitor extends ClassVisitor {
     }
     
     public TraceConfigClassVisitor() {
-        super(Opcodes.ASM9);
+        super(ASMHelper.getCurrentASM());
     }    
 
     @Override

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyRuntimeTransformer.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyRuntimeTransformer.java
@@ -240,8 +240,8 @@ public class LibertyRuntimeTransformer implements ClassFileTransformer {
                 return null;
             }
         } else {
-            if ( classFileVersion > Opcodes.V22 ) {
-                return "Class version [ " + classFileVersion + " ] Maximum [ " + Opcodes.V22 + " ]";
+            if ( classFileVersion > ASMHelper.getMaximumJavaLevel() ) {
+                return "Class version [ " + classFileVersion + " ] Maximum [ " + ASMHelper.getMaximumJavaLevel() + " ]";
             } else {
                 return null;
             }

--- a/dev/com.ibm.ws.ras.instrument_test/test/com/ibm/ws/ras/RasTransformTest.java
+++ b/dev/com.ibm.ws.ras.instrument_test/test/com/ibm/ws/ras/RasTransformTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -33,11 +33,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.util.TraceClassVisitor;
 
 import com.ibm.ws.ras.instrument.internal.main.LibertyRuntimeTransformer;
+
+import io.openliberty.asm.ASMHelper;
 
 //TODO add tests that make sure classes are instrumented with trace.
 @SuppressWarnings("deprecation")
@@ -73,6 +74,7 @@ public class RasTransformTest extends LibertyRuntimeTransformer {
         majorCodeMap.put("20", 64);
         majorCodeMap.put("21", 65);
         majorCodeMap.put("22", 66);
+	majorCodeMap.put("23", 67);
 	}
 	
 	/**
@@ -157,7 +159,7 @@ public class RasTransformTest extends LibertyRuntimeTransformer {
         StringWriter sw = null;
         sw = new StringWriter();
         ClassReader reader = new ClassReader(classBytes);
-        ClassNode directory = new ClassNode(Opcodes.ASM9);
+        ClassNode directory = new ClassNode(ASMHelper.getCurrentASM());
         ClassVisitor visitor = new TraceClassVisitor(directory, new PrintWriter(sw));
         
         try {


### PR DESCRIPTION
This PR updates the current level of ASM from 9.6 (Java 22 support) to 9.7 (Java 23 support) for us to begin Java 23 testing.