### PR TITLE
Remove logservice trace

### DIFF
--- a/dev/io.openliberty.ejbcontainer.mdb.checkpoint_fat/publish/servers/checkpointMsgEndpointServer/bootstrap.properties
+++ b/dev/io.openliberty.ejbcontainer.mdb.checkpoint_fat/publish/servers/checkpointMsgEndpointServer/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=event=enabled:checkpoint=all:logservice=all:rarInstall=all:WAS.j2c=all:app.manager=all:applications=all:com.ibm.ws.ejbcontainer.fat.rar.core.*=all:com.ibm.ws.ejbcontainer.mdb.internal.*=all
+com.ibm.ws.logging.trace.specification=*=event=enabled:checkpoint=all:rarInstall=all:WAS.j2c=all:app.manager=all:applications=all:com.ibm.ws.ejbcontainer.fat.rar.core.*=all:com.ibm.ws.ejbcontainer.mdb.internal.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties


### PR DESCRIPTION
Remove logservice trace from the checkpoint MDB FAT test server to improve startup performance, and to reduce test time and resource usage.

For RTC299742.