### PR TITLE
JAX-WS: Fix LibertyWebServiceClientInInterceptor and add Unit Tests

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
@@ -237,4 +237,4 @@ instrument.classesExcludes: com/ibm/ws/jaxws/internal/resources/*.class
 	com.ibm.ws.kernel.boot;version=latest,\
 	com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2, \
-    com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3;version=latest
+        com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3;version=latest

--- a/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
@@ -229,10 +229,12 @@ instrument.classesExcludes: com/ibm/ws/jaxws/internal/resources/*.class
 	com.ibm.ws.kernel.boot.core;version=latest
 
 -testpath: \
-	org.hamcrest:hamcrest-all;version=1.3, \
-	org.jmock:jmock;strategy=exact;version=2.5.1, \
-	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
-	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-	com.ibm.ws.junit.extensions;version=latest, \
-	com.ibm.ws.kernel.boot;version=latest, \
-	com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest
+	org.hamcrest:hamcrest-all;version='1.3',\
+	org.jmock:jmock;strategy=exact;version='2.5.1',\
+	org.jmock:jmock-junit4;strategy=exact;version='2.5.1',\
+	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
+	com.ibm.ws.junit.extensions;version=latest,\
+	com.ibm.ws.kernel.boot;version=latest,\
+	com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
+	com.ibm.websphere.javaee.jaxws.2.2, \
+    com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3;version=latest

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
@@ -76,7 +76,7 @@ public class LibertyWebServiceClientInInterceptor  extends AbstractPhaseIntercep
             ignoreUnexpectedElements = WebServicesClientConfigHolder.getIgnoreUnexpectedElements(WebServiceConfigConstants.DEFAULT_PROP);
         }
         
-        // If both values are null, then we can just skip the rest of this interceptor and return
+        // If both values are null, then we can just skip the rest of this intercepter and return
         if(enableSchemaValidation == null && ignoreUnexpectedElements == null) {
             if (debug) {
                 Tr.debug(tc, "No webServiceClient configuration found. returning.");
@@ -84,43 +84,29 @@ public class LibertyWebServiceClientInInterceptor  extends AbstractPhaseIntercep
             return;
         }
         
+        
+        // Enable or disable schema validation as long as property is non-null
+        if(enableSchemaValidation != null) {
+            message.put("schema-validation-enabled", (boolean) enableSchemaValidation);
 
-        
-        if (debug) {
-            Tr.debug(tc, "Found webServiceClient configuration - enableSchemaValidation = " + enableSchemaValidation + ", ignoreUnexpectedElements = " + ignoreUnexpectedElements);
-            
-        }
-        
-        // now that we've done pulled the config, we can cast the Objects to proper booleans
-        boolean enableSchemaValidationValue = (boolean) enableSchemaValidation;
-        boolean ignoreUnexpectedElementsValue = (boolean) ignoreUnexpectedElements;
-        
-        // If both values are set like this, these are the default behaviors and we can just no-op return. 
-        if(enableSchemaValidationValue == true && ignoreUnexpectedElementsValue == false) {
-            if (debug) {
-                Tr.debug(tc, "The webServiceClient configuration found matches the default behavior, returning.");
-            }
-            return;
-        }
-        
-        if(enableSchemaValidationValue == false) { // since the existing behavior already sets this with a true value, only change it when value is false
-            // Set the CXF property for enabling schema validation based on the value from our config
-            MessageUtils.getContextualBoolean(message, "schema-validation-enabled", (boolean) enableSchemaValidation);
-            
             if (debug) {
                 Tr.debug(tc, "Set schema-validation-enabled to " + enableSchemaValidation);
                 
             }
         }
-            
-        if(ignoreUnexpectedElementsValue == true) { // existing behavior sets this to true, but since we have to invert to match the property, only set it when our property is true
-            // Set the CXF property for enabling schema validation based on the value from our config
+        
+        // Set ignoreUnexpectedElements as long as property is non-null
+        if(ignoreUnexpectedElements != null) {
+
+            // Existing behavior sets this to true, but we have to invert to match the property, and
+            // set the CXF property for enabling schema validation based on the value from our config
             // TODO implement custom Validation Event Handler to ignore only UnexpectedElementExceptions
-            MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER, !ignoreUnexpectedElementsValue); // Since we are using our internal property to set a CXF property, we must invert the value
+            message.put(JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER, ! (boolean) ignoreUnexpectedElements); // Since we are using our internal property to set a CXF property, we must invert the value
             
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Set JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER to  " + !ignoreUnexpectedElementsValue);
+            if (debug) {
+                Tr.debug(tc, "Set JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER to  " + !(boolean) ignoreUnexpectedElements);
             } 
+            
         }
     }
 

--- a/dev/com.ibm.ws.jaxws.2.3.common/test/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptorTest.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/test/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptorTest.java
@@ -1,0 +1,635 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.client;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import javax.xml.namespace.QName;
+
+
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.binding.BindingFactoryManager;
+import org.apache.cxf.binding.soap.Soap11;
+import org.apache.cxf.binding.soap.SoapBindingFactory;
+import org.apache.cxf.binding.soap.model.SoapBindingInfo;
+import org.apache.cxf.bus.extension.ExtensionManagerBus;
+import org.apache.cxf.bus.managers.BindingFactoryManagerImpl;
+import org.apache.cxf.message.ExchangeImpl;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.message.MessageUtils;
+import org.apache.cxf.service.Service;
+import org.apache.cxf.service.ServiceImpl;
+import org.apache.cxf.service.model.BindingInfo;
+import org.apache.cxf.service.model.BindingOperationInfo;
+import org.apache.cxf.service.model.EndpointInfo;
+import org.apache.cxf.service.model.InterfaceInfo;
+import org.apache.cxf.service.model.ServiceInfo;
+import org.apache.cxf.endpoint.Endpoint;
+import org.apache.cxf.endpoint.EndpointException;
+import org.apache.cxf.endpoint.EndpointImpl;
+import org.apache.cxf.jaxb.JAXBDataBinding;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+
+import com.ibm.ws.jaxws.internal.WebServiceConfigConstants;
+
+import test.common.SharedOutputManager;
+
+/**
+ *      Unit Tests that check the correct behavior of the LibertyWebServiceClientInInterceptor when
+ *      the webServiceClient configuration is set.
+ */
+public class LibertyWebServiceClientInInterceptorTest {
+    
+    // Property that LibertyWebServiceClientInInterceptor uses to set schema validation on the message
+    final String SCHEMA_VALIDATION = "schema-validation-enabled";
+    
+    // serviceName set in "config"
+    final String SERVICE_NAME = "TestService";
+    
+    // Uncomment this Logger if debugging is needed
+    // Logger LOG = Logger.getLogger("LibertyWebServiceClientInInterceptorTest");
+    
+    static {
+        // Since the webServiceClient configuration is in beta, need to set the system property to pass tests
+        System.getProperties().setProperty("com.ibm.ws.beta.edition", "true");
+    }
+    
+    // the Message instance shared across tests
+    private static Message message;
+    
+    // Config impls that need to be instantiated before the intercepter can be run.
+    private static WebServiceClientConfigImpl config;
+    private static WebServiceClientConfigImpl config1;
+    
+    // Default property map
+    Map<String, Object> webServiceClientDefaultProps = new HashMap<String, Object>();
+    
+    // serviceName property map
+    Map<String, Object> webServiceClientServiceNameProps = new HashMap<String, Object>();
+    
+    // Map of Maps
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    
+    // Intercepter instance used for testing
+    LibertyWebServiceClientInInterceptor interceptor = new LibertyWebServiceClientInInterceptor();
+    
+    // Since the Intercepter checks for service name, we need to set it on the exchange.
+    QName testServiceQName= new QName("http://unittest.openliberty.io", SERVICE_NAME);
+    
+    @Rule
+    public TestRule rule = outputMgr;
+
+    @Rule
+    public TestName name = new TestName();
+
+    @Before 
+    public void setup() throws EndpointException {
+        
+        // Instantiate all the necessary CXF objects needed to invoke a our intercepter's handleMessage(..) method
+        // Starting with the SoapBindingFactory
+        SoapBindingFactory soapBindingFactory = new SoapBindingFactory();
+        
+        // Build the CXF service with the ServiceInfo model based on our QName
+        ServiceInfo serviceInfo = new ServiceInfo();
+        serviceInfo.setName(testServiceQName);
+        Service service = new ServiceImpl(serviceInfo);
+        
+        // Add a CXF bus
+        Bus  bus = new ExtensionManagerBus();
+        
+        // Build the BindingFactoryManager and associate it with our bus
+        BindingFactoryManager bindingFactory = new BindingFactoryManagerImpl(bus);
+        bindingFactory.registerBindingFactory(SERVICE_NAME, soapBindingFactory);
+        
+        // Build the CXF EndpointInfo Model associated with the message.
+        EndpointInfo ei = new EndpointInfo();
+        ei.setAddress("http://unittest.openliberty.io");
+        ei.setName(testServiceQName);
+        
+
+        // Build the CXF InterfaceInfo Model associated with the message.
+        InterfaceInfo ii = serviceInfo.createInterface(new QName("http://unittest.openliberty.io", "TestServiceInterface"));
+        serviceInfo.setInterface(ii);
+        ii.addOperation(new QName("http://unittest.openliberty.io", "testOperation"));
+        
+
+        // Build the CXF BindingInfo Model associated with the message.
+        SoapBindingInfo bindingInfo = new SoapBindingInfo(serviceInfo, "http://schemas.xmlsoap.org/soap/", Soap11.getInstance());
+        bindingInfo.setTransportURI("http://schemas.xmlsoap.org/soap/");
+        BindingOperationInfo boi =  bindingInfo.buildOperation(new QName("http://unittest.openliberty.io", "testOperation"), null, null);
+        ei.setBinding(bindingInfo);
+        
+        // Create a new endpoint based on our Bus, Service, Info Model
+        Endpoint testEndpoint = new EndpointImpl(bus, service, ei);
+        
+        // Create a new Exchange and associate everything with it
+        ExchangeImpl exchange = new ExchangeImpl();
+        
+        exchange.put(Endpoint.class, testEndpoint);
+        exchange.put(Service.class, testEndpoint.getService());
+        exchange.put(BindingInfo.class, bindingInfo);
+        exchange.put(BindingOperationInfo.class, boi);
+        exchange.put(Bus.class, bus);
+        exchange.put(ServiceInfo.class, serviceInfo);
+        exchange.put(InterfaceInfo.class, ii);
+        
+        // Create a basic message to pass to handleMessage(Message message) and set our exchange
+        StringWriter sw = new StringWriter();
+        sw.append("<today/>");
+        message = new MessageImpl();
+        message.put(BindingInfo.class, bindingInfo);
+        message.put(BindingOperationInfo.class, boi);
+        message.setExchange(exchange);
+        message.put(Message.CONTENT_TYPE, "application/xml");
+        message.setContent(Writer.class, sw);
+
+    }
+    
+    @After
+    public void tearDown() {
+        
+    }
+    
+    
+    /********************* webServiceClientConfig tests when serviceName not set *********************/
+    
+    
+    /*
+     * Tests that we get the expected values from the webServiceClient config when default is used
+     * and enableSchemaValidation only is set to false. 
+     */
+    @Test
+    public void testHandleMessageWithDefaultEnableSchemaValidationSetToFalse() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientDefaultProps.clear();
+
+        // Set only global enableSchemaValidation
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, false);
+        
+        config  = new WebServiceClientConfigImpl(webServiceClientDefaultProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values.
+        assertFalse("The LibertyWebServiceClientInInterceptor should have set to the " + SCHEMA_VALIDATION + " property to false", MessageUtils.getContextualBoolean(message, SCHEMA_VALIDATION));
+    }
+    
+    /*
+     * Tests that we get the expected values from the webServiceClient config when default is used
+     * and ignoreUnexpectedElemnts only is set to false. 
+     */
+    @Test
+    public void testHandleMessageWithDefaultIgnoreUnexpectedElemntsSetToFalse() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientDefaultProps.clear();
+
+        // Set only global ignoreUnexpectedElements
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, false);
+        
+        config  = new WebServiceClientConfigImpl(webServiceClientDefaultProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values.
+        assertTrue("The LibertyWebServiceClientInInterceptor should have set to the " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " property to true", MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER));
+        
+    }
+    
+    /*
+     * Tests that we get the expected values from the webServiceClient config when default is used
+     * and enableSchemaValidation only is set to true. 
+     */
+    @Test
+    public void testHandleMessageWithDefaultEnableSchemaValidationSetToTrue() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientDefaultProps.clear();
+
+        // Set only global enableSchemaValidation
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, true);
+        
+        config  = new WebServiceClientConfigImpl(webServiceClientDefaultProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values.
+        assertTrue("The LibertyWebServiceClientInInterceptor should have set to the " + SCHEMA_VALIDATION + " property to true", MessageUtils.getContextualBoolean(message, SCHEMA_VALIDATION));
+    }
+    
+    /*
+     * Tests that we get the expected values from the webServiceClient config when default is used
+     * and ignoreUnexpectedElemnts only is set to true. 
+     */
+    @Test
+    public void testHandleMessageWithDefaultIgnoreUnexpectedElemntsSetToTrue() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientDefaultProps.clear();
+        
+        // Set only global ignoreUnexpectedElements
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, true);
+        
+        config  = new WebServiceClientConfigImpl(webServiceClientDefaultProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values.
+        assertFalse("The LibertyWebServiceClientInInterceptor should have set to the " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " property to false", MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER));
+        
+    }
+
+    /*
+     * Tests that we get the expected values from the webServiceClient config when default is used
+     * and both config properties are set to false. 
+     */
+    @Test
+    public void testHandleMessageWithDefaultBothSetToFalse() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientDefaultProps.clear();
+        
+        // this properties map should map to all serviceNames, setting both to false
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, false);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, false);
+        
+        config  = new WebServiceClientConfigImpl(webServiceClientDefaultProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values.
+        // NOTE:
+        //  Because the  JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER boolean has to be flipped, we assertFalse when setting WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP to true.
+        assertTrue("The LibertyWebServiceClientInInterceptor should have set to the " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " property to true", MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER));
+        assertFalse("The LibertyWebServiceClientInInterceptor should have set to the " + SCHEMA_VALIDATION + " property to false", MessageUtils.getContextualBoolean(message, SCHEMA_VALIDATION));
+    }
+    
+    /*
+     * Tests that we get the expected values from the webServiceClient config when default is used
+     * and both config properties are set to false. 
+     */
+    @Test
+    public void testHandleMessageWithDefaultSetToTrue() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientDefaultProps.clear();
+        
+        // this properties map should map to all serviceNames, setting both to true
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, true);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, true);
+        
+        config  = new WebServiceClientConfigImpl(webServiceClientDefaultProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values
+        // NOTE:
+        //  Because the  JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER boolean has to be flipped, we assertFalse when setting WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP to true.
+        assertFalse("The LibertyWebServiceClientInInterceptor should have set to the " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " property to false", MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER));
+        assertTrue("The LibertyWebServiceClientInInterceptor should have set to the " + SCHEMA_VALIDATION + " property to true", MessageUtils.getContextualBoolean(message, SCHEMA_VALIDATION));
+    }
+
+    
+    
+    
+    /********************* webServiceClientConfig tests when serviceName IS set *********************/
+    
+
+    
+   
+    /*
+     * Tests that we get the expected values from the webServiceClient config when "TestService" is used
+     * and enableSchemaValidation only is set to false. 
+     */
+    @Test
+    public void testHandleMessageWithServiceNameEnableSchemaValidationSetToFalse() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientServiceNameProps.clear();
+        
+        // set the serviceName properties
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, false);
+        
+        config1  = new WebServiceClientConfigImpl(webServiceClientServiceNameProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values.
+        assertFalse("The LibertyWebServiceClientInInterceptor should have set to the " + SCHEMA_VALIDATION + " property to false", MessageUtils.getContextualBoolean(message, SCHEMA_VALIDATION));
+    }
+    
+    /*
+     * Tests that we get the expected values from the webServiceClient config when default is used
+     * and enableSchemaValidation only is set to true. 
+     */
+    @Test
+    public void testHandleMessageWithServiceNameEnableSchemaValidationSetToTrue() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientServiceNameProps.clear();
+        
+        // set the serviceName properties
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, true);
+        
+        config1  = new WebServiceClientConfigImpl(webServiceClientServiceNameProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values.
+        assertTrue("The LibertyWebServiceClientInInterceptor should have set to the " + SCHEMA_VALIDATION + " property to true", MessageUtils.getContextualBoolean(message, SCHEMA_VALIDATION));
+    }
+    
+    
+    /*
+     * Tests that we get the expected values from the webServiceClient config when default is used
+     * and ignoreUnexpectedElemnts only is set to false. 
+     */
+    @Test
+    public void testHandleMessageWithServiceNameIgnoreUnexpectedElemntsSetToFalse() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientServiceNameProps.clear();
+        
+        // set the serviceName properties
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, false);
+        
+        config1  = new WebServiceClientConfigImpl(webServiceClientServiceNameProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values.
+        assertTrue("The LibertyWebServiceClientInInterceptor should have set to the " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " property to true", MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER));
+        
+    }
+    
+
+    /*
+     * Tests that we get the expected values from the webServiceClient config when default is used
+     * and ignoreUnexpectedElemnts only is set to true. 
+     */
+    @Test
+    public void testHandleMessageWithServiceNameIgnoreUnexpectedElemntsSetToTrue() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientServiceNameProps.clear();
+        
+        // set the serviceName properties
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, SERVICE_NAME);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, true);
+        
+        config1  = new WebServiceClientConfigImpl(webServiceClientServiceNameProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values.
+        assertFalse("The LibertyWebServiceClientInInterceptor should have set to the " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " property to false", MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER));
+        
+    }
+
+    
+    @Test
+    public void testHandleMessageWithServiceNameBothSetToFalse() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientServiceNameProps.clear();
+        
+        // set the serviceName properties
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, SERVICE_NAME);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, false);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, false);
+        
+        config1  = new WebServiceClientConfigImpl(webServiceClientServiceNameProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values.
+        // NOTE:
+        //  Because the  JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER boolean has to be flipped, we assertFalse when setting WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP to true.
+        assertTrue("The LibertyWebServiceClientInInterceptor should have set to the " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " property to true", MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER));
+        assertFalse("The LibertyWebServiceClientInInterceptor should have set to the " + SCHEMA_VALIDATION + " property to false", MessageUtils.getContextualBoolean(message, SCHEMA_VALIDATION));
+        
+    }
+    
+    @Test
+    public void testHandleMessageWithServiceNameBothSetToTrue() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientServiceNameProps.clear();
+        
+        // set the serviceName properties
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, SERVICE_NAME);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, true);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, true);
+        
+        config1  = new WebServiceClientConfigImpl(webServiceClientServiceNameProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values
+        // NOTE:
+        //  Because the  JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER boolean has to be flipped, we assertFalse when setting WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP to true.
+        assertFalse("The LibertyWebServiceClientInInterceptor should have set to the " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " property to false", MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER));
+        assertTrue("The LibertyWebServiceClientInInterceptor should have set to the " + SCHEMA_VALIDATION + " property to true", MessageUtils.getContextualBoolean(message, SCHEMA_VALIDATION));
+        
+    }
+    
+
+    
+    
+    
+    /********************* webServiceClientConfig tests when serviceName IS set and global is ALSO set *********************/
+    
+
+    
+    /*
+     * This test verifies that with both global and a serviceName webServiceClient configurations that have both enableSchemaValidation
+     * and ignoreUnexpectedElements set that when the serviceName config has both set to true, that 
+     * the message will still return the values for the serviceName configuration and not the client configuration
+     */
+    @Test
+    public void testHandleMessageWithServiceNameSetToFalseGlobalSetToTrue() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientDefaultProps.clear();
+        webServiceClientServiceNameProps.clear();
+        
+
+        // Set the global default values
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, true);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, true);
+        
+        // set the serviceName properties
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, SERVICE_NAME);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, false);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, false);
+        
+        
+        config  = new WebServiceClientConfigImpl(webServiceClientDefaultProps);
+        config1  = new WebServiceClientConfigImpl(webServiceClientServiceNameProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values.
+        // NOTE:
+        //  Because the  JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER boolean has to be flipped, we assertFalse when setting WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP to true.
+        assertTrue("The LibertyWebServiceClientInInterceptor should have set to the " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " property to true", MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER));
+        assertFalse("The LibertyWebServiceClientInInterceptor should have set to the " + SCHEMA_VALIDATION + " property to false", MessageUtils.getContextualBoolean(message, SCHEMA_VALIDATION));
+        
+    }
+    
+    /*
+     * This test verifies that with both global and a serviceName webServiceClient configurations that have both enableSchemaValidation
+     * and ignoreUnexpectedElements set that when the serviceName config has both set to false, that 
+     * the message will still return the values for the serviceName configuration and not the client configuration
+     */
+    @Test
+    public void testHandleMessageWithServiceNameSetToTrueGlobalSetToFalse() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientDefaultProps.clear();
+        webServiceClientServiceNameProps.clear();
+        
+        // Set the global default values
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, false);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, false);
+        
+        // set the serviceName properties
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, SERVICE_NAME);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, true);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, true);
+        
+        config  = new WebServiceClientConfigImpl(webServiceClientDefaultProps);
+        config1  = new WebServiceClientConfigImpl(webServiceClientServiceNameProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values
+        // NOTE:
+        //  Because the  JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER boolean has to be flipped, we assertFalse when setting WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP to true.
+        assertFalse("The LibertyWebServiceClientInInterceptor should have set to the " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " property to false", MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER));
+        assertTrue("The LibertyWebServiceClientInInterceptor should have set to the " + SCHEMA_VALIDATION + " property to true", MessageUtils.getContextualBoolean(message, SCHEMA_VALIDATION));
+        
+    }
+    
+    /*
+     * This test verifies that with both global and a serviceName webServiceClient configurations 
+     * where the config with serviceName set to true has enableSchemaValidation set to true and the 
+     * global webServiceClient configuration has ignoreUnexpectedElements set to false
+     * the message will return the correct values for both settings.
+     */
+    @Test
+    public void testHandleMessageWithServiceNameEnableSchemaValidationSetToFalseGlobalIgnoreUnexpectedElemntsSetToTrue() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientDefaultProps.clear();
+        webServiceClientServiceNameProps.clear();
+        
+
+        // Set the global default values
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, false);
+        
+        // set the serviceName properties
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, SERVICE_NAME);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, true);
+        
+        
+        config  = new WebServiceClientConfigImpl(webServiceClientDefaultProps);
+        config1  = new WebServiceClientConfigImpl(webServiceClientServiceNameProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values.
+        // NOTE:
+        //  Because the  JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER boolean has to be flipped, we assertFalse when setting WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP to true.
+        assertFalse("The LibertyWebServiceClientInInterceptor should have set to the " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " property to true", MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER));
+        assertFalse("The LibertyWebServiceClientInInterceptor should have set to the " + SCHEMA_VALIDATION + " property to false", MessageUtils.getContextualBoolean(message, SCHEMA_VALIDATION));
+        
+    }
+    
+    
+    /*
+     * This test verifies that with both global and a serviceName webServiceClient configurations 
+     * where the config with serviceName has ignoreUnexpectedElements set to true and the 
+     * global webServiceClient configuration has enableSchemaValidation set to false
+     * the message will return the correct values for both settings.
+     */
+    @Test
+    public void testHandleMessageWithServiceNameIgnoreUnexpectedElemntsSetToFalseGlobalEnableSchemaValidationSetToTrue() {
+
+        // Clear props first to ensure correct values are set. 
+        webServiceClientDefaultProps.clear();
+        webServiceClientServiceNameProps.clear();
+        
+        // Set the global default values
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, WebServiceConfigConstants.DEFAULT_PROP);
+        webServiceClientDefaultProps.put(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP, false);
+        
+        // set the serviceName properties
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.SERVICE_NAME_PROP, SERVICE_NAME);
+        webServiceClientServiceNameProps.put(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP, true);
+        
+        config  = new WebServiceClientConfigImpl(webServiceClientDefaultProps);
+        config1  = new WebServiceClientConfigImpl(webServiceClientServiceNameProps);
+       
+        // invoke LibertyWebServiceClientInInterceptor.handleMessage(message)
+        interceptor.handleMessage(message);
+
+        // Assert message has the set values
+        // NOTE:
+        //  Because the  JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER boolean has to be flipped, we assertFalse when setting WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP to true.
+        assertTrue("The LibertyWebServiceClientInInterceptor should have set to the " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " property to false", MessageUtils.getContextualBoolean(message, JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER));
+        assertTrue("The LibertyWebServiceClientInInterceptor should have set to the " + SCHEMA_VALIDATION + " property to true", MessageUtils.getContextualBoolean(message, SCHEMA_VALIDATION));
+        
+    }
+}


### PR DESCRIPTION
This PR fixes a few issues in the `LibertyWebServiceClientInInterceptor` as well as adds the `LibertyWebServiceClientInInterceptorTest` unit tests. 