### PR TITLE
Increase trace for concurrent persistent FAT

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/publish/servers/com.ibm.ws.concurrent.persistent.fat.simctrl/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/publish/servers/com.ibm.ws.concurrent.persistent.fat.simctrl/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014, 2019 IBM Corporation and others.
+# Copyright (c) 2014, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 
-com.ibm.ws.logging.trace.specification=*=info=enabled:persistentExecutor=all:com.ibm.ws.config.*=all:logservice=all
+com.ibm.ws.logging.trace.specification=*=info=enabled:persistentExecutor=all:com.ibm.ws.config.*=all:logservice=all:WAS.j2c=all
 com.ibm.ws.logging.max.file.size=0
 
 ds.loglevel=debug 


### PR DESCRIPTION
- Add WAS.j2c trace to diagnose why connection pool shut down during server start
