### PR TITLE
Prevent transactions feature from loading automatically with Validation 3.1

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/beanValidation-3.1/io.openliberty.beanValidation-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/beanValidation-3.1/io.openliberty.beanValidation-3.1.feature
@@ -37,7 +37,6 @@ IBM-SPI-Package: \
 -features=com.ibm.websphere.appserver.eeCompatible-11.0, \
   io.openliberty.jakarta.validation-3.1, \
   io.openliberty.beanValidationCore-2.0, \
-  com.ibm.websphere.appserver.transaction-2.0, \
   io.openliberty.expressionLanguage-6.0, \
   io.openliberty.jakarta.cdi-4.1
 -bundles=\


### PR DESCRIPTION
For Jakarta Validation feature to load only necessary features, to minimize feature conflict and improve startup time removing `com.ibm.websphere.appserver.transaction-2.0` feature.
fixes #25904