### PR TITLE
Do not cache OpenAPI model if user code is used to create it

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal.services/src/io/openliberty/microprofile/openapi20/internal/services/impl/ConfigFieldProvider20Impl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal.services/src/io/openliberty/microprofile/openapi20/internal/services/impl/ConfigFieldProvider20Impl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.microprofile.openapi20.internal.services.impl;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
@@ -106,6 +107,19 @@ public class ConfigFieldProvider20Impl implements ConfigFieldProvider {
     @Override
     public Collection<ConfigField> getConfigFields() {
         return Arrays.asList(ConfigField20.values());
+    }
+
+    @Override
+    public Collection<ConfigField> getIndexingConfigFields() {
+        ArrayList<ConfigField> result = new ArrayList<>();
+        result.add(ConfigField20.SCAN_DISABLE);
+        result.add(ConfigField20.SCAN_CLASSES);
+        result.add(ConfigField20.SCAN_EXCLUDE_CLASSES);
+        result.add(ConfigField20.SCAN_PACKAGES);
+        result.add(ConfigField20.SCAN_EXCLUDE_PACKAGES);
+        result.add(ConfigField20.SCAN_DEPENDENCIES_DISABLE);
+        result.add(ConfigField20.SCAN_DEPENDENCIES_JARS);
+        return result;
     }
 
     @Override

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/cache/ConfigSerializer.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/cache/ConfigSerializer.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -67,6 +67,35 @@ public class ConfigSerializer {
             }
         }
         return result;
