### PR TITLE
Audit-2.0 to go for beta release

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.audit2.0.restHandler.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.audit2.0.restHandler.feature
@@ -10,5 +10,5 @@ IBM-Install-Policy: when-satisfied
 
 -bundles=io.openliberty.request.probe.audit.rest
 WLP-Activation-Type: parallel
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.auditCollector-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.auditCollector-2.0.feature
@@ -9,6 +9,6 @@ IBM-Process-Types: server
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1", \
   io.openliberty.auditCollector1.0.internal.ee-6.0; ibm.tolerates:="9.0"
 
-kind=noship
-edition=full
+kind=beta
+edition=core
 

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/audit-2.0/com.ibm.websphere.appserver.audit-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/audit-2.0/com.ibm.websphere.appserver.audit-2.0.feature
@@ -9,6 +9,6 @@ Subsystem-Name: Audit 2.0
   com.ibm.websphere.appserver.auditCollector-2.0
 -bundles=com.ibm.ws.security.audit.utils, \
   com.ibm.ws.security.audit.file
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-InstantOn-Enabled: true


### PR DESCRIPTION
We want to move the audit-2.0 for beta release. This change does that.

#27475