### PR TITLE
Add more extensive instructions with resolution failures.

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/BaselineServletUnitTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/BaselineServletUnitTest.java
@@ -13,6 +13,7 @@
 package com.ibm.ws.feature.tests;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -61,6 +62,14 @@ public class BaselineServletUnitTest extends FeatureResolutionUnitTestBase {
 
     public static File getDataFile_WL() {
         return new File(DATA_FILE_PATH_WL);
+    }
+
+    @Override
+    public List<File> getDataFiles() {
+        List<File> dataFiles = new ArrayList<>(2);
+        dataFiles.add(getDataFile_OL());
+        dataFiles.add(getDataFile_WL());
+        return dataFiles;
     }
 
     // To use change the name of parameterized tests, you say:

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/BaselineSingletonUnitTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/BaselineSingletonUnitTest.java
@@ -13,6 +13,7 @@
 package com.ibm.ws.feature.tests;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -61,6 +62,14 @@ public class BaselineSingletonUnitTest extends FeatureResolutionUnitTestBase {
 
     public static File getDataFile_WL() {
         return new File(DATA_FILE_PATH_WL);
+    }
+
+    @Override
+    public List<File> getDataFiles() {
+        List<File> dataFiles = new ArrayList<>(2);
+        dataFiles.add(getDataFile_OL());
+        dataFiles.add(getDataFile_WL());
+        return dataFiles;
     }
 
     // To use change the name of parameterized tests, you say:

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/FeatureResolutionUnitTestBase.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/FeatureResolutionUnitTestBase.java
@@ -40,11 +40,12 @@ import com.ibm.ws.kernel.feature.internal.util.VerifyXML;
 import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
 import com.ibm.ws.kernel.feature.resolver.FeatureResolver;
 import com.ibm.ws.kernel.feature.resolver.FeatureResolver.Result;
+// import com.ibm.ws.kernel.feature.resolver.FeatureResolver.Result;
 
 /**
  * Feature resolution testing.
  */
-public class FeatureResolutionUnitTestBase {
+public abstract class FeatureResolutionUnitTestBase {
 
     public static void largeDashes(PrintStream stream) {
         stream.println("============================================================");
@@ -96,25 +97,71 @@ public class FeatureResolutionUnitTestBase {
             }
         }
 
-        public String getMessage() {
+        public String getMessage(List<File> dataFiles) {
             StringBuilder builder = new StringBuilder();
             builder.append("Feature resolution [ " + description + " ]");
             builder.append(" failed with [ ");
             builder.append(Integer.toString(messages.size()));
-            builder.append(" ] errors: ");
+            builder.append(" ] errors:\n");
 
             int errorNo = 0;
             for (String error : messages) {
-                if (errorNo > 3) {
-                    builder.append("...");
-                    break;
-                } else if (errorNo > 0) {
-                    builder.append(", ");
+                if (errorNo > 0) {
+                    builder.append(",\n");
                 }
-
                 builder.append(error);
                 errorNo++;
             }
+            builder.append('\n');
+
+            builder.append("Expected / baseline data was read from these files:\n");
+            for (File dataFile : dataFiles) {
+                builder.append("  [ " + dataFile.getAbsolutePath() + " ]\n");
+            }
+            builder.append('\n');
+            builder.append('\n');
+
+            builder.append("The failure message usually displays one or more features which were\n");
+            builder.append("added or which were removed from the resolution result.\n");
+            builder.append("The necessary correction will be to update the baseline data with\n");
+            builder.append("the added or removed features.\n");
+            builder.append('\n');
+
+            builder.append("For more information, see:\n");
+            builder.append("open-liberty/dev/com.ibm.ws.kernel.feature.resolver_fat/\n");
+            builder.append("  /src/com/ibm/ws/feature/tests/readme.txt/n");
+            builder.append('\n');
+
+            builder.append("Notes:\n");
+            builder.append('\n');
+
+            builder.append("Usually, two data files are read, one with open-liberty specific\n");
+            builder.append("data, and one with WAS liberty specific data:\n");
+            builder.append("  * If the feature update which triggers the failure was made in\n");
+            builder.append("    open-liberty, both data files should be updated.\n");
+            builder.append("  * If the feature update which triggers the failure was made in\n");
+            builder.append("    WAS-liberty, only the WAS liberty data files should be updated.\n");
+            builder.append('\n');
+
+            builder.append("As a convenience, the FAT test log contains suggested XML text\n");
+            builder.append("which may be used to update the baseline data file.");
+            builder.append('\n');
+
+            builder.append("The format of the baseline data files is a list of resolution cases,\n");
+            builder.append("each having one or more features which are to be resolved (inputs),\n");
+            builder.append("and each having a list of resolved features (outputs).  When multiple\n");
+            builder.append("baseline data files are used, their contents are additive.\n");
+            builder.append('\n');
+            builder.append("NOTE: Often, WAS-liberty cases replace open-liberty cases.\n");
+            builder.append('\n');
+
+            builder.append("When testing feature updates, the following tests are recommended to be run:\n");
+            builder.append("  dev/com.ibm.ws.kernel.feature (unit tests)");
+            builder.append("  com.ibm.ws.kernel.feature.resolver_fat\n");
+            builder.append("  io.openliberty.jakartaee9.internal_fat\n");
+            builder.append("  io.openliberty.jakartaee10.internal_fat\n");
+            builder.append("  io.openliberty.jakartaee11.internal_fat\n");
+            builder.append('\n');
 
             return builder.toString();
         }
@@ -235,6 +282,8 @@ public class FeatureResolutionUnitTestBase {
         return testCase;
     }
 
+    public abstract List<File> getDataFiles();
+
     //
 
     public String getPreferredPlatforms() {
@@ -337,7 +386,7 @@ public class FeatureResolutionUnitTestBase {
         List<String> rootErrors = detectFeatureErrors(inputCase.input.roots);
         if (rootErrors != null) {
             FailureSummary summary = addRootFailure(inputCase, rootErrors);
-            fail(summary.getMessage());
+            fail(summary.getMessage(getDataFiles()));
             return; // 'fail' never returns.
         }
 
@@ -381,7 +430,7 @@ public class FeatureResolutionUnitTestBase {
 
         if ((errors != null) && !errors.isEmpty()) {
             FailureSummary summary = addFailure(inputCase, extra, missing);
-            fail(summary.getMessage());
+            fail(summary.getMessage(getDataFiles()));
             return; // 'fail' never returns.
         }
     }

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/MicroProfileCrossPlatformUnitTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/MicroProfileCrossPlatformUnitTest.java
@@ -13,6 +13,7 @@
 package com.ibm.ws.feature.tests;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -61,6 +62,14 @@ public class MicroProfileCrossPlatformUnitTest extends FeatureResolutionUnitTest
 
     public static File getDataFile_WL() {
         return new File(DATA_FILE_PATH_WL);
+    }
+
+    @Override
+    public List<File> getDataFiles() {
+        List<File> dataFiles = new ArrayList<>(2);
+        dataFiles.add(getDataFile_OL());
+        dataFiles.add(getDataFile_WL());
+        return dataFiles;
     }
 
     // To use change the name of parameterized tests, you say:

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/readme.txt
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/readme.txt
@@ -1,4 +1,106 @@
-[FEATURE RESOLUTION FAT NOTES][TFB][23-Apr-2024][START]
+[FEATURE RESOLUTION FAT NOTES][TFB][22-May-2024][START]>
+
+Part 1: Feature testing
+
+When testing feature updates, the following tests are recommended to be run:
+
+Unit tests:
+
+  dev/com.ibm.ws.kernel.feature
+  
+FATs:
+
+  com.ibm.ws.kernel.feature.resolver_fat
+  io.openliberty.jakartaee9.internal_fat
+  io.openliberty.jakartaee10.internal_fat
+  io.openliberty.jakartaee11.internal_fat
+
+---
+
+Part 2: Updating baseline data:
+
+A typical resolution failure obtained from subclasses of the
+feature resolution unit test "FeatureResolutionUnitTestBase"
+is a change to what features are resolved.
+
+Baseline test cases are recorded in several data files under
+"com.ibm.ws.kernel.feature.resolver_fat/publish/verify".
+
+Cases for all public features:
+
+    singleton_expected.xml
+    singleton_expected_WL.xml
+
+Cases which combine a single versioned servlet feature with single
+versionless feature:
+
+    servlet_expected.xml
+    servlet_expected_WL.xml
+
+For example, the resolution of  "acmeCA-2.0" as a server feature is
+present in "singleton_expected.xml":
+
+    <case>
+        <name>com.ibm.websphere.appserver.acmeCA-2.0_SERVER</name>
+        <description>Singleton [ com.ibm.websphere.appserver.acmeCA-2.0 ] [ SERVER ]</description>
+        <input>
+            <server/>
+            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
+            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
+            <root>com.ibm.websphere.appserver.acmeCA-2.0</root>
+        </input>
+        <output>
+            <resolved>com.ibm.websphere.appserver.certificateCreator-2.0</resolved>
+            <resolved>json-1.0</resolved>
+            <resolved>com.ibm.websphere.appserver.eeCompatible-6.0</resolved>
+            <resolved>io.openliberty.servlet.api-3.1</resolved>
+            <resolved>com.ibm.websphere.appserver.javaeeddSchema-1.0</resolved>
+            <resolved>com.ibm.websphere.appserver.servlet-servletSpi1.0</resolved>
+            <!-- ... additional resolved features ... -->
+        </output>
+    </case>
+
+This shows a single case described as the resolution of the singleton "acmCA-2.0"
+as a server feature.  This example has omitted most of the resolved features.
+
+The meaning of a feature resolution case is that the the input features are
+expected to resolve to the output features. 
+
+Each case has an "input" element, which provides resolution settings, a list of
+kernel features, and a list of root features.  The root features are generally
+the most import input and are what distinguish cases.
+
+Each case has an "output" element which has a full listing of the resolved
+features.  The output element lists all public and private internal features
+which were resolved from the inputs.
+
+Usually, two data files are read, one with open-liberty specific data,
+and one with WAS liberty specific data.  When multiple data files are
+read, later read files overlay the earlier read files, using case name
+as key.
+
+Failures are usually because one or more features was added or removed to the
+resolution result.  The necessary correction will be to update the base line
+data with the added or removed features.  That is, adding or removing
+"resolved" elements from cases which failed.  The correction is made directly
+to the case file.
+
+  * If the feature update which triggers the failure was made in
+    open-liberty, both data files should be updated.
+    
+  * If the feature update which triggers the failure was made in
+    WAS-liberty, only the WAS liberty data files should be updated.
+
+As a convenience, the FAT test log contains suggested XML text which may be
+used to update the baseline data file.");
+
+Alternatively, the entire case data can be regenerated using
+"VersionlessResolutionTest".  See section 3 of these notes for more information
+about regenerating the case data.
+
+---
+
+Part 3: Generating entirely new baseline data
 
 Several of the feature resolution FATs follow the pattern of:
 
@@ -85,4 +187,4 @@ dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/
   BaselineServletUnitTest.java
   BaselineSingletonUnitTest.java
 
-[FEATURE RESOLUTION FAT NOTES][TFB][23-Apr-2024][END]
+[FEATURE RESOLUTION FAT NOTES][TFB][22-May-2024][END]


### PR DESCRIPTION
Update the resolver failure message to display more information about how to fix the error.