### PR TITLE
Increase trace for concurrent persistent FAT

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/publish/servers/com.ibm.ws.concurrent.persistent.fat.simctrl/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/publish/servers/com.ibm.ws.concurrent.persistent.fat.simctrl/bootstrap.properties
@@ -12,7 +12,7 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 
-com.ibm.ws.logging.trace.specification=*=info=enabled:persistentExecutor=all:com.ibm.ws.config.*=all:logservice=all:WAS.j2c=all
+com.ibm.ws.logging.trace.specification=*=info=enabled:persistentExecutor=all:com.ibm.ws.config.*=all:logservice=all:WAS.j2c=all:RRA=all:WAS.database=all
 com.ibm.ws.logging.max.file.size=0
 
 ds.loglevel=debug 


### PR DESCRIPTION
- Add WAS.database and RRA trace to diagnose why connection pool shut down during server start
