### PR TITLE
use ApplicationScoped for repository bean

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -247,8 +247,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
      * Invoked when the bean for the repository is disposed.
      */
     public void beanDisposed() {
-        // TODO re-enable when using a single bean for the repository rather than sharing the repository across multiple beans
-        // isDisposed.set(true);
+        isDisposed.set(true);
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2023 IBM Corporation and others.
+ * Copyright (c) 2022,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,12 +14,12 @@ package io.openliberty.data.internal.persistence.cdi;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -28,8 +28,12 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import io.openliberty.data.internal.persistence.EntityManagerBuilder;
 import io.openliberty.data.internal.persistence.QueryInfo;
 import io.openliberty.data.internal.persistence.RepositoryImpl;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanAttributes;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.inject.spi.InterceptionFactory;
@@ -43,78 +47,38 @@ import jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator;
  *
  * @param <R> repository interface.
  */
-public class RepositoryProducer<R, P> implements Producer<R> {
+public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, BeanAttributes<R> {
     private final static TraceComponent tc = Tr.register(RepositoryProducer.class);
 
-    /**
-     * Factory class for repository producers.
-     */
-    @Trivial
-    static class Factory<P> implements ProducerFactory<P> {
-        private final BeanManager beanMgr;
-        private final EntityManagerBuilder entityManagerBuilder;
-        private final DataExtension extension;
-        private RepositoryImpl<?> handler;
-        private final ReentrantReadWriteLock handlerLock = new ReentrantReadWriteLock();
-        private final Class<?> primaryEntityClass;
-        private final DataExtensionProvider provider;
-        private final Map<Class<?>, List<QueryInfo>> queriesPerEntityClass;
-        private final Class<?> repositoryInterface;
+    private static final Set<Annotation> QUALIFIERS = Set.of(Any.Literal.INSTANCE, Default.Literal.INSTANCE);
 
-        Factory(Class<?> repositoryInterface, BeanManager beanMgr, DataExtensionProvider provider, DataExtension extension,
-                EntityManagerBuilder entityManagerBuilder, Class<?> primaryEntityClass, Map<Class<?>, List<QueryInfo>> queriesPerEntityClass) {
-            this.beanMgr = beanMgr;
-            this.entityManagerBuilder = entityManagerBuilder;
-            this.extension = extension;
-            this.primaryEntityClass = primaryEntityClass;
-            this.provider = provider;
-            this.queriesPerEntityClass = queriesPerEntityClass;
-            this.repositoryInterface = repositoryInterface;
-        }
+    private final BeanManager beanMgr;
+    private final Set<Type> beanTypes;
+    private final EntityManagerBuilder entityManagerBuilder;
+    private final DataExtension extension;
+    private final Map<R, R> intercepted = new ConcurrentHashMap<>();
+    private final Class<?> primaryEntityClass;
+    private final DataExtensionProvider provider;
+    private final Map<Class<?>, List<QueryInfo>> queriesPerEntityClass;
+    private final Class<?> repositoryInterface;
 
-        @Override
-        public <R> Producer<R> createProducer(Bean<R> bean) {
-            return new RepositoryProducer<>(bean, this);
-        }
-
-        /**
-         * Lazily initialize the repository implementation.
-         * TODO This could be moved to produce if we use CDI to guarantee only a single instance is produced.
-         *
-         * @return repository implementation.
-         */
-        private RepositoryImpl<?> getHandler() {
-            handlerLock.readLock().lock();
-            try {
-                if (handler == null)
-                    try {
-                        // Switch to write lock for lazy initialization
-                        handlerLock.readLock().unlock();
-                        handlerLock.writeLock().lock();
-
-                        if (handler == null)
-                            handler = new RepositoryImpl<>(provider, extension, entityManagerBuilder, //
-                                            repositoryInterface, primaryEntityClass, queriesPerEntityClass);
-                    } finally {
-                        // Downgrade to read lock for rest of method
-                        handlerLock.readLock().lock();
-                        handlerLock.writeLock().unlock();
-                    }
-
-                return handler;
-            } finally {
-                handlerLock.readLock().unlock();
-            }
-        }
+    RepositoryProducer(Class<?> repositoryInterface, BeanManager beanMgr, DataExtensionProvider provider, DataExtension extension,
+                       EntityManagerBuilder entityManagerBuilder, Class<?> primaryEntityClass, Map<Class<?>, List<QueryInfo>> queriesPerEntityClass) {
+        this.beanMgr = beanMgr;
+        this.beanTypes = Set.of(repositoryInterface);
+        this.entityManagerBuilder = entityManagerBuilder;
+        this.extension = extension;
+        this.primaryEntityClass = primaryEntityClass;
+        this.provider = provider;
+        this.queriesPerEntityClass = queriesPerEntityClass;
+        this.repositoryInterface = repositoryInterface;
     }
 
-    private final Bean<R> bean;
-    private final Factory<P> factory;
-    private final Map<R, R> intercepted = new ConcurrentHashMap<>();
-
-    public RepositoryProducer(Bean<R> bean, Factory<P> factory) {
-        this.bean = bean;
-        this.factory = factory;
+    @Override
+    @SuppressWarnings("unchecked")
+    @Trivial
+    public <T> Producer<T> createProducer(Bean<T> bean) {
+        return (Producer<T>) this;
     }
 
     @Override
@@ -135,20 +99,56 @@ public class RepositoryProducer<R, P> implements Producer<R> {
 
     @Override
     @Trivial
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    @Trivial
+    public Set<Annotation> getQualifiers() {
+        return QUALIFIERS;
+    }
+
+    @Override
+    @Trivial
+    public Class<? extends Annotation> getScope() {
+        return ApplicationScoped.class;
+    }
+
+    @Override
+    @Trivial
+    public Set<Class<? extends Annotation>> getStereotypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    @Trivial
+    public Set<Type> getTypes() {
+        return beanTypes;
+    }
+
+    @Override
+    @Trivial
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    @Trivial
     public R produce(CreationalContext<R> cc) {
         @SuppressWarnings("unchecked")
-        Class<R> repositoryInterface = (Class<R>) bean.getBeanClass();
+        Class<R> repositoryInterface = (Class<R>) this.repositoryInterface;
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "produce", cc, repositoryInterface.getName());
 
-        InterceptionFactory<R> interception = factory.beanMgr.createInterceptionFactory(cc, repositoryInterface);
+        InterceptionFactory<R> interception = beanMgr.createInterceptionFactory(cc, repositoryInterface);
 
         boolean intercept = false;
         AnnotatedTypeConfigurator<R> configurator = interception.configure();
         for (Annotation anno : configurator.getAnnotated().getAnnotations())
-            if (factory.beanMgr.isInterceptorBinding(anno.annotationType())) {
+            if (beanMgr.isInterceptorBinding(anno.annotationType())) {
                 intercept = true;
                 configurator.add(anno);
                 if (trace && tc.isDebugEnabled())
@@ -156,16 +156,19 @@ public class RepositoryProducer<R, P> implements Producer<R> {
             }
         for (AnnotatedMethodConfigurator<? super R> method : configurator.methods())
             for (Annotation anno : method.getAnnotated().getAnnotations())
-                if (factory.beanMgr.isInterceptorBinding(anno.annotationType())) {
+                if (beanMgr.isInterceptorBinding(anno.annotationType())) {
                     intercept = true;
                     method.add(anno);
                     if (trace && tc.isDebugEnabled())
                         Tr.debug(this, tc, "add " + anno + " for " + method.getAnnotated().getJavaMember());
                 }
 
+        RepositoryImpl<?> handler = new RepositoryImpl<>(provider, extension, entityManagerBuilder, //
+                        repositoryInterface, primaryEntityClass, queriesPerEntityClass);
+
         R instance = repositoryInterface.cast(Proxy.newProxyInstance(repositoryInterface.getClassLoader(),
                                                                      new Class<?>[] { repositoryInterface },
-                                                                     factory.getHandler()));
+                                                                     handler));
 
         if (intercept) {
             R r = interception.createInterceptedInstance(instance);


### PR DESCRIPTION
Use ApplicationScoped for the repository bean so that a single instance is created, allowing us to get rid of some locking/coordination.  This also removes some unnecessary code, such as a doPrivileged which is not needed for EE 11 features and consolidates some other code.