### PR TITLE
Infinite loop scenario in DatabaseStoreService

### DIFF
--- a/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseStoreService.java
+++ b/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseStoreService.java
@@ -174,12 +174,13 @@ public class DatabaseStoreService implements SessionStoreService {
         // The approach of blocking is aligned CacheStoreService with MAX_WAIT
         final long MAX_WAIT = TimeUnit.SECONDS.toNanos(20);
         for (long start = System.nanoTime(); !isCompletedPassivation() && System.nanoTime() - start < MAX_WAIT;)
+        {    
             try {
                 TimeUnit.MILLISECONDS.sleep(100); // sleep 1/10th of a second
             } catch (InterruptedException e) {
                 FFDCFilter.processException(e, this.getClass().getName(), "180");
             }
-        
+        }
         serializationServiceRef.deactivate(context);
         
     }

--- a/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseStoreService.java
+++ b/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseStoreService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseStoreService.java
+++ b/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseStoreService.java
@@ -173,7 +173,7 @@ public class DatabaseStoreService implements SessionStoreService {
         // Block the progress of deactivate so that session manager is able to access the DB until it finishes stopping applications.
         // The approach of blocking is aligned CacheStoreService with MAX_WAIT
         final long MAX_WAIT = TimeUnit.SECONDS.toNanos(20);
-        for (long start = System.nanoTime(); !completedPassivation && System.nanoTime() - start < MAX_WAIT;)
+        for (long start = System.nanoTime(); !isCompletedPassivation() && System.nanoTime() - start < MAX_WAIT;)
             try {
                 TimeUnit.MILLISECONDS.sleep(100); // sleep 1/10th of a second
             } catch (InterruptedException e) {


### PR DESCRIPTION
For database session when application thread stopped unexpectedly without setting the isCompletedPassivation() == true in DatabaseStoreService, the deactivate method below will goes into infinite loop and often gives Java coredumps.

            while (!isCompletedPassivation()){
                try {
                    Thread.sleep(100L); // sleep 1/10th of a second
                } catch (InterruptedException e) {
                    FFDCFilter.processException(e, this.getClass().getName(), "180");
                } finally {
                    serializationServiceRef.deactivate(context);
                }
            }