### PR TITLE
JAX-WS: Class name is added to CXF logs

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.bnd
@@ -142,7 +142,8 @@ Export-Package: \
   org.apache.cxf.ws.addressing.wsdl;version=${exportVer}, \
   org.apache.cxf.wsdl.http;version=${exportVer}, \
   com.ibm.ws.cxf.client;version=${exportVer}, \
-  com.ibm.ws.cxf.client.component;version=${exportVer}
+  com.ibm.ws.cxf.client.component;version=${exportVer}, \
+  io.openliberty.cxf.logging;version=${exportVer}
 
 DynamicImport-Package: \
   com.ctc.wstx.*, \
@@ -169,7 +170,8 @@ instrument.classesExcludes: \
   org/apache/cxf/interceptor/*.class, \
   org/apache/cxf/service/model/*.class, \
   org/apache/cxf/staxutils/*.class, \
-  org/apache/cxf/common/logging/*.class
+  org/apache/cxf/common/logging/*.class, \
+  io/openliberty/cxf/logging/*.class
 
 -buildpath: \
   javax.activation:activation;version=1.1, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.bnd
@@ -168,7 +168,8 @@ instrument.classesExcludes: \
   org/apache/cxf/phase/*.class, \
   org/apache/cxf/interceptor/*.class, \
   org/apache/cxf/service/model/*.class, \
-  org/apache/cxf/staxutils/*.class
+  org/apache/cxf/staxutils/*.class, \
+  org/apache/cxf/common/logging/*.class
 
 -buildpath: \
   javax.activation:activation;version=1.1, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/io/openliberty/cxf/logging/CXFLogger.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/io/openliberty/cxf/logging/CXFLogger.java
@@ -10,6 +10,8 @@
 package io.openliberty.cxf.logging;
 
 import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
 import com.ibm.ws.logging.internal.WsLogger;
 
 /**
@@ -29,7 +31,7 @@ public class CXFLogger extends WsLogger {
      */
     public CXFLogger(String name, String resourceBundleName, Class<?> c) {
         super(name, c, resourceBundleName);
-        setClassName(c.getCanonicalName());
+        setClassName(c.getName());
     }
 
     /**
@@ -67,9 +69,7 @@ public class CXFLogger extends WsLogger {
      * @return
      */
     public static CXFLogger getLogger(String loggerName, String bundleName, Class<?> cls) {
-        CXFLogger logger = (CXFLogger) CXFLogger.getLogger(loggerName, bundleName);
-        logger.setClassName(cls.getCanonicalName());
-        return logger;
+        return new CXFLogger(loggerName, bundleName, cls);
     }
 
     /**
@@ -80,4 +80,15 @@ public class CXFLogger extends WsLogger {
     public static CXFLogger getLogger(String loggerName, Class<?> cls) {
         return getLogger(loggerName, null, cls);
     }
+
+    /**
+     * @param logger
+     * @param cls
+     * @return
+     */
+    public static Logger getLogger(Logger logger, Class<?> cls) {
+        return getLogger(logger.getName(), logger.getResourceBundleName(), cls);
+    }
+    
+    
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/io/openliberty/cxf/logging/CXFLogger.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/io/openliberty/cxf/logging/CXFLogger.java
@@ -7,42 +7,38 @@
  * 
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package org.apache.cxf.common.logging;
+package io.openliberty.cxf.logging;
 
-import java.util.logging.Level;
 import java.util.logging.LogRecord;
