### PR TITLE
eliminate unsupported select codepath

### DIFF
--- a/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -50,14 +50,8 @@ public class Data_1_0 implements DataVersionCompatibility {
 
     @Override
     @Trivial
-    public Annotation getSelectAnnotation(Method method) {
+    public String[] getSelections(Method method) {
         return null;
-    }
-
-    @Override
-    @Trivial
-    public String[] getSelections(Annotation select) {
-        throw new UnsupportedOperationException(); // unreachable
     }
 
     @Override

--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -96,14 +96,9 @@ public class Data_1_1 implements DataVersionCompatibility {
 
     @Override
     @Trivial
-    public Annotation getSelectAnnotation(Method method) {
-        return method.getAnnotation(Select.class);
-    }
-
-    @Override
-    @Trivial
-    public String[] getSelections(Annotation select) {
-        return ((Select) select).value();
+    public String[] getSelections(Method method) {
+        Annotation select = method.getAnnotation(Select.class);
+        return select == null ? null : ((Select) select).value();
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1182,20 +1182,18 @@ public class QueryInfo {
      * @param orderBy array of OrderBy annotations if present, otherwise an empty array.
      * @param count   The Count annotation if present, otherwise null.
      * @param exists  The Exists annotation if present, otherwise null.
-     * @param select  The Select annotation value if present, otherwise null.
      * @return Count, Delete, Exists, Find, Insert, Query, Save, or Update annotation if present. Otherwise null.
      * @throws UnsupportedOperationException if the combination of annotations is not valid.
      */
     @Trivial
     Annotation validateAnnotationCombinations(Delete delete, Insert insert, Update update, Save save,
                                               Find find, jakarta.data.repository.Query query, OrderBy[] orderBy,
-                                              Annotation count, Annotation exists, Annotation select) {
+                                              Annotation count, Annotation exists) {
         int o = orderBy.length == 0 ? 0 : 1;
 
         // These can be paired with OrderBy:
         int f = find == null ? 0 : 1;
         int q = query == null ? 0 : 1;
-        int s = select == null ? 0 : 1;
 
         // These cannot be paired with OrderBy or with each other:
         int ius = (insert == null ? 0 : 1) +
@@ -1209,12 +1207,12 @@ public class QueryInfo {
 
         if (iusdce + f > 1 // more than one of (Insert, Update, Save, Delete, Count, Exists, Find)
             || iusdce + o > 1 // more than one of (Insert, Update, Save, Delete, Count, Exists, OrderBy)
-            || iusdce + q + s > 1) { // one of (Insert, Update, Save, Delete, Count, Exists) with Query or Select, or both Query and Select
+            || iusdce + q > 1) { // one of (Insert, Update, Save, Delete, Count, Exists) with Query
 
             // Invalid combination of multiple annotations
 
             List<String> annoClassNames = new ArrayList<String>();
-            for (Annotation anno : Arrays.asList(count, delete, exists, find, insert, query, save, select, update))
+            for (Annotation anno : Arrays.asList(count, delete, exists, find, insert, query, save, update))
                 if (anno != null)
                     annoClassNames.add(anno.annotationType().getName());
             if (orderBy.length > 0)

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
@@ -46,20 +46,14 @@ public interface DataVersionCompatibility {
     String getFunctionCall(Annotation functionAnno);
 
     /**
-     * Obtains the Select annotation if present on the method. Otherwise null.
+     * Obtains the value of the Select annotation if present on the method.
+     * Otherwise null.
      *
      * @param method repository method. Must not be null.
-     * @return Select annotation if present, otherwise null.
+     * @return values of the Select annotation indicating the columns to select,
+     *         otherwise null.
      */
-    Annotation getSelectAnnotation(Method method);
-
-    /**
-     * Obtains the value of the Select annotation.
-     *
-     * @param select Select annotation. Must not be null.
-     * @return values of the Select annotation indicating the columns to select.
-     */
-    String[] getSelections(Annotation select);
+    String[] getSelections(Method method);
 
     /**
      * Return a 2-element array where the first element is the entity attribute name

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -1135,7 +1135,7 @@ public class DataExperimentalServlet extends FATServlet {
                                      .collect(Collectors.toList()));
 
         assertEquals(List.of("030-2 E314", "050-2 B125", "050-2 G105"),
-                     reservations.findByStopOrStartOrStart(OffsetDateTime.of(2022, 5, 25, 14, 0, 0, 0, CDT),
+                     reservations.findByStopOrStartAtAnyOf(OffsetDateTime.of(2022, 5, 25, 14, 0, 0, 0, CDT),
                                                            OffsetDateTime.of(2022, 5, 25, 11, 0, 0, 0, CDT),
                                                            OffsetDateTime.of(2022, 5, 25, 14, 0, 0, 0, CDT))
                                      .parallel()
@@ -1143,10 +1143,10 @@ public class DataExperimentalServlet extends FATServlet {
                                      .collect(Collectors.toList()));
 
         assertEquals(List.of(10030004L, 10030005L, 10030006L, 10030009L),
-                     reservations.findByStopOrStartOrStartOrStart(OffsetDateTime.of(2022, 5, 25, 11, 0, 0, 0, CDT),
-                                                                  OffsetDateTime.of(2022, 5, 25, 7, 30, 0, 0, CDT),
-                                                                  OffsetDateTime.of(2022, 5, 25, 11, 0, 0, 0, CDT),
-                                                                  OffsetDateTime.of(2022, 5, 25, 14, 0, 0, 0, CDT))
+                     reservations.findByStopOrStartAtAnyOf(OffsetDateTime.of(2022, 5, 25, 11, 0, 0, 0, CDT),
+                                                           OffsetDateTime.of(2022, 5, 25, 7, 30, 0, 0, CDT),
+                                                           OffsetDateTime.of(2022, 5, 25, 11, 0, 0, 0, CDT),
+                                                           OffsetDateTime.of(2022, 5, 25, 14, 0, 0, 0, CDT))
                                      .parallel()
                                      .sorted()
                                      .boxed()
@@ -1157,9 +1157,9 @@ public class DataExperimentalServlet extends FATServlet {
                              OffsetDateTime.of(2022, 5, 25, 13, 0, 0, 0, CDT).toInstant(),
                              OffsetDateTime.of(2022, 5, 25, 13, 0, 0, 0, CDT).toInstant(),
                              OffsetDateTime.of(2022, 5, 25, 14, 0, 0, 0, CDT).toInstant()),
-                     reservations.findByStopOrStopOrStop(OffsetDateTime.of(2022, 5, 25, 14, 0, 0, 0, CDT),
-                                                         OffsetDateTime.of(2022, 5, 25, 15, 0, 0, 0, CDT),
-                                                         OffsetDateTime.of(2022, 5, 25, 11, 0, 0, 0, CDT))
+                     reservations.findByStoppingAtAnyOf(OffsetDateTime.of(2022, 5, 25, 14, 0, 0, 0, CDT),
+                                                        OffsetDateTime.of(2022, 5, 25, 15, 0, 0, 0, CDT),
+                                                        OffsetDateTime.of(2022, 5, 25, 11, 0, 0, 0, CDT))
                                      .map(r -> r.start().toInstant())
                                      .sorted()
                                      .collect(Collectors.toList()));
@@ -1443,9 +1443,9 @@ public class DataExperimentalServlet extends FATServlet {
 
         reservations.saveAll(List.of(r1, r2, r3, r4));
 
-        ReservedTimeSlot[] reserved = reservations.findTimeSlotByLocationAndStartBetweenOrderByStart("30-2 C206",
-                                                                                                     OffsetDateTime.of(2022, 6, 3, 0, 0, 0, 0, CDT),
-                                                                                                     OffsetDateTime.of(2022, 6, 3, 23, 59, 59, 0, CDT));
+        ReservedTimeSlot[] reserved = reservations.findTimeSlotWithin("30-2 C206",
+                                                                      OffsetDateTime.of(2022, 6, 3, 0, 0, 0, 0, CDT),
+                                                                      OffsetDateTime.of(2022, 6, 3, 23, 59, 59, 0, CDT));
         assertArrayEquals(new ReservedTimeSlot[] { new ReservedTimeSlot(r2.start, r2.stop),
                                                    new ReservedTimeSlot(r1.start, r1.stop),
                                                    new ReservedTimeSlot(r3.start, r3.stop) },

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Reservations.java
@@ -49,6 +49,7 @@ import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 
+import io.openliberty.data.repository.Or;
 import io.openliberty.data.repository.Select;
 import io.openliberty.data.repository.comparison.GreaterThanEqual;
 import io.openliberty.data.repository.comparison.In;
@@ -130,15 +131,25 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
 
     Stream<Reservation> findByStopOrStart(OffsetDateTime stop, OffsetDateTime start);
 
+    @Find
     @Select("location")
-    Stream<String> findByStopOrStartOrStart(OffsetDateTime stop, OffsetDateTime start1, OffsetDateTime start2);
+    Stream<String> findByStopOrStartAtAnyOf(OffsetDateTime stop,
+                                            @Or @By("start") OffsetDateTime start1,
+                                            @Or @By("start") OffsetDateTime start2);
 
+    @Find
     @Select("meetingID")
-    LongStream findByStopOrStartOrStartOrStart(OffsetDateTime stop, OffsetDateTime start1, OffsetDateTime start2, OffsetDateTime start3);
+    LongStream findByStopOrStartAtAnyOf(OffsetDateTime stop,
+                                        @Or @By("start") OffsetDateTime start1,
+                                        @Or @By("start") OffsetDateTime start2,
+                                        @Or @By("start") OffsetDateTime start3);
 
     // Use a stream of record as the return type
+    @Find
     @Select({ "start", "stop" })
-    Stream<ReservedTimeSlot> findByStopOrStopOrStop(OffsetDateTime stop1, OffsetDateTime stop2, OffsetDateTime stop3);
+    Stream<ReservedTimeSlot> findByStoppingAtAnyOf(@By("stop") OffsetDateTime stop1,
+                                                   @Or @By("stop") OffsetDateTime stop2,
+                                                   @Or @By("stop") OffsetDateTime stop3);
 
     Page<Reservation> findByHostStartsWith(String hostPrefix, PageRequest pagination, Sort<Reservation> sort);
 
@@ -152,8 +163,12 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
     List<Long> findMeetingIdByStopWithSecond(int second);
 
     // Use a record as the return type
+    @Find
     @Select({ "start", "stop" })
-    ReservedTimeSlot[] findTimeSlotByLocationAndStartBetweenOrderByStart(String location, OffsetDateTime startAfter, OffsetDateTime startBefore);
+    @OrderBy("start")
+    ReservedTimeSlot[] findTimeSlotWithin(String location,
+                                          @By("start") @GreaterThanEqual OffsetDateTime startAfter,
+                                          @By("start") @LessThanEqual OffsetDateTime startBefore);
 
     ArrayDeque<Reservation> findByLocationStartsWith(String locationPrefix);
 

--- a/dev/io.openliberty.data/src/io/openliberty/data/repository/Select.java
+++ b/dev/io.openliberty.data/src/io/openliberty/data/repository/Select.java
@@ -16,6 +16,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
@@ -23,16 +25,25 @@ import jakarta.data.repository.Insert;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 
+// This annotation will not be needed at all and can be removed if the Find
+// annotation is enhanced to accept the entity attribute names, or if some
+// other alternative approach is added to Jakarta Data.
 /**
- * <p>Specifies which entity attribute values are retrieved by a repository method
- * find operation and, in the case of multiple entity attributes, also the ordering
- * of these entity attribute values to use when constructing results for the method.</p>
+ * <p>Specifies which entity attribute values are retrieved by a repository
+ * {@link Find} method. For a single entity attribute, the method return type
+ * can be the type of the entity attribute or an array, {@link List},
+ * {@link Stream}, or {@link Optional} of that type
+ * For one or more entity attributes, the method return type is a Java class
+ * or record with a public constructor that accepts the entity attributes in
+ * the same order specified or an array, {@link List}, {@link Stream}, or
+ * {@link Optional} of that type.</p>
  *
  * <p>Example query for single attribute value:</p>
  *
  * <pre>
- * {@literal @Select}("price")
- * Optional{@literal <Float>} priceOf({@literal @By("id")} long productId);
+ * {@code @Find}
+ * {@code @Select}("price")
+ * Optional{@code <Float>} priceOf({@code @By(ID)} long productId);
  * </pre>
  *
  * <p>Example usage:</p>
@@ -44,20 +55,21 @@ import jakarta.data.repository.Update;
  * <p>Example query of Employee entities converted to record type Person(firstName, surname):</p>
  *
  * <pre>
- * {@literal @Select}("firstName", "lastName")
- * {@literal @OrderBy}("lastName")
- * {@literal @OrderBy}("firstName")
- * List{@literal <Person>} ofAge({@literal @By("age")} int yearsOld);
+ * {@code @Find}
+ * {@code @Select}({"firstName", "lastName"})
+ * {@code @OrderBy}("lastName")
+ * {@code @OrderBy}("firstName")
+ * List{@code <Person>} ofAge({@code @By("age")} int yearsOld);
  * </pre>
  *
  * <p>Example usage:</p>
  *
  * <pre>
- * List{@literal <Person>} thirtyYearOlds = employees.ofAge(30);
+ * List{@code <Person>} thirtyYearOlds = employees.ofAge(30);
  * </pre>
  *
  * <p>Do not use in combination with the {@link jakarta.data.repository.Query Query},
- * {@link Count}, {@link Delete}, {@link Exists}, {@link Find}, {@link Insert}, {@link Save}, or {@link Update} annotation,
+ * {@link Count}, {@link Delete}, {@link Exists}, {@link Insert}, {@link Save}, or {@link Update} annotation,
  * or with any annotation in the {@link io.openliberty.data.repository.update} package.</p>
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -73,15 +85,17 @@ public @interface Select {
      * An example of returning a single attribute,
      *
      * <pre>
-     * &#64;Select("price")
-     * List&#60;Float&#62; findByProductIdIn(Collection<String> productIds);
+     * {@code @Find}
+     * {@code @Select("price")}
+     * List&#60;Float&#62; pricesOf({@code @By("productId") @In} Collection<String> ids);
      * </pre>
      *
      * An example of returning multiple attributes as a different type,
      *
      * <pre>
-     * &#64;Select({ "productId", "available" })
-     * List&#60;SurplusItem&#62; findByAvailableGreaterThan(int targetInventoryLevel);
+     * {@code @Find}
+     * {@code @Select}({ "productId", "available" })
+     * List&#60;SurplusItem&#62; overstocked({@code @By("available") @GreaterThan} int targetInventoryLevel);
      * </pre>
      *
      * @return names of entity attributes to select.


### PR DESCRIPTION
Eliminate unsupported codepath for selecting results. Also, remove another doPrivileged that is unnecessary for Jakarta EE 11 features.  With this change, Select, which is being used to simulate a capability that we would like to see added to Find in the future, will no longer be handled on its own or in combination with Query by Method Name. The intent is to align only with the future direction of enhancing the Find annotation.