### PR TITLE
Prevent unnecessary FFDC when server stops

### DIFF
--- a/dev/com.ibm.tx.jta/src/com/ibm/tx/jta/impl/RecoveryManager.java
+++ b/dev/com.ibm.tx.jta/src/com/ibm/tx/jta/impl/RecoveryManager.java
@@ -1309,7 +1309,7 @@ public class RecoveryManager implements Runnable {
                 if (tc.isEventEnabled())
                     Tr.event(tc, "completed wait for replay completion");
             } catch (InterruptedException exc) {
-                if (localRecovery)
+                if (localRecovery && !FrameworkState.isStopping())
                     FFDCFilter.processException(exc, "com.ibm.tx.jta.impl.RecoveryManager.waitForReplayCompletion", "1242", this);
                 if (tc.isEventEnabled())
                     Tr.event(tc, "Wait for resync complete interrupted.");

--- a/dev/com.ibm.tx.jta/src/com/ibm/tx/jta/impl/TxRecoveryAgentImpl.java
+++ b/dev/com.ibm.tx.jta/src/com/ibm/tx/jta/impl/TxRecoveryAgentImpl.java
@@ -1106,12 +1106,8 @@ public class TxRecoveryAgentImpl implements RecoveryAgent {
 
         // The optional SQL Peer Lock parameters
         int peerLockTimeBeforeStale = cp.getPeerTimeBeforeStale();
-        if (tc.isEntryEnabled())
-            Tr.debug(tc, "peerLockTimeBeforeStale - ", peerLockTimeBeforeStale);
         heartbeatLog.setTimeBeforeLogStale(peerLockTimeBeforeStale);
         int timeBetweenHeartbeats = cp.getTimeBetweenHeartbeats();
-        if (tc.isEntryEnabled())
-            Tr.debug(tc, "timeBetweenHeartbeats - ", timeBetweenHeartbeats);
         heartbeatLog.setTimeBetweenHeartbeats(timeBetweenHeartbeats);
         if (tc.isEntryEnabled())
             Tr.exit(tc, "configureSQLPeerLockParameters");
@@ -1129,12 +1125,8 @@ public class TxRecoveryAgentImpl implements RecoveryAgent {
 
         // The optional SQL HADB Retry parameters
         int logRetryInterval = cp.getLogRetryInterval();
-        if (tc.isEntryEnabled())
-            Tr.debug(tc, "logRetryInterval - ", logRetryInterval);
         heartbeatLog.setLogRetryInterval(logRetryInterval);
         int logRetryLimit = cp.getLogRetryLimit();
-        if (tc.isEntryEnabled())
-            Tr.debug(tc, "logRetryLimit - ", logRetryLimit);
         heartbeatLog.setLogRetryLimit(logRetryLimit);
         if (tc.isEntryEnabled())
             Tr.exit(tc, "configureSQLHADBRetryParameters");
@@ -1152,12 +1144,8 @@ public class TxRecoveryAgentImpl implements RecoveryAgent {
 
         // The optional SQL HADB Retry parameters
         int lightweightLogRetryInterval = cp.getLightweightLogRetryInterval();
-        if (tc.isEntryEnabled())
-            Tr.debug(tc, "lightweightLogRetryInterval - ", lightweightLogRetryInterval);
         heartbeatLog.setLightweightLogRetryInterval(lightweightLogRetryInterval);
         int lightweightLogRetryLimit = cp.getLightweightLogRetryLimit();
-        if (tc.isEntryEnabled())
-            Tr.debug(tc, "lightweightLogRetryLimit - ", lightweightLogRetryLimit);
         heartbeatLog.setLightweightLogRetryLimit(lightweightLogRetryLimit);
         if (tc.isEntryEnabled())
             Tr.exit(tc, "configureSQLHADBLightweightRetryParameters");

--- a/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/RecoveryDirectorImpl.java
+++ b/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/RecoveryDirectorImpl.java
@@ -21,6 +21,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.wsspi.kernel.service.utils.FrameworkState;
 
 //------------------------------------------------------------------------------
 //Class: RecoveryDirectorImpl
@@ -516,6 +517,12 @@ public class RecoveryDirectorImpl implements RecoveryDirector {
     public void directInitialization(FailureScope failureScope) throws RecoveryFailedException, PeerLostLogOwnershipException, LogsUnderlyingTablesMissingException {
         if (tc.isEntryEnabled())
             Tr.entry(tc, "directInitialization", new Object[] { failureScope, this });
+
+        if (FrameworkState.isStopping()) {
+            if (tc.isEntryEnabled())
+                Tr.exit(tc, "directInitialization", "Server is stopping");
+            return;
+        }
 
         // Use configuration to determine if recovery is local (for z/OS).
         final FailureScope currentFailureScope = Configuration.localFailureScope(); /* @LI1578-22A */


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.jta_fat,com.ibm.ws.transaction.cloud_fat.base,com.ibm.ws.transaction.cloud_fat.db2.0,com.ibm.ws.transaction.cloud_fat.db2.1,com.ibm.ws.transaction.cloud_fat.db2.2,com.ibm.ws.transaction.cloud_fat.derby.0,com.ibm.ws.transaction.cloud_fat.derby.1,com.ibm.ws.transaction.cloud_fat.derby.2,com.ibm.ws.transaction.cloud_fat.dualFS,com.ibm.ws.transaction.cloud_fat.oracle.0,com.ibm.ws.transaction.cloud_fat.oracle.1,com.ibm.ws.transaction.cloud_fat.oracle.2,com.ibm.ws.transaction.cloud_fat.peerlocking.1,com.ibm.ws.transaction.cloud_fat.peerlocking.2,com.ibm.ws.transaction.cloud_fat.postgresql.0,com.ibm.ws.transaction.cloud_fat.postgresql.1,com.ibm.ws.transaction.cloud_fat.postgresql.2,com.ibm.ws.transaction.cloud_fat.simpleFS,com.ibm.ws.transaction.cloud_fat.sqlserver.0,com.ibm.ws.transaction.cloud_fat.sqlserver.1,com.ibm.ws.transaction.cloud_fat.sqlserver.2,com.ibm.ws.transaction.core_fat.base,com.ibm.ws.transaction.core_fat.baseDB,com.ibm.ws.transaction.core_fat.cdi,com.ibm.ws.transaction.core_fat.commitPriority,com.ibm.ws.transaction.core_fat.heuristics,com.ibm.ws.transaction.core_fat.heuristicsDB,com.ibm.ws.transaction.core_fat.misc,com.ibm.ws.transaction.core_fat.startMultiEJB,com.ibm.ws.transaction.core_fat.startup,com.ibm.ws.transaction.core_fat.xa,com.ibm.ws.transaction.core_fat.xaDB,com.ibm.ws.transaction.db_fat,com.ibm.ws.transaction.hadb_fat.db2.1,com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.db2.retriablecodes,com.ibm.ws.transaction.hadb_fat.derby.1,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.derby.retriablecodes,com.ibm.ws.transaction.hadb_fat.oracle.1,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.oracle.retriablecodes,com.ibm.ws.transaction.hadb_fat.postgresql.1,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.postgresql.retriablecodes,com.ibm.ws.transaction.hadb_fat.sqlserver.1,com.ibm.ws.transaction.hadb_fat.sqlserver.2,com.ibm.ws.transaction.hadb_fat.sqlserver.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes,com.ibm.ws.transaction.recovery_fat.1,com.ibm.ws.transaction.recovery_fat.2,com.ibm.ws.transaction.recovery_fat.3,com.ibm.ws.tx.jta_fat,com.ibm.ws.tx.jta_fat_hibernate,com.ibm.ws.wsat.common_fat,com.ibm.ws.wsat.concurrent_fat,com.ibm.ws.wsat.migration_fat.1,com.ibm.ws.wsat.migration_fat.2,com.ibm.ws.wsat.migration_fat.3,com.ibm.ws.wsat.migration_fat.4,com.ibm.ws.wsat.migration_fat.5,com.ibm.ws.wsat.migration_fat.6,com.ibm.ws.wsat.migration_fat.7,com.ibm.ws.wsat.recovery_fat.lps,com.ibm.ws.wsat.recovery_fat.multi.1,com.ibm.ws.wsat.recovery_fat.multi.2,com.ibm.ws.wsat.recovery_fat.multi.3,com.ibm.ws.wsat.recovery_fat.multi.4,com.ibm.ws.wsat.recovery_fat.multi.5,com.ibm.ws.wsat.recovery_fat.multi.6,com.ibm.ws.wsat.recovery_fat.multi.7,com.ibm.ws.wsat.recovery_fat.single.1,com.ibm.ws.wsat.recovery_fat.single.2,com.ibm.ws.wsat_fat.assertion,com.ibm.ws.wsat_fat.db,com.ibm.ws.wsat_fat.db_optional,com.ibm.ws.wsat_fat.dbs,com.ibm.ws.wsat_fat.dbs_optional,com.ibm.ws.wsat_fat.multi,com.ibm.ws.wsat_fat.multi.misroute,com.ibm.ws.wsat_fat.ssl.misroute,com.ibm.ws.wsat_fat.ssl,io.openliberty.checkpoint_fat_transaction