### PR TITLE
Skip signature testing for Jakarta Data on windows

### DIFF
--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
@@ -69,8 +69,11 @@ public class DataCoreTckLauncher {
         additionalProps.put("tck_protocol", "rest");
         additionalProps.put("jakarta.profile", "core");
 
-        //FIXME Always skip signature tests since our implementation has experimental API
-        additionalProps.put("included.groups", "core & persistence");
+        if (FATSuite.shouldRunSignatureTests()) {
+            additionalProps.put("included.groups", "core & persistence");
+        } else {
+            additionalProps.put("included.groups", "core & persistence & !signature");
+        }
 
         //Comment out to use SNAPSHOT
         additionalProps.put("jakarta.data.groupid", "jakarta.data");
@@ -103,8 +106,11 @@ public class DataCoreTckLauncher {
         additionalProps.put("tck_protocol", "rest");
         additionalProps.put("jakarta.profile", "core");
 
-        //FIXME Always skip signature tests since our implementation has experimental API
-        additionalProps.put("included.groups", "core & nosql & !signature");
+        if (FATSuite.shouldRunSignatureTests()) {
+            additionalProps.put("included.groups", "core & nosql");
+        } else {
+            additionalProps.put("included.groups", "core & nosql & !signature");
+        }
 
         //Comment out to use SNAPSHOT
         additionalProps.put("jakarta.data.groupid", "jakarta.data");

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
@@ -20,9 +20,14 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import com.ibm.websphere.simplicity.log.Log;
+
 import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.TestModeFilter;
 import componenttest.topology.database.container.DatabaseContainerFactory;
+import componenttest.topology.impl.JavaInfo;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -38,4 +43,34 @@ public class FATSuite extends TestContainerSuite {
 
     @ClassRule
     public static MongoDBContainer noSQLDatabase = new MongoDBContainer(DockerImageName.parse("mongo:6.0.6"));
+
+    public static boolean shouldRunSignatureTests() {
+        boolean result = false;
+        String reason = "";
+
+        try {
+            if (TestModeFilter.shouldRun(TestMode.FULL)) {
+                reason = "Signature test is not run in " + TestModeFilter.FRAMEWORK_TEST_MODE + " mode.";
+                return result = false;
+            }
+
+            if (System.getProperty("os.name", "unknown").toLowerCase().contains("windows")) {
+                reason = "signature test plugin not supported on Windows.";
+                return result = false;
+            }
+
+            if (JavaInfo.JAVA_VERSION != 17 && JavaInfo.JAVA_VERSION != 21) {
+                reason = "signature test not supported on non-LTS java versions: " + JavaInfo.JAVA_VERSION;
+                return result = false;
+            }
+
+            //default option
+            reason = "signature test can run as configured";
+            return result = true;
+
+        } finally {
+            Log.info(FATSuite.class, "shouldRunSignatureTests", "Return: " + result + ", because " + reason);
+        }
+
+    }
 }


### PR DESCRIPTION
Signature test plugin is unsupported on windows: 

```
Warning: incorrect classpath parameter: /
C:/path/to/wlp/dev/api/spec/io.openliberty.jakarta.data.1.0_1.0.89.jar:
C:\path\to\wlp\usr\servers\io.openliberty.org.jakarta.data.1.0.core\..\..\shared\jimage\output\java.base:
C:\path\to\wlp\usr\servers\io.openliberty.org.jakarta.data.1.0.core\..\..\shared\jimage\output\java.rmi:
C:\path\to\wlp\usr\servers\io.openliberty.org.jakarta.data.1.0.core\..\..\shared\jimage\output\java.sql:
C:\path\to\wlp\usr\servers\io.openliberty.org.jakarta.data.1.0.core\..\..\shared\jimage\output\java.naming 

java.nio.file.InvalidPathException: Illegal char <:> at index 142: 
C:\path\to\wlp\dev\api\spec\io.openliberty.jakarta.data.1.0_1.0.89.jar:
C:\path\to\wlp\usr\servers\io.openliberty.org.jakarta.data.1.0.core\..\..\shared\jimage\output\java.base:
C:\path\to\wlp\usr\servers\io.openliberty.org.jakarta.data.1.0.core\..\..\shared\jimage\output\java.rmi:
C:\path\to\wlp\usr\servers\io.openliberty.org.jakarta.data.1.0.core\..\..\shared\jimage\output\java.sql:
C:\path\to\wlp\usr\servers\io.openliberty.org.jakarta.data.1.0.core\..\..\shared\jimage\output\java.naming
This directory or jar file will be ignored!
```

