### PR TITLE
CVEReporting: Adding checkpoint FAT tests

### DIFF
--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/CVEReportingElement.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/CVEReportingElement.java
@@ -16,11 +16,11 @@ import javax.xml.bind.annotation.XmlAttribute;
  */
 public class CVEReportingElement extends ConfigElement {
 
-    private boolean enabled;
+    private String enabled;
 
     private String urlLink;
 
-    public Boolean getEnabled() {
+    public String getEnabled() {
         return enabled;
     }
 
@@ -29,8 +29,12 @@ public class CVEReportingElement extends ConfigElement {
     }
 
     @XmlAttribute(name = "enabled")
-    public void setEnabled(Boolean b) {
+    public void setEnabled(String b) {
         this.enabled = b;
+    }
+
+    public void setEnabled(Boolean b) {
+        this.enabled = b == null ? null : b.toString();
     }
 
     @XmlAttribute(name = "urlLink")

--- a/dev/io.openliberty.reporting.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.reporting.internal_fat/bnd.bnd
@@ -15,6 +15,9 @@ src: \
 		
 fat.project: true
 
+tested.features: \
+	checkpoint
+
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
 	org.hamcrest:hamcrest-all;version='1.3',\

--- a/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/CVEReportingCheckpointTest.java
+++ b/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/CVEReportingCheckpointTest.java
@@ -1,0 +1,82 @@
+package io.openliberty.reporting.internal.fat;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.CheckpointTest;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
+/**
+ * Cve Reporting checkpoint test class. We only want to test the config for this
+ * feature as everything else will be the same as expected for any other server
+ * with or without InstantOn enabled.
+ */
+@RunWith(FATRunner.class)
+@CheckpointTest
+public class CVEReportingCheckpointTest extends FATServletClient {
+
+    public static final String SERVER_NAME = "io.openliberty.reporting.server";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        server.setCheckpoint(CheckpointPhase.AFTER_APP_START, false, null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+        if (server.isStarted()) {
+            server.stopServer();
+        }
+
+        // server.restoreServerConfiguration();
+    }
+
+    @Test
+    public void testIsEnabledByDefault() throws Exception {
+        server.startServer();
+        server.checkpointRestore();
+        server.addIgnoredErrors(Collections.singletonList("CWWKF1704W"));
+
+        assertNotNull("The feature is disabled", server.waitForStringInLog("CWWKF1700I:.*"));
+    }
+
+    @Test
+    public void testIsDisabled() throws Exception {
+        ServerConfiguration config = server.getServerConfiguration();
+        config.getCVEReporting().setEnabled(false);
+        server.updateServerConfiguration(config);
+        server.startServer();
+        server.checkpointRestore();
+
+        assertNotNull("The feature is enabled", server.waitForStringInLog("CWWKF1701I:.*"));
+    }
+
+    @Test
+    public void testIsEnabled() throws Exception {
+        ServerConfiguration config = server.getServerConfiguration();
+        config.getCVEReporting().setEnabled(true);
+        server.updateServerConfiguration(config);
+        server.startServer();
+        server.checkpointRestore();
+        server.addIgnoredErrors(Collections.singletonList("CWWKF1704W"));
+
+        assertNotNull("The feature is disabled", server.waitForStringInLog("CWWKF1700I:.*"));
+    }
+
+}

--- a/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/CVEReportingCheckpointTest.java
+++ b/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/CVEReportingCheckpointTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -37,6 +38,11 @@ public class CVEReportingCheckpointTest extends FATServletClient {
     @Server(SERVER_NAME)
     public static LibertyServer server;
 
+    @BeforeClass
+    public static void setup() throws Exception {
+        server.saveServerConfiguration();
+    }
+
     @After
     public void tearDown() throws Exception {
 
@@ -44,7 +50,7 @@ public class CVEReportingCheckpointTest extends FATServletClient {
             server.stopServer();
         }
 
-        // server.restoreServerConfiguration();
+        server.restoreServerConfiguration();
     }
 
     @Test

--- a/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/FATSuite.java
@@ -15,7 +15,8 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({ CVEReportingConfigTest.class, CVEDataTest.class, CVEResponseTest.class })
+@SuiteClasses({ CVEReportingConfigTest.class, CVEDataTest.class, CVEResponseTest.class,
+        CVEReportingCheckpointTest.class })
 public class FATSuite {
 
 }

--- a/dev/io.openliberty.reporting.internal_fat/publish/servers/io.openliberty.reporting.checkpoint.server/bootstrap.properties
+++ b/dev/io.openliberty.reporting.internal_fat/publish/servers/io.openliberty.reporting.checkpoint.server/bootstrap.properties
@@ -1,0 +1,10 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties

--- a/dev/io.openliberty.reporting.internal_fat/publish/servers/io.openliberty.reporting.checkpoint.server/jvm.options
+++ b/dev/io.openliberty.reporting.internal_fat/publish/servers/io.openliberty.reporting.checkpoint.server/jvm.options
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+-Dcom.ibm.ws.beta.edition=true
+-Dcve.insight.enabled=true

--- a/dev/io.openliberty.reporting.internal_fat/publish/servers/io.openliberty.reporting.checkpoint.server/server.xml
+++ b/dev/io.openliberty.reporting.internal_fat/publish/servers/io.openliberty.reporting.checkpoint.server/server.xml
@@ -1,0 +1,33 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+
+<server description="Server for testing CVE reporting">
+
+    <include location="../fatTestPorts.xml"/>
+    
+    <featureManager>
+		<feature>componentTest-2.0</feature>
+	</featureManager>
+
+    <quickStartSecurity userName="theUser" userPassword="thePassword"/>
+    
+    <cveReporting enabled="${ENABLED_A}" urlLink="TESTING"/>
+
+    <variable name="ENABLED_A" defaultValue="true" />
+    
+    <logging  traceSpecification="io.openliberty.reporting.internal*=all"
+        traceFileName="trace.log"
+        maxFileSize="20"
+        maxFiles="10"
+        traceFormat="BASIC" />
+    
+    <keyStore id="defaultKeyStore" password="Liberty"/>
+
+</server>


### PR DESCRIPTION
Adding in CVE Reporting checkpoint FAT tests.

These only test if the feature configuration works as expected. This is because the behaviour after `checkpointRestore` remains the same as for when instantOn is disabled.