### PR TITLE
Fix memory leak in JAXRSClientConfigHolder

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/clientconfig/JAXRSClientConfigHolder.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/clientconfig/JAXRSClientConfigHolder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ package com.ibm.ws.jaxrs20.clientconfig;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -39,7 +40,11 @@ public class JAXRSClientConfigHolder {
 
     // a cached map of search results
     // that have been processed to look up the best match for the uri strings
-    private static volatile Map<String, Map<String, String>> resolvedConfigInfo = new HashMap<>();
+    private static volatile Map<String, Map<String, String>> resolvedConfigInfo = new LinkedHashMap<String, Map<String, String>>(500,0.75f,true) {
+        protected boolean removeEldestEntry(Map.Entry<String, Map<String, String>> eldest) {
+            return true;
+        }
+    };
 
     private static boolean wildcardsPresentInConfigInfo = false;
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/src/com/ibm/ws/jaxrs21/clientconfig/JAXRSClientConfigHolder.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/src/com/ibm/ws/jaxrs21/clientconfig/JAXRSClientConfigHolder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ package com.ibm.ws.jaxrs21.clientconfig;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -39,7 +40,11 @@ public class JAXRSClientConfigHolder {
 
     // a cached map of search results
     // that have been processed to look up the best match for the uri strings
-    private static volatile Map<String, Map<String, String>> resolvedConfigInfo = new HashMap<>();
+    private static volatile Map<String, Map<String, String>> resolvedConfigInfo = new LinkedHashMap<String, Map<String, String>>(500,0.75f,true) {
+        protected boolean removeEldestEntry(Map.Entry<String, Map<String, String>> eldest) {
+            return true;
+        }
+    };
 
     private static boolean wildcardsPresentInConfigInfo = false;
 


### PR DESCRIPTION
Fixes #28877 
Fixes #PH61509
Change to LinkedHashMap in JAXRSClientConfigHolder to avoid memory leak.

Information from case:

> Customer's production system have server (WAS FOR Z/OS 23.0.0.3, z/OS Connect 03.00.69/wlp-1.0.75.cl230320230319-1900) for data query. They found the abnormal GCP usage rate due to ZCEE and the message JVMDUMP039I JVM out of memory.

APAR PH61509

