### PR TITLE
Update stabilized features to not start up when using Jakarta 11

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/couchdb-1.0/com.ibm.websphere.appserver.couchdb-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/couchdb-1.0/com.ibm.websphere.appserver.couchdb-1.0.feature
@@ -5,7 +5,8 @@ visibility=public
 IBM-ShortName: couchdb-1.0
 Subsystem-Name: CouchDB Integration 1.0
 -features=com.ibm.websphere.appserver.appLifecycle-1.0, \
-  com.ibm.websphere.appserver.classloading-1.0
+  com.ibm.websphere.appserver.classloading-1.0, \
+  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0, 8.0, 9.0, 10.0"
 -bundles=com.ibm.ws.couchdb
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mongodb-2.0/com.ibm.websphere.appserver.mongodb-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mongodb-2.0/com.ibm.websphere.appserver.mongodb-2.0.feature
@@ -5,7 +5,8 @@ visibility=public
 IBM-ShortName: mongodb-2.0
 Subsystem-Name: MongoDB Integration 2.0
 -features=com.ibm.websphere.appserver.appLifecycle-1.0, \
-  com.ibm.websphere.appserver.classloading-1.0
+  com.ibm.websphere.appserver.classloading-1.0, \
+  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0, 8.0, 9.0, 10.0"
 -bundles=com.ibm.ws.mongo
 kind=ga
 edition=base

--- a/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/EE11Features.java
+++ b/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/EE11Features.java
@@ -137,6 +137,19 @@ public class EE11Features {
                                                                OPEN_LIBERTY_ONLY);
 
         this.serverFeatures_wl = getInstalledFeatures(installRoot, !OPEN_LIBERTY_ONLY);
+
+        // Temporarily remove features that currently work with EE 11, but will be updated to no longer work with EE 11.
+        // When the changes are in, this list of features will be moved to remove from the compatible list.
+        serverFeatures_wl.remove("appState-1.0");
+        serverFeatures_wl.remove("appState-2.0");
+        serverFeatures_wl.remove("bluemixUtility-1.0");
+        serverFeatures_wl.remove("cloudAutowiring-1.0");
+        serverFeatures_wl.remove("logAnalysis-1.0");
+        serverFeatures_wl.remove("mediaServerControl-1.0");
+        serverFeatures_wl.remove("productInsights-1.0");
+        serverFeatures_wl.remove("serverStatus-1.0");
+        serverFeatures_wl.remove("timedOperations-1.0");
+
         this.versionedFeatures_wl = getVersionedFeatures(serverFeatures_wl);
 
         this.compatibleFeatures_wl = getCompatibleFeatures(versionedFeatures_wl, !OPEN_LIBERTY_ONLY);
@@ -207,6 +220,8 @@ public class EE11Features {
         features.remove("sipServlet-1.1"); // purposely not supporting EE 11
         features.remove("springBoot-1.5"); // springBoot 3.0 only supports EE11
         features.remove("springBoot-2.0");
+        features.remove("couchdb-1.0"); // stabilized
+        features.remove("mongodb-2.0"); // stabilized
 
         features.remove("mpReactiveMessaging-3.0"); //still in development
         features.remove("mpTelemetry-2.0"); //Not yet assigned to an MPXX_FEATURES_ARRAY


### PR DESCRIPTION
- Update features that do not have any dependencies on Java / Jakarta EE features, to not start up when started with Jakarta EE 11 features
- Update EE 11 feature compatibility tests to not include WebSphere Liberty features that will have this same update until the change is made so that we do not get test failures while in this transition period.

#build