### PR TITLE
Use stopAppStartUponListenerException for EE 8

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFATServer/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFATServer/server.xml
@@ -18,6 +18,8 @@
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>
-    
+    <webContainer>
+        <stopAppStartUponListenerException>true</stopAppStartUponListenerException>
+    </webContainer>
     <variable name="VARIABLE_SOURCE_DIRS" defaultValue="defaultSrcDir" />
 </server>


### PR DESCRIPTION
Needed to fix a hard break in the FULL mode from `testFailAppStart` testcase added in #28297