### PR TITLE
Issue #28350: Avoid NullPointerException for connection during shutdown

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/fat/src/com/ibm/ws/concurrent/persistent/fat/configupd/db/ExecEnabledDBStoreConfigUpdateTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/fat/src/com/ibm/ws/concurrent/persistent/fat/configupd/db/ExecEnabledDBStoreConfigUpdateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -64,9 +64,12 @@ public class ExecEnabledDBStoreConfigUpdateTest {
 
     @AfterClass
     public static void afterSuite() throws Exception {
+    	// CWWKC1556W: task deferred until application available; application not yet started after update
+    	// J2CA0024E: Method rollback, within transaction; configuration update during execution
+    	// J2CA0081E: Method cleanup failed; configuration update during execution already destroyed connection
         if (server != null) {
             if (server.isStarted())
-                server.stopServer("CWWKC1556W");
+                server.stopServer("CWWKC1556W", "J2CA0024E", "J2CA0081E:.*cleanup");
             server.updateServerConfiguration(originalConfigForAfterSuite);
         }
     }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2023 IBM Corporation and others.
+ * Copyright (c) 2001, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -3190,8 +3190,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                     break;
                 }
                 
-                if (!currentAutoCommit)
-                    try { // autoCommit is off
+                if (!currentAutoCommit && sqlConn != null)
+                    try { // autoCommit is off; has not been destroyed yet
                         sqlConn.rollback();
                     } catch (SQLException se) {
                         FFDCFilter.processException(se, "com.ibm.ws.rsadapter.spi.WSRdbManagedConnectionImpl.cleanupTransactions", "1223", this);


### PR DESCRIPTION
- Avoid NullPointerException when destroy is called a second time or if cleanup is called after destroy
- Update test to tolerate a meaningful exception thrown from cleanup; not expected from destroy

fixes #28350 