### PR TITLE
Change io.openliberty.mpTelemetry-2.0.feature to beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.mpTelemetry2.0.ee-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.mpTelemetry2.0.ee-10.0.feature
@@ -13,6 +13,6 @@ singleton=true
   io.openliberty.microprofile.telemetry.2.0.internal.jakarta,\
   io.openliberty.io.opentelemetry.2.0.jakarta,\
   io.openliberty.microprofile.telemetry.internal.common.jakarta
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel 

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.mpTelemetry2.0.ee-7.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.mpTelemetry2.0.ee-7.0.feature
@@ -13,6 +13,6 @@ singleton=true
   io.openliberty.microprofile.telemetry.2.0.internal, \
   io.openliberty.io.opentelemetry.2.0, \
   io.openliberty.microprofile.telemetry.internal.common
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel 

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.mpTelemetry2.0.ee-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.mpTelemetry2.0.ee-8.0.feature
@@ -13,6 +13,6 @@ singleton=true
   io.openliberty.microprofile.telemetry.2.0.internal, \
   io.openliberty.io.opentelemetry.2.0, \
   io.openliberty.microprofile.telemetry.internal.common
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel 

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.mpTelemetry2.0.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.mpTelemetry2.0.ee-9.0.feature
@@ -13,6 +13,6 @@ singleton=true
   io.openliberty.microprofile.telemetry.2.0.internal.jakarta,\
   io.openliberty.io.opentelemetry.2.0.jakarta,\
   io.openliberty.microprofile.telemetry.internal.common.jakarta
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel 

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-2.0/io.openliberty.mpTelemetry-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-2.0/io.openliberty.mpTelemetry-2.0.feature
@@ -40,7 +40,7 @@ IBM-API-Package: \
   io.openliberty.org.jetbrains.annotation,\
   io.openliberty.io.zipkin.zipkin2.2.0
 -jars=io.openliberty.mpTelemetry.2.0.thirdparty; location:="dev/api/third-party/,lib/"
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true


### PR DESCRIPTION
Removes the noship flag for the mpTelemetry 2.0 feature and changes it to beta. 

Fixes #28591 
