### PR TITLE
Update java9.options file for OpenJCEPlus

### DIFF
--- a/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
@@ -74,3 +74,6 @@ jdk.management.agent/jdk.internal.agent=ALL-UNNAMED
 # Also for https://github.com/OpenLiberty/open-liberty/issues/20858
 --add-exports
 java.base/jdk.internal.vm=ALL-UNNAMED
+# for OpenJCEPlus (299515) 
+--add-exports
+openjceplus/com.ibm.misc=ALL-UNNAMED


### PR DESCRIPTION
OpenJCEPlus is new in Semeru Java 17.0.10 and causes a `java.lang.IllegalAccessError` exception in our `com.ibm.ws.collective.security_test` unit test

```
java.lang.IllegalAccessError: Class com/ibm/crypto/provider/IBMJCE(unnamed module 0x0000000083FC6A58) can not access class com/ibm/misc/Debug(openjceplus) because module openjceplus does not export package com/ibm/misc to module unnamed module 0x0000000083FC6A58
```

Need to update the java9.options file with the change to allow this unit test to pass
```
--add-exports
openjceplus/com.ibm.misc=ALL-UNNAMED
```
