### PR TITLE
Fix Jakarta Data checkpoint tests for DB Rotation

### DIFF
--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -56,8 +56,6 @@ public class DataTest extends FATServletClient {
         // Get driver type
         DatabaseContainerType type = DatabaseContainerType.valueOf(testContainer);
         server.addEnvVar("DB_DRIVER", type.getDriverName());
-        server.addEnvVar("DB_USER", testContainer.getUsername());
-        server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
 
         // Set up server DataSource properties
         DatabaseContainerUtil.setupDataSourceDatabaseProperties(server, testContainer);

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.checkpoint.fat/server.env
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.checkpoint.fat/server.env
@@ -1,0 +1,1 @@
+# Placeholder for server environment variables after checkpoint

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.checkpoint.fat/server.xml
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.checkpoint.fat/server.xml
@@ -47,7 +47,11 @@
   </dataSource>
 
   <library id="JDBCLibrary">
-    <fileset dir="${shared.resource.dir}/jdbc" includes="derby.jar"/>
+    <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
   </library>
+
+  <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codeBase="${server.config.dir}/apps/ProviderTestApp.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+  <javaPermission codeBase="${server.config.dir}/apps/ProviderTestApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
 
 </server>

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATestCheckpoint.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATestCheckpoint.java
@@ -12,6 +12,13 @@
  *******************************************************************************/
 package test.jakarta.data.jpa;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -48,21 +55,35 @@ public class DataJPATestCheckpoint extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        // Get driver type
-        DatabaseContainerType type = DatabaseContainerType.valueOf(testContainer);
-        server.addEnvVar("DB_DRIVER", type.getDriverName());
-
         // Set up server DataSource properties
-        DatabaseContainerUtil.setupDataSourceDatabaseProperties(server, testContainer);
+        DatabaseContainerUtil.setupDataSourcePropertiesForCheckpoint(server, testContainer);
 
         WebArchive war = ShrinkHelper.buildDefaultApp("DataJPATestApp", "test.jakarta.data.jpa.web");
         ShrinkHelper.exportAppToServer(server, war);
-        server.setCheckpoint(CheckpointPhase.AFTER_APP_START, true, null);
+
+        configureEnvVariable(server, Collections.singletonMap("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName()));
+
+        server.setCheckpoint(CheckpointPhase.AFTER_APP_START, false, null);
         server.startServer();
+
+        //Server started, application started, checkpoint taken, server is now stopped.
+        //Configure environment variable used by servlet
+        configureEnvVariable(server, Collections.singletonMap("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName()));
+
+        server.checkpointRestore();
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer();
+    }
+
+    static void configureEnvVariable(LibertyServer server, Map<String, String> newEnv) throws Exception {
+        Properties serverEnvProperties = new Properties();
+        serverEnvProperties.putAll(newEnv);
+        File serverEnvFile = new File(server.getFileFromLibertyServerRoot("server.env").getAbsolutePath());
+        try (OutputStream out = new FileOutputStream(serverEnvFile)) {
+            serverEnvProperties.store(out, "");
+        }
     }
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.checkpoint.fat.jpa/server.env
+++ b/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.checkpoint.fat.jpa/server.env
@@ -1,0 +1,1 @@
+# Placeholder for server environment variables after checkpoint

--- a/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.checkpoint.fat.jpa/server.xml
+++ b/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.checkpoint.fat.jpa/server.xml
@@ -49,7 +49,9 @@
   </dataSource>
 
   <library id="JDBCLibrary">
-    <fileset dir="${shared.resource.dir}/jdbc" includes="derby.jar"/>
+    <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
   </library>
+
+  <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 
 </server>


### PR DESCRIPTION
Fixes defect where the following errors occurs during server startup: 

```txt
java.lang.RuntimeException: java.sql.SQLNonTransientException: DSRA4000E: No implementations of org.postgresql.xa.PGXADataSource are found for dataSource[DefaultDataSource] with library JDBCLibrary. The name or location of JDBC driver JAR files might be incorrect or inaccessible. Searched in: [/home/ci/Build/workspace/ebcTestRunner/dev/autoFVT/image/output/wlp/usr/shared/resources/jdbc/derby.jar]. Searched under packages: [org.postgresql.xa].
```

The server.xml needs to be updated to use the JDBC Driver for the Database being used during the build.
Also added the extra permissions to avoid future failures. 

