### PR TITLE
Use ServiceCaller to access JAASService

### DIFF
--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/jaas/modules/LoginModuleHelper.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/jaas/modules/LoginModuleHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,17 +12,15 @@
  *******************************************************************************/
 package com.ibm.ws.security.authentication.jaas.modules;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-
+import com.ibm.ws.kernel.service.util.ServiceCaller;
 import com.ibm.ws.security.authentication.internal.JAASService;
-import com.ibm.wsspi.security.common.auth.module.IdentityAssertionLoginModule;
 
 /**
  *
  */
 public class LoginModuleHelper {
     private static JAASService testJaasService = null;
+    private static final ServiceCaller<JAASService> jaasService = new ServiceCaller<>(LoginModuleHelper.class, JAASService.class);
 
     /**
      * Get the {@link JAASService} that contains various services we need to interact with.
@@ -34,8 +32,7 @@ public class LoginModuleHelper {
             return testJaasService;
         }
 
-        BundleContext bc = FrameworkUtil.getBundle(IdentityAssertionLoginModule.class).getBundleContext();
-        return bc.getService(bc.getServiceReference(JAASService.class));
+        return jaasService.current().orElseThrow(() -> new NullPointerException("No JAASService found."));
     }
 
     /**


### PR DESCRIPTION
This avoids overflowing the usecount of the OSGi service and simplifies getting the service over and over.
