### PR TITLE
Fix SIP - Servlet 3.1 Integration

### DIFF
--- a/dev/com.ibm.ws.sipcontainer.servlet.3.1/src/com/ibm/ws/sip/container/was/servlet31/converged/ConvergedHttpSessionContext31Impl.java
+++ b/dev/com.ibm.ws.sipcontainer.servlet.3.1/src/com/ibm/ws/sip/container/was/servlet31/converged/ConvergedHttpSessionContext31Impl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,19 +13,28 @@
 package com.ibm.ws.sip.container.was.servlet31.converged;
 
 import javax.servlet.ServletContext;
-import javax.servlet.sip.ConvergedHttpSession;
+import javax.servlet.http.HttpSession;
 
+import com.ibm.sip.util.log.Log;
+import com.ibm.sip.util.log.LogMgr;
 import com.ibm.ws.session.SessionApplicationParameters;
-import com.ibm.ws.session.SessionData;
 import com.ibm.ws.session.SessionManagerConfig;
 import com.ibm.ws.session.SessionStoreService;
+import com.ibm.ws.webcontainer.session.impl.HttpSessionImpl;
 import com.ibm.ws.webcontainer31.session.impl.HttpSessionContext31Impl;
 import com.ibm.wsspi.session.ISession;
+import com.ibm.wsspi.session.IStore;
 import com.ibm.wsspi.sip.converge.ConvergedHttpSessionContextImpl;
 import com.ibm.wsspi.sip.converge.ConvergedHttpSessionImpl;
+import com.ibm.wsspi.sip.converge.IConvergedHttpSessionContext;
 
