### PR TITLE
Do not make experimental annotations API

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/io.openliberty.data-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/io.openliberty.data-1.0.feature
@@ -4,10 +4,6 @@ visibility=public
 singleton=true
 IBM-ShortName: data-1.0
 IBM-API-Package: \
-  io.openliberty.data.repository; type="ibm-api",\
-  io.openliberty.data.repository.comparison; type="ibm-api",\
-  io.openliberty.data.repository.function; type="ibm-api",\
-  io.openliberty.data.repository.update; type="ibm-api",\
   jakarta.data; type="spec",\
   jakarta.data.exceptions; type="spec",\
   jakarta.data.metamodel; type="spec",\
@@ -17,15 +13,15 @@ IBM-API-Package: \
   jakarta.data.repository; type="spec",\
   jakarta.data.spi; type="spec"
 Subsystem-Name: Jakarta Data 1.0
-#TODO io.openliberty.jakartaeePlatform-11.0
+#TODO io.openliberty.jakartaeePlatform-11.0 and stop tolerating EE 10
 -features=\
   com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="11.0",\
   io.openliberty.cdi-4.0; ibm.tolerates:="4.1",\
   io.openliberty.jakarta.data-1.0
+#TODO remove io.openliberty.data from this feature before GA or move it out of dev/api/
 -bundles=\
   io.openliberty.data; location:="dev/api/ibm/,lib/",\
   io.openliberty.data.internal
--files=dev/api/ibm/javadoc/io.openliberty.data_1.0-javadoc.zip
 kind=beta
 edition=base
 WLP-Activation-Type: parallel


### PR DESCRIPTION
The experimental annotations package should not be API in the data-1.0 feature. This PR is the first part, which removes their declaration as API from the feature, causing them to no longer be available to applications.  A second PR will need to split them out of the code so that we can also avoid including them in the dev/api/ibm location