### PR TITLE
Connectors support for InstantOn

### DIFF
--- a/dev/com.ibm.ws.jca/bnd.bnd
+++ b/dev/com.ibm.ws.jca/bnd.bnd
@@ -197,6 +197,7 @@ instrument.classesExcludes: com/ibm/ws/jca/internal/resources/*.class
 	com.ibm.wsspi.org.osgi.service.event;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.websphere.appserver.api.ssl;version=latest,\
+    com.ibm.ws.kernel.boot.common;version=latest,\
 	com.ibm.ws.kernel.service;version=latest,\
 	com.ibm.ws.logging.core;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\

--- a/dev/com.ibm.ws.jca/resources/com/ibm/ws/jca/internal/resources/J2CAMessages.nlsprops
+++ b/dev/com.ibm.ws.jca/resources/com/ibm/ws/jca/internal/resources/J2CAMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2012, 2018 IBM Corporation and others.
+# Copyright (c) 2012, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -49,9 +49,25 @@ J2CA8510.create.timed.out=J2CA8510E: A timer could not be created for resource a
 J2CA8510.create.timed.out.explanation=It is taking longer than expected to create the timer.
 J2CA8510.create.timed.out.useraction=Verify if there is a high load on the system and consider decreasing it.
 
+J2CA8511.create.timer.failed.checkpoint=J2CA8511E: The server checkpoint request failed because the {0} resource adapter created a timer.
+J2CA8511.create.timer.failed.checkpoint.explanation=Liberty does not support resource adapters that create a timer while applications start when a server checkpoint is requested.
+J2CA8511.create.timer.failed.checkpoint.useraction=Configure the checkpoint to occur before the application starts by using the at=beforeAppStart server checkpoint option.
+
+J2CA8512.create.timer.not.supported.checkpoint=J2CA8512E: A timer could not be created for the {0} resource adapter during the server checkpoint request.
+J2CA8512.create.timer.not.supported.checkpoint.explanation=Liberty does not support the creation of timers by resource adapters while applications start when a server checkpoint is requested.
+J2CA8512.create.timer.not.supported.checkpoint.useraction=Configure the checkpoint to occur before the application starts by using the at=beforeAppStart server checkpoint option.
+
 J2CA8600.work.start.timeout=J2CA8600E: The work {0} submitted by resource adapter {1} did not start within {2} milliseconds.
 J2CA8600.work.start.timeout.explanation=The attempt to start the work has timed out.
 J2CA8600.work.start.timeout.useraction=Verify if there is a high load on the system and consider decreasing it, or contact the resource adapter vendor to consider if they should increase the work timeout that they use when submitting work to the JCA work manager.
+
+J2CA8601.work.submit.failed.checkpoint=J2CA8601E: The server checkpoint request failed because the {0} resource adapter submitted work {1}.
+J2CA8601.work.submit.failed.checkpoint.explanation=Liberty does not support resource adapters that submit work while applications start when a server checkpoint is requested.
+J2CA8601.work.submit.failed.checkpoint.useraction=Configure the checkpoint to occur before the application starts by using the at=beforeAppStart server checkpoint option.
+
+J2CA8602.work.submit.not.supported.checkpoint=J2CA8602E: The {0} work that was submitted by the {1} resource adapter was rejected during the server checkpoint request.
+J2CA8602.work.submit.not.supported.checkpoint.explanation=Liberty does not support the submission of work by resource adapters while applications start when a server checkpoint is requested.
+J2CA8602.work.submit.not.supported.checkpoint.useraction=Configure the checkpoint to occur before the application starts by using the at=beforeAppStart server checkpoint option.
 
 # 8622 deleted
 
@@ -168,6 +184,3 @@ BEAN_VALIDATION_FAILED_J2CA0238.useraction=Consult the documentation of the Reso
 BEAN_ARCHIVE_RESOURCE_ADAPTERS_NOT_SUPPORT_J2CA0241=J2CA0241W: Resource Adapter Bean Archives are not supported.
 BEAN_ARCHIVE_RESOURCE_ADAPTERS_NOT_SUPPORT_J2CA0241.explanation=The beans.xml file in the META-INF directory will be ignored, as CDI Managed Bean Archive Resource Adapters are not supported.
 BEAN_ARCHIVE_RESOURCE_ADAPTERS_NOT_SUPPORT_J2CA0241.useraction=Remove the beans.xml file from the META-INF directory, as CDI Managed Bean Archive Resource Adapters are not supported.
-
-
-

--- a/dev/com.ibm.ws.jca/resources/com/ibm/ws/jca/internal/resources/J2CAMessages.nlsprops
+++ b/dev/com.ibm.ws.jca/resources/com/ibm/ws/jca/internal/resources/J2CAMessages.nlsprops
@@ -51,11 +51,11 @@ J2CA8510.create.timed.out.useraction=Verify if there is a high load on the syste
 
 J2CA8511.create.timer.failed.checkpoint=J2CA8511E: The server checkpoint request failed because the {0} resource adapter created a timer.
 J2CA8511.create.timer.failed.checkpoint.explanation=Liberty does not support resource adapters that create a timer while applications start when a server checkpoint is requested.
-J2CA8511.create.timer.failed.checkpoint.useraction=Configure the checkpoint to occur before the application starts by using the at=beforeAppStart server checkpoint option.
+J2CA8511.create.timer.failed.checkpoint.useraction=Configure the checkpoint to occur before the application starts by using the beforeAppStart server checkpoint option.
 
 J2CA8512.create.timer.not.supported.checkpoint=J2CA8512E: A timer could not be created for the {0} resource adapter during the server checkpoint request.
 J2CA8512.create.timer.not.supported.checkpoint.explanation=Liberty does not support the creation of timers by resource adapters while applications start when a server checkpoint is requested.
-J2CA8512.create.timer.not.supported.checkpoint.useraction=Configure the checkpoint to occur before the application starts by using the at=beforeAppStart server checkpoint option.
+J2CA8512.create.timer.not.supported.checkpoint.useraction=Configure the checkpoint to occur before the application starts by using the beforeAppStart server checkpoint option.
 
 J2CA8600.work.start.timeout=J2CA8600E: The work {0} submitted by resource adapter {1} did not start within {2} milliseconds.
 J2CA8600.work.start.timeout.explanation=The attempt to start the work has timed out.
@@ -63,11 +63,11 @@ J2CA8600.work.start.timeout.useraction=Verify if there is a high load on the sys
 
 J2CA8601.work.submit.failed.checkpoint=J2CA8601E: The server checkpoint request failed because the {0} resource adapter submitted work {1}.
 J2CA8601.work.submit.failed.checkpoint.explanation=Liberty does not support resource adapters that submit work while applications start when a server checkpoint is requested.
-J2CA8601.work.submit.failed.checkpoint.useraction=Configure the checkpoint to occur before the application starts by using the at=beforeAppStart server checkpoint option.
+J2CA8601.work.submit.failed.checkpoint.useraction=Configure the checkpoint to occur before the application starts by using the beforeAppStart server checkpoint option.
 
 J2CA8602.work.submit.not.supported.checkpoint=J2CA8602E: The {0} work that was submitted by the {1} resource adapter was rejected during the server checkpoint request.
 J2CA8602.work.submit.not.supported.checkpoint.explanation=Liberty does not support the submission of work by resource adapters while applications start when a server checkpoint is requested.
-J2CA8602.work.submit.not.supported.checkpoint.useraction=Configure the checkpoint to occur before the application starts by using the at=beforeAppStart server checkpoint option.
+J2CA8602.work.submit.not.supported.checkpoint.useraction=Configure the checkpoint to occur before the application starts by using the beforeAppStart server checkpoint option.
 
 # 8622 deleted
 

--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/internal/J2CTimer.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/internal/J2CTimer.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,6 +20,7 @@ import java.util.TreeMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.resource.spi.RetryableUnavailableException;
 import javax.resource.spi.UnavailableException;
@@ -28,6 +29,9 @@ import javax.resource.spi.work.WorkManager;
 import com.ibm.wsspi.threadcontext.ThreadContext;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
+
+import io.openliberty.checkpoint.spi.CheckpointHook;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 
 public class J2CTimer extends Timer {
 
@@ -38,13 +42,18 @@ public class J2CTimer extends Timer {
 
     /**
      * Main constructor for creating a new J2CTimer
-     * 
+     *
      * @param bootstrapContext the bootstrap context.
      * @throws UnavailbleException if unable to create the timer.
      */
     public J2CTimer(BootstrapContextImpl bootstrapContext) throws UnavailableException {
         super("resourceAdapter[" + bootstrapContext.resourceAdapterID + "]-Timer", true);
         this.bootstrapContext = bootstrapContext;
+
+        if (!CheckpointPhase.getPhase().restored()) {
+            CheckpointHookForNewJ2CTimer.add(bootstrapContext.resourceAdapterID);
+            throw new UnavailableException(Utils.getMessage("J2CA8512.create.timer.not.supported.checkpoint", bootstrapContext.resourceAdapterID));
+        }
 
         if (bootstrapContext.propagateThreadContext) {
             // Immediately run a task that contextualizes the timer thread.
@@ -110,9 +119,9 @@ public class J2CTimer extends Timer {
 
         /**
          * Construct a new ContextualizerTask.
-         * 
+         *
          * @param threadContextDescriptor thread context descriptor.
-         * @param results queue that is populated with the thread context once it is propagated to the timer thread.
+         * @param results                 queue that is populated with the thread context once it is propagated to the timer thread.
          */
         private ContextualizerTask(ThreadContextDescriptor threadContextDescriptor, BlockingQueue<Object> results) {
             this.threadContextDescriptor = threadContextDescriptor;
@@ -129,6 +138,28 @@ public class J2CTimer extends Timer {
                 results.add(threadContext);
             } catch (Throwable x) {
                 results.add(new UnavailableException(x));
+            }
+        }
+    }
+
+    /**
+     * Fail checkpoint whenever the RA creates a timer
+     */
+    private static class CheckpointHookForNewJ2CTimer implements CheckpointHook {
+        private static final CheckpointHookForNewJ2CTimer instance = new CheckpointHookForNewJ2CTimer();
+
+        @Override
+        public void prepare() {
+            throw new IllegalStateException(Utils.getMessage("J2CA8511.create.timer.failed.checkpoint", raId));
+        }
+
+        private static final AtomicBoolean alreadyAdded = new AtomicBoolean(false);
+        private String raId;
+
+        private static void add(String raId) {
+            if (alreadyAdded.compareAndSet(false, true)) {
+                instance.raId = raId;
+                CheckpointPhase.getPhase().addMultiThreadedHook(instance);
             }
         }
     }

--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/internal/J2CTimer.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/internal/J2CTimer.java
@@ -143,23 +143,26 @@ public class J2CTimer extends Timer {
     }
 
     /**
-     * Fail checkpoint whenever the RA creates a timer
+     * Fail checkpoint whenever an RA creates a timer during application startup.
      */
     private static class CheckpointHookForNewJ2CTimer implements CheckpointHook {
-        private static final CheckpointHookForNewJ2CTimer instance = new CheckpointHookForNewJ2CTimer();
 
         @Override
         public void prepare() {
             throw new IllegalStateException(Utils.getMessage("J2CA8511.create.timer.failed.checkpoint", raId));
         }
 
+        private final String raId;
+
+        private CheckpointHookForNewJ2CTimer(String raId) {
+            this.raId = raId;
+        }
+
         private static final AtomicBoolean alreadyAdded = new AtomicBoolean(false);
-        private String raId;
 
         private static void add(String raId) {
             if (alreadyAdded.compareAndSet(false, true)) {
-                instance.raId = raId;
-                CheckpointPhase.getPhase().addMultiThreadedHook(instance);
+                CheckpointPhase.getPhase().addMultiThreadedHook(new CheckpointHookForNewJ2CTimer(raId));
             }
         }
     }

--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/internal/WorkProxy.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/internal/WorkProxy.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2020 IBM Corporation and others.
+ * Copyright (c) 1997, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.resource.ResourceException;
 import javax.resource.spi.ResourceAdapterAssociation;
@@ -52,6 +53,9 @@ import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
 import com.ibm.wsspi.threadcontext.jca.JCAContextProvider;
 
+import io.openliberty.checkpoint.spi.CheckpointHook;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
 /**
  * A wrapper for Work.
  * This wrapper takes care of execution context handling, work listener notification
@@ -63,16 +67,16 @@ public class WorkProxy implements Callable<Void>, Runnable {
      *
      * @pre theWork != null
      *
-     * @param theWork the actual Work object that is passed in by the RA.
-     * @param theStartTimeout abort the request after this amount of time has passed
-     *            and the actual Work has not yet started.
-     *            A start timeout occurs when the thread pool is to busy
-     *            to allocate a thread to start the work on.
-     * @param theContext controls what context information is used by the thread to
-     *            establish its context
-     * @param theListener send state changes to the Work to this object.
-     * @param bootstrapContext the bootstrap context.
-     * @param runningWork list of work that is running.
+     * @param theWork             the actual Work object that is passed in by the RA.
+     * @param theStartTimeout     abort the request after this amount of time has passed
+     *                                and the actual Work has not yet started.
+     *                                A start timeout occurs when the thread pool is to busy
+     *                                to allocate a thread to start the work on.
+     * @param theContext          controls what context information is used by the thread to
+     *                                establish its context
+     * @param theListener         send state changes to the Work to this object.
+     * @param bootstrapContext    the bootstrap context.
+     * @param runningWork         list of work that is running.
      * @param applyDefaultContext determines whether or not to apply default context for thread context types that aren't otherwise specified or configured.
      * @throws ResourceException if unable to associate with the resource adapter.
      */
@@ -91,6 +95,12 @@ public class WorkProxy implements Callable<Void>, Runnable {
         lsnr = theListener;
         this.bootstrapContext = bootstrapContext;
         this.runningWork = runningWork;
+
+        if (!CheckpointPhase.getPhase().restored()) {
+            CheckpointHookForNewWorkProxy.add(bootstrapContext.resourceAdapterID, work.toString());
+            throw new WorkRejectedException(Utils.getMessage("J2CA8602.work.submit.not.supported.checkpoint", work, bootstrapContext.resourceAdapterID));
+        }
+
         // JCA 11.4
         // If the resource adapter returns a null or an empty List when the WorkManager
         // makes a call to the getWorkContexts method, the WorkManager must treat it as if no
@@ -322,8 +332,8 @@ public class WorkProxy implements Callable<Void>, Runnable {
      * Handle a work context setup failure.
      *
      * @param workContext the work context.
-     * @param errorCode error code from javax.resource.spi.work.WorkContextErrorCodes
-     * @param cause Throwable to chain as the cause. Can be null.
+     * @param errorCode   error code from javax.resource.spi.work.WorkContextErrorCodes
+     * @param cause       Throwable to chain as the cause. Can be null.
      * @return WorkCompletedException to raise the the invoker.
      */
     private WorkCompletedException contextSetupFailure(Object context, String errorCode, Throwable cause) {
@@ -455,4 +465,27 @@ public class WorkProxy implements Callable<Void>, Runnable {
      * obtain the listener.
      */
     protected WorkListener lsnr;
+
+    /**
+     * Fail checkpoint when the RA submits a work request
+     */
+    private static class CheckpointHookForNewWorkProxy implements CheckpointHook {
+        private static final CheckpointHookForNewWorkProxy instance = new CheckpointHookForNewWorkProxy();
+
+        @Override
+        public void prepare() {
+            throw new IllegalStateException(Utils.getMessage("J2CA8601.work.submit.failed.checkpoint", raId, workId));
+        }
+
+        private static final AtomicBoolean alreadyAdded = new AtomicBoolean(false);
+        private String raId, workId;
+
+        private static void add(String raId, String workId) {
+            if (alreadyAdded.compareAndSet(false, true)) {
+                instance.raId = raId;
+                instance.workId = workId;
+                CheckpointPhase.getPhase().addMultiThreadedHook(instance);
+            }
+        }
+    }
 }

--- a/dev/com.ibm.ws.jca_fat_derbyra/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat_derbyra/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -25,7 +25,8 @@ fat.project: true
 tested.features:\
 	appsecurity-3.0, servlet-4.0, enterprisebeans-4.0, concurrent-2.0, enterprisebeansremote-4.0, jdbc-4.2, enterprisebeanshome-4.0, enterprisebeanslite-4.0, enterprisebeanspersistenttimer-4.0,\
 	appsecurity-4.0, servlet-5.0, expressionlanguage-4.0, cdi-3.0, connectors-2.0, concurrent-3.0, connectors-2.1, xmlbinding-4.0, servlet-6.0,\
-	expressionlanguage-5.0, appsecurity-5.0, jsonp-2.1, cdi-4.0
+	expressionlanguage-5.0, appsecurity-5.0, jsonp-2.1, cdi-4.0,\
+	checkpoint
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyRACheckpointLimitationsTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyRACheckpointLimitationsTest.java
@@ -1,0 +1,306 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jca.fat.derbyra;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.util.Map;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ProgramOutput;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.CheckpointTest;
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEEAction;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServer.CheckpointInfo;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
+/**
+ * Verify the Connectors feature fails checkpoint whenever a timer is created or
+ * work is submitted during application startup within a server checkpoint request.
+ * Also, verify the Connectors feature supports these behaviors when the checkpoint
+ * occurs before the applications are started.
+ */
+@CheckpointTest
+@RunWith(FATRunner.class)
+public class DerbyRACheckpointLimitationsTest extends FATServletClient {
+
+    private static final String SERVER_NAME = "com.ibm.ws.jca.fat.derbyra.checkpoint";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    static final String APP = "derbyRAApp";
+    static final String WAR_NAME = "fvtweb";
+    static final String RAR_NAME = "DerbyRA";
+
+    static final String DerbyRAAnnoServlet = "fvtweb/DerbyRAAnnoServlet";
+    static final String DerbyRACheckpointServlet = "fvtweb/DerbyRACheckpointServlet";
+    static final String DerbyRACFDServlet = "fvtweb/DerbyRACFDServlet";
+    static final String DerbyRAServlet = "fvtweb/DerbyRAServlet";
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, WAR_NAME + ".war");
+        war.addPackage("web");
+        war.addPackage("web.cfd");
+        war.addPackage("web.mdb");
+        war.addAsWebInfResource(new File("test-applications/fvtweb/resources/WEB-INF/ibm-web-bnd.xml"));
+        war.addAsWebInfResource(new File("test-applications/fvtweb/resources/WEB-INF/web.xml"));
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP + ".ear");
+        ear.addAsModule(war);
+        ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/derbyRAApp");
+        ShrinkHelper.exportAppToServer(server, ear, DeployOptions.SERVER_ONLY, DeployOptions.OVERWRITE);
+
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, RAR_NAME + ".rar");
+        rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");
+        rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml"));
+        rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/wlp-ra.xml"));
+        rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/permissions.xml"));
+        rar.addAsLibrary(new File("publish/shared/resources/derby/derby.jar"));
+
+        ShrinkHelper.exportToServer(server, "connectors", rar);
+
+        server.addEnvVar("PERMISSION",
+                         (JakartaEEAction.isEE9OrLaterActive()) ? "jakarta.resource.spi.security.PasswordCredential" : "javax.resource.spi.security.PasswordCredential");
+
+    }
+
+    TestMethod testMethod;
+
+    @Before
+    public void setupTest() throws Exception {
+        testMethod = getTestMethod(TestMethod.class, testName);
+        //switch (testMethod) {
+        //    case testCreateTimerBAS:
+        //    case testSubmitWorkBAS:
+        //        break;
+        //    case testCreateTimerAAS:
+        //    case testSubmitWorkAAS:
+        //        break;
+        //    default:
+        //        break;
+        //}
+    }
+
+    @After
+    public void tearDownTest() throws Exception {
+        switch (testMethod) {
+            case testCreateTimerBAS:
+            case testSubmitWorkBAS:
+                server.stopServer(new String[] { "CWWKG0027W", // Possible timeout while updating server configuration
+                                                 "SRVE9967W" }); // Manifest class path derbyLocale_cs.jar not found in Derby archives
+                break;
+            case testCreateTimerAAS:
+            case testSubmitWorkAAS:
+                // Server should fail checkpoint and stop
+                if (server.isStarted()) {
+                    server.stopServer("SRVE9967W");
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        if (server.isStarted())
+            server.stopServer("SRVE9967W");
+    }
+
+    // FYI: These tests include assertions regarding RA lifecycle events during checkpoint and restore.
+    //      The assertions may be removed if considered superfluous.
+
+    @Test
+    public void testCreateTimerBAS() throws Exception {
+        Map<String, String> jvmOptions = server.getJvmOptionsAsMap();
+        jvmOptions.put("-Dunsupported.action", "derbyra.start.create.timer");
+        //jvmOptions.put("-Dunsupported.action", "servlet.init.create.timer"); // FAILS NORMAL AND INSTANTON SERVERS
+        //jvmOptions.put("-Dunsupported.action", "servlet.init.create.timer.async"); // WORKS
+        server.setJvmOptions(jvmOptions);
+
+        // Server checkpoint BAS performs CRIU dump when triggered by RA metadata processing during
+        // RA install. Resources and applications must not create timers nor submit work.
+        server.setCheckpoint(CheckpointPhase.BEFORE_APP_START, false, null);
+        server.addCheckpointRegexIgnoreMessages("SRVE9967W");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
+
+        assertNotNull("The connector runtime did not log message J2CA7018I indicating the server is installing the RA.",
+                      server.waitForStringInLogUsingMark("J2CA7018I: .* DerbyRA"));
+
+        assertNull("The connector runtime unexpectedly logged message J2CA8512E indicating createTimer() failed with exception.",
+                   server.waitForStringInLogUsingMark("J2CA8512E: .*J2CA8512E: .*DerbyRA", 1000L));
+
+        assertNull("The connector runtime unexpectedly logged message J2CA8511E indicating the checkpoint request failed because the RA created a timer.",
+                   server.waitForStringInLogUsingMark("J2CA8511E: .* DerbyRA", 1000L));
+
+        server.checkpointRestore();
+
+        assertNotNull("The connector runtime did not log message J2CA7001I indicating the server installed the RA",
+                      server.waitForStringInLogUsingMark("J2CA7001I: .* DerbyRA"));
+
+        assertNotNull("The test work scheduled during did not execute during servlet init()",
+                      server.waitForStringInLogUsingMark("--- DerbyRA start createTimer: "));
+
+        // Verify some connector function
+        runTest(server, DerbyRAServlet, "initDatabaseTables");
+        runTest(server, DerbyRAAnnoServlet, "testActivationSpec");
+    }
+
+    @Test
+    public void testSubmitWorkBAS() throws Exception {
+        Map<String, String> jvmOptions = server.getJvmOptionsAsMap();
+        jvmOptions.put("-Dunsupported.action", "servlet.init.submit.work.async");
+        //jvmOptions.put("-Dunsupported.action", "servlet.init.submit.work"); // FAILS NORMAL AND INSTANTON SERVERS
+        server.setJvmOptions(jvmOptions);
+
+        server.setCheckpoint(CheckpointPhase.BEFORE_APP_START, false, null);
+        server.addCheckpointRegexIgnoreMessages("SRVE9967W");
+        server.startServer(getTestMethodNameOnly(testName) + ".log");
+
+        assertNotNull("The connector runtime did not log message J2CA7018I indicating the server is installing the RA.",
+                      server.waitForStringInLogUsingMark("J2CA7018I: .* DerbyRA"));
+
+        assertNull("The work manager unexpectedly logged message J2CA8602E indicating the submitted work was rejected with exception.",
+                   server.waitForStringInLogUsingMark("J2CA8602E: .* DerbyRA", 1000L));
+
+        assertNull("The connector runtime unexpectedly logged message J2CA8601E indicating the checkpoint request failed because the RA submitted work.",
+                   server.waitForStringInLogUsingMark("J2CA8601E:  .*DerbyRA .*TestWork", 1000L));
+
+        server.checkpointRestore();
+
+        assertNotNull("The connector runtime did not log message J2CA7001I indicating the server installed the RA",
+                      server.waitForStringInLogUsingMark("J2CA7001I: .* DerbyRA"));
+
+        assertNotNull("The test work scheduled during did not execute during servlet init()",
+                      server.waitForStringInLogUsingMark("--- DerbyRACheckpointServlet TestWork run"));
+
+        runTest(server, DerbyRAServlet, "initDatabaseTables");
+        runTest(server, DerbyRAAnnoServlet, "testActivationSpec");
+    }
+
+    @Test
+    @ExpectedFFDC({ "io.openliberty.checkpoint.internal.criu.CheckpointFailedException",
+                    "java.security.PrivilegedActionException" }) // Wraps J2CA8512E javax.resource.spi.UnavailableException
+    @AllowedFFDC("java.lang.RuntimeException") // JMX local connector unavailable during shutdown of failed checkpoint
+    public void testCreateTimerAAS() throws Exception {
+        Map<String, String> jvmOptions = server.getJvmOptionsAsMap();
+        jvmOptions.put("-Dunsupported.action", "servlet.init.create.timer");
+        server.setJvmOptions(jvmOptions);
+
+        // Expect server checkpoint to fail; note required CheckpointInfo()
+        server.setCheckpoint(new CheckpointInfo(CheckpointPhase.AFTER_APP_START, false, true, true, null));
+        server.addCheckpointRegexIgnoreMessages("SRVE9967W");
+        ProgramOutput output = server.startServer(getTestMethodNameOnly(testName) + ".log");
+        int returnCode = output.getReturnCode();
+        assertEquals("The server checkpoint request did not return failure code 72 indicating checkpoint failed.",
+                     72, returnCode);
+
+        assertNotNull("The connector runtime did not log message J2CA8512E indicating createTimer() failed with exception.",
+                      server.waitForStringInLogUsingMark("J2CA8512E: .* DerbyRA"));
+
+        assertNotNull("The connector runtime did not log message J2CA8511E indicating the checkpoint request failed because the RA created a timer.",
+                      server.waitForStringInLogUsingMark("J2CA8511E: .* DerbyRA"));
+    }
+
+    @Test
+    @ExpectedFFDC({ "io.openliberty.checkpoint.internal.criu.CheckpointFailedException",
+                    "javax.resource.spi.work.WorkRejectedException" })
+    @AllowedFFDC("java.lang.RuntimeException")
+    public void testSubmitWorkAAS() throws Exception {
+        Map<String, String> jvmOptions = server.getJvmOptionsAsMap();
+        jvmOptions.put("-Dunsupported.action", "servlet.init.submit.work");
+        server.setJvmOptions(jvmOptions);
+
+        server.setCheckpoint(new CheckpointInfo(CheckpointPhase.AFTER_APP_START, false, true, true, null));
+        server.addCheckpointRegexIgnoreMessages("SRVE9967W");
+        ProgramOutput output = server.startServer(getTestMethodNameOnly(testName) + ".log");
+        int returnCode = output.getReturnCode();
+        assertEquals("The server checkpoint request did not return failure code 72 indicating checkpoint failed.",
+                     72, returnCode);
+
+        assertNotNull("The work manager did not log message J2CA8602E indicating the submitted work was rejected with exception.",
+                      server.waitForStringInLogUsingMark("J2CA8602E: .*TestWork.* DerbyRA"));
+
+        assertNotNull("The work manager did not log message J2CA8601E indicating the checkpoint request failed because the RA submitted work.",
+                      server.waitForStringInLogUsingMark("J2CA8601E: .*DerbyRA .*TestWork"));
+    }
+
+    //@Test
+    public void testActivationSpecAAS() throws Exception {
+        runTest(server, DerbyRAAnnoServlet, "testActivationSpec");
+    }
+
+    static enum TestMethod {
+        testCreateTimerBAS,
+        testCreateTimerAAS,
+        testSubmitWorkBAS,
+        testSubmitWorkAAS,
+        unknown;
+    }
+
+    /**
+     * @return the TestMethod enum value for the current testName (see FATServletClient).
+     */
+    static public <T extends Enum<T>> T getTestMethod(Class<T> type, TestName testName) {
+        String simpleName = getTestMethodNameOnly(testName);
+        try {
+            T t = Enum.valueOf(type, simpleName);
+            Log.info(FATSuite.class, testName.getMethodName(), "got test method: " + t);
+            return t;
+        } catch (IllegalArgumentException e) {
+            Log.info(type, simpleName, "No configuration enum: " + testName);
+            fail("Unknown test name: " + testName);
+            return null;
+        }
+    }
+
+    /**
+     * @return the testName string without the class name and RepeatTest suffix.
+     */
+    static String getTestMethodNameOnly(TestName testName) {
+        String testMethodSimpleName = getTestMethodSimpleName(testName);
+        // Sometimes the method name includes the class name; remove the class name.
+        int dot = testMethodSimpleName.indexOf('.');
+        if (dot != -1) {
+            testMethodSimpleName = testMethodSimpleName.substring(dot + 1);
+        }
+        return testMethodSimpleName;
+    }
+}

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyRACheckpointTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyRACheckpointTest.java
@@ -1,0 +1,271 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jca.fat.derbyra;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.CheckpointTest;
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEEAction;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
+//import static com.ibm.ws.jca.fat.derbyra.FATSuite.setMockCheckpoint;
+
+@CheckpointTest
+@RunWith(FATRunner.class)
+public class DerbyRACheckpointTest extends FATServletClient {
+
+    private static final String SERVER_NAME = "com.ibm.ws.jca.fat.derbyra.checkpoint";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    static final String APP = "derbyRAApp";
+    static final String WAR_NAME = "fvtweb";
+    static final String RAR_NAME = "DerbyRA";
+
+    static final String DerbyRAAnnoServlet = "fvtweb/DerbyRAAnnoServlet";
+    static final String DerbyRACheckpointServlet = "fvtweb/DerbyRACheckpointServlet";
+    static final String DerbyRACFDServlet = "fvtweb/DerbyRACFDServlet";
+    static final String DerbyRAServlet = "fvtweb/DerbyRAServlet";
+
+    static final String[] IGNORE_REGEX = new String[] { "SRVE9967W", // The manifest class path derbyLocale_cs.jar can not be found in jar file wsjar:file:/C:/Users/IBM_ADMIN/Documents/workspace/build.image/wlp/usr/servers/com.ibm.ws.jca.fat.derbyra/connectors/DerbyRA.rar!/derby.jar or its parent.
+                                                        // This may just be because we don't care about including manifest files in our test buckets, if that's the case, we can ignore this.
+                                                        "J2CA0027E: .*eis/ds3", // Intentionally caused failure on XA.commit in order to cause in-doubt transaction
+                                                        "J2CA0081E", //Expected due to simulated exception in testConnPoolStatsExceptionDestroy
+                                                        "WTRN0048W: .*XAER_RMFAIL" };
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, WAR_NAME + ".war");
+        war.addPackage("web");
+        war.addPackage("web.cfd");
+        war.addPackage("web.mdb");
+        war.addAsWebInfResource(new File("test-applications/fvtweb/resources/WEB-INF/ibm-web-bnd.xml"));
+        war.addAsWebInfResource(new File("test-applications/fvtweb/resources/WEB-INF/web.xml"));
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP + ".ear");
+        ear.addAsModule(war);
+        ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/derbyRAApp");
+        ShrinkHelper.exportAppToServer(server, ear, DeployOptions.SERVER_ONLY, DeployOptions.OVERWRITE);
+
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, RAR_NAME + ".rar");
+        rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");
+        rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml"));
+        rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/wlp-ra.xml"));
+        rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/permissions.xml"));
+        rar.addAsLibrary(new File("publish/shared/resources/derby/derby.jar"));
+
+        ShrinkHelper.exportToServer(server, "connectors", rar);
+
+        server.addEnvVar("PERMISSION",
+                         (JakartaEEAction.isEE9OrLaterActive()) ? "jakarta.resource.spi.security.PasswordCredential" : "javax.resource.spi.security.PasswordCredential");
+
+        // Checkpoint and restore the server
+        server.setCheckpoint(CheckpointPhase.AFTER_APP_START, false, null);
+        server.addCheckpointRegexIgnoreMessages(IGNORE_REGEX);
+        server.startServer();
+        server.checkpointRestore();
+
+        // Mock checkpoint and restore the server
+        //setCheckpointPhase(server, CheckpointPhase.AFTER_APP_START);
+        //server.startServer();
+
+        FATServletClient.runTest(server, DerbyRAServlet, "initDatabaseTables");
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        if (server.isStarted()) {
+            server.stopServer(IGNORE_REGEX);
+        }
+    }
+
+    @Test
+    public void testActivationSpecAAS() throws Exception {
+        runTest(server, DerbyRAAnnoServlet, "testActivationSpec");
+    }
+
+    @ExpectedFFDC({ "javax.ejb.EJBException",
+                    "javax.transaction.HeuristicMixedException",
+                    "javax.transaction.xa.XAException",
+                    "com.ibm.websphere.csi.CSITransactionRolledbackException" })
+    @AllowedFFDC({ "java.lang.RuntimeException" }) // Wraps expected exception;  msg delivers within inbound security context in EE10
+    @Test
+    public void testActivationSpecXARecoveryAAS() throws Exception {
+        server.setMarkToEndOfLog();
+        runTest(server, DerbyRAAnnoServlet, "testActivationSpecXARecovery");
+        // Wait for FFDC messages which can be reported asynchronously to the servlet thread
+        server.waitForStringInLogUsingMark("FFDC1015I.*EJBException");
+    }
+
+    @Test
+    public void testAdminObjectDirectLookupAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testAdminObjectDirectLookup");
+    }
+
+    @Test
+    public void testAdminObjectInjectedAAS() throws Exception {
+        runTest(server, DerbyRAAnnoServlet, "testAdminObjectInjected");
+    }
+
+    @Test
+    public void testAdminObjectLookUpJavaAppAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testAdminObjectLookUpJavaApp");
+    }
+
+    @Test
+    public void testAdminObjectResourceEnvRefAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testAdminObjectResourceEnvRef");
+    }
+
+    @Test
+    public void testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseEnabledAAS() throws Exception {
+        runTest(server, DerbyRACFDServlet, "testConnectionFactoryDefinitionLeakConnectionWithAutoCloseEnabled");
+        runTest(server, DerbyRACFDServlet, "testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseEnabledClosed");
+    }
+
+    @Test
+    public void testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseDisabledAAS() throws Exception {
+        runTest(server, DerbyRACFDServlet, "testConnectionFactoryDefinitionLeakConnectionWithAutoCloseDisabled");
+        runTest(server, DerbyRACFDServlet, "testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseDisabledNotClosed");
+    }
+
+    @Test
+    public void testExecutionContextAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testExecutionContext");
+    }
+
+    @Test
+    public void testHandleListClosesParkedHandleWhenMDBTransactionEndsAAS() throws Exception {
+        runTest(server, DerbyRAAnnoServlet, "testHandleListClosesParkedHandleWhenMDBTransactionEnds");
+    }
+
+    @Test
+    public void testJCADataSourceDirectLookupAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testJCADataSourceDirectLookup");
+    }
+
+    @Test
+    public void testJCADataSourceInjectedAAS() throws Exception {
+        runTest(server, DerbyRAAnnoServlet, "testJCADataSourceInjected");
+    }
+
+    @Test
+    public void testJCADataSourceInjectedAsCommonDataSourceAAS() throws Exception {
+        runTest(server, DerbyRAAnnoServlet, "testJCADataSourceInjectedAsCommonDataSource");
+    }
+
+    @Test
+    public void testJCADataSourceLookUpJavaModuleAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testJCADataSourceLookUpJavaModule");
+    }
+
+    @Test
+    public void testJCADataSourceResourceRefAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testJCADataSourceResourceRef");
+    }
+
+    @Test
+    public void testNonDissociatableHandlesCannotBeParkedAcrossTransactionScopesAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testNonDissociatableHandlesCannotBeParkedAcrossTransactionScopes");
+    }
+
+    @Test
+    public void testNonDissociatableHandlesParkedAcrossEJBMethodsAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testNonDissociatableHandlesParkedAcrossEJBMethods");
+    }
+
+    @Test
+    public void testNonDissociatableSharableHandleIsClosedAcrossServletMethodsAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testNonDissociatableSharableHandleLeftOpenAfterServletMethod");
+        runTest(server, DerbyRAServlet, "testNonDissociatableSharableHandleIsClosed");
+    }
+
+    @Test
+    public void testParkNonDissociatableSharableHandleAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testParkNonDissociatableSharableHandle");
+    }
+
+    @Test
+    public void testRecursiveTimerAAS() throws Exception {
+        runTest(server, DerbyRAAnnoServlet, "testRecursiveTimer");
+    }
+
+    @Test
+    public void testTransactionContextAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testTransactionContext");
+    }
+
+    @Test
+    public void testTransactionSynchronizationRegistryAAS() throws Exception {
+        runTest(server, DerbyRAAnnoServlet, "testTransactionSynchronizationRegistry");
+    }
+
+    @Test
+    public void testUnsharableConnectionAcrossEJBGlobalTranAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testUnsharableConnectionAcrossEJBGlobalTran");
+    }
+
+    @ExpectedFFDC("javax.transaction.xa.XAException") // intentionally caused failure to make the transaction in-doubt
+    @Test
+    public void testXARecoveryAAS() throws Exception {
+        runTest(server, DerbyRAAnnoServlet, "testXARecovery");
+    }
+
+    @Test
+    public void testXATerminatorAAS() throws Exception {
+        runTest(server, DerbyRAAnnoServlet, "testXATerminator");
+    }
+
+    @ExpectedFFDC({ "javax.resource.ResourceException" }) //simulated exception in destroy
+    @Test
+    public void testConnPoolStatsExceptionInDestroyAAS() throws Exception {
+        runTest(server, DerbyRAServlet, "testConnPoolStatsExceptionInDestroy");
+    }
+
+    @Test
+    public void testErrorInFreeConnAAS() throws Exception {
+        server.setTraceMarkToEndOfDefaultTrace();
+        runTest(server, DerbyRAServlet, "testErrorInFreeConn");
+        assertEquals("J2CA1004I should have been found in logs", 1, server.findStringsInLogsUsingMark("J2CA1004I", server.getDefaultTraceFile()).size());
+    }
+
+    @Test
+    public void testErrorInUsedConnAAS() throws Exception {
+        server.setTraceMarkToEndOfDefaultTrace();
+        runTest(server, DerbyRAServlet, "testErrorInUsedConn");
+        assertEquals("J2CA0056I should have been found in logs", 1, server.findStringsInLogsUsingMark("J2CA0056I", server.getDefaultTraceFile()).size());
+    }
+}

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/FATSuite.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/FATSuite.java
@@ -1,16 +1,21 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jca.fat.derbyra;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -23,13 +28,17 @@ import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.JavaInfo;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 
 @RunWith(Suite.class)
 @SuiteClasses({
                 AlwaysPassesTest.class,
                 DerbyResourceAdapterTest.class,
                 DerbyResourceAdapterSecurityTest.class,
-                LoginModuleInStandaloneResourceAdapterTest.class
+                LoginModuleInStandaloneResourceAdapterTest.class,
+                DerbyRACheckpointLimitationsTest.class,
+                DerbyRACheckpointTest.class
 })
 public class FATSuite {
     @ClassRule
@@ -46,6 +55,40 @@ public class FATSuite {
             repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
                             .andWith(new JakartaEE9Action());
         }
-
     }
