### PR TITLE
Partitioned SSO test updates

### DIFF
--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonValidationTools.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonValidationTools.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -341,7 +341,7 @@ public class CommonValidationTools {
 
     }
 
-    private String getResponseHeadersString(Object response) throws Exception {
+    public String getResponseHeadersString(Object response) throws Exception {
         Map<String, String[]> headers = AutomationTools.getResponseHeaders(response);
         if (headers == null) {
             return null;

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/Constants.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/Constants.java
@@ -852,6 +852,8 @@ public class Constants extends com.ibm.ws.security.fat.common.Constants {
     public static final String SOCIAL_JWT_TOKEN = "Social JWT Token";
 
     /*********************************** Same Site **********************************************/
+    public static final String SAMESITE_KEY = "SameSite";
+    public static final String PARTITIONEDCOOKIE_KEY = "Partitioned";
     public static final String SAMESITE_DISABLED = "Disabled";
     public static final String SAMESITE_LAX = "Lax";
     public static final String SAMESITE_NONE = "None";

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/SameSiteTestTools.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/SameSiteTestTools.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.oauth_oidc.fat.commonTest;
 
@@ -43,6 +43,7 @@ public class SameSiteTestTools {
     public static CommonValidationTools validationTools = new CommonValidationTools();
 
     public static final String SameSiteCookieKey = "mySameSiteCookie";
+    public static final String PartitionedCookieKey = "myPartitionedCookie";
     public static final String SsoRequiresSSL = "mySsoRequiresSSL";
     public static final String HttpsRequiredKey = "myHttpsRequired";
     public static final String RedirectHostKey = "redirectHost";
@@ -60,7 +61,7 @@ public class SameSiteTestTools {
     protected static List<String> configUpdateMsgs = Arrays.asList(MessageConstants.CWWKG0017I_CONFIG_UPDATE_COMPLETE);
 
     private TestServer testOPServer = null;
-    private TestServer testRPServer = null;
+    private TestServer testClientServer = null;
     private TestServer genericTestServer = null;
     private List<TestServer> serverRefList = null;
 
@@ -71,10 +72,10 @@ public class SameSiteTestTools {
     // We can't just extend the CommonTests class as too many classes that don't need these tools
     // will be polluted with them, so, keep a local instance of the server refs for use by the methods
     // in this class
-    public SameSiteTestTools(TestServer opServer, TestServer rpServer, TestServer rsServer, List<TestServer> servers) {
+    public SameSiteTestTools(TestServer opServer, TestServer clientServer, TestServer rsServer, List<TestServer> servers) {
 
         testOPServer = opServer;
-        testRPServer = rpServer;
+        testClientServer = clientServer;
         genericTestServer = rsServer;
         serverRefList = servers;
     }
@@ -166,9 +167,10 @@ public class SameSiteTestTools {
         variablesToSet.put(CookiesEnabledKey, "true");
         variablesToSet.put(CookieHttpOnlyKey, "true");
         variablesToSet.put(SameSiteCookieKey, Constants.SAMESITE_DISABLED);
+        variablesToSet.put(PartitionedCookieKey, "false");
         variablesToSet.put(SsoRequiresSSL, "false");
         variablesToSet.put(HttpsRequiredKey, "false");
-        variablesToSet.put(RedirectHostKey, testRPServer.getServerHttpsString());
+        variablesToSet.put(RedirectHostKey, testClientServer.getServerHttpsString());
 
         return variablesToSet;
 
@@ -199,37 +201,38 @@ public class SameSiteTestTools {
     }
 
     /**
-     * Create a map of the default settings for an RP server
+     * Create a map of the default settings for an RP/Social server
      *
-     * @return - map of default RP variables
+     * @return - map of default client variables
      * @throws Exception
      */
-    public Map<String, String> setDefaultRPConfigSettingsMap() throws Exception {
+    public Map<String, String> setDefaultClientConfigSettingsMap() throws Exception {
 
         Map<String, String> variablesToSet = new HashMap<String, String>();
         variablesToSet.put(CookieSecureKey, "true");
         variablesToSet.put(CookiesEnabledKey, "true");
         variablesToSet.put(CookieHttpOnlyKey, "true");
         variablesToSet.put(SameSiteCookieKey, Constants.SAMESITE_DISABLED);
+        variablesToSet.put(PartitionedCookieKey, "false");
         variablesToSet.put(SsoRequiresSSL, "false");
         variablesToSet.put(HttpsRequiredKey, "false");
         variablesToSet.put(AuthorizationHostKey, testOPServer.getServerHttpsString());
         variablesToSet.put(TokenHostKey, testOPServer.getServerHttpsString());
         variablesToSet.put(IntrospectHostKey, testOPServer.getServerHttpsString());
-        variablesToSet.put(RedirectHostKey, testRPServer.getServerHttpsString());
+        variablesToSet.put(RedirectHostKey, testClientServer.getServerHttpsString());
         //        variablesToSet.put(RedirectHostKey, testRPServer.getServerHttpsCanonicalString());
 
         return variablesToSet;
 
     }
 
-    // updates the RP server with the default config values (could also say restores the default values)
-    public Map<String, String> setRPConfigSettings() throws Exception {
-        return setRPConfigSettings(new HashMap<String, String>());
+    // updates the Client server with the default config values (could also say restores the default values)
+    public Map<String, String> setClientConfigSettings() throws Exception {
+        return setConfigConfigSettings(new HashMap<String, String>());
     }
 
     /**
-     * Creates a map of the default settings for the RP plus
+     * Creates a map of the default settings for the Client plus
      * any values to override or add to those settings
      *
      * @param updates
@@ -237,13 +240,13 @@ public class SameSiteTestTools {
      * @return - updated map of variable settings
      * @throws Exception
      */
-    public Map<String, String> setRPConfigSettings(Map<String, String> updates) throws Exception {
+    public Map<String, String> setConfigConfigSettings(Map<String, String> updates) throws Exception {
 
-        Map<String, String> variables = setDefaultRPConfigSettingsMap();
+        Map<String, String> variables = setDefaultClientConfigSettingsMap();
         for (Entry<String, String> update : updates.entrySet()) {
             variables.put(update.getKey(), update.getValue());
         }
-        updateServerSettings(testRPServer, variables);
+        updateServerSettings(testClientServer, variables);
         return variables;
     }
 
@@ -260,12 +263,13 @@ public class SameSiteTestTools {
         variablesToSet.put(CookiesEnabledKey, "true");
         variablesToSet.put(CookieHttpOnlyKey, "true");
         variablesToSet.put(SameSiteCookieKey, Constants.SAMESITE_DISABLED);
+        variablesToSet.put(PartitionedCookieKey, "false");
         variablesToSet.put(SsoRequiresSSL, "false");
         variablesToSet.put(HttpsRequiredKey, "false");
         variablesToSet.put(AuthorizationHostKey, testOPServer.getServerHttpsString());
         variablesToSet.put(TokenHostKey, testOPServer.getServerHttpsString());
         variablesToSet.put(IntrospectHostKey, testOPServer.getServerHttpsString());
-        variablesToSet.put(RedirectHostKey, testRPServer.getServerHttpsString());
+        variablesToSet.put(RedirectHostKey, testClientServer.getServerHttpsString());
         variablesToSet.put(ValidationHostKey, testOPServer.getServerHttpsString());
 
         return variablesToSet;

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/structures/SameSiteTestExpectations.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/structures/SameSiteTestExpectations.java
@@ -1,21 +1,21 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.oauth_oidc.fat.commonTest.structures;
 
+import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
+
 /**
- * This is the test class that will run basic OpenID Connect RP tests.
- * This test class extends GenericRPTests.
- * GenericRPTests contains common code for all RP tests.
+ * This is the test class that will run basic OpenID Connect RP/Social samesite and partitioned tests.
  *
  **/
 
@@ -24,32 +24,41 @@ public class SameSiteTestExpectations {
     public static Class<?> thisClass = SameSiteTestExpectations.class;
 
     public static enum TestServerExpectations {
-        ALL_SERVERS_SUCCEED, OP_GENERIC_FAILURE, RP_GENERIC_FAILURE, RP_REDIRECT_FAILURE, RS_GENERIC_FAILURE, ONLY_BROWSER_SHOWS_FAILURE
+        ALL_SERVERS_SUCCEED, OP_GENERIC_FAILURE, CLIENT_GENERIC_FAILURE, CLIENT_REDIRECT_FAILURE, RS_GENERIC_FAILURE, ONLY_BROWSER_SHOWS_FAILURE
     };
 
     private TestServerExpectations baseTest = TestServerExpectations.ALL_SERVERS_SUCCEED;
-    private TestServerExpectations httpRPAppUrlTest = TestServerExpectations.ALL_SERVERS_SUCCEED;;
+    private TestServerExpectations httpClientAppUrlTest = TestServerExpectations.ALL_SERVERS_SUCCEED;;
     private TestServerExpectations httpRedirectUrlTest = TestServerExpectations.ALL_SERVERS_SUCCEED;;
     private TestServerExpectations httpAuthEndpointUrlTestResult = TestServerExpectations.ALL_SERVERS_SUCCEED;;
     private TestServerExpectations httpTokenEndpointUrlTestResult = TestServerExpectations.ALL_SERVERS_SUCCEED;;
     private TestServerExpectations rsHttpValidationEndpointUrlTestResult = TestServerExpectations.ALL_SERVERS_SUCCEED;;
+    private String samesiteSetting = Constants.SAMESITE_NONE;
+    private boolean partitionedCookie = false;
 
     public SameSiteTestExpectations() {
-        this(TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED);
+        this(TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, Constants.SAMESITE_DISABLED, false);
     }
 
-    public SameSiteTestExpectations(TestServerExpectations inHttpRPAppUrlTest, TestServerExpectations inHttpRedirectUrlTest, TestServerExpectations inHttpAuthEndpointUrlTestResult, TestServerExpectations inHttpTokenEndpointUrlTestResult, TestServerExpectations inRSHttpValidationEndpointUrlTestResult,
-            TestServerExpectations inOPSSORequiresSSLTestResult, TestServerExpectations inRPSSORequiresSSLTestResult, TestServerExpectations inRSSSORequiresSSLTestResult) {
-        this(TestServerExpectations.ALL_SERVERS_SUCCEED, inHttpRPAppUrlTest, inHttpRedirectUrlTest, inHttpAuthEndpointUrlTestResult, inHttpTokenEndpointUrlTestResult, inRSHttpValidationEndpointUrlTestResult);
+    public SameSiteTestExpectations(String samesiteSettings, boolean partitionedCookie) {
+        this(TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, TestServerExpectations.ALL_SERVERS_SUCCEED, samesiteSettings, partitionedCookie);
     }
 
-    public SameSiteTestExpectations(TestServerExpectations inBaseTest, TestServerExpectations inHttpRPAppUrlTest, TestServerExpectations inHttpRedirectUrlTest, TestServerExpectations inHttpAuthEndpointUrlTestResult, TestServerExpectations inHttpTokenEndpointUrlTestResult, TestServerExpectations inRSHttpValidationEndpointUrlTestResult) {
+    public SameSiteTestExpectations(TestServerExpectations inHttpClientAppUrlTest, TestServerExpectations inHttpRedirectUrlTest, TestServerExpectations inHttpAuthEndpointUrlTestResult, TestServerExpectations inHttpTokenEndpointUrlTestResult, TestServerExpectations inRSHttpValidationEndpointUrlTestResult,
+            TestServerExpectations inOPSSORequiresSSLTestResult, TestServerExpectations inClientSSORequiresSSLTestResult, TestServerExpectations inRSSSORequiresSSLTestResult, String samesiteSetting, boolean isPartitionedCookie) {
+        this(TestServerExpectations.ALL_SERVERS_SUCCEED, inHttpClientAppUrlTest, inHttpRedirectUrlTest, inHttpAuthEndpointUrlTestResult, inHttpTokenEndpointUrlTestResult, inRSHttpValidationEndpointUrlTestResult, samesiteSetting, isPartitionedCookie);
+    }
+
+    public SameSiteTestExpectations(TestServerExpectations inBaseTest, TestServerExpectations inHttpClientAppUrlTest, TestServerExpectations inHttpRedirectUrlTest, TestServerExpectations inHttpAuthEndpointUrlTestResult, TestServerExpectations inHttpTokenEndpointUrlTestResult, TestServerExpectations inRSHttpValidationEndpointUrlTestResult, String inSamesiteSetting, boolean inPartitionedCookie) {
         baseTest = inBaseTest;
-        httpRPAppUrlTest = inHttpRPAppUrlTest;
+        httpClientAppUrlTest = inHttpClientAppUrlTest;
         httpRedirectUrlTest = inHttpRedirectUrlTest;
         httpAuthEndpointUrlTestResult = inHttpAuthEndpointUrlTestResult;
         httpTokenEndpointUrlTestResult = inHttpTokenEndpointUrlTestResult;
         rsHttpValidationEndpointUrlTestResult = inRSHttpValidationEndpointUrlTestResult;
+        samesiteSetting = inSamesiteSetting;
+        partitionedCookie = inPartitionedCookie;
+
     }
 
     public void setBaseTestResult(TestServerExpectations inBaseTest) {
@@ -60,12 +69,12 @@ public class SameSiteTestExpectations {
         return baseTest;
     }
 
-    public void setHttpRPAppUrlTestResult(TestServerExpectations inHttpRPAppUrlTest) {
-        httpRPAppUrlTest = inHttpRPAppUrlTest;
+    public void setHttpClientAppUrlTestResult(TestServerExpectations inHttpClientAppUrlTest) {
+        httpClientAppUrlTest = inHttpClientAppUrlTest;
     }
 
-    public TestServerExpectations getHttpRPAppUrlTestResult() {
-        return httpRPAppUrlTest;
+    public TestServerExpectations getHttpClientAppUrlTestResult() {
+        return httpClientAppUrlTest;
     }
 
     public void setHttpRedirectUrlTestResult(TestServerExpectations inHttpRedirectUrlTest) {
@@ -104,4 +113,19 @@ public class SameSiteTestExpectations {
         rsHttpValidationEndpointUrlTestResult = inOPSSORequiresSSLTestResult;
     }
 
+    public void setSamesiteSetting(String inSamesiteSetting) {
+        samesiteSetting = inSamesiteSetting;
+    }
+
+    public String getSamesiteSetting() {
+        return samesiteSetting;
+    }
+
+    public void setPartitionedCookie(boolean inPartitionedCookie) {
+        partitionedCookie = inPartitionedCookie;
+    }
+
+    public boolean getPartitionedCookie() {
+        return partitionedCookie;
+    }
 }

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/CommonTests/SameSiteTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/CommonTests/SameSiteTests.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 package com.ibm.ws.security.openidconnect.client.fat.CommonTests;
@@ -115,7 +115,40 @@ public class SameSiteTests extends CommonTest {
 
     }
 
-    public void mainPathTest(SameSiteTestExpectations.TestServerExpectations testExpectation, TestSettings settings,
+    public List<validationData> addHeaderCookiesExpectations(List<validationData> expectations, SameSiteTestExpectations.TestServerExpectations testExpectation, String samesiteSetting, boolean partitionedCookie) throws Exception {
+
+        String[] cookies = null;
+        if (testExpectation.equals(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE) && samesiteSetting.equals(Constants.SAMESITE_NONE)) {
+            cookies = new String[] { "WASReqURL" };
+        } else {
+            if (testExpectation.equals(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE) && samesiteSetting.equals(Constants.SAMESITE_NONE)) {
+                //            if (testExpectation.equals(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE) || testExpectation.equals(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE)) {
+                cookies = new String[] { "WASOidcCode", "WASOidcState" };
+            } else {
+                cookies = new String[] { "WASOidcCode", "WASOidcState", "WASOidcSession", "WASOidcNonce", "WAS_" };
+            }
+        }
+        for (String cookie : cookies) {
+            if (samesiteSetting.equals(Constants.SAMESITE_DISABLED)) {
+                expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_DOES_NOT_MATCH, "Was expecting SameSite to NOT be included in the cookie setting for: " + cookie, null, cookie + ".*" + Constants.SAMESITE_KEY);
+                expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_DOES_NOT_MATCH, "Was expecting that Partitioned is NOT included in the cookie setting for: " + cookie + " and it was there.", null, cookie + ".*" + Constants.PARTITIONEDCOOKIE_KEY);
+            } else {
+                expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Was expecting SameSite=" + samesiteSetting + " be included in the cookie setting for: " + cookie + " and it was NOT there.", null, cookie + ".*" + Constants.SAMESITE_KEY + "=" + samesiteSetting);
+                if (samesiteSetting.equals(Constants.SAMESITE_NONE)) {
+                    if (partitionedCookie) {
+                        expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Was expecting that Partitioned be included in the cookie setting for: " + cookie + " and it was NOT there.", null, cookie + ".*" + Constants.PARTITIONEDCOOKIE_KEY);
+                    } else {
+                        expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_DOES_NOT_MATCH, "Was expecting that Partitioned is NOT included in the cookie setting for: " + cookie + " and it was there.", null, cookie + ".*" + Constants.PARTITIONEDCOOKIE_KEY);
+                    }
+                } else {
+                    expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_DOES_NOT_MATCH, "Was expecting that Partitioned is NOT included in the cookie setting for: " + cookie + " and it was there.", null, cookie + ".*" + Constants.PARTITIONEDCOOKIE_KEY);
+                }
+            }
+        }
+        return expectations;
+    }
+
+    public void mainPathTest(SameSiteTestExpectations.TestServerExpectations testExpectation, String samesiteSetting, boolean partitionedCookie, TestSettings settings,
             String subTestPrefix) throws Exception {
 
         WebClient webClient = getAndSaveWebClient(true);
@@ -136,16 +169,18 @@ public class SameSiteTests extends CommonTest {
         case OP_GENERIC_FAILURE:
             expectations = badExpectations(testOPServer, subTestPrefix);
             break;
-        case RP_GENERIC_FAILURE:
+        case CLIENT_GENERIC_FAILURE:
             expectations = badExpectations(testRPServer, subTestPrefix);
             break;
-        case RP_REDIRECT_FAILURE:
+        case CLIENT_REDIRECT_FAILURE:
             expectations = badRedirectExpectations(testRPServer, subTestPrefix);
             break;
         default:
             expectations = setGoodExpectations(settings, subTestPrefix);
             break;
         }
+
+        expectations = addHeaderCookiesExpectations(expectations, testExpectation, samesiteSetting, partitionedCookie);
 
         genericRP(_testName, webClient, settings, Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT, expectations);
 
@@ -166,7 +201,7 @@ public class SameSiteTests extends CommonTest {
         Map<String, String> opSettings = samesiteTestTools.createOrRestoreConfigSettings(inOPSettings);
         Map<String, String> rpSettings = samesiteTestTools.createOrRestoreConfigSettings(inRPSettings);
 
-        mainPathTest(testExpectations.getBaseTestResult(), testSettings, "Base Tests");
+        mainPathTest(testExpectations.getBaseTestResult(), testExpectations.getSamesiteSetting(), testExpectations.getPartitionedCookie(), testSettings, "Base Tests");
 
         /*********************************************************/
         /* test using http with the request to the app on the RP */
@@ -176,7 +211,7 @@ public class SameSiteTests extends CommonTest {
         TestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setTestURL(
                 testRPServer.getServerHttpString() + "/" + Constants.OPENID_APP + "/" + Constants.DEFAULT_SERVLET);
-        mainPathTest(testExpectations.getHttpRPAppUrlTestResult(), updatedTestSettings, "Http RP App request");
+        mainPathTest(testExpectations.getHttpClientAppUrlTestResult(), testExpectations.getSamesiteSetting(), testExpectations.getPartitionedCookie(), updatedTestSettings, "Http RP App request");
         // No server config's were updated in the previous test, so, nothing has to be restored
 
         /*********************************************************/
@@ -186,7 +221,7 @@ public class SameSiteTests extends CommonTest {
         /*********************************************************/
         rpSettings.put(SameSiteTestTools.RedirectHostKey, testRPServer.getServerHttpString());
         samesiteTestTools.updateServerSettings(testRPServer, rpSettings);
-        mainPathTest(testExpectations.getHttpRedirectUrlTestResult(), testSettings, "Http RP Redirect");
+        mainPathTest(testExpectations.getHttpRedirectUrlTestResult(), testExpectations.getSamesiteSetting(), testExpectations.getPartitionedCookie(), testSettings, "Http RP Redirect");
 
         /*********************************************************/
         /*
@@ -198,8 +233,7 @@ public class SameSiteTests extends CommonTest {
         rpSettings.put(SameSiteTestTools.AuthorizationHostKey, testOPServer.getServerHttpString());
         samesiteTestTools.updateServerSettings(testOPServer, opSettings);
         samesiteTestTools.updateServerSettings(testRPServer, rpSettings);
-        mainPathTest(testExpectations.getHttpAuthEndpointUrlTestResult(), testSettings,
-                "Http RP Authorization Endpoint");
+        mainPathTest(testExpectations.getHttpAuthEndpointUrlTestResult(), testExpectations.getSamesiteSetting(), testExpectations.getPartitionedCookie(), testSettings, "Http RP Authorization Endpoint");
 
         /*********************************************************/
         /*
@@ -211,7 +245,7 @@ public class SameSiteTests extends CommonTest {
         rpSettings.put(SameSiteTestTools.TokenHostKey, testOPServer.getServerHttpString());
         samesiteTestTools.updateServerSettings(testOPServer, opSettings);
         samesiteTestTools.updateServerSettings(testRPServer, rpSettings);
-        mainPathTest(testExpectations.getHttpTokenEndpointUrlTestResult(), testSettings, "Http RP Token Endpoint");
+        mainPathTest(testExpectations.getHttpTokenEndpointUrlTestResult(), testExpectations.getSamesiteSetting(), testExpectations.getPartitionedCookie(), testSettings, "Http RP Token Endpoint");
 
     }
 
@@ -220,7 +254,7 @@ public class SameSiteTests extends CommonTest {
     public void SameSiteTests_OPdisabledRPdisabled() throws Exception {
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(); // use defaults
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(); // use defaults
+        Map<String, String> rpSettings = samesiteTestTools.setClientConfigSettings(); // use defaults
 
         runVariations(opSettings, rpSettings);
     }
@@ -235,12 +269,12 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SsoRequiresSSL, "true");
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
         SameSiteTestExpectations testExpectations = new SameSiteTestExpectations();
-        testExpectations.setHttpRPAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
         testExpectations
-                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE);
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
         runVariations(testExpectations, opSettings, rpSettings);
 
     }
@@ -252,9 +286,9 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_LAX);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings();
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, rpSettings);
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_LAX, false), opSettings, rpSettings);
     }
 
     @Test
@@ -264,12 +298,12 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings();
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations();
-        testExpectations.setHttpRPAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE);
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
         testExpectations
-                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE);
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
         runVariations(testExpectations, opSettings, rpSettings);
     }
 
@@ -280,9 +314,9 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_STRICT);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings();
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, rpSettings);
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_STRICT, false), opSettings, rpSettings);
     }
 
     /*****/
@@ -295,7 +329,7 @@ public class SameSiteTests extends CommonTest {
         opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_LAX);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings();
+        Map<String, String> rpSettings = samesiteTestTools.setClientConfigSettings();
 
         runVariations(opSettings, rpSettings);
     }
@@ -309,9 +343,9 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_LAX);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, rpSettings);
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_LAX, false), opSettings, rpSettings);
     }
 
     @Test
@@ -323,12 +357,12 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations();
-        testExpectations.setHttpRPAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE);
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
         testExpectations
-                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE);
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
         runVariations(testExpectations, opSettings, rpSettings);
     }
 
@@ -341,9 +375,9 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_STRICT);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, rpSettings);
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_STRICT, false), opSettings, rpSettings);
     }
 
     /*****/
@@ -356,7 +390,7 @@ public class SameSiteTests extends CommonTest {
         opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings();
+        Map<String, String> rpSettings = samesiteTestTools.setClientConfigSettings();
 
         runVariations(opSettings, rpSettings);
 
@@ -371,9 +405,9 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_LAX);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, rpSettings);
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_LAX, false), opSettings, rpSettings);
     }
 
     @Mode(TestMode.LITE)
@@ -386,12 +420,12 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations();
-        testExpectations.setHttpRPAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE);
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
         testExpectations
-                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE);
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
         runVariations(testExpectations, opSettings, rpSettings);
     }
 
