### PR TITLE
Generate Set-Cookie from SessionCookieConfig not include the configured attributes

### DIFF
--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/session/impl/HttpSessionContextImpl60.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/session/impl/HttpSessionContextImpl60.java
@@ -13,12 +13,15 @@ import java.util.logging.Level;
 
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.session.SessionApplicationParameters;
+import com.ibm.ws.session.SessionContext;
 import com.ibm.ws.session.SessionManagerConfig;
 import com.ibm.ws.session.SessionStoreService;
 import com.ibm.ws.session.http.AbstractHttpSession;
 import com.ibm.ws.session.utils.LoggingUtil;
 import com.ibm.ws.webcontainer31.session.impl.HttpSessionContext31Impl;
 import com.ibm.wsspi.session.ISession;
+import com.ibm.wsspi.session.ISessionAffinityManager;
+import com.ibm.wsspi.session.IStore;
 import com.ibm.wsspi.session.SessionAffinityContext;
 
 import io.openliberty.session.impl.SessionCookieConfigImpl60;
@@ -73,7 +76,7 @@ public class HttpSessionContextImpl60 extends HttpSessionContext31Impl {
     @Override
     public Object createSessionObject(ISession isess, ServletContext servCtx) {
         if (TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE)) {
-            LoggingUtil.SESSION_LOGGER_CORE.log(Level.FINE, methodClassName + " createSessionObject");
+            LoggingUtil.SESSION_LOGGER_CORE.log(Level.FINE, methodClassName + " createSessionObject -> WCHttpSessionImpl60");
         }
 
         return new WCHttpSessionImpl60(isess, this, servCtx);
@@ -93,5 +96,13 @@ public class HttpSessionContextImpl60 extends HttpSessionContext31Impl {
         }
 
         return session;
+    }
+
+    @Override
+    public ISessionAffinityManager createSessionAffinityManager(SessionManagerConfig smc, SessionContext sctx, IStore istore) {
+        if (TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE)) {
+            LoggingUtil.SESSION_LOGGER_CORE.log(Level.FINE, methodClassName + " createSessionAffinityManager -> SessionAffinityManagerImpl60");
+        }
+        return new SessionAffinityManagerImpl60(smc, sctx, istore);
     }
 }

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/session/impl/SessionAffinityManagerImpl60.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal/src/io/openliberty/webcontainer60/session/impl/SessionAffinityManagerImpl60.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.webcontainer60.session.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+
+import com.ibm.ws.session.SessionContext;
+import com.ibm.ws.session.SessionManagerConfig;
+import com.ibm.ws.session.utils.LoggingUtil;
+import com.ibm.ws.webcontainer.session.impl.SessionAffinityManagerImpl;
+import com.ibm.wsspi.session.IStore;
+import com.ibm.wsspi.session.SessionAffinityContext;
+import com.ibm.wsspi.webcontainer.servlet.IExtendedResponse;
+
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.SessionCookieConfig;
+import jakarta.servlet.http.Cookie;
+
+public class SessionAffinityManagerImpl60 extends SessionAffinityManagerImpl {
+
+    private static final String methodClassName = "SessionAffinityManagerImpl60";
+
+    public SessionAffinityManagerImpl60(SessionManagerConfig smc, SessionContext sctx, IStore istore) {
+        super(smc, sctx, istore);
+
+        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE)) {
+            LoggingUtil.SESSION_LOGGER_CORE.logp(Level.FINE, methodClassName, methodClassName, "Clone ID of this server=" + _cloneID);
+        }
+    }
+
+    public void setCookie(ServletRequest request, ServletResponse response, SessionAffinityContext affinityContext, Object session) {
+        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE)) {
+            LoggingUtil.SESSION_LOGGER_CORE.entering(methodClassName, "setCookie");
+        }
+
+        Cookie cookie = super.cookieGenerator(request, response, affinityContext, session);
+
+        //setAttribute any remaining
+        if (cookie != null) {
+            SessionCookieConfig scc = _smc.getSessionCookieConfig();
+
+            Map<String, String> cookieAttrs = scc.getAttributes();
+            if (cookieAttrs != null) {
+                ArrayList<String> preDefinedAttList = new ArrayList<String>(Arrays.asList("COMMENT", "DOMAIN", "HTTPONLY", "MAX-AGE", "PATH", "SECURE")); //Exclude the predefined attributes
+                String key, value;
+
+                for (Entry<String, String> entry : cookieAttrs.entrySet()) {
+                    key = entry.getKey();
+                    if (!preDefinedAttList.contains(key.toUpperCase(Locale.ENGLISH))) {
+                        value = entry.getValue();
+
+                        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE)) {
+                            LoggingUtil.SESSION_LOGGER_CORE.logp(Level.FINE, methodClassName, "setCookie", "setAttribute (" + key + "," + value + ")");
+                        }
+                        cookie.setAttribute(key, value);
+                    }
+                }
+            }
+
+            ((IExtendedResponse) response).addSessionCookie(cookie);
+        }
+
+        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE)) {
+            LoggingUtil.SESSION_LOGGER_CORE.exiting(methodClassName, "setCookie [" + cookie + "]");
+        }
+    }
+}

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/fat/src/io/openliberty/webcontainer/servlet60/fat/tests/Servlet60SessionCookieConfigXMLTest.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/fat/src/io/openliberty/webcontainer/servlet60/fat/tests/Servlet60SessionCookieConfigXMLTest.java
@@ -1,19 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package io.openliberty.webcontainer.servlet60.fat.tests;
 
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.logging.Logger;
 
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -107,12 +106,20 @@ public class Servlet60SessionCookieConfigXMLTest {
                 //fail-fast check
                 assertTrue("The response did not contain the following String: " + expectedGeneralResponse, responseText.contains(expectedGeneralResponse));
 
+                //Application checked all the attributes and reported back here.
                 String headerValue = response.getHeader("TestResult").getValue();
-
-                LOG.info("\n TestResult : " + headerValue);
-
+                LOG.info("\n TestResult : " + headerValue + "\n");
                 assertTrue("The response does not contain Result [PASS]. TestResult header [" + headerValue + "]", headerValue.contains("Result [PASS]"));
 
+                //Check Set-Cookie seen by client
+                headerValue = response.getHeader("Set-Cookie").getValue();
+                LOG.info("\n Set-Cookie : " + headerValue + "\n");
+                ArrayList<String> preDefinedAttList = new ArrayList<String>(Arrays.asList("attnameunique=attvalueunique_viawebxml", "attname2=attvalue2_viawebxml",
+                                                                                          "attname1=attvalue1_viawebxml"));
+                headerValue = headerValue.toLowerCase();
+                for (String att : preDefinedAttList) {
+                    assertTrue("The Set-Cookie header does not contain the attribute pair [" + att + "]", headerValue.contains(att));
+                }
             }
         }
     }

