### PR TITLE
Update TCK to use new 3.0.1 version

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -3139,7 +3139,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
       <artifactId>microprofile-reactive-messaging-api</artifactId>
-      <version>3.0</version>
+      <version>3.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.rest.client</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -623,7 +623,7 @@ org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-stream
 org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-core:1.0.1
 org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-core:3.0
 org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api:1.0
-org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api:3.0
+org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api:3.0.1
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.0.1
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.1
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.2.0

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -68,8 +68,6 @@ org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191203
 org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191203
-org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-parent:3.0.1-ibm20230830
-org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-tck:3.0.1-ibm20230830
 org.eclipse.microprofile.rest.client:microprofile-rest-client-tck:1.2.2-20210215
 org.eclipse.microprofile.rest.client:microprofile-rest-client-tck:1.3.5-20210215
 org.eclipse.microprofile.rest.client:microprofile-rest-client-tck:1.4.2-20210215

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.reactive.messaging-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.reactive.messaging-3.0.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.org.eclipse.microprofile.reactive.messaging-3.0
 WLP-DisableAllFeatures-OnConflict: true
 singleton=true
 -bundles=io.openliberty.io.smallrye.reactive.messaging-api4
--jars=io.openliberty.org.eclipse.microprofile.reactive.messaging.3.0; location:="dev/api/stable/"; mavenCoordinates="org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api:3.0"
+-jars=io.openliberty.org.eclipse.microprofile.reactive.messaging.3.0; location:="dev/api/stable/"; mavenCoordinates="org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api:3.0.1"
 -features=io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0,6.1", \
   io.openliberty.org.eclipse.microprofile.reactive.streams.operators-3.0, \
   io.openliberty.org.eclipse.microprofile.config-3.0; ibm.tolerates:="3.1", \

--- a/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2023 IBM Corporation and others.
+  ~ Copyright (c) 2023, 2024 IBM Corporation and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License 2.0
   ~ which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@
     </repositories>
 
     <properties>
-        <microprofile.reactive.messaging.version>3.0</microprofile.reactive.messaging.version>
+        <microprofile.reactive.messaging.version>3.0.1</microprofile.reactive.messaging.version>
         <microprofile.reactive.streams.version>3.0</microprofile.reactive.streams.version>
         <arquillian.version>1.7.0.Final</arquillian.version>
         <arquillian.liberty.managed.jakarta.version>2.1.1</arquillian.liberty.managed.jakarta.version>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
             <artifactId>microprofile-reactive-messaging-tck</artifactId>
-            <version>3.0.1-ibm20230830</version>
+            <version>${microprofile.reactive.messaging.version}</version>
         </dependency>
 
         <dependency>

--- a/dev/io.openliberty.org.eclipse.microprofile/reactive.messaging.3.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/reactive.messaging.3.0.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2023 IBM Corporation and others.
+# Copyright (c) 2019, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -24,9 +24,9 @@ Export-Package: \
   org.eclipse.microprofile.reactive.messaging.spi
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api;3.0;EXACT}
+  @${repo;org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api;3.0.1;EXACT}
 
  -maven-dependencies: \
-   dep1;groupId=org.eclipse.microprofile.reactive.messaging;artifactId=microprofile-reactive-messaging-api;version=3.0;scope=runtime
+   dep1;groupId=org.eclipse.microprofile.reactive.messaging;artifactId=microprofile-reactive-messaging-api;version=3.0.1;scope=runtime
 
 WS-TraceGroup: REACTIVEMESSAGE


### PR DESCRIPTION
Replace custom version of the TCK with latest TCK version of RM 3.0

There is no difference for 3.0 and 3.0.1 of the spec or API. All changes are in the TCK
