### PR TITLE
Changing FixManagerTests to be able to run on IFix builds

### DIFF
--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FixManagerTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FixManagerTest.java
@@ -91,14 +91,17 @@ public class FixManagerTest {
         Log.exiting(c, METHOD_NAME);
     }
 
-    @Test
-    public void testEmptyString() throws Exception {
-        server.startServer();
-        runTest(server, FEATURE_MANAGER_CONTEXT_ROOT, "emptyFixList");
-    }
+    /**
+     * This test is not able to run within IFix Builds as those will never be empty.
+     */
+//    @Test
+//    public void testEmptyString() throws Exception {
+//        server.startServer();
+//        runTest(server, FEATURE_MANAGER_CONTEXT_ROOT, "emptyFixList");
+//    }
 
     @Test
-    public void testSingleIFixOutput() throws Exception {
+    public void testSingleIFixAddedOutput() throws Exception {
         server.copyFileToLibertyInstallRoot("lib", "ProvisioningInterimFixesTestBundle4_1.0.0.jar");
         server.copyFileToLibertyInstallRoot("lib", "ProvisioningInterimFixesTestBundle4_1.0.0.20130101.jar");
         server.setServerConfigurationFile("singleInterimFixServer.xml");
@@ -108,7 +111,7 @@ public class FixManagerTest {
     }
 
     @Test
-    public void testMultiIFixOutput() throws Exception {
+    public void testMultiIFixAddedOutput() throws Exception {
         server.copyFileToLibertyInstallRoot("lib", "ProvisioningInterimFixesTestBundle1_1.0.0.jar");
         server.copyFileToLibertyInstallRoot("lib", "ProvisioningInterimFixesTestBundle1_1.0.0.20130101.jar");
         server.copyFileToLibertyInstallRoot("lib", "ProvisioningInterimFixesTestBundle2_1.0.0.jar");
@@ -124,7 +127,7 @@ public class FixManagerTest {
     }
 
     @Test
-    public void testSingleTFixOutput() throws Exception {
+    public void testSingleTFixAddedOutput() throws Exception {
         server.copyFileToLibertyInstallRoot("lib", "ProvisioningTestBundle_1.0.1.jar");
         server.copyFileToLibertyInstallRoot("lib", "ProvisioningTestBundle_1.0.1.201204040001-TestAPAR0001.jar");
         server.setServerConfigurationFile("testFixesServer.xml");
@@ -134,7 +137,7 @@ public class FixManagerTest {
     }
 
     @Test
-    public void testMultipleTFixOutput() throws Exception {
+    public void testMultipleTFixAddedOutput() throws Exception {
         server.copyFileToLibertyInstallRoot("lib", "ProvisioningTestBundle_1.0.1.jar");
         server.copyFileToLibertyInstallRoot("lib", "ProvisioningTestBundle_1.0.1.201204040001-TestAPAR0001-TestAPAR0002.jar");
         server.setServerConfigurationFile("testFixesServer.xml");

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.feature.fix.manager/src/test/kernel/feature/fix/manager/FixManagerServlet.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.feature.fix.manager/src/test/kernel/feature/fix/manager/FixManagerServlet.java
@@ -9,7 +9,6 @@
  *******************************************************************************/
 package test.kernel.feature.fix.manager;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
@@ -19,6 +18,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.hamcrest.Matchers;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
@@ -33,82 +33,62 @@ public class FixManagerServlet extends FATServlet {
 
     public void emptyFixList(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         FixManager fixManagerService = null;
-        try {
-            BundleContext ctxt = (BundleContext) req.getServletContext().getAttribute("osgi-bundlecontext");
-            ServiceReference<FixManager> fixManagerRef = ctxt.getServiceReference(FixManager.class);
-            if (fixManagerRef != null) {
-                fixManagerService = ctxt.getService(fixManagerRef);
-            }
-            if (fixManagerService != null) {
-                assertEquals("getIFix list should return: ", 0, fixManagerService.getIFixes().size());
-                assertEquals("getTFix list should return: ", 0, fixManagerService.getTFixes().size());
-            }
-        } finally {
+        BundleContext ctxt = (BundleContext) req.getServletContext().getAttribute("osgi-bundlecontext");
+        ServiceReference<FixManager> fixManagerRef = ctxt.getServiceReference(FixManager.class);
+        if (fixManagerRef != null) {
+            fixManagerService = ctxt.getService(fixManagerRef);
+        }
+        if (fixManagerService != null) {
+            assertEquals("getIFix list should return: ", 0, fixManagerService.getIFixes().size());
+            assertEquals("getTFix list should return: ", 0, fixManagerService.getTFixes().size());
         }
     }
 
     public void singleIFix(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         FixManager fixManagerService = null;
-        try {
-            BundleContext ctxt = (BundleContext) req.getServletContext().getAttribute("osgi-bundlecontext");
-            ServiceReference<FixManager> fixManagerRef = ctxt.getServiceReference(FixManager.class);
-            if (fixManagerRef != null) {
-                fixManagerService = ctxt.getService(fixManagerRef);
-            }
-            if (fixManagerService != null) {
-                assertEquals("getIFix list should return: ", 1, fixManagerService.getIFixes().size());
-                assertThat(fixManagerService.getIFixes(), containsInAnyOrder("APAR0007"));
-            }
-        } finally {
+        BundleContext ctxt = (BundleContext) req.getServletContext().getAttribute("osgi-bundlecontext");
+        ServiceReference<FixManager> fixManagerRef = ctxt.getServiceReference(FixManager.class);
+        if (fixManagerRef != null) {
+            fixManagerService = ctxt.getService(fixManagerRef);
+        }
+        if (fixManagerService != null) {
+            assertThat(fixManagerService.getIFixes(), Matchers.hasItem("APAR0007"));
         }
     }
 
     public void multiIFixes(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         FixManager fixManagerService = null;
-        try {
-            BundleContext ctxt = (BundleContext) req.getServletContext().getAttribute("osgi-bundlecontext");
-            ServiceReference<FixManager> fixManagerRef = ctxt.getServiceReference(FixManager.class);
-            if (fixManagerRef != null) {
-                fixManagerService = ctxt.getService(fixManagerRef);
-            }
-            if (fixManagerService != null) {
-                assertEquals("getIFix list should return: ", 4, fixManagerService.getIFixes().size());
-                assertThat(fixManagerService.getIFixes(), containsInAnyOrder("APAR0005", "APAR0006", "APAR0007", "APAR0008"));
-            }
-        } finally {
+        BundleContext ctxt = (BundleContext) req.getServletContext().getAttribute("osgi-bundlecontext");
+        ServiceReference<FixManager> fixManagerRef = ctxt.getServiceReference(FixManager.class);
+        if (fixManagerRef != null) {
+            fixManagerService = ctxt.getService(fixManagerRef);
+        }
+        if (fixManagerService != null) {
+            assertThat(fixManagerService.getIFixes(), Matchers.hasItems("APAR0005", "APAR0006", "APAR0007", "APAR0008"));
         }
     }
 
     public void singleTFix(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         FixManager fixManagerService = null;
-        try {
-            BundleContext ctxt = (BundleContext) req.getServletContext().getAttribute("osgi-bundlecontext");
-            ServiceReference<FixManager> fixManagerRef = ctxt.getServiceReference(FixManager.class);
-            if (fixManagerRef != null) {
-                fixManagerService = ctxt.getService(fixManagerRef);
-            }
-            if (fixManagerService != null) {
-                assertEquals("getTFix list should return: ", 1, fixManagerService.getTFixes().size());
-                assertThat(fixManagerService.getTFixes(), containsInAnyOrder("TestAPAR0001"));
-            }
-        } finally {
+        BundleContext ctxt = (BundleContext) req.getServletContext().getAttribute("osgi-bundlecontext");
+        ServiceReference<FixManager> fixManagerRef = ctxt.getServiceReference(FixManager.class);
+        if (fixManagerRef != null) {
+            fixManagerService = ctxt.getService(fixManagerRef);
+        }
+        if (fixManagerService != null) {
+            assertThat(fixManagerService.getTFixes(), Matchers.hasItem("TestAPAR0001"));
         }
     }
 
     public void multiTFixes(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         FixManager fixManagerService = null;
-        try {
-            BundleContext ctxt = (BundleContext) req.getServletContext().getAttribute("osgi-bundlecontext");
-            ServiceReference<FixManager> fixManagerRef = ctxt.getServiceReference(FixManager.class);
-            if (fixManagerRef != null) {
-                fixManagerService = ctxt.getService(fixManagerRef);
-            }
-            if (fixManagerService != null) {
-                System.out.println("SIZEEE: " + fixManagerService.getTFixes());
-                assertEquals("getTFix list should return: ", 2, fixManagerService.getTFixes().size());
-                assertThat(fixManagerService.getTFixes(), containsInAnyOrder("TestAPAR0001", "TestAPAR0002"));
-            }
-        } finally {
+        BundleContext ctxt = (BundleContext) req.getServletContext().getAttribute("osgi-bundlecontext");
+        ServiceReference<FixManager> fixManagerRef = ctxt.getServiceReference(FixManager.class);
+        if (fixManagerRef != null) {
+            fixManagerService = ctxt.getService(fixManagerRef);
+        }
+        if (fixManagerService != null) {
+            assertThat(fixManagerService.getTFixes(), Matchers.hasItems("TestAPAR0001", "TestAPAR0002"));
         }
     }
 


### PR DESCRIPTION
Currently the tests were just checking the length of iFixes that we got from the FeatureManager class, with these changes the tests will only be looking for the specific iFixes we are adding from within the tests.

Fix for [299879](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=299879).