### PR TITLE
don't use root tmp directory

### DIFF
--- a/dev/com.ibm.ws.cdi.third.party_fat/publish/servers/cdi20HibernateSearchServer/persistence.xml
+++ b/dev/com.ibm.ws.cdi.third.party_fat/publish/servers/cdi20HibernateSearchServer/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,7 @@
           value="filesystem"/>
 
 <property name="hibernate.search.default.indexBase"
-          value="/tmp/lucene/indexes"/>
+          value="INDEX-PATH"/>
 
         </properties>
     </persistence-unit>


### PR DESCRIPTION
Resolves https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=300059

I'm informed that on AIX there's a problem with using /tmp so this PR dynamically modifies the permissions.xml file to use a directory inside the server.