--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/test-applications/SessionCookieConfigSCI.jar/src/testsci/jar/servlets/TestSessionCookieConfigServlet.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/test-applications/SessionCookieConfigSCI.jar/src/testsci/jar/servlets/TestSessionCookieConfigServlet.java
@@ -1,22 +1,19 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package testsci.jar.servlets;
 
 import java.io.IOException;
 import java.util.logging.Logger;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.SessionCookieConfig;
 import jakarta.servlet.http.HttpServlet;
@@ -24,10 +21,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
- *  Test servlet to retrieve session cookie data from web.xml or application (via SCI)
+ * Test servlet to retrieve session cookie data from web.xml or application (via SCI)
  *
- *  When both configs are presented, SCI takes precedence.
- *  In the test, use jvm.options set.cookie.config.sci.setCookieConfigViaSCI to control the SCI or web.xml
+ * When both configs are presented, SCI takes precedence.
+ * In the test, use jvm.options set.cookie.config.sci.setCookieConfigViaSCI to control the SCI or web.xml
  */
 public class TestSessionCookieConfigServlet extends HttpServlet {
     private static final long serialVersionUID = 1L;
@@ -42,22 +39,20 @@ public class TestSessionCookieConfigServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         ServletOutputStream sos = response.getOutputStream();
         sos.println("Hello World from TestSessionCookieConfigServlet");
-        
+
         //TestSessionCookieConfigServlet?testName=TestIllegalOperation
         String testName = request.getParameter("testName");
 
-        if (testName != null){
+        if (testName != null) {
             //setAttribute after app started will cause IllegalStateException
-            if (testName.equals("TestIllegalOperation")){
+            if (testName.equals("TestIllegalOperation")) {
                 testIllegalOperation(response);
             }
-        }
-        else if (ServletContainerInitializerImpl.isSetCookieConfigViaSCI){
+        } else if (ServletContainerInitializerImpl.isSetCookieConfigViaSCI) {
             LOG.info("JVM property set.cookie.config.sci.setCookieConfigViaSCI set to true");
             testGetSessionCookieConfigSCI(response);
-        }
-        else {
-            testGetSessionCookieConfigXML(response);
+        } else {
+            testGetSessionCookieConfigXML(request, response);
         }
     }
 
@@ -68,13 +63,12 @@ public class TestSessionCookieConfigServlet extends HttpServlet {
 
     //Change values in SCI files to simulate the wrong returned values.
     //SCI values will override the web.xml setting
-    private void testGetSessionCookieConfigSCI(HttpServletResponse response)  {
-        
+    private void testGetSessionCookieConfigSCI(HttpServletResponse response) {
         ServletContext context = getServletContext();
         SessionCookieConfig scc = context.getSessionCookieConfig();
 
         LOG.info(" testGetSessionCookieConfigSCI | ServletContext [" + context + " | SessionCookieConfig [" + scc + "]");
-       
+
         String cookieName;
         String cookieValue;
         int cookieInt;
@@ -87,125 +81,113 @@ public class TestSessionCookieConfigServlet extends HttpServlet {
             testPass = false;
             sBuilderResponse.append(" FAIL getDomain() expecting [setAttDomain_viaSCI] , actual [" + cookieValue + "] |");
             LOG.info("Test scc.getDomain() FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" getDomain() PASS |");
-        
-        if ( !((cookieInt = scc.getMaxAge()) == 2022) ) {
+
+        if (!((cookieInt = scc.getMaxAge()) == 2022)) {
             testPass = false;
             sBuilderResponse.append(" FAIL getMaxAge() expecting [2022] , actual [" + cookieInt + "] |");
             LOG.info("Test scc.getMaxAge() FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" getMaxAge() PASS |");
-        
+
         if (!(cookieValue = scc.getName()).equals("SessionCookieConfig6_viaSCI")) {
             testPass = false;
             sBuilderResponse.append(" FAIL getName() expecting [SessionCookieConfig6_viaSCI] , actual [" + cookieValue + "] |");
             LOG.info("Test scc.getName() FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" getName() PASS |");
-        
+
         if (!(cookieValue = scc.getPath()).equals("setPATH_viaSCI")) {
             testPass = false;
             sBuilderResponse.append(" FAIL getPath() expecting [setPATH_viaSCI] , actual [" + cookieValue + "] |");
             LOG.info("Test scc.getPath() FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" getPath() PASS |");
-        
+
         if (!scc.isHttpOnly()) {
             testPass = false;
             sBuilderResponse.append(" FAIL isHttpOnly() expecting [true] , actual [" + scc.isHttpOnly() + "] |");
             LOG.info("Test scc.isHttpOnly() FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" isHttpOnly() PASS |");
-        
+
         //Test precedence - SCI overwrite web.xml
         if (!(cookieValue = scc.getAttribute("AttName1")).equals("AttValue1SCI")) {
             testPass = false;
             sBuilderResponse.append(" FAIL getAttribute(\"AttName1\") expecting [AttValue1SCI] , actual [" + cookieValue + "] |");
             LOG.info("Test precedence order FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" Test precedence order PASS |");
-       
+
         //Test getAttribute from web.xml
         if (!(cookieValue = scc.getAttribute("AttNameUnique")).equals("AttValueUnique_viaWebXML")) {
             testPass = false;
             sBuilderResponse.append(" FAIL getAttribute(\"AttNameUnique\") expecting [AttValueUnique_viaWebXML] , actual [" + cookieValue + "] |");
             LOG.info("Test getAttribute web.xml FAIL");
-        }
-        else
-            sBuilderResponse.append(" Test getAttribute web.xml PASS |"); 
-        
+        } else
+            sBuilderResponse.append(" Test getAttribute web.xml PASS |");
+
         //Note the lower case att name
         if (!(cookieValue = scc.getAttribute("attname5")).equals("AttValue5")) {
             testPass = false;
             sBuilderResponse.append(" FAIL getAttribute(\"attname5\") expecting [AttValue5] , actual [" + cookieValue + "] |");
             LOG.info(" Test lower case att name FAIL");
-        } 
-        else
+        } else
             sBuilderResponse.append(" Test lower case att name PASS |");
-        
+
         //Test specific Domain that set via setAttribute and retrieve via getAttribute
         if (!(cookieValue = scc.getAttribute("DOMAIN")).equals("setAttDomain_viaSCI")) {
             testPass = false;
             sBuilderResponse.append(" FAIL getAttribute(\"DOMAIN\") expecting [setAttDomain_viaSCI] , actual [" + cookieValue + "] |");
             LOG.info(" Test getAttribute(\"DOMAIN\") FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" Test getAttribute(\"DOMAIN\") PASS |");
-        
+
         if (!(cookieValue = scc.getAttribute("path")).equals("setPATH_viaSCI")) {
             testPass = false;
             sBuilderResponse.append(" FAIL getAttribute(\"path\") expecting [setPATH_viaSCI] , actual [" + cookieValue + "] |");
             LOG.info("Test getAttribute(\"path\") FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" Test getAttribute(\"path\") PASS |");
-        
+
         //Validate setAttribute with null name.  Servlet has verified the translated message code and reports whether PASS or FAIL.
         if (!(cookieValue = scc.getAttribute("ReportedNullAttName")).equals("PASS")) {
             testPass = false;
             sBuilderResponse.append(" FAIL getAttribute(\"ReportedNullAttName\") expecting [PASS] , actual [" + cookieValue + "] |");
             LOG.info(" Test NULL att name FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" Test NULL att name PASS |");
-       
+
         //Validate setAttribute with invalid name.
         if (!(cookieValue = scc.getAttribute("ReportedInvalidAttName")).equals("PASS")) {
             testPass = false;
             sBuilderResponse.append(" FAIL getAttribute(\"ReportedInvalidAttName\") expecting [PASS] , actual [" + cookieValue + "] |");
             LOG.info(" Test report invalid att name FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" Test report invalid att name PASS |");
-      
-        
+
         //Final result - any of the above tests fail will make test fail
         if (testPass)
             sBuilderResponse.append("]  Result [PASS]");
         else
             sBuilderResponse.append("]  Result [FAIL]");
-       
+
         //Client check this header.
-        response.setHeader("TestResult", sBuilderResponse.toString());                   
-       
+        response.setHeader("TestResult", sBuilderResponse.toString());
+
         LOG.info(sBuilderResponse.toString());
     }
 
-
     //Test session cookie-config from web.xml
-    private void testGetSessionCookieConfigXML(HttpServletResponse response)  {
+    private void testGetSessionCookieConfigXML(HttpServletRequest request, HttpServletResponse response) {
         ServletContext context = getServletContext();
         SessionCookieConfig scc = context.getSessionCookieConfig();
 
         LOG.info(" testGetSessionCookieConfigXML | ServletContext [" + context + " . SessionCookieConfig [" + scc + "]");
-       
+
+        request.getSession(true); //generate the Set-Cookie header which client will verify
+
         String cookieName;
         String cookieValue;
         int cookieInt;
@@ -218,54 +200,43 @@ public class TestSessionCookieConfigServlet extends HttpServlet {
             testPass = false;
             sBuilderResponse.append(" FAIL getDomain() expecting [CookieConfigDomain_viaWebXML] , actual [" + cookieValue + "] ||");
             LOG.info("Test scc.getDomain() FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" getDomain() PASS |");
-            
-        
-        if ( !((cookieInt = scc.getMaxAge()) == 2021) ) {
+
+        if (!((cookieInt = scc.getMaxAge()) == 2021)) {
             testPass = false;
             sBuilderResponse.append(" FAIL getMaxAge() expecting [2021] , actual [" + cookieInt + "] ||");
             LOG.info("Test scc.getMaxAge() FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" getMaxAge() PASS |");
-            
-        
+
         if (!(cookieValue = scc.getName()).equals("CookieConfigName_viaWebXML")) {
             testPass = false;
             sBuilderResponse.append(" FAIL getName() expecting [CookieConfigName_viaWebXML] , actual [" + cookieValue + "] ||");
             LOG.info("Test scc.getName() FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" getName() PASS |");
-            
-        
+
         if (!(cookieValue = scc.getPath()).equals("CookieConfigPath_viaWebXML")) {
             testPass = false;
             sBuilderResponse.append(" FAIL getPath() expecting [CookieConfigPath_viaWebXML] , actual [" + cookieValue + "] ||");
             LOG.info("Test scc.getPath() FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" getPath() PASS |");
-            
-        
+
         if (!scc.isHttpOnly()) {
             testPass = false;
             sBuilderResponse.append(" FAIL isHttpOnly() expecting [true] , actual [" + scc.isHttpOnly() + "] ||");
             LOG.info("Test scc.isHttpOnly() FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" isHttpOnly() PASS |");
-            
 
-         //Test Domain via getAttribute
+        //Test Domain via getAttribute
         if (!(cookieValue = scc.getAttribute("DOMAIN")).equals("CookieConfigDomain_viaWebXML")) {
             testPass = false;
             sBuilderResponse.append(" FAIL getAttribute(\"DOMAIN\") expecting [CookieConfigDomain_viaWebXML] , actual [" + cookieValue + "] ||");
             LOG.info("Test scc.getAttribute(\"DOMAIN\") FAIL");
-        }
-        else
+        } else
             sBuilderResponse.append(" getAttribute(\"DOMAIN\") PASS |");
 
         //Test set/getAttribute from web.xml.  NPE can happen if the web.xml cannot parse for some reasons; thus the try/catch
@@ -274,65 +245,60 @@ public class TestSessionCookieConfigServlet extends HttpServlet {
                 testPass = false;
                 sBuilderResponse.append(" FAIL getAttribute(\"AttName1\")) expecting [AttValue1_viaWebXML] , actual [" + cookieValue + "] ||");
                 LOG.info("Test scc.getAttribute(\"AttName1\") FAIL");
-            }
-            else
+            } else
                 sBuilderResponse.append(" getAttribute(\"AttName1\") PASS |");
-           
+
             //test getAttributes
             if (!(scc.getAttributes().get("AttName2")).equals("AttValue2_viaWebXML")) {
                 testPass = false;
                 sBuilderResponse.append(" FAIL  getAttributes().get(\"AttName2\") expecting [AttValue2_viaWebXML] , actual [" + cookieValue + "] ||");
                 LOG.info("Test scc.getAttributes.get(\"AttName2\") FAIL");
-            }
-            else
+            } else
                 sBuilderResponse.append(" getAttributes().get(\"AttName2\") PASS |");
-                
+
             //test getAttributes.get("path") with lower case path
             if (!(scc.getAttributes().get("path")).equals("CookieConfigPath_viaWebXML")) {
                 testPass = false;
                 sBuilderResponse.append(" FAIL getAttributes().get(\"path\") expecting [CookieConfigPath_viaWebXML] , actual [" + cookieValue + "] ||");
                 LOG.info("Test scc.getAttributes.get(\"AttName2\") FAIL");
-            }
-            else
+            } else
                 sBuilderResponse.append(" getAttributes().get(\"path\") PASS |");
-        }
-        catch (Exception e) { 
+        } catch (Exception e) {
             testPass = false;
             sBuilderResponse.append(" getAttribute() tests FAIL with an exception [" + e + "] ||");
             LOG.info("Test scc.getAttribute() FAIL with Exception " + e);
         }
-        
+
         if (testPass)
             sBuilderResponse.append("]  Result [PASS]");
         else
             sBuilderResponse.append("]  Result [FAIL]");
-       
+
         //Client check this header.
-        response.setHeader("TestResult", sBuilderResponse.toString());                   
-       
+        response.setHeader("TestResult", sBuilderResponse.toString());
+
         LOG.info(sBuilderResponse.toString());
     }
-    
+
     //Test setAttribute after ServletContext has been initialized to cause IllegalStateException
-    private void testIllegalOperation(HttpServletResponse response)  {
+    private void testIllegalOperation(HttpServletResponse response) {
         ServletContext context = getServletContext();
         SessionCookieConfig scc = context.getSessionCookieConfig();
 
         LOG.info(" testIllegalOperation | ServletContext [" + context + " . SessionCookieConfig [" + scc + "]");
-        
+
         StringBuilder sBuilderResponse = new StringBuilder("TEST testIllegalOperation . Message [");
         try {
-            scc.setAttribute("AttName" , "AttValue");
+            scc.setAttribute("AttName", "AttValue");
             sBuilderResponse.append(" setAttribute after ServletContext already initialized does NOT cause IllegalException.  Result [FAIL]");
-        }
-        catch (IllegalStateException e) {
+        } catch (IllegalStateException e) {
             LOG.info("Test setAttribute after ServletContext intialized causes IllegalStateException , e [" + e + "] . Test PASS");
             sBuilderResponse.append(" setAttribute after ServletContext already initialized causes IllegalStateException.  Result [PASS]");
         }
 
         //Client check this header.
-        response.setHeader("TestResult", sBuilderResponse.toString());                   
-        
+        response.setHeader("TestResult", sBuilderResponse.toString());
+
         LOG.info(sBuilderResponse.toString());
     }
 }


### PR DESCRIPTION
fixes https://github.com/OpenLiberty/open-liberty/issues/28431

Set-Cookie does not include the `<attribute-name>` and `<attribute-value>` which are configured in the web.xml `<session-config>`