### PR TITLE
Add com.ibm.ws.jaxws.webcontainer package to thread context

### DIFF
--- a/dev/com.ibm.ws.jaxws.webcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.webcontainer/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -48,7 +48,7 @@ Service-Component: com.ibm.ws.jaxws.webcontainer.jaxWsWebContainerManager; \
   
 
 Export-Package: \
-    com.ibm.ws.jaxws.webcontainer;version=${exportVer}
+    com.ibm.ws.jaxws.webcontainer;version=${exportVer};thread-context=true
 
 Import-Package: \
    javax.xml.ws.*;version="[2.2,3)", \


### PR DESCRIPTION
- Fixes the exception below that occurs when starting a xmlWS-4.0 application with faces-4.1 feature also in the same server.xml.  This does not happen with faces-4.0.

jakarta.faces.FacesException: java.lang.ClassNotFoundException: com.ibm.ws.jaxws.webcontainer.LibertyJaxWsServlet
	at org.apache.myfaces.util.lang.ClassUtils.simpleClassForName(ClassUtils.java:265)
	at org.apache.myfaces.application.FacesServletMappingUtils.isFacesServlet(FacesServletMappingUtils.java:177)
	at org.apache.myfaces.webapp.MyFacesContainerInitializer.checkForFacesServlet(MyFacesContainerInitializer.java:330)
	at org.apache.myfaces.webapp.MyFacesContainerInitializer.onStartup(MyFacesContainerInitializer.java:143)
	at io.openliberty.faces40.internal.ee.WASMyFacesContainerInitializer.onStartup(WASMyFacesContainerInitializer.java:74)
	at com.ibm.ws.webcontainer.webapp.WebApp.initializeServletContainerInitializers(WebApp.java:2577)
	at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:1052)
	at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:6722)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost.startWebApp(DynamicVirtualHost.java:484)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost.startWebApplication(DynamicVirtualHost.java:479)
	at com.ibm.ws.webcontainer.osgi.WebContainer.startWebApplication(WebContainer.java:1208)
	at com.ibm.ws.webcontainer.osgi.WebContainer.access$100(WebContainer.java:113)
	at com.ibm.ws.webcontainer.osgi.WebContainer$3.run(WebContainer.java:996)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:280)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:857)
Caused by: java.lang.ClassNotFoundException: com.ibm.ws.jaxws.webcontainer.LibertyJaxWsServlet
	at java.base/java.lang.Class.forNameImpl(Native Method)
	at java.base/java.lang.Class.forName(Class.java:429)
	at org.apache.myfaces.util.lang.ClassUtils.classForName(ClassUtils.java:219)
	at org.apache.myfaces.util.lang.ClassUtils.simpleClassForName(ClassUtils.java:258)
	... 18 more