### PR TITLE
Remove CVE Reporting bundle from Kernel manifest

### DIFF
--- a/dev/com.ibm.ws.kernel.boot/publish/platform/kernelCore-1.0.mf
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/kernelCore-1.0.mf
@@ -24,7 +24,6 @@ Subsystem-Content: org.eclipse.osgi; version="[3.10, 4)"; type="boot.jar",
  com.ibm.ws.org.apache.aries.jmx.core.whiteboard; version="[1.0, 1.1)"; start-phase:="KERNEL_LATE",
  com.ibm.ws.org.apache.aries.jmx.api; version="[1.0, 1.1)"; start-phase:="KERNEL_LATE",
  com.ibm.ws.kernel.feature; version="[1.0, 1.1)"; start-phase:="FEATURE_PREPARE",
- io.openliberty.reporting.internal; version="[1.0, 1.1)"; start-phase:="FEATURE_PREPARE",
  io.openliberty.checkpoint; version="[1.0, 1.1)"; start-phase:="FEATURE_PREPARE"
 WebSphere-SystemBundleProvider: true
 IBM-API-Package: com.ibm.websphere.config.mbeans; type="ibm-api",

--- a/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/FATSuite.java
@@ -10,13 +10,18 @@
 
 package io.openliberty.reporting.internal.fat;
 
+import componenttest.custom.junit.runner.AlwaysPassesTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({ CVEReportingConfigTest.class, CVEDataTest.class, CVEResponseTest.class,
-        CVEReportingCheckpointTest.class })
+@SuiteClasses({ AlwaysPassesTest.class,
+//        CVEReportingConfigTest.class,
+//        CVEDataTest.class,
+//        CVEResponseTest.class,
+//        CVEReportingCheckpointTest.class
+})
 public class FATSuite {
 
 }


### PR DESCRIPTION
A Fat must contain at least one test otherwise is considered impossible, so AlwaysPassesTest allows for all the real tests to be disabled without causing other build issues

