### PR TITLE
Update features that depend on appSecurity-6.0 to be marked for beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -340,7 +340,7 @@ public class FeatureInfo {
     /** {@inheritDoc} */
     @Override
     public String toString() {
-        return name + " " + visibility;
+        return name + " " + visibility + " " + edition;
     }
 
 }

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.audit1.0.internal.ee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.audit1.0.internal.ee-11.0.feature
@@ -11,5 +11,5 @@ visibility = private
 -bundles=\
   com.ibm.ws.request.probe.audit.servlet.jakarta
 
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.constrainedDelegation1.0.internal.ee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.constrainedDelegation1.0.internal.ee-11.0.feature
@@ -4,5 +4,5 @@ singleton=true
 visibility = private
 -features=io.openliberty.appSecurity-6.0, \
   com.ibm.websphere.appserver.eeCompatible-11.0
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jwtSso1.0.internal.ee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jwtSso1.0.internal.ee-11.0.feature
@@ -6,7 +6,8 @@ visibility = private
   com.ibm.websphere.appserver.servlet-6.1, \
   io.openliberty.appSecurity-6.0, \
   io.openliberty.jsonp-2.1, \
-  io.openliberty.org.eclipse.microprofile.jwt-2.1
+  io.openliberty.org.eclipse.microprofile.jwt-2.1, \
+  io.openliberty.noShip-1.0
 -bundles=\
   io.openliberty.security.common.internal, \
   io.openliberty.security.jwtsso.internal, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.oauth2.0.internal.ee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.oauth2.0.internal.ee-11.0.feature
@@ -10,5 +10,5 @@ visibility = private
   io.openliberty.security.jwt.internal, \
   io.openliberty.security.common.internal, \
   io.openliberty.security.common.jwt.internal
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.passwordUtilities1.0.internal.ee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.passwordUtilities1.0.internal.ee-11.0.feature
@@ -6,5 +6,5 @@ singleton=true
   io.openliberty.appSecurity-6.0, \
   com.ibm.websphere.appserver.servlet-6.1, \
   com.ibm.websphere.appserver.transaction-2.0
-kind=noship
-edition=full
+kind=beta
+edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.passwordUtilities1.1.internal.ee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.passwordUtilities1.1.internal.ee-11.0.feature
@@ -7,5 +7,5 @@ singleton=true
   io.openliberty.appSecurity-6.0, \
   com.ibm.websphere.appserver.servlet-6.1, \
   com.ibm.websphere.appserver.transaction-2.0
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.samlWeb2.0.internal.ee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.samlWeb2.0.internal.ee-11.0.feature
@@ -8,5 +8,5 @@ visibility = private
 -bundles=\
   io.openliberty.security.saml.internal.wab.2.0, \
   io.openliberty.security.common.internal
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.spnego1.0.internal.ee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.spnego1.0.internal.ee-11.0.feature
@@ -6,5 +6,5 @@ visibility = private
   com.ibm.websphere.appserver.servlet-6.1
 -bundles=\
   io.openliberty.security.spnego.internal
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsSecurity1.1.internal.jaxws-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsSecurity1.1.internal.jaxws-11.0.feature
@@ -17,5 +17,5 @@ singleton=true
  com.ibm.ws.org.apache.cxf.rt.security.saml.3.4.1.jakarta, \
  com.ibm.ws.wssecurity.3.4.1.jakarta, \
  io.openliberty.wssecurity
-kind=noship
-edition=full
+kind=beta
+edition=base


### PR DESCRIPTION
- Update value-add features that depend appSecurity-6.0 to be beta since appSecurity-6.0 was moved to beta.
- Update jwtSso-1.0 EE 11 private features to depend on the noship-1.0 feature since it cannot be moved to beta / ga until there is a MP features that supports EE 11.
- Update VisibilityTest to remove the special exception for connectors where there was a mismatch of private and public singleton features with the same base name.
- Add a new test to VisibilityTest to make sure singleton features with the same base name have the same edition except for a few exceptions that are expected where we moved editions between versions.  This helps making sure things are put in the right edition when moving them from noship to beta or ga.