### PR TITLE
Update to include common FAT jars in fattest.simplicity

### DIFF
--- a/dev/build.example_fat/build.gradle
+++ b/dev/build.example_fat/build.gradle
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,7 +13,7 @@
 
 dependencies {
   //if there is a existing project, reference it directly
-  requiredLibs project(':io.openliberty.org.apache.commons.logging')
+  //requiredLibs project(':io.openliberty.org.apache.commons.logging')
   
   //if not, Define G:A:V coordinates of each dependency
   //requiredLibs 'commons-logging:commons-logging:1.1.3'

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -389,7 +389,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.4</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -73,7 +73,7 @@ com.sun.xml.ws:jaxws-rt:3.0.2
 com.sun.xml.ws:jaxws-tools:2.3.6
 com.sun.xml.ws:jaxws-tools:3.0.2
 com.unboundid:unboundid-ldapsdk:5.1.0
-commons-cli:commons-cli:1.4
+commons-cli:commons-cli:1.5.0
 commons-codec:commons-codec:1.16.1
 commons-collections:commons-collections:3.2.2
 commons-digester:commons-digester:2.1

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -9,20 +9,27 @@
  -->
 <project name="standard.launch.tasks">
 
+	<target name="initBootstrapProperties">
+		<property name="bootstrapping.properties" value="${dir.component.root}/bootstrapping.properties" />
+		<property file="${bootstrapping.properties}" />
+	</target>
+
 	<!-- This is needed for Moonstone autowas to work -->
-	<target name="init-test-tasks-autowas" unless="inited-test-tasks">
+	<target name="init-test-tasks-autowas" unless="inited-test-tasks" depends="initBootstrapProperties">
 		<property name="inited-test-tasks" value="true" />
+		<condition property="local.java.dir" value="lib" else="build/libs/lib">
+			<available file="${local.java}/lib"/>
+		</condition>
 		<path id="test-buildtasks-autowas">
-			<fileset dir="./build/lib/" includes="infra.buildtasks*.jar" />
-			<fileset dir="./build/lib/" includes="asm*.jar" />
-			<fileset dir="./build/lib/" includes="jsch*.jar" />
+			<fileset dir="${local.java}/${local.java.dir}/" includes="infra.buildtasks*.jar" />
+			<fileset dir="${local.java}/${local.java.dir}/" includes="asm*.jar" />
+			<fileset dir="${local.java}/${local.java.dir}/" includes="jsch*.jar" />
 		</path>
 		<taskdef resource="com/ibm/aries/componenttest/buildtasks/buildtasks.properties" classpathref="test-buildtasks-autowas" loaderref="test-buildtasks-autowas_ldr" />
 		<taskdef resource="com/ibm/aries/buildtasks/buildtasks.properties" classpathref="test-buildtasks-autowas" loaderref="test-buildtasks-autowas_ldr" />
 	</target>
 
-	<target name="initProperties" depends="init-test-tasks-autowas">
-		<property name="bootstrapping.properties" value="${dir.component.root}/bootstrapping.properties" />
+	<target name="initProperties" depends="initBootstrapProperties,init-test-tasks-autowas">
 		<property name="configuration.properties" value="${dir.component.root}/configuration.properties" />
 		<property name="logging.properties" value="${dir.component.root}/logging.properties" />
 		<property name="gen.logging.properties" value="${dir.log}/logging.properties" />
@@ -279,11 +286,13 @@
 			<!-- java libraries for secure SSH authentication -->
 			<fileset dir="${local.java}/lib/" erroronmissingdir="false">
 				<include name="*.jar" />
+				<exclude name="${bnd.transform.jar.to.exclude}" />
 			</fileset>
 
 			<!-- The maven dependencies of fattest.simplicity -->
 			<fileset dir="${local.java}/build/libs/lib" erroronmissingdir="false">
 				<include name="*.jar" />
+				<exclude name="${bnd.transform.jar.to.exclude}" />
 			</fileset>
 
 			<fileset dir="${ant.home}/lib/" includes="ant-junit*.jar, ant.jar" />

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -61,10 +61,6 @@ Private-Package: \
     com.ibm.websphere.simplicity.configuration
 
 Include-Resource: \
-    @${repo;org.bouncycastle:bcpg-jdk18on;1.75;EXACT},\
-    @${repo;org.bouncycastle:bcpkix-jdk18on;1.75;EXACT},\
-    @${repo;org.bouncycastle:bcprov-jdk18on;1.75;EXACT},\
-    @${repo;org.bouncycastle:bcutil-jdk18on;1.75;EXACT},\
     init-sqlserver.sql=resources/init-sqlserver.sql
 
 test.project: true
@@ -75,19 +71,20 @@ fat.test.container.images: testcontainers/ryuk:0.6.0, testcontainers/sshd:1.1.0,
 -buildpath: \
     com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
     commons-httpclient:commons-httpclient;version=3.1,\
-    com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
+    com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
     com.ibm.websphere.javaee.servlet.3.0;version=latest,\
     io.openliberty.jakarta.servlet.5.0;version=latest,\
     org.eclipse.transformer:org.eclipse.transformer.cli;version=0.5.0,\
     org.eclipse.transformer:org.eclipse.transformer.bnd.analyzer;version=0.5.0,\
     org.eclipse.transformer:org.eclipse.transformer.jakarta;version=0.5.0,\
     org.eclipse.transformer:org.eclipse.transformer;version=0.5.0,\
-    biz.aQute.bnd:biz.aQute.bnd.transform;version=7.0.0,\
-    commons-cli:commons-cli;version=latest,\
+    biz.aQute.bnd:biz.aQute.bnd.transform;strategy=exact;version=6.4.1,\
+    biz.aQute.bnd:biz.aQute.bnd.transform;strategy=exact;version=7.0.0,\
+    commons-cli:commons-cli;strategy=exact;version='1.5.0',\
     com.ibm.ws.common.encoder;version=latest,\
     com.ibm.ws.componenttest;version=latest,\
     com.ibm.ws.timedexit.internal;version=latest,\
-	com.ibm.ws.jaxb.tools;version=latest,\
+    com.ibm.ws.jaxb.tools;version=latest,\
     httpunit:httpunit;version=1.5.4,\
     javax.activation:activation;version=1.1,\
     net.sf.jtidy:jtidy;version=9.3.8,\
@@ -104,15 +101,17 @@ fat.test.container.images: testcontainers/ryuk:0.6.0, testcontainers/sshd:1.1.0,
     org.jboss.arquillian.core:arquillian-core-api;version=1.7.0.Alpha13,\
     org.jboss.arquillian.test:arquillian-test-spi;version=1.7.0.Alpha13,\
     com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+    io.openliberty.org.apache.commons.logging;version=latest,\
     io.openliberty.org.testcontainers;version=latest,\
     com.ibm.websphere.javaee.cdi.1.2;version=latest,\
     io.openliberty.jakarta.cdi.3.0;version=latest,\
     com.ibm.ws.kernel.boot;version=latest,\
     io.openliberty.org.eclipse.openj9.criu;version=latest,\
     com.ibm.ws.org.slf4j.api;version=latest,\
+    com.ibm.ws.org.slf4j.simple;version=latest,\
     io.openliberty.com.fasterxml.jackson;version=latest,\
     org.seleniumhq.selenium:selenium-api;version=4.8.3,\
     org.seleniumhq.selenium:selenium-support;version=4.8.3,\
-    org.bouncycastle:bcpg-jdk18on;version=1.75,\
-    org.bouncycastle:bcpkix-jdk18on;version=1.75,\
-    org.bouncycastle:bcprov-jdk18on;version=1.75
+    io.openliberty.org.bouncycastle.bcpkix-jdk18on;version=latest,\
+    io.openliberty.org.bouncycastle.bcprov-jdk18on;version=latest,\
+    io.openliberty.org.bouncycastle.bcutil-jdk18on;version=latest

--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -21,7 +21,21 @@ task assembleBootstrap(type: Copy) {
 }
 
 task assembleBinaryDependencies() {
+    dependsOn ':com.ibm.websphere.javaee.jaxb.2.2:jar'
+    dependsOn ':com.ibm.websphere.javaee.jsonp.1.0:jar'
+    dependsOn ':com.ibm.ws.common.encoder:jar'
     dependsOn ':com.ibm.ws.jaxb.tools:jar'
+    dependsOn ':com.ibm.ws.junit.extensions:jar'
+    dependsOn ':com.ibm.ws.logging.core:jar'
+    dependsOn ':com.ibm.ws.org.glassfish.json:jar'
+    dependsOn ':com.ibm.ws.org.slf4j.api:jar'
+    dependsOn ':com.ibm.ws.org.slf4j.simple:jar'
+    dependsOn ':io.openliberty.com.fasterxml.jackson:jar'
+    dependsOn ':io.openliberty.org.apache.commons.logging:jar'
+    dependsOn ':io.openliberty.org.bouncycastle.bcpkix-jdk18on:jar'
+    dependsOn ':io.openliberty.org.bouncycastle.bcprov-jdk18on:jar'
+    dependsOn ':io.openliberty.org.bouncycastle.bcutil-jdk18on:jar'
+    dependsOn ':io.openliberty.org.testcontainers:jar'
     File buildDirLib = new File(buildDir, 'lib')
     outputs.dir buildDirLib
     doLast {
@@ -38,8 +52,36 @@ task assembleBinaryDependencies() {
             }
         }
         copy {
+            from new File(project(':com.ibm.websphere.javaee.jaxb.2.2').buildDir, 'com.ibm.websphere.javaee.jaxb.2.2.jar')
+            from new File(project(':com.ibm.websphere.javaee.jsonp.1.0').buildDir, 'com.ibm.websphere.javaee.jsonp.1.0.jar')
             from new File(project(':com.ibm.ws.jaxb.tools').buildDir, 'com.ibm.ws.jaxb.tools.jar')
+            from new File(project(':com.ibm.ws.junit.extensions').buildDir, 'com.ibm.ws.junit.extensions.jar')
+            from new File(project(':com.ibm.ws.logging.core').buildDir, 'com.ibm.ws.logging.core.jar')
+            from new File(project(':com.ibm.ws.org.glassfish.json').buildDir, 'com.ibm.ws.org.glassfish.json.1.0.jar')
+            from new File(project(':com.ibm.ws.org.slf4j.api').buildDir, 'com.ibm.ws.org.slf4j.api.jar')
+            from new File(project(':com.ibm.ws.org.slf4j.simple').buildDir, 'com.ibm.ws.org.slf4j.simple.jar')
+            from new File(project(':io.openliberty.com.fasterxml.jackson').buildDir, 'io.openliberty.com.fasterxml.jackson.jar')
+            from new File(project(':io.openliberty.org.apache.commons.logging').buildDir, 'io.openliberty.org.apache.commons.logging.jar')
+            from new File(project(':io.openliberty.org.bouncycastle.bcpkix-jdk18on').buildDir, 'io.openliberty.org.bouncycastle.bcpkix-jdk18on.jar')
+            from new File(project(':io.openliberty.org.bouncycastle.bcprov-jdk18on').buildDir, 'io.openliberty.org.bouncycastle.bcprov-jdk18on.jar')
+            from new File(project(':io.openliberty.org.bouncycastle.bcutil-jdk18on').buildDir, 'io.openliberty.org.bouncycastle.bcutil-jdk18on.jar')
+            from new File(project(':io.openliberty.org.testcontainers').buildDir, 'io.openliberty.org.testcontainers.jar')
             into buildDirLib
+        }
+        copy {
+            from cnf.file('mavenlibs')
+            into buildDirLib
+            include 'infra.buildtasks-core-7.0.2.jar'
+            include 'asm-all-5.2.jar'
+            include 'org.apache.aries.util-*.jar'
+            include 'osgi.core*.jar'
+            include 'jsch-*.jar'
+        }
+        copy {
+            from project(':com.ibm.ws.common.encoder').buildDir
+            into buildDirLib
+            include 'com.ibm.ws.common.encoder.jar'
+            rename 'com.ibm.ws.common.encoder.jar', 'fattest.encoder.jar'
         }
     }
 }

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -100,17 +100,17 @@ task addJakartaTransformerRules(type: Copy) {
 task addJakartaTransformer(type: Copy) {
   mustRunAfter jar
   dependsOn addJakartaTransformerRules
-  from configurations.jakartaTransformer
+/*  from configurations.jakartaTransformer
   from configurations.jakartaTransformerPreJava17
   from configurations.jakartaTransformerJava17Plus
-  into new File(autoFvtDir, 'lib')
+  into new File(autoFvtDir, 'lib')*/
 }
 
 task copyTestContainers(type: Copy) {
   dependsOn ':io.openliberty.org.testcontainers:assembleTestContainerData'
   mustRunAfter jar
-  from configurations.testcontainers
-  into new File(autoFvtDir, 'lib')
+/*  from configurations.testcontainers
+  into new File(autoFvtDir, 'lib')*/
 }
 
 task addDerby(type: Copy) {
@@ -164,7 +164,7 @@ task autoFVT {
     }
 
     // Copy the buildtask jars
-    copy {
+    /*copy {
       from cnf.file('mavenlibs')
       into new File(autoFvtDir, 'build/lib')
       include 'asm-all-5.2.jar'
@@ -192,7 +192,7 @@ task autoFVT {
     copy {
       from cnf.file('mavenlibs/infra.buildtasks-core-7.0.2.jar')
       into new File(autoFvtDir, 'build/lib')
-    }
+    }*/
 
     // Copy the bundle jar
     copy {
@@ -202,11 +202,11 @@ task autoFVT {
     }
 
     // Include JSON-P processor implementation
-    copy {
+    /*copy {
       from project(':com.ibm.ws.org.glassfish.json').buildDir
       include '*.jar'
       into new File(autoFvtDir, 'lib')
-    }
+    }*/
 
     // Copy the DDL files
     // TODO: Consider if this can be removed, it looks like there's only a single project for this rule
@@ -293,12 +293,12 @@ task autoFVT {
     }
 
     // TODO: This is to compensate for the fact that the ant build of fattest.simplicity produced this jar but the gradle build doesn't
-    copy {
+    /*copy {
       from project(':com.ibm.ws.common.encoder').buildDir
       include 'com.ibm.ws.common.encoder.jar'
       rename 'com.ibm.ws.common.encoder.jar', 'fattest.encoder.jar'
       into new File(autoFvtDir, 'lib')
-    }
+    }*/
 
     // Copy the published files
     copy {
@@ -317,11 +317,11 @@ task autoFVT {
     }
 
     // Copy the logging libraries over for use while running FATs
-    copy {
+    /*copy {
       from project(':com.ibm.ws.logging.core').buildDir
       include 'com.ibm.ws.logging.core.jar'
       into new File(autoFvtDir, 'lib')
-    }
+    }*/
 
     // Copy all non-java app resources, such as *.html or *.jsp
     copy {


### PR DESCRIPTION
- Update to not put the same jars into the autoFVT.zip files for all FATs. Instead put them in the fattest.simplicity/build/libs/lib directory that all FATs will end up using. This should save 12 to 13 MB per autoFVT.zip file.
