### PR TITLE
Instant, BigDecimal, and BigInteger basic types

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DebtPerWorker.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DebtPerWorker.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+
+/**
+ * Java record that has a subset of fields of the DemographicInfo entity.
+ */
+public record DebtPerWorker(
+                BigDecimal publicDebt,
+                BigDecimal intragovernmentalDebt,
+                BigInteger numFullTimeWorkers) {
+    BigDecimal get() {
+        return publicDebt.add(intragovernmentalDebt)
+                        .divide(new BigDecimal(numFullTimeWorkers),
+                                2,
+                                RoundingMode.HALF_UP);
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DemographicInfo.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DemographicInfo.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * Entity that has the Instant, BigDecimal, and BigInteger basic types
+ * which are not used anywhere else in tests.
+ */
+@Entity
+public class DemographicInfo {
+
+    @Column
+    public Instant collectedOn;
+
+    @GeneratedValue
+    @Id
+    public BigInteger id;
+
+    @Column
+    public BigDecimal publicDebt;
+
+    @Column
+    public BigDecimal intragovernmentalDebt;
+
+    @Column
+    public BigInteger numFullTimeWorkers;
+
+    public DemographicInfo() {
+    }
+
+    public DemographicInfo(int year, int month, int day,
+                           long numFullTimeWorkers,
+                           double intragovernmentalDebt, double publicDebt) {
+        this.collectedOn = ZonedDateTime.of(year, month, day, 12, 0, 0, 0, ZoneId.of("America/New_York")).toInstant();
+        this.numFullTimeWorkers = BigInteger.valueOf(numFullTimeWorkers);
+        this.intragovernmentalDebt = BigDecimal.valueOf(intragovernmentalDebt);
+        this.publicDebt = BigDecimal.valueOf(publicDebt);
+    }
+
+    @Override
+    public String toString() {
+        return "DemographicInfo from " + collectedOn;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Stream;
+
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for the DemographicInfo entity, which covers the basic types
+ * Instant, BigDecimal, and BigInteger.
+ */
+@Repository
+public interface Demographics {
+
+    @Find
+    Stream<DebtPerWorker> debtPerFullTimeWorker();
+
+    @OrderBy("publicDebt")
+    List<DemographicInfo> findByPublicDebtBetween(BigDecimal min, BigDecimal max);
+
+    // TODO support for Instant requires JPA 3.2, after which the following can be tried out:
+
+    //@Query("SELECT publicDebt / numFullTimeWorkers FROM DemographicInfo WHERE EXTRACT (YEAR FROM collectedOn) = ?1")
+    //Optional<BigDecimal> publicDebtPerFullTimeWorker(int year);
+
+    //@Find
+    //Optional<DemographicInfo> read(Instant collectedOn);
+
+    @OrderBy("numFullTimeWorkers")
+    @Query("WHERE numFullTimeWorkers >= :min AND numFullTimeWorkers <= :max")
+    List<Instant> whenFullTimeEmploymentWithin(BigInteger min, BigInteger max);
+
+    @Insert
+    void write(DemographicInfo info);
+}


### PR DESCRIPTION
Add tests for 3 of the Jakarta Data basic types that do not currently have coverage:
Instant
BigDecimal
BigInteger

Some repository methods for Instant are temporarily commented out with a TODO comment that JPA 3.2 (which adds support for Instant) will be needed first.