### PR TITLE
Initialize Derby before concurrent access in FAT

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-bundles/userFeature/src/test/concurrent/persistent/feature/TaskStoreTester.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-bundles/userFeature/src/test/concurrent/persistent/feature/TaskStoreTester.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -82,6 +82,9 @@ public class TaskStoreTester implements ResourceFactory {
     	record.setHostName("host1");
     	record.setLibertyServer("libertyServer1");
     	record.setUserDir("C:/myFolder");
+
+    	// Warm up Derby; Derby has issues if first access is from concurrent threads
+    	System.out.println("initial find = " + taskStore.find(record));
 
     	Callable<Long> findOrCreate = new Callable<Long>() {
     		public Long call() throws Exception {


### PR DESCRIPTION
Derby has issues if the first access is from concurrent threads, so update FAT to access derby first from one thread before attempting concurrent access.
