### PR TITLE
Repeat Hazelcast tests for Jakarta EE11

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2022 IBM Corporation and others.
+# Copyright (c) 2018, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -20,8 +20,10 @@ src: \
 fat.project: true
 
 tested.features: \
+  cdi-4.1,\
   servlet-5.0,\
   servlet-6.0,\
+  servlet-6.1,\
   componenttest-2.0,\
   timedexit-1.0,\
   cdi-3.0,\

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/FATSuite.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -48,9 +48,9 @@ public class FATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()) // run all tests as-is (e.g. EE8 features)
-                    .andWith(FeatureReplacementAction.EE9_FEATURES() // run all tests again with EE9 features+packages
-                                    .conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                    .andWith(FeatureReplacementAction.EE10_FEATURES());
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
+                    .andWith(FeatureReplacementAction.EE11_FEATURES());
 
     @BeforeClass
     public static void beforeSuite() throws Exception {

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/HazelcastClientTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/HazelcastClientTest.java
@@ -1,16 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.session.cache.fat;
+
+import static componenttest.annotation.SkipForRepeat.EE9_OR_LATER_FEATURES;
 
 import java.io.File;
 import java.util.Arrays;
@@ -35,7 +37,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat({ SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES })
+@SkipForRepeat({ EE9_OR_LATER_FEATURES })
 public class HazelcastClientTest extends FATServletClient {
 
     @Server("sessionCacheServerA")

--- a/dev/com.ibm.ws.session.cache_fat_config/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache_fat_config/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2022 IBM Corporation and others.
+# Copyright (c) 2018, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ tested.features: \
   monitor-1.0,\
   servlet-5.0,\
   servlet-6.0,\
+  servlet-6.1,\
   componenttest-2.0
 
 

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/FATSuite.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -27,7 +27,6 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpUtils;
@@ -40,20 +39,10 @@ import componenttest.topology.utils.HttpUtils;
 public class FATSuite {
 
     @ClassRule
-    public static RepeatTests r;
-
-    static {
-        // EE10 requires Java 11.  If we only specify EE10 for lite mode it will cause no tests to run which causes an error.
-        // If we are running on Java 8 have EE9 be the lite mode test to run.
-        if (JavaInfo.JAVA_VERSION >= 11) {
-            r = RepeatTests.with(new EmptyAction().fullFATOnly()) // run all tests as-is (e.g. EE8 features)
-                            .andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly()) // run all tests again with EE9 features+packages
-                            .andWith(FeatureReplacementAction.EE10_FEATURES());
-        } else {
-            r = RepeatTests.with(new EmptyAction().fullFATOnly()) // run all tests as-is (e.g. EE8 features)
-                            .andWith(FeatureReplacementAction.EE9_FEATURES()); // run all tests again with EE9 features+packages
-        }
-    }
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()) // run all tests as-is (e.g. EE8 features)
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
+                    .andWith(FeatureReplacementAction.EE11_FEATURES());
 
     public static String run(LibertyServer server, String path, String testMethod, List<String> session) throws Exception {
         HttpURLConnection con = HttpUtils.getHttpConnection(server, path + '?' + FATServletClient.TEST_METHOD + '=' + testMethod);


### PR DESCRIPTION
Repeat Hazelcast Session FATs for Jakarta EE 11 and Servlet 6.1

com.ibm.ws.session.cache_fat

com.ibm.ws.session.cache_fat_config
