### PR TITLE
Remove InstantOn beta guards for Jakarta Messaging, Connectors and MDB

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/connectors-2.0/io.openliberty.connectors-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/connectors-2.0/io.openliberty.connectors-2.0.feature
@@ -24,4 +24,4 @@ Subsystem-Category: JakartaEE9Application
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
-WLP-InstantOn-Enabled: true; type:=beta
+WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/connectors-2.1/io.openliberty.connectors-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/connectors-2.1/io.openliberty.connectors-2.1.feature
@@ -24,4 +24,4 @@ Subsystem-Category: JakartaEE10Application
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
-WLP-InstantOn-Enabled: true; type:=beta
+WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jca-1.7/com.ibm.websphere.appserver.jca-1.7.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jca-1.7/com.ibm.websphere.appserver.jca-1.7.feature
@@ -24,4 +24,4 @@ Subsystem-Category: JavaEE7Application
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
-WLP-InstantOn-Enabled: true; type:=beta
+WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jms-2.0/com.ibm.websphere.appserver.jms-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jms-2.0/com.ibm.websphere.appserver.jms-2.0.feature
@@ -20,4 +20,4 @@ Subsystem-Name: Java Message Service 2.0
 -bundles=com.ibm.ws.jms20.feature
 kind=ga
 edition=base
-WLP-InstantOn-Enabled: true; type:=beta
+WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mdb-3.2/com.ibm.websphere.appserver.mdb-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mdb-3.2/com.ibm.websphere.appserver.mdb-3.2.feature
@@ -93,4 +93,4 @@ Subsystem-Category: JavaEE7Application
 Subsystem-Name: Message-Driven Beans 3.2
 kind=ga
 edition=base
-WLP-InstantOn-Enabled: true; type:=beta
+WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mdb-4.0/io.openliberty.mdb-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mdb-4.0/io.openliberty.mdb-4.0.feature
@@ -94,4 +94,4 @@ Subsystem-Name: Jakarta Enterprise Beans 4.0 Message-Driven Beans
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
-WLP-InstantOn-Enabled: true; type:=beta
+WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/messaging-3.0/io.openliberty.messaging-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/messaging-3.0/io.openliberty.messaging-3.0.feature
@@ -22,4 +22,4 @@ Subsystem-Name: Jakarta Messaging 3.0
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
-WLP-InstantOn-Enabled: true; type:=beta
+WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/messaging-3.1/io.openliberty.messaging-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/messaging-3.1/io.openliberty.messaging-3.1.feature
@@ -22,4 +22,4 @@ Subsystem-Name: Jakarta Messaging 3.1
 kind=ga
 edition=base
 WLP-Activation-Type: parallel
-WLP-InstantOn-Enabled: true; type:=beta
+WLP-InstantOn-Enabled: true

--- a/dev/io.openliberty.ejbcontainer.mdb.checkpoint_fat/publish/servers/checkpointMsgEndpointServer/bootstrap.properties
+++ b/dev/io.openliberty.ejbcontainer.mdb.checkpoint_fat/publish/servers/checkpointMsgEndpointServer/bootstrap.properties
@@ -4,7 +4,3 @@ osgi.console=5678
 bootstrap.include=../testports.properties
 io.openliberty.ejb.security.startWaitTime=30
 websphere.java.security.exempt=true
-# Features mdb-3.2, mdb-4.0, jca-1.7, connectors-2.0, connectors-2.1, jms-2.0, messaging-3.0, messaging-3.1
-# are enabled for InstantOn beta; feature jmsMdb-3.2 is superceded by mdb-3.2 and is not formally enabled 
-# for InstantOn
-#io.openliberty.checkpoint.allowed.features=jca-1.7,connectors-2.0,connectors-2.1,jms-2.0,messaging-3.0,messaging-3.1

--- a/dev/io.openliberty.ejbcontainer.mdb.checkpoint_fat/publish/servers/checkpointMsgEndpointServer/jvm.options
+++ b/dev/io.openliberty.ejbcontainer.mdb.checkpoint_fat/publish/servers/checkpointMsgEndpointServer/jvm.options
@@ -1,2 +1,0 @@
-# Enable MDB features for InstantOn
--Dcom.ibm.ws.beta.edition=true


### PR DESCRIPTION
For epic issue #26039 

Remove the InstantOn beta guards from the Jakarta Messaging, Connectors, and MDB features.  Modify tests to use the GA version of these features.