@@ -407,12 +441,12 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SsoRequiresSSL, "true");
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations();
-        testExpectations.setHttpRPAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE);
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
         testExpectations
-                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE);
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
         runVariations(testExpectations, opSettings, rpSettings);
 
     }
@@ -426,9 +460,9 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_STRICT);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, rpSettings);
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_STRICT, false), opSettings, rpSettings);
     }
 
     /*****/
@@ -441,7 +475,7 @@ public class SameSiteTests extends CommonTest {
         opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_STRICT);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings();
+        Map<String, String> rpSettings = samesiteTestTools.setClientConfigSettings();
 
         runVariations(opSettings, rpSettings);
     }
@@ -455,9 +489,9 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_LAX);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, rpSettings);
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_LAX, false), opSettings, rpSettings);
     }
 
     @Test
@@ -469,12 +503,12 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations();
-        testExpectations.setHttpRPAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE);
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
         testExpectations
-                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE);
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
         runVariations(testExpectations, opSettings, rpSettings);
     }
 
@@ -487,9 +521,336 @@ public class SameSiteTests extends CommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_STRICT);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> rpSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_STRICT, false), opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPdisabledRPdisabledPartitionedTrue() throws Exception {
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(); // use defaults
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates); // use defaults
 
         runVariations(opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPdisabledRPnonePartitionedFalse() throws Exception {
+
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings();
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPdisabledRPnonePartitionedTrue() throws Exception {
+
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings();
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, true);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPlaxRPdisabledPartitionedTrue() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_LAX);
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPlaxRPnonePartitionedFalse() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_LAX);
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPlaxRPnonePartitionedTrue() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_LAX);
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, true);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    /*****/
+    /*****/
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedFalseRPdisabled() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setClientConfigSettings();
+
+        runVariations(opSettings, rpSettings);
+
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedTruRPdisabled() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setClientConfigSettings();
+
+        runVariations(opSettings, rpSettings);
+
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedFalseRPlax() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_LAX);
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_LAX, false), opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedTrueRPlax() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_LAX);
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_LAX, false), opSettings, rpSettings);
+    }
+
+    @Mode(TestMode.LITE)
+    @Test
+    public void SameSiteTests_OPnonePartitionedFalseRPnonePartitionedFalse() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Mode(TestMode.LITE)
+    @Test
+    public void SameSiteTests_OPnonePartitionedFalseRPnonePartitionedTrue() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, true);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedTrueRPnonePartitionedFalse() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedTrueRPnonePartitionedTrue() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, true);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedFalseRPstrict() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_STRICT);
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_STRICT, false), opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedTrueRPstrict() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_STRICT);
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_STRICT, true), opSettings, rpSettings);
+    }
+
+    /*****/
+    /*****/
+
+    @Test
+    public void SameSiteTests_OPstrictRPnonePartitionedFalse() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_STRICT);
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Mode(TestMode.LITE)
+    @Test
+    public void SameSiteTests_OPstrictRPnonePartitionedTrue() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_STRICT);
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(Constants.SAMESITE_NONE, true);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPstrictRPstrictPartitionedTrue() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_STRICT);
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, Constants.SAMESITE_STRICT);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(new SameSiteTestExpectations(Constants.SAMESITE_STRICT, false), opSettings, rpSettings);
     }
 
 }

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/publish/files/serversettings/miscNoSslSamesiteSettings.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/publish/files/serversettings/miscNoSslSamesiteSettings.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@
 	<webAppSecurity
 		httpOnlyCookies="false"
 		sameSiteCookie="${mySameSiteCookie}"
