### PR TITLE
Clarify the scope of the webAppSecurity attributes

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/l10n/metatype.properties
@@ -15,7 +15,7 @@
 
 #
 webAppSecurityService.config=Web Container Application Security
-webAppSecurityService.config.desc=Configures web container application security for user applications only.
+webAppSecurityService.config.desc=Configures web container security for user applications only.
 
 requiredRole=Required role
 requiredRole.desc=Required role used for authorization checks.

--- a/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/l10n/metatype.properties
@@ -15,7 +15,7 @@
 
 #
 webAppSecurityService.config=Web Container Application Security
-webAppSecurityService.config.desc=Configures web container application security.
+webAppSecurityService.config.desc=Configures web container application security for user applications only.
 
 requiredRole=Required role
 requiredRole.desc=Required role used for authorization checks.


### PR DESCRIPTION
Clarifying the scope of webAppSecurity attributes. 
fixes #28326 