-public class ConvergedHttpSessionContext31Impl extends HttpSessionContext31Impl{
+public class ConvergedHttpSessionContext31Impl extends HttpSessionContext31Impl implements IConvergedHttpSessionContext {
     
+    /**
+	 * Class Logger.
+	 */
+	private static final transient LogMgr c_logger = Log.get(ConvergedHttpSessionContext31Impl.class);
+
 	/**
      * @param smc
      * @param sap
@@ -50,7 +59,40 @@ public class ConvergedHttpSessionContext31Impl extends HttpSessionContext31Impl{
      * @param scheme
      * @return
      */
-    public String getSipBaseUrlForEncoding(ConvergedHttpSession session, String contextPath, String relativePath, String scheme) {
+    public String getSipBaseUrlForEncoding(String contextPath, String relativePath, String scheme) {
         return ConvergedHttpSessionContextImpl.getSipBaseUrlForEncoding(_smc, contextPath, relativePath, scheme, this);
     }
+
+        /*
+     * Added for SIP/HTTP Converged App Support. SIP container calls this method via
+     * com.ibm.wsspi.servlet.session.ConvergedAppUtils to get an HTTP session reference
+     * for those HTTP sessions that belong to application sessions.
+     */
+    public HttpSession getHttpSessionById(String sessId) {
+    	HttpSessionImpl sd = null;
+        IStore iStore = _coreHttpSessionManager.getIStore();
+
+        if (c_logger.isTraceEntryExitEnabled()) {
+        	StringBuffer sb = new StringBuffer(sessId).append(" ").append(iStore.getId());
+            c_logger.traceEntry(this, "getHttpSessionById",sb.toString());
+        }
+        try {
+            iStore.setThreadContext();
+            sd = (HttpSessionImpl)_coreHttpSessionManager.getSession(sessId, true);
+        } finally {
+            iStore.unsetThreadContext();
+        }
+        
+        if (sd!=null) {
+        	if (c_logger.isTraceEntryExitEnabled()) {
+                	 c_logger.traceExit(this, "getHttpSessionById","got a session");
+            }
+            return (HttpSession)sd.getFacade();
+        } 
+    	
+        if (c_logger.isTraceEntryExitEnabled()) {
+    		 c_logger.traceExit(this, "getHttpSessionById", null);
+        }
+        return null;
+    } 
 }

--- a/dev/com.ibm.ws.sipcontainer.servlet.3.1/src/com/ibm/ws/sip/container/was/servlet31/converged/ConvergedHttpSessionContext31Impl.java
+++ b/dev/com.ibm.ws.sipcontainer.servlet.3.1/src/com/ibm/ws/sip/container/was/servlet31/converged/ConvergedHttpSessionContext31Impl.java
@@ -63,10 +63,13 @@ public class ConvergedHttpSessionContext31Impl extends HttpSessionContext31Impl 
         return ConvergedHttpSessionContextImpl.getSipBaseUrlForEncoding(_smc, contextPath, relativePath, scheme, this);
     }
 
-        /*
+    /*
      * Added for SIP/HTTP Converged App Support. SIP container calls this method via
      * com.ibm.wsspi.servlet.session.ConvergedAppUtils to get an HTTP session reference
      * for those HTTP sessions that belong to application sessions.
+     * 
+     * NOTE: This was copied from com.ibm.ws.sipcontainer/src/com/ibm/wsspi/sip/converge/ConvergedHttpSessionContextImpl.java
+     * Any changes should be applied to both methods. 
      */
     public HttpSession getHttpSessionById(String sessId) {
     	HttpSessionImpl sd = null;

--- a/dev/com.ibm.ws.sipcontainer.servlet.3.1/src/com/ibm/ws/sip/container/was/servlet31/converged/SessionContextRegistryConverged31Impl.java
+++ b/dev/com.ibm.ws.sipcontainer.servlet.3.1/src/com/ibm/ws/sip/container/was/servlet31/converged/SessionContextRegistryConverged31Impl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,7 @@ package com.ibm.ws.sip.container.was.servlet31.converged;
 import com.ibm.ws.session.SessionApplicationParameters;
 import com.ibm.ws.session.SessionManagerConfig;
 import com.ibm.ws.webcontainer.httpsession.SessionManager;
-import com.ibm.ws.webcontainer.session.IHttpSessionContext;
-import com.ibm.wsspi.sip.converge.ConvergedHttpSessionContextImpl;
+import com.ibm.ws.webcontainer31.session.IHttpSessionContext31;
 import com.ibm.wsspi.sip.converge.SessionContextRegistryConvergedImpl;
 
 /**
@@ -38,8 +37,8 @@ public class SessionContextRegistryConverged31Impl extends SessionContextRegistr
     *
     * @see com.ibm.ws.webcontainer.session.impl.SessionContextRegistryImpl#createSessionContextObject(com.ibm.ws.session.SessionManagerConfig, com.ibm.ws.session.SessionApplicationParameters)
     */
-   protected IHttpSessionContext createSessionContextObject(SessionManagerConfig smc, SessionApplicationParameters sap)
-   {
-       return new ConvergedHttpSessionContextImpl(smc, sap, this.smgr.getSessionStoreService());
-   } 
+    protected IHttpSessionContext31 createSessionContextObject(SessionManagerConfig smc, SessionApplicationParameters sap)
+    {
+        return new ConvergedHttpSessionContext31Impl(smc, sap, this.smgr.getSessionStoreService());
+    }
 }

--- a/dev/com.ibm.ws.sipcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.sipcontainer/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2023 IBM Corporation and others.
+# Copyright (c) 2019, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ Export-Package: \
   com.ibm.websphere.sip.*, \
   com.ibm.ws.sip.container.pmi.*, \
   com.ibm.ws.sip.container.was, \
+  com.ibm.sip.util.log;version=1.0.89, \
   com.ibm.ws.sip.container.was.filters;thread-context=true, \
   com.ibm.ws.sip.container.was.message;thread-context=true, \
   com.ibm.wsspi.sip.*

--- a/dev/com.ibm.ws.sipcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.sipcontainer/bnd.bnd
@@ -25,7 +25,7 @@ Export-Package: \
   com.ibm.websphere.sip.*, \
   com.ibm.ws.sip.container.pmi.*, \
   com.ibm.ws.sip.container.was, \
-  com.ibm.sip.util.log;version=1.0.89, \
+  com.ibm.sip.util.log, \
   com.ibm.ws.sip.container.was.filters;thread-context=true, \
   com.ibm.ws.sip.container.was.message;thread-context=true, \
   com.ibm.wsspi.sip.*

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/sip/util/log/package-info.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/sip/util/log/package-info.java
@@ -1,17 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-/**
- * @version 1.0.17
+/*
+ * @version 1.0.0
  */
-@org.osgi.annotation.versioning.Version("1.0.17")
-package com.ibm.ws.sip.container.was.servlet31.converged;
+@org.osgi.annotation.versioning.Version("1.0.0")
+package com.ibm.sip.util.log;

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/wsspi/sip/converge/ConvergedHttpSessionContextImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/wsspi/sip/converge/ConvergedHttpSessionContextImpl.java
@@ -210,6 +210,9 @@ public class ConvergedHttpSessionContextImpl extends HttpSessionContextImpl impl
      * Added for SIP/HTTP Converged App Support. SIP container calls this method via
      * com.ibm.wsspi.servlet.session.ConvergedAppUtils to get an HTTP session reference
      * for those HTTP sessions that belong to application sessions.
+     * 
+     * NOTE: This method was duplicated to com.ibm.ws.sipcontainer.servlet.3.1/com/ibm/ws/sip/container/was/servlet31/converged/ConvergedHttpSessionContext31Impl.java
+     * Any changes should be applied to both methods. 
      */
     public HttpSession getHttpSessionById(String sessId) {
     	HttpSessionImpl sd = null;

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/wsspi/sip/converge/ConvergedHttpSessionContextImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/wsspi/sip/converge/ConvergedHttpSessionContextImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@ import com.ibm.ws.webcontainer.session.impl.HttpSessionImpl;
 import com.ibm.wsspi.session.ISession;
 import com.ibm.wsspi.session.IStore;
 
-public class ConvergedHttpSessionContextImpl extends HttpSessionContextImpl {
+public class ConvergedHttpSessionContextImpl extends HttpSessionContextImpl implements IConvergedHttpSessionContext {
 
     /**
 	 * Class Logger.

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/wsspi/sip/converge/ConvergedHttpSessionImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/wsspi/sip/converge/ConvergedHttpSessionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -199,7 +199,7 @@ public class ConvergedHttpSessionImpl extends HttpSessionImpl implements Converg
             	c_logger.traceEntry(this,"encodeURL", "encoding url with relative path = " + relativePath +" and scheme = " + scheme);
             }
             String contextPath = getServletContext().getContextPath();
-            ConvergedHttpSessionContextImpl sessCtx = (ConvergedHttpSessionContextImpl)this.getSessCtx();
+            IConvergedHttpSessionContext sessCtx = (IConvergedHttpSessionContext)this.getSessCtx();
             String fullyQualifiedUrl = sessCtx.getSipBaseUrlForEncoding(contextPath, relativePath, scheme);
             if (c_logger.isTraceEntryExitEnabled()) {
             	c_logger.traceExit(this, "encodeURL", "going to encode fully qualified url = " + fullyQualifiedUrl);

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/wsspi/sip/converge/IConvergedHttpSessionContext.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/wsspi/sip/converge/IConvergedHttpSessionContext.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.wsspi.sip.converge;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpSession;
+
+import com.ibm.wsspi.session.ISession;
+
+public interface IConvergedHttpSessionContext {
+    public Object createSessionObject(ISession isess, ServletContext servCtx);
+
+    public String getSipBaseUrlForEncoding(String contextPath, String relativePath, String scheme);
+
+    public HttpSession getHttpSessionById(String sessId);
+}

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/wsspi/sip/converge/SessionContextRegistryConvergedImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/wsspi/sip/converge/SessionContextRegistryConvergedImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,7 @@ public class SessionContextRegistryConvergedImpl extends SessionContextRegistryI
     		c_logger.traceEntry(this, "getHttpSessionById", "sessionID = " + sessionId);
 		}
         HttpSession sess = null;
-        ConvergedHttpSessionContextImpl wsCtx = getSessionContextByName(virtualHost + contextRoot);
+        IConvergedHttpSessionContext wsCtx = getSessionContextByName(virtualHost + contextRoot);
         if (wsCtx ==null) {
             if (contextRoot.startsWith("/")) {
                 wsCtx = getSessionContextByName(virtualHost + contextRoot.substring(1));
@@ -85,8 +85,8 @@ public class SessionContextRegistryConvergedImpl extends SessionContextRegistryI
     /*
      * Tries to get the WsSessionContext with the given appName as the key
      */
-    static private ConvergedHttpSessionContextImpl getSessionContextByName(String appname) {
-        return (ConvergedHttpSessionContextImpl)scrSessionContexts.get(appname);
+    static private IConvergedHttpSessionContext getSessionContextByName(String appname) {
+        return (IConvergedHttpSessionContext) scrSessionContexts.get(appname);
     }    
     
 }


### PR DESCRIPTION
fixes #28125


This PR creates a new interface for `ConvergedHttpSessionContextImpl` and `ConvergedHttpSessionContext31Impl` to be compatible with each other.  