### PR TITLE
Increased Hung Request Threshold in RequestTiming FAT

### DIFF
--- a/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestTiming.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -502,8 +502,8 @@ public class HungRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testHungRequestTiming() throws Exception {
-        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 2s");
-        server.setServerConfigurationFile("server_hungRequestThreshold2.xml");
+        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 30s");
+        server.setServerConfigurationFile("server_hungRequestThreshold30.xml");
         String srvConfigCompletedMsg = server.waitForStringInLog("CWWKG0017I|CWWKG0018I", 90000);
 
         assertNotNull("The server configuration was successfully updated message was not found!", srvConfigCompletedMsg);

--- a/dev/com.ibm.ws.request.timing.hung_fat/publish/files/server_hungRequestThreshold30.xml
+++ b/dev/com.ibm.ws.request.timing.hung_fat/publish/files/server_hungRequestThreshold30.xml
@@ -1,0 +1,17 @@
+<server description="new server">
+
+  <!-- Enable features -->
+    <featureManager>
+        <feature>jsp-2.2</feature>
+      <feature>requestTiming-1.0</feature>
+    </featureManager>
+  
+	<httpEndpoint id="defaultHttpEndpoint" host="*" />
+
+	<include location="../fatTestPorts.xml"/>
+	<include location="serverSessionConfig.xml"/>
+  	
+   <requestTiming slowRequestThreshold="0"/>
+   <requestTiming hungRequestThreshold = "30s" />
+  
+</server>


### PR DESCRIPTION
fixes #27651
- Increased the Hung Request threshold to 30 seconds in the `TestHungRequestTiming` test, so the test has enough time to generate the appropriate java dumps 1 minute apart, and it does not slow down the system with the continuous Hung Request detections, if the threshold is really small, as it was previously (2 seconds), since the test sleeps for 5 minutes.