### PR TITLE
Explicitly drop recovery tables after tests

### DIFF
--- a/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/CloudFATServletClient.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/CloudFATServletClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,9 +24,8 @@ import com.ibm.ws.transaction.fat.util.FATUtils;
 import com.ibm.ws.transaction.fat.util.SetupRunner;
 
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.FATServletClient;
 
-public abstract class CloudFATServletClient extends FATServletClient {
+public abstract class CloudFATServletClient extends CloudTestBase {
 
     private static boolean _isDerby;
 

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/CloudTestBase.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/CloudTestBase.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package tests;
+
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.transaction.fat.util.TxTestContainerSuite;
+
+import componenttest.topology.utils.FATServletClient;
+
+public class CloudTestBase extends FATServletClient {
+
+    private static String[] testRecoveryTables = new String[] {
+                                                                "WAS_PARTNER_LOGcloud0011",
+                                                                "WAS_LEASES_LOG",
+                                                                "WAS_TRAN_LOGcloud0011",
+                                                                "WAS_PARTNER_LOGcloud0021",
+                                                                "WAS_TRAN_LOGcloud0021"
+    };
+
+    protected static void dropTables() {
+        Log.info(CloudTestBase.class, "dropTables", String.join(", ", testRecoveryTables));
+        TxTestContainerSuite.dropTables(testRecoveryTables);
+    }
+}

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DBRotationTest.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DBRotationTest.java
@@ -155,7 +155,7 @@ public class DBRotationTest extends CloudFATServletClient {
     @AfterClass
     public static void teardown() throws Exception {
 
-        TxTestContainerSuite.afterSuite();
+        dropTables();
     }
 
     /**

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DualServerDynamicTestBase.java
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/fat/src/tests/DualServerDynamicTestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,6 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.tx.jta.ut.util.LastingXAResourceImpl;
 import com.ibm.tx.jta.ut.util.XAResourceImpl;
 import com.ibm.websphere.simplicity.RemoteFile;
-import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.transaction.fat.util.FATUtils;
 import com.ibm.ws.transaction.fat.util.SetupRunner;
 import com.ibm.ws.transaction.fat.util.TxShrinkHelper;
@@ -33,14 +32,13 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.topology.database.container.DatabaseContainerType;
 import componenttest.topology.database.container.DatabaseContainerUtil;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.FATServletClient;
 
 /*
  * These tests are based on the original JTAREC recovery tests.
  * Test plan is attached to RTC WI 213854
  */
 @Mode
-public class DualServerDynamicTestBase extends FATServletClient {
+public class DualServerDynamicTestBase extends CloudTestBase {
 
     protected static LibertyServer serverTemplate;
     public static final String APP_NAME = "transaction";
@@ -159,11 +157,5 @@ public class DualServerDynamicTestBase extends FATServletClient {
         server2.setServerStartTimeout(FATUtils.LOG_SEARCH_TIMEOUT);
 
         server2.setHttpDefaultPort(server2.getHttpSecondaryPort());
-    }
-
-    public static void dropTables() {
-        Log.info(DualServerDynamicTestBase.class, "dropTables", "WAS_PARTNER_LOGcloud0011, WAS_LEASES_LOG, WAS_TRAN_LOGcloud0011, WAS_PARTNER_LOGcloud0021, WAS_TRAN_LOGcloud0021");
-        TxTestContainerSuite.dropTables("WAS_PARTNER_LOGcloud0011", "WAS_LEASES_LOG", "WAS_TRAN_LOGcloud0011", "WAS_PARTNER_LOGcloud0021",
-                                        "WAS_TRAN_LOGcloud0021");
     }
 }


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.transaction.cloud_fat.base,com.ibm.ws.transaction.cloud_fat.db2.0,com.ibm.ws.transaction.cloud_fat.db2.1,com.ibm.ws.transaction.cloud_fat.db2.2,com.ibm.ws.transaction.cloud_fat.derby.0,com.ibm.ws.transaction.cloud_fat.derby.1,com.ibm.ws.transaction.cloud_fat.derby.2,com.ibm.ws.transaction.cloud_fat.dualFS,com.ibm.ws.transaction.cloud_fat.oracle.0,com.ibm.ws.transaction.cloud_fat.oracle.1,com.ibm.ws.transaction.cloud_fat.oracle.2,com.ibm.ws.transaction.cloud_fat.peerlocking.1,com.ibm.ws.transaction.cloud_fat.peerlocking.2,com.ibm.ws.transaction.cloud_fat.postgresql.0,com.ibm.ws.transaction.cloud_fat.postgresql.1,com.ibm.ws.transaction.cloud_fat.postgresql.2,com.ibm.ws.transaction.cloud_fat.simpleFS,com.ibm.ws.transaction.cloud_fat.sqlserver.0,com.ibm.ws.transaction.cloud_fat.sqlserver.1,com.ibm.ws.transaction.cloud_fat.sqlserver.2