### PR TITLE
entities in core test buckets should avoid experimental function

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.fail;
 import static test.jakarta.data.web.Assertions.assertIterableEquals;
 
 import java.time.Duration;
-import java.time.OffsetDateTime;
 import java.time.Year;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -129,9 +128,6 @@ public class DataTestServlet extends FATServlet {
 
     @Inject
     Receipts receipts;
-
-    @Inject
-    Shipments shipments;
 
     @Inject
     Things things;
@@ -3474,88 +3470,6 @@ public class DataTestServlet extends FATServlet {
     public void testParameterAnnotationTakesPrecedenceOverMethodPrefix() {
         Prime nine = primes.findByBinary("10011").orElseThrow();
         assertEquals(19L, nine.numberId);
-    }
-
-    /**
-     * Invoke methods that are annotated with the Select, Where, Update, and Delete annotations.
-     */
-    @Test
-    public void testPartialQueryAnnotations() {
-        Shipment s1 = new Shipment();
-        s1.setDestination("200 1st Ave SW, Rochester, MN 55902");
-        s1.setLocation("44.027354, -92.468482");
-        s1.setId(1);
-        s1.setOrderedAt(OffsetDateTime.now().minusMinutes(45));
-        s1.setStatus("IN_TRANSIT");
-        shipments.save(s1);
-
-        Shipment s2 = new Shipment();
-        s2.setDestination("201 4th St SE, Rochester, MN 55904");
-        s2.setLocation("2800 37th St NW, Rochester, MN 55901");
-        s2.setId(2);
-        s2.setOrderedAt(OffsetDateTime.now().minusMinutes(20));
-        s2.setStatus("READY_FOR_PICKUP");
-        shipments.save(s2);
-
-        Shipment s3 = new Shipment();
-        s3.setDestination("151 4th St SE, Rochester, MN 55904");
-        s3.setLocation("44.057840, -92.496301");
-        s3.setId(3);
-        s3.setOrderedAt(OffsetDateTime.now().minusMinutes(13));
-        s3.setStatus("IN_TRANSIT");
-        shipments.save(s3);
-
-        Shipment s4 = new Shipment();
-        s4.setDestination("151 4th St SE, Rochester, MN 55904");
-        s4.setLocation("2800 37th St NW, Rochester, MN 55901 ");
-        s4.setId(4);
-        s4.setOrderedAt(OffsetDateTime.now().minusMinutes(4));
-        s4.setStatus("READY_FOR_PICKUP");
-        shipments.save(s4);
-
-        Shipment s5 = new Shipment();
-        s5.setDestination("201 4th St SE, Rochester, MN 55904");
-        s5.setLocation("2800 37th St NW, Rochester, MN 55901");
-        s5.setId(5);
-        s5.setOrderedAt(OffsetDateTime.now().minusSeconds(50));
-        s5.setStatus("PREPARING");
-        shipments.save(s5);
-
-        assertEquals(true, shipments.dispatch(2, "READY_FOR_PICKUP",
-                                              "IN_TRANSIT", "44.036217, -92.488040", OffsetDateTime.now()));
-        assertEquals("IN_TRANSIT", shipments.getStatus(2));
-
-        // @OrderBy "destination"
-        assertIterableEquals(List.of("151 4th St SE, Rochester, MN 55904",
-                                     "200 1st Ave SW, Rochester, MN 55902",
-                                     "201 4th St SE, Rochester, MN 55904"),
-                             shipments.find("IN_TRANSIT")
-                                             .map(o -> o.getDestination())
-                                             .collect(Collectors.toList()));
-
-        // @OrderBy "status", then "orderedAt" descending
-        assertIterableEquals(List.of(3L, 2L, 1L, 5L, 4L),
-                             Stream.of(shipments.getAll()).map(o -> o.getId()).collect(Collectors.toList()));
-
-        Shipment s = shipments.find(3);
-        String previousLocation = s.getLocation();
-
-        assertEquals(true, shipments.updateLocation(3, previousLocation, "44.029468, -92.483191"));
-        assertEquals(false, shipments.updateLocation(3, previousLocation, "44.029406, -92.489553"));
-
-        s = shipments.find(3);
-        assertEquals("44.029468, -92.483191", s.getLocation());
-
-        assertEquals(true, shipments.cancel(4, Set.of("PREPARING", "READY_FOR_PICKUP"),
-                                            "CANCELED", OffsetDateTime.now()));
-        assertEquals(true, shipments.cancel(5, Set.of("PREPARING", "READY_FOR_PICKUP"),
-                                            "CANCELED", OffsetDateTime.now()));
-        assertEquals(false, shipments.cancel(10, Set.of("PREPARING", "READY_FOR_PICKUP"),
-                                             "CANCELED", OffsetDateTime.now()));
-
-        assertEquals(2, shipments.statusBasedRemoval("CANCELED"));
-
-        assertEquals(3, shipments.removeEverything());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -4924,7 +4924,7 @@ public class DataTestServlet extends FATServlet {
         tran.begin();
         try {
             assertEquals(true, persons.setFirstNameInCurrentTransaction(p3.ssn_id, "Ty")); // update with MANDATORY
-            assertEquals("Ty", persons.getFirstNameInCurrentOrNoTransaction(p3.ssn_id)); // read value with SUPPORTS
+            assertEquals("Ty", persons.getPersonInCurrentOrNoTransaction(p3.ssn_id).firstName); // read value with SUPPORTS
         } finally {
             tran.rollback();
         }
@@ -4934,7 +4934,7 @@ public class DataTestServlet extends FATServlet {
 
         System.out.println("TxType.SUPPORTS from no transaction");
 
-        assertEquals("Tyler", persons.getFirstNameInCurrentOrNoTransaction(p3.ssn_id));
+        assertEquals("Tyler", persons.getPersonInCurrentOrNoTransaction(p3.ssn_id).firstName);
 
         System.out.println("TxType.REQUIRED in transaction");
 
@@ -5033,7 +5033,7 @@ public class DataTestServlet extends FATServlet {
 
         System.out.println("TxType.NOT_SUPPORTED from no transaction");
 
-        assertEquals("Tyler", persons.getFirstNameInCurrentOrNoTransaction(p3.ssn_id));
+        assertEquals("Tyler", persons.getPersonInCurrentOrNoTransaction(p3.ssn_id).firstName);
 
         personnel.removeAll().get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
     }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
@@ -12,23 +12,18 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
-import static jakarta.data.repository.By.ID;
-
 import java.util.List;
 
-import jakarta.data.repository.By;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 import jakarta.transaction.Transactional;
 import jakarta.transaction.Transactional.TxType;
-
-import io.openliberty.data.repository.Select;
-import io.openliberty.data.repository.update.Assign;
 
 /**
  * This example only references the entity class as a parameterized type.
@@ -41,10 +36,9 @@ public interface PersonRepo {
     @Query("WHERE lastName=?1")
     List<Person> find(String lastName);
 
-    @Find
+    @Query("SELECT firstName WHERE lastName=:lastName")
     @OrderBy("firstName")
-    @Select("firstName")
-    List<String> findFirstNames(@By("lastName") String surname);
+    List<String> findFirstNames(@Param("lastName") String surname);
 
     @Insert
     void insert(Person p);
@@ -59,34 +53,33 @@ public interface PersonRepo {
     void save(List<Person> people);
 
     @Find
-    @Select("firstName")
     @Transactional(TxType.SUPPORTS)
-    String getFirstNameInCurrentOrNoTransaction(Long ssn_id);
+    Person getPersonInCurrentOrNoTransaction(Long ssn_id);
 
-    @Update
+    @Query("UPDATE Person SET firstName=?2 WHERE ID(THIS)=?1")
     @Transactional(TxType.REQUIRED)
     boolean setFirstNameInCurrentOrNewTransaction(Long ssn_id,
-                                                  @Assign String firstName);
+                                                  String firstName);
 
-    @Update
+    @Query("UPDATE Person SET firstName=:newFirstName WHERE id(this)=:ssn")
     @Transactional(TxType.MANDATORY)
-    boolean setFirstNameInCurrentTransaction(@By(ID) Long ssn,
-                                             @Assign("firstName") String newFirstName);
+    boolean setFirstNameInCurrentTransaction(Long ssn,
+                                             String newFirstName);
 
-    @Update
+    @Query("UPDATE Person SET firstName=:firstName WHERE id(THIS)=:id")
     @Transactional(TxType.REQUIRES_NEW)
-    boolean setFirstNameInNewTransaction(Long ssn_id,
-                                         @Assign("FirstName") String newFirstName);
+    boolean setFirstNameInNewTransaction(@Param("id") Long ssn,
+                                         @Param("firstName") String newFirstName);
 
-    @Update
+    @Query("UPDATE Person SET firstName=?2 WHERE ID(this)=?1")
     @Transactional(TxType.NEVER)
-    boolean setFirstNameWhenNoTransactionIsPresent(@By(ID) Long id,
-                                                   @Assign("FIRSTNAME") String newFirstName);
+    boolean setFirstNameWhenNoTransactionIsPresent(Long id,
+                                                   String newFirstName);
 
-    @Update
+    @Query("UPDATE Person SET firstName=?2 WHERE Id(This)=?1")
     @Transactional(TxType.NOT_SUPPORTED)
-    boolean setFirstNameWithCurrentTransactionSuspended(@By(ID) Long id,
-                                                        @Assign("firstname") String newFirstName);
+    boolean setFirstNameWithCurrentTransactionSuspended(Long id,
+                                                        String newFirstName);
 
     @Update
     boolean updateOne(Person person);

--- a/dev/io.openliberty.data.internal_fat_exp/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_exp/build.gradle
@@ -16,3 +16,9 @@ addRequiredLibraries.dependsOn addDerby
 dependencies {
   requiredLibs project(':io.openliberty.jakarta.data.1.0')
 }
+
+apply plugin: 'java'
+
+compileJava {
+  options.compilerArgs << '-parameters'
+}

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.data.Limit;
 import jakarta.data.Sort;
@@ -55,6 +56,9 @@ public class DataExperimentalServlet extends FATServlet {
 
     @Inject
     Reservations reservations;
+
+    @Inject
+    Shipments shipments;
 
     @Inject
     Towns towns;
@@ -465,6 +469,90 @@ public class DataExperimentalServlet extends FATServlet {
         } finally {
             assertEquals(1, towns.deleteWithinPopulationRange(214000, 270000).length);
         }
+    }
+
+    /**
+     * Invoke methods that are annotated with the Select, Where, Update, and Delete annotations.
+     */
+    @Test
+    public void testPartialQueryAnnotations() {
+        Shipment s1 = new Shipment();
+        s1.setDestination("200 1st Ave SW, Rochester, MN 55902");
+        s1.setLocation("44.027354, -92.468482");
+        s1.setId(1);
+        s1.setOrderedAt(OffsetDateTime.now().minusMinutes(45));
+        s1.setStatus("IN_TRANSIT");
+        shipments.save(s1);
+
+        Shipment s2 = new Shipment();
+        s2.setDestination("201 4th St SE, Rochester, MN 55904");
+        s2.setLocation("2800 37th St NW, Rochester, MN 55901");
+        s2.setId(2);
+        s2.setOrderedAt(OffsetDateTime.now().minusMinutes(20));
+        s2.setStatus("READY_FOR_PICKUP");
+        shipments.save(s2);
+
+        Shipment s3 = new Shipment();
+        s3.setDestination("151 4th St SE, Rochester, MN 55904");
+        s3.setLocation("44.057840, -92.496301");
+        s3.setId(3);
+        s3.setOrderedAt(OffsetDateTime.now().minusMinutes(13));
+        s3.setStatus("IN_TRANSIT");
+        shipments.save(s3);
+
+        Shipment s4 = new Shipment();
+        s4.setDestination("151 4th St SE, Rochester, MN 55904");
+        s4.setLocation("2800 37th St NW, Rochester, MN 55901 ");
+        s4.setId(4);
+        s4.setOrderedAt(OffsetDateTime.now().minusMinutes(4));
+        s4.setStatus("READY_FOR_PICKUP");
+        shipments.save(s4);
+
+        Shipment s5 = new Shipment();
+        s5.setDestination("201 4th St SE, Rochester, MN 55904");
+        s5.setLocation("2800 37th St NW, Rochester, MN 55901");
+        s5.setId(5);
+        s5.setOrderedAt(OffsetDateTime.now().minusSeconds(50));
+        s5.setStatus("PREPARING");
+        shipments.save(s5);
+
+        assertEquals(true, shipments.dispatch(2, "READY_FOR_PICKUP",
+                                              "IN_TRANSIT", "44.036217, -92.488040", OffsetDateTime.now()));
+        assertEquals("IN_TRANSIT", shipments.getStatus(2));
+
+        // @OrderBy "destination"
+        assertEquals(List.of("151 4th St SE, Rochester, MN 55904",
+                             "200 1st Ave SW, Rochester, MN 55902",
+                             "201 4th St SE, Rochester, MN 55904"),
+                     shipments.find("IN_TRANSIT")
+                                     .map(o -> o.getDestination())
+                                     .collect(Collectors.toList()));
+
+        // @OrderBy "status", then "orderedAt" descending
+        assertEquals(List.of(3L, 2L, 1L, 5L, 4L),
+                     Stream.of(shipments.getAll())
+                                     .map(o -> o.getId())
+                                     .collect(Collectors.toList()));
+
+        Shipment s = shipments.find(3);
+        String previousLocation = s.getLocation();
+
+        assertEquals(true, shipments.updateLocation(3, previousLocation, "44.029468, -92.483191"));
+        assertEquals(false, shipments.updateLocation(3, previousLocation, "44.029406, -92.489553"));
+
+        s = shipments.find(3);
+        assertEquals("44.029468, -92.483191", s.getLocation());
+
+        assertEquals(true, shipments.cancel(4, Set.of("PREPARING", "READY_FOR_PICKUP"),
+                                            "CANCELED", OffsetDateTime.now()));
+        assertEquals(true, shipments.cancel(5, Set.of("PREPARING", "READY_FOR_PICKUP"),
+                                            "CANCELED", OffsetDateTime.now()));
+        assertEquals(false, shipments.cancel(10, Set.of("PREPARING", "READY_FOR_PICKUP"),
+                                             "CANCELED", OffsetDateTime.now()));
+
+        assertEquals(2, shipments.statusBasedRemoval("CANCELED"));
+
+        assertEquals(3, shipments.removeEverything());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Reservations.java
@@ -53,6 +53,7 @@ import io.openliberty.data.repository.comparison.GreaterThanEqual;
 import io.openliberty.data.repository.comparison.In;
 import io.openliberty.data.repository.comparison.LessThan;
 import io.openliberty.data.repository.comparison.LessThanEqual;
+import io.openliberty.data.repository.comparison.StartsWith;
 import io.openliberty.data.repository.function.ElementCount;
 import io.openliberty.data.repository.function.Extract;
 import io.openliberty.data.repository.function.Not;
@@ -162,6 +163,11 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
     @Select(distinct = true, value = "lengthInMinutes")
     @OrderBy("lengthInMinutes")
     List<Long> lengthsBelow(@By("lengthInMinutes") @LessThan int max);
+
+    @Find
+    @Select("location")
+    @OrderBy("location")
+    List<String> locationsThatStartWith(@By("location") @StartsWith String beginningOfLocationName);
 
     int removeByHostNotIn(Collection<String> hosts);
 

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/ScheduledShipment.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/ScheduledShipment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package test.jakarta.data.web;
+package test.jakarta.data.experimental.web;
 
 import java.time.OffsetDateTime;
 

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Shipment.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Shipment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2023 IBM Corporation and others.
+ * Copyright (c) 2022,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package test.jakarta.data.web;
+package test.jakarta.data.experimental.web;
 
 import java.time.OffsetDateTime;
 

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Shipments.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Shipments.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package test.jakarta.data.web;
+package test.jakarta.data.experimental.web;
 
 import java.time.OffsetDateTime;
 import java.util.Set;

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Town.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Town.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2023,2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.experimental.web;
+
+import java.util.Set;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Version;
+
+/**
+ * An entity that uses IdClass to have a composite id.
+ */
+@Entity
+@IdClass(TownId.class)
+public class Town {
+    public Set<Integer> areaCodes;
+
+    @Version
+    long changeCount;
+
+    @Id
+    public String name;
+
+    public int population;
+
+    @Id
+    public String stateName;
+
+    public Town() {
+    }
+
+    Town(String name, String state, int population, Set<Integer> areaCodes) {
+        this.name = name;
+        this.stateName = state;
+        this.population = population;
+        this.areaCodes = areaCodes;
+    }
+
+    @Override
+    public String toString() {
+        return "Town of " + name + ", " + stateName + " pop " + population + " in " + areaCodes + " v" + changeCount;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/TownId.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/TownId.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.experimental.web;
+
+import java.io.Serializable;
+
+/**
+ * Id class for Town entity.
+ */
+public class TownId implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public String name;
+
+    public String stateName;
+
+    public TownId(String name, String state) {
+        this.name = name;
+        this.stateName = state;
+    }
+
+    public static TownId of(String name, String state) {
+        return new TownId(name, state);
+    }
+
+    @Override
+    public String toString() {
+        return name + ", " + stateName;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Towns.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Towns.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2023,2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.experimental.web;
+
+import static jakarta.data.repository.By.ID;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import jakarta.data.page.CursoredPage;
+import jakarta.data.page.PageRequest;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Repository;
+import jakarta.data.repository.Update;
+
+import io.openliberty.data.repository.Count;
+import io.openliberty.data.repository.Exists;
+import io.openliberty.data.repository.Or;
+import io.openliberty.data.repository.comparison.GreaterThan;
+import io.openliberty.data.repository.comparison.GreaterThanEqual;
+import io.openliberty.data.repository.comparison.LessThanEqual;
+import io.openliberty.data.repository.comparison.StartsWith;
+import io.openliberty.data.repository.function.IgnoreCase;
+import io.openliberty.data.repository.function.Not;
+import io.openliberty.data.repository.update.Assign;
+
+/**
+ *
+ */
+@Repository
+public interface Towns {
+    @Insert
+    Town add(Town c);
+
+    @Exists
+    boolean areFoundIn(@By("stateName") String state);
+
+    @Count
+    long countByStateButNotTown_Or_NotTownButWithTownName(@By("stateName") String state, @By(ID) @Not TownId exceptForInState,
+                                                          @Or @By(ID) @Not TownId exceptForTown, @By("name") String town);
+
+    @Delete
+    TownId[] deleteWithinPopulationRange(@By("population") @GreaterThanEqual int min,
+                                         @By("population") @LessThanEqual int max);
+
+    @Exists
+    boolean existsById(@By(ID) TownId id);
+
+    @Find
+    Optional<Town> findById(@By(ID) TownId id);
+
+    @Find
+    @OrderBy("name")
+    Stream<Town> findByIdIsOneOf(@By(ID) TownId id1,
+                                 @Or @By(ID) @IgnoreCase TownId id2,
+                                 @Or @By(ID) TownId id3);
+
+    @Find
+    @OrderBy("stateName")
+    Stream<Town> findByNameButNotId(@By("name") String townName,
+                                    @By(ID) @Not TownId exceptFor);
+
+    @Exists
+    boolean isBiggerThan(@By("population") @GreaterThan int minPopulation,
+                         TownId id);
+
+    @Find
+    @OrderBy("stateName")
+    @OrderBy("name")
+    Stream<Town> largerThan(@By("population") @GreaterThan int minPopulation,
+                            @By(ID) @IgnoreCase @Not TownId exceptFor,
+                            @By("stateName") @StartsWith String statePattern);
+
+    @Update
+    int replace(@By(ID) TownId id,
+                @Assign("name") String newTownName,
+                @Assign("stateName") String newStateName,
+                // TODO switch the above to the following once IdClass is supported for updates
+                //@Assign(ID) TownId newId,
+                @Assign("population") int newPopulation,
+                @Assign("areaCodes") Set<Integer> newAreaCodes);
+
+    @Update
+    int replace(String name,
+                String stateName,
+                @Assign("name") String newTownName,
+                @Assign("stateName") String newStateName,
+                @Assign("areaCodes") Set<Integer> newAreaCodes,
+                @Assign("population") int newPopulation);
+
+    @Find
+    @OrderBy(value = ID, descending = true)
+    CursoredPage<Town> sizedWithin(@By("population") @GreaterThanEqual int minPopulation,
+                                   @By("population") @LessThanEqual int maxPopulation,
+                                   PageRequest pagination);
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat_jpa/bnd.bnd
@@ -48,7 +48,6 @@ tested.features: \
   com.ibm.ws.persistence.jakarta;version=latest,\
   com.ibm.ws.tx.embeddable.jakarta;version=latest,\
   fattest.simplicity;version=latest,\
-  io.openliberty.data,\
   io.openliberty.jakarta.annotation.2.1,\
   io.openliberty.jakarta.cdi.4.0,\
   io.openliberty.jakarta.data.1.0,\

--- a/dev/io.openliberty.data.internal_fat_jpa/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_jpa/build.gradle
@@ -23,7 +23,6 @@ addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn copyJdbcDrivers
 
 dependencies {
-  requiredLibs project(':io.openliberty.data')
   requiredLibs project(':io.openliberty.jakarta.data.1.0')
 }
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
@@ -26,13 +26,6 @@ import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 
-import io.openliberty.data.repository.Select;
-import io.openliberty.data.repository.comparison.GreaterThanEqual;
-import io.openliberty.data.repository.comparison.LessThanEqual;
-import io.openliberty.data.repository.comparison.StartsWith;
-import io.openliberty.data.repository.function.AbsoluteValue;
-import io.openliberty.data.repository.function.IgnoreCase;
-
 /**
  *
  */
@@ -74,10 +67,9 @@ public interface Businesses extends BasicRepository<Business, Integer> {
 
     @Find
     @OrderBy("name") // Business.name, not Business.Location.Address.Street.name
-    @Select("name")
-    List<String> onSouthSideOf(@By("locationAddressCity") String city,
-                               @By("locationAddressState") String state,
-                               @By("locationAddress.street_direction") @IgnoreCase @StartsWith String streetDirectionPrefix);
+    List<Business> onSouthSideOf(@By("locationAddressCity") String city,
+                                 @By("locationAddressState") String state,
+                                 @By("locationAddress.street_direction") String streetDirection);
 
     // Save with a different entity type does not conflict with the primary entity type from BasicRepository
     @Save
@@ -89,7 +81,6 @@ public interface Businesses extends BasicRepository<Business, Integer> {
     @Query("UPDATE Business b SET b.location=?1, b.name=?2 WHERE b.id=?3")
     boolean updateWithJPQL(Location newLocation, String newName, long id);
 
-    @Find
-    List<Business> withLongitudeIgnoringSignWithin(@By("location.longitude") @AbsoluteValue @GreaterThanEqual float min,
-                                                   @By("location.longitude") @AbsoluteValue @LessThanEqual float max);
+    @Query("WHERE ABS(location.longitude) >= :min AND ABS(location.longitude) <= :max")
+    List<Business> withLongitudeIgnoringSignWithin(float min, float max);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -15,7 +15,6 @@ import static jakarta.data.repository.By.ID;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import jakarta.data.Limit;
@@ -29,30 +28,12 @@ import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
-import jakarta.data.repository.Update;
-
-import io.openliberty.data.repository.Count;
-import io.openliberty.data.repository.Exists;
-import io.openliberty.data.repository.Or;
-import io.openliberty.data.repository.comparison.GreaterThan;
-import io.openliberty.data.repository.comparison.GreaterThanEqual;
-import io.openliberty.data.repository.comparison.LessThanEqual;
-import io.openliberty.data.repository.comparison.StartsWith;
-import io.openliberty.data.repository.function.IgnoreCase;
-import io.openliberty.data.repository.function.Not;
-import io.openliberty.data.repository.update.Assign;
 
 /**
  *
  */
 @Repository
 public interface Cities {
-    @Exists
-    boolean areFoundIn(@By("stateName") String state);
-
-    @Count
-    long countByStateButNotCity_Or_NotCityButWithCityName(@By("stateName") String state, @By(ID) @Not CityId exceptForInState,
-                                                          @Or @By(ID) @Not CityId exceptForCity, @By("name") String city);
 
     @Delete
     void delete(City city); // copied from BasicRepository
@@ -77,31 +58,13 @@ public interface Cities {
     List<CityId> deleteSome(@By("stateName") String state,
                             Limit limit);
 
-    @Delete
-    CityId[] deleteWithinPopulationRange(@By("population") @GreaterThanEqual int min,
-                                         @By("population") @LessThanEqual int max);
-
-    @Exists
-    boolean existsById(@By(ID) CityId id);
-
     boolean existsByNameAndStateName(String name, String state);
 
     @Find
     Optional<City> findById(@By(ID) CityId id);
 
-    @Find
-    @OrderBy("name")
-    Stream<City> findByIdIsOneOf(@By(ID) CityId id1,
-                                 @Or @By(ID) @IgnoreCase CityId id2,
-                                 @Or @By(ID) CityId id3);
-
     @OrderBy("stateName")
     Stream<City> findByName(String name);
-
-    @Find
-    @OrderBy("stateName")
-    Stream<City> findByNameButNotId(String name,
-                                    @By(ID) @Not CityId exceptFor);
 
     @OrderBy(value = "stateName", descending = true)
     Stream<CityId> findByNameStartsWith(String prefix);
@@ -130,17 +93,6 @@ public interface Cities {
 
     CityId findFirstByNameOrderByPopulationDesc(String name);
 
-    @Exists
-    boolean isBiggerThan(@By("population") @GreaterThan int minPopulation,
-                         CityId id);
-
-    @Find
-    @OrderBy("stateName")
-    @OrderBy("name")
-    Stream<City> largerThan(@By("population") @GreaterThan int minPopulation,
-                            @By(ID) @IgnoreCase @Not CityId exceptFor,
-                            @By("stateName") @StartsWith String statePattern);
-
     @Delete
     void remove(City city);
 
@@ -148,38 +100,8 @@ public interface Cities {
 
     List<City> removeByStateNameOrderByName(String state);
 
-    @Update
-    int replace(@By(ID) CityId id,
-                @Assign("name") String newCityName,
-                @Assign("stateName") String newStateName,
-                // TODO switch the above to the following once IdClass is supported for updates
-                //@Assign(ID) CityId newId,
-                @Assign("population") int newPopulation,
-                @Assign("areaCodes") Set<Integer> newAreaCodes);
-
-    @Update
-    int replace(String name,
-                String stateName,
-                @Assign("name") String newCityName,
-                @Assign("stateName") String newStateName,
-                @Assign("areaCodes") Set<Integer> newAreaCodes,
-                @Assign("population") int newPopulation);
-
-    @Find
-    @OrderBy(value = ID, descending = true)
-    CursoredPage<City> sizedWithin(@By("population") @GreaterThanEqual int minPopulation,
-                                   @By("population") @LessThanEqual int maxPopulation,
-                                   PageRequest pagination);
-
     @Save
     City save(City c);
-
-    @Update
-    int updateIdPopulationAndAreaCodes(@By(ID) CityId oldId,
-                                       @By("population") int oldPopulation,
-                                       @Assign(ID) CityId newId,
-                                       @Assign("population") int newPopulation,
-                                       @Assign("areaCodes") Set<Integer> newAreaCodes);
 
     @Find
     @OrderBy("stateName")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/TaxPayers.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/TaxPayers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,10 +19,9 @@ import java.util.stream.Stream;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
-
-import io.openliberty.data.repository.Select;
 
 /**
  * Repository for the TaxPayer entity.
@@ -32,7 +31,7 @@ public interface TaxPayers extends DataRepository<TaxPayer, Long> {
     @Delete
     long delete();
 
-    @Select("bankAccounts")
+    @Query("SELECT bankAccounts WHERE o.ssn=?1")
     Set<AccountId> findAccountsBySSN(long ssn);
 
     Stream<AccountId> findBankAccountsByFilingStatus(TaxPayer.FilingStatus status);


### PR DESCRIPTION
This PR includes refactoring/moving of entities to the test bucket for experimental function in a number of places where there are capabilities tested that did not make it into version 1.0.  After this, this _jpa bucket is runnable entirely on spec API only. The other core test bucket still needs more work.