### PR TITLE
Add Feature label to issues opened using feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_feature.md
+++ b/.github/ISSUE_TEMPLATE/03_feature.md
@@ -2,7 +2,7 @@
 name: Open Liberty Feature Template
 about: Steps for Feature Creation and Delivery (Open Liberty org members only)
 title: 'Open Liberty Feature Template'
-labels: Epic
+labels: Epic,Feature
 assignees: ''
 
 ---


### PR DESCRIPTION
Updates the feature template to automatically add the `Feature` label to the issues created from it. That can give us a way to query for all features created using the template, and look for ones that might seem out of place or are unexpected.