### PR TITLE
Improve beta and release post templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/04_blog_post_beta.md
+++ b/.github/ISSUE_TEMPLATE/04_blog_post_beta.md
@@ -8,33 +8,15 @@ assignees: ReeceNana
 ---
 
 The information you provide here will be included in the Open Liberty beta blog post ([example](https://openliberty.io/blog/2020/08/05/jakarta-grpc-beta-20009.html)), which will be published on [openliberty.io/blog/](https://www.openliberty.io/blog/), and potentially elsewhere, to promote this beta feature/function of Open Liberty. For this post to be included in the beta issue please make sure that this is completed by the end of Friday following the GM (Tuesday). The beta and release blogs are created using automation and rely on you following the template's structure. **DO NOT REMOVE/ALTER THE `<GHA>` TAGS THROUGHOUT THIS TEMPLATE.**
-
-Please provide the following information:
-&#8203;<GHA-BLOG-RELATED-FEATURES>
-1. Which Liberty feature(s) does your update relate to? 
-    
-    Human-readable name (eg WebSockets feature): 
-   
-    Short feature name (eg websockets-1.0):  
-   
-   
-    </GHA-BLOG-RELATED-FEATURES>
-
-    <GHA-BLOG-TARGET-PERSONA>
-2. Who is the target persona? Who do you expect to use the update? eg application developer, operations.  
-    
-    
-    </GHA-BLOG-TARGET-PERSONA>
    
     <GHA-BLOG-SUMMARY>
-3. Provide a summary of the update, including the following points:
+Please provide a summary of the update, including the following points:
    
    - A sentence or two that introduces the update to someone new to the general technology/concept.
-
+   - The Human-readable name and short feature name for your feature- eg WebSockets feature (websockets-1.0).
+   - Who is the target persona? Who do you expect to use the update? eg application developer, operations. 
    - What was the problem before and how does your update make their life better? (Why should they care?)
-   
-   - Briefly explain how to make your update work. Include screenshots, diagrams, and/or code snippets, and provide a `server.xml` snippet.
-   
+   - Briefly explain how to make your update work. Include screenshots, diagrams, and/or code snippets, and provide a `server.xml` snippet.  
    - Where can they find out more about this specific update (eg Open Liberty docs, Javadoc) and/or the wider technology?  
     
     

--- a/.github/ISSUE_TEMPLATE/05_blog_post_ga_release.md
+++ b/.github/ISSUE_TEMPLATE/05_blog_post_ga_release.md
@@ -14,32 +14,18 @@ Please provide the following information:
 1. If this was previously published in a beta blog post, then provide the link to that `OpenLiberty/open-liberty` beta blog post issue on the next line between the `<GHA-BLOG-BETA-LINK>` tags. If nothing has changed since the beta, you're done and can omit the remaining steps. If you need to make updates/alterations to the beta content, then do all the steps. 
    <GHA-BLOG-BETA-LINK>https://github.com/OpenLiberty/open-liberty/issues/0</GHA-BLOG-BETA-LINK>
 
-   <GHA-BLOG-RELATED-FEATURES>
-2. Which Liberty feature(s) does your update relate to?
-    
-   Human-readable name (eg WebSockets feature):
-   
-   Short feature name (eg websockets-1.0): 
-
-   
-   </GHA-BLOG-RELATED-FEATURES>
-
-   <GHA-BLOG-TARGET-PERSONA>
-3. Who is the target persona? Who do you expect to use the update? eg application developer, operations.
-    
-   
-   </GHA-BLOG-TARGET-PERSONA>
-
    <GHA-BLOG-SUMMARY>
-4. Provide a summary of the update, including the following points:
+Please provide a summary of the update, including the following points:
    
    - A sentence or two that introduces the update to someone new to the general technology/concept.
-
+   - The Human-readable name and short feature name for your feature- eg WebSockets feature (websockets-1.0).
+   - Who is the target persona? Who do you expect to use the update? eg application developer, operations. 
    - What was the problem before and how does your update make their life better? (Why should they care?)
-   
-   - Briefly explain how to make your update work. Include screenshots, diagrams, and/or code snippets, and provide a `server.xml` snippet.
-   
-   - Where can they find out more about this specific update (eg Open Liberty docs, Javadoc) and/or the wider technology?
+   - Briefly explain how to make your update work. Include screenshots, diagrams, and/or code snippets, and provide a `server.xml` snippet.  
+   - Where can they find out more about this specific update (eg Open Liberty docs, Javadoc) and/or the wider technology?  
+    
+    
+
 
    </GHA-BLOG-SUMMARY>
 


### PR DESCRIPTION
#28461

Remove unused sections of release and beta post issues. This PR corresponds to https://github.com/OpenLiberty/blogs/pull/3794 in the blogs repo, which removes unused tags from the GHA automation