+		partitionedCookie="${myPartitionedCookie}"
 		ssoRequiresSSL="${mySsoRequiresSSL}"
 		allowFailOverToBasicAuth="true" />
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.op/jvm.options
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.op/jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021, 2024 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rp/jvm.options
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rp/jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,3 +16,5 @@
 -Dhttp.proxyHost=1.2.3.4
 -Dhttps.proxyPort=34567
 -Dhttps.proxyHost=1.2.3.4
+
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/fat/src/com/ibm/ws/security/social/fat/LibertyOP/CommonTests/SameSiteTests.java
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/fat/src/com/ibm/ws/security/social/fat/LibertyOP/CommonTests/SameSiteTests.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,12 +17,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.fat.common.utils.AutomationTools;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.RSCommonTestTools;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.SameSiteTestTools;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestServer;
@@ -36,6 +40,7 @@ import com.ibm.ws.security.social.fat.utils.SocialTestSettings;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.topology.impl.LibertyServerWrapper;
 
 @RunWith(FATRunner.class)
@@ -84,7 +89,112 @@ public class SameSiteTests extends SocialCommonTest {
         return expectations;
     }
 
-    public void mainPathTest(SameSiteTestExpectations.TestServerExpectations testExpectation, SocialTestSettings settings, String subTestPrefix) throws Exception {
+    public void validateCookies(Object response, SameSiteTestExpectations.TestServerExpectations testExpectation, String samesiteSetting, boolean partitionedCookie) throws Exception {
+
+        String[] cookies = {};
+        String[] clearedCookies = {};
+        List<validationData> expectations = null;
+
+        if (!testExpectation.equals(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE)) { // no cookies to check on redirect failure
+            if (testExpectation.equals(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE) && samesiteSetting.equals(SocialConstants.SAMESITE_NONE)) {
+                if (RepeatTestFilter.getRepeatActionsAsString().contains(OAuthOIDCRepeatActions.oidc_type)) {
+                    cookies = new String[] { "WASOidcCode", "WASOidcState", "WASOidcNonce" };
+                    clearedCookies = new String[] { "WASReqURLOidc", "WASOidcSession" };
+                } else {
+                    cookies = new String[] { "WASSocialState" };
+                    clearedCookies = new String[] { "WASReqURL", "WASPostParam" };
+                }
+            } else {
+                if (RepeatTestFilter.getRepeatActionsAsString().contains(OAuthOIDCRepeatActions.oidc_type)) {
+                    cookies = new String[] { "WASOidcCode", "WASOidcState", "WASOidcSession", "WASOidcNonce", "WASReqURLOidc", "LtpaToken2" };
+                } else {
+                    cookies = new String[] { "LtpaToken2" };
+                    clearedCookies = new String[] { "WASReqURL", "WASPostParam", "WASSocialState" };
+                }
+            }
+        }
+        for (String cookie : cookies) {
+            if (_testName.toLowerCase().contains(SocialConstants.SAMESITE_DISABLED.toLowerCase()) && samesiteSetting.equals(SocialConstants.SAMESITE_DISABLED)) {
+                //                if (samesiteSetting.equals(SocialConstants.SAMESITE_DISABLED)) {
+                expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.RESPONSE_HEADER, SocialConstants.STRING_DOES_NOT_MATCH, "Was expecting SameSite to NOT be included in the cookie setting for: " + cookie, null, cookie + ".*" + SocialConstants.SAMESITE_KEY);
+                expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.RESPONSE_HEADER, SocialConstants.STRING_DOES_NOT_MATCH, "Was expecting that Partitioned is NOT included in the cookie setting for: " + cookie + " and it was there.", null, cookie + ".*" + SocialConstants.PARTITIONEDCOOKIE_KEY);
+            } else {
+                expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.RESPONSE_HEADER, SocialConstants.STRING_MATCHES, "Was expecting SameSite=" + samesiteSetting + " be included in the cookie setting for: " + cookie + " and it was NOT there.", null, cookie + ".*" + SocialConstants.SAMESITE_KEY + "=" + samesiteSetting);
+                if (samesiteSetting.equals(SocialConstants.SAMESITE_NONE)) {
+                    if (partitionedCookie) {
+                        expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.RESPONSE_HEADER, SocialConstants.STRING_MATCHES, "Was expecting that Partitioned be included in the cookie setting for: " + cookie + " and it was NOT there.", null, cookie + ".*" + SocialConstants.PARTITIONEDCOOKIE_KEY);
+                    } else {
+                        expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.RESPONSE_HEADER, SocialConstants.STRING_DOES_NOT_MATCH, "Was expecting that Partitioned is NOT included in the cookie setting for: " + cookie + " and it was there.", null, cookie + ".*" + SocialConstants.PARTITIONEDCOOKIE_KEY);
+                    }
+                } else {
+                    expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.RESPONSE_HEADER, SocialConstants.STRING_DOES_NOT_MATCH, "Was expecting that Partitioned is NOT included in the cookie setting for: " + cookie + " and it was there.", null, cookie + ".*" + SocialConstants.PARTITIONEDCOOKIE_KEY);
+                }
+            }
+        }
+        for (String cookie : clearedCookies) {
+            expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.RESPONSE_HEADER, SocialConstants.STRING_DOES_NOT_MATCH, "Was expecting SameSite to NOT be included in the cookie setting for: " + cookie, null, cookie + ".*" + SocialConstants.SAMESITE_KEY);
+            expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN, SocialConstants.RESPONSE_HEADER, SocialConstants.STRING_DOES_NOT_MATCH, "Was expecting that Partitioned is NOT included in the cookie setting for: " + cookie + " and it was there.", null, cookie + ".*" + SocialConstants.PARTITIONEDCOOKIE_KEY);
+        }
+
+        headerCheck(response, expectations);
+    }
+
+    public void headerCheck(Object response, List<validationData> expectations) throws Exception {
+
+        String thisMethod = "headerCheck";
+
+        if (expectations == null) {
+            return;
+        }
+        Map<String, String[]> headers = AutomationTools.getResponseHeaders(response);
+        if (headers == null) {
+            return;
+        }
+
+        String fullResponseContent = validationTools.getResponseHeadersString(response);
+        for (validationData expected : expectations) {
+            boolean found = false;
+            for (Entry<String, String[]> header : headers.entrySet()) {
+                for (String value : header.getValue()) {
+
+                    Pattern pattern = Pattern.compile(expected.getValidationValue());
+                    Matcher m = pattern.matcher(value);
+                    found = m.find();
+                    if (found) {
+                        Log.info(thisClass, "headerCheck", "Breaking (one value)");
+                        break;
+                    }
+                }
+                if (found) {
+                    Log.info(thisClass, "headerCheck", "Breaking (one header)");
+                    break;
+                }
+            }
+            Log.info(thisClass, "headerCheck", "string was found: " + Boolean.toString(found));
+
+            if (expected.getCheckType().equals(SocialConstants.STRING_MATCHES) || expected.getCheckType().equals(SocialConstants.STRING_EQUALS)) {
+                //                        Pattern pattern = Pattern.compile(expected.getValidationValue());
+                //                        Matcher m = pattern.matcher(value);
+                //                        found = m.find();
+
+                msgUtils.assertTrueAndLog(thisMethod, expected.getPrintMsg()
+                        + " Was expecting [" + expected.getValidationValue() + "]"
+                        + " but received " + fullResponseContent,
+                        found);
+            } else {
+                //                        Pattern pattern = Pattern.compile(expected.getValidationValue());
+                //                        Matcher m = pattern.matcher(value);
+
+                msgUtils.assertTrueAndLog(thisMethod, expected.getPrintMsg()
+                        + " Was not expecting [" + expected.getValidationValue() + "]"
+                        + " but received " + fullResponseContent,
+                        !found);
+
+            }
+        }
+    }
+
+    public void mainPathTest(SameSiteTestExpectations.TestServerExpectations testExpectation, String samesiteSetting, boolean partitionedCookie, SocialTestSettings settings, String subTestPrefix) throws Exception {
 
         WebClient webClient = getAndSaveWebClient();
 
@@ -104,10 +214,10 @@ public class SameSiteTests extends SocialCommonTest {
         case OP_GENERIC_FAILURE:
             expectations = badExpectations(testOPServer, subTestPrefix);
             break;
-        case RP_GENERIC_FAILURE:
+        case CLIENT_GENERIC_FAILURE:
             expectations = badExpectations(genericTestServer, subTestPrefix);
             break;
-        case RP_REDIRECT_FAILURE:
+        case CLIENT_REDIRECT_FAILURE:
             expectations = badRedirectExpectations(genericTestServer, subTestPrefix);
             break;
         // some failures result in only messages on the browser
@@ -120,7 +230,9 @@ public class SameSiteTests extends SocialCommonTest {
             break;
         }
 
-        genericSocial(_testName, webClient, inovke_social_login_actions, settings, expectations);
+        Object response = genericSocial(_testName, webClient, inovke_social_login_actions, settings, expectations);
+
+        validateCookies(response, testExpectation, samesiteSetting, partitionedCookie);
 
         msgUtils.printMethodName(_testName + " Step/Sub-Test " + subTestPrefix, "Ending TEST ");
         samesiteTestTools.logStepInServerSideLogs("ENDING", _testName + " Step/Sub-Test " + subTestPrefix);
@@ -140,7 +252,7 @@ public class SameSiteTests extends SocialCommonTest {
 
         SocialTestSettings updatedTestSettings = socialSettings.copyTestSettings();
 
-        mainPathTest(testExpectations.getBaseTestResult(), socialSettings, "Base Tests");
+        mainPathTest(testExpectations.getBaseTestResult(), testExpectations.getSamesiteSetting(), testExpectations.getPartitionedCookie(), socialSettings, "Base Tests");
 
         /*********************************************************/
         /* test using http with the request to the app on the RP */
@@ -148,7 +260,7 @@ public class SameSiteTests extends SocialCommonTest {
         // NOTE:  we are updating the actual "TestSettings" with a different url
         // only this test is using the updated settings (not updatedTestSettings passed in call to mainPathTest)
         updatedTestSettings.setProtectedResource(genericTestServer.getServerHttpString() + "/helloworld/rest/helloworld");
-        mainPathTest(testExpectations.getHttpRPAppUrlTestResult(), updatedTestSettings, "Http Social App request");
+        mainPathTest(testExpectations.getHttpClientAppUrlTestResult(), testExpectations.getSamesiteSetting(), testExpectations.getPartitionedCookie(), updatedTestSettings, "Http Social App request");
         // No server config's were updated in the previous test, so, nothing has to be restored
 
         // oidc enforces https use with all of the endpoints and that check will occur before we would encounter
@@ -163,7 +275,7 @@ public class SameSiteTests extends SocialCommonTest {
             /*********************************************************/
             socialRPSettings.put(SameSiteTestTools.RedirectHostKey, genericTestServer.getServerHttpString());
             samesiteTestTools.updateServerSettings(genericTestServer, socialRPSettings);
-            mainPathTest(testExpectations.getHttpRedirectUrlTestResult(), socialSettings, "Http Social Redirect");
+            mainPathTest(testExpectations.getHttpRedirectUrlTestResult(), testExpectations.getSamesiteSetting(), testExpectations.getPartitionedCookie(), socialSettings, "Http Social Redirect");
 
             /*********************************************************/
             /*
@@ -176,7 +288,7 @@ public class SameSiteTests extends SocialCommonTest {
             socialRPSettings.put(SameSiteTestTools.AuthorizationHostKey, testOPServer.getServerHttpString());
             samesiteTestTools.updateServerSettings(testOPServer, opSettings);
             samesiteTestTools.updateServerSettings(genericTestServer, socialRPSettings);
-            mainPathTest(testExpectations.getHttpAuthEndpointUrlTestResult(), socialSettings, "Http Social Authorization Endpoint");
+            mainPathTest(testExpectations.getHttpAuthEndpointUrlTestResult(), testExpectations.getSamesiteSetting(), testExpectations.getPartitionedCookie(), socialSettings, "Http Social Authorization Endpoint");
 
             /*********************************************************/
             /*
@@ -189,7 +301,7 @@ public class SameSiteTests extends SocialCommonTest {
             socialRPSettings.put(SameSiteTestTools.TokenHostKey, testOPServer.getServerHttpString());
             samesiteTestTools.updateServerSettings(testOPServer, opSettings);
             samesiteTestTools.updateServerSettings(genericTestServer, socialRPSettings);
-            mainPathTest(testExpectations.getHttpTokenEndpointUrlTestResult(), socialSettings, "Http Social Token Endpoint");
+            mainPathTest(testExpectations.getHttpTokenEndpointUrlTestResult(), testExpectations.getSamesiteSetting(), testExpectations.getPartitionedCookie(), socialSettings, "Http Social Token Endpoint");
         }
     }
 
@@ -198,7 +310,7 @@ public class SameSiteTests extends SocialCommonTest {
     public void SameSiteTests_OPdisabledSOCIALdisabled() throws Exception {
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(); // use defaults
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(); // use defaults
+        Map<String, String> socialRPSettings = samesiteTestTools.setClientConfigSettings(); // use defaults
 
         runVariations(opSettings, socialRPSettings);
     }
@@ -213,11 +325,11 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SsoRequiresSSL, "true");
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
         SameSiteTestExpectations testExpectations = new SameSiteTestExpectations();
-        testExpectations.setHttpRPAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE);
-        testExpectations.setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations.setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
         runVariations(testExpectations, opSettings, socialRPSettings);
 
     }
@@ -229,9 +341,9 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_LAX);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings();
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, socialRPSettings);
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_LAX, false), opSettings, socialRPSettings);
     }
 
     @Test
@@ -241,11 +353,11 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings();
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations();
-        testExpectations.setHttpRPAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE);
-        testExpectations.setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE);
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations.setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
         runVariations(testExpectations, opSettings, socialRPSettings);
     }
 
@@ -256,9 +368,9 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_STRICT);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings();
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, socialRPSettings);
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_STRICT, false), opSettings, socialRPSettings);
     }
 
     /*****/
@@ -271,7 +383,7 @@ public class SameSiteTests extends SocialCommonTest {
         opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_LAX);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings();
+        Map<String, String> socialRPSettings = samesiteTestTools.setClientConfigSettings();
 
         runVariations(opSettings, socialRPSettings);
     }
@@ -285,9 +397,9 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_LAX);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, socialRPSettings);
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_LAX, false), opSettings, socialRPSettings);
     }
 
     //    @Mode(TestMode.LITE)
