### PR TITLE
Fix Transaction FAT and messages regarding checkpoint phase

### DIFF
--- a/dev/com.ibm.tx.jta/resources/com/ibm/ws/Transaction/resources/TransactionMsgs.nlsprops
+++ b/dev/com.ibm.tx.jta/resources/com/ibm/ws/Transaction/resources/TransactionMsgs.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2002, 2023 IBM Corporation and others.
+# Copyright (c) 2002, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -876,7 +876,7 @@ WTRN0153_INVALID_LOG_AT_SHUTDOWN.useraction=Correct any conditions that are indi
 
 WTRN0154_ERROR_CHECKPOINT_NEW_TX=WTRN0154E: The server checkpoint request failed because the transaction service is unable to begin a transaction.
 WTRN0154_ERROR_CHECKPOINT_NEW_TX.explanation=Liberty does not support applications that begin or require a transaction while the application starts when a server checkpoint is requested.
-WTRN0154_ERROR_CHECKPOINT_NEW_TX.useraction=Use the server checkpoint at=deployment option or modify the application to begin transactions after it has started.
+WTRN0154_ERROR_CHECKPOINT_NEW_TX.useraction=Configure the checkpoint to occur before the application starts by using the beforeAppStart server checkpoint option or modify the application to begin transactions after it has started.
 
 # 0 - Stack trace of call to create new tx
 WTRN0155_CHECKPOINT_NEW_TX_STACK=WTRN0155W: An application began or required a transaction during the server checkpoint request. The following stack trace for this thread was captured when the transaction was created: {0}

--- a/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/ServletStartupTest.java
+++ b/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/ServletStartupTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -31,9 +31,9 @@ import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
+import componenttest.annotation.CheckpointTest;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.CheckpointTest;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.rules.repeater.JakartaEE10Action;
@@ -79,13 +79,13 @@ public class ServletStartupTest extends FATServletClient {
 
         testMethod = getTestMethod(TestMethod.class, testName);
         switch (testMethod) {
-            case testServletInitUserTranAtDeployment:
+            case testServletInitUserTranBAS:
                 server.restoreServerConfiguration();
                 ShrinkHelper.defaultApp(server, APP_NAME, new DeployOptions[] { DeployOptions.OVERWRITE }, "servlets.startup.*");
 
                 server.setCheckpoint(CheckpointPhase.BEFORE_APP_START, false, null);
                 break;
-            case testServletInitUserTranAtApplications:
+            case testServletInitUserTranAAS:
                 server.restoreServerConfiguration();
                 ShrinkHelper.defaultApp(server, APP_NAME, new DeployOptions[] { DeployOptions.OVERWRITE }, "servlets.startup.*");
 
@@ -103,11 +103,11 @@ public class ServletStartupTest extends FATServletClient {
     }
 
     @Test
-    public void testServletInitUserTranAtDeployment() throws Exception {
+    public void testServletInitUserTranBAS() throws Exception {
         // Request a server checkpoint
         server.startServer(getTestMethodNameOnly(testName) + ".log");
 
-        assertNull("The StartupServlet.init() method should not execute checkpoint at=deployment, but did.",
+        assertNull("The StartupServlet.init() method should not execute checkpoint at=beforeAppStart, but did.",
                    server.waitForStringInLogUsingMark("StartupServlet init starting", 1000));
 
         server.checkpointRestore();
@@ -118,7 +118,7 @@ public class ServletStartupTest extends FATServletClient {
 
     @Test
     @ExpectedFFDC("io.openliberty.checkpoint.internal.criu.CheckpointFailedException")
-    public void testServletInitUserTranAtApplications() throws Exception {
+    public void testServletInitUserTranAAS() throws Exception {
         // Request a server checkpoint
         ProgramOutput output = server.startServer(getTestMethodNameOnly(testName) + ".log");
         int returnCode = output.getReturnCode();
@@ -132,8 +132,8 @@ public class ServletStartupTest extends FATServletClient {
     }
 
     static enum TestMethod {
-        testServletInitUserTranAtApplications,
-        testServletInitUserTranAtDeployment,
+        testServletInitUserTranAAS,
+        testServletInitUserTranBAS,
         unknown;
     }
 }

--- a/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/TransactionalBeanTest.java
+++ b/dev/io.openliberty.checkpoint_fat_transaction/fat/src/io/openliberty/checkpoint/fat/TransactionalBeanTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -33,8 +33,8 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.ws.transactional.web.TransactionalBeanServlet;
 
-import componenttest.annotation.Server;
 import componenttest.annotation.CheckpointTest;
+import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
@@ -47,7 +47,7 @@ import io.openliberty.checkpoint.spi.CheckpointPhase;
 
 /**
  * Verify the server (CDI) maintains transaction boundaries for @Transactional managed
- * beans within servers restored after checkpoint at=applications.
+ * beans within servers restored after checkpoint at=afterAppStart.
  *
  * The jakarta.transaction.Transactional annotation provides the application the ability
  * to declaratively control transaction boundaries on CDI managed beans, as well as classes


### PR DESCRIPTION
- Improve the WTRN0154E useraction to specify the `beforeAppStart` option rather than `deployment`; and improve the phrasing to resemble new, similar Connectors messages.

- Modify Transaction Checkpoint FAT classes to use the appropriate phase options. 