### PR TITLE
InstantOn - run EntityManagerBuilder in forground

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/bnd.bnd
+++ b/dev/io.openliberty.data.internal.persistence/bnd.bnd
@@ -64,6 +64,7 @@ instrument.classesExcludes: io/openliberty/data/internal/persistence/resources/*
   com.ibm.ws.beanvalidation.jakarta;version=latest,\
   com.ibm.ws.cdi.interfaces.jakarta;version=latest, \
   com.ibm.ws.container.service;version=latest,\
+  com.ibm.ws.kernel.boot.common;version=latest,\
   com.ibm.ws.org.objectweb.asm;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.persistence.jakarta;version=latest,\


### PR DESCRIPTION
Before checkpoint we want to run the builders in the foreground to ensure they complete before we do the checkpoint.