@@ -300,11 +412,11 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations();
-        testExpectations.setHttpRPAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE);
-        testExpectations.setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE);
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations.setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
         runVariations(testExpectations, opSettings, socialRPSettings);
     }
 
@@ -317,9 +429,9 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_STRICT);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, socialRPSettings);
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_STRICT, false), opSettings, socialRPSettings);
     }
 
     /*****/
@@ -332,7 +444,7 @@ public class SameSiteTests extends SocialCommonTest {
         opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings();
+        Map<String, String> socialRPSettings = samesiteTestTools.setClientConfigSettings();
 
         runVariations(opSettings, socialRPSettings);
 
@@ -347,9 +459,9 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_LAX);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, socialRPSettings);
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_LAX, false), opSettings, socialRPSettings);
     }
 
     //    @Mode(TestMode.LITE)
@@ -362,11 +474,11 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations();
-        testExpectations.setHttpRPAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE);
-        testExpectations.setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE);
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations.setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
         runVariations(testExpectations, opSettings, socialRPSettings);
     }
 
@@ -382,11 +494,11 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SsoRequiresSSL, "true");
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations();
-        testExpectations.setHttpRPAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE);
-        testExpectations.setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE);
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations.setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
         runVariations(testExpectations, opSettings, socialRPSettings);
 
     }
