### PR TITLE
Updating Jakarta Validation 3.1 to M2

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1522,6 +1522,11 @@
       <version>3.0.2</version>
     </dependency>
     <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+      <version>3.1.0-M2</version>
+    </dependency>
+    <dependency>
       <groupId>jakarta.websocket</groupId>
       <artifactId>jakarta.websocket-api</artifactId>
       <version>2.0.0</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -300,6 +300,7 @@ jakarta.servlet:jakarta.servlet-api:6.1.0-M2
 jakarta.transaction:jakarta.transaction-api:1.3.3
 jakarta.transaction:jakarta.transaction-api:2.0.1
 jakarta.validation:jakarta.validation-api:3.0.2
+jakarta.validation:jakarta.validation-api:3.1.0-M2
 jakarta.websocket:jakarta.websocket-api:2.0.0
 jakarta.websocket:jakarta.websocket-api:2.1.0
 jakarta.websocket:jakarta.websocket-api:2.2.0-M1

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.validation-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.validation-3.1.feature
@@ -4,7 +4,7 @@ visibility=private
 singleton=true
 -features=com.ibm.websphere.appserver.eeCompatible-11.0, \
   io.openliberty.noShip-1.0
--bundles=io.openliberty.jakarta.validation.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.validation:jakarta.validation-api:3.0.2"
+-bundles=io.openliberty.jakarta.validation.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.validation:jakarta.validation-api:3.1.0-M2"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.jakarta/validation.3.1.bnd
+++ b/dev/io.openliberty.jakarta/validation.3.1.bnd
@@ -20,7 +20,7 @@ Bundle-SymbolicName: io.openliberty.jakarta.validation.3.1; singleton:=true
 Export-Package: jakarta.validation.*;version="3.1.0"
 
 -includeresource: \
-  @${repo;jakarta.validation:jakarta.validation-api;3.0.2;EXACT}!/!(META-INF/maven/*|module-info.class)
+  @${repo;jakarta.validation:jakarta.validation-api;3.1.0.M2;EXACT}!/!(META-INF/maven/*|module-info.class)
 
 -maven-dependencies: \
-   dep1;groupId=jakarta.ws.rs;artifactId=jakarta.validation-api;version=3.0.2;scope=runtime
+   dep1;groupId=jakarta.validation;artifactId=jakarta.validation-api;version=3.1.0-M2;scope=runtime


### PR DESCRIPTION
Updates Jakarta Validation 3.1 feature and bundle to use the 3.1.0-M2 version