### PR TITLE
Fix data test and skip on Db2

### DIFF
--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package test.jakarta.data;
 
+import static componenttest.annotation.SkipIfSysProp.DB_DB2;
+
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import jakarta.enterprise.inject.spi.Extension;
 
@@ -29,6 +31,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
@@ -114,6 +117,7 @@ public class DataTest extends FATServletClient {
      * This test has conditional logic based on the JDBC driver/database.
      */
     @Test
+    @SkipIfSysProp(DB_DB2) //Failing on Db2 due to eclipselink issue.
     public void testFindAndDeleteReturnsObjects() throws Exception {
         runTest(server, "DataTestApp", "testFindAndDeleteReturnsObjects&jdbcJarName=" + jdbcJarName);
     }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1330,16 +1330,16 @@ public class DataTestServlet extends FATServlet {
         Package p0 = (Package) deletesList.get(0);
         Package p1 = (Package) deletesList.get(1);
         if (supportsOrderByForUpdate) {
-            assertEquals(70071, p0);
-            assertEquals(17.0f, p.length, 0.001f);
-            assertEquals(17.1f, p.width, 0.001f);
-            assertEquals(7.7f, p.height, 0.001f);
-            assertEquals("testFindAndDeleteReturnsObjects#70071", p.description);
-            assertEquals(70077, p1);
-            assertEquals(77.0f, p.length, 0.001f);
-            assertEquals(17.7f, p.width, 0.001f);
-            assertEquals(7.7f, p.height, 0.001f);
-            assertEquals("testFindAndDeleteReturnsObjects#70077", p.description);
+            assertEquals(70071, p0.id);
+            assertEquals(17.0f, p0.length, 0.001f);
+            assertEquals(17.1f, p0.width, 0.001f);
+            assertEquals(7.7f, p0.height, 0.001f);
+            assertEquals("testFindAndDeleteReturnsObjects#70071", p0.description);
+            assertEquals(70077, p1.id);
+            assertEquals(77.0f, p1.length, 0.001f);
+            assertEquals(17.7f, p1.width, 0.001f);
+            assertEquals(7.7f, p1.height, 0.001f);
+            assertEquals("testFindAndDeleteReturnsObjects#70077", p1.description);
         }
         assertEquals("Found " + p0.id + "; expected one of " + remaining, true, remaining.remove(p0.id));
         assertEquals("Found " + p1.id + "; expected one of " + remaining, true, remaining.remove(p1.id));


### PR DESCRIPTION
Fixes some asserts in testFindAndDeleteReturnsObjects and skips on Db2 due to an issue in EclipseLink and/or Db2.
Part of #28181