### PR TITLE
Include OpenJCE Plus in Path

### DIFF
--- a/dev/cnf/resources/bin/tool
+++ b/dev/cnf/resources/bin/tool
@@ -275,17 +275,26 @@ if [ -n "$defaultFileEncoding" ]; then
 fi
 
 if [ -z "${JAVA_HOME}" ]; then
+  # JAVA_HOME not set.  Locate java using the PATH.
   JAVA_PATH_FROM_PATH=$(command -v java)
   if [ -n "${JAVA_PATH_FROM_PATH}" ] ; then
-    JPMS_MODULE_FILE_LOCATION=$(dirname $(dirname $JAVA_PATH_FROM_PATH))/lib/modules
+    JPMS_MODULE_FILE_LOCATION=$(dirname "$(dirname "${JAVA_PATH_FROM_PATH}")")/lib/modules
+    JMODS_FILE_LOCATION=$(dirname "$(dirname "${JAVA_PATH_FROM_PATH}")")/jmods
   fi
 else
   JPMS_MODULE_FILE_LOCATION="${JAVA_HOME}/lib/modules"
+  JMODS_FILE_LOCATION="${JAVA_HOME}/jmods"
 fi
 
 # If this is a Java 9 JDK, add some JDK 9 workarounds to the JVM_ARGS
 if [ -f "${JPMS_MODULE_FILE_LOCATION}" ]; then
   JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/sun.security.action=ALL-UNNAMED ${JVM_ARGS}"
+
+  if [ -d "${JMODS_FILE_LOCATION}" ]; then
+    if [ -f "${JMODS_FILE_LOCATION}/openjceplus.jmod" ]; then
+      JVM_ARGS="--add-exports openjceplus/com.ibm.misc=ALL-UNNAMED ${JVM_ARGS}"
+    fi
+  fi
 fi
 
 # Prevent the Java invocation appearing as an application on a mac

--- a/dev/cnf/resources/bin/tool.bat
+++ b/dev/cnf/resources/bin/tool.bat
@@ -55,6 +55,8 @@ if NOT defined JAVA_HOME (
 
 @REM If this is a Java 9 JDK, add some JDK 9 workarounds to the JVM_ARGS
 if exist "%JAVA_HOME%\lib\modules" set JVM_ARGS=--add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/sun.security.action=ALL-UNNAMED !JVM_ARGS!
+@REM If this is a Java 17 JDK, add some JDK 9 workarounds to the JVM_ARGS
+if exist "%JAVA_HOME%\jmods\openjceplus.jmod" set JVM_ARGS=--add-exports openjceplus/com.ibm.misc=ALL-UNNAMED !JVM_ARGS!
 
 set JVM_ARGS=-Djava.awt.headless=true !JVM_ARGS!
 set TOOL_JAVA_CMD_QUOTED=!JAVA_CMD_QUOTED! !JVM_ARGS! -jar "!WLP_INSTALL_DIR!\bin\@TOOL_JAR@"


### PR DESCRIPTION
Starting in JDK 17.0.0.10 we need to include the openjceplus module in the script paths.
