### PR TITLE
Add Telemetry logging exporter provider for metrics

### DIFF
--- a/dev/io.openliberty.io.opentelemetry.2.0/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider
+++ b/dev/io.openliberty.io.opentelemetry.2.0/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider
@@ -1,1 +1,2 @@
 io.opentelemetry.exporter.otlp.internal.OtlpMetricExporterProvider
+io.opentelemetry.exporter.logging.internal.LoggingMetricExporterProvider


### PR DESCRIPTION
Allows opentelemetry to export metrics to the console for debugging and testing purposes