-
-import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.logging.internal.WsLogger;
 
 /**
- *  CXFLogger is inherited from the WsLogger class to preserve same behavior
- *  except the one that we aimed to change. Which is to add class name to log records
+ * CXFLogger is inherited from the WsLogger class to preserve same behavior
+ * except the one that we aimed to change. Which is to add class name to log records.
+ * The whole design is aimed to support the addition of class name to the logRecord 
+ * in public void log(LogRecord logRecord) method in line logRecord.setSourceClassName(getClassName());
  */
 public class CXFLogger extends WsLogger {
 
-    private String className="";
-    
+    private String className = "";
+
     /**
      * @param name
-     * @param c
      * @param resourceBundleName
+     * @param c
      */
     public CXFLogger(String name, String resourceBundleName, Class<?> c) {
         super(name, c, resourceBundleName);
         setClassName(c.getCanonicalName());
     }
-    
+
     /**
-     * This method is not aimed to use since due to trace injection 
-     * it creates significant amount of excessive logs
-     * this.className will be used instead
      * @return the className
      */
     public String getClassName() {
         return this.className;
     }
- 
+
     /**
      * @param className the className to set
      */
@@ -50,49 +46,23 @@ public class CXFLogger extends WsLogger {
         this.className = clsName;
     }
 
-    @Trivial
+    /*
+     * @see java.util.logging.Logger#log(java.util.logging.LogRecord)
+     */
     @Override
-    public void log(Level level, String msg) {
-        logp(level,this.className,"",msg);
+    public void log(LogRecord logRecord) {
+        if (logRecord == null) {
+            return;
+        }
+        // The whole point this task is to 
+        // add the class name to the logRecord
+        logRecord.setSourceClassName(getClassName());
+        super.log(logRecord);
     }
 
-    @Trivial
-    @Override
-    public void severe(String msg) {
-        logp(Level.SEVERE,this.className,"",msg);
-    }
-
-    @Trivial
-    @Override
-    public void warning(String msg) {
-        logp(Level.WARNING,this.className,"",msg);
-    }
-
-    @Trivial
-    @Override
-    public void info(String msg) {
-        logp(Level.INFO,this.className,"",msg);
-    }
-
-    @Trivial
-    @Override
-    public void fine(String msg) {
-        logp(Level.FINE,this.className,"",msg);
-    }
-
-    @Trivial
-    @Override
-    public void finer(String msg) {
-        logp(Level.FINER,this.className,"",msg);
-    }
-
-    @Trivial
-    @Override
-    public void finest(String msg) {
-        logp(Level.FINEST,this.className,"",msg);
-    }
     /**
-     * @param logger
+     * @param loggerName
+     * @param bundleName
      * @param cls
      * @return
      */
@@ -101,14 +71,13 @@ public class CXFLogger extends WsLogger {
         logger.setClassName(cls.getCanonicalName());
         return logger;
     }
+
     /**
      * @param loggerName
      * @param cls
      * @return
      */
     public static CXFLogger getLogger(String loggerName, Class<?> cls) {
-        CXFLogger logger = (CXFLogger) getLogger(loggerName);
-        logger.setClassName(cls.getCanonicalName());
-        return logger;
+        return getLogger(loggerName, null, cls);
     }
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/logging/CXFLogger.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/logging/CXFLogger.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.apache.cxf.common.logging;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.logging.internal.WsLogger;
+
+/**
+ *  CXFLogger is inherited from the WsLogger class to preserve same behavior
+ *  except the one that we aimed to change. Which is to add class name to log records
+ */
+public class CXFLogger extends WsLogger {
+
+    private String className="";
+    
+    /**
+     * @param name
+     * @param c
+     * @param resourceBundleName
+     */
+    public CXFLogger(String name, String resourceBundleName, Class<?> c) {
+        super(name, c, resourceBundleName);
+        setClassName(c.getCanonicalName());
+    }
+    
+    /**
+     * This method is not aimed to use since due to trace injection 
+     * it creates significant amount of excessive logs
+     * this.className will be used instead
+     * @return the className
+     */
+    public String getClassName() {
+        return this.className;
+    }
+ 
+    /**
+     * @param className the className to set
+     */
+    public void setClassName(String clsName) {
+        this.className = clsName;
+    }
+
+    @Trivial
+    @Override
+    public void log(Level level, String msg) {
+        logp(level,this.className,"",msg);
+    }
+
+    @Trivial
+    @Override
+    public void severe(String msg) {
+        logp(Level.SEVERE,this.className,"",msg);
+    }
+
+    @Trivial
+    @Override
+    public void warning(String msg) {
+        logp(Level.WARNING,this.className,"",msg);
+    }
+
+    @Trivial
+    @Override
+    public void info(String msg) {
+        logp(Level.INFO,this.className,"",msg);
+    }
+
+    @Trivial
+    @Override
+    public void fine(String msg) {
+        logp(Level.FINE,this.className,"",msg);
+    }
+
+    @Trivial
+    @Override
+    public void finer(String msg) {
+        logp(Level.FINER,this.className,"",msg);
+    }
+
+    @Trivial
+    @Override
+    public void finest(String msg) {
+        logp(Level.FINEST,this.className,"",msg);
+    }
+    /**
+     * @param logger
+     * @param cls
+     * @return
+     */
+    public static CXFLogger getLogger(String loggerName, String bundleName, Class<?> cls) {
+        CXFLogger logger = (CXFLogger) CXFLogger.getLogger(loggerName, bundleName);
+        logger.setClassName(cls.getCanonicalName());
+        return logger;
+    }
+    /**
+     * @param loggerName
+     * @param cls
+     * @return
+     */
+    public static CXFLogger getLogger(String loggerName, Class<?> cls) {
+        CXFLogger logger = (CXFLogger) getLogger(loggerName);
+        logger.setClassName(cls.getCanonicalName());
+        return logger;
+    }
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/logging/LogUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/logging/LogUtils.java
@@ -272,9 +272,9 @@ public final class LogUtils {
                 try {
                     b = BundleUtils.getBundle(cls, bundleName);
                 } catch (MissingResourceException rex) {
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {  // Liberty change begin
                         Tr.debug(tc, "Exception occured finding the bundle: " + rex.getMessage());
-                    }
+                    }   // Liberty change end
                 }
             }
             if (b != null) {
@@ -354,12 +354,12 @@ public final class LogUtils {
                         throw ite;
                     }
                 } catch (Exception e) {
-                    if (e.getMessage().equals(CXFLOGGERFAILED)) {
+                    if (e.getMessage().equals(CXFLOGGERFAILED)) { // Liberty change begin
                         // Ignore the exception. Logger will be created with the code below
                         // This is the exception created to skip execution till this point
-                    } else {
+                    } else { // Liberty change end
                         throw new RuntimeException(e);
-                    }
+                    }   // Liberty change 
                 }
             }
 
@@ -642,7 +642,6 @@ public final class LogUtils {
     private static void throwFallBackToOriginalLoggerException() throws Exception       {
         throw new Exception(CXFLOGGERFAILED);
     }
-    // Liberty change end
 
     /**
      * @return the loggerClassbackup
@@ -692,4 +691,5 @@ public final class LogUtils {
     private static Class<?> getLoggerClass() {
         return loggerClass;
     }
+    // Liberty change end
 }


### PR DESCRIPTION
Fixes #28305

For all CXF codes this change overwrite all high level logs (fine, finest etc.) to replace bundle name with source class name where the log is originated. 