### PR TITLE
Re-introduce  (re-switch) `io.openliberty.httpStat-monitor1.0.jakarta` to beta (incl. fixes)

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.httpStat-monitor1.0.jakarta.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.httpStat-monitor1.0.jakarta.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.httpStat-monitor1.0.jakarta
 Manifest-Version: 1.0
 IBM-API-Package: io.openliberty.http.monitor.mbean; type="ibm-api"
 IBM-Provision-Capability: \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.pages-3.1)(osgi.identity=com.ibm.websphere.appserver.servlet-6.0)(osgi.identity=io.openliberty.servlet.internal-6.0)(osgi.identity=com.ibm.websphere.appserver.servlet-6.1)(osgi.identity=io.openliberty.servlet.internal-6.1)))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.servlet.internal-6.0)(osgi.identity=io.openliberty.servlet.internal-6.1)))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.monitor-1.0))"
 IBM-Install-Policy: when-satisfied
 -bundles=io.openliberty.http.monitor

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.httpStat-monitor1.0.jakarta.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.httpStat-monitor1.0.jakarta.feature
@@ -1,10 +1,11 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.httpStat-monitor1.0.jakarta
 Manifest-Version: 1.0
+IBM-API-Package: io.openliberty.http.monitor.mbean; type="ibm-api"
 IBM-Provision-Capability: \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.pages-3.1)(osgi.identity=com.ibm.websphere.appserver.servlet-6.0)(osgi.identity=com.ibm.websphere.appserver.servlet-6.1)))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.pages-3.1)(osgi.identity=com.ibm.websphere.appserver.servlet-6.0)(osgi.identity=io.openliberty.servlet.internal-6.0)(osgi.identity=com.ibm.websphere.appserver.servlet-6.1)(osgi.identity=io.openliberty.servlet.internal-6.1)))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.monitor-1.0))"
 IBM-Install-Policy: when-satisfied
 -bundles=io.openliberty.http.monitor
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/singleton_expected.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/singleton_expected.xml
@@ -13998,6 +13998,7 @@
             <resolved>io.openliberty.cdi3.0-transaction2.0</resolved>
             <resolved>io.openliberty.cdi3.0-appSecurity</resolved>
             <resolved>io.openliberty.restfulWS3.0-monitor1.0</resolved>
+            <resolved>io.openliberty.httpStat-monitor1.0.jakarta</resolved>
         </output>
     </case>
     <case>
@@ -14135,6 +14136,7 @@
             <resolved>io.openliberty.cdi3.0-transaction2.0</resolved>
             <resolved>io.openliberty.cdi3.0-appSecurity</resolved>
             <resolved>io.openliberty.restfulWS3.0-monitor1.0</resolved>
+            <resolved>io.openliberty.httpStat-monitor1.0.jakarta</resolved>
         </output>
     </case>
     <case>
@@ -14962,6 +14964,7 @@
             <resolved>io.openliberty.servlet5.0-monitor1.0</resolved>
             <resolved>io.openliberty.cdi3.0-transaction2.0</resolved>
             <resolved>com.ibm.websphere.appserver.securityContext-1.0</resolved>
+            <resolved>io.openliberty.httpStat-monitor1.0.jakarta</resolved>
         </output>
     </case>
     <case>
@@ -15058,6 +15061,7 @@
             <resolved>io.openliberty.servlet5.0-monitor1.0</resolved>
             <resolved>io.openliberty.cdi3.0-transaction2.0</resolved>
             <resolved>com.ibm.websphere.appserver.securityContext-1.0</resolved>
+            <resolved>io.openliberty.httpStat-monitor1.0.jakarta</resolved>
         </output>
     </case>
     <case>

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/singleton_expected_WL.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/singleton_expected_WL.xml
@@ -10207,6 +10207,7 @@
         <resolved>io.openliberty.cdi3.0-transaction2.0</resolved>
         <resolved>io.openliberty.cdi3.0-appSecurity</resolved>
         <resolved>io.openliberty.restfulWS3.0-monitor1.0</resolved>
+        <resolved>io.openliberty.httpStat-monitor1.0.jakarta</resolved>
     </output>
 </case>
 
@@ -10346,6 +10347,7 @@
         <resolved>io.openliberty.cdi3.0-transaction2.0</resolved>
         <resolved>io.openliberty.cdi3.0-appSecurity</resolved>
         <resolved>io.openliberty.restfulWS3.0-monitor1.0</resolved>
+        <resolved>io.openliberty.httpStat-monitor1.0.jakarta</resolved>
     </output>
 </case>
 
@@ -11039,6 +11041,7 @@
         <resolved>io.openliberty.servlet5.0-monitor1.0</resolved>
         <resolved>io.openliberty.cdi3.0-transaction2.0</resolved>
         <resolved>com.ibm.websphere.appserver.securityContext-1.0</resolved>
+        <resolved>io.openliberty.httpStat-monitor1.0.jakarta</resolved>
     </output>
 </case>
 
@@ -11137,6 +11140,7 @@
         <resolved>io.openliberty.servlet5.0-monitor1.0</resolved>
         <resolved>io.openliberty.cdi3.0-transaction2.0</resolved>
         <resolved>com.ibm.websphere.appserver.securityContext-1.0</resolved>
+        <resolved>io.openliberty.httpStat-monitor1.0.jakarta</resolved>
     </output>
 </case>
 

--- a/dev/io.openliberty.http.monitor/bnd.bnd
+++ b/dev/io.openliberty.http.monitor/bnd.bnd
@@ -31,16 +31,7 @@ src: src
 WS-TraceGroup: 
 
 Import-Package: \
-    !*.internal.*,\
-    !jakarta.ws.rs.*,\
-    !com.ibm.ws.webcontainer.srt,\
-    !com.ibm.ws.webcontainer40.osgi.webapp,\
-    !com.ibm.wsspi.genericbnf,\
-    !com.ibm.wsspi.webcontainer.webapp,\
     !com.ibm.ws.http.*,\
-    !com.ibm.wsspi.http.*,\
-    !jakarta.*,\
-    !javax.*,\
     *
 
 Export-Package: \
@@ -52,17 +43,7 @@ Liberty-Monitoring-Components: \
 			io.openliberty.http.monitor.HttpStatsMonitor
 
 DynamicImport-Package: \
-  jakarta.ws.rs;version="[3.1.0,4.0.0)",\
-  jakarta.ws.rs.*;version="[3.1.0,4.0.0)",\
-  com.ibm.ws.http.*,\
-  com.ibm.wsspi.http;version="[2.1.0,3.0.0)",\
-  com.ibm.wsspi.http.*;version="[1.0.0,2.0.0)",\
-  com.ibm.wsspi.webcontainer.webapp,\
-  com.ibm.ws.webcontainer.srt,\
-  com.ibm.ws.webcontainer40.osgi.webapp,\
-  com.ibm.wsspi.genericbnf,\
-  jakarta.*,\
-  javax.*
+  com.ibm.ws.http.*
 
 -buildpath: \
     com.ibm.ws.logging;version=latest,\
@@ -75,8 +56,6 @@ DynamicImport-Package: \
 	io.openliberty.jakarta.servlet.6.0;version=latest,\
 	com.ibm.ws.webcontainer.jakarta;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	io.openliberty.jakarta.restfulWS.3.1,\
-	io.openliberty.jakarta.annotation.2.1;version=latest,\
 	com.ibm.ws.channelfw;version=latest,\
 	com.ibm.ws.container.service,\
 	com.ibm.ws.kernel.boot.core;version=latest

--- a/dev/io.openliberty.http.monitor/bnd.bnd
+++ b/dev/io.openliberty.http.monitor/bnd.bnd
@@ -46,7 +46,7 @@ Import-Package: \
 Export-Package: \
   io.openliberty.http.monitor;thread-context=true,\
   io.openliberty.http.monitor.metrics,\
-  io.openliberty.http.monitor.mbean; type="ibm-api"
+  io.openliberty.http.monitor.mbean
 
 Liberty-Monitoring-Components: \
 			io.openliberty.http.monitor.HttpStatsMonitor
@@ -78,4 +78,5 @@ DynamicImport-Package: \
 	io.openliberty.jakarta.restfulWS.3.1,\
 	io.openliberty.jakarta.annotation.2.1;version=latest,\
 	com.ibm.ws.channelfw;version=latest,\
-	com.ibm.ws.container.service
+	com.ibm.ws.container.service,\
+	com.ibm.ws.kernel.boot.core;version=latest

--- a/dev/io.openliberty.http.monitor/bnd.bnd
+++ b/dev/io.openliberty.http.monitor/bnd.bnd
@@ -25,7 +25,8 @@ src: src
 
 -dsannotations: \
   io.openliberty.http.monitor.ServletContainerInitializer,\
-  io.openliberty.http.monitor.metrics.RestMetricManager
+  io.openliberty.http.monitor.metrics.RestMetricManager,\
+  io.openliberty.http.monitor.MonitorAppStateListener
 
 WS-TraceGroup: 
 
@@ -45,7 +46,7 @@ Import-Package: \
 Export-Package: \
   io.openliberty.http.monitor;thread-context=true,\
   io.openliberty.http.monitor.metrics,\
-  io.openliberty.http.monitor.mbean
+  io.openliberty.http.monitor.mbean; type="ibm-api"
 
 Liberty-Monitoring-Components: \
 			io.openliberty.http.monitor.HttpStatsMonitor
@@ -76,4 +77,5 @@ DynamicImport-Package: \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	io.openliberty.jakarta.restfulWS.3.1,\
 	io.openliberty.jakarta.annotation.2.1;version=latest,\
-	com.ibm.ws.channelfw;version=latest
+	com.ibm.ws.channelfw;version=latest,\
+	com.ibm.ws.container.service

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpStatsMonitor.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpStatsMonitor.java
@@ -19,7 +19,6 @@ import com.ibm.websphere.monitor.annotation.This;
 import com.ibm.websphere.monitor.meters.MeterCollection;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink;
 import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.webcontainer.servlet.ServletWrapper;

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpStatsMonitor.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpStatsMonitor.java
@@ -300,7 +300,7 @@ public class HttpStatsMonitor extends StatisticActions {
 		Set<String> retSet = appNameToStat.get(appName);
 		if (retSet != null) {
 			for (String statName : retSet) {
-				HttpConnByRoute.remove(statName));
+				HttpConnByRoute.remove(statName);
 			}
 		}
 	}

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpStatsMonitor.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpStatsMonitor.java
@@ -21,6 +21,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.webcontainer.servlet.ServletWrapper;
 import com.ibm.wsspi.http.channel.values.StatusCodes;
 import com.ibm.wsspi.pmi.factory.StatisticActions;
@@ -91,7 +92,15 @@ public class HttpStatsMonitor extends StatisticActions {
 	@ProbeSite(clazz = "com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink", method = "sendResponse", args = "com.ibm.wsspi.http.channel.values.StatusCodes,java.lang.String,java.lang.Exception,boolean")
 	public void atSendResponseReturn(@This Object probedHttpDispatcherLinkObj) {
 
-		
+		/*
+		 * Just prevent probed code execution. This bundle starts from an auto-feature.
+		 * User's are not explicitly enabling this so lets not throw an exception. We'll
+		 * quietly get out of the way.
+		 */
+		if (!ProductInfo.getBetaEdition()) {
+			return;
+		}
+
 		long elapsedNanos = System.nanoTime() - tl_startNanos.get();
 		HttpStatAttributes retrievedHttpStatAttr = tl_httpStats.get();
 
@@ -135,7 +144,16 @@ public class HttpStatsMonitor extends StatisticActions {
 	@ProbeAtEntry
 	@ProbeSite(clazz = "com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink", method = "sendResponse", args = "com.ibm.wsspi.http.channel.values.StatusCodes,java.lang.String,java.lang.Exception,boolean")
 	public void atSendResponse(@This Object probedHttpDispatcherLinkObj, @Args Object[] myargs) {
-		
+
+		/*
+		 * Just prevent probed code execution. This bundle starts from an auto-feature.
+		 * User's are not explicitly enabling this so lets not throw an exception. We'll
+		 * quietly get out of the way.
+		 */
+		if (!ProductInfo.getBetaEdition()) {
+			return;
+		}
+
 		tl_httpStats.set(null);; //reset just in case
 		
 		tl_startNanos.set(System.nanoTime());
@@ -197,6 +215,19 @@ public class HttpStatsMonitor extends StatisticActions {
      * @param appName Can be null (would mean its from these probes -- ergo server, don't have to worry about unloading)
      */
 	public void updateHttpStatDuration(HttpStatAttributes httpStatAttributes, Duration duration, String appName) {
+
+		/*
+		 * Just prevent this from happening. This bundle starts from an auto-feature.
+		 * User's are not explicitly enabling this so lets not throw an exception. We'll
+		 * quietly get out of the way.
+		 * 
+		 * Other beta blocks should prevent this from ever happening. But regardless,
+		 * this method is the lynch-pin. This is where MBean is registered and Metrics
+		 * are registered to Metric/Meter registries.
+		 */
+		if (!ProductInfo.getBetaEdition()) {
+			return;
+		}
 
 		/*
 		 * First validate that we got all properties.

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpStatsMonitor.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpStatsMonitor.java
@@ -299,7 +299,9 @@ public class HttpStatsMonitor extends StatisticActions {
 	public void removeStat(String appName) {
 		Set<String> retSet = appNameToStat.get(appName);
 		if (retSet != null) {
-			retSet.stream().forEach( statName -> HttpConnByRoute.remove(statName));
+			for (String statName : retSet) {
+				HttpConnByRoute.remove(statName));
+			}
 		}
 	}
 	

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpStatsMonitor.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpStatsMonitor.java
@@ -21,6 +21,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink;
+import com.ibm.ws.webcontainer.servlet.ServletWrapper;
 import com.ibm.wsspi.http.channel.values.StatusCodes;
 import com.ibm.wsspi.pmi.factory.StatisticActions;
 
@@ -29,7 +30,12 @@ import io.openliberty.http.monitor.metrics.RestMetricManager;
 import com.ibm.wsspi.http.HttpRequest;
 
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.servlet.GenericServlet;
 
 /**
  *
@@ -41,6 +47,8 @@ public class HttpStatsMonitor extends StatisticActions {
 
 	private static final ThreadLocal<HttpStatAttributes> tl_httpStats = new ThreadLocal<HttpStatAttributes>();
 	private static final ThreadLocal<Long> tl_startNanos = new ThreadLocal<Long>();
+	
+	private static final ConcurrentHashMap<String,Set<String>> appNameToStat = new ConcurrentHashMap<String,Set<String>>();
 	
 	private static HttpStatsMonitor instance;
 
@@ -94,7 +102,7 @@ public class HttpStatsMonitor extends StatisticActions {
 			return;
 		}
 
-		updateHttpStatDuration(retrievedHttpStatAttr, Duration.ofNanos(elapsedNanos));
+		updateHttpStatDuration(retrievedHttpStatAttr, Duration.ofNanos(elapsedNanos), null);
 
 	}
 	
@@ -182,8 +190,13 @@ public class HttpStatsMonitor extends StatisticActions {
 		}
 	}
 
-
-	public void updateHttpStatDuration(HttpStatAttributes httpStatAttributes, Duration duration) {
+    /**
+     * 
+     * @param httpStatAttributes
+     * @param duration
+     * @param appName Can be null (would mean its from these probes -- ergo server, don't have to worry about unloading)
+     */
+	public void updateHttpStatDuration(HttpStatAttributes httpStatAttributes, Duration duration, String appName) {
 
 		/*
 		 * First validate that we got all properties.
@@ -202,7 +215,7 @@ public class HttpStatsMonitor extends StatisticActions {
 
 		HttpStats hms = HttpConnByRoute.get(key);
 		if (hms == null) {
-			hms = initializeHttpStat(key, httpStatAttributes);
+			hms = initializeHttpStat(key, httpStatAttributes, appName);
 		}
 
 		//Monitor bundle when updating statistics will do synchronization
@@ -219,7 +232,7 @@ public class HttpStatsMonitor extends StatisticActions {
 		}
 	}
 
-	private synchronized HttpStats initializeHttpStat(String key, HttpStatAttributes statAttri) {
+	private synchronized HttpStats initializeHttpStat(String key, HttpStatAttributes statAttri, String appName) {
 		/*
 		 * Check again it was added, thread that was blocking may have been adding it
 		 */
@@ -229,8 +242,37 @@ public class HttpStatsMonitor extends StatisticActions {
 
 		HttpStats httpMetricStats = new HttpStats(statAttri);
 		HttpConnByRoute.put(key, httpMetricStats);
+		
+		/*
+		 * null means from server.
+		 * Specifically splash page.
+		 * 
+		 * Add to appName -> stat cache
+		 */
+		if (appName != null) {
+			appNameToStat.compute(appName, (appNameKey, currValSet) -> {
+				if (currValSet == null) {
+					HashSet<String> hs = new HashSet<String>();
+					hs.add(key);
+					return hs;
+				} else {
+					currValSet.add(key);
+					return currValSet;
+				}
+			});
+		}
+		
 		return httpMetricStats;
 	}
+	
+	
+	public void removeStat(String appName) {
+		Set<String> retSet = appNameToStat.get(appName);
+		if (retSet != null) {
+			retSet.stream().forEach( statName -> HttpConnByRoute.remove(statName));
+		}
+	}
+	
 
 	/**
 	 * Resolve the object name (specifically the name property)
@@ -261,12 +303,21 @@ public class HttpStatsMonitor extends StatisticActions {
 			sb.append(";httpRoute:" + route.replace("*", "\\*"));
 		});
 
-		httpRoute.ifPresent(route -> {
+		errorType.ifPresent(route -> {
 			sb.append(";errorType:" + errorType);
 		});
 
 		sb.append("\""); // ending quote
 		return sb.toString();
 	}
+	
+    @ProbeAtEntry
+    @ProbeSite(clazz = "com.ibm.ws.webcontainer.servlet.ServletWrapper", method = "destroy")
+    public void atServletDestroy(@This GenericServlet s) {
+    	
+        String appName = (String) s.getServletContext().getAttribute("com.ibm.websphere.servlet.enterprise.application.name");
+        removeStat(appName);
+    	
+    }
 
 }

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/MonitorAppStateListener.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/MonitorAppStateListener.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.http.monitor;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
+import com.ibm.ws.container.service.state.ApplicationStateListener;
+import com.ibm.ws.container.service.state.StateChangeException;
+
+@Component(service = { ApplicationStateListener.class }, configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true)
+public class MonitorAppStateListener implements ApplicationStateListener{
+
+	@Override
+	public void applicationStarting(ApplicationInfo appInfo) throws StateChangeException {
+
+	}
+
+	@Override
+	public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {
+
+	}
+
+	@Override
+	public void applicationStopping(ApplicationInfo appInfo) {
+
+	}
+
+	@Override
+	public void applicationStopped(ApplicationInfo appInfo) {
+		HttpStatsMonitor.getInstance().removeStat(appInfo.getDeploymentName());
+		
+	}
+
+}

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/MonitorAppStateListener.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/MonitorAppStateListener.java
@@ -15,6 +15,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
 import com.ibm.ws.container.service.state.ApplicationStateListener;
 import com.ibm.ws.container.service.state.StateChangeException;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 
 @Component(service = { ApplicationStateListener.class }, configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true)
 public class MonitorAppStateListener implements ApplicationStateListener{
@@ -36,6 +37,16 @@ public class MonitorAppStateListener implements ApplicationStateListener{
 
 	@Override
 	public void applicationStopped(ApplicationInfo appInfo) {
+    	/*
+    	 * Just prevent this from happening.
+    	 * This bundle starts from an auto-feature.
+    	 * User's are not explicitly enabling this so
+    	 * lets not throw an exception. We'll
+    	 * quietly get out of the way.
+    	 */
+    	if (!ProductInfo.getBetaEdition()) { 
+    		return;
+    	}
 		HttpStatsMonitor.getInstance().removeStat(appInfo.getDeploymentName());
 		
 	}

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/ServletContainerInitializer.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/ServletContainerInitializer.java
@@ -15,6 +15,8 @@ import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 
+import com.ibm.ws.kernel.productinfo.ProductInfo;
+
 import jakarta.servlet.FilterRegistration;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
@@ -25,13 +27,23 @@ import jakarta.servlet.ServletException;
 @Component(configurationPolicy = IGNORE)
 public class ServletContainerInitializer implements jakarta.servlet.ServletContainerInitializer {
 
-    //happens when app id deployed
-    @Override
-    public void onStartup(Set<Class<?>> c, ServletContext sc) throws ServletException {
-        FilterRegistration.Dynamic filterRegistration = sc
-                .addFilter("io.openliberty.http.monitor.ServletFilter", ServletFilter.class);
-        filterRegistration.addMappingForUrlPatterns(null, true, "/*");
-        filterRegistration.setAsyncSupported(true);
+	// happens when app id deployed
+	@Override
+	public void onStartup(Set<Class<?>> c, ServletContext sc) throws ServletException {
 
-    }
+		/*
+		 * Just prevent Servlet filter registration. This bundle starts from an
+		 * auto-feature. User's are not explicitly enabling this so lets not throw an
+		 * exception. We'll quietly get out of the way.
+		 */
+		if (!ProductInfo.getBetaEdition()) {
+			return;
+		}
+
+		FilterRegistration.Dynamic filterRegistration = sc.addFilter("io.openliberty.http.monitor.ServletFilter",
+				ServletFilter.class);
+		filterRegistration.addMappingForUrlPatterns(null, true, "/*");
+		filterRegistration.setAsyncSupported(true);
+
+	}
 }

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/ServletFilter.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/ServletFilter.java
@@ -215,7 +215,7 @@ public class ServletFilter implements Filter {
 							}
 						} else if ((pathInfo == null) && 
 								(webAppDispatcherContext40.getServletPathForMapping() != null) 
-								&& (!webAppDispatcherContext40.getServletPathForMapping().isBlank())){
+								&& (!webAppDispatcherContext40.getServletPathForMapping().isEmpty())){
 							
 							/*
 							 * PathInfo is null, httpServlet Mapping is null.

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/ServletFilter.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/ServletFilter.java
@@ -317,11 +317,6 @@ public class ServletFilter implements Filter {
 		httpStat.setNetworkProtocolVersion(networkVersion);
 	}
 	
-	/*
-	 * 
-	 * 
-	 */
-	
 	/**
 	 * Taken from WebApprrorReport.constructErrorReport()
 	 * Trimmed to remove unecessary servlet 30 if statement.

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/mbean/HttpStatsMXBean.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/mbean/HttpStatsMXBean.java
@@ -18,30 +18,40 @@ public interface HttpStatsMXBean {
 	 * HTTP Attributes
 	 */
 	
+	@Deprecated //As per beta-fencing guidelines //As per beta-fencing guidelines
 	public String getRequestMethod();
 	
+	@Deprecated //As per beta-fencing guidelines
 	public int getResponseStatus();
 	
+	@Deprecated //As per beta-fencing guidelines
 	public String getHttpRoute();
 	
+	@Deprecated //As per beta-fencing guidelines
 	public String getScheme();
 	
+	@Deprecated //As per beta-fencing guidelines
 	public String getNetworkProtocolName();
 	
+	@Deprecated //As per beta-fencing guidelines
 	public String getNetworkProtocolVersion();
 		
+	@Deprecated //As per beta-fencing guidelines
 	public String getServerName();
 	
+	@Deprecated //As per beta-fencing guidelines
 	public int getServerPort();
 	
+	@Deprecated //As per beta-fencing guidelines
 	public String getErrorType();
 	
 	/*
 	 * Metric values
 	 */
-	
+	@Deprecated //As per beta-fencing guidelines
 	public long getCount();
 	
+	@Deprecated //As per beta-fencing guidelines
 	public double getDuration();
     
 }

--- a/dev/io.openliberty.microprofile.metrics.internal.5.0_fat/build.gradle
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.0_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,11 @@ task copyPrometheus(type: Copy) {
   into new File(autoFvtDir, 'publish/shared/resources/prometheuslib/')
 }
 
+task copyHdrHistogramPrometheus(type: Copy) {
+  shouldRunAfter jar
+  from configurations.hdrHistogram
+  into new File(autoFvtDir, 'publish/shared/resources/prometheuslib/')
+}
 
 task copyHdrHistogramUseless(type: Copy) {
   shouldRunAfter jar
@@ -84,6 +89,7 @@ task copySimpleClient(type: Copy) {
  addRequiredLibraries {
   dependsOn copyMicrometerCore
   dependsOn copyPrometheus
+  dependsOn copyHdrHistogramPrometheus
   dependsOn copyHdrHistogramUseless
   dependsOn copySimpleClientCommon
   dependsOn copySimpleClientTracerCommon

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/build.gradle
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,11 @@ task copyPrometheus(type: Copy) {
   into new File(autoFvtDir, 'publish/shared/resources/prometheuslib/')
 }
 
+task copyHdrHistogramPrometheus(type: Copy) {
+  shouldRunAfter jar
+  from configurations.hdrHistogram
+  into new File(autoFvtDir, 'publish/shared/resources/prometheuslib/')
+}
 
 task copyHdrHistogramUseless(type: Copy) {
   shouldRunAfter jar
@@ -84,6 +89,7 @@ task copySimpleClient(type: Copy) {
  addRequiredLibraries {
   dependsOn copyMicrometerCore
   dependsOn copyPrometheus
+  dependsOn copyHdrHistogramPrometheus
   dependsOn copyHdrHistogramUseless
   dependsOn copySimpleClientCommon
   dependsOn copySimpleClientTracerCommon


### PR DESCRIPTION
#build

Fixes: #28514

https://github.com/OpenLiberty/open-liberty/pull/28455 Was reverted. This PR reintroduces those changes.

This PR also includes fix from : https://github.com/OpenLiberty/open-liberty/pull/28505 (comments from the original PR). This is in commit https://github.com/OpenLiberty/open-liberty/pull/28537/commits/563dff27d9145edf1f8392b1f154303fefcc9acc
 - Beta guard since auto features aren't beta-guarded 
 - The beta guards here just silently do nothing. Since it's an auto feature, users are not explicitly enabling this feature so it may be better to be silent and not execute any of the code.
 - Refactor auto-feature's required feature list 
 - Removed unnecessary string in bnd.bnd


This PR also includes an additional update in commit : https://github.com/OpenLiberty/open-liberty/commit/ae4bafb9f72d27736ec2fe4203418e587bdcdf22
- handles exceptions in the servlet filter to obtain the proper response code. This matches what is done in the webcontainer bundle. They do processing of the runtime exception after filters finish executing.


This PR also includes adding to the `singleton_expected.xml`  in commit https://github.com/OpenLiberty/open-liberty/commit/3c0d090fb42ea78424cf4eeba5145a2a59a566de (This was the reason why #28455 was reverted)

FATS WIP: https://github.com/OpenLiberty/open-liberty/pull/28565