### PR TITLE
Increase lease length to work around dodgy alarms on macs

### DIFF
--- a/dev/com.ibm.ws.wsat.concurrent_fat/test-applications/threadedServer/src/com/ibm/ws/wsat/threadedserver/server/MultiThreaded.java
+++ b/dev/com.ibm.ws.wsat.concurrent_fat/test-applications/threadedServer/src/com/ibm/ws/wsat/threadedserver/server/MultiThreaded.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -43,7 +43,7 @@ public class MultiThreaded {
 		try {
 			xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(
 						xaResInfo1);
-			final int recoveryId1 = TM.registerResourceInfo("xaResInfo1",
+			final int recoveryId1 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo1);
 			result1 = TM.enlist(xaRes1, recoveryId1);
 		} catch (Exception e) {

--- a/dev/com.ibm.ws.wsat.migration_fat.1/test-applications/simpleClient/src/web/simpleclient/ClientServletBase.java
+++ b/dev/com.ibm.ws.wsat.migration_fat.1/test-applications/simpleClient/src/web/simpleclient/ClientServletBase.java
@@ -358,7 +358,7 @@ public abstract class ClientServletBase extends FATServlet {
 							.getXAResourceImpl(xaResInfo)
 							.setPrepareAction(prepareAction);
 				}
-				final int recoveryId = TM.registerResourceInfo("xaResInfo",
+				final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 						xaResInfo);
 				xaRes.setExpectedDirection(expectedDirection);
 				boolean result = TM.enlist(xaRes, recoveryId);

--- a/dev/com.ibm.ws.wsat.migration_fat.1/test-applications/simpleClient/src/web/simpleclient/SleepClientServlet.java
+++ b/dev/com.ibm.ws.wsat.migration_fat.1/test-applications/simpleClient/src/web/simpleclient/SleepClientServlet.java
@@ -378,7 +378,7 @@ public class SleepClientServlet extends FATServlet {
 							.getXAResourceImpl(xaResInfo)
 							.setPrepareAction(prepareAction);
 				}
-				final int recoveryId = TM.registerResourceInfo("xaResInfo",
+				final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 						xaResInfo);
 				xaRes.setExpectedDirection(expectedDirection);
 				boolean result = TM.enlist(xaRes, recoveryId);

--- a/dev/com.ibm.ws.wsat.migration_fat.1/test-applications/simpleService/src/web/simpleservice/WSATSimple.java
+++ b/dev/com.ibm.ws.wsat.migration_fat.1/test-applications/simpleService/src/web/simpleservice/WSATSimple.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -98,7 +98,7 @@ public class WSATSimple {
 						.getXAResourceImpl(xaResInfo)
 						.setPrepareAction(prepareAction);
 			}
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
 			xaRes.setExpectedDirection(expectedDirection);
 			result = TM.enlist(xaRes, recoveryId);
@@ -179,9 +179,9 @@ public class WSATSimple {
 						.setPrepareAction(prepareAction2);
 			}
 
-			final int recoveryId1 = TM.registerResourceInfo("xaResInfo1",
+			final int recoveryId1 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo1);
-			final int recoveryId2 = TM.registerResourceInfo("xaResInfo2",
+			final int recoveryId2 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo2);
 			xaRes1.setExpectedDirection(expectedDirection);
 			xaRes2.setExpectedDirection(expectedDirection);
@@ -224,9 +224,9 @@ public class WSATSimple {
 				xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(
 						xaResInfo2);
 
-			final int recoveryId1 = TM.registerResourceInfo("xaResInfo1",
+			final int recoveryId1 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo1);
-			final int recoveryId2 = TM.registerResourceInfo("xaResInfo2",
+			final int recoveryId2 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo2);
 			xaRes1.setExpectedDirection(expectedDirection);
 			xaRes2.setExpectedDirection(expectedDirection);

--- a/dev/com.ibm.ws.wsat.migration_fat.4/test-applications/LPSClient/src/web/lpsclient/LPSClientServlet.java
+++ b/dev/com.ibm.ws.wsat.migration_fat.4/test-applications/LPSClient/src/web/lpsclient/LPSClientServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -707,7 +707,7 @@ public class LPSClientServlet extends HttpServlet {
 							.getXAResourceImpl(xaResInfo)
 							.setPrepareAction(prepareAction);
 				}
-				final int recoveryId = TM.registerResourceInfo("xaResInfo",
+				final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 						xaResInfo);
 				xaRes.setExpectedDirection(expectedDirection);
 				boolean result = TM.enlist(xaRes, recoveryId);

--- a/dev/com.ibm.ws.wsat.migration_fat.4/test-applications/LPSService/src/web/lpsservice/LastParticipantSupport.java
+++ b/dev/com.ibm.ws.wsat.migration_fat.4/test-applications/LPSService/src/web/lpsservice/LastParticipantSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -160,7 +160,7 @@ public class LastParticipantSupport {
 					.getXAResourceInfo(0);
 			XAResourceImpl xaRes = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
 			xaRes.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
 			result2 = TM.enlist(xaRes, recoveryId);
@@ -202,7 +202,7 @@ public class LastParticipantSupport {
 					.getXAResourceInfo(0);
 			XAResourceImpl xaRes = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
 			result2 = TM.enlist(xaRes, recoveryId);
 		} catch (IllegalStateException e) {
@@ -239,7 +239,7 @@ public class LastParticipantSupport {
 					.getXAResourceInfo(0);
 			XAResourceImpl xaRes = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
 			xaRes.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
 			result1 = TM.enlist(xaRes, recoveryId);
@@ -281,7 +281,7 @@ public class LastParticipantSupport {
 					.getXAResourceInfo(0);
 			XAResourceImpl xaRes = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
 			result1 = TM.enlist(xaRes, recoveryId);
 
@@ -327,7 +327,7 @@ public class LastParticipantSupport {
 			XAResourceImpl xaRes = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo)
 					.setPrepareAction(XAException.XA_RDONLY);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
 			xaRes.setExpectedDirection(XAResourceImpl.DIRECTION_COMMIT);
 			result2 = TM.enlist(xaRes, recoveryId);
@@ -375,7 +375,7 @@ public class LastParticipantSupport {
 			XAResourceImpl xaRes = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo)
 					.setPrepareAction(XAException.XA_RDONLY);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
 			result1 = TM.enlist(xaRes, recoveryId);
 
@@ -438,13 +438,13 @@ public class LastParticipantSupport {
 			XAResourceImpl xaRes4 = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo4)
 					.setPrepareAction(XAException.XA_RDONLY);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
-			final int recoveryId2 = TM.registerResourceInfo("xaResInfo2",
+			final int recoveryId2 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo2);
-			final int recoveryId3 = TM.registerResourceInfo("xaResInfo3",
+			final int recoveryId3 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo3);
-			final int recoveryId4 = TM.registerResourceInfo("xaResInfo4",
+			final int recoveryId4 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo4);
 			result1 = TM.enlist(xaRes, recoveryId);
 			result2 = TM.enlist(xaRes2, recoveryId2);
@@ -519,13 +519,13 @@ public class LastParticipantSupport {
 			XAResourceImpl xaRes4 = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo4)
 					.setPrepareAction(XAException.XA_RDONLY);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
-			final int recoveryId2 = TM.registerResourceInfo("xaResInfo2",
+			final int recoveryId2 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo2);
-			final int recoveryId3 = TM.registerResourceInfo("xaResInfo3",
+			final int recoveryId3 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo3);
-			final int recoveryId4 = TM.registerResourceInfo("xaResInfo4",
+			final int recoveryId4 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo4);
 			result1 = TM.enlist(xaRes, recoveryId);
 			result2 = TM.enlist(xaRes2, recoveryId2);
@@ -602,13 +602,13 @@ public class LastParticipantSupport {
 			XAResourceImpl xaRes4 = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo4)
 					.setPrepareAction(XAException.XA_RDONLY);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
-			final int recoveryId2 = TM.registerResourceInfo("xaResInfo2",
+			final int recoveryId2 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo2);
-			final int recoveryId3 = TM.registerResourceInfo("xaResInfo3",
+			final int recoveryId3 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo3);
-			final int recoveryId4 = TM.registerResourceInfo("xaResInfo4",
+			final int recoveryId4 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo4);
 			result2 = TM.enlist(xaRes, recoveryId);
 			result3 = TM.enlist(xaRes2, recoveryId2);
@@ -671,9 +671,9 @@ public class LastParticipantSupport {
 					.getXAResourceImpl(xaResInfo);
 			XAResourceImpl xaRes2 = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo2);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
-			final int recoveryId2 = TM.registerResourceInfo("xaResInfo2",
+			final int recoveryId2 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo2);
 			xaRes.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
 			xaRes2.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
@@ -730,9 +730,9 @@ public class LastParticipantSupport {
 					.setPrepareAction(XAException.XA_RBROLLBACK);
 			XAResourceImpl xaRes2 = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo2);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
-			final int recoveryId2 = TM.registerResourceInfo("xaResInfo2",
+			final int recoveryId2 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo2);
 			xaRes.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
 			xaRes2.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
@@ -784,9 +784,9 @@ public class LastParticipantSupport {
 			XAResourceImpl xaRes2 = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo2)
 					.setPrepareAction(XAException.XA_RBROLLBACK);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
-			final int recoveryId2 = TM.registerResourceInfo("xaResInfo2",
+			final int recoveryId2 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo2);
 			xaRes.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
 			xaRes2.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
@@ -837,9 +837,9 @@ public class LastParticipantSupport {
 					.getXAResourceImpl(xaResInfo);
 			XAResourceImpl xaRes2 = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo2);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
-			final int recoveryId2 = TM.registerResourceInfo("xaResInfo2",
+			final int recoveryId2 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo2);
 			xaRes.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
 			xaRes2.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
@@ -887,9 +887,9 @@ public class LastParticipantSupport {
 					.getXAResourceImpl(xaResInfo);
 			XAResourceImpl xaRes2 = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo2);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
-			final int recoveryId2 = TM.registerResourceInfo("xaResInfo2",
+			final int recoveryId2 = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo2);
 			xaRes.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
 			xaRes2.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
@@ -963,7 +963,7 @@ public class LastParticipantSupport {
 					.getXAResourceInfo(0);
 			XAResourceImpl xaRes = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
 			result1 = TM.enlist(xaRes, recoveryId);
 		} catch (IllegalStateException e) {
@@ -998,7 +998,7 @@ public class LastParticipantSupport {
 					.getXAResourceInfo(0);
 			XAResourceImpl xaRes = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
 			xaRes.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
 			result1 = TM.enlist(xaRes, recoveryId);
@@ -1035,7 +1035,7 @@ public class LastParticipantSupport {
 			XAResourceImpl xaRes = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo)
 					.setPrepareAction(XAException.XA_RBROLLBACK);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
 			xaRes.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
 			result1 = TM.enlist(xaRes, recoveryId);
@@ -1071,7 +1071,7 @@ public class LastParticipantSupport {
 					.getXAResourceInfo(0);
 			XAResourceImpl xaRes = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
 			xaRes.setExpectedDirection(XAResourceImpl.DIRECTION_ROLLBACK);
 			result1 = TM.enlist(xaRes, recoveryId);
@@ -1108,7 +1108,7 @@ public class LastParticipantSupport {
 			XAResourceImpl xaRes = XAResourceFactoryImpl.instance()
 					.getXAResourceImpl(xaResInfo)
 					.setPrepareAction(XAException.XA_RDONLY);
-			final int recoveryId = TM.registerResourceInfo("xaResInfo",
+			final int recoveryId = TM.registerResourceInfo(XAResourceInfoFactory.filter,
 					xaResInfo);
 			result1 = TM.enlist(xaRes, recoveryId);
 		} catch (IllegalStateException e) {

--- a/dev/com.ibm.ws.wsat.migration_fat.7/publish/servers/MigrationServer1/server.xml
+++ b/dev/com.ibm.ws.wsat.migration_fat.7/publish/servers/MigrationServer1/server.xml
@@ -19,13 +19,13 @@
 	/>
 
 	<transaction
-	  backendURL="http://localhost:${bvt.prop.HTTP_default}"
-      recoveryIdentity="Server1"
-      recoveryGroup="defaultGroup"
-      recoverOnStartup="true"
-      waitForRecovery="true"
-    />
+    backendURL="http://localhost:${bvt.prop.HTTP_default}"
+    recoveryIdentity="Server1"
+    recoveryGroup="defaultGroup"
+    recoverOnStartup="true"
+    waitForRecovery="true"
+    leaseLength="3h"
+  />
 
-	<javaPermission name="*" actions="*" className="java.security.AllPermission"/>
-
+  <javaPermission name="*" actions="*" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.wsat.migration_fat.7/publish/servers/MigrationServer2/server.xml
+++ b/dev/com.ibm.ws.wsat.migration_fat.7/publish/servers/MigrationServer2/server.xml
@@ -1,39 +1,40 @@
 <server>
-	<featureManager>
-		<feature>localConnector-1.0</feature>
-		<feature>jsp-2.3</feature>
-		<feature>wsAtomicTransaction-1.2</feature>
-		<feature>jndi-1.0</feature>
-		<feature>servlet-3.1</feature>
-		<feature>cdi-1.2</feature>
-		<feature>txtest-1.0</feature>
-	</featureManager>
+  <featureManager>
+    <feature>cdi-1.2</feature>
+    <feature>jndi-1.0</feature>
+    <feature>jsp-2.3</feature>
+    <feature>localConnector-1.0</feature>
+    <feature>servlet-3.1</feature>
+    <feature>txtest-1.0</feature>
+    <feature>wsAtomicTransaction-1.2</feature>
+  </featureManager>
 
-	<include location="../fatTestCommon.xml" />
+  <include location="../fatTestCommon.xml" />
 
-  	<httpEndpoint id="defaultHttpEndpoint"
-                host="*"
-                httpPort="${bvt.prop.HTTP_secondary}"
-                httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+  <httpEndpoint id="defaultHttpEndpoint"
+    host="*"
+    httpPort="${bvt.prop.HTTP_secondary}"
+    httpsPort="${bvt.prop.HTTP_secondary.secure}"
+  />
 
-	<tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
+  <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
-	<httpOptions
-		readTimeout="150s"
-		writeTimeout="150s"
-		persistTimeout="150s"
-	/>
+  <httpOptions
+    readTimeout="150s"
+    writeTimeout="150s"
+    persistTimeout="150s"
+  />
 
-	<transaction
-	  backendURL="http://localhost:${bvt.prop.HTTP_secondary}"
-      recoveryIdentity="Server2"
-      recoveryGroup="defaultGroup"
-      recoverOnStartup="true"
-      waitForRecovery="true"
-    />
+  <transaction
+    backendURL="http://localhost:${bvt.prop.HTTP_secondary}"
+    recoveryIdentity="Server2"
+    recoveryGroup="defaultGroup"
+    recoverOnStartup="true"
+    waitForRecovery="true"
+    leaseLength="3h"
+  />
 
-	<wsAtomicTransaction asyncResponseTimeout="60000"/>
+  <wsAtomicTransaction asyncResponseTimeout="60000"/>
 
-	<javaPermission name="*" actions="*" className="java.security.AllPermission"/>
-
+  <javaPermission name="*" actions="*" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.wsat.migration_fat.7/publish/servers/MigrationServer3/server.xml
+++ b/dev/com.ibm.ws.wsat.migration_fat.7/publish/servers/MigrationServer3/server.xml
@@ -1,20 +1,21 @@
 <server>
 	<featureManager>
-		<feature>localConnector-1.0</feature>
-		<feature>jsp-2.3</feature>
-		<feature>wsAtomicTransaction-1.2</feature>
-		<feature>jndi-1.0</feature>
-		<feature>servlet-3.1</feature>
 		<feature>cdi-1.2</feature>
+		<feature>jndi-1.0</feature>
+		<feature>jsp-2.3</feature>
+		<feature>localConnector-1.0</feature>
+		<feature>servlet-3.1</feature>
 		<feature>txtest-1.0</feature>
+		<feature>wsAtomicTransaction-1.2</feature>
 	</featureManager>
 
 	<include location="../fatTestCommon.xml" />
 
 	<httpEndpoint id="defaultHttpEndpoint"
-                host="*"
-                httpPort="${bvt.prop.HTTP_tertiary}"
-                httpsPort="${bvt.prop.HTTP_tertiary.secure}"/>
+    host="*"
+    httpPort="${bvt.prop.HTTP_tertiary}"
+    httpsPort="${bvt.prop.HTTP_tertiary.secure}"
+  />
 
 	<tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
@@ -25,15 +26,15 @@
 	/>
 
 	<transaction
-	  	backendURL="http://localhost:${bvt.prop.HTTP_tertiary}"
-        recoveryIdentity="Server3"
+    backendURL="http://localhost:${bvt.prop.HTTP_tertiary}"
+    recoveryIdentity="Server3"
 		recoveryGroup="defaultGroup"
-        recoverOnStartup="true"
-        waitForRecovery="true"
-    />
+    recoverOnStartup="true"
+    waitForRecovery="true" 
+    leaseLength="3h"
+  />
 
 	<wsAtomicTransaction asyncResponseTimeout="60000"/>
 
 	<javaPermission name="*" actions="*" className="java.security.AllPermission"/>
-
 </server>

--- a/dev/io.openliberty.checkpoint_fat_transaction/test-applications/transactioncloud/src/servlets/cloud/Base2PCCloudServlet.java
+++ b/dev/io.openliberty.checkpoint_fat_transaction/test-applications/transactioncloud/src/servlets/cloud/Base2PCCloudServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,9 +34,6 @@ import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
 public class Base2PCCloudServlet extends FATServlet {
-
-    /**  */
-    private static final String filter = "(testfilter=jon)";
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -73,17 +70,17 @@ public class Base2PCCloudServlet extends FATServlet {
             final XAResource xaRes1 = XAResourceFactoryImpl.instance()
                             .getXAResourceImpl(xaResInfo1)
                             .setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance()
                             .getXAResourceImpl(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance()
                             .getXAResourceImpl(xaResInfo3);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -130,17 +127,17 @@ public class Base2PCCloudServlet extends FATServlet {
 
             final XAResource xaRes1 = XAResourceFactoryImpl.instance()
                             .getXAResourceImpl(xaResInfo1);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance()
                             .getXAResourceImpl(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance()
                             .getXAResourceImpl(xaResInfo3);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -165,12 +162,12 @@ public class Base2PCCloudServlet extends FATServlet {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance()
                             .getXAResource(xaResInfo1);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance()
                             .getXAResource(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             XAResourceImpl.dumpState();
@@ -216,12 +213,12 @@ public class Base2PCCloudServlet extends FATServlet {
                             .getXAResourceImpl(xaResInfo1)
                             .setPrepareAction(
                                               XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance()
                             .getXAResource(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -268,14 +265,14 @@ public class Base2PCCloudServlet extends FATServlet {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance()
                             .getXAResource(xaResInfo1);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance()
                             .getXAResourceImpl(xaResInfo2)
                             .setPrepareAction(
                                               XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -322,19 +319,19 @@ public class Base2PCCloudServlet extends FATServlet {
                             .getXAResourceImpl(xaResInfo1)
                             .setPrepareAction(
                                               XAException.XA_RBROLLBACK);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance()
                             .getXAResourceImpl(xaResInfo2)
                             .setRollbackAction(
                                                XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance()
                             .getXAResource(xaResInfo3);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -378,15 +375,15 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setPrepareAction(XAException.XA_RBROLLBACK);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo3).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -428,15 +425,15 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo1);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo3).setPrepareAction(XAException.XA_RBROLLBACK);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -477,11 +474,11 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -548,11 +545,11 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo1);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -589,11 +586,11 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.rollback();
@@ -630,11 +627,11 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo1);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.rollback();
@@ -671,11 +668,11 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setCommitAction(XAException.XA_HEURRB);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -716,11 +713,11 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setCommitAction(XAException.XA_HEURMIX);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -761,11 +758,11 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setCommitAction(XAException.XA_HEURCOM);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -806,11 +803,11 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setCommitAction(XAException.XA_HEURHAZ);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -852,15 +849,15 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setPrepareAction(XAException.XA_RBROLLBACK);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo3).setRollbackAction(XAException.XA_HEURRB);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -902,15 +899,15 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setPrepareAction(XAException.XA_RBROLLBACK);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo3).setRollbackAction(XAException.XA_HEURCOM);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -952,15 +949,15 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setPrepareAction(XAException.XA_RBROLLBACK);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo3).setRollbackAction(XAException.XA_HEURMIX);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -1002,15 +999,15 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setPrepareAction(XAException.XA_RBROLLBACK);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo3).setRollbackAction(XAException.XA_HEURHAZ);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -1054,7 +1051,7 @@ public class Base2PCCloudServlet extends FATServlet {
                 if (i == 0) {
                     xaRes.setPrepareAction(XAResourceImpl.DIE);
                 }
-                final int recoveryId = tm.registerResourceInfo(filter, xaResInfo);
+                final int recoveryId = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo);
                 tm.enlist(xaRes, recoveryId);
             }
 
@@ -1097,7 +1094,7 @@ public class Base2PCCloudServlet extends FATServlet {
                 if (i == 0) {
                     xaRes.setCommitAction(XAResourceImpl.DIE);
                 }
-                final int recoveryId = tm.registerResourceInfo(filter, xaResInfo);
+                final int recoveryId = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo);
                 tm.enlist(xaRes, recoveryId);
             }
 
@@ -1140,7 +1137,7 @@ public class Base2PCCloudServlet extends FATServlet {
                 if (i == 0) {
                     xaRes.setPrepareAction(XAResourceImpl.DIE);
                 }
-                final int recoveryId = tm.registerResourceInfo(filter, xaResInfo);
+                final int recoveryId = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo);
                 tm.enlist(xaRes, recoveryId);
             }
 
@@ -1183,7 +1180,7 @@ public class Base2PCCloudServlet extends FATServlet {
                 if (i == 0) {
                     xaRes.setCommitAction(XAResourceImpl.DIE);
                 }
-                final int recoveryId = tm.registerResourceInfo(filter, xaResInfo);
+                final int recoveryId = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo);
                 tm.enlist(xaRes, recoveryId);
             }
 
@@ -1224,15 +1221,15 @@ public class Base2PCCloudServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2, 1);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2, 1);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo3);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3, -1);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3, -1);
             tm.enlist(xaRes3, recoveryId3);
 
             // prepare order should be 3,2,1

--- a/dev/io.openliberty.checkpoint_fat_transaction/test-applications/transactionrecovery/src/servlets/recovery/RecoveryServlet.java
+++ b/dev/io.openliberty.checkpoint_fat_transaction/test-applications/transactionrecovery/src/servlets/recovery/RecoveryServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -35,9 +35,6 @@ public class RecoveryServlet extends FATServlet {
     /* Tran timeout for test setup */
     private static final int SETUP_TIMEOUT = 300; // 5 mins
 
-    /**  */
-    private static final String filter = "(testfilter=jon)";
-
     public void commitSuicide(HttpServletRequest request,
                               HttpServletResponse response) throws Exception {
         Runtime.getRuntime().halt(0);
@@ -54,11 +51,11 @@ public class RecoveryServlet extends FATServlet {
 
         tm.begin();
         final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1);
-        final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+        final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
         tm.enlist(xaRes1, recoveryId1);
 
         final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo2);
-        final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+        final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
         tm.enlist(xaRes2, recoveryId2);
 
         tm.commit();
@@ -81,12 +78,12 @@ public class RecoveryServlet extends FATServlet {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance()
                             .getXAResource(xaResInfo1);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance()
                             .getXAResource(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             XAResourceImpl.dumpState();
@@ -133,12 +130,12 @@ public class RecoveryServlet extends FATServlet {
                             .getXAResourceImpl(xaResInfo1)
                             .setPrepareAction(
                                               XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance()
                             .getXAResource(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -186,14 +183,14 @@ public class RecoveryServlet extends FATServlet {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance()
                             .getXAResource(xaResInfo1);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance()
                             .getXAResourceImpl(xaResInfo2)
                             .setPrepareAction(
                                               XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -241,19 +238,19 @@ public class RecoveryServlet extends FATServlet {
                             .getXAResourceImpl(xaResInfo1)
                             .setPrepareAction(
                                               XAException.XA_RBROLLBACK);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance()
                             .getXAResourceImpl(xaResInfo2)
                             .setRollbackAction(
                                                XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance()
                             .getXAResource(xaResInfo3);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -298,15 +295,15 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setPrepareAction(XAException.XA_RBROLLBACK);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo3).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -349,15 +346,15 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo1);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo3).setPrepareAction(XAException.XA_RBROLLBACK);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -399,11 +396,11 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -441,11 +438,11 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo1);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -483,11 +480,11 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.rollback();
@@ -525,11 +522,11 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo1);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.rollback();
@@ -567,11 +564,11 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setCommitAction(XAException.XA_HEURRB);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -613,11 +610,11 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setCommitAction(XAException.XA_HEURMIX);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -659,11 +656,11 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setCommitAction(XAException.XA_HEURCOM);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -705,11 +702,11 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setCommitAction(XAException.XA_HEURHAZ);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             tm.commit();
@@ -752,15 +749,15 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setPrepareAction(XAException.XA_RBROLLBACK);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo3).setRollbackAction(XAException.XA_HEURRB);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -803,15 +800,15 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setPrepareAction(XAException.XA_RBROLLBACK);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo3).setRollbackAction(XAException.XA_HEURCOM);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -854,15 +851,15 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setPrepareAction(XAException.XA_RBROLLBACK);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo3).setRollbackAction(XAException.XA_HEURMIX);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -905,15 +902,15 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setPrepareAction(XAException.XA_RBROLLBACK);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo2).setRollbackAction(XAResourceImpl.DIE);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo3).setRollbackAction(XAException.XA_HEURHAZ);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3);
             tm.enlist(xaRes3, recoveryId3);
 
             tm.commit();
@@ -959,7 +956,7 @@ public class RecoveryServlet extends FATServlet {
                 if (i == 0) {
                     xaRes.setPrepareAction(XAResourceImpl.DIE);
                 }
-                final int recoveryId = tm.registerResourceInfo(filter, xaResInfo);
+                final int recoveryId = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo);
                 tm.enlist(xaRes, recoveryId);
             }
 
@@ -1004,7 +1001,7 @@ public class RecoveryServlet extends FATServlet {
                 if (i == 0) {
                     xaRes.setCommitAction(XAResourceImpl.DIE);
                 }
-                final int recoveryId = tm.registerResourceInfo(filter, xaResInfo);
+                final int recoveryId = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo);
                 tm.enlist(xaRes, recoveryId);
             }
 
@@ -1049,7 +1046,7 @@ public class RecoveryServlet extends FATServlet {
                 if (i == 0) {
                     xaRes.setPrepareAction(XAResourceImpl.DIE);
                 }
-                final int recoveryId = tm.registerResourceInfo(filter, xaResInfo);
+                final int recoveryId = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo);
                 tm.enlist(xaRes, recoveryId);
             }
 
@@ -1094,7 +1091,7 @@ public class RecoveryServlet extends FATServlet {
                 if (i == 0) {
                     xaRes.setCommitAction(XAResourceImpl.DIE);
                 }
-                final int recoveryId = tm.registerResourceInfo(filter, xaResInfo);
+                final int recoveryId = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo);
                 tm.enlist(xaRes, recoveryId);
             }
 
@@ -1136,15 +1133,15 @@ public class RecoveryServlet extends FATServlet {
         try {
             tm.begin();
             final XAResource xaRes1 = XAResourceFactoryImpl.instance().getXAResourceImpl(xaResInfo1).setCommitAction(XAResourceImpl.DIE);
-            final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+            final int recoveryId1 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo1);
             tm.enlist(xaRes1, recoveryId1);
 
             final XAResource xaRes2 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo2);
-            final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2, 1);
+            final int recoveryId2 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo2, 1);
             tm.enlist(xaRes2, recoveryId2);
 
             final XAResource xaRes3 = XAResourceFactoryImpl.instance().getXAResource(xaResInfo3);
-            final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3, -1);
+            final int recoveryId3 = tm.registerResourceInfo(XAResourceInfoFactory.filter, xaResInfo3, -1);
             tm.enlist(xaRes3, recoveryId3);
 
             // prepare order should be 3,2,1