+
+    // MOCK CHECKPOINT SUPPORT
+    // Command line options "--internal-checkpoint-at=before/afterAppStart" and system
+    // property "io.openliberty.checkpoint.stub.criu" enable the server to stub-out
+    // calls to criu operations during checkpoint and restore.
+
+    // Use mock support for tests that don't care about criu and jvm criu function,
+    // or for debugging a test server over checkpoint and restore in the same process.
+    static final List<String> INTERNAL_CHECKPOINT_INACTIVE = Collections.emptyList();
+    static final List<String> INTERNAL_CHECKPOINT_BEFORE_APP_START = Arrays.asList("--internal-checkpoint-at=beforeAppStart");
+    static final List<String> INTERNAL_CHECKPOINT_AFTER_APP_START = Arrays.asList("--internal-checkpoint-at=afterAppStart");
+
+    /*
+     * Enable stubbed criu operations within checkpoint-and restore at the specified
+     * checkpoint phase.
+     */
+    public static void setMockCheckpoint(LibertyServer server, CheckpointPhase checkpointPhase) throws Exception {
+        Map<String, String> jvmOptions = server.getJvmOptionsAsMap();
+        switch (checkpointPhase) {
+            case BEFORE_APP_START:
+                jvmOptions.put("-Dio.openliberty.checkpoint.stub.criu", "true");
+                server.setExtraArgs(INTERNAL_CHECKPOINT_BEFORE_APP_START);
+                break;
+            case AFTER_APP_START:
+                jvmOptions.put("-Dio.openliberty.checkpoint.stub.criu", "true");
+                server.setExtraArgs(INTERNAL_CHECKPOINT_AFTER_APP_START);
+                break;
+            default:
+                // Normal server operation; no checkpoint-restore
+                jvmOptions.remove("-Dio.openliberty.checkpoint.stub.criu");
+                server.setExtraArgs(INTERNAL_CHECKPOINT_INACTIVE);
+        }
+        server.setJvmOptions(jvmOptions);
+    }
+
 }

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.checkpoint/bootstrap.properties
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.checkpoint/bootstrap.properties
@@ -1,0 +1,6 @@
+com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:com.ibm.ws.app.manager.module.internal.DeployedAppInfoBase=all:logservice=all:rarInstall=all:WAS.j2c=all:test=all:web.*=all:com.ibm.ws.config.xml.internal.MetaTypeRegistry=all:com.ibm.ws.connectionpool.monitor.*=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+bootstrap.include=../testports.properties
+ds.lock.timeout.milliseconds=30000
+websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.checkpoint/jvm.options
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.checkpoint/jvm.options
@@ -1,0 +1,10 @@
+# Enable unsupported RA behaviors in checkpoint test artifacts
+#-Dunsupported.action=derbyra.start.create timer
+#-Dunsupported.action=servlet.init.create timer
+#-Dunsupported.action=servlet.init.create timer.async
+#-Dunsupported.action=servlet.init.submit.work
+#-Dunsupported.action=servlet.init.submit.work.async
+
+# Enable features jca-1.7, connectors-2.0, connectors-2.1 for InstantOn
+# TODO Remove at GA
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.checkpoint/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.checkpoint/server.xml
@@ -1,0 +1,93 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+      <feature>componenttest-1.0</feature>
+      <feature>servlet-4.0</feature>
+      <feature>ejbLite-3.2</feature>
+      <feature>jca-1.7</feature>
+      <feature>mdb-3.2</feature>
+      <feature>passwordUtilities-1.0</feature>
+      <feature>localConnector-1.0</feature>
+      <feature>monitor-1.0</feature>
+      <feature>concurrent-1.0</feature>
+    </featureManager>
+
+    <include optional="true" location="../fatTestPorts.xml"/>
+
+    <variable name="onError" value="FAIL"/>
+
+    <resourceAdapter location="${server.config.dir}/connectors/DerbyRA.rar" contextServiceRef="DefaultContextService"/>
+
+    <connectionFactory jndiName="eis/ds1">
+      <connectionManager maxPoolSize="2" connectionTimeout="0"/>
+      <containerAuthData user="DS1USER" password="{xor}GwxuDwgb"/>
+      <properties.DerbyRA/>
+    </connectionFactory>
+    
+    <connectionFactory jndiName="eis/ds2">
+      <containerAuthData user="DS1USER" password="{xor}GwxuDwgb"/>
+      <properties.DerbyRA exceptionOnDestroy="true"/>
+    </connectionFactory>
+
+    <connectionFactory jndiName="eis/ds3">
+      <connectionManager maxPoolSize="1"/>
+      <properties.DerbyRA userName="DS1USER" password="{xor}GwxuDwgb" xaSuccessLimit="0"/>
+    </connectionFactory>
+    
+    <connectionFactory jndiName="eis/ds4">
+      <connectionManager enableSharingForDirectLookups="false"/>
+      <containerAuthData user="DS1USER" password="{xor}GwxuDwgb"/>
+      <properties.DerbyRA/>
+    </connectionFactory>
+
+    <connectionFactory jndiName="eis/ds5">
+      <connectionManager maxPoolSize="1" connectionTimeout="0" autoCloseConnections="true" temporarilyAssociateIfDissociateUnavailable="true"/>
+      <properties.DerbyRA dissociatable="false" lazyEnlistable="true" userName="DS1USER" password="{xor}GwxuDwgb"/>
+    </connectionFactory>
+
+    <activationSpec id="derbyRAApp/fvtweb/DerbyRAMessageDrivenBean">
+      <recoveryAuthData userName="ActvSpecUser" password="ActvSpecPwd"/> <!-- convenient place to test recoveryAuthData for activation specs -->
+      <!-- TODO remove configuration of qmid once application server starts setting the value on XA recovery path -->
+      <properties.DerbyRA keyPrefix="mdbtest" qmid="This-QMID-Is-Required-For-XA-Recovery"/>
+    </activationSpec>
+
+    <adminObject jndiName="eis/bootstrapContext">
+      <properties.DerbyRA.BootstrapContext/>
+    </adminObject>
+
+    <adminObject jndiName="eis/map1">
+      <properties.DerbyRA.Map tableName="MAP1"/>
+    </adminObject>
+
+    <!-- "APP" is the default schema for Derby -->
+    <authData id="APP" user="APP" password="{aes}APb9ZaYzUL+JsfFD/OOBGaPM0evjmx5AnvmzbaKgffyX"/>
+
+    <application type="ear" id="derbyRAApp" location="derbyRAApp.ear"/>
+
+    <transaction heuristicRetryInterval="2"/>
+
+    <!-- 
+    NOTE: for this bucket to run cleanly with j2sec enabled with IBM JDK, the following permission must 
+    be manually granted in the java.policy file at $JAVA_HOME/jre/lib/security/java.policy: 
+    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect";
+    -->
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+    <javaPermission className="javax.security.auth.PrivateCredentialPermission" signedBy="${env.PERMISSION}" principalType="*" principalName="*" actions="read"/>
+    <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission className="java.lang.RuntimePermission" name="modifyThread"/>
+    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission className="javax.management.MBeanPermission" name="*" actions="*"/>
+    <javaPermission className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
+    <javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read,write"/>
+</server>

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRACheckpointServlet.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRACheckpointServlet.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import java.util.Timer;
+
+import javax.annotation.Resource;
+import javax.resource.spi.BootstrapContext;
+import javax.resource.spi.UnavailableException;
+import javax.resource.spi.work.ExecutionContext;
+import javax.resource.spi.work.Work;
+import javax.resource.spi.work.WorkException;
+import javax.resource.spi.work.WorkManager;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+
+/**
+ * Servlet
+ */
+@WebServlet(urlPatterns = "DerbyRACheckpointServlet", loadOnStartup = 1)
+public class DerbyRACheckpointServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Resource(name = "java:global/env/eis/bootstrapContext", lookup = "eis/bootstrapContext")
+    private BootstrapContext bc;
+
+    /**
+     * Execute an unsupported RA action during application startup.
+     */
+    @Override
+    public void init() {
+        System.out.println("--- DerbyRACheckpointServlet init starting ---");
+
+        final String action = System.getProperty("unsupported.action", "unknown").toLowerCase();
+        if ("servlet.init.create.timer".equals(action)) {
+            try {
+                Timer timer = bc.createTimer();
+                System.out.println("--- DerbyRACheckpointServlet init createTimer: " + timer + " ---");
+            } catch (NullPointerException | UnavailableException e) {
+                System.out.println("--- DerbyRACheckpointServlet init createTimer failed with exception: " + e + " ---");
+            }
+        } else if ("servlet.init.create.timer.async".equals(action)) {
+            try {
+                ExecutionContext executionContext = new ExecutionContext();
+                TestWork work = new TestWork(bc, action);
+                FATWorkListener listener = new FATWorkListener();
+                bc.getWorkManager().startWork(work, WorkManager.INDEFINITE, executionContext, listener);
+                System.out.println("--- DerbyRACheckpointServlet init async work submitted ---");
+            } catch (NullPointerException | WorkException we) {
+                System.out.println("--- DerbyRACheckpointServlet init submit async work failed with exception: " + we + " ---");
+            }
+        } else if ("servlet.init.submit.work".equals(action)) {
+            try {
+                ExecutionContext executionContext = new ExecutionContext();
+                TestWork work = new TestWork(bc, action);
+                FATWorkListener listener = new FATWorkListener();
+                bc.getWorkManager().doWork(work);
+                System.out.println("--- DerbyRACheckpointServlet init sync work submitted ---");
+            } catch (NullPointerException | WorkException we) {
+                System.out.println("--- DerbyRACheckpointServlet init submit sync work failed with exception: " + we + " ---");
+            }
+        } else if ("servlet.init.submit.work.async".equals(action)) {
+            try {
+                ExecutionContext executionContext = new ExecutionContext();
+                TestWork work = new TestWork(bc, action);
+                FATWorkListener listener = new FATWorkListener();
+                bc.getWorkManager().startWork(work, WorkManager.INDEFINITE, executionContext, listener);
+                System.out.println("--- DerbyRACheckpointServlet init async work submitted ---");
+            } catch (NullPointerException | WorkException we) {
+                System.out.println("--- DerbyRACheckpointServlet init submit async work failed with exception: " + we + " ---");
+            }
+        }
+        System.out.println("--- DerbyRACheckpointServlet init completed ---");
+    }
+
+    static class TestWork implements Work {
+
+        BootstrapContext bc;
+        String action;
+
+        public TestWork(BootstrapContext _bc, String _action) {
+            this.bc = _bc;
+            this.action = _action;
+        }
+
+        @Override
+        public void run() {
+            System.out.println("--- DerbyRACheckpointServlet TestWork run ---");
+            if (action.contains("create.timer")) {
+                try {
+                    Timer timer = bc.createTimer();
+                    System.out.println("--- DerbyRACheckpointServlet TestWork createTimer: " + timer + " ---");
+                } catch (NullPointerException | UnavailableException e) {
+                    System.out.println("--- DerbyRACheckpointServlet TestWork createTimer failed with exception: " + e + " ---");
+                }
+            }
+        }
+
+        @Override
+        public void release() {
+            System.out.println("--- DerbyRACheckpointServlet TestWork release ---");
+        }
+    }
+}

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyResourceAdapter.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyResourceAdapter.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,6 +17,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Timer;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -29,6 +30,7 @@ import javax.resource.spi.ActivationSpec;
 import javax.resource.spi.BootstrapContext;
 import javax.resource.spi.ResourceAdapter;
 import javax.resource.spi.ResourceAdapterInternalException;
