### PR TITLE
Include productName in request data

### DIFF
--- a/dev/io.openliberty.reporting.internal/src/io/openliberty/reporting/internal/CVEResponseHandler.java
+++ b/dev/io.openliberty.reporting.internal/src/io/openliberty/reporting/internal/CVEResponseHandler.java
@@ -70,10 +70,10 @@ public class CVEResponseHandler {
 
                         if (bulletin.containsKey(cveObj.get("url"))) {
                             StringBuilder cve = new StringBuilder(bulletin.get(cveObj.get("url")));
-                            cve.append(", ").append(cveObj.get("cveId"));
+                            cve.append(", ").append(cveObj.get("id"));
                             bulletin.put(cveObj.get("url").toString(), cve.toString());
                         } else {
-                            bulletin.put(cveObj.get("url").toString(), cveObj.get("cveId").toString());
+                            bulletin.put(cveObj.get("url").toString(), cveObj.get("id").toString());
                         }
 
                     }

--- a/dev/io.openliberty.reporting.internal/src/io/openliberty/reporting/internal/DataCollector.java
+++ b/dev/io.openliberty.reporting.internal/src/io/openliberty/reporting/internal/DataCollector.java
@@ -48,6 +48,7 @@ public class DataCollector {
         data.put("id", uniqueID);
         data.put("productEdition", productEdition);
         data.put("productVersion", productVersion);
+        data.put("productName", productName);
         data.put("features", String.join(",", installedFeatures));
         data.put("javaVendor", javaVendor);
         data.put("javaVersion", javaRuntimeInfo);
@@ -67,6 +68,8 @@ public class DataCollector {
 
     private final String productVersion;
     private final String productEdition;
+
+    private final String productName = "Liberty";
 
     private final Set<String> iFixSet = new HashSet<>();
 

--- a/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/CVEDataTest.java
+++ b/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/CVEDataTest.java
@@ -77,6 +77,8 @@ public class CVEDataTest extends FATServletClient {
         assertThat("The property 'productEdition' did not match", props.getProperty("productEdition"),
                    Matchers.isIn(productEdition));
 
+        assertThat("The property 'productName' did not match", props.getProperty("productName"), Matchers.is("Liberty"));
+
         assertTrue("The property 'productVersion' did not match at the start",
                    props.getProperty("productVersion").matches("^\\d\\d\\..*"));
 

--- a/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/response/CVEReportingResponseEndpoints.java
+++ b/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/response/CVEReportingResponseEndpoints.java
@@ -58,9 +58,9 @@ public class CVEReportingResponseEndpoints extends Application {
 
         Cves cves = new Cves();
         Cves cvesNew = new Cves();
-        cves.setCveId("CVE-2023-50312");
+        cves.setId("CVE-2023-50312");
         cves.setUrl("https://www.ibm.com/support/pages/node/7125527");
-        cvesNew.setCveId("CVE-2023-50313");
+        cvesNew.setId("CVE-2023-50313");
         cvesNew.setUrl("https://www.ibm.com/support/pages/node/7125528");
 
         cvesList.add(cves);
@@ -76,10 +76,10 @@ public class CVEReportingResponseEndpoints extends Application {
         Cves cvesJava = new Cves();
         Cves cvesNewJava = new Cves();
 
-        cvesJava.setCveId("CVE-2023-50314");
+        cvesJava.setId("CVE-2023-50314");
         cvesJava.setUrl("https://www.ibm.com/support/pages/node/7125529");
 
-        cvesNewJava.setCveId("CVE-2023-50315");
+        cvesNewJava.setId("CVE-2023-50315");
         cvesNewJava.setUrl("https://www.ibm.com/support/pages/node/7125529");
 
         cvesList.clear();

--- a/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/response/Cves.java
+++ b/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/response/Cves.java
@@ -12,7 +12,7 @@ package io.openliberty.reporting.internal.fat.response;
 
 public class Cves {
 
-    private String cveId;
+    private String id;
 
     private String url;
 
@@ -21,16 +21,16 @@ public class Cves {
     }
 
     public Cves(String cveId, String url) {
-        this.cveId = cveId;
+        this.id = cveId;
         this.url = url;
     }
 
-    public String getCveId() {
-        return this.cveId;
+    public String getId() {
+        return this.id;
     }
 
-    public void setCveId(String cveId) {
-        this.cveId = cveId;
+    public void setId(String id) {
+        this.id = id;
     }
 
     public String getUrl() {

--- a/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/response/JsonData.java
+++ b/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/response/JsonData.java
@@ -14,6 +14,7 @@ public class JsonData {
     public String id;
     public String productEdition;
     public String productVersion;
+    public String productName;
     public String[] features;
     public String javaVendor;
     public String javaVersion;


### PR DESCRIPTION
Replace `cveId` with `id` given it is returned within the context of a list of CVEs, therefore not needed

Update Tests to check for productName and update response to be correct.