--- a/dev/io.openliberty.org.testcontainers/cache/projects
+++ b/dev/io.openliberty.org.testcontainers/cache/projects
@@ -183,4 +183,5 @@ io.openliberty.microprofile.health.3.1.internal_fat
 io.openliberty.microprofile.openapi.ui.internal_fat
 io.openliberty.microprofile.reactive.messaging.internal_fat
 io.openliberty.microprofile.telemetry.1.0.internal.container_fat
+io.openliberty.org.apache.myfaces.4.0_fat
 io.openliberty.org.apache.myfaces.4.1_fat


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.jta_fat,com.ibm.ws.transaction.cloud_fat.base,com.ibm.ws.transaction.cloud_fat.db2.0,com.ibm.ws.transaction.cloud_fat.db2.1,com.ibm.ws.transaction.cloud_fat.db2.2,com.ibm.ws.transaction.cloud_fat.derby.0,com.ibm.ws.transaction.cloud_fat.derby.1,com.ibm.ws.transaction.cloud_fat.derby.2,com.ibm.ws.transaction.cloud_fat.dualFS,com.ibm.ws.transaction.cloud_fat.oracle.0,com.ibm.ws.transaction.cloud_fat.oracle.1,com.ibm.ws.transaction.cloud_fat.oracle.2,com.ibm.ws.transaction.cloud_fat.peerlocking.1,com.ibm.ws.transaction.cloud_fat.peerlocking.2,com.ibm.ws.transaction.cloud_fat.postgresql.0,com.ibm.ws.transaction.cloud_fat.postgresql.1,com.ibm.ws.transaction.cloud_fat.postgresql.2,com.ibm.ws.transaction.cloud_fat.simpleFS,com.ibm.ws.transaction.cloud_fat.sqlserver.0,com.ibm.ws.transaction.cloud_fat.sqlserver.1,com.ibm.ws.transaction.cloud_fat.sqlserver.2,com.ibm.ws.transaction.core_fat.base,com.ibm.ws.transaction.core_fat.baseDB,com.ibm.ws.transaction.core_fat.cdi,com.ibm.ws.transaction.core_fat.commitPriority,com.ibm.ws.transaction.core_fat.heuristics,com.ibm.ws.transaction.core_fat.heuristicsDB,com.ibm.ws.transaction.core_fat.misc,com.ibm.ws.transaction.core_fat.startMultiEJB,com.ibm.ws.transaction.core_fat.startup,com.ibm.ws.transaction.core_fat.xa,com.ibm.ws.transaction.core_fat.xaDB,com.ibm.ws.transaction.db_fat,com.ibm.ws.transaction.hadb_fat.db2.1,com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.db2.retriablecodes,com.ibm.ws.transaction.hadb_fat.derby.1,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.derby.retriablecodes,com.ibm.ws.transaction.hadb_fat.oracle.1,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.oracle.retriablecodes,com.ibm.ws.transaction.hadb_fat.postgresql.1,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.postgresql.retriablecodes,com.ibm.ws.transaction.hadb_fat.sqlserver.1,com.ibm.ws.transaction.hadb_fat.sqlserver.2,com.ibm.ws.transaction.hadb_fat.sqlserver.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes,com.ibm.ws.transaction.recovery_fat.1,com.ibm.ws.transaction.recovery_fat.2,com.ibm.ws.transaction.recovery_fat.3,com.ibm.ws.tx.jta_fat,com.ibm.ws.tx.jta_fat_hibernate,com.ibm.ws.wsat.common_fat,com.ibm.ws.wsat.concurrent_fat,com.ibm.ws.wsat.migration_fat.1,com.ibm.ws.wsat.migration_fat.2,com.ibm.ws.wsat.migration_fat.3,com.ibm.ws.wsat.migration_fat.4,com.ibm.ws.wsat.migration_fat.5,com.ibm.ws.wsat.migration_fat.6,com.ibm.ws.wsat.migration_fat.7,com.ibm.ws.wsat.recovery_fat.lps,com.ibm.ws.wsat.recovery_fat.multi.1,com.ibm.ws.wsat.recovery_fat.multi.2,com.ibm.ws.wsat.recovery_fat.multi.3,com.ibm.ws.wsat.recovery_fat.multi.4,com.ibm.ws.wsat.recovery_fat.multi.5,com.ibm.ws.wsat.recovery_fat.multi.6,com.ibm.ws.wsat.recovery_fat.multi.7,com.ibm.ws.wsat.recovery_fat.single.1,com.ibm.ws.wsat.recovery_fat.single.2,com.ibm.ws.wsat_fat.assertion,com.ibm.ws.wsat_fat.db,com.ibm.ws.wsat_fat.db_optional,com.ibm.ws.wsat_fat.dbs,com.ibm.ws.wsat_fat.dbs_optional,com.ibm.ws.wsat_fat.multi,com.ibm.ws.wsat_fat.multi.misroute,com.ibm.ws.wsat_fat.ssl.misroute,com.ibm.ws.wsat_fat.ssl,io.openliberty.checkpoint_fat_transaction