### PR TITLE
Update persistence-3.2 feature to use Liberty's asm bundle

### DIFF
--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/AbstractJPAProviderIntegration.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/AbstractJPAProviderIntegration.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -154,6 +154,16 @@ public abstract class AbstractJPAProviderIntegration implements JPAProviderInteg
             }
 
             Properties properties = puInfo.getProperties();
+
+            /**
+             * Instead of using the EclipseLink provided ASM implementation, use the one that liberty already has
+             * to remove ASM classes being loaded twice into memory.
+             */
+            if (!properties.containsKey("eclipselink.asm.service") &&
+                JPAAccessor.getJPAComponent().getJPAVersion().greaterThanOrEquals(JPAVersion.JPA32)) {
+                props.put("eclipselink.asm.service", "ow2");
+            }
+
             /*
              * Section 4.8.5 of the JPA Specification:
              * If SUM, AVG, MAX, or MIN is used, and there are no values

--- a/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/AsmServiceTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/AsmServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -44,6 +44,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEEAction;
 import componenttest.topology.database.container.DatabaseContainerType;
 import componenttest.topology.database.container.DatabaseContainerUtil;
 import componenttest.topology.impl.LibertyServer;
@@ -219,7 +220,7 @@ public class AsmServiceTest extends JPAFATServletClient {
     @Test
     public void testWithDefaultASM() throws Exception {
         // Default should be Eclipselink's ASM.
-        runAsmTest(serverWithDefaultAsm, "EclipseLink");
+        runAsmTest(serverWithDefaultAsm, JakartaEEAction.isEE11OrLaterActive() ? "OW2" : "EclipseLink");
     }
 
     @Test


### PR DESCRIPTION
- When doing persistence 3.2 or higher EclipseLink startup, set eclipselink.asm.service to ow2 to instruct eclipselink to use normal ASM instead of their own implementation.