@@ -400,9 +512,9 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_STRICT);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, socialRPSettings);
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_STRICT, false), opSettings, socialRPSettings);
     }
 
     /*****/
@@ -415,7 +527,7 @@ public class SameSiteTests extends SocialCommonTest {
         opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_STRICT);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings();
+        Map<String, String> socialRPSettings = samesiteTestTools.setClientConfigSettings();
 
         runVariations(opSettings, socialRPSettings);
     }
@@ -429,9 +541,9 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_LAX);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, socialRPSettings);
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_LAX, false), opSettings, socialRPSettings);
     }
 
     @Test
@@ -443,11 +555,11 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations();
-        testExpectations.setHttpRPAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_GENERIC_FAILURE);
-        testExpectations.setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.RP_REDIRECT_FAILURE);
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations.setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
         runVariations(testExpectations, opSettings, socialRPSettings);
     }
 
@@ -460,9 +572,333 @@ public class SameSiteTests extends SocialCommonTest {
         rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_STRICT);
 
         Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
-        Map<String, String> socialRPSettings = samesiteTestTools.setRPConfigSettings(rpUpdates);
+        Map<String, String> socialRPSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
 
-        runVariations(opSettings, socialRPSettings);
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_STRICT, false), opSettings, socialRPSettings);
     }
 