+import javax.resource.spi.UnavailableException;
 import javax.resource.spi.endpoint.MessageEndpointFactory;
 import javax.resource.spi.work.HintsContext;
 import javax.resource.spi.work.SecurityContext;
@@ -168,6 +170,8 @@ public class DerbyResourceAdapter implements ResourceAdapter {
         } catch (Exception x) {
             throw new ResourceAdapterInternalException(x);
         }
+
+        doCheckpointUnsupportedActions();
     }
 
     /** {@inheritDoc} */
@@ -194,6 +198,20 @@ public class DerbyResourceAdapter implements ResourceAdapter {
             throw x;
         } catch (Exception x) {
             throw new RuntimeException(x);
+        }
+    }
+
+    void doCheckpointUnsupportedActions() {
+        System.out.println("--- DerbyRA start ---");
+        // No need to check checkpoint phase
+        final String action = System.getProperty("unsupported.action", "unknown").toLowerCase();
+        if ("derbyra.start.create.timer".equals(action)) {
+            try {
+                Timer timer = bootstrapContext.createTimer();
+                System.out.println("--- DerbyRA start createTimer: " + timer + " ---");
+            } catch (NullPointerException | UnavailableException e) {
+                System.out.println("--- DerbyRA start createTimer failed with exception: " + e + " ---");
+            }
         }
     }
 }

