### PR TITLE
Allowing Delete and OrderBy

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1200,13 +1200,15 @@ public class QueryInfo {
                   (update == null ? 0 : 1) +
                   (save == null ? 0 : 1);
 
-        int iusdce = ius +
-                     (delete == null ? 0 : 1) +
-                     (count == null ? 0 : 1) +
-                     (exists == null ? 0 : 1);
+        int iusce = ius +
+                    (count == null ? 0 : 1) +
+                    (exists == null ? 0 : 1);
+
+        int iusdce = iusce +
+                     (delete == null ? 0 : 1);
 
         if (iusdce + f > 1 // more than one of (Insert, Update, Save, Delete, Count, Exists, Find)
-            || iusdce + o > 1 // more than one of (Insert, Update, Save, Delete, Count, Exists, OrderBy)
+            || iusce + o > 1 // more than one of (Insert, Update, Save, Delete, Count, Exists, OrderBy)
             || iusdce + q > 1) { // one of (Insert, Update, Save, Delete, Count, Exists) with Query
 
             // Invalid combination of multiple annotations

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1127,6 +1127,7 @@ public class DataTestServlet extends FATServlet {
     public void testFindAndDeleteMultipleAnnotated(HttpServletRequest request, HttpServletResponse response) {
         packages.save(new Package(60001, 61.0f, 41.0f, 26.0f, "testFindAndDeleteMultipleAnnotated"));
         packages.save(new Package(60002, 62.0f, 42.0f, 25.0f, "testFindAndDeleteMultipleAnnotated"));
+        packages.save(new Package(60003, 59.0f, 39.0f, 24.0f, "testFindAndDeleteMultipleAnnotated"));
 
         String jdbcJarName = request.getParameter("jdbcJarName").toLowerCase();
         boolean supportsOrderByForUpdate = !jdbcJarName.startsWith("derby");
@@ -1134,27 +1135,34 @@ public class DataTestServlet extends FATServlet {
         List<Package> list = supportsOrderByForUpdate //
                         ? packages.takeOrdered("testFindAndDeleteMultipleAnnotated") //
                         : packages.take("testFindAndDeleteMultipleAnnotated");
-        assertEquals(list.toString(), 2, list.size());
+        assertEquals(list.toString(), 3, list.size());
 
         if (!supportsOrderByForUpdate) {
             System.out.println("Sorting results in test code.");
-            list.sort(Comparator.comparing(p -> p.id));
+            list.sort(Comparator.comparing(p -> p.width));
         }
 
         Package p0 = list.get(0);
         Package p1 = list.get(1);
+        Package p2 = list.get(2);
 
-        assertEquals(60001, p0.id);
-        assertEquals(61.0f, p0.length, 0.01f);
-        assertEquals(41.0f, p0.width, 0.01f);
-        assertEquals(26.0f, p0.height, 0.01f);
+        assertEquals(60003, p0.id);
+        assertEquals(59.0f, p0.length, 0.01f);
+        assertEquals(39.0f, p0.width, 0.01f);
+        assertEquals(24.0f, p0.height, 0.01f);
         assertEquals("testFindAndDeleteMultipleAnnotated", p0.description);
 
-        assertEquals(60002, p1.id);
-        assertEquals(62.0f, p1.length, 0.01f);
-        assertEquals(42.0f, p1.width, 0.01f);
-        assertEquals(25.0f, p1.height, 0.01f);
+        assertEquals(60001, p1.id);
+        assertEquals(61.0f, p1.length, 0.01f);
+        assertEquals(41.0f, p1.width, 0.01f);
+        assertEquals(26.0f, p1.height, 0.01f);
         assertEquals("testFindAndDeleteMultipleAnnotated", p1.description);
+
+        assertEquals(60002, p2.id);
+        assertEquals(62.0f, p2.length, 0.01f);
+        assertEquals(42.0f, p2.width, 0.01f);
+        assertEquals(25.0f, p2.height, 0.01f);
+        assertEquals("testFindAndDeleteMultipleAnnotated", p2.description);
 
         assertEquals(Collections.EMPTY_LIST, packages.take("testFindAndDeleteMultipleAnnotated"));
     }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -95,7 +95,7 @@ public interface Packages extends BasicRepository<Package, Integer> {
     List<Package> take(@By("description") String desc);
 
     @Delete
-    @OrderBy("id")
+    @OrderBy("width")
     List<Package> takeOrdered(String description);
 
     boolean updateByIdAddHeightMultiplyLengthDivideWidth(int id, float heightToAdd, float lengthMultiplier, float widthDivisor);


### PR DESCRIPTION
Allows a Delete annotation with OrderBy annotations. Adds a little complexity to the test case so the elements aren't saved in the same order they should be returned.
Part of https://github.com/OpenLiberty/open-liberty/issues/28181