### PR TITLE
Use propagated gtrid in local Xid of imported transaction

### DIFF
--- a/dev/com.ibm.tx.jta/src/com/ibm/ws/Transaction/JTA/Util.java
+++ b/dev/com.ibm.tx.jta/src/com/ibm/ws/Transaction/JTA/Util.java
@@ -1,7 +1,7 @@
 package com.ibm.ws.Transaction.JTA;
 
 /*******************************************************************************
- * Copyright (c) 2001, 2021 IBM Corporation and others.
+ * Copyright (c) 2001, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -275,6 +275,21 @@ public final class Util {
             result.append(digits.charAt(b[i] & 0xf));
         }
         return (result.toString());
+    }
+
+    /**
+     * Use this when generating an Xid from one of our own global Ids
+     */
+    public static byte[] fromHexString(String s) {
+        byte[] result = new byte[s.length() / 2];
+        for (int i = 0; i < result.length; i++) {
+            int high = digits.indexOf(s.charAt(2 * i));
+            int low = digits.indexOf(s.charAt(2 * i + 1));
+            if (high < 0 || low < 0)
+                return null;
+            result[i] = (byte) ((high << 4) + low);
+        }
+        return result;
     }
 
     /**

--- a/dev/com.ibm.ws.wsat_fat.multi/fat/src/tests/MultiServerTest.java
+++ b/dev/com.ibm.ws.wsat_fat.multi/fat/src/tests/MultiServerTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -84,9 +85,11 @@ public class MultiServerTest extends WSATTest {
 		DBTestBase.initWSATTest(server3);
 
 		ShrinkHelper.defaultDropinApp(server, "oneway", "web.oneway.*");
-		ShrinkHelper.defaultDropinApp(server, "endtoend", "web.endtoend.*");
-		ShrinkHelper.defaultDropinApp(server2, "endtoend", "web.endtoend.*");
-		ShrinkHelper.defaultDropinApp(server3, "endtoend", "web.endtoend.*");
+
+        final WebArchive app = ShrinkHelper.buildDefaultApp("endtoend", "web.endtoend.*");
+        ShrinkHelper.exportDropinAppToServer(server, app);
+        ShrinkHelper.exportDropinAppToServer(server2, app);
+        ShrinkHelper.exportDropinAppToServer(server3, app);
 
 		FATUtils.startServers(server, server2, server3);
 	}
@@ -156,8 +159,10 @@ public class MultiServerTest extends WSATTest {
 		HttpURLConnection con = getHttpConnection(new URL(urlStr), 
 				HttpURLConnection.HTTP_OK, REQUEST_TIMEOUT,"testTwoServerCommit");
 		BufferedReader br = HttpUtils.getConnectionStream(con);
+		
+		assertNotNull(server2.waitForStringInTraceUsingMark("Using gtrid from parent"));
 
-                server2.waitForStringInTraceUsingMark("< commitOperation Exit");
+		server2.waitForStringInTraceUsingMark("< commitOperation Exit");
 
 		String result = br.readLine();
 		assertNotNull(result);

--- a/dev/io.openliberty.org.testcontainers/cache/projects
+++ b/dev/io.openliberty.org.testcontainers/cache/projects
@@ -183,4 +183,5 @@ io.openliberty.microprofile.health.3.1.internal_fat
 io.openliberty.microprofile.openapi.ui.internal_fat
 io.openliberty.microprofile.reactive.messaging.internal_fat
 io.openliberty.microprofile.telemetry.1.0.internal.container_fat
+io.openliberty.org.apache.myfaces.4.0_fat
 io.openliberty.org.apache.myfaces.4.1_fat


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.jta_fat,com.ibm.ws.transaction.cloud_fat.base,com.ibm.ws.transaction.cloud_fat.db2.0,com.ibm.ws.transaction.cloud_fat.db2.1,com.ibm.ws.transaction.cloud_fat.db2.2,com.ibm.ws.transaction.cloud_fat.derby.0,com.ibm.ws.transaction.cloud_fat.derby.1,com.ibm.ws.transaction.cloud_fat.derby.2,com.ibm.ws.transaction.cloud_fat.dualFS,com.ibm.ws.transaction.cloud_fat.oracle.0,com.ibm.ws.transaction.cloud_fat.oracle.1,com.ibm.ws.transaction.cloud_fat.oracle.2,com.ibm.ws.transaction.cloud_fat.peerlocking.1,com.ibm.ws.transaction.cloud_fat.peerlocking.2,com.ibm.ws.transaction.cloud_fat.postgresql.0,com.ibm.ws.transaction.cloud_fat.postgresql.1,com.ibm.ws.transaction.cloud_fat.postgresql.2,com.ibm.ws.transaction.cloud_fat.simpleFS,com.ibm.ws.transaction.cloud_fat.sqlserver.0,com.ibm.ws.transaction.cloud_fat.sqlserver.1,com.ibm.ws.transaction.cloud_fat.sqlserver.2,com.ibm.ws.transaction.core_fat.base,com.ibm.ws.transaction.core_fat.baseDB,com.ibm.ws.transaction.core_fat.cdi,com.ibm.ws.transaction.core_fat.commitPriority,com.ibm.ws.transaction.core_fat.heuristics,com.ibm.ws.transaction.core_fat.heuristicsDB,com.ibm.ws.transaction.core_fat.misc,com.ibm.ws.transaction.core_fat.startMultiEJB,com.ibm.ws.transaction.core_fat.startup,com.ibm.ws.transaction.core_fat.xa,com.ibm.ws.transaction.core_fat.xaDB,com.ibm.ws.transaction.db_fat,com.ibm.ws.transaction.hadb_fat.db2.1,com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.db2.retriablecodes,com.ibm.ws.transaction.hadb_fat.derby.1,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.derby.retriablecodes,com.ibm.ws.transaction.hadb_fat.oracle.1,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.oracle.retriablecodes,com.ibm.ws.transaction.hadb_fat.postgresql.1,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.postgresql.retriablecodes,com.ibm.ws.transaction.hadb_fat.sqlserver.1,com.ibm.ws.transaction.hadb_fat.sqlserver.2,com.ibm.ws.transaction.hadb_fat.sqlserver.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes,com.ibm.ws.transaction.recovery_fat.1,com.ibm.ws.transaction.recovery_fat.2,com.ibm.ws.transaction.recovery_fat.3,com.ibm.ws.tx.jta_fat,com.ibm.ws.tx.jta_fat_hibernate,com.ibm.ws.wsat.common_fat,com.ibm.ws.wsat.concurrent_fat,com.ibm.ws.wsat.migration_fat.1,com.ibm.ws.wsat.migration_fat.2,com.ibm.ws.wsat.migration_fat.3,com.ibm.ws.wsat.migration_fat.4,com.ibm.ws.wsat.migration_fat.5,com.ibm.ws.wsat.migration_fat.6,com.ibm.ws.wsat.migration_fat.7,com.ibm.ws.wsat.recovery_fat.lps,com.ibm.ws.wsat.recovery_fat.multi.1,com.ibm.ws.wsat.recovery_fat.multi.2,com.ibm.ws.wsat.recovery_fat.multi.3,com.ibm.ws.wsat.recovery_fat.multi.4,com.ibm.ws.wsat.recovery_fat.multi.5,com.ibm.ws.wsat.recovery_fat.multi.6,com.ibm.ws.wsat.recovery_fat.multi.7,com.ibm.ws.wsat.recovery_fat.single.1,com.ibm.ws.wsat.recovery_fat.single.2,com.ibm.ws.wsat_fat.assertion,com.ibm.ws.wsat_fat.db,com.ibm.ws.wsat_fat.db_optional,com.ibm.ws.wsat_fat.dbs,com.ibm.ws.wsat_fat.dbs_optional,com.ibm.ws.wsat_fat.multi,com.ibm.ws.wsat_fat.multi.misroute,com.ibm.ws.wsat_fat.ssl.misroute,com.ibm.ws.wsat_fat.ssl,io.openliberty.checkpoint_fat_transaction