+    }
+
+    /**
+     * Convert the config relevant to annotation indexing into a Properties object so that it can be easily compared.
+     *
+     * @param config the config
+     * @return the properties which affect annotation indexing
+     */
+    public Properties getIndexingConfig(OpenApiConfig config) {
+        Properties result = new Properties();
+        for (ConfigField field : configFieldProvider.getIndexingConfigFields()) {
+            String value = field.getValue(config);
+            if (value != null) {
+                result.put(field.getMethod(), value);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Get the set of config keys which may be contained in a map returned by {@link #getIndexingConfig(OpenApiConfig)}.
+     *
+     * @return the list of property keys which affect annotation indexing
+     */
+    public Set<String> getIndexingConfigKeys() {
+        return configFieldProvider.getIndexingConfigFields()
+                                  .stream()
+                                  .map(ConfigField::getMethod)
+                                  .collect(Collectors.toSet());
     }
 
     private static Set<String> getPathNames(OpenAPI model) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/services/ConfigFieldProvider.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/services/ConfigFieldProvider.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,7 +14,9 @@ package io.openliberty.microprofile.openapi20.internal.services;
 
 import java.util.Collection;
 
+import io.openliberty.microprofile.openapi20.internal.utils.IndexUtils;
 import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.runtime.scanner.FilteredIndexView;
 
 /**
  * Provides the {@link ConfigField ConfigFields} for a specific version of the {@link OpenApiConfig} interface
@@ -32,6 +34,15 @@ public interface ConfigFieldProvider {
      * @return the fields which can be read from {@code OpenApiConfig}
      */
     public Collection<ConfigField> getConfigFields();
+
+    /**
+     * Get the {@link ConfigField ConfigFields} which affect the building of the Jandex index.
+     * <p>
+     * This should include all the config fields used by {@link IndexUtils} and {@link FilteredIndexView} to choose which classes to index.
+     *
+     * @return the fields which affect class indexing
+     */
+    public Collection<ConfigField> getIndexingConfigFields();
 
     /**
      * Serialize the configured servers from the config for the given path

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/IndexUtils.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/IndexUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.util.Set;
 
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 
@@ -42,8 +43,8 @@ public class IndexUtils {
     private static final TraceComponent tc = Tr.register(IndexUtils.class);
 
     /**
-     * The getIndexView method generates an org.jboss.jandex.IndexView that contains all of the classes that need to be
-     * scanned for OpenAPI/JAX-RS annotations. This IndexView is passes to the SmallRye OpenAPI implementation which
+     * The getIndexView method generates an org.jboss.jandex.Index that contains all of the classes that need to be
+     * scanned for OpenAPI/JAX-RS annotations. This Index is passed to the SmallRye OpenAPI implementation which
      * performs the scanning.
      *
      * @param webModuleInfo
@@ -52,10 +53,10 @@ public class IndexUtils {
      *     The module classes container info for the web module
      * @param config
      *     The configuration that may specify which classes/packages/JARs to include/exclude.
-     * @return IndexView
-     * The org.jboss.jandex.IndexView instance.
+     * @return Index
+     * The org.jboss.jandex.Index instance.
      */
-    public static IndexView getIndexView(WebModuleInfo webModuleInfo, ModuleClassesContainerInfo moduleClassesContainerInfo, OpenApiConfig config) {
+    public static Index getIndex(WebModuleInfo webModuleInfo, ModuleClassesContainerInfo moduleClassesContainerInfo, OpenApiConfig config) {
 
         long startTime = System.currentTimeMillis();
 
@@ -73,14 +74,14 @@ public class IndexUtils {
         }
 
         // Complete the index
-        IndexView view = indexer.complete();
+        Index index = indexer.complete();
         long endTime = System.currentTimeMillis();
         if (LoggingUtils.isEventEnabled(tc)) {
-            Tr.event(tc, "Index size: " + view.getKnownClasses().size());
+            Tr.event(tc, "Index size: " + index.getKnownClasses().size());
             Tr.event(tc, "Indexing elapsed time: " + (endTime - startTime));
         }
 
-        return view;
+        return index;
     }
 
     private static void indexContainer(Container container, String packageName, Indexer indexer, FilteredIndexView filter) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.PropertiesAsset;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
@@ -37,6 +38,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import io.openliberty.microprofile.openapi20.fat.FATSuite;
+import io.openliberty.microprofile.openapi20.fat.cache.filter.MyOASFilter;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
@@ -60,6 +62,7 @@ public class CacheTest {
         server.startServer();
 
         // check that document is generated and cache written
+        assertThat(server.findStringsInTrace("Building Jandex index"), not(empty()));
         assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
         assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
 
@@ -84,6 +87,7 @@ public class CacheTest {
         server.startServer();
 
         // check that document is generated and cache written
+        assertThat(server.findStringsInTrace("Building Jandex index"), not(empty()));
         assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
         assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
 
@@ -98,6 +102,7 @@ public class CacheTest {
 
         // check that cache is not used
         assertThat(server.findStringsInTrace("Cache out of date because files have changed"), not(empty()));
+        assertThat(server.findStringsInTrace("Index out of date because files have changed"), not(empty()));
         assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
         assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
     }
@@ -112,6 +117,7 @@ public class CacheTest {
         server.startServer();
 
         // check that document is generated and cache written
+        assertThat(server.findStringsInTrace("Building Jandex index"), not(empty()));
         assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
         assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
 
@@ -127,6 +133,67 @@ public class CacheTest {
         // check that cache is not used
         assertThat(server.findStringsInTrace("Cache out of date because config is not the same"), not(empty()));
         assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+    }
+
+    @Test
+    public void testCacheMissIndexOk() throws Exception {
+        // Deploy app
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "cacheTest.war").addPackage(CacheTest.class.getPackage());
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        // start server
+        server.startServer();
+
+        // check that document is generated and cache written
+        assertThat(server.findStringsInTrace("Building Jandex index"), not(empty()));
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+        assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
+
+        // stop server without archiving it
+        server.stopServer(false);
+
+        // Update server config
+        server.setAdditionalSystemProperties(Collections.singletonMap("MP_OPENAPI_SERVERS", "http://example.com/"));
+
+        // start server without clean (since that would clear the cache)
+        server.startServer(false);
+
+        // check that cache is not used but the index is
+        assertThat(server.findStringsInTrace("Cache out of date because config is not the same"), not(empty()));
+        assertThat(server.findStringsInTrace("Using Jandex index from cache"), not(empty()));
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+        assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
+    }
+
+    @Test
+    public void testFilterAppNotCached() throws Exception {
+        // Deploy app with a filter configured
+        PropertiesAsset config = new PropertiesAsset().addProperty("mp.openapi.filter", MyOASFilter.class.getName());
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "cacheTest.war")
+                                   .addPackage(CacheTest.class.getPackage())
+                                   .addPackage(MyOASFilter.class.getPackage())
+                                   .addAsResource(config, "META-INF/microprofile-config.properties");
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        // start server
+        server.startServer();
+
+        // check that document is generated and cache written
+        assertThat(server.findStringsInTrace("Building Jandex index"), not(empty()));
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+        assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
+
+        // stop server without archiving it
+        server.stopServer(false);
+
+        // start server without clean (since that would clear the cache)
+        server.startServer(false);
+
+        // check that cache is not used but the index is
+        assertThat(server.findStringsInTrace("Cache not usable because a filter or reader is registered"), not(empty()));
+        assertThat(server.findStringsInTrace("Using Jandex index from cache"), not(empty()));
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+        assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
     }
 
     @After

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/filter/MyOASFilter.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/filter/MyOASFilter.java
@@ -1,18 +1,22 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 IBM Corporation and others.
+ * Copyright (c) 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-addRequiredLibraries.dependsOn addJakartaTransformer
+package io.openliberty.microprofile.openapi20.fat.cache.filter;
 
-dependencies {
-  requiredLibs project(':io.openliberty.com.fasterxml.jackson')
-  requiredLibs project(':io.openliberty.org.eclipse.microprofile')
+import org.eclipse.microprofile.openapi.OASFilter;
+
+public class MyOASFilter implements OASFilter {
+
+    // This filter doesn't actually do anything
+    // But it *could* be reading anything from the environment
+    // So if it's configured to be used, we can't cache the model
 }

--- a/dev/io.openliberty.microprofile.openapi.3.1.internal.services/src/io/openliberty/microprofile/openapi31/internal/services/impl/ConfigFieldProvider31Impl.java
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal.services/src/io/openliberty/microprofile/openapi31/internal/services/impl/ConfigFieldProvider31Impl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.microprofile.openapi31.internal.services.impl;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
@@ -112,6 +113,19 @@ public class ConfigFieldProvider31Impl implements ConfigFieldProvider {
     @Override
     public Collection<ConfigField> getConfigFields() {
         return Arrays.asList(ConfigField31.values());
+    }
+
+    @Override
+    public Collection<ConfigField> getIndexingConfigFields() {
+        ArrayList<ConfigField> result = new ArrayList<>();
+        result.add(ConfigField31.SCAN_DISABLE);
+        result.add(ConfigField31.SCAN_CLASSES);
+        result.add(ConfigField31.SCAN_EXCLUDE_CLASSES);
+        result.add(ConfigField31.SCAN_PACKAGES);
+        result.add(ConfigField31.SCAN_EXCLUDE_PACKAGES);
+        result.add(ConfigField31.SCAN_DEPENDENCIES_DISABLE);
+        result.add(ConfigField31.SCAN_DEPENDENCIES_JARS);
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Do not cache the OpenAPI model if the user has registered an OASFilter
or an OASModelReader. The users code could reference anything in the
environment so we can't safely invalidate the cache.

Additionally store the Jandex index (if created) in the cache. The
Jandex index can still be used if config which does not affect indexing
changes or if the user registers an OASFilter or OASModelReader.
Creating the Jandex index is the slowest part of building the OpenAPI
model.

Fixes #28475