+    @Test
+    public void SameSiteTests_OPdisabledSOCIALdisabledPartitionedTrue() throws Exception {
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(); // use defaults
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates); // use defaults
+
+        runVariations(opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPdisabledSOCIALnonePartitionedFalse() throws Exception {
+
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings();
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPdisabledSOCIALnonePartitionedTrue() throws Exception {
+
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings();
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, true);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPlaxSOCIALdisabledPartitionedTrue() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_LAX);
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPlaxSOCIALnonePartitionedFalse() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_LAX);
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPlaxSOCIALnonePartitionedTrue() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_LAX);
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, true);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    /*****/
+    /*****/
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedFalseSOCIALdisabled() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setClientConfigSettings();
+
+        runVariations(opSettings, rpSettings);
+
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedTruSOCIALdisabled() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setClientConfigSettings();
+
+        runVariations(opSettings, rpSettings);
+
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedFalseSOCIALlax() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_LAX);
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_LAX, false), opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedTrueSOCIALlax() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_LAX);
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_LAX, false), opSettings, rpSettings);
+    }
+
+    @Mode(TestMode.LITE)
+    @Test
+    public void SameSiteTests_OPnonePartitionedFalseSOCIALnonePartitionedFalse() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedFalseSOCIALnonePartitionedTrue() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, true);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedTrueSOCIALnonePartitionedFalse() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedTrueSOCIALnonePartitionedTrue() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, true);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedFalseSOCIALstrict() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_STRICT);
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_STRICT, false), opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPnonePartitionedTrueSOCIALstrict() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        opUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_STRICT);
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_STRICT, true), opSettings, rpSettings);
+    }
+
+    /*****/
+    /*****/
+
+    @Test
+    public void SameSiteTests_OPstrictSOCIALnonePartitionedFalse() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_STRICT);
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "false");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, false);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPstrictSOCIALnonePartitionedTrue() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_STRICT);
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_NONE);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        SameSiteTestExpectations testExpectations = new SameSiteTestExpectations(SocialConstants.SAMESITE_NONE, true);
+        testExpectations.setHttpClientAppUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_GENERIC_FAILURE);
+        testExpectations
+                .setHttpRedirectUrlTestResult(SameSiteTestExpectations.TestServerExpectations.CLIENT_REDIRECT_FAILURE);
+        runVariations(testExpectations, opSettings, rpSettings);
+    }
+
+    @Test
+    public void SameSiteTests_OPstrictSOCIALstrictPartitionedTrue() throws Exception {
+
+        Map<String, String> opUpdates = new HashMap<String, String>();
+        opUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_STRICT);
+        Map<String, String> rpUpdates = new HashMap<String, String>();
+        rpUpdates.put(SameSiteTestTools.SameSiteCookieKey, SocialConstants.SAMESITE_STRICT);
+        rpUpdates.put(SameSiteTestTools.PartitionedCookieKey, "true");
+
+        Map<String, String> opSettings = samesiteTestTools.setOPConfigSettings(opUpdates);
+        Map<String, String> rpSettings = samesiteTestTools.setConfigConfigSettings(rpUpdates);
+
+        runVariations(new SameSiteTestExpectations(SocialConstants.SAMESITE_STRICT, false), opSettings, rpSettings);
+    }
 }

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/op_samesite_misc.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/op_samesite_misc.xml
@@ -1,6 +1,6 @@
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@
 	<webAppSecurity
 		httpOnlyCookies="false"
 		sameSiteCookie="${mySameSiteCookie}"
