### PR TITLE
Upload tck user documentation concurrency 3.1

### DIFF
--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/README.md
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/README.md
@@ -1,7 +1,7 @@
 # Jakarta Concurrency TCK Open Liberty Implementation
 
 This project runs the Jakarta Concurrency Technology Compatibility Kit (TCK) on Open Liberty.
-Before running this project it is recommended to read the documentation located in the base [TCK project](https://github.com/eclipse-ee4j/concurrency-api/blob/master/tck/README.md)
+Before running this project it is recommended to read the documentation located in the base [TCK project](https://github.com/jakartaee/concurrency/blob/3.0.3/tck/README.md)
 
 ## Overview
 

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/README.md
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/README.md
@@ -198,7 +198,7 @@ For more detailed instructions on building Open Liberty please see the [Building
 Finally, you can run the TCK using the `buildandrun` gradle task
 
 ```sh
-./gradlew io.openliberty.jakarta.concurrency.3.0_fat_tck:buildandrun
+./gradlew io.openliberty.jakarta.concurrency.3.1_fat_tck:buildandrun
 ```
 
 NOTE: Running the TCK using this method will use a published TCK version, and not the `SNAPSHOT` version from a local build. 

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/README.md
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/README.md
@@ -1,7 +1,7 @@
 # Jakarta Concurrency TCK Open Liberty Implementation
 
 This project runs the Jakarta Concurrency Technology Compatibility Kit (TCK) on Open Liberty.
-Before running this project it is recommended to read the documentation located in the base [TCK project](https://github.com/eclipse-ee4j/concurrency-api/blob/master/tck/README.md)
+Before running this project it is recommended to read the documentation located in the base [TCK project](https://github.com/jakartaee/concurrency/blob/main/tck/README.md)
 
 ## Overview
 

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/README.md
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/README.md
@@ -1,0 +1,212 @@
+# Jakarta Concurrency TCK Open Liberty Implementation
+
+This project runs the Jakarta Concurrency Technology Compatibility Kit (TCK) on Open Liberty.
+Before running this project it is recommended to read the documentation located in the base [TCK project](https://github.com/eclipse-ee4j/concurrency-api/blob/master/tck/README.md)
+
+## Overview
+
+In order to aid in the development of the `concurrent-3.1` feature, this project is configured specifically to allow
+the feature developers to run the TCK against a development image of Open Liberty.
+
+## Choose a test strategy
+
+This project has been constructed to support two different test strategies.
+
+1. Running the TCK for Verification
+   1. This strategy is for those who want to run the TCK to verify compatibility, but do not need to run against a development environment.
+2. Running the TCK for Developers
+   1. This strategy is for those who are familiar with the Open Liberty project and are helping to develop the `concurrent-3.1` feature.
+
+Many of the assets in this project are used in different ways based on the strategy being used. 
+Therefore, each strategy below has a `Background` section to explain how the different assets interact and end up depending on the strategy.
+
+## Requirements
+
+- JDK 17 or higher
+- [Maven 3.8.0 or higher](https://maven.apache.org/download.cgi)
+
+## Getting started
+
+### Building Jakarta Concurrency
+
+If you want to test against the latest API and TCK versions the first step will be to clone and build the Jakarta Concurrency project.
+
+```sh
+git clone git@github.com:jakartaee/concurrency.git
+cd concurrency
+mvn clean install
+```
+
+The API and TCK libraries will be tagged with the `3.1.0` version. Keep this in mind if you plan to follow the [Running the TCK for Verification](#Running-the-TCK-for-Verification) section. 
+
+### Getting Open Liberty
+
+You will first need to clone the Open Liberty project:
+
+```sh
+git clone git@github.com:OpenLiberty/open-liberty.git
+cd open-liberty/dev
+```
+
+## Running the TCK for Verification
+
+### Background
+
+1. `build.gradle` 
+   1. This project is set up using gradle.
+   2. The `build.gradle` file has tasks to set up a `wlp` directory with an Open Liberty install.
+   3. There are additional tasks that will copy dependencies, configurations, and create a server.
+2. `publish/servers`
+   1. This is where the server configuration files are located.
+   2. These files will be copied to `wlp/usr/servers/ConcurrentTCKServer` at build time.
+   3. A special `logging.properties` file is also here to ensure that the TCK logs are formatted and saved to a specific location.
+3. `publish/tckRunner`
+   1. This is a maven project that will actually run the TCK. 
+   2. This project contains the TCK configuration files that will be copied to the `wlp` directory at build time.
+   3. This includes the pom.xml that is used to get the TCK itself, and the dependencies to run the TCK. 
+   4. This is also where the TestNG and Arquillian configuration files are located.
+4. `fat/src`
+   1. This asset is ignored for this test strategy.
+
+### Project set up
+
+First, check out the release branch: 
+
+```sh
+git checkout release
+git pull
+```
+
+To make things simpler this project contains custom gradle tasks for setting up a standalone Liberty Profile.
+
+First open `build.gradle`. 
+You need to complete the `TODO` under dependencies.
+Provide a WebSphere Liberty Profile (WLP) dependency that corresponds to the release you want to test against.
+
+Then, run the `buildWLP` task
+
+```sh
+./gradlew io.openliberty.jakarta.concurrency.3.1_fat_tck:buildWLP -Djakarta.tck.platform=web
+```
+
+To run in full mode use `-Djakarta.tck.platform=full`
+
+This will create a `wlp` directory within this project.
+Navigate to this directory and start your server:
+
+```sh
+cd io.openliberty.jakarta.concurrency.3.1_fat_tck/wlp
+
+./bin/server start ConcurrentTCKServer \
+-Denv.tck_port=9080 \
+-Denv.tck_port_secure=9443 \
+-Djimage.dir=$PWD/usr/shared/jimage/output
+```
+### Run the TCK
+
+Now you can run the TCK tests. 
+
+```sh
+mvn clean test -B \
+-Dwlp=$PWD \
+-Dtck_server=ConcurrentTCKServer \
+-Dtck_failSafeUndeployment=true \
+-Dtck_appDeployTimeout=180 \
+-Dtck_appUndeployTimeout=60 \
+-Dtck_port=9080 \
+-Djakarta.tck.platform=web \
+-Dsun.rmi.transport.tcp.responseTimeout=60000 \
+-Djava.util.logging.config.file=$PWD/logging.properties
+```
+
+To run in full mode use `-Djakarta.tck.platform=full`
+
+By default the TCK will run against a staged version of Jakarta API and TCK uploaded to sonatype.
+If you want to test against a local `3.1.0-SNAPSHOT` then set these properties on the command above: 
+
+```txt
+-Djakarta.concurrent.tck.groupid=jakarta.enterprise.concurrent \
+-Djakarta.concurrent.tck.version=3.1.0-SNAPSHOT
+```
+
+Finally, remember to stop the running server
+
+```sh
+./bin/server stop ConcurrentTCKServer
+```
+
+### View the results
+
+The test results will be located under the following directory:
+
+```txt
+/wlp/tck/target/surefire/surefire-reports
+```
+
+## Running the TCK for Developers
+
+### Background
+
+1. `build.gradle` 
+   1. This project is built and run using gradle.
+   2. The parent gradle project has a `fat.gradle` file that controls this project's build and runtime lifecycle.
+   3. The build.gradle file in this project has specific tasks to pull and copy dependencies needed by the server at runtime. 
+2. `publish/servers`
+   1. This is where the server configuration files are located.
+   2. These files will be copied to `build/libs/autoFVT` and later deployed to the `wlp` directory at runtime.
+   3. A special `logging.properties` file is also here to ensure that the TCK logs are formatted and saved to a specific location.
+3. `publish/tckRunner`
+   1. This is a maven sub-project that will actually run the TCK. 
+   2. This sub-project contains the TCK configuration files that will be copied to the `build/libs/autoFVT` directory at build time.
+   3. This includes the pom.xml that is used to get the TCK itself, and the dependencies to run the TCK. 
+   4. This is also where the TestNG and Arquillian configuration files are located.
+4. `fat/src`
+   1. At runtime we use JUnit to run a proxy test.
+   2. This test will start the Open Liberty development server.
+   3. Then, this test will then run the `mvn clean test` target on the `tckRunner` sub-project.
+
+### Project set up
+
+Option 1) If you are working on new functionality and want to run the TCK against the latest version of 
+Open Liberty then you will want to check the release (default) branch:
+
+```sh
+git checkout release
+git pull
+```
+
+Option 2) If you want to run the TCK against a specific release of Open Liberty to check compatibility, 
+then you will want to check out the corresponding release branch:
+
+```sh
+git fetch --all --tags
+git checkout <your-release-branch>
+```
+
+You will need to build a development image of Open Liberty to test against based on the 
+branch checked out above:
+
+```sh
+./gradlew cnf:initialize
+./gradlew assemble :com.ibm.websphere.appserver.features:releaseNeeded
+```
+
+For more detailed instructions on building Open Liberty please see the [Building Open Liberty Wiki](https://github.com/OpenLiberty/open-liberty/wiki/Building-Open-Liberty)
+
+### Run the TCK
+
+Finally, you can run the TCK using the `buildandrun` gradle task
+
+```sh
+./gradlew io.openliberty.jakarta.concurrency.3.0_fat_tck:buildandrun
+```
+
+NOTE: Running the TCK using this method will use a published TCK version, and not the `SNAPSHOT` version from a local build. 
+
+### View the results
+
+The test results will be located under the following directory:
+
+```txt
+build/libs/autoFVT/results/junit
+```

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/bnd.bnd
@@ -23,4 +23,4 @@ src: \
 
 fat.project: true
 
-tested.features: appsecurity-6.0, cdi-4.1, concurrent-3.1, pages-4.0
+tested.features: appsecurity-6.0, cdi-4.1, concurrent-3.1, pages-4.0, connectors-2.1, noship-1.0

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/build.gradle
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,4 +11,72 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+configurations { 
+  arquillian
+  wlp
+}
+
+dependencies {
+  arquillian 'io.openliberty.arquillian:arquillian-liberty-support-jakarta:2.1.1'
+
+  //TODO Configure WLP dependency if doing verification testing, Example below:
+  //wlp 'io.openliberty.beta:openliberty-runtime:24.0.0.5-beta@zip'
+}
+
 addRequiredLibraries.dependsOn addDerby
+
+// These tasks are used only for external users who do not want to build all of liberty to run TCK
+
+ext {
+	fromServer = System.getProperty("jakarta.tck.platform", "web") == "web" ? "ConcurrentTCKWebServer" : "ConcurrentTCKFullServer"
+}
+
+task getWLP(type: Copy) {
+  from configurations.wlp.collect{zipTree (it)}
+  into project.projectDir
+}
+
+task copyArquillianFeatureWLP(type: Copy) {
+  mustRunAfter getWLP
+  from configurations.arquillian
+  into new File(project.projectDir, 'wlp/usr/extension/')
+}
+
+task createServer(type: Exec) {
+  mustRunAfter getWLP
+  workingDir project.projectDir
+  commandLine './wlp/bin/server', 'create', 'ConcurrentTCKServer'
+}
+
+
+task copyDerbyWLP(type: Copy) {
+  mustRunAfter createServer
+  from configurations.derby
+  into new File(project.projectDir, 'wlp/usr/shared/resources/derby/')
+  rename 'derby-.*.jar', 'derby.jar'
+}
+
+task copyConfigWLP(type: Copy) {
+  mustRunAfter createServer  
+  from new File(project.projectDir, "publish/servers/${project.ext.fromServer}")
+  into new File(project.projectDir, 'wlp/usr/servers/ConcurrentTCKServer/')
+  exclude '**/bootstrap.properties' //Specific to Open Liberty test infrastructure
+  exclude 'configDropins/*'         //Specific to Open Liberty test infrastructure
+}
+
+task copyRunnerWLP(type: Copy) {
+  mustRunAfter createServer
+  from new File(project.projectDir, 'publish/tckRunner/')
+  into new File(project.projectDir, 'wlp/')
+  exclude 'tck/pom.xml' //remove the pom we use for dev testing
+  rename 'standalone.pom.xml', 'pom.xml' //replace with the standalone pom
+}
+
+task buildWLP {
+  dependsOn 'getWLP'
+  dependsOn 'copyArquillianFeatureWLP'
+  dependsOn 'createServer'
+  dependsOn 'copyDerbyWLP'
+  dependsOn 'copyConfigWLP'
+  dependsOn 'copyRunnerWLP'
+}

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/build.gradle
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/build.gradle
@@ -11,6 +11,24 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+// Custom repository for Open Liberty version used for certification
+repositories {
+  ivy {
+    url 'https://public.dhe.ibm.com/ibmdl/export/pub/software/'
+    
+    //https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/tck/2024-04-23_2000/openliberty-24.0.0.6-beta-cl240520240423-2000.zip'
+    
+    patternLayout {
+      artifact '/[organization]/[module]/tck/2024-04-23_2000/[revision].[ext]'
+    }
+    
+    metadataSources {
+      ivyDescriptor()
+      artifact()
+    } 
+  }
+}
+
 configurations { 
   arquillian
   wlp
@@ -19,8 +37,9 @@ configurations {
 dependencies {
   arquillian 'io.openliberty.arquillian:arquillian-liberty-support-jakarta:2.1.1'
 
-  //TODO Configure WLP dependency if doing verification testing, Example below:
-  //wlp 'io.openliberty.beta:openliberty-runtime:24.0.0.5-beta@zip'
+  //TODO Configure WLP dependency if doing verification testing, Examples below:
+  //wlp 'openliberty:runtime:openliberty-24.0.0.6-beta-cl240520240423-2000@zip' // certification version
+  //wlp 'io.openliberty.beta:openliberty-runtime:24.0.0.6-beta@zip'             // future versions
 }
 
 addRequiredLibraries.dependsOn addDerby
@@ -28,7 +47,7 @@ addRequiredLibraries.dependsOn addDerby
 // These tasks are used only for external users who do not want to build all of liberty to run TCK
 
 ext {
-	fromServer = System.getProperty("jakarta.tck.platform", "web") == "web" ? "ConcurrentTCKWebServer" : "ConcurrentTCKFullServer"
+    fromServer = System.getProperty("jakarta.tck.platform", "web") == "web" ? "ConcurrentTCKWebServer" : "ConcurrentTCKFullServer"
 }
 
 task getWLP(type: Copy) {

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/servers/ConcurrentTCKFullServer/server.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/servers/ConcurrentTCKFullServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022, 2023 IBM Corporation and others.
+    Copyright (c) 2022, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -12,15 +12,12 @@
  -->
 <server>
     <featureManager>
-        <!-- Features being tested -->
-        <feature>jakartaee-11.0</feature>
-		
-        <!-- Minimum features required 
+
         <feature>concurrent-3.1</feature>
         <feature>enterpriseBeans-4.0</feature>
+        <feature>jdbc-4.3</feature>
         <feature>appSecurity-6.0</feature>
         <feature>pages-4.0</feature>
-        -->
 		 
         <!-- Features needed for arquillan support -->
         <feature>localConnector-1.0</feature>

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/servers/ConcurrentTCKWebServer/server.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/servers/ConcurrentTCKWebServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022, 2023 IBM Corporation and others.
+    Copyright (c) 2022, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -12,16 +12,12 @@
  -->
 <server>
     <featureManager>
-        <!-- Features being tested -->
-        <feature>webProfile-11.0</feature>
-        
-        <!-- Minimum features required 
+
         <feature>concurrent-3.1</feature>
         <feature>enterpriseBeansLite-4.0</feature>
         <feature>jdbc-4.3</feature>
         <feature>appSecurity-6.0</feature>
         <feature>pages-4.0</feature>
-        -->
         
         <!-- Features needed for arquillan support -->
         <feature>localConnector-1.0</feature>

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/standalone.pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/standalone.pom.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+    Copyright (c) 2024 IBM Corporation and others. All rights reserved.
+    This program and the accompanying materials are made available under the 
+    terms of the Eclipse Public License 2.0 which accompanies this distribution, 
+    and is available at 
+        http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0 
+    Contributors: 
+        IBM Corporation - initial API and implementation
+-->
+<!-- NOTE: This pom is used for Standalone Testing -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty.jakarta.enterprise.concurrent</groupId>
+    <artifactId>tck.runner.tck</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Jakarta Concurrency TCK Runner TCK Module</name>
+
+    <properties>
+        <jakarta.concurrent.tck.groupid>jakarta.enterprise.concurrent</jakarta.concurrent.tck.groupid>
+        <jakarta.concurrent.tck.version>3.1.0-SNAPSHOT</jakarta.concurrent.tck.version>
+        <jakarta.concurrent.version>3.1.0</jakarta.concurrent.version>
+        
+        <arquillian.version>1.7.0.Alpha13</arquillian.version>
+        <arquillian.liberty.managed>2.1.3</arquillian.liberty.managed>
+		<junit5.version>5.7.0</junit5.version>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+
+        <!--  the below is used in arquillian.xml -->
+        <wlp>${wlp}</wlp>
+        
+        <targetDirectory>${project.basedir}/target</targetDirectory>
+    </properties>
+
+	<repositories>
+		<!-- For artifacts not yet in Maven Central -->
+		<repository>
+			<id>sonatype-nexus-staging</id>
+			<name>Sonatype Nexus Staging</name>
+			<url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+		<!-- For artifacts not yet in Stagging repo use DHE -->
+		<repository>
+			<name>IBM DHE Maven repository</name>
+			<id>DHE</id>
+			<url>https://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
+		</repository>
+	</repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- TCK Dependency -->
+        <dependency>
+            <groupId>${jakarta.concurrent.tck.groupid}</groupId>
+            <artifactId>jakarta.enterprise.concurrent-tck</artifactId>
+            <version>${jakarta.concurrent.tck.version}</version>
+        </dependency>
+        <!-- API Dependency -->
+        <dependency>
+            <groupId>jakarta.enterprise.concurrent</groupId>
+            <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+            <version>${jakarta.concurrent.version}</version>
+        </dependency>
+        <!-- Other API Dependencies -->
+        <!-- TODO update to Jakarta EE 11 bundles -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+            <version>4.0.1</version>
+        </dependency>
+        <!-- TEST DEPENDENCIES -->
+        <dependency>
+            <groupId>io.openliberty.arquillian</groupId>
+            <artifactId>arquillian-liberty-managed-jakarta-junit5</artifactId>
+            <version>${arquillian.liberty.managed}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.tools</groupId>
+            <artifactId>sigtest-maven-plugin</artifactId>
+            <version>1.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <directory>${targetDirectory}</directory>
+        <defaultGoal>clean test</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <id>build-classpath</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>build-classpath</goal>
+                        </goals>
+                        <configuration>
+                            <!-- configure the plugin here -->
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.0</version> <!-- Any changes to the surefire version must be tested against ZOS -->
+                <configuration>
+                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <dependenciesToScan>
+                        <dependency>${jakarta.concurrent.tck.groupid}:jakarta.enterprise.concurrent-tck</dependency>
+                    </dependenciesToScan>
+                    <systemPropertyVariables>
+                        <wlp>${wlp}</wlp>
+                        <tck_server>${tck_server}</tck_server>
+                        <tck_port>${tck_port}</tck_port>
+                        <sun.rmi.transport.tcp.responseTimeout>${sun.rmi.transport.tcp.responseTimeout}</sun.rmi.transport.tcp.responseTimeout>
+                        <java.util.logging.config.file>${basedir}/../logging.properties</java.util.logging.config.file>
+                    </systemPropertyVariables>
+                    <groups>${jakarta.tck.platform}</groups> <!-- Groups to include i.e. web/full -->
+                    <reportNameSuffix>${jakarta.tck.platform}</reportNameSuffix>
+                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Add instructions to the `io.openliberty.jakarta.concurrency.3.1_fat_tck` to allow external users to verify the concurrency reference implementation.