### PR TITLE
Fix timing in EJB timer FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/test-applications/NpTimerConfigRetryEJB.jar/src/com/ibm/ws/ejbcontainer/timer/np/config/retry/ejb/TimerRetryBeanE.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/test-applications/NpTimerConfigRetryEJB.jar/src/com/ibm/ws/ejbcontainer/timer/np/config/retry/ejb/TimerRetryBeanE.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corporation and others.
+ * Copyright (c) 2009, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -42,6 +42,7 @@ public class TimerRetryBeanE {
 
     public static volatile int count = 0;
     public static ArrayList<Long> timestamps = new ArrayList<Long>();
+    public static ArrayList<Long> nextTimes = new ArrayList<Long>();
     private static CountDownLatch timerLatch;
     public static String timerInfo;
     public static boolean timerExists;
@@ -68,7 +69,8 @@ public class TimerRetryBeanE {
     public void doTimeoutStuff(Timer timer) {
         svLogger.info("Entering TimerRetryBeanE.doTimeoutStuff(), with pre-execution count of **" + count + "**");
 
-        svLogger.info("NEXT TIMEOUT" + timer.getNextTimeout());
+        svLogger.info("NEXT TIMEOUT " + timer.getNextTimeout() + ", " + timer.getNextTimeout().getTime());
+        nextTimes.add(Long.valueOf(timer.getNextTimeout().getTime()));
 
         count++;
         timestamps.add(Long.valueOf(System.currentTimeMillis()));

--- a/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/test-applications/NpTimerConfigRetryEJB.jar/src/com/ibm/ws/ejbcontainer/timer/np/config/retry/ejb/TimerRetryDriverBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/test-applications/NpTimerConfigRetryEJB.jar/src/com/ibm/ws/ejbcontainer/timer/np/config/retry/ejb/TimerRetryDriverBean.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corporation and others.
+ * Copyright (c) 2009, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -134,6 +134,7 @@ public class TimerRetryDriverBean implements TimerRetryDriver {
         currentBean = BEAN_E;
         TimerRetryBeanE.count = 0;
         TimerRetryBeanE.timestamps.clear();
+        TimerRetryBeanE.nextTimes.clear();
         ivTimerRetryBeanE.doWork(testName, retries);
 
         svLogger.info("Leaving TimerRetryDriverBean.forceEverythingToFailIntervalTimer()...");
@@ -177,6 +178,7 @@ public class TimerRetryDriverBean implements TimerRetryDriver {
             svLogger.info("Getting results for BeanE...");
             props.put(COUNT_KEY, Integer.valueOf(TimerRetryBeanE.count));
             props.put(TIMESTAMP_KEY, TimerRetryBeanE.timestamps);
+            props.put(NEXTTIMEOUT_KEY, TimerRetryBeanE.nextTimes);
             props.put(TIMER_EXISTS, Boolean.valueOf(TimerRetryBeanE.timerExists));
         } else if (currentBean == BEAN_F) {
             svLogger.info("Getting results for BeanF...");

--- a/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/test-applications/NpTimerConfigRetryWeb.war/src/com/ibm/ws/ejbcontainer/timer/np/config/retry/web/NpTimerConfigRetryServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/test-applications/NpTimerConfigRetryWeb.war/src/com/ibm/ws/ejbcontainer/timer/np/config/retry/web/NpTimerConfigRetryServlet.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import javax.ejb.EJB;
@@ -126,7 +127,7 @@ public class NpTimerConfigRetryServlet extends FATServlet {
 
         // TimerRetryDriver driverBean = getDriverBean();
 
-        svLogger.info("MHD: Calling my bean to force retry scenario...");
+        svLogger.info("Calling BeanA to force retry scenario...");
         driverBean.forceOneFailure("testForceImmediateRetry");
 
         svLogger.info("Waiting for timer to fail and immediate retry to occur...");
@@ -363,8 +364,8 @@ public class NpTimerConfigRetryServlet extends FATServlet {
 
         // TimerRetryDriver driverBean = getDriverBean();
 
-        svLogger.info("Calling BeanB to force retry, which should get skipped because we explicitly configured to never retry...");
-        driverBean.forceEverythingToFailIntervalTimer("testConfiguredForZeroRetriesTimerReschedules", 6);
+        svLogger.info("Calling BeanE to force retry, which should get skipped because we explicitly configured to never retry...");
+        driverBean.forceEverythingToFailIntervalTimer("testConfiguredForTwoRetriesTimerReschedules", 6);
 
         svLogger.info("Waiting for timer to fail and expected retries to occur...");
         driverBean.waitForTimersAndCancel(0);
@@ -374,10 +375,22 @@ public class NpTimerConfigRetryServlet extends FATServlet {
         int count = ((Integer) props.get(TimerRetryDriverBean.COUNT_KEY)).intValue();
         @SuppressWarnings("unchecked")
         ArrayList<Long> timestamps = (ArrayList<Long>) props.get(TimerRetryDriverBean.TIMESTAMP_KEY);
+        @SuppressWarnings("unchecked")
+        ArrayList<Long> nextTimes = (ArrayList<Long>) props.get(TimerRetryDriverBean.NEXTTIMEOUT_KEY);
         boolean timerExists = ((Boolean) props.get(TimerRetryDriverBean.TIMER_EXISTS)).booleanValue();
-        assertEquals("Timeout count **" + count + "** was not the expected value of 6. Interval Timer not resetting number of retries", 6, count);
-        assertEquals("Timestamps size **" + timestamps.size() + "** was not the expected value of 6.", 6, timestamps.size());
+
+        // Slow systems may result in catch-up timers, so at least 6, but as many as 9; tolerate up to 9
+        assertTrue("Timeout count **" + count + "** was not in the expected range of 6 to 9. Interval Timer not resetting number of retries", 6 <= count && count <= 9);
+        assertTrue("Timestamps size **" + timestamps.size() + "** was not in the expected range of 6 to 9.", 6 <= timestamps.size() && timestamps.size() <= 9);
+        assertTrue("NextTimes size **" + nextTimes.size() + "** was not in the expected range of 6 to 9.", 6 <= nextTimes.size() && nextTimes.size() <= 9);
         assertTrue("Timer did not exist after max retries", timerExists);
+
+        // Every 3 NextTime should match (initial + 2 retries); then move on to next interval
+        assertEquals("NextTime [0] and [1] not equal", nextTimes.get(0), nextTimes.get(1));
+        assertEquals("NextTime [1] and [2] not equal", nextTimes.get(1), nextTimes.get(2));
+        assertFalse("NextTime [2] and [3] equal", nextTimes.get(2) == nextTimes.get(3));
+        assertEquals("NextTime [3] and [4] not equal", nextTimes.get(3), nextTimes.get(4));
+        assertEquals("NextTime [4] and [5] not equal", nextTimes.get(4), nextTimes.get(5));
     }
 
     /**
@@ -604,6 +617,7 @@ public class NpTimerConfigRetryServlet extends FATServlet {
 
         svLogger.info("Calling BeanD to create situation where retries and regularly scheduled timeouts overlap...");
         driverBean.forceRetrysAndRegularSchedulesToOverlap("testOverlappingRetriesAndRegularlyScheduled", 7);
+        long startTime = System.nanoTime();
 
         svLogger.info("Waiting for timer to fail and expected retries to occur...");
         driverBean.waitForTimersAndCancel(NO_CANCEL_DELAY);
@@ -616,7 +630,14 @@ public class NpTimerConfigRetryServlet extends FATServlet {
         ArrayList<Long> timestamps = (ArrayList<Long>) props.get(TimerRetryDriverBean.TIMESTAMP_KEY);
         @SuppressWarnings("unchecked")
         ArrayList<Long> nextTimes = (ArrayList<Long>) props.get(TimerRetryDriverBean.NEXTTIMEOUT_KEY);
-        assertEquals("Attempt count **" + count + "** was not the expected value of 7.", 7, count);
+
+        // Tolerate a slow system; if time to trip latch is > 22ms, then an 8th attempt for a makeup may occur
+        long actualDuration = TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+        if (actualDuration < 22) {
+            assertEquals("Attempt count **" + count + "** was not the expected value of 7.", 7, count);
+        } else {
+            assertTrue("Attempt count **" + count + "** was not in expected range of 7 to 8.", count == 7 || count == 8);
+        }
         boolean validIntervalForImmediateRetry = verifyImmediateRetryAcceptable(timestamps.get(0).longValue(), timestamps.get(1).longValue());
         boolean validIntervalForDelayedRetry = verifyRetryIntervalAcceptable(timestamps.get(1).longValue(), timestamps.get(2).longValue(), 10000);
         boolean validIntervalForFirstMakeUp = verifyImmediateRetryAcceptable(timestamps.get(2).longValue(), timestamps.get(3).longValue());


### PR DESCRIPTION
Tolerate slow test systems
- allow for extra catch-up timers when there is a delay in scheduling

Also include a couple of test improvements
- minor corrections in messages logged by test
- improved checking for next scheduled time of repeated timers
