### PR TITLE
Include all dependencies in archive expander jar.

### DIFF
--- a/dev/com.ibm.ws.filetransfer.routing.archiveExpander/bnd.bnd
+++ b/dev/com.ibm.ws.filetransfer.routing.archiveExpander/bnd.bnd
@@ -30,7 +30,7 @@ Private-Package: \
 Import-Package: \
  !org.apache.commons.compress.compressors.lzw, \
  !org.apache.commons.compress, \
- !org.apache.commons.compress.parallel, 
+ !org.apache.commons.compress.parallel, \
  !org.apache.commons.io.file, *
 
 -includeresource: \

--- a/dev/com.ibm.ws.filetransfer.routing.archiveExpander/bnd.bnd
+++ b/dev/com.ibm.ws.filetransfer.routing.archiveExpander/bnd.bnd
@@ -30,9 +30,26 @@ Private-Package: \
 Import-Package: \
  !org.apache.commons.compress.compressors.lzw, \
  !org.apache.commons.compress, \
- !org.apache.commons.compress.parallel, *
+ !org.apache.commons.compress.parallel, 
+ !org.apache.commons.io.file, *
 
 -includeresource: \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/input/NullInputStream*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/NullOutputStream*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/NullWriter*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/QueueOutputStream*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/ThresholdingOutputStream*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/ByteArrayOutputStream*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/AbstractByteArrayOutputStream*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/StringBuilderWriter*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/AppendableWriter*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/UnsynchronizedByteArrayOutputStream*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/input/BoundedInputStream*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/Charsets*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/IOUtils*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/CloseableURLConnection*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/StandardLineSeparator*, \
+ @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/function/IOTriFunction*, \
  @${repo;com.ibm.ws.org.apache.commons.compress}!/org/apache/commons/compress/archivers/ArchiveEntry*, \
  @${repo;com.ibm.ws.org.apache.commons.compress}!/org/apache/commons/compress/archivers/ArchiveInputStream*, \
  @${repo;com.ibm.ws.org.apache.commons.compress}!/org/apache/commons/compress/compressors/bzip2/BZip2CompressorInputStream*, \


### PR DESCRIPTION
Although archive expander is a bundle, it also runs as a standalone executable jar as part of collectives file transfer. Hence it needs to include all dependencies, including the recently added commons.io dependencies caused by the upgrade to commons.compress 1.26

This is the fix for bug #28552


