### PR TITLE
Clarify how to use beta blog issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_feature.md
+++ b/.github/ISSUE_TEMPLATE/03_feature.md
@@ -25,7 +25,7 @@ When available, add links to required feature documents. Use "N/A" to mark parti
     - Click "Share" > select "People with link" > click "Link Settings" > under "Link Expiration" select "Disable Shared Link on" > set an expiration date ~10 years into the future
     - If you lack permissions, contact [OpenLiberty/release-architect](https://github.com/orgs/OpenLiberty/teams/release-architect)
 - FTS: Link to Feature Test Summary GH Issue
-- Beta Blog: Link to Beta Blog Post GH Issue
+- Beta Blog(s): Link to Beta Blog Post(s) GH Issue(s)
 - GA Blog: Link to GA Blog Post GH Issue
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -142,7 +142,8 @@ In order to facilitate early feedback from users, all new features and functiona
 - [ ] [Beta fence](https://github.com/OpenLiberty/open-liberty/wiki/Beta-Fencing) the functionality
   - E.g. `kind=beta`, `ibm:beta`, `ProductInfo.getBetaEdition()`
 - [ ] Beta development complete and feature ready for inclusion in a beta release
-  - Add label `target:beta` and the appropriate `target:YY00X-beta` (where YY00X is the targeted beta version).
+  - Add label `target:beta` and the appropriate `target:YY00X-beta` (where YY00X is the targeted beta version) to the feature issue.
+    - Note: This is expected to be done only once, for the initial beta that includes this feature. You do not need to add a `target:YY00(X+1)-beta`, `target:YY00(X+2)-beta`, etc. label for each additional beta that includes this feature.
 - [ ] Feature delivered into beta
   - ([OpenLiberty/release-manager](https://github.com/orgs/OpenLiberty/teams/release-manager)) adds label `release:YY00X-beta` (where YY00X is the first beta version that included the functionality).
 
@@ -150,6 +151,9 @@ In order to facilitate early feedback from users, all new features and functiona
 - [ ] Beta blog issue created and populated using the [Open Liberty BETA blog post](https://github.com/OpenLiberty/open-liberty/issues/new/choose) template.
   - Add a link to the beta blog issue in the [Documents](#documents) section.
   - Note: This is for inclusion into the overall [beta release blog post](https://openliberty.io/blog/?search=beta&key=tag).  If, in addition, you'd also like to create a dedicated blog post about your feature, then follow the "Standalone Feature Blog Post" instructions under the [Other Deliverables](#other-deliverables) section.
+  - A feature may have multiple beta blogs associated with it. This is especially useful for features that are continuously adding functionality each release and want to advertise what is new since the previous beta.
+    - Each beta blog issue should have the appropriate `target:YY00X-beta` label added to it.
+    - Include each beta blog issue in the [Documents](#documents) section.
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ## **GA**

--- a/.github/ISSUE_TEMPLATE/03_feature.md
+++ b/.github/ISSUE_TEMPLATE/03_feature.md
@@ -25,7 +25,7 @@ When available, add links to required feature documents. Use "N/A" to mark parti
     - Click "Share" > select "People with link" > click "Link Settings" > under "Link Expiration" select "Disable Shared Link on" > set an expiration date ~10 years into the future
     - If you lack permissions, contact [OpenLiberty/release-architect](https://github.com/orgs/OpenLiberty/teams/release-architect)
 - FTS: Link to Feature Test Summary GH Issue
-- Beta Blog(s): Link to Beta Blog Post(s) GH Issue(s)
+- Beta Blog(s): Link to Beta Blog Post GH Issue(s)
 - GA Blog: Link to GA Blog Post GH Issue
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/.github/ISSUE_TEMPLATE/04_blog_post_beta.md
+++ b/.github/ISSUE_TEMPLATE/04_blog_post_beta.md
@@ -41,7 +41,7 @@ Please provide the following information:
     </GHA-BLOG-SUMMARY>
 
 ## What happens next?
-- Add the label for the beta you're targeting: `target:YY00X-beta`.
+- Add the label to the blog issue for the beta you're targeting (e.g. `target:YY00X-beta`).
 - Make sure this blog post is linked back to the Epic for this feature/function.
 - Your paragraph will be included in the beta blog post. It might be edited for style and consistency.
 - You will be asked to review a draft before publication.


### PR DESCRIPTION
Clarifies:
- Where to add `target:YY00X-beta` labels
- One feature may have multiple beta blog issues related to it