--- a/dev/com.ibm.ws.security.auth.data.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.auth.data.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2023 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -41,6 +41,7 @@ instrument.classesExcludes: com/ibm/ws/security/auth/data/common/internal/resour
 	com.ibm.websphere.org.osgi.service.component;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
+	com.ibm.ws.kernel.boot.common;version=latest,\
 	com.ibm.ws.logging;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest
 
@@ -55,5 +56,6 @@ instrument.classesExcludes: com/ibm/ws/security/auth/data/common/internal/resour
 	cglib:cglib;version=3.3.0, \
 	com.ibm.ws.org.objectweb.asm;version=latest, \
 	com.ibm.ws.kernel.boot;version=latest, \
+	com.ibm.ws.kernel.boot.common;version=latest, \
 	com.ibm.ws.kernel.service;version=latest, \
 	com.ibm.ws.crypto.passwordutil;version=latest

--- a/dev/com.ibm.ws.security.auth.data.common/src/com/ibm/ws/security/auth/data/internal/AuthDataImpl.java
+++ b/dev/com.ibm.ws.security.auth.data.common/src/com/ibm/ws/security/auth/data/internal/AuthDataImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,6 +24,8 @@ import com.ibm.websphere.crypto.PasswordUtil;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.security.auth.data.AuthData;
 import com.ibm.wsspi.kernel.service.utils.SerializableProtectedString;
