### PR TITLE
Removing workaround for json4j bundle

### DIFF
--- a/dev/wlp-featureTasks/src/com/ibm/ws/wlp/feature/tasks/FeatureBnd.java
+++ b/dev/wlp-featureTasks/src/com/ibm/ws/wlp/feature/tasks/FeatureBnd.java
@@ -315,9 +315,7 @@ public class FeatureBnd extends Task {
                 Attrs attributes = c.getValue();
                 // check the location attribute and if lib/ needs to be added, add it.
                 addLibFolderIfRequired(attributes);
-                if (!c.getKey().equals("com.ibm.json4j")) {
-                    content.put(c.getKey(), attributes);
-                }
+                content.put(c.getKey(), attributes);
             }
 
             // Now we go through all the entries in Subsystem-Content.


### PR DESCRIPTION
This was required to build successfully as `productInsights` and `usageMetering` (in WL) were still trying to initialise json4j bundle even thought it was changed to startup at kernel. Now that json4j has been removed from both those features this workaround can be removed.