### PR TITLE
Log a warning message when HTTP Session Cache attributes are updated at restore

### DIFF
--- a/dev/com.ibm.ws.session.cache/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache/bnd.bnd
@@ -43,10 +43,11 @@ Service-Component=com.ibm.ws.session.cache;\
   userTransaction=javax.transaction.UserTransaction;\
   cacheManagerService=io.openliberty.jcache.CacheManagerService;\
   configCondition=org.osgi.service.condition.Condition;\
-  dynamic:="monitor,userTransaction";\
-  greedy:="library,monitor,userTransaction";\
-  optional:="monitor,userTransaction,cacheManagerService";\
-  properties:="library.target=(id=unbound),monitor.target=(id=unbound),cacheManagerService.target=(id=unbound),configCondition.target=(osgi.condition.id=session.cache.config)"
+  runningCondition=org.osgi.service.condition.Condition;\
+  dynamic:="monitor,userTransaction,runningCondition";\
+  greedy:="library,monitor,userTransaction,runningCondition";\
+  optional:="monitor,userTransaction,cacheManagerService,runningCondition";\
+  properties:="library.target=(id=unbound),monitor.target=(id=unbound),cacheManagerService.target=(id=unbound),configCondition.target=(osgi.condition.id=session.cache.config),runningCondition.target=(osgi.condition.id=io.openliberty.process.running)"
 
 -buildpath: \
 	com.ibm.websphere.appserver.spi.kernel.service,\

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
@@ -69,9 +69,9 @@ CONFIG_ATTRIBUTE_IGNORED=SESN0311W: The {0} configuration attribute was specifie
 CONFIG_ATTRIBUTE_IGNORED.explanation=The specified configuration is ignored as it is provided by the specified cacheManagerRef.
 CONFIG_ATTRIBUTE_IGNORED.useraction=No action is required.
 
-UPDATED_CONFIG_NOT_USED_AT_RESTORE=SESN0312W: The HTTP Session Cache configuration attribute {0} has changed when restoring the server process. If the value of the attribute changes when restoring the server process, the application will not use the updated value.
-UPDATED_CONFIG_NOT_USED_AT_RESTORE.explanation=The specified configuration attribute cannot be modified when restoring the server process.
-UPDATED_CONFIG_NOT_USED_AT_RESTORE.useraction=Provide a predetermined value for the configuration attribute before the checkpoint.
+UPDATED_CONFIG_NOT_USED_AT_RESTORE=SESN0312W: The {0} HTTP Session Cache configuration attribute changed since the server was checkpointed. If the value of the attribute is changed after the server checkpoint, but before the server process is restored, the application does not use the updated value.
+UPDATED_CONFIG_NOT_USED_AT_RESTORE.explanation=The specified configuration attribute cannot be modified during the time between the server checkpoint and the server process restore.
+UPDATED_CONFIG_NOT_USED_AT_RESTORE.useraction=Set the value for the attribute before you perform the server checkpoint.
 
 INTERNAL_SERVER_ERROR=Internal Server Error
 

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
@@ -69,6 +69,10 @@ CONFIG_ATTRIBUTE_IGNORED=SESN0311W: The {0} configuration attribute was specifie
 CONFIG_ATTRIBUTE_IGNORED.explanation=The specified configuration is ignored as it is provided by the specified cacheManagerRef.
 CONFIG_ATTRIBUTE_IGNORED.useraction=No action is required.
 
+UPDATED_CONFIG_NOT_USED_AT_RESTORE=SESN0312W: The HTTP Session Cache configuration attribute {0} has changed when restoring the server process. If the value of the attribute changes when restoring the server process, the application will not use the updated value.
+UPDATED_CONFIG_NOT_USED_AT_RESTORE.explanation=The specified configuration attribute cannot be modified when restoring the server process.
+UPDATED_CONFIG_NOT_USED_AT_RESTORE.useraction=Provide a predetermined value for the configuration attribute before the checkpoint.
+
 INTERNAL_SERVER_ERROR=Internal Server Error
 
 SESSION_CACHE_CONFIG_MESSAGE=Verify that the server configuration contains a valid httpSessionCache configuration. See the sample configuration. {0}

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -125,6 +125,8 @@ public class CacheStoreService implements Introspector, SessionStoreService {
     private volatile String tcCachingProvider; // requires lazy activation
 
     volatile UserTransaction userTransaction;
+    
+    private Condition runningCondition;
 
     /**
      * Declarative Services method to activate this component.
@@ -162,7 +164,7 @@ public class CacheStoreService implements Introspector, SessionStoreService {
     }
 
     protected void modified(Map<String, Object> config) {
-        if (checkpointPhase != CheckpointPhase.INACTIVE && checkpointPhase.restored()) {
+        if (checkpointPhase != CheckpointPhase.INACTIVE && runningCondition == null) {
             for (Map.Entry<String, Object> entry: config.entrySet()) {
                 String key = entry.getKey();
                 Object newValue = entry.getValue();
@@ -590,6 +592,10 @@ public class CacheStoreService implements Introspector, SessionStoreService {
     protected void setConfigCondition(Condition configCondition) {
         // do nothing; this is just a reference that we use to force the component to recycle
     }
+    
+    protected void setRunningCondition(Condition runningCondition) {
+        this.runningCondition = runningCondition;
+    }
 
     protected void setSerializationService(SerializationService serializationService) {
         this.serializationService = serializationService;
@@ -610,6 +616,10 @@ public class CacheStoreService implements Introspector, SessionStoreService {
                     configureMonitoring(cacheName);
                 return null;
             });
+    }
+    
+    protected void unsetRunningCondition(Condition runningCondition) {
+        this.runningCondition = null;
     }
 
     protected void unsetSerializationService(SerializationService serializationService) {

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -89,7 +89,6 @@ public class CacheStoreService implements Introspector, SessionStoreService {
                                                                                           "writeInterval"));
 
     Map<String, Object> configurationProperties;
-    Map<String, Object> oldConfigurationProperties;
     private static final int BASE_PREFIX_LENGTH = CONFIG_KEY_PROPERTIES.length();
     private static final int TOTAL_PREFIX_LENGTH = BASE_PREFIX_LENGTH + 3; //3 is the length of .0.
     
@@ -135,7 +134,6 @@ public class CacheStoreService implements Introspector, SessionStoreService {
      * @param props   service properties
      */
     protected void activate(ComponentContext context, Map<String, Object> props) {
-        oldConfigurationProperties = new HashMap<String, Object>(props);
         processConfiguration(props);       
     }
 
@@ -169,7 +167,7 @@ public class CacheStoreService implements Introspector, SessionStoreService {
                 String key = entry.getKey();
                 Object newValue = entry.getValue();
                 
-                Object oldValue = oldConfigurationProperties.get(key);
+                Object oldValue = configurationProperties.get(key);
                 if (sessionCacheAttributes.contains(key) && !Objects.deepEquals(newValue, oldValue)) {
                     Tr.warning(tc, "UPDATED_CONFIG_NOT_USED_AT_RESTORE", key);
                 }       

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/bnd.bnd
@@ -24,7 +24,8 @@ tested.features: \
   mpConfig-3.1, \
   servlet-6.0, \
   mpMetrics-5.1, \
-  cdi-4.0
+  cdi-4.0, \
+  checkpoint
 
 
 -buildpath: \

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/build.gradle
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/build.gradle
@@ -34,9 +34,9 @@ dependencies {
   infinispanCore 'org.infinispan:infinispan-core:12.1.7.Final'
   infinispanJCache 'org.infinispan:infinispan-jcache:12.1.7.Final'
   infinispanJCacheCommons 'org.infinispan:infinispan-jcache-commons:12.1.7.Final'
-  protostream 'org.infinispan.protostream:protostream:4.3.0.Alpha13'
+  protostream 'org.infinispan.protostream:protostream:4.4.1.Final'
   jbossLogging 'org.jboss.logging:jboss-logging:3.4.1.Final'
-  jGroups 'org.jgroups:jgroups:4.1.6.Final'
+  jGroups 'org.jgroups:jgroups:4.2.12.Final'
   rxjava 'io.reactivex.rxjava2:rxjava:2.2.9'
   smallryeMetrics 'io.smallrye:smallrye-metrics:2.1.5'
 }

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/fat/src/io/openliberty/checkpoint/session/cache/infinispan/CheckpointSessionCacheConfigUpdateTest.java
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/fat/src/io/openliberty/checkpoint/session/cache/infinispan/CheckpointSessionCacheConfigUpdateTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.checkpoint.session.cache.infinispan;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.time.ZonedDateTime;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.config.HttpSessionCache;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.CheckpointTest;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
+@RunWith(FATRunner.class)
+@CheckpointTest
+public class CheckpointSessionCacheConfigUpdateTest extends FATServletClient {
+    public static final String checkpointServer = "com.ibm.ws.session.cache.config.fat.infinispan.checkpointServer";
+
+    @Server(checkpointServer)
+    public static LibertyServer server;
+
+    public static String[] servers = new String[] { checkpointServer };
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        server.setCheckpoint(CheckpointPhase.AFTER_APP_START, false, null);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer("SESN0312W");
+    }
+
+    @Test
+    public void testUpdateInConfigAfterCheckpoint() throws Exception {
+        int hour = ZonedDateTime.now().getHour();
+        int hour1 = (hour + 8) % 24;
+        int hour2 = (hour + 16) % 24;
+        // Reconfigure server
+        ServerConfiguration config = server.getServerConfiguration();
+        HttpSessionCache httpSessionCache = config.getHttpSessionCaches().get(0);
+        httpSessionCache.setWriteContents("GET_AND_SET_ATTRIBUTES");
+        httpSessionCache.setWriteFrequency("TIME_BASED_WRITE");
+        httpSessionCache.setWriteInterval("15s");
+        httpSessionCache.setScheduleInvalidationFirstHour(Integer.toString(hour1));
+        httpSessionCache.setScheduleInvalidationSecondHour(Integer.toString(hour2));
+        server.updateServerConfiguration(config);
+        server.checkpointRestore();
+        assertNotNull("'SESN0312W: The HTTP Session Cache configuration attribute writeContents has changed when restoring the server process' not found in log.",
+                      server.waitForStringInLog("SESN0312W: .*writeContents*"));
+        assertNotNull("'SESN0312W: The HTTP Session Cache configuration attribute writeFrequency has changed when restoring the server process' not found in log.",
+                      server.waitForStringInLog("SESN0312W: .*writeFrequency*"));
+        assertNotNull("'SESN0312W: The HTTP Session Cache configuration attribute writeInterval has changed when restoring the server process' not found in log.",
+                      server.waitForStringInLog("SESN0312W: .*writeInterval*"));
+        assertNotNull("'SESN0312W: The HTTP Session Cache configuration attribute scheduleInvalidationFirstHour has changed when restoring the server process' not found in log.",
+                      server.waitForStringInLog("SESN0312W: .*scheduleInvalidationFirstHour*"));
+        assertNotNull("'SESN0312W:The HTTP Session Cache configuration attribute scheduleInvalidationSecondHour has changed when restoring the server process' not found in log.",
+                      server.waitForStringInLog("SESN0312W: .*scheduleInvalidationSecondHour*"));
+
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/fat/src/io/openliberty/checkpoint/session/cache/infinispan/CheckpointSessionCacheConfigUpdateTest.java
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/fat/src/io/openliberty/checkpoint/session/cache/infinispan/CheckpointSessionCacheConfigUpdateTest.java
@@ -67,15 +67,15 @@ public class CheckpointSessionCacheConfigUpdateTest extends FATServletClient {
         httpSessionCache.setScheduleInvalidationSecondHour(Integer.toString(hour2));
         server.updateServerConfiguration(config);
         server.checkpointRestore();
-        assertNotNull("'SESN0312W: The HTTP Session Cache configuration attribute writeContents has changed when restoring the server process' not found in log.",
+        assertNotNull("'SESN0312W: The writeContents HTTP Session Cache configuration attribute changed' not found in log.",
                       server.waitForStringInLog("SESN0312W: .*writeContents*"));
-        assertNotNull("'SESN0312W: The HTTP Session Cache configuration attribute writeFrequency has changed when restoring the server process' not found in log.",
+        assertNotNull("'SESN0312W: The writeFrequency HTTP Session Cache configuration attribute changed' not found in log.",
                       server.waitForStringInLog("SESN0312W: .*writeFrequency*"));
-        assertNotNull("'SESN0312W: The HTTP Session Cache configuration attribute writeInterval has changed when restoring the server process' not found in log.",
+        assertNotNull("'SESN0312W: The writeInterval HTTP Session Cache configuration attribute changed' not found in log' not found in log.",
                       server.waitForStringInLog("SESN0312W: .*writeInterval*"));
-        assertNotNull("'SESN0312W: The HTTP Session Cache configuration attribute scheduleInvalidationFirstHour has changed when restoring the server process' not found in log.",
+        assertNotNull("'SESN0312W: The scheduleInvalidationFirstHour HTTP Session Cache configuration attribute changed' not found in log' not found in log.",
                       server.waitForStringInLog("SESN0312W: .*scheduleInvalidationFirstHour*"));
-        assertNotNull("'SESN0312W:The HTTP Session Cache configuration attribute scheduleInvalidationSecondHour has changed when restoring the server process' not found in log.",
+        assertNotNull("'SESN0312W: The scheduleInvalidationSecondHour HTTP Session Cache configuration attribute changed' not found in log' not found in log.",
                       server.waitForStringInLog("SESN0312W: .*scheduleInvalidationSecondHour*"));
 
     }

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/fat/src/io/openliberty/checkpoint/session/cache/infinispan/CheckpointSessionCacheOneServerTest.java
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/fat/src/io/openliberty/checkpoint/session/cache/infinispan/CheckpointSessionCacheOneServerTest.java
@@ -101,7 +101,7 @@ public class CheckpointSessionCacheOneServerTest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         executor.shutdownNow();
-        server.stopServer();
+        server.stopServer("SESN0312W");
         configureEnvVariable(server, emptyMap());
     }
 

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/fat/src/io/openliberty/checkpoint/session/cache/infinispan/FATSuite.java
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/fat/src/io/openliberty/checkpoint/session/cache/infinispan/FATSuite.java
@@ -19,17 +19,21 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpUtils;
 
@@ -38,13 +42,23 @@ import componenttest.topology.utils.HttpUtils;
                 AlwaysPassesTest.class,
                 CheckpointSessionCacheOneServerTest.class,
                 CheckpointSessionCacheTwoServerTest.class,
-                CheckpointSessionCacheTwoServerTimeoutTest.class
+                CheckpointSessionCacheTwoServerTimeoutTest.class,
+                CheckpointSessionCacheConfigUpdateTest.class
 })
 
 public class FATSuite {
 
     public static final String CACHE_MANAGER_EE9_ID = JakartaEE9Action.ID + "_CacheManager";
     public static final String CACHE_MANAGER_EE10_ID = JakartaEE10Action.ID + "_CacheManager";
+
+    @BeforeClass
+    public static void beforeSuite() throws Exception {
+        // Delete the Infinispan jars that might have been left around by previous test buckets.
+        LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.session.cache.config.fat.infinispan.checkpointServer");
+        Machine machine = server.getMachine();
+        String installRoot = server.getInstallRoot();
+        LibertyFileManager.deleteLibertyDirectoryAndContents(machine, installRoot + "/usr/shared/resources/infinispan");
+    }
 
     public static String run(LibertyServer server, String path, String testMethod, List<String> session) throws Exception {
         HttpURLConnection con = HttpUtils.getHttpConnection(server, path + '?' + FATServletClient.TEST_METHOD + '=' + testMethod);

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/publish/servers/com.ibm.ws.session.cache.config.fat.infinispan.checkpointServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/publish/servers/com.ibm.ws.session.cache.config.fat.infinispan.checkpointServer/bootstrap.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2018,2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.session.*=all:checkpoint=all
+websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/publish/servers/com.ibm.ws.session.cache.config.fat.infinispan.checkpointServer/derby.properties
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/publish/servers/com.ibm.ws.session.cache.config.fat.infinispan.checkpointServer/derby.properties
@@ -1,0 +1,4 @@
+# derby connection MUST fail if user is invalid (in order to test authData in server.xml)
+derby.connection.requireAuthentication=true
+derby.authentication.provider=BUILTIN
+derby.user.userName=userPassword

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/publish/servers/com.ibm.ws.session.cache.config.fat.infinispan.checkpointServer/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/publish/servers/com.ibm.ws.session.cache.config.fat.infinispan.checkpointServer/jvm.options
@@ -1,0 +1,3 @@
+-Djava.net.preferIPv4Stack=true
+-Xdump:java:events=throw+systhrow,filter=org/eclipse/openj9/criu/JVMCheckpointException,request=exclusive+preempt
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/publish/servers/com.ibm.ws.session.cache.config.fat.infinispan.checkpointServer/server.xml
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/publish/servers/com.ibm.ws.session.cache.config.fat.infinispan.checkpointServer/server.xml
@@ -1,0 +1,46 @@
+<!--
+    Copyright (c) 2021, 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <featureManager>
+        <feature>servlet-5.0</feature>
+        <feature>componenttest-2.0</feature>
+        <feature>jdbc-4.2</feature>
+        <feature>jndi-1.0</feature>
+        <feature>monitor-1.0</feature>
+        <feature>mpMetrics-4.0</feature> <!-- one of the Infinispan JARs has a hard dependency on MicroProfile Metrics API -->
+        <feature>mpReactiveStreams-3.0</feature> <!-- Infinispan JARs have a hard dependency on Reactive Streams API -->
+        <feature>sessionCache-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <httpSession hideSessionValues="false"/>
+    
+    <httpSessionCache libraryRef="InfinispanLib" uri="file:///${shared.resource.dir}/infinispan/infinispan.xml"/>
+    
+     <library id="InfinispanLib">
+        <fileset dir="${shared.resource.dir}/infinispan" includes="*.jar"/>
+    </library>
+
+	<library id="DerbyLib">
+	    <file name="${shared.resource.dir}/derby/derby.jar"/>
+	</library>
+
+    <!-- Used for testing that data source can be stored in a session -->
+	<authData id="DerbyAuth" user="userName" password="userPassword"/>    
+    <dataSource id="DerbyDS" jndiName="jdbc/derby" containerAuthDataRef="DerbyAuth">
+	    <jdbcDriver libraryRef="DerbyLib"/>
+	    <properties.derby.embedded createDatabase="create" databaseName="memory:testdb"/>
+	</dataSource>
+</server>

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan_container/fat/src/io/openliberty/checkpoint/session/cache/infinispan/container/CheckpointSessionCacheOneServerTest.java
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan_container/fat/src/io/openliberty/checkpoint/session/cache/infinispan/container/CheckpointSessionCacheOneServerTest.java
@@ -107,7 +107,7 @@ public class CheckpointSessionCacheOneServerTest extends FATServletClient {
     public static void tearDown() throws Exception {
         try {
             executor.shutdownNow();
-            server.stopServer();
+            server.stopServer("SESN0312W");
         } finally {
             server.restoreServerConfiguration();
         }

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan_container/fat/src/io/openliberty/checkpoint/session/cache/infinispan/container/CheckpointSessionCacheTwoServerTest.java
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan_container/fat/src/io/openliberty/checkpoint/session/cache/infinispan/container/CheckpointSessionCacheTwoServerTest.java
@@ -124,10 +124,10 @@ public class CheckpointSessionCacheTwoServerTest extends FATServletClient {
         } finally {
             try {
                 if (serverA.isStarted())
-                    serverA.stopServer();
+                    serverA.stopServer("SESN0312W");
             } finally {
                 if (serverB.isStarted())
-                    serverB.stopServer();
+                    serverB.stopServer("SESN0312W");
             }
             configureEnvVariable(serverA, emptyMap());
             configureEnvVariable(serverB, emptyMap());
@@ -148,7 +148,7 @@ public class CheckpointSessionCacheTwoServerTest extends FATServletClient {
 
         // Now verify the cache failed over to Server B
         appB.sessionGet("testFailover-1", "foo", session);
-        serverB.stopServer();
+        serverB.stopServer("SESN0312W");
     }
 
     /**


### PR DESCRIPTION
for #28330

A warning message is logged when HTTP Session Cache attributes are updated at restore stating they cannot be updated at restore.