### PR TITLE
Fix errors during Database Rotation

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_EJB.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -186,6 +186,12 @@ public class BeanValidation20_EJB extends JPAFATServletClient {
             loader.getCommonLibraryRefs().add("OpenJPALib");
             cel.add(loader);
         }
+
+        // Always add the JDBC driver as common library ref as hibername/openjpa might need access to it
+        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+        ClassloaderElement loader = new ClassloaderElement();
+        loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
+        cel.add(loader);
 
         server.setMarkToEndOfLog();
         ServerConfiguration sc = server.getServerConfiguration();

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_EJB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_Web.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation20_Web.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -177,6 +177,12 @@ public class BeanValidation20_Web extends JPAFATServletClient {
             loader.getCommonLibraryRefs().add("OpenJPALib");
             cel.add(loader);
         }
+
+        // Always add the JDBC driver as common library ref as hibername/openjpa might need access to it
+        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+        ClassloaderElement loader = new ClassloaderElement();
+        loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
+        cel.add(loader);
 
         server.setMarkToEndOfLog();
         ServerConfiguration sc = server.getServerConfiguration();

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation_EJB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation_EJB.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -186,6 +186,12 @@ public class BeanValidation_EJB extends JPAFATServletClient {
             loader.getCommonLibraryRefs().add("OpenJPALib");
             cel.add(loader);
         }
+
+        // Always add the JDBC driver as common library ref as hibername/openjpa might need access to it
+        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+        ClassloaderElement loader = new ClassloaderElement();
+        loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
+        cel.add(loader);
 
         server.setMarkToEndOfLog();
         ServerConfiguration sc = server.getServerConfiguration();

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation_Web.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/BeanValidation_Web.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -179,6 +179,12 @@ public class BeanValidation_Web extends JPAFATServletClient {
             loader.getCommonLibraryRefs().add("OpenJPALib");
             cel.add(loader);
         }
+
+        // Always add the JDBC driver as common library ref as hibername/openjpa might need access to it
+        ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+        ClassloaderElement loader = new ClassloaderElement();
+        loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
+        cel.add(loader);
 
         server.setMarkToEndOfLog();
         ServerConfiguration sc = server.getServerConfiguration();

--- a/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/AsmServiceTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/AsmServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/AsmServiceTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/AsmServiceTest.java
@@ -67,6 +67,10 @@ public class AsmServiceTest extends JPAFATServletClient {
     private final static Set<String> populateSet = new HashSet<String>();
     private static long timestart = 0;
 
+    private final static String[] IGNORED_WARNINGS = new String[] {
+                                                                    "CWWJP9991W", // From Eclipselink drop-and-create tables option
+    };
+
     public static final JdbcDatabaseContainer<?> testContainer = FATSuite.testContainer;
 
     static {
@@ -201,7 +205,7 @@ public class AsmServiceTest extends JPAFATServletClient {
             setupDatabaseApp(server);
             setupTestApplication(server);
             runTest(server);
-            server.stopServer();
+            server.stopServer(IGNORED_WARNINGS);
             if (server.defaultTraceFileExists()) {
                 List<String> asmImplMsgList = server.findStringsInTrace("[eclipselink] " + expectedAsmImpl + " ASM implementation is used.");
                 Assert.assertFalse(asmImplMsgList.isEmpty());

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/fat/src/com/ibm/ws/jpa/tests/jpaconfig/tests/DefaultProperties_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/fat/src/com/ibm/ws/jpa/tests/jpaconfig/tests/DefaultProperties_EJB.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -230,6 +230,12 @@ public class DefaultProperties_EJB extends JPAFATServletClient {
                 loader.getCommonLibraryRefs().add("OpenJPALib");
                 cel.add(loader);
             }
+
+            // Always add the JDBC driver as common library ref as hibername/openjpa might need access to it
+            ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+            ClassloaderElement loader = new ClassloaderElement();
+            loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
+            cel.add(loader);
 
             server.setMarkToEndOfLog();
             ServerConfiguration sc = server.getServerConfiguration();

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/fat/src/com/ibm/ws/jpa/tests/jpaconfig/tests/DefaultProperties_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/fat/src/com/ibm/ws/jpa/tests/jpaconfig/tests/DefaultProperties_EJB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/fat/src/com/ibm/ws/jpa/tests/jpaconfig/tests/DefaultProperties_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/fat/src/com/ibm/ws/jpa/tests/jpaconfig/tests/DefaultProperties_Web.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/fat/src/com/ibm/ws/jpa/tests/jpaconfig/tests/DefaultProperties_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/fat/src/com/ibm/ws/jpa/tests/jpaconfig/tests/DefaultProperties_Web.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -201,6 +201,12 @@ public class DefaultProperties_Web extends JPAFATServletClient {
                 loader.getCommonLibraryRefs().add("OpenJPALib");
                 cel.add(loader);
             }
+
+            // Always add the JDBC driver as common library ref as hibername/openjpa might need access to it
+            ConfigElementList<ClassloaderElement> cel = appRecord.getClassloaders();
+            ClassloaderElement loader = new ClassloaderElement();
+            loader.getCommonLibraryRefs().add("AnonymousJDBCLib");
+            cel.add(loader);
 
             server.setMarkToEndOfLog();
             ServerConfiguration sc = server.getServerConfiguration();


### PR DESCRIPTION
failure_group-f6233dd1-21a0-4f6f-b70b-806aac880b47
W CWWJP9991W: [eclipselink.server] Failed to find MBean Server: null or empty List returned from MBeanServerFactory.findMBeanServer(null)

failure_group-c3b9f95b-2141-494c-8424-d1b759733dca
PostgreSQL
Caused by: java.lang.ClassNotFoundException: org.postgresql.util.PGobject

failure_group-cc166913-e9d4-4038-a13d-561416c9cf10
PostgreSQL
Caused by: java.lang.ClassNotFoundException: org.postgresql.util.PGobject