+
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 
 /**
  * The auth data from server.xml.
@@ -46,7 +48,11 @@ public class AuthDataImpl implements AuthData {
         username = (String) props.get(CFG_KEY_USER);
         SerializableProtectedString sps = (SerializableProtectedString) props.get(CFG_KEY_PASSWORD);
         String configuredPassword = sps == null ? "" : new String(sps.getChars());
-        password = PasswordUtil.passwordDecode(configuredPassword);
+
+        // Cipher algorithims may be unavailable at server checkpoint
+        CheckpointPhase.onRestore(() -> {
+            password = PasswordUtil.passwordDecode(configuredPassword);
+        });
 
         principal = (String) props.get("krb5Principal");
         String sCcache = (String) props.get("krb5TicketCache");

--- a/dev/com.ibm.ws.security.auth.data.common/src/com/ibm/ws/security/auth/data/internal/AuthDataImpl.java
+++ b/dev/com.ibm.ws.security.auth.data.common/src/com/ibm/ws/security/auth/data/internal/AuthDataImpl.java
@@ -50,6 +50,7 @@ public class AuthDataImpl implements AuthData {
         String configuredPassword = sps == null ? "" : new String(sps.getChars());
 
         // Cipher algorithims may be unavailable at server checkpoint
+        password = configuredPassword;
         CheckpointPhase.onRestore(() -> {
             password = PasswordUtil.passwordDecode(configuredPassword);
         });

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointPasswordUtilities/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointPasswordUtilities/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022, 2023 IBM Corporation and others.
+    Copyright (c) 2022, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -21,9 +21,15 @@
     </featureManager>
 
     <application type="war" id="DefaultPrincipalMappingApp" name="DefaultPrincipalMappingApp" location="${server.config.dir}/apps/DefaultPrincipalMappingApp.war"/>
-    
+
+    <variable name="auth.user.password" defaultValue="{aes}APb9ZaYzUL+JsfFD/OOBGaPM0evjmx5AnvmzbaKgffyX" /> <!-- APPPWD -->
+    <variable name="default.user.password" defaultValue="{aes}APb9ZaYzUL+JsfFD/OOBGaPM0evjmx5AnvmzbaKgffyX" /> <!-- APPPWD -->
+
+    <!-- This authData will be overridden at restore by environment vars -->
     <authData id="myAuthData" user="${auth.user.name}" password="${auth.user.password}" />
 
-    <include location="../fatTestPorts.xml"/>
+    <!-- This authData will configure at restore and is not overridden -->
+    <authData id="defaultAuthData" user="APPUSR" password="${default.user.password}" />
 
+    <include location="../fatTestPorts.xml"/>
 </server>

--- a/dev/io.openliberty.checkpoint_fat/test-applications/DefaultPrincipalMappingApp/src/io/openliberty/checkpoint/fat/passwordutil/web/DefaultPrincipalMappingServlet.java
+++ b/dev/io.openliberty.checkpoint_fat/test-applications/DefaultPrincipalMappingApp/src/io/openliberty/checkpoint/fat/passwordutil/web/DefaultPrincipalMappingServlet.java
@@ -63,4 +63,14 @@ public class DefaultPrincipalMappingServlet extends FATServlet {
         assertEquals("The user name must be set in the auth data.", "testUser", authData.getUserName());
         assertEquals("The password must be set in the auth data.", "testPassword", String.valueOf(authData.getPassword()));
     }
+
+    /**
+     * Verify authData attributes configure at restore when not overridden.
+     */
+    @Test
+    public void getDefaultAuthDataUsingAuthDataProvider() throws Exception {
+        AuthData authData = AuthDataProvider.getAuthData("defaultAuthData");
+        assertEquals("The user name must be set in the auth data.", "APPUSR", authData.getUserName());
+        assertEquals("The password must be set in the auth data.", "APPPWD", String.valueOf(authData.getPassword()));
+    }
 }


### PR DESCRIPTION
For epic issue #26039 

- [x] Implement Connectors InstantOn limitations that prohibit timer creation and work submission during application startup within server checkpoint requests. The new function introduces four messages: `J2CA8511E`, `J2CA8512E`, `J2CA8601E`, `J2CA8602E`.

Add checkpoint tests (`@CheckpointTest`) for...

- [x] Connectors limitations: `DerbyRACheckpointLimitationsTest`
- [x] Connectors multi-function bringup: `DerbyRACheckpointTest`