+		partitionedCookie="${myPartitionedCookie}"
 		ssoRequiresSSL="${mySsoRequiresSSL}"
 		allowFailOverToBasicAuth="true" />
 

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/rp_samesite_misc.xml
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/files/serversettings/rp_samesite_misc.xml
@@ -29,6 +29,7 @@
 
 	<webAppSecurity
 		sameSiteCookie="${mySameSiteCookie}"
+		partitionedCookie="${myPartitionedCookie}"
 		ssoRequiresSSL="${mySsoRequiresSSL}"/>
 				
 	<javaPermission className="javax.security.auth.AuthPermission" name="wssecurity.getRunAsSubject" />

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/servers/com.ibm.ws.security.social_fat.LibertyOP.op/jvm.options
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/servers/com.ibm.ws.security.social_fat.LibertyOP.op/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/servers/com.ibm.ws.security.social_fat.LibertyOP.social/jvm.options
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/publish/servers/com.ibm.ws.security.social_fat.LibertyOP.social/jvm.options
@@ -3,3 +3,4 @@
 -Dhttp.proxyHost=1.2.3.4
 -Dhttps.proxyPort=34567
 -Dhttps.proxyHost=1.2.3.4
+-Dcom.ibm.ws.beta.edition=true


### PR DESCRIPTION
Update the OIDC and Social client FATs to include tests for Partitioned in the SSO cookies
#27983 