### PR TITLE
Update EclipseLink ASM to 9.7

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -3024,7 +3024,7 @@
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>org.eclipse.persistence.asm</artifactId>
-      <version>9.6.0</version>
+      <version>9.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -600,7 +600,7 @@ org.eclipse.microprofile.rest.client:microprofile-rest-client-api:2.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:3.0.1
 org.eclipse.parsson:parsson:1.1.4
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.14
-org.eclipse.persistence:org.eclipse.persistence.asm:9.6.0
+org.eclipse.persistence:org.eclipse.persistence.asm:9.7.0
 org.eclipse.persistence:org.eclipse.persistence.core:2.7.14
 org.eclipse.persistence:org.eclipse.persistence.core:3.0.4
 org.eclipse.persistence:org.eclipse.persistence.core:4.0.2

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
@@ -18,7 +18,7 @@ eclVersion=2.7.14
 eclHash=d05cebc
 eclFullVersion=${eclVersion}
 eclPackageVersion=2.0.16
-asmFullVersion=9.6.0
+asmFullVersion=9.7.0
 
 Bundle-SymbolicName: com.ibm.websphere.appserver.thirdparty.eclipselink.2.7
 Bundle-Description: EclipseLink JPA

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
@@ -18,7 +18,7 @@ eclVersion=2.6.10.WAS
 eclHash=f193aac
 eclFullVersion=${eclVersion}-${eclHash}
 eclPackageVersion=1.0.16
-asmFullVersion=9.6.0
+asmFullVersion=9.7.0
 
 Bundle-SymbolicName: com.ibm.websphere.appserver.thirdparty.eclipselink
 Bundle-Description: EclipseLink JPA

--- a/dev/io.openliberty.persistence.3.0.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.persistence.3.0.thirdparty/bnd.bnd
@@ -17,7 +17,7 @@ bVersion=1.0
 eclVersion=3.0.4
 eclFullVersion=${eclVersion}
 eclPackageVersion=3.0.4
-asmFullVersion=9.6.0
+asmFullVersion=9.7.0
 
 Bundle-SymbolicName: io.openliberty.persistence.3.0.thirdparty
 Bundle-Description: EclipseLink JPA

--- a/dev/io.openliberty.persistence.3.1.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/bnd.bnd
@@ -17,7 +17,7 @@ bVersion=1.0
 eclVersion=4.0.2
 eclFullVersion=${eclVersion}
 eclPackageVersion=4.0.2
-asmFullVersion=9.6.0
+asmFullVersion=9.7.0
 
 Bundle-SymbolicName: io.openliberty.persistence.3.1.thirdparty
 Bundle-Description: EclipseLink JPA

--- a/dev/io.openliberty.persistence.3.2.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/bnd.bnd
@@ -17,7 +17,7 @@ bVersion=1.0
 eclVersion=4.0.2
 eclFullVersion=${eclVersion}
 eclPackageVersion=4.0.2
-asmFullVersion=9.6.0
+asmFullVersion=9.7.0
 
 Bundle-SymbolicName: io.openliberty.persistence.3.2.thirdparty
 Bundle-Description: EclipseLink JPA


### PR DESCRIPTION
Update EclipseLink ASM to 9.7 for Java 23 support.

for https://github.com/OpenLiberty/open-liberty/issues/28131