### PR TITLE
improve error messages and remove commented out invalid scenario

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -20,6 +20,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.RecordComponent;
+import java.time.temporal.Temporal;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -197,6 +199,51 @@ public class EntityInfo {
         }
 
         return names;
+    }
+
+    /**
+     * Generates example method names for Query by Method Name using attribute names/types for this entity.
+     *
+     * @return list of example method names.
+     */
+    List<String> getExampleMethodNames() {
+        List<String> examples = new ArrayList<>(5);
+        String[] prefixes = { "find", "delete", "count", "exists" };
+        String[] numSuffixes = { "LessThanEqual(max)", "Between(min, max)", "GreaterThan(exclusiveMin)", "NotIn(setOfValues)" };
+        String[] strSuffixes = { "StartsWith(prefix)", "IgnoreCaseContains(pattern)", "EndsWith(suffix)", "NotLike(pattern)" };
+        int b = 0, e = 0, n = 0, p = 0, s = 0;
+        for (Map.Entry<String, Class<?>> attrClass : attributeTypes.entrySet()) {
+            String attrName = attrClass.getKey();
+            Class<?> attrType = attrClass.getValue();
+            if (attrName.length() > 2
+                && !attrName.toLowerCase().contains("version")
+                && attrName.indexOf('.') < 0 && attrName.indexOf('_') < 0)
+                if (CharSequence.class.isAssignableFrom(attrType))
+                    examples.add(prefixes[p++] + "By" +
+                                 Character.toUpperCase(attrName.charAt(0)) + attrName.substring(1) +
+                                 strSuffixes[s++]);
+                else if (boolean.class.equals(attrType) || Boolean.class.equals(attrType))
+                    examples.add(prefixes[p++] + "By" +
+                                 Character.toUpperCase(attrName.charAt(0)) + attrName.substring(1) +
+                                 (b++ % 2 == 0 ? "False()" : "True()"));
+                else if (attrType.isPrimitive()
+                         || Number.class.isAssignableFrom(attrType)
+                         || Temporal.class.isAssignableFrom(attrType))
+                    examples.add(prefixes[p++] + "By" +
+                                 Character.toUpperCase(attrName.charAt(0)) + attrName.substring(1) +
+                                 numSuffixes[n++]);
+                else if (attrType.isEnum())
+                    examples.add(prefixes[p++] + "By" +
+                                 Character.toUpperCase(attrName.charAt(0)) + attrName.substring(1) +
+                                 (e++ % 2 == 0 ? "NotIn(setOfValues)" : "In(setOfValues)"));
+            if (p >= 4)
+                break;
+        }
+        if (p == 0) {
+            examples.add("findById(id)");
+            examples.add("deleteByIdNotIn(setOfValues)");
+        }
+        return examples;
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2612,15 +2612,6 @@ public class DataJPATestServlet extends FATServlet {
 
         // Delete
         rebates.remove(r1);
-        // TODO allow entity return type on delete?
-        //r1 = rebates.remove(r1);
-        //assertEquals(Integer.valueOf(1), r1.id());
-        //assertEquals(1.00, r1.amount(), 0.001f);
-        //assertEquals(LocalTime.of(11, 31, 0), r1.purchaseMadeAt());
-        //assertEquals(LocalDate.of(2023, Month.OCTOBER, 16), r1.purchaseMadeOn());
-        //assertEquals(Rebate.Status.PAID, r1.status());
-        //assertEquals(LocalDateTime.of(2023, Month.OCTOBER, 16, 11, 44, 0), r1.updatedAt());
-        //assertEquals(Integer.valueOf(initialVersion + 2), r1.version());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Rebates.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Rebates.java
@@ -75,7 +75,6 @@ public interface Rebates { // Do not allow this interface to inherit from other 
     @Save
     Collection<Rebate> processMultiple(Collection<Rebate> r);
 
-    // TODO allow entity return types for Delete?
     @Delete
     void remove(Rebate r);
 


### PR DESCRIPTION
Removes a commented out test scenario where a delete method with entity parameter returns the entity. That return type would not be supported by the spec.
Also, improves the error message that would be logged if someone attempts that scenario, and improves several other error messages as well, including one that provides example repository method names.  This one is updated to provide the examples in terms of the entity attribute names and types of the entity that is used with the repository/method.