### PR TITLE
Fix bogus IllegalStateException when closing connection while in chunking mode

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
@@ -1214,9 +1214,9 @@ public abstract class HTTPConduit
 
         @Override
         public void thresholdNotReached() {
-            if (chunking) {
-                setFixedLengthStreamingMode(buffer.size());
-            }
+//            if (chunking) {
+//                setFixedLengthStreamingMode(buffer.size());
+//            }
         }
 
         // methods used for the outgoing side

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/URLConnectionHTTPConduit.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/URLConnectionHTTPConduit.java
@@ -480,17 +480,7 @@ public class URLConnectionHTTPConduit extends HTTPConduit {
             // Liberty Change for issue #25866-unexpected_EOF_from_server
             // The bug [CXF-6227] is a performance bug observed for Java 7
             // In case of a performance drop is observed, need to create a work around
-            boolean isRestMessage = true; // It's safer to set isRestMessage, because 
-            // calling setFixedLengthStreamingMode method creates IllegalStateException at JAX-RS 
-            Exchange exchange = outMessage.getExchange();
-            if(exchange != null)        {
-                //This property return true if it's a rest web service
-                isRestMessage = PropertyUtils.isTrue(exchange.get(org.apache.cxf.message.Message.REST_MESSAGE));
-            }
-            // Call setFixedLengthStreamingMode for JAX-WS only
-            if(!isRestMessage)   { 
-                connection.setFixedLengthStreamingMode(i);
-            }
+            connection.setFixedLengthStreamingMode(i);
             // Liberty Change End
         }
         @FFDCIgnore(PrivilegedActionException.class) // Liberty Change


### PR DESCRIPTION

The SocketException reported in #28049 occurred because the code to invoke `setFixedLengthStreamingMode()` on the connection in `org.apache.cxf.transport.http.URLConnectionHTTPConduit.setFixedLengthStreamingMode()` had been commented out as it cause some tests to fail.   Following investigation I discovered that code in `org.apache.cxf.transport.http.HTTPConduit.thresholdNotReached()` was accidentally calling `setFixedLengthStreamingMode()` when chunking was in force.   This is a mistake as it will cause an IllegalStateException (as the failing FAT uncovered).   This is clear in [HttpURLConnection](https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/net/HttpURLConnection.java), where setFixedLengthStreamMode()will throw and IllegalStateException whenever chunking is enabled:
```
        if (chunkLength != -1) {
            throw new IllegalStateException ("Chunked encoding streaming mode set");
        }

```
Therefore, `org.apache.cxf.transport.http.HTTPConduit.thresholdNotReached()` should never execute this code:
```
            if (chunking) {
                setFixedLengthStreamingMode(buffer.size());
            }

``` 
as it will always result in an IllegalStateException.