### PR TITLE
Set-Cookie header with arbitrary attributes

### DIFF
--- a/dev/com.ibm.ws.transport.http/resources/com/ibm/ws/http/channel/internal/resources/httpchannelmessages.nlsprops
+++ b/dev/com.ibm.ws.transport.http/resources/com/ibm/ws/http/channel/internal/resources/httpchannelmessages.nlsprops
@@ -1,14 +1,11 @@
 ###############################################################################
-# Copyright (c) 2002, 2022 IBM Corporation and others.
+# Copyright (c) 2002, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 #
 #COMPONENTPREFIX CWWKT
@@ -215,3 +212,8 @@ log.rollover.start.time.format.warning.useraction=Ensure that the rollover start
 log.rollover.interval.too.short.warning=CWWKT0046W: The log rollover interval cannot be less than 1 minute long. If a value that is less than 1 minute is specified, the log rollover interval is set to a default of 1 day.
 log.rollover.interval.too.short.warning.explanation=The log rollover interval cannot be less than 1 minute long.
 log.rollover.interval.too.short.warning.useraction=Specify a log rollover interval that is equal to or greater than 1 minute.
+
+#only if the Set-Cookie is added with the response set/addHeader API.  The best practice is to use Cookie() API which already has this check and uses its own message.
+cookie.attribute.name.invalid=CWWKT0047E: The [{0}] cookie attribute contains an invalid character.
+cookie.attribute.name.invalid.explanation=The cookie attribute name cannnot contain any special [\()<>@,;:\\/[]?={} \t] character.
+cookie.attribute.name.invalid.useraction=Correct the cookie attribute name to not use any special character.

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/cookies/CookieHeaderByteParser.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/cookies/CookieHeaderByteParser.java
@@ -190,16 +190,11 @@ public class CookieHeaderByteParser {
                             cookiesList.add(cookie);
                         } else {
                             /*
-                             * arbitrary attribute .i.e not the well known HttpOnly, SameSite ....
+                             * arbitrary attribute .i.e not the well known HttpOnly, SameSite, Partitioned ....
                              */
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                 Tr.debug(tc, "parse ; arbitrary setAttribute , name [" + cName + "] , value [" + cValue + "]");
                             }
-
-                            //????????? PMDINH TO-DO test to see if attribute already exists
-                            String existenceAtt = cookie.getAttribute(cName);
-                            if (existenceAtt != null)
-                                System.out.println("PMDINH Existing Atttribute [" + cName + "]");
 
                             cookie.setAttribute(cName, cValue);
                         }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/cookies/CookieUtils.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/cookies/CookieUtils.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.http.channel.internal.cookies;
@@ -42,6 +42,7 @@ public class CookieUtils {
     private static final String longAgo = "; Expires=Thu, 01-Dec-94 16:00:00 GMT";
     private static final String longAgoRFC1123 = "; Expires=Thu, 01 Dec 1994 16:00:00 GMT";
     private static boolean skipCookiePathQuotes = false;
+    private static boolean isEE11 = HttpDispatcher.isEE11();
 
     /**
      * Default constructor for the utility class.
@@ -388,7 +389,7 @@ public class CookieUtils {
             buffer.append(value);
         }
 
-        if(ProductInfo.getBetaEdition()) {
+        if (ProductInfo.getBetaEdition()) {
             value = cookie.getAttribute("partitioned");
             if (null != value && !value.equalsIgnoreCase("false")) {
                 buffer.append("; Partitioned");
@@ -471,7 +472,7 @@ public class CookieUtils {
             buffer.append(value);
         }
 
-        if(ProductInfo.getBetaEdition()) {
+        if (ProductInfo.getBetaEdition()) {
             value = cookie.getAttribute("partitioned");
             if (null != value && !value.equalsIgnoreCase("false")) {
                 buffer.append("; Partitioned");
@@ -570,7 +571,7 @@ public class CookieUtils {
             buffer.append(value);
         }
 
-        if(ProductInfo.getBetaEdition()) {
+        if (ProductInfo.getBetaEdition()) {
             value = cookie.getAttribute("partitioned");
             if (null != value && !value.equalsIgnoreCase("false")) {
                 buffer.append("; Partitioned");
@@ -599,18 +600,49 @@ public class CookieUtils {
                 key = entry.getKey();
                 // add partitioned if not in beta.
                 // skip if in beta since it's added above already
-                if((key.equals("partitioned") && ProductInfo.getBetaEdition())){
+                if ((key.equals("partitioned") && ProductInfo.getBetaEdition())) {
                     continue;
                 }
-                if (!(key.equals("samesite") || key.equals("port") || key.equals("commenturl")) ) {
+                if (!(key.equals("samesite") || key.equals("port") || key.equals("commenturl"))) {
                     value = entry.getValue();
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc, "setAttribute (" + key + " , " + value + ")");
                     }
-                    buffer.append("; " + key + "=");
-                    buffer.append(value);
+                    if (isEE11) {
+                        if (hasReservedCharacters(key)) { //entire cookie is discarded. Flow continues
+                            String message = Tr.formatMessage(tc, "cookie.attribute.name.invalid", key);
+                            Tr.error(tc, message);
+                            throw new IllegalArgumentException(message);
+                        }
+
+                        if (value == null || value.trim().equalsIgnoreCase("null")) {
+                            continue;
+                        } else if (value.isEmpty() || value.contentEquals("=")) { // i.e the specified value is just the "="; Cookie.setAttribute("Cookie_NAME_ONLY_SIGN", "=");
+                            buffer.append("; " + key);
+                            continue;
+                        }
+
+                        buffer.append("; " + key + "=" + value);
+                    }
+                    // EE10
+                    else {
+                        buffer.append("; " + key + "=");
+                        buffer.append(value);
+                    }
                 }
             }
         }
+    }
+
+    private static boolean hasReservedCharacters(String value) {
+        int len = value.length();
+        for (int i = 0; i < len; i++) {
+            char c = value.charAt(i);
+            if (c < 0x20 || c >= 0x7f || TSPECIALS.indexOf(c) != -1) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/cookies/CookieUtils.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/cookies/CookieUtils.java
@@ -591,6 +591,10 @@ public class CookieUtils {
     /*
      * since Servlet 6.0 - Support Cookie's setAttribute
      * exclude "samesite", "port", "commenturl" attribute since they already set
+     *
+     * Updated Servlet 6.1:
+     * - handle empty and null value;
+     * - handle invalid character in attribute name;
      */
     private static void setAttributes(HttpCookie cookie, StringBuilder buffer) {
         Map<String, String> cookieAttrs = cookie.getAttributes();

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/HttpDispatcher.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/HttpDispatcher.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2022 IBM Corporation and others.
+ * Copyright (c) 2009, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.http.dispatcher.internal;
 
@@ -82,6 +79,9 @@ public class HttpDispatcher {
     //Servlet 6.0
     private volatile ServiceReference<HttpBehavior> cookieBehaviorRef;
     private static volatile boolean useEE10Cookies = false;
+
+    //Servlet 6.1 (EE11)
+    private static volatile boolean isEE11 = false;
 
     static final String CONFIG_ALIAS = "httpDispatcher";
 
@@ -796,21 +796,27 @@ public class HttpDispatcher {
     protected synchronized void setCookiesBehavior(ServiceReference<HttpBehavior> reference) {
         cookieBehaviorRef = reference;
         useEE10Cookies = (Boolean) reference.getProperty(HttpBehavior.USE_EE10_COOKIES);
+        isEE11 = reference.getProperty(HttpBehavior.IS_EE11) == null ? false : true;
 
-        Tr.debug(tc, "setCookiesBehavior useEE10Cookies [" + useEE10Cookies + "]");
+        Tr.debug(tc, "setCookiesBehavior , useEE10Cookies [" + useEE10Cookies + "] , isEE11 [" + isEE11 + "]");
     }
 
     protected synchronized void unsetCookiesBehavior(ServiceReference<HttpBehavior> reference) {
         if (reference == this.cookieBehaviorRef) {
             cookieBehaviorRef = null;
             useEE10Cookies = false;
+            isEE11 = false;
 
-            Tr.debug(tc, "unsetCookiesBehavior useEE10Cookies [" + useEE10Cookies + "]");
+            Tr.debug(tc, "unsetCookiesBehavior , useEE10Cookies [" + useEE10Cookies + "] , isEE11 [" + isEE11 + "]");
         }
     }
 
     public static boolean useEE10Cookies() {
         return useEE10Cookies;
+    }
+
+    public static boolean isEE11() {
+        return isEE11;
     }
 
     /**

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/ee/behaviors/HttpBehavior.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/ee/behaviors/HttpBehavior.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.wsspi.http.ee.behaviors;
 
@@ -24,4 +21,10 @@ public class HttpBehavior {
      * $ is used only for $Versions in the request Cookie; prefix any other will be treated as new cookie ($ is part of a cookie name)
      */
     public static final String USE_EE10_COOKIES = "useEE10Cookies";
+
+    /*
+     * Since Servlet 6.1 (EE11)
+     * Use to process the Cookie's behavior in EE11
+     */
+    public static final String IS_EE11 = "isEE11";
 }

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal.factories/bnd.bnd
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal.factories/bnd.bnd
@@ -45,7 +45,7 @@ Service-Component: \
   com.ibm.ws.webcontainer.v61.httpBehavior; \
     implementation:=com.ibm.wsspi.http.ee.behaviors.HttpBehavior; \
     provide:=com.ibm.wsspi.http.ee.behaviors.HttpBehavior; \
-    properties:="useEE10Cookies:Boolean=true"
+    properties:="useEE10Cookies:Boolean=true,isEE11:Boolean=true"
 
 # For each exported package, create (in that package) a package-info.java
 # file, and place an @version javadoc tag in package-level javadoc. 

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/.classpath
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/.classpath
@@ -15,6 +15,7 @@
     <classpathentry kind="src" path="test-applications/RequestParameterTest.war/src"/>
     <classpathentry kind="src" path="test-applications/ResponseNoOpAfterCommit.war/src"/>
     <classpathentry kind="src" path="test-applications/ResponseSendRedirectTest.war/src"/>
+    <classpathentry kind="src" path="test-applications/SetCookieViaResponseHeader.war/src"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
     <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
         <attributes>

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/bnd.bnd
@@ -25,7 +25,8 @@ src: \
     test-applications/ReadWriteByteBuffer.war/src,\
     test-applications/RequestParameterTest.war/src,\
     test-applications/ResponseNoOpAfterCommit.war/src,\
-    test-applications/ResponseSendRedirectTest.war/src
+    test-applications/ResponseSendRedirectTest.war/src,\
+    test-applications/SetCookieViaResponseHeader.war/src
 
 fat.project: true
 

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/fat/src/io/openliberty/webcontainer/servlet61/fat/FATSuite.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/fat/src/io/openliberty/webcontainer/servlet61/fat/FATSuite.java
@@ -29,6 +29,7 @@ import io.openliberty.webcontainer.servlet61.fat.tests.Servlet61ReadWriteByteBuf
 import io.openliberty.webcontainer.servlet61.fat.tests.Servlet61RequestParameterTest;
 import io.openliberty.webcontainer.servlet61.fat.tests.Servlet61ResponseNoOpAfterCommit;
 import io.openliberty.webcontainer.servlet61.fat.tests.Servlet61ResponseSendRedirectTest;
+import io.openliberty.webcontainer.servlet61.fat.tests.Servlet61SetCookieRandomAttributes;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -44,7 +45,8 @@ import io.openliberty.webcontainer.servlet61.fat.tests.Servlet61ResponseSendRedi
     Servlet61ReadWriteByteBufferTest.class,
     Servlet61RequestParameterTest.class,
     Servlet61ResponseNoOpAfterCommit.class,
-    Servlet61ResponseSendRedirectTest.class
+    Servlet61ResponseSendRedirectTest.class,
+    Servlet61SetCookieRandomAttributes.class
 })
 public class FATSuite {
     /**

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/fat/src/io/openliberty/webcontainer/servlet61/fat/tests/Servlet61SetCookieRandomAttributes.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/fat/src/io/openliberty/webcontainer/servlet61/fat/tests/Servlet61SetCookieRandomAttributes.java
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.webcontainer.servlet61.fat.tests;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.logging.Logger;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Test ServletResponse addHeader and setHeader to add "Set-Cookie" with arbitrary attributes.
+ * Verify that the response Set-Cookie at client is not splitted up into multiple Set-Cookie headers
+ * Verify that attribute name with EMPTY value will show up with just the attribute name (there is no = trailing)
+ * Verify that attribute name with NULL value will : (1) remove the existing attribute with same name. (2) remove itself
+ *
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class Servlet61SetCookieRandomAttributes {
+    private static final Logger LOG = Logger.getLogger(Servlet61SetCookieRandomAttributes.class.getName());
+    private static final String TEST_APP_NAME = "SetCookieViaResponseHeader";
+
+    private StringBuilder headerSetCookie = new StringBuilder();
+    private int foundSetCookieHeaders = 0;
+    private String setCookieHeadersString = null;
+
+    private int EXPECTED_COOKIE_HEADERS = 3;
+
+    //These attributes in all tests
+    final String COOKIE_EXPECTED_ATT = "cookie_att_name=cookie_att_value";
+    final String SETHEADER_EXPECTED_ATT = "set_att_name=set_att_value";
+    final String ADDHEADER_EXPECTED_ATT = "add_att_name=add_att_value";
+
+    @Server("servlet61_SetCookieAttributes")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        LOG.info("Setup : servlet61_SetCookieAttributes.");
+        ShrinkHelper.defaultDropinApp(server, TEST_APP_NAME + ".war", "setcookie.servlets");
+
+        ArrayList<String> expectedErrors = new ArrayList<String>();
+        expectedErrors.add("CWWKT0047E:.*"); //Session Cookie attribute name has illegal character.
+        server.addIgnoredErrors(expectedErrors);
+
+        server.startServer(Servlet61SetCookieRandomAttributes.class.getSimpleName() + ".log");
+        LOG.info("Setup : startServer, ready for Tests.");
+    }
+
+    @AfterClass
+    public static void testCleanup() throws Exception {
+        LOG.info("testCleanUp : stop server");
+        // Stop the server
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /*
+     * Set-Cookie using Cookie() API - test : arbitrary attribute name and value - Expected no splitted Set-Cookie headers
+     *
+     * Expected response cookies:
+     * [set-cookie: cookie_att_test=cookie_value; httponly; cookie_att_name=cookie_att_value]
+     * [set-cookie: set_cookie_att_test=set_cookie_value; secure; httponly; samesite=none; set_att_name=set_att_value]
+     * [set-cookie: add_cookie_att_test=add_cookie_value; secure; httponly; samesite=strict; add_att_name=add_att_value]
+     */
+    @Test
+    public void test_SetCookie_Attributes() throws Exception {
+        LOG.info("====== <test_SetCookie_Attributes> ======");
+
+        runTest("test_SetCookie_Attributes");
+
+        setCookieHeadersString = headerSetCookie.toString().toLowerCase();
+        LOG.info("\n" + setCookieHeadersString);
+
+        assertCommonAttributes();
+    }
+
+    /*
+     * Test attribute name with NULL attribute value :
+     *  NULL attribute value removes the existing attribute
+     *  NULL attribute value removes itself
+     *
+     * Expected response cookies:
+     * [set-cookie: cookie_null_test=cookie_value; httponly; cookie_att_name=cookie_att_value]
+     * [set-cookie: set_cookie_null_test=set_cookie_value; secure; samesite=none; set_att_name=set_att_value]
+     * [set-cookie: add_cookie_null_test=add_cookie_value; secure; samesite=strict; add_att_name=add_att_value]
+     */
+    @Test
+    public void test_SetCookie_Attributes_NULL() throws Exception {
+        LOG.info("====== <test_SetCookie_Attributes_NULL> ======");
+
+        //removed the previous attributes with the new attributes which has NULL value
+        final String COOKIE_NOT_EXPECTED_REMOVED = "cookie_be_removed";
+        final String SET_NOT_EXPECTED_REMOVED = "set_be_removed";
+        final String ADD_NOT_EXPECTED_REMOVED= "add_be_removed";
+
+        final String COOKIE_NOT_EXPECTED_NULL_VALUE = "cookie_null_value";
+        final String SET_NOT_EXPECTED_NULL_VALUE = "set_null_value";
+        final String ADD_NOT_EXPECTED_NULL_VALUE = "add_null_value";
+
+        runTest("test_SetCookie_Attributes_NULL");
+
+        setCookieHeadersString = headerSetCookie.toString().toLowerCase(); //make it easier to search in the log
+        LOG.info("\n" + setCookieHeadersString);
+
+        assertCommonAttributes();
+
+        assertTrue("Cookie NULL Test - NOT Expected attribute [" + COOKIE_NOT_EXPECTED_REMOVED + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", !(setCookieHeadersString.contains(COOKIE_NOT_EXPECTED_REMOVED)));
+        assertTrue("Set Header NULL Test - NOT Expected attribute [" + SET_NOT_EXPECTED_REMOVED + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", !(setCookieHeadersString.contains(SET_NOT_EXPECTED_REMOVED)));
+        assertTrue("Add Header NULL Test - NOT Expected attribute [" + ADD_NOT_EXPECTED_REMOVED + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", !(setCookieHeadersString.contains(ADD_NOT_EXPECTED_REMOVED)));
+
+        assertTrue("Cookie NULL Test - NOT Expected attribute [" + COOKIE_NOT_EXPECTED_NULL_VALUE + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", !(setCookieHeadersString.contains(COOKIE_NOT_EXPECTED_NULL_VALUE)));
+        assertTrue("Set Header NULL Test - NOT Expected attribute [" + SET_NOT_EXPECTED_NULL_VALUE + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", !(setCookieHeadersString.contains(SET_NOT_EXPECTED_NULL_VALUE)));
+        assertTrue("Add Header NULL Test - NOT Expected attribute [" + ADD_NOT_EXPECTED_NULL_VALUE + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", !(setCookieHeadersString.contains(ADD_NOT_EXPECTED_NULL_VALUE)));
+    }
+
+
+    /*
+     * Test Empty attribute value : only attribute name showing without any = sign
+     *
+     * Expected response cookies:
+     * [set-cookie: cookie_empty_test=cookie_value; httponly; cookie_att_name=cookie_att_value; cookie_name_only_sign; cookie_name_only]
+     * [set-cookie: set_cookie_empty_test=set_cookie_value; secure; samesite=none; set_name_only_sign; set_name_only; set_att_name=set_att_value]
+     * [set-cookie: add_cookie_empty_test=add_cookie_value; secure; samesite=strict; add_att_name=add_att_value; add_name_only_sign; add_name_only]
+     */
+    @Test
+    public void test_SetCookie_Attributes_EMPTY() throws Exception {
+        LOG.info("====== <test_SetCookie_Attributes_EMPTY> ======");
+
+        final String COOKIE_EXPECTED_NAME_ONLY = "cookie_name_only";
+        final String SET_EXPECTED_NAME_ONLY = "set_name_only";
+        final String ADD_EXPECTED_NAME_ONLY = "add_name_only";
+
+        //The cookies were set with trailing = sign (i.e ; cookie_name_only_sign=); The = is NOT expected in the response(i.e ; cookie_name_only_sign)
+        final String COOKIE_NOT_EXPECTED_NAME_ONLY_SIGN = "cookie_name_only_sign=";
+        final String SET_NOT_EXPECTED_NAME_ONLY_SIGN = "set_name_only_sign=";
+        final String ADD_NOT_EXPECTED_NAME_ONLY_SIGN = "add_name_only_sign=";
+
+        runTest("test_SetCookie_Attributes_EMPTY");
+
+        setCookieHeadersString = headerSetCookie.toString().toLowerCase();
+        LOG.info("\n" + setCookieHeadersString);
+
+        assertCommonAttributes();
+
+        assertTrue("Cookie EMPTY Test - Expected attribute [" + COOKIE_EXPECTED_NAME_ONLY + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", (setCookieHeadersString.contains(COOKIE_EXPECTED_NAME_ONLY)));
+        assertTrue("Set Header EMPTY Test - Expected attribute [" + SET_EXPECTED_NAME_ONLY + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", (setCookieHeadersString.contains(SET_EXPECTED_NAME_ONLY)));
+        assertTrue("Add Header EMPTY Test - Expected attribute [" + ADD_EXPECTED_NAME_ONLY + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", (setCookieHeadersString.contains(ADD_EXPECTED_NAME_ONLY)));
+
+        //Not expected trailing = sign
+        assertTrue("Cookie EMPTY Test - NOT Expected attribute [" + COOKIE_NOT_EXPECTED_NAME_ONLY_SIGN + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", !(setCookieHeadersString.contains(COOKIE_NOT_EXPECTED_NAME_ONLY_SIGN)));
+        assertTrue("Set Header EMPTY Test - NOT Expected attribute [" + SET_NOT_EXPECTED_NAME_ONLY_SIGN + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", !(setCookieHeadersString.contains(SET_NOT_EXPECTED_NAME_ONLY_SIGN)));
+        assertTrue("Add Header EMPTY Test - NOT Expected attribute [" + ADD_NOT_EXPECTED_NAME_ONLY_SIGN + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", !(setCookieHeadersString.contains(ADD_NOT_EXPECTED_NAME_ONLY_SIGN)));
+
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalArgumentException" })
+    public void test_SetCookie_Illegal_Attribute_Name() throws Exception {
+        LOG.info("====== <test_SetCookie_Illegal_Attribute_Name> ======");
+
+        EXPECTED_COOKIE_HEADERS = 1;    //temporary set it to 1 for the Cookie Set-Cookie.
+        runTest("test_SetCookie_Illegal_Attribute_Name");
+
+        EXPECTED_COOKIE_HEADERS = 3;   //reset...just in case this test run first.
+
+        //nothing to assert explicitly here
+        // expectedErrors.add("CWWKT0047E:.*") in setup will validate and error out the test if CWWKT0047E is not there
+        // ExpectedFFDC above will complaint if it is not found
+    }
+
+    //Common attribute names and values that should be found in all tests
+    private void assertCommonAttributes() {
+        LOG.info("====== <assertCommonAttributes> ======");
+
+        assertTrue("Cookie - Expected attribute [" + COOKIE_EXPECTED_ATT + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", (setCookieHeadersString.contains(COOKIE_EXPECTED_ATT)));
+        assertTrue("Set Header - Expected attribute [" + SETHEADER_EXPECTED_ATT + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", (setCookieHeadersString.contains(SETHEADER_EXPECTED_ATT)));
+        assertTrue("Add Header - Expected attribute [" + ADDHEADER_EXPECTED_ATT + "] not found from Set-Cookie headers [" + setCookieHeadersString + "]", (setCookieHeadersString.contains(ADDHEADER_EXPECTED_ATT)));
+    }
+
+    /**
+     * @param testToRun - name of the test/method for the servlet to execute
+     */
+    private void runTest(String testToRun) throws Exception {
+        LOG.info("====== <runTest> [" + testToRun + "] ENTRY ======");
+
+        String url = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + TEST_APP_NAME + "/TestSetCookieAttributesViaResponseHeader";
+        HttpGet httpMethod = new HttpGet(url);
+        httpMethod.addHeader("runTest", testToRun);
+
+        LOG.info("Sending [" + url + "]");
+
+        foundSetCookieHeaders = 0;
+        headerSetCookie.setLength(0);
+
+        try (final CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            try (final CloseableHttpResponse response = client.execute(httpMethod)) {
+                String responseText = EntityUtils.toString(response.getEntity());
+                LOG.info("\n" + "Response Text: \n[" + responseText + "]");
+                Header[] headers = response.getHeaders();
+
+                for (Header header : headers) {
+                    LOG.info("\n" + "Header: " + header);
+                    if (header.getName().equals("Set-Cookie")) {
+                        foundSetCookieHeaders++;
+                        headerSetCookie.append("[" +header + "] \n");
+                    }
+                }
+            }
+        }
+
+        //quick fail if not find 3 set-cookie headers
+        assertTrue("Expected " + EXPECTED_COOKIE_HEADERS + " Set-Cookie headers but found [" + foundSetCookieHeaders + "]", foundSetCookieHeaders == EXPECTED_COOKIE_HEADERS);
+
+        LOG.info("====== <runTest> [" + testToRun + "] RETURN ======");
+    }
+}

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/publish/servers/servlet61_SetCookieAttributes/bootstrap.properties
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/publish/servers/servlet61_SetCookieAttributes/bootstrap.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7777
+com.ibm.ws.logging.trace.specification=*=info=enabled:HTTPChannel=all:GenericBNF=all:HTTPDispatcher=all:com.ibm.ws.http*=all
+com.ibm.ws.logging.max.file.size=50
+com.ibm.ws.logging.max.files=10
+com.ibm.ws.logging.trace.format=BASIC

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/publish/servers/servlet61_SetCookieAttributes/server.xml
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/publish/servers/servlet61_SetCookieAttributes/server.xml
@@ -1,0 +1,17 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server description="Server for testing Set-Cookie Arbitrary Attributes via setHeader and addHeader">
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>servlet-6.1</feature>
+    </featureManager>
+
+</server>

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/test-applications/SetCookieViaResponseHeader.war/src/setcookie/servlets/SetCookieAttributesViaResponseHeader.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/test-applications/SetCookieViaResponseHeader.war/src/setcookie/servlets/SetCookieAttributesViaResponseHeader.java
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package setcookie.servlets;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Set-Cookie servlet using Cookie API, reponse setHeader() and addHeader() to verify that the Set-Cookie is not splitted for arbitrary attributes
+ * Also verify: Attribute name with EMPTY value does not have trailing equal sign
+ *              Attribute name with NULL value removes the existing attribute name and itself.
+ */
+@WebServlet(urlPatterns = {"/TestSetCookieAttributesViaResponseHeader/*"}, name = "SetCookieAttributesViaResponseHeader")
+public class SetCookieAttributesViaResponseHeader extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+    private static final String CLASS_NAME = SetCookieAttributesViaResponseHeader.class.getName();
+
+    //Common
+    HttpServletRequest request;
+    HttpServletResponse response;
+    StringBuilder responseSB;
+    ServletOutputStream sos;
+
+    final String SET_COOKIE = "Set-Cookie";
+
+    final String SET_COOKIE_VALUE = "SET_COOKIE_ATT_TEST=SET_COOKIE_VALUE; Secure; SameSite=None; SET_ATT_NAME=SET_ATT_VALUE; HttpOnly";
+    final String ADD_COOKIE_VALUE = "ADD_COOKIE_ATT_TEST=ADD_COOKIE_VALUE; ADD_ATT_NAME=ADD_ATT_VALUE; Secure; SameSite=Strict; HttpOnly";
+
+    final String SET_COOKIE_EMPTY_VALUE = "SET_COOKIE_EMPTY_TEST=SET_COOKIE_VALUE; SET_ATT_NAME=SET_ATT_VALUE; Secure; SameSite=None; SET_NAME_ONLY_SIGN=; SET_NAME_ONLY";
+    final String ADD_COOKIE_EMPTY_VALUE = "ADD_COOKIE_EMPTY_TEST=ADD_COOKIE_VALUE; Secure; ADD_NAME_ONLY_SIGN=; ADD_NAME_ONLY; ADD_ATT_NAME=ADD_ATT_VALUE; SameSite=Strict";
+
+    final String SET_COOKIE_NULL_VALUE = "SET_COOKIE_NULL_TEST=SET_COOKIE_VALUE; SET_ATT_NAME=SET_ATT_VALUE; Secure; SameSite=None; SET_BE_REMOVED=REMOVE_ME; SET_BE_REMOVED=null; SET_NULL_VALUE=null";
+    final String ADD_COOKIE_NULL_VALUE = "ADD_COOKIE_NULL_TEST=ADD_COOKIE_VALUE; ADD_ATT_NAME=ADD_ATT_VALUE; ADD_BE_REMOVED=REMOVE_ME; Secure; ADD_BE_REMOVED=null; ADD_NULL_VALUE=null; SameSite=Strict";
+
+    final String SET_COOKIE_ILLEGAL_NAME = "SET_COOKIE_ILLEGAL_NAME_TEST=SET_COOKIE_VALUE; SET_ATT_NAME=SET_ATT_VALUE; Secure; SameSite=None; SET_?_QUESTION_MARK_IS_ILLEGAL=SET_NAME; SET_NULL_VALUE=null";
+
+
+    public SetCookieAttributesViaResponseHeader() {
+        super();
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        LOGENTER("doGET");
+
+        request = req;
+        response = resp;
+        responseSB = new StringBuilder();
+        sos = response.getOutputStream();
+
+        switch (request.getHeader("runTest")) {
+            case "test_SetCookie_Attributes" : test_SetCookie_Attributes(); break;
+            case "test_SetCookie_Attributes_EMPTY" : test_SetCookie_Attributes_EMPTY(); break;
+            case "test_SetCookie_Attributes_NULL" : test_SetCookie_Attributes_NULL(); break;
+            case "test_SetCookie_Illegal_Attribute_Name" : test_SetCookie_Illegal_Attribute_Name(); break;
+        }
+
+        if (!responseSB.isEmpty()) {
+            sos.println(responseSB.toString());
+        }
+
+        LOGEXIT("doGET");
+    }
+
+    /*
+     * Create Set-Cookie via Cookie(), response.setHeader, and response.setHeader
+     * Set arbitrary attribute
+     */
+    private void test_SetCookie_Attributes() throws IOException{
+        String method = new Object(){}.getClass().getEnclosingMethod().getName();
+        LOGENTER(method);
+
+        LOG1("Set-Cookie using Cookie API");
+        Cookie wcCookieAtt = new Cookie("Cookie_ATT_Test", "Cookie_Value");
+        wcCookieAtt.setAttribute("Cookie_ATT_Name", "Cookie_ATT_Value");
+        wcCookieAtt.setHttpOnly(true);
+        wcCookieAtt.setSecure(false);
+
+        response.addCookie(wcCookieAtt);
+
+        LOG1("setHeader Set-Cookie");
+        response.setHeader(SET_COOKIE,SET_COOKIE_VALUE);
+
+        LOG1("addHeader Set-Cookie");
+        response.addHeader(SET_COOKIE,ADD_COOKIE_VALUE);
+
+        responseSB.append("Test Set-Cookie attribute name and attribute value using Cookie() API, response.setHeader() and addHeader()");
+
+        LOGEXIT(method);
+    }
+
+    /*
+     * To test attribute name with empty value.
+     * setAttribute ("name","") -> ; name
+     */
+    private void test_SetCookie_Attributes_EMPTY() throws IOException{
+
+        String method = new Object(){}.getClass().getEnclosingMethod().getName();
+        LOGENTER(method);
+
+        LOG1("Create Set-Cookie using Cookie API");
+        Cookie wcCookieAtt = new Cookie("Cookie_EMPTY_TEST", "Cookie_Value");
+        wcCookieAtt.setAttribute("Cookie_ATT_Name", "Cookie_ATT_Value");
+        wcCookieAtt.setHttpOnly(true);
+        wcCookieAtt.setAttribute("Cookie_NAME_ONLY", "");
+        wcCookieAtt.setAttribute("Cookie_NAME_ONLY_SIGN", "=");         //value is "=" which should be removed
+
+        response.addCookie(wcCookieAtt);
+
+        LOG1("setHeader Set-Cookie");
+        response.setHeader(SET_COOKIE,SET_COOKIE_EMPTY_VALUE);
+
+        LOG1("addHeader Set-Cookie");
+        response.addHeader(SET_COOKIE,ADD_COOKIE_EMPTY_VALUE);
+
+        responseSB.append("Test Set-Cookie with EMPTY attribute values using Cookie API, response.setHeader and addHeader");
+
+        LOGEXIT(method);
+    }
+
+    /*
+     * To test NULL attribute value which remove existing att name, also itself
+     */
+    private void test_SetCookie_Attributes_NULL() throws IOException{
+        String method = new Object(){}.getClass().getEnclosingMethod().getName();
+
+        LOGENTER(method);
+
+        LOG1("Create Set-Cookie using Cookie API");
+        Cookie wcCookieAtt = new Cookie("Cookie_NULL_TEST", "Cookie_Value");
+        wcCookieAtt.setAttribute("Cookie_ATT_Name", "Cookie_ATT_Value");
+        wcCookieAtt.setHttpOnly(true);
+        wcCookieAtt.setAttribute("Cookie_NULL_VALUE", null);
+        wcCookieAtt.setAttribute("Cookie_BE_REMOVED", "REMOVE_ME");
+        wcCookieAtt.setAttribute("Cookie_BE_REMOVED", null);
+
+        response.addCookie(wcCookieAtt);
+
+        LOG1("setHeader Set-Cookie with NULL attribute value");
+        response.setHeader(SET_COOKIE,SET_COOKIE_NULL_VALUE);
+
+        LOG1("addHeader Set-Cookie with NULL attribute value");
+        response.addHeader(SET_COOKIE,ADD_COOKIE_NULL_VALUE);
+
+        responseSB.append("Test Set-Cookie with NULL attribute values using Cookie API, response.setHeader and addHeader");
+
+        LOGEXIT(method);
+    }
+
+    /*
+     * Attribute name cannot have special characters "()<>@,;:\\/[]?={} \t
+     *
+     * Runtime IllegalArgumentException with translated message "CWWKT0047E: Cookie attribute name [{0}] contains an invalid character."
+     * The bad set-cookie is dropped and Response continues.
+     *
+     */
+    private void test_SetCookie_Illegal_Attribute_Name() throws IOException{
+        String method = new Object(){}.getClass().getEnclosingMethod().getName();
+        LOGENTER(method);
+
+        LOG1("setHeader Set-Cookie with Illegal character in attribute name.  This will result in exception!");
+        response.setHeader(SET_COOKIE,SET_COOKIE_ILLEGAL_NAME);
+
+        LOG1("Create Set-Cookie using Cookie API");
+        Cookie wcCookieAtt = new Cookie("Cookie_ATT_NAME_TEST", "Cookie_Value");
+        wcCookieAtt.setAttribute("Cookie_ATT_Name", "Cookie_ATT_Value");
+        wcCookieAtt.setHttpOnly(true);
+
+        response.addCookie(wcCookieAtt);
+
+        LOGEXIT(method);
+    }
+
+    //#########################################################
+    private void LOG(String s) {
+        System.out.println(CLASS_NAME + " " + s);
+    }
+
+    //one tab \t
+    private void LOG1(String s) {
+        System.out.println(CLASS_NAME + "\t" + s);
+    }
+
+    private void LOGENTER(String method) {
+        LOG(">>>>>>>>>>>>>>>> TESTING [" + method + "] ENTER >>>>>>>>>>>>>>>>");
+    }
+
+    private void LOGEXIT(String method) {
+        LOG("<<<<<<<<<<<<<<<<<< TESTING [" + method + "] EXIT <<<<<<<<<<<<<<<<<<");
+    }
+}


### PR DESCRIPTION
fixes https://github.com/OpenLiberty/open-liberty/issues/22324

Support Set-Cookie with random attributes that are added via response's setHeader or addHeader without generating new Set-Cookie.

Also address the following behaviors:
1. If the attribute name has an empty value, it will show up by itself without any = sign. 
Example: `setAttribute("Name","")`  will show up in Set-Cookie as  `; Name`
2. If the attribute name has NULL value, it will remove any previous set attribute with same name, and also itself.
Example: `setAttribute("NULL_NAME","A_Value")`  then `setAttribute("NULL_NAME", null)` -> Set-Cookie does not have this attribute

`setAttribute("JUST_NULL_NAME",null)` -> not showing in Set-Cookie 