### PR TITLE
Update JSON B/P TCKs to not run on Java 23

### DIFF
--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/fat/src/io/openliberty/jakarta/jsonb/tck/JsonbTckLauncher.java
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/fat/src/io/openliberty/jakarta/jsonb/tck/JsonbTckLauncher.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -39,6 +40,7 @@ import componenttest.topology.utils.tck.TCKRunner;
  */
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 11)
+@MaximumJavaLevel(javaLevel = 21) //Fails on Java 23 due to updates to CLDR https://jdk.java.net/23/release-notes#JDK-8319990
 public class JsonbTckLauncher {
 
     final static Map<String, String> additionalProps = new HashMap<>();

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/fat/src/io/openliberty/jakarta/jsonp/tck/JsonpTckLauncher.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/fat/src/io/openliberty/jakarta/jsonp/tck/JsonpTckLauncher.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -38,6 +39,7 @@ import componenttest.topology.utils.tck.TCKRunner;
  */
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 11)
+@MaximumJavaLevel(javaLevel = 21) //Possibility to fail on Java 23 due to CLDR updates https://jdk.java.net/23/release-notes#JDK-8319990
 public class JsonpTckLauncher {
 
     //This is a standalone test no server needed


### PR DESCRIPTION
JSON Binding and Processing TCKs were written only to run on Java 11 -> 21.
Via internal testing it seems the JSON Binding TCK fails on Java 21 due to changes in non-break spaces in unicode.

```txt
Failed to correctly customize number format during marshalling using JsonbNumberFormat annotation on field.
Expected: a string matching the pattern '\{\s*"instance"\s*:\s*"123\u00a0456,789"\s*\}'
     but: was "{\"instance\":\"123 456,789\"}"
    at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
    at ee.jakarta.tck.json.bind.customizedmapping.numberformat.NumberFormatCustomizationTest.testNumberFormatField(NumberFormatCustomizationTest.java:112)
```

The JSON Binding / Processing TCKs should be updated for Jakarta EE 12 to support Java 21 -> 27

