### PR TITLE
Update test to handle slow test system

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/fat/src/com/ibm/ws/security/openidconnect/client/fat/jaxrs/CommonTests/JaxRSClientReAuthnTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/fat/src/com/ibm/ws/security/openidconnect/client/fat/jaxrs/CommonTests/JaxRSClientReAuthnTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 IBM Corporation and others.
+ * Copyright (c) 2016, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -611,7 +611,7 @@ public class JaxRSClientReAuthnTests extends CommonTest {
         // RP LTPA token, we do NOT have to login again
         genericRP(_testName, wc, updatedTestSettings, Constants.GET_LOGIN_PAGE_ONLY, expectationsNoLogin);
 
-        helpers.testSleep(20);
+        helpers.testSleep(35);
         cookieTools.removeCookieFromConverstation(wc, Constants.OP_COOKIE);
 
         // again, since we have the LTPA Token, the RP does NOT make us login, but the OP sees the expired tokens

--- a/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/publish/files/serversettings/provider_OP_ReAuthn.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat.jaxrs/publish/files/serversettings/provider_OP_ReAuthn.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2023 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -85,7 +85,7 @@
 		filter="request-url%=helloworld_bothShortLifetime"
 		oauthOnly="true"
 		httpsRequired="false"
-		accessTokenLifetime="15s"
+		accessTokenLifetime="30s"
 		autoAuthorize="true"
 		jwtAccessToken="${oidcCreateJWTToken}"
 	>


### PR DESCRIPTION
Tests that validate that tokens expire and we'll need to reauthenticate are failing because the tokens are timing out too quickly.  It's not valid right after we login in and not after some elapsed time.
Increasing the lifetime of the token and the time that we'll sleep and wait for the token to expire.