### PR TITLE
Remove beta guard from Connectors Checkpoint FAT

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.checkpoint/jvm.options
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.checkpoint/jvm.options
@@ -4,7 +4,3 @@
 #-Dunsupported.action=servlet.init.create timer.async
 #-Dunsupported.action=servlet.init.submit.work
 #-Dunsupported.action=servlet.init.submit.work.async
-
-# Enable features jca-1.7, connectors-2.0, connectors-2.1 for InstantOn
-# TODO Remove at GA
--Dcom.ibm.ws.beta.edition=true


### PR DESCRIPTION
For epic issue https://github.com/OpenLiberty/open-liberty/issues/26039

Enable Connectors FAT checkpoint test server to run in normal rather than beta mode.