### PR TITLE
Dynamically adjust transaction timeouts on slow test servers

### DIFF
--- a/dev/com.ibm.ws.componenttest.2.0/src/componenttest/app/FATServlet.java
+++ b/dev/com.ibm.ws.componenttest.2.0/src/componenttest/app/FATServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -59,6 +59,7 @@ public abstract class FATServlet extends HttpServlet {
         if (method != null && method.length() > 0) {
             try {
                 before();
+                before(request, response);
 
                 // Use reflection to try invoking various test method signatures:
                 // 1)  method(HttpServletRequest request, HttpServletResponse response)
@@ -115,6 +116,9 @@ public abstract class FATServlet extends HttpServlet {
      * Override to mimic JUnit's {@code @Before} annotation.
      */
     protected void before() throws Exception {
+    }
+
+    protected void before(HttpServletRequest request, HttpServletResponse response) {
     }
 
     /**

--- a/dev/com.ibm.ws.componenttest/src/componenttest/app/FATServlet.java
+++ b/dev/com.ibm.ws.componenttest/src/componenttest/app/FATServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -59,6 +59,7 @@ public abstract class FATServlet extends HttpServlet {
         if (method != null && method.length() > 0) {
             try {
                 before();
+                before(request, response);
 
                 // Use reflection to try invoking various test method signatures:
                 // 1)  method(HttpServletRequest request, HttpServletResponse response)
@@ -115,6 +116,9 @@ public abstract class FATServlet extends HttpServlet {
      * Override to mimic JUnit's {@code @Before} annotation.
      */
     protected void before() throws Exception {
+    }
+
+    protected void before(HttpServletRequest request, HttpServletResponse response) throws Exception {
     }
 
     /**

--- a/dev/com.ibm.ws.transaction.fat.util/src/com/ibm/ws/wsat/fat/util/WSATTest.java
+++ b/dev/com.ibm.ws.transaction.fat.util/src/com/ibm/ws/wsat/fat/util/WSATTest.java
@@ -18,6 +18,7 @@ import java.net.ProtocolException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.Duration;
 
 import org.junit.Rule;
 import org.junit.rules.TestName;
@@ -36,6 +37,11 @@ public abstract class WSATTest extends FATServletClient {
 	public static String WSAT_DETECTED = "Detected WS-AT policy, however there is no active transaction in current thread";
 
 	@Rule public TestName testName = new TestName();
+	
+	// Normal number of seconds it takes a server to start up
+	// Transaction timeouts will be adjusted if actual startup
+	// time varies from this
+	protected final static Duration normalStartTime = Duration.ofSeconds(12);
 
 	public final static int REQUEST_TIMEOUT = 60;
 	public final static int START_TIMEOUT = 600000;

--- a/dev/com.ibm.ws.wsat.migration_fat.1/fat/src/tests/SimpleTest.java
+++ b/dev/com.ibm.ws.wsat.migration_fat.1/fat/src/tests/SimpleTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.fail;
 import java.io.BufferedReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.time.Duration;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -56,9 +57,6 @@ public class SimpleTest extends DBTestBase {
 
 	public static String[] serverNames = new String[] {"MigrationServer1", "MigrationServer2"};
 
-	public static String BASE_URL;
-	public static String BASE_URL2;
-
 	@BeforeClass
 	public static void beforeTests() throws Exception {
 
@@ -71,10 +69,8 @@ public class SimpleTest extends DBTestBase {
 	            s.setServerStartTimeout(FATUtils.LOG_SEARCH_TIMEOUT);
 	        }
 	    };
-	    
-		BASE_URL = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort();
+
 		server2.setHttpDefaultPort(Integer.parseInt(System.getProperty("HTTP_secondary")));
-		BASE_URL2 = "http://" + server2.getHostname() + ":" + server2.getHttpDefaultPort();
 
 		DBTestBase.initWSATTest(server);
 		DBTestBase.initWSATTest(server2);
@@ -82,7 +78,10 @@ public class SimpleTest extends DBTestBase {
 		ShrinkHelper.defaultDropinApp(server, "simpleClient", "web.simpleclient");
 		ShrinkHelper.defaultDropinApp(server2, "simpleService", "web.simpleservice");
 
-		FATUtils.startServers(runner, server, server2);;
+		final Duration meanStartTime = FATUtils.startServers(runner, server, server2);
+		final float perfFactor = (float)normalStartTime.getSeconds() / (float)meanStartTime.getSeconds();
+		Log.info(SimpleTest.class, "beforeTests", "Mean startup time: "+meanStartTime+", Perf factor="+perfFactor);
+		setTestQuerySuffix("perfFactor="+perfFactor);
 	}
 
 	@AfterClass

--- a/dev/com.ibm.ws.wsat.migration_fat.1/test-applications/simpleClient/src/web/simpleclient/ClientServletBase.java
+++ b/dev/com.ibm.ws.wsat.migration_fat.1/test-applications/simpleClient/src/web/simpleclient/ClientServletBase.java
@@ -19,6 +19,8 @@ import java.time.Duration;
 import java.time.Instant;
 
 import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.transaction.RollbackException;
 import javax.transaction.Status;
 import javax.transaction.UserTransaction;
@@ -49,7 +51,7 @@ public abstract class ClientServletBase extends FATServlet {
 
 	protected Instant tranEndTime;
 	protected int timeout = (int) DEFAULT_TIMEOUT;
-	protected float perfFactor;
+	protected float perfFactor = 1.0f;
 
 	protected static final String[] noXARes = new String[]{};
 	protected static final String[] OneXARes = new String[]{""}; 
@@ -64,8 +66,17 @@ public abstract class ClientServletBase extends FATServlet {
 	protected UserTransaction ut;
 
 	@Override
-    protected void before() throws Exception {
+    protected void before(HttpServletRequest request, HttpServletResponse response) throws Exception {
+		
     	XAResourceImpl.clear();
+    	
+    	final String pf = request.getParameter("perfFactor");
+    	if (pf != null) {
+    		perfFactor = Float.parseFloat(pf);
+    		
+    		timeout = (int)((float)DEFAULT_TIMEOUT / perfFactor);
+    		System.out.println("Transaction timeout will be "+timeout);
+    	}
     }
 
 	protected String execute(String BASE_URL, String commitRollback, int expectedDirection, String expectResult) {

--- a/dev/com.ibm.ws.wsat.migration_fat.1/test-applications/simpleClient/src/web/simpleclient/SleepClientServlet.java
+++ b/dev/com.ibm.ws.wsat.migration_fat.1/test-applications/simpleClient/src/web/simpleclient/SleepClientServlet.java
@@ -22,6 +22,8 @@ import java.time.Instant;
 
 import javax.annotation.Resource;
 import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.transaction.RollbackException;
 import javax.transaction.Status;
 import javax.transaction.UserTransaction;
@@ -62,9 +64,18 @@ public class SleepClientServlet extends FATServlet {
 	@Resource
 	UserTransaction ut;
 
-    @Override
-    protected void before() throws Exception {
+	@Override
+    protected void before(HttpServletRequest request, HttpServletResponse response) throws Exception {
+		
     	XAResourceImpl.clear();
+    	
+    	final String pf = request.getParameter("perfFactor");
+    	if (pf != null) {
+    		perfFactor = Float.parseFloat(pf);
+    		
+    		timeout = (int)((float)DEFAULT_TIMEOUT / perfFactor);
+    		System.out.println("Transaction timeout will be "+timeout);
+    	}
     }
 
     @Test

--- a/dev/com.ibm.ws.wsat.migration_fat.2/fat/src/tests/ComplexTest.java
+++ b/dev/com.ibm.ws.wsat.migration_fat.2/fat/src/tests/ComplexTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,32 +12,23 @@
  *******************************************************************************/
 package tests;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.BufferedReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
+import java.time.Duration;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.transaction.fat.util.FATUtils;
 import com.ibm.ws.wsat.fat.util.DBTestBase;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.HttpUtils;
 import web.simpleclient.ComplexClientServlet;
-import web.simpleclient.SimpleClientServlet;
 
 @AllowedFFDC(value = { "javax.transaction.SystemException" })
 @RunWith(FATRunner.class)
@@ -53,18 +44,11 @@ public class ComplexTest extends DBTestBase {
 	@Server("MigrationServer3")
 	public static LibertyServer server3;
 
-	private static String BASE_URL;
-	private static String BASE_URL2;
-	private static String BASE_URL3;
-
 	@BeforeClass
 	public static void beforeTests() throws Exception {
 
-		BASE_URL = "http://" + server1.getHostname() + ":" + server1.getHttpDefaultPort();
 		server2.setHttpDefaultPort(Integer.parseInt(System.getProperty("HTTP_secondary")));
-		BASE_URL2 = "http://" + server2.getHostname() + ":" + server2.getHttpDefaultPort();
 		server3.setHttpDefaultPort(Integer.parseInt(System.getProperty("HTTP_tertiary")));
-		BASE_URL3 = "http://" + server3.getHostname() + ":" + server3.getHttpDefaultPort();
 
 		DBTestBase.initWSATTest(server1);
 		DBTestBase.initWSATTest(server2);
@@ -78,7 +62,10 @@ public class ComplexTest extends DBTestBase {
 		server2.setServerStartTimeout(START_TIMEOUT);
 		server3.setServerStartTimeout(START_TIMEOUT);
 
-		FATUtils.startServers(server1, server2, server3);
+		final Duration meanStartTime = FATUtils.startServers(server1, server2, server3);
+		final float perfFactor = (float)normalStartTime.getSeconds() / (float)meanStartTime.getSeconds();
+		Log.info(ComplexTest.class, "beforeTests", "Mean startup time: "+meanStartTime+", Perf factor="+perfFactor);
+		setTestQuerySuffix("perfFactor="+perfFactor);
 	}
 
 	@AfterClass
@@ -88,80 +75,5 @@ public class ComplexTest extends DBTestBase {
 		DBTestBase.cleanupWSATTest(server1);
 		DBTestBase.cleanupWSATTest(server2);
 		DBTestBase.cleanupWSATTest(server3);
-	}
-
-//	@Test
-//	public void testWSATRE064FVT() {
-//		callServlet("WSATRE064FVT");		
-//	}
-//
-//	@Test
-//	public void testWSATRE065FVT() {
-//		callServlet("WSATRE065FVT");
-//	}
-//
-//	@Test
-//	@AllowedFFDC(value = { "javax.transaction.xa.XAException", "javax.transaction.RollbackException", "javax.transaction.SystemException" })
-//	public void testWSATRE066FVT() {
-//		callServlet("WSATRE066FVT");
-//	}
-//
-//	@Test
-//	@AllowedFFDC(value = { "javax.transaction.xa.XAException", "javax.transaction.RollbackException", "javax.transaction.SystemException" })
-//	public void testWSATRE067FVT() {
-//		callServlet("WSATRE067FVT");
-//	}
-//
-//	@Test
-//	@ExpectedFFDC(value = { "javax.transaction.xa.XAException", "javax.transaction.RollbackException" })
-//	public void testWSATRE068FVT() {
-//		callServlet("WSATRE068FVT");
-//	}
-//
-//	@Test
-//	public void testWSATRE069FVT() {
-//		callServlet("WSATRE069FVT");
-//	}
-//
-//	@Test
-//	public void testWSATRE070FVT() {
-//		callServlet("WSATRE070FVT");
-//	}
-//
-//	@Test
-//	@AllowedFFDC(value = { "javax.transaction.xa.XAException", "javax.transaction.RollbackException", "javax.transaction.SystemException" })
-//	public void testWSATRE071FVT() {
-//		callServlet("WSATRE071FVT");
-//	}
-//
-//	@Test
-//	@AllowedFFDC(value = { "javax.transaction.xa.XAException", "javax.transaction.RollbackException", "javax.transaction.SystemException" })
-//	public void testWSATRE072FVT() {
-//		callServlet("WSATRE072FVT");
-//	}
-//
-//	@Test
-//	@AllowedFFDC(value = { "javax.transaction.xa.XAException", "javax.transaction.RollbackException", "javax.transaction.SystemException" })
-//	public void testWSATRE073FVT() {
-//		callServlet("WSATRE073FVT");
-//	}
-
-	private void callServlet(String testMethod){
-		try {
-			String urlStr = BASE_URL + "/simpleClient/SimpleClientServlet"
-					+ "?method=" + Integer.parseInt(testMethod.substring(6, 9))
-					+ "&baseurl=" + BASE_URL2 +"&baseurl2=" + BASE_URL3 ;
-			System.out.println(testMethod + " URL: " + urlStr);
-			HttpURLConnection con = getHttpConnection(new URL(urlStr), 
-					HttpURLConnection.HTTP_OK, REQUEST_TIMEOUT);
-			BufferedReader br = HttpUtils.getConnectionStream(con);
-			String result = br.readLine();
-			assertNotNull(result);
-			System.out.println(testMethod + " Result : " + result);
-			assertTrue("Cannot get expected reply from server, result = '" + result + "'",
-					result.contains("Test passed"));
-		} catch (Exception e) {
-			fail("Exception happens: " + e.toString());
-		}
 	}
 }

--- a/dev/com.ibm.ws.wsat.migration_fat.3/fat/src/tests/SleepTest.java
+++ b/dev/com.ibm.ws.wsat.migration_fat.3/fat/src/tests/SleepTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,13 +12,6 @@
  *******************************************************************************/
 package tests;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.BufferedReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.time.Duration;
 
 import org.junit.AfterClass;
@@ -35,7 +28,6 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.HttpUtils;
 import web.simpleclient.SleepClientServlet;
 
 @RunWith(FATRunner.class)
@@ -48,19 +40,13 @@ public class SleepTest extends DBTestBase {
 	@Server("MigrationServer2")
 	public static LibertyServer server2;
 
-	private static String BASE_URL;
-	private static String BASE_URL2;
-	
-	private static final Duration normalStartupTime = Duration.ofSeconds(30); // Normal test machine startup time
-	private static Duration meanStartupTime;
+	private static Duration meanStartTime;
 
 	@BeforeClass
 	public static void beforeTests() throws Exception {
 		System.getProperties().entrySet().stream().forEach(e -> Log.info(SleepTest.class, "beforeTests", e.getKey() + " -> " + e.getValue()));
 
-		BASE_URL = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort();
 		server2.setHttpDefaultPort(Integer.parseInt(System.getProperty("HTTP_secondary")));
-		BASE_URL2 = "http://" + server2.getHostname() + ":" + server2.getHttpDefaultPort();
 
 		DBTestBase.initWSATTest(server);
 		DBTestBase.initWSATTest(server2);
@@ -78,9 +64,10 @@ public class SleepTest extends DBTestBase {
 		
 		server2.updateServerConfiguration(config);
 
-		meanStartupTime = FATUtils.startServers(server, server2);
-
-		Log.info(SleepTest.class, "beforeTests", "Mean server start time: " + meanStartupTime);
+		meanStartTime = FATUtils.startServers(server, server2);
+		final float perfFactor = (float)normalStartTime.getSeconds() / (float)meanStartTime.getSeconds();
+		Log.info(SleepTest.class, "beforeTests", "Mean startup time: "+meanStartTime+", Perf factor="+perfFactor);
+		setTestQuerySuffix("perfFactor="+perfFactor);
 	}
 
 	@AfterClass
@@ -89,96 +76,5 @@ public class SleepTest extends DBTestBase {
 
 		DBTestBase.cleanupWSATTest(server);
 		DBTestBase.cleanupWSATTest(server2);
-	}
-//
-//	@Test
-//	@AllowedFFDC(value = { "javax.transaction.xa.XAException", "javax.transaction.RollbackException", "javax.transaction.SystemException" })
-//	public void testWSATRE094FVT() {
-//		callServlet("WSATRE094FVT");
-//	}
-//
-//	@Test
-//	public void testWSATRE095FVT() {
-//		callServlet("WSATRE095FVT");
-//	}
-//
-//	@Test
-//	@AllowedFFDC(value = { "javax.transaction.SystemException" })
-//	public void testWSATRE096FVT() {
-//		callServlet("WSATRE096FVT");
-//	}
-//
-//	@Test
-//	public void testWSATRE097FVT() {
-//		callServlet("WSATRE097FVT");
-//	}
-//
-//	@Test
-//	@AllowedFFDC(value = { "javax.transaction.SystemException" })
-//	public void testWSATRE098FVT() {
-//		callServlet("WSATRE098FVT");
-//	}
-//
-//	@Test
-//	public void testWSATRE099FVT() {
-//		callServlet("WSATRE099FVT");
-//	}
-//
-//	@Test
-//	@AllowedFFDC(value = { "javax.transaction.SystemException" })
-//	public void testWSATRE100FVT() {
-//		callServlet("WSATRE100FVT");
-//	}
-//
-//	@Test
-//	public void testWSATRE101FVT() {
-//		callServlet("WSATRE101FVT");
-//	}
-//
-//	@Test
-//	@AllowedFFDC(value = { "javax.transaction.xa.XAException", "javax.transaction.RollbackException" })
-//	public void testWSATRE102FVT() {
-//		callServlet("WSATRE102FVT");
-//	}
-//
-//	@Test
-//	public void testWSATRE103FVT() {
-//		callServlet("WSATRE103FVT");
-//	}
-//
-//	@Test
-//	public void testWSATRE104FVT() {
-//		callServlet("WSATRE104FVT");
-//	}
-//
-//	@Test
-//	public void testWSATRE105FVT() {
-//		callServlet("WSATRE105FVT");
-//	}
-
-	private void callServlet(String testMethod){
-		try {
-			float perf = (float)normalStartupTime.getSeconds() / (float)meanStartupTime.getSeconds();
-			perf = (float) (perf > 1.0 ? 1.0 : perf);
-			Log.info(SleepTest.class, "callServlet", "Perf: " + Float.toString(perf));
-			
-			// The perf param is an indication of how slow the test machine is
-			String urlStr = BASE_URL + "/simpleClient/SimpleClientServlet"
-					+ "?method=" + Integer.parseInt(testMethod.substring(6, 9))
-					+ "&baseurl=" + BASE_URL2
-					+ "&perf=" + perf;
-			Log.info(SleepTest.class, "callServlet", "URL: " + urlStr);
-			HttpURLConnection con = getHttpConnection(new URL(urlStr), 
-					HttpURLConnection.HTTP_OK, REQUEST_TIMEOUT);
-			BufferedReader br = HttpUtils.getConnectionStream(con);
-			String result = br.readLine();
-			assertNotNull(result);
-			System.out.println(testMethod + " Result : " + result);
-			assertTrue("Cannot get expected reply from server, result = '" + result + "'",
-					result.contains("Test passed"));
-		} catch (Exception e) {
-			e.printStackTrace(System.out);
-			fail("Exception happens: " + e.toString());
-		}
 	}
 }

--- a/dev/com.ibm.ws.wsat.migration_fat.4/fat/src/tests/LPSTest.java
+++ b/dev/com.ibm.ws.wsat.migration_fat.4/fat/src/tests/LPSTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import static org.junit.Assert.fail;
 import java.io.BufferedReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -70,7 +71,11 @@ public class LPSTest extends DBTestBase {
 
 		server.setServerStartTimeout(START_TIMEOUT);
 		server2.setServerStartTimeout(START_TIMEOUT);
-		FATUtils.startServers(server, server2);
+
+		final Duration meanStartTime = FATUtils.startServers(server, server2);
+		final float perfFactor = (float)normalStartTime.getSeconds() / (float)meanStartTime.getSeconds();
+		Log.info(LPSTest.class, "beforeTests", "Mean startup time: "+meanStartTime+", Perf factor="+perfFactor);
+		setTestQuerySuffix("perfFactor="+perfFactor);
 	}
 
 	@AfterClass

--- a/dev/com.ibm.ws.wsat.migration_fat.6/fat/src/tests/DBRerouteTest.java
+++ b/dev/com.ibm.ws.wsat.migration_fat.6/fat/src/tests/DBRerouteTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package tests;
+
+import java.time.Duration;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -26,7 +28,6 @@ import com.ibm.ws.wsat.fat.util.DBTestBase;
 import componenttest.annotation.Server;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 import componenttest.topology.database.container.DatabaseContainerType;
 import componenttest.topology.database.container.DatabaseContainerUtil;
 import componenttest.topology.database.container.PostgreSQLContainer;
@@ -76,11 +77,7 @@ public class DBRerouteTest extends SimpleTest {
 //		System.getProperties().entrySet().stream().forEach(e -> Log.info(RerouteTest.class, "Properties", e.getKey() + " -> " + e.getValue()));
 //		System.getenv().entrySet().stream().forEach(e -> Log.info(RerouteTest.class, "Environment", e.getKey() + " -> " + e.getValue()));
 
-		BASE_URL = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort();
-
 		server2.setHttpDefaultPort(Integer.parseInt(System.getProperty("HTTP_secondary")));
-		BASE_URL2 = "http://" + server2.getHostname() + ":" + server2.getHttpDefaultPort();
-
 		server3.setHttpDefaultPort(Integer.parseInt(System.getProperty("HTTP_tertiary")));
 
 		DBTestBase.initWSATTest(server);
@@ -89,7 +86,10 @@ public class DBRerouteTest extends SimpleTest {
 		ShrinkHelper.defaultDropinApp(server, "simpleClient", "web.simpleclient");
 		ShrinkHelper.defaultDropinApp(server2, "simpleService", "web.simpleservice");
 
-		FATUtils.startServers(runner, server, server2, server3);
+		final Duration meanStartTime = FATUtils.startServers(runner, server, server2, server3);
+		final float perfFactor = (float)normalStartTime.getSeconds() / (float)meanStartTime.getSeconds();
+		Log.info(DBRerouteTest.class, "beforeTests", "Mean startup time: "+meanStartTime+", Perf factor="+perfFactor);
+		setTestQuerySuffix("perfFactor="+perfFactor);
 	}
 
 	@AfterClass

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/FATServletClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/FATServletClient.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -41,6 +41,9 @@ import componenttest.topology.impl.LibertyServer;
 public class FATServletClient {
     public static final String SUCCESS = "SUCCESS";
     public static final String TEST_METHOD = "testMethod";
+
+    // Extra query parameters
+    private static String querySuffix;
 
     @Rule
     public TestName testName = new TestName();
@@ -225,10 +228,22 @@ public class FATServletClient {
      * @return          the path and query (e.g., {@code "/test?testMethod=test"})
      */
     public static String getPathAndQuery(String path, String testName) {
+        StringBuffer ret = new StringBuffer("/").append(path);
         if (!path.contains("?")) {
-            return '/' + path + '?' + FATServletClient.TEST_METHOD + '=' + testName;
+            ret.append('?');
         } else {
-            return '/' + path + '&' + FATServletClient.TEST_METHOD + '=' + testName;
+            ret.append('&');
         }
+
+        ret.append(FATServletClient.TEST_METHOD).append('=').append(testName);
+        if (querySuffix != null) {
+            ret.append('&').append(querySuffix);
+        }
+
+        return ret.toString();
+    }
+
+    public static void setTestQuerySuffix(String suffix) {
+        querySuffix = suffix;
     }
 }


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.jta_fat,com.ibm.ws.transaction.cloud_fat.base,com.ibm.ws.transaction.cloud_fat.db2.0,com.ibm.ws.transaction.cloud_fat.db2.1,com.ibm.ws.transaction.cloud_fat.db2.2,com.ibm.ws.transaction.cloud_fat.derby.0,com.ibm.ws.transaction.cloud_fat.derby.1,com.ibm.ws.transaction.cloud_fat.derby.2,com.ibm.ws.transaction.cloud_fat.dualFS,com.ibm.ws.transaction.cloud_fat.oracle.0,com.ibm.ws.transaction.cloud_fat.oracle.1,com.ibm.ws.transaction.cloud_fat.oracle.2,com.ibm.ws.transaction.cloud_fat.peerlocking.1,com.ibm.ws.transaction.cloud_fat.peerlocking.2,com.ibm.ws.transaction.cloud_fat.postgresql.0,com.ibm.ws.transaction.cloud_fat.postgresql.1,com.ibm.ws.transaction.cloud_fat.postgresql.2,com.ibm.ws.transaction.cloud_fat.simpleFS,com.ibm.ws.transaction.cloud_fat.sqlserver.0,com.ibm.ws.transaction.cloud_fat.sqlserver.1,com.ibm.ws.transaction.cloud_fat.sqlserver.2,com.ibm.ws.transaction.core_fat.base,com.ibm.ws.transaction.core_fat.baseDB,com.ibm.ws.transaction.core_fat.cdi,com.ibm.ws.transaction.core_fat.commitPriority,com.ibm.ws.transaction.core_fat.heuristics,com.ibm.ws.transaction.core_fat.heuristicsDB,com.ibm.ws.transaction.core_fat.misc,com.ibm.ws.transaction.core_fat.startMultiEJB,com.ibm.ws.transaction.core_fat.startup,com.ibm.ws.transaction.core_fat.xa,com.ibm.ws.transaction.core_fat.xaDB,com.ibm.ws.transaction.db_fat,com.ibm.ws.transaction.hadb_fat.db2.1,com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.db2.retriablecodes,com.ibm.ws.transaction.hadb_fat.derby.1,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.derby.retriablecodes,com.ibm.ws.transaction.hadb_fat.oracle.1,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.oracle.retriablecodes,com.ibm.ws.transaction.hadb_fat.postgresql.1,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.postgresql.retriablecodes,com.ibm.ws.transaction.hadb_fat.sqlserver.1,com.ibm.ws.transaction.hadb_fat.sqlserver.2,com.ibm.ws.transaction.hadb_fat.sqlserver.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes,com.ibm.ws.transaction.recovery_fat.1,com.ibm.ws.transaction.recovery_fat.2,com.ibm.ws.transaction.recovery_fat.3,com.ibm.ws.tx.jta_fat,com.ibm.ws.tx.jta_fat_hibernate,com.ibm.ws.wsat.common_fat,com.ibm.ws.wsat.concurrent_fat,com.ibm.ws.wsat.migration_fat.1,com.ibm.ws.wsat.migration_fat.2,com.ibm.ws.wsat.migration_fat.3,com.ibm.ws.wsat.migration_fat.4,com.ibm.ws.wsat.migration_fat.5,com.ibm.ws.wsat.migration_fat.6,com.ibm.ws.wsat.migration_fat.7,com.ibm.ws.wsat.recovery_fat.lps,com.ibm.ws.wsat.recovery_fat.multi.1,com.ibm.ws.wsat.recovery_fat.multi.2,com.ibm.ws.wsat.recovery_fat.multi.3,com.ibm.ws.wsat.recovery_fat.multi.4,com.ibm.ws.wsat.recovery_fat.multi.5,com.ibm.ws.wsat.recovery_fat.multi.6,com.ibm.ws.wsat.recovery_fat.multi.7,com.ibm.ws.wsat.recovery_fat.single.1,com.ibm.ws.wsat.recovery_fat.single.2,com.ibm.ws.wsat_fat.assertion,com.ibm.ws.wsat_fat.db,com.ibm.ws.wsat_fat.db_optional,com.ibm.ws.wsat_fat.dbs,com.ibm.ws.wsat_fat.dbs_optional,com.ibm.ws.wsat_fat.multi,com.ibm.ws.wsat_fat.multi.misroute,com.ibm.ws.wsat_fat.ssl.misroute,com.ibm.ws.wsat_fat.ssl,io.openliberty.checkpoint_fat_transaction