### PR TITLE
CVE Reporting: Functionality for when ssl or transportSecurity features are enabled

### DIFF
--- a/dev/io.openliberty.reporting.internal/src/io/openliberty/reporting/internal/CVEServiceClient.java
+++ b/dev/io.openliberty.reporting.internal/src/io/openliberty/reporting/internal/CVEServiceClient.java
@@ -18,9 +18,13 @@ import java.net.ConnectException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 
 import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
 
 import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.Tr;
@@ -85,6 +89,14 @@ public class CVEServiceClient {
     private static HttpsURLConnection getConnection(URL url) throws IOException {
         HttpsURLConnection connection = null;
         connection = (HttpsURLConnection) url.openConnection();
+        SSLContext sc = null;
+        try {
+            sc = SSLContext.getInstance("TLSv1.2");
+            sc.init(null, null, null);
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            throw new SSLHandshakeException("Issue when creating a secure connection: " + e);
+        }
+        connection.setSSLSocketFactory(sc.getSocketFactory());
         connection.setRequestMethod("POST");
         connection.setRequestProperty("Content-Type", "application/json");
         connection.setRequestProperty("Accept", "application/json");

--- a/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/response/CVEReportingResponseEndpoints.java
+++ b/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/response/CVEReportingResponseEndpoints.java
@@ -46,8 +46,6 @@ public class CVEReportingResponseEndpoints extends Application {
 
         data = dataReceived;
 
-        System.out.println("CONSUMED: " + data);
-
         System.out.println("POST COMPLETED");
 
         CveProduct cveProduct = new CveProduct();

--- a/dev/io.openliberty.reporting.internal_fat/publish/servers/io.openliberty.reporting.response.app.server/server.xml
+++ b/dev/io.openliberty.reporting.internal_fat/publish/servers/io.openliberty.reporting.response.app.server/server.xml
@@ -38,6 +38,6 @@
     <!-- <webApplication contextRoot="/" /> -->
 
     <!-- Default SSL configuration enables trust for default certificates from the Java runtime -->
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+	<ssl id="defaultSSLConfig" />
 
 </server>

--- a/dev/io.openliberty.reporting.internal_fat/publish/servers/io.openliberty.reporting.response.test.server/server.xml
+++ b/dev/io.openliberty.reporting.internal_fat/publish/servers/io.openliberty.reporting.response.test.server/server.xml
@@ -35,6 +35,13 @@
 
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
+    
+    <ssl id="defaultSSLConfig"
+      keyStoreRef="NewKeyStore"
+      trustStoreRef="NewTrustStore"/>
+      
+    <keyStore id="NewKeyStore" location="NewKeyStore.jks" type="JKS" password="Liberty" />
+    <keyStore id="NewTrustStore" location="NewTrustStore.jks" type="JKS" password="Liberty" />
 	
 
 </server>


### PR DESCRIPTION
Making sure that CVE Reporting connection is using the value of the `javax.net.ssl.trustStore` when either ssl or transportSecurity features are enabled. 