### PR TITLE
If configured to use jar URLs then do not return virtual dir URLs

### DIFF
--- a/dev/com.ibm.ws.artifact.zip/resources/com/ibm/ws/artifact/zip/internal/resources/ZipArtifactMessages.nlsprops
+++ b/dev/com.ibm.ws.artifact.zip/resources/com/ibm/ws/artifact/zip/internal/resources/ZipArtifactMessages.nlsprops
@@ -121,5 +121,5 @@ missing.zip.file.useraction=Check that the specified file exits and has permissi
 
 # # {0} A jar: URL.
 CWWKM0129W.missing.dir.entry=CWWKM0129W: The archive {0} does not have the expected directory entry path: {1}
-CWWKM0129W.missing.dir.entry.explanation=The archive used in the resource URL has entries contained within the directory, but the archive is missing an entry for the directory itself. The directory URL is not returned. This may cause some applications that scan for resources to fail to find some resources in the archive file.
-CWWKM0129W.missing.dir.entry.useraction=The archive file should be built to include all the directory entries.
+CWWKM0129W.missing.dir.entry.explanation=The archive that is used in the resource URL has entries that are contained within the directory, but the archive is missing an entry for the directory itself. The directory URL is not returned. This omission can cause some applications that scan for resources to fail to find some resources in the archive file.
+CWWKM0129W.missing.dir.entry.useraction=The archive file must be built to include all the directory entries.

--- a/dev/com.ibm.ws.artifact.zip/resources/com/ibm/ws/artifact/zip/internal/resources/ZipArtifactMessages.nlsprops
+++ b/dev/com.ibm.ws.artifact.zip/resources/com/ibm/ws/artifact/zip/internal/resources/ZipArtifactMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011 IBM Corporation and others.
+# Copyright (c) 2011, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -118,3 +118,8 @@ reaper.reopen.active.useraction=Restart the server.  When updating application f
 missing.zip.file=CWWKM0128E: The {0} zip file is missing.
 missing.zip.file.explanation=An exception occurred during archive processing because the specified file was not found. 
 missing.zip.file.useraction=Check that the specified file exits and has permissions that are readable by the server.
+
+# # {0} A jar: URL.
+CWWKM0129W.missing.dir.entry=CWWKM0129W: The archive {0} does not have the expected directory entry path: {1}
+CWWKM0129W.missing.dir.entry.explanation=The archive used in the resource URL has entries contained within the directory, but the archive is missing an entry for the directory itself. The directory URL is not returned. This may cause some applications that scan for resources to fail to find some resources in the archive file.
+CWWKM0129W.missing.dir.entry.useraction=The archive file should be built to include all the directory entries.

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
@@ -462,7 +462,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
      *     this container.
      */
     @Trivial
-    private String getProtocol() {
+    String getProtocol() {
         return ( containerFactoryHolder.useJarUrls() ? "jar" : "wsjar" );
     }
 
@@ -661,7 +661,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
      *
      * @return The absolute path to the archive file.
      */
-    private String getArchiveFilePath() {
+    String getArchiveFilePath() {
         if ( archiveFileLock == null ) {
             return archiveFilePath;
         } else {

--- a/dev/com.ibm.ws.artifact_fat/.classpath
+++ b/dev/com.ibm.ws.artifact_fat/.classpath
@@ -5,6 +5,7 @@
 	<classpathentry kind="src" path="test-applications/testServlet1/src"/>
 	<classpathentry kind="src" path="test-applications/testServlet2/src"/>
 	<classpathentry kind="src" path="test-applications/jarneeder.war/src"/>
+	<classpathentry kind="src" path="test-applications/noDirZip/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.artifact_fat/bnd.bnd
+++ b/dev/com.ibm.ws.artifact_fat/bnd.bnd
@@ -18,7 +18,8 @@ src: \
 	test-applications/jarneeder.war/src, \
 	test-applications/testServlet1/src, \
 	test-applications/testServlet2/src, \
-	test-applications/HoldingServlet/src
+	test-applications/HoldingServlet/src, \
+	test-applications/noDirZip/src
 
 test.project: true
 

--- a/dev/com.ibm.ws.artifact_fat/fat/src/com/ibm/ws/artifact/fat/FATNoDirectoryZipTest.java
+++ b/dev/com.ibm.ws.artifact_fat/fat/src/com/ibm/ws/artifact/fat/FATNoDirectoryZipTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.artifact.fat;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.RemoteFile;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import nodirzip.fat.test.app.NoDirectoryZipServlet;
+
+@RunWith(FATRunner.class)
+public class FATNoDirectoryZipTest extends FATServletClient {
+
+    public static final String APP_NAME = "noDirZip";
+    public static final String APP_PACKAGE = NoDirectoryZipServlet.class.getPackage().getName();
+
+    @Server("com.ibm.ws.artifact.nodir.zip")
+    @TestServlet(servlet = NoDirectoryZipServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void createTestApp() throws Exception {
+        ShrinkHelper.defaultApp(server, APP_NAME, new DeployOptions[] { DeployOptions.OVERWRITE }, APP_PACKAGE);
+        RemoteFile appFile = server.getFileFromLibertyServerRoot("apps/" + APP_NAME + ".war");
+        // backup the original appFile which contains directory entries
+        RemoteFile backupFile = server.getMachine().getFile(server.getFileFromLibertyServerRoot("apps"), "backup.war");
+        appFile.rename(backupFile);
+
+        // read the backup and write it back to the original, with no directory entries
+        byte[] buf = new byte[1024];
+        try (ZipOutputStream zipOut = new ZipOutputStream(appFile.openForWriting(false));
+                ZipInputStream zipIn = new ZipInputStream(backupFile.openForReading())) {
+            ZipEntry zipEntry;
+            while ((zipEntry = zipIn.getNextEntry()) != null) {
+                if (!zipEntry.isDirectory()) {
+                    // only put non-directory entries in the final appFile
+                    zipOut.putNextEntry(zipEntry);
+                    int len;
+                    while((len = zipIn.read(buf)) > 0) {
+                        zipOut.write(buf, 0, len);
+                    }
+                }
+            }
+            // Add a library file with a single resource in the application package; also no directory entries
+            zipOut.putNextEntry(new ZipEntry("WEB-INF/lib/inner.jar"));
+            ByteArrayOutputStream saved;
+            try (ByteArrayOutputStream innerBytes = saved  = new ByteArrayOutputStream();
+                    ZipOutputStream innerZipOut = new ZipOutputStream(innerBytes)) {
+                innerZipOut.putNextEntry(new ZipEntry(APP_PACKAGE.replace('.', '/') + "/test.txt"));
+                innerZipOut.write("testing".getBytes());
+            }
+            zipOut.write(saved.toByteArray());
+        }
+        // Final appFile (noDirZip.war) has the following entries:
+        // WEB-INF/classes/nodirzip/fat/test/app/NoDirectoryZipServlet.class
+        // WEB-INF/lib/inner.jar
+        // The inner.jar has the following entry:
+        // nodirzip/fat/test/app/test.txt
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        server.startServer(testName.getMethodName() + ".log");
+    }
+
+    @After
+    public void checkForWarnings() throws Exception {
+        // There are 4 sub-package (directory) elements in the application package nodirzip.fat.test.app
+        // The root WAR and the inner.jar both have no directories and hava content in this package.
+        // The test drives resource requests multiple times for each sub-package/folder which will
+        // search the root WAR and the inner.jar multiple times.
+        // The warning message is only displayed once for each directory request so we expect:
+        // 8 warnings = 4 (directories) * 2 (archives with no directory entries)
+        List<String> warnings = server.findStringsInLogs("CWWKM0129W");
+        assertEquals("Wrong number of warnings", 8, warnings.size());
+    }
+    
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer("CWWKM0129W");
+    }
+
+}

--- a/dev/com.ibm.ws.artifact_fat/fat/src/com/ibm/ws/artifact/fat/FATResourceProtocol.java
+++ b/dev/com.ibm.ws.artifact_fat/fat/src/com/ibm/ws/artifact/fat/FATResourceProtocol.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013,2017 IBM Corporation and others.
+ * Copyright (c) 2013,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,35 +14,34 @@ package com.ibm.ws.artifact.fat;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
-import java.net.ProtocolException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-
 import org.junit.Assert;
-import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.ClassloadingElement;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.HttpUtils;
 
-import com.ibm.websphere.simplicity.config.ClassloadingElement;
-import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import com.ibm.websphere.simplicity.ShrinkHelper;
-
 /**
  * FAT used to test the ability to configure and to dynamically update
  * the resource protocol configuration.
  */
+@RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 public class FATResourceProtocol {
     private static final Class<? extends FATResourceProtocol> CLASS = FATResourceProtocol.class;

--- a/dev/com.ibm.ws.artifact_fat/fat/src/com/ibm/ws/artifact/fat/FATSuite.java
+++ b/dev/com.ibm.ws.artifact_fat/fat/src/com/ibm/ws/artifact/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012,2017 IBM Corporation and others.
+ * Copyright (c) 2012,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,8 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses( { 
                     FATResourceProtocol.class, 
                     FATReaperIntrospectionTest.class,
-                    FATReaperMultipleIntrospectionTest.class
+                    FATReaperMultipleIntrospectionTest.class,
+                    FATNoDirectoryZipTest.class
                 })
 public class FATSuite {
     // EMPTY

--- a/dev/com.ibm.ws.artifact_fat/publish/servers/com.ibm.ws.artifact.nodir.zip/.gitignore
+++ b/dev/com.ibm.ws.artifact_fat/publish/servers/com.ibm.ws.artifact.nodir.zip/.gitignore
@@ -1,0 +1,3 @@
+/apps
+/logs
+/workarea

--- a/dev/com.ibm.ws.artifact_fat/publish/servers/com.ibm.ws.artifact.nodir.zip/bootstrap.properties
+++ b/dev/com.ibm.ws.artifact_fat/publish/servers/com.ibm.ws.artifact.nodir.zip/bootstrap.properties
@@ -1,0 +1,1 @@
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.artifact_fat/publish/servers/com.ibm.ws.artifact.nodir.zip/server.xml
+++ b/dev/com.ibm.ws.artifact_fat/publish/servers/com.ibm.ws.artifact.nodir.zip/server.xml
@@ -1,0 +1,17 @@
+<server description="Test server: Verify zip with no directory">
+
+  <featureManager>
+    <feature>servlet-4.0</feature>
+    <feature>componenttest-1.0</feature>
+  </featureManager>
+
+  <!-- <logging traceSpecification="com.ibm.ws.artifact*=all" maxFileSize="20" maxFiles="10"/> -->
+
+  <classloading useJarUrls="true" />
+  <application location="noDirZip.war"/>
+
+  <include location="../fatTestPorts.xml"/>
+
+  <javaPermission className="java.security.AllPermission"/>
+
+</server>

--- a/dev/com.ibm.ws.artifact_fat/test-applications/noDirZip/src/nodirzip/fat/test/app/NoDirectoryZipServlet.java
+++ b/dev/com.ibm.ws.artifact_fat/test-applications/noDirZip/src/nodirzip/fat/test/app/NoDirectoryZipServlet.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package nodirzip.fat.test.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@WebServlet("/nodirzip")
+public class NoDirectoryZipServlet extends FATServlet {
+
+    @Test
+    public void testNoDirectoryEntryZip(HttpServletRequest request, HttpServletResponse resp) throws Exception {
+        resp.getWriter().println("Running no directory test");
+        String classFileName = getClass().getSimpleName() + ".class";
+        URL testClassFile = getClass().getResource(classFileName);
+        assertNotNull("Missing class resource.", testClassFile);
+        assertEquals("Wrong protocol", "jar", testClassFile.getProtocol());
+        String dirPath = '/' + getClass().getPackage().getName().replace('.', '/') + '/';
+
+        // do this twice to make sure we only show the warning once per path
+        getResourceParents(dirPath);
+        getResourceParents(dirPath);
+
+        // also calling CL.getResources to make sure no URLs get returned for that
+        getResources(dirPath);
+
+        // now call for something that really doesn't exist
+        getResources(dirPath + "subDirMissing/");
+    }
+
+    private void getResourceParents(String dirPath) {
+        do {
+            URL testURL = getClass().getResource(dirPath);
+            assertNull("Should not have found directory URL: " + testURL, testURL);
+            int nextSlash = dirPath.lastIndexOf('/', dirPath.length() - 2);
+            dirPath = dirPath.substring(0, nextSlash + 1);
+        } while (dirPath.length() > 1);
+    }
+
+    private void getResources(String dirPath) throws IOException {
+        List<URL> resources = Collections.list(getClass().getClassLoader().getResources(dirPath));
+        assertTrue("Found the directory resources: ", resources.isEmpty());
+    }
+
+}


### PR DESCRIPTION
If the class loader is configured to use jar URLs then it should not return jar URLs from JARs/ZIPs to directory entries that do not exist.