### PR TITLE
Remove Content-Type header from common SSO HTTP GET request

### DIFF
--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpUtils.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.common.http;
 
@@ -254,8 +251,6 @@ public class HttpUtils {
 
     String getHttpJsonRequestAsString(HttpClient httpClient, String url) throws SocialLoginWrapperException, IOException {
         List<NameValuePair> headers = new ArrayList<>();
-        headers.add(new BasicNameValuePair("Content-Type", "application/json"));
-
         return getHttpRequestAsString(httpClient, url, headers);
     }
     


### PR DESCRIPTION
Some common SSO code for sending HTTP GET requests includes the `Content-Type` header, which doesn't make sense. This changes takes out that header from the request.

Resolves #28344