### PR TITLE
CVE Reporting: Adding in logic to set uri for cloud service from ProductInfo

### DIFF
--- a/dev/build.image/publish/openliberty.properties
+++ b/dev/build.image/publish/openliberty.properties
@@ -18,3 +18,4 @@ com.ibm.websphere.productInstallType=Archive
 com.ibm.websphere.productEdition=Open
 com.ibm.websphere.productLicenseType=EPL
 com.ibm.websphere.productPublicKeyId=0xBD9FD5BE9E68CA00
+com.ibm.websphere.cveReportingUri=https://cves.openliberty.io/report

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/productinfo/ProductInfo.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/productinfo/ProductInfo.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -50,6 +50,7 @@ public class ProductInfo {
     public static final String COM_IBM_WEBSPHERE_LOG_REPLACED_PRODUCT = "com.ibm.websphere.logReplacedProduct";
     public static final String BETA_EDITION_JVM_PROPERTY = "com.ibm.ws.beta.edition";
     public static final String EARLY_ACCESS = "EARLY_ACCESS";
+    public static final String COM_IBM_WEBSPHERE_CVEREPORTINGURI_KEY = "com.ibm.websphere.cveReportingUri";
 
     private static FileFilter versionFileFilter = new FileFilter() {
         @Override
@@ -342,6 +343,10 @@ public class ProductInfo {
         }
 
         return versionFiles;
+    }
+
+    public String getCVEReportingUri() {
+        return properties.getProperty(COM_IBM_WEBSPHERE_CVEREPORTINGURI_KEY);
     }
 
 }

--- a/dev/io.openliberty.reporting.internal/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/io.openliberty.reporting.internal/resources/OSGI-INF/metatype/metatype.xml
@@ -24,7 +24,7 @@
          
         <AD id="enabled" name="%enabled" description="%enabled.desc" required="false" type="Boolean" default="true" />
         
-        <AD id="urlLink" type="String" default="https://cves.openliberty.io/report" 
+        <AD id="urlLink" type="String"
             required="false"
             name="internal" 
             description="internal use only"/>

--- a/dev/io.openliberty.reporting.internal/src/io/openliberty/reporting/internal/ReporterTask.java
+++ b/dev/io.openliberty.reporting.internal/src/io/openliberty/reporting/internal/ReporterTask.java
@@ -58,9 +58,9 @@ public class ReporterTask implements Runnable {
     public void run() {
         // Run if disabled flag has not been found
         try {
-            DataCollector collector = new DataCollector(featureProvisioner, fixManager, serverInfo);
-            Map<String, String> data = collector.getData();
             Map<String, ? extends ProductInfo> allProductInfo = ProductInfo.getAllProductInfo();
+            DataCollector collector = new DataCollector(featureProvisioner, fixManager, serverInfo, allProductInfo);
+            Map<String, String> data = collector.getData();
             String productUri = (allProductInfo.containsKey("com.ibm.websphere.appserver")) ? allProductInfo.get("com.ibm.websphere.appserver").getCVEReportingUri() : allProductInfo.get("io.openliberty").getCVEReportingUri();
             String urlLink = setUrl(productUri, (String) props.get("urlLink"));
             JSONObject response = new CVEServiceClient().retrieveCVEData(data, urlLink);

--- a/dev/io.openliberty.reporting.internal/test/io/openliberty/reporting/internal/ReporterTaskTest.java
+++ b/dev/io.openliberty.reporting.internal/test/io/openliberty/reporting/internal/ReporterTaskTest.java
@@ -36,4 +36,74 @@ public class ReporterTaskTest {
         assertEquals("java.lang.Exception: TEST3: java.lang.Exception: TEST2: java.lang.Exception: TEST1", response);
     }
 
+    @Test
+    public void testSetUrlIfNull() throws DataCollectorException {
+        String uri = "https://cves.openliberty.io/report";
+        String urlLink = null;
+
+        String link = ReporterTask.setUrl(uri, urlLink);
+
+        assertEquals("https://cves.openliberty.io/report", link);
+    }
+
+    @Test
+    public void testSetUrlIfEmpty() throws DataCollectorException {
+        String uri = "https://cves.openliberty.io/report";
+        String urlLink = "";
+
+        String link = ReporterTask.setUrl(uri, urlLink);
+
+        assertEquals("https://cves.openliberty.io/report", link);
+    }
+
+    @Test
+    public void testSetUrlIfNullAndZOS() throws DataCollectorException {
+        String uri = "https://cves.websphere.ibm.com/report";
+        String urlLink = null;
+
+        String link = ReporterTask.setUrl(uri, urlLink);
+
+        assertEquals("https://cves.websphere.ibm.com/report", link);
+    }
+
+    @Test
+    public void testSetUrlIfEmptyAndZOS() throws DataCollectorException {
+        String uri = "https://cves.websphere.ibm.com/report";
+        String urlLink = "";
+
+        String link = ReporterTask.setUrl(uri, urlLink);
+
+        assertEquals("https://cves.websphere.ibm.com/report", link);
+    }
+
+    @Test
+    public void testSetUrlIfSet() throws DataCollectorException {
+        String uri = "https://cves.websphere.ibm.com/report";
+        String urlLink = "TESTING";
+
+        String link = ReporterTask.setUrl(uri, urlLink);
+
+        assertEquals("TESTING", link);
+    }
+
+    @Test
+    public void testSetUrlIfUriNull() throws DataCollectorException {
+        String uri = null;
+        String urlLink = null;
+
+        String link = ReporterTask.setUrl(uri, urlLink);
+
+        assertEquals("https://cves.openliberty.io/report", link);
+    }
+
+    @Test
+    public void testSetUrlIfUriEmpty() throws DataCollectorException {
+        String uri = "";
+        String urlLink = null;
+
+        String link = ReporterTask.setUrl(uri, urlLink);
+
+        assertEquals("https://cves.openliberty.io/report", link);
+    }
+
 }


### PR DESCRIPTION
- Adding in new property which will be used by CVE Reporting to avoid having a java hardcoded uri
- Adding a getter for `com.ibm.websphere.cveReportingUri` in ProductInfo class
- Adding in logic to set the uri in ReporterTask class
- Adding in unit tests to test the new setUrl method