### PR TITLE
jsfContainer Failing FAT Tests Changed from HTMLUnit to Selenium

### DIFF
--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23CDIGeneralTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23CDIGeneralTests.java
@@ -514,8 +514,14 @@ public class JSF23CDIGeneralTests {
         input.sendKeys("Hello World");
 
         page.findElement(By.id("form1:submitButton")).click();
+
+        // Dismiss alert that is used in testFacesBehaviorBeanInjection as it prevents Selenium from reading page
         driver.switchTo().alert().dismiss();
+
         page.waitForCondition(webDriver -> page.isInPage("Hello Earth"));
+
+        // Log the page for debugging if necessary in the future.
+        Log.info(c, name.getMethodName(), driver.getPageTextReduced());
 
         assertTrue(page.isInPage("Hello Earth"));
     }
@@ -546,6 +552,7 @@ public class JSF23CDIGeneralTests {
 
         page.findElement(By.id("form1:submitButton")).click();
 
+        // Dismiss alert that is used in testFacesBehaviorBeanInjection as it prevents Selenium from reading page
         driver.switchTo().alert().dismiss();
 
         // Log the page for debugging if necessary in the future.

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/bnd.bnd
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2022 IBM Corporation and others.
+# Copyright (c) 2018, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -57,7 +57,7 @@ src: \
 fat.project: true
 
 -buildpath: \
-  com.google.guava:guava;version=latest,\
+	com.google.guava:guava;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
@@ -70,10 +70,10 @@ fat.project: true
 	io.openliberty.org.apache.commons.logging;version=latest,\
 	io.openliberty.org.apache.commons.codec;version=latest,\
 	net.sourceforge.htmlunit:htmlunit;version=2.20,\
-  io.openliberty.org.testcontainers;version=latest,\
-  org.seleniumhq.selenium:selenium-api;version=4.8.3,\
-  org.seleniumhq.selenium:selenium-chrome-driver;version=4.8.3,\
-  org.seleniumhq.selenium:selenium-chromium-driver;version=4.8.3,\
-  org.seleniumhq.selenium:selenium-remote-driver;version=4.8.3,\
-  org.seleniumhq.selenium:selenium-support;version=4.8.3,\
+	io.openliberty.org.testcontainers;version=latest,\
+	org.seleniumhq.selenium:selenium-api;version=4.8.3,\
+	org.seleniumhq.selenium:selenium-chrome-driver;version=4.8.3,\
+	org.seleniumhq.selenium:selenium-chromium-driver;version=4.8.3,\
+	org.seleniumhq.selenium:selenium-remote-driver;version=4.8.3,\
+	org.seleniumhq.selenium:selenium-support;version=4.8.3,\
 	xml-apis:xml-apis;version=1.4.01

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/bnd.bnd
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/bnd.bnd
@@ -15,6 +15,11 @@ bVersion=1.0
 
 quietTransformer=true
 
+fat.test.container.images:\
+    seleniarm/standalone-chromium:4.8.3,\
+    selenium/standalone-chrome:4.8.3,\
+    alpine:3.16
+
 tested.features: \
   enterprisebeanslite-4.0, \
   enterprisebeanslite-5.0, \
@@ -52,6 +57,7 @@ src: \
 fat.project: true
 
 -buildpath: \
+  com.google.guava:guava;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
@@ -64,4 +70,10 @@ fat.project: true
 	io.openliberty.org.apache.commons.logging;version=latest,\
 	io.openliberty.org.apache.commons.codec;version=latest,\
 	net.sourceforge.htmlunit:htmlunit;version=2.20,\
+  io.openliberty.org.testcontainers;version=latest,\
+  org.seleniumhq.selenium:selenium-api;version=4.8.3,\
+  org.seleniumhq.selenium:selenium-chrome-driver;version=4.8.3,\
+  org.seleniumhq.selenium:selenium-chromium-driver;version=4.8.3,\
+  org.seleniumhq.selenium:selenium-remote-driver;version=4.8.3,\
+  org.seleniumhq.selenium:selenium-support;version=4.8.3,\
 	xml-apis:xml-apis;version=1.4.01

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/build.gradle
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/build.gradle
@@ -21,7 +21,11 @@ configurations {
     myfaces40
 }
 
+apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
+
 dependencies {
+    requiredLibs 'org.seleniumhq.selenium:selenium-java:4.8.3'
+    requiredLibs 'com.google.guava:guava:32.0.1-jre'
     requiredLibs 'net.sourceforge.cssparser:cssparser:0.9.23'
     requiredLibs 'net.sourceforge.htmlunit:htmlunit:2.20'
     requiredLibs 'net.sourceforge.htmlunit:htmlunit-core-js:2.17'
@@ -94,8 +98,8 @@ dependencies {
       'org.apache.myfaces.core:myfaces-impl:3.0.2'
     mojarra40 'org.glassfish:jakarta.faces:4.0.0'
     // Do not update since newer JS (in MyFaces 4.0.0-RC5+) is not supported 
-    myfaces40 'org.apache.myfaces.core:myfaces-api:4.0.0-RC4',
-      'org.apache.myfaces.core:myfaces-impl:4.0.0-RC4'
+    myfaces40 'org.apache.myfaces.core:myfaces-api:4.0.1',
+      'org.apache.myfaces.core:myfaces-impl:4.0.1'
     }
 
 task addMojarra(type: Copy) {

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/build.gradle
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -152,4 +152,5 @@ addRequiredLibraries {
     dependsOn addMyFacesLibs
     dependsOn copyPermissionFile
     dependsOn addJakartaTransformer
+    dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
@@ -18,6 +18,7 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+import org.testcontainers.utility.DockerImageName;
 
 import com.ibm.ws.fat.util.FatLogHandler;
 import com.ibm.ws.jsf.container.fat.tests.CDIFlowsTests;
@@ -30,6 +31,7 @@ import com.ibm.ws.jsf.container.fat.tests.JSF23CDIGeneralTests;
 import com.ibm.ws.jsf.container.fat.tests.JSF23WebSocketTests;
 import com.ibm.ws.jsf.container.fat.tests.JSFContainerTest;
 
+import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
@@ -80,10 +82,18 @@ public class FATSuite {
     public static final String MOJARRA_API_IMP_40 = "publish/files/mojarra40/jakarta.faces-4.0.0.jar";
     public static final String MYFACES_API = "publish/files/myfaces/myfaces-api-2.3.10.jar";
     public static final String MYFACES_IMP = "publish/files/myfaces/myfaces-impl-2.3.10.jar";
-    public static final String MYFACES_IMP_40 = "publish/files/myfaces40//myfaces-impl-4.0.0-RC4.jar";
+    public static final String MYFACES_IMP_40 = "publish/files/myfaces40//myfaces-impl-4.0.1.jar";
     // For ErrorPathsTest#testBadImplVersion_MyFaces Test (apps need the correct api since the tests checks for a bad implementation)
     public static final String MYFACES_API_30 = "publish/files/myfaces30/myfaces-api-3.0.2.jar";
-    public static final String MYFACES_API_40 = "publish/files/myfaces40/myfaces-api-4.0.0-RC4.jar";
+    public static final String MYFACES_API_40 = "publish/files/myfaces40/myfaces-api-4.0.1.jar";
+
+    public static DockerImageName getChromeImage() {
+        if (FATRunner.ARM_ARCHITECTURE) {
+            return DockerImageName.parse("seleniarm/standalone-chromium:4.8.3").asCompatibleSubstituteFor("selenium/standalone-chrome");
+        } else {
+            return DockerImageName.parse("selenium/standalone-chrome:4.8.3");
+        }
+    }
 
     public static WebArchive addMojarra(WebArchive app) throws Exception {
         if (JakartaEEAction.isEE10OrLaterActive()) {

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
@@ -52,7 +52,7 @@ import componenttest.topology.impl.JavaInfo;
                 JSF23WebSocketTests.class
 })
 
-public class FATSuite {
+public class FATSuite extends TestContainerSuite {
 
     @ClassRule
     public static RepeatTests repeat;

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/selenium_util/CustomDriver.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/selenium_util/CustomDriver.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package com.ibm.ws.jsf23.fat.selenium_util;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+/**
+*  Used in conjunction with WebPage to behave similarly as HTMLUnit's HtmlPage
+* 
+* Copied over from ChromeDevtoolsDriver 
+* - https://github.com/jakartaee/faces/blob/1d71aae51f7d5ae684a3f43db0521b7e7e6aa4f6/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ChromeDevtoolsDriver.java
+* Modified because chrome dev tools is unavailable via Test Containers 
+* - Created https://github.com/testcontainers/testcontainers-java/issues/7242 requesting chrome dev tool support 
+* 
+*/
+public class CustomDriver implements ExtendedWebDriver {
+
+    RemoteWebDriver driver;
+
+    public CustomDriver(RemoteWebDriver driver){
+        this.driver = driver;
+    }
+
+    public RemoteWebDriver getRemoteWebDriver(){
+        return this.driver;
+    }
+
+    @Override
+    public String getPageText() {
+        String head = this.driver.findElement(By.tagName("head")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
+        String body = this.driver.findElement(By.tagName("body")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
+        return head + " " + body;
+    }
+
+    @Override
+    public String getPageTextReduced() {
+        String head = this.driver.findElement(By.tagName("head")).getAttribute("innerText");
+        String body = this.driver.findElement(By.tagName("body")).getAttribute("innerText");
+        // handle blanks and nbsps
+        return (head + " " + body).replaceAll("[\\s\\u00A0]+", " ");
+    }
+
+    @Override
+    public WebDriver.Options manage() {
+        return driver.manage();
+    }
+
+    @Override
+    public WebDriver.Navigation navigate() {
+        return driver.navigate();
+    }
+    
+    public Set<String> getWindowHandles() {
+        return driver.getWindowHandles();
+    }
+
+    public String getWindowHandle() {
+        return driver.getWindowHandle();
+    }
+
+    public WebDriver.TargetLocator switchTo() {
+        return driver.switchTo();
+    }
+
+    public void close() {
+        driver.close();
+    }
+
+    public void quit() {
+        driver.quit();
+    }
+
+    public void get(String url) {
+        driver.get(url);
+    }
+
+    public String getCurrentUrl() {
+        return driver.getCurrentUrl();
+    }
+
+    public String getTitle() {
+        return driver.getTitle();
+    }
+
+    public String getPageSource() {
+        return driver.getPageSource();
+    }
+
+
+    public WebElement findElement(By by) {
+        return driver.findElement(by);
+    }
+
+    public List<WebElement> findElements(By by) {
+        return driver.findElements(by);
+    }
+
+}

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/selenium_util/ExtendedWebDriver.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/selenium_util/ExtendedWebDriver.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package com.ibm.ws.jsf23.fat.selenium_util;
+
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+/**
+ * an extended web driver interface which takes the response into consideration
+ * selenium does not have an official api but several webdrivers
+ * allow access to the data via various means
+ *
+ * Another possibility would have been a proxy, but I could not find any properly
+ * working proxy for selenium
+ * 
+ * Copied and Modified from https://github.com/jakartaee/faces/blob/1d71aae51f7d5ae684a3f43db0521b7e7e6aa4f6/tck/util/src/main/java/ee/jakarta/tck/faces/test/util/selenium/ExtendedWebDriver.java
+ */
+public interface ExtendedWebDriver extends WebDriver {
+
+    /**
+     * @return the innerText of the Page
+     */
+    String getPageText();
+
+    /**
+     * returns the innerText of the page in a blank reduced state (more than one blank is reduced to one
+     * invisible blanks like nbsp are replaced by normal blanks)
+     * @return 
+     */
+    String getPageTextReduced();
+
+    /*
+     * Return the wrapped remote web driver
+     */
+    RemoteWebDriver getRemoteWebDriver();
+
+
+}

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/selenium_util/WebPage.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/selenium_util/WebPage.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package com.ibm.ws.jsf23.fat.selenium_util;
+
+import org.openqa.selenium.*;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Mimics the html unit webpage
+ * Modified from original source as Chrome Dev Tools are not accessible when used with TestContainers
+ * See issue https://github.com/testcontainers/testcontainers-java/issues/7242
+ */
+public class WebPage {
+
+    public static final Duration STD_TIMEOUT = Duration.ofMillis(8000);
+    public static final Duration LONG_TIMEOUT = Duration.ofMillis(16000);
+
+    protected ExtendedWebDriver webDriver;
+
+    public WebPage(ExtendedWebDriver webDriver) {
+        this.webDriver = webDriver;
+    }
+
+    public WebDriver getWebDriver() {
+        return (WebDriver) webDriver;
+    }
+
+    public void setWebDriver(ExtendedWebDriver webDriver) {
+        this.webDriver = webDriver;
+    }
+
+    public void get(String url) {
+        webDriver.get(url);
+    }
+
+    public String getTitle() {
+        return webDriver.getTitle();
+    }
+
+    /**
+     * waits for a certain condition is met, until a timeout is hit. In case of exceeding the condition, a runtime exception
+     * is thrown!
+     *
+     * @param isTrue the condition lambda to check
+     * @param timeout timeout duration
+     */
+    public <V> void waitForCondition(Function<? super WebDriver, V> isTrue, Duration timeout) {
+        synchronized (webDriver) {
+            WebDriverWait wait = new WebDriverWait(webDriver, timeout);
+            wait.until(isTrue);
+        }
+    }
+
+    /**
+     * The same as before, but with the long default timeout of LONG_TIMEOUT (16000ms)
+     *
+     * @param isTrue condition lambda
+     */
+    public <V> void waitForCondition(Function<? super WebDriver, V> isTrue) {
+        synchronized (webDriver) {
+            WebDriverWait wait = new WebDriverWait(webDriver, LONG_TIMEOUT);
+            wait.until(isTrue);
+        }
+    }
+
+    /**
+     * Wait for a certain period of time
+     *
+     * @param timeout the timeout to wait (note due to the asynchronous nature of the web drivers, any code running on the
+     * browser itself will proceed (aka javascript) only the client operations are stalled.
+     */
+    public void wait(Duration timeout) {
+        synchronized (webDriver) {
+            try {
+                webDriver.wait(timeout.toMillis());
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * wait until the current Ajax request targeting the same page has stopped and then tests for blocking running scripts
+     * still running. A small initial delay cannot hurt either
+     */
+    public void waitReqJs() {
+        this.wait(STD_TIMEOUT);
+    }
+
+    /**
+     * waits for backgrounds processes on the browser to complete
+     *
+     * @param timeOut the timeout duration until the wait can proceed before being interupopted
+     */
+    public void waitForPageToLoad(Duration timeOut) {
+        ExpectedCondition<Boolean> expectation =
+            driver -> webDriver.getRemoteWebDriver().executeScript("return document.readyState")
+                               .equals("complete");
+
+        synchronized (webDriver) {
+            WebDriverWait wait = new WebDriverWait(webDriver, timeOut);
+            wait.until(expectation);
+        }
+    }
+
+        /**
+     * wait until the page load is finished
+     */
+    public void waitForPageToLoad() {
+        waitForPageToLoad(STD_TIMEOUT);
+    }
+
+    /**
+     * conditional waiter and checker which checks whether the page text is present we add our own waiter internally,
+     * because pageSource always delivers
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isInPageText(String text) {
+        try {
+            // values are not returned by getPageText
+            String values = getInputValues();
+
+            waitForCondition(webDriver1 -> (webDriver.getPageText() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    public boolean isInPageTextReduced(String text) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> (webDriver.getPageTextReduced() + values.replaceAll("\\s+", " ")).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    public boolean matchesPageText(String regexp) {
+        try {
+            waitForCondition(webDriver1 -> webDriver.getPageText().matches(regexp), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * adds the reduced page text functionality to the regexp match
+     *
+     * @param regexp
+     * @return
+     */
+    public boolean matchesPageTextReduced(String regexp) {
+        try {
+            waitForCondition(webDriver1 -> webDriver.getPageTextReduced().matches(regexp), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is not in the page we add our own waiter internally,
+     * because pageSource always delivers
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isNotInPageText(String text) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> !(webDriver.getPageText() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is in the page we add our own waiter internally, because
+     * pageSource always delivers this version of isInPage checks explicitly the full markup not only the text
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isInPage(String text) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> (webDriver.getPageSource() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is not in the page we add our own waiter internally,
+     * because pageSource always delivers we need to add two different condition checkers herte because a timeout
+     * automatically throws internally an error which is mapped to false We therefore cannot simply wait for the condition
+     * either being met or timeout with one method
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isNotInPage(String text) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> !(webDriver.getPageSource() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException ex) {
+            // timeout is wanted in this case and should result in a false
+            return false;
+        }
+    }
+
+    /**
+     * conditional waiter and checker which checks whether a text is in the page we add our own waiter internally, because
+     * pageSource always delivers we need to add two different condition checkers herte because a timeout automatically
+     * throws internally an error which is mapped to false We therefore cannot simply wait for the condition either being
+     * met or timeout with one method
+     *
+     * @param text to check
+     * @return true in case of found false in case of found after our standard timeout is reached
+     */
+    public boolean isInPage(String text, boolean allowExceptions) {
+        try {
+            String values = getInputValues();
+            waitForCondition(webDriver1 -> (webDriver.getPageSource() + values).contains(text), STD_TIMEOUT);
+            return true;
+        } catch (TimeoutException exception) {
+            if (allowExceptions) {
+                throw exception;
+            }
+            exception.printStackTrace();
+            return false;
+        }
+    }
+
+
+    public WebElement findElement(By by) {
+        return webDriver.findElement(by);
+    }
+
+    public List<WebElement> findElements(By by) {
+        return webDriver.findElements(by);
+    }
+
+        public String getPageSource() {
+        return webDriver.getPageSource();
+    }
+
+    /**
+     * Convenience method to get all anchor elmements
+     *
+     * @return a list of a hrefs as WebElements
+     */
+    public List<WebElement> getAnchors() {
+        return webDriver.findElements(By.cssSelector("a[href]"));
+    }
+
+        private String getInputValues() {
+        return webDriver.findElements(By.cssSelector("input, textarea, select")).stream()
+                .map(webElement -> webElement.getAttribute("value")).reduce("", (str1, str2) -> str1 + " " + str2);
+    }
+
+}

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF23CDIGeneralTests.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF23CDIGeneralTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF23WebSocketTests.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF23WebSocketTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/utils/JSFUtils.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/utils/JSFUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/utils/JSFUtils.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/utils/JSFUtils.java
@@ -62,6 +62,21 @@ public class JSFUtils {
 
         return sb.toString();
     }
+
+    public static String createSeleniumURLString(LibertyServer server, String contextRoot, String path) {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("http://")
+                        .append("host.testcontainers.internal")
+                        .append(":")
+                        .append(server.getHttpDefaultPort())
+                        .append("/")
+                        .append(contextRoot)
+                        .append("/")
+                        .append(path);
+
+        return sb.toString();
+    }
     
     /**
      * Create a custom wait mechanism that waits for any background JavaScript to finish

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resourcesFaces40/implicit_objects.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resourcesFaces40/implicit_objects.xhtml
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:test="http://xmlns.jcp.org/jsf/composite/test">
+    
+	<h:head>
+	    <title>JSF 2.3 EL resolution of implicit objects using CDI</title> 
+	</h:head>
+	<h:body>
+		JSF 2.3 EL resolution of implicit objects using CDI
+    	<br/>
+    	Bean: #{elImplicitObjectBean}
+    	<br/>
+    	<br/>
+        Application name: <h:outputText value="#{application.getServletContextName()}"/>
+        <br/>
+        <br/>
+        ApplicationScope application name: <h:outputText value="#{applicationScope.get('com.ibm.websphere.servlet.enterprise.application.name')}"/>
+        <br/>
+        <br/>
+        Component getStyle: <h:outputText style="font-weight:bold" value="#{component.getStyle()}"/>
+        <br/>
+        <br/>
+        CompositeComponent label: <test:compositeTest label="Hello World"/>
+        <br/>
+        <br/>
+        FacesContext project stage: <h:outputText value="#{facesContext.getApplication().getProjectStage()}"/>
+        <br/>
+        <br/>
+        Flash isRedirect: <h:outputText value="#{flash.isRedirect()}"/>
+        <br/>
+        <br/>
+        Header: <h:outputText value="#{header.get('User-Agent')}"/>
+        <br/>
+        <br/>
+        HeaderValues: <ui:repeat var="item" value="#{headerValues.get('User-Agent')}"> <h:outputText value="#{item}"/> </ui:repeat>
+        <br/>
+        <br/>
+        InitParam: <h:outputText value="#{initParam.get('WELD_CONTEXT_ID_KEY')}"/>
+        <br/>
+        <br/>
+        Param: <h:outputText value="#{param.get('message')}"/>
+        <br/>
+        <br/>
+        ParamValues: <ui:repeat var="item" value="#{paramValues.get('message')}"> <h:outputText value="#{item}"/> </ui:repeat> 
+        <br/>
+        <br/>
+        Session isNew: <h:outputText value="#{session.isNew()}"/>
+        <br/>
+        <br/>
+        View viewId: <h:outputText value="#{view.getViewId()}"/>
+        <br/>
+        <br/>
+        ViewScope isEmpty: <h:outputText value="#{viewScope.isEmpty()}"/>
+	</h:body>
+</html>

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resourcesFaces40/implicit_objects.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resourcesFaces40/implicit_objects.xhtml
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-    Copyright (c) 2018 IBM Corporation and others.
+    Copyright (c) 2018, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resourcesJSF23/implicit_objects.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resourcesJSF23/implicit_objects.xhtml
@@ -43,10 +43,10 @@
         Flash isRedirect: <h:outputText value="#{flash.isRedirect()}"/>
         <br/>
         <br/>
-        Header: <h:outputText value="#{header.get('headerMessage')}"/>
+        Header: <h:outputText value="#{header.get('User-Agent')}"/>
         <br/>
         <br/>
-        HeaderValues: <ui:repeat var="item" value="#{headerValues.get('headerMessage')}"> <h:outputText value="#{item}"/> </ui:repeat>
+        HeaderValues: <ui:repeat var="item" value="#{headerValues.get('User-Agent')}"> <h:outputText value="#{item}"/> </ui:repeat>
         <br/>
         <br/>
         InitParam: <h:outputText value="#{initParam.get('WELD_CONTEXT_ID_KEY')}"/>

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resourcesJSF23/implicit_objects.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resourcesJSF23/implicit_objects.xhtml
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-    Copyright (c) 2018 IBM Corporation and others.
+    Copyright (c) 2018, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/src/com/ibm/ws/jsf23/fat/elcdi/beans/ELImplicitObjectBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/src/com/ibm/ws/jsf23/fat/elcdi/beans/ELImplicitObjectBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/src/com/ibm/ws/jsf23/fat/elcdi/beans/ELImplicitObjectBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/src/com/ibm/ws/jsf23/fat/elcdi/beans/ELImplicitObjectBean.java
@@ -157,7 +157,7 @@ public class ELImplicitObjectBean implements Serializable {
                 facesContext.addMessage(null, new FacesMessage("Flow map object is null: Exception: " + e.getMessage()));
             }
 
-            facesContext.addMessage(null, new FacesMessage("Message from HeaderMap: " + headerMap.get("headerMessage")));
+            facesContext.addMessage(null, new FacesMessage("Message from HeaderMap: " + headerMap.get("User-Agent")));
 
             facesContext.addMessage(null, new FacesMessage("Cookie object from CookieMap: " + cookieMap.get("JSESSIONID")));
 
@@ -167,7 +167,7 @@ public class ELImplicitObjectBean implements Serializable {
 
             facesContext.addMessage(null, new FacesMessage("Message from RequestParameterValuesMap: " + Arrays.toString(requestParameterValuesMap.get("message"))));
 
-            facesContext.addMessage(null, new FacesMessage("Message from HeaderValuesMap: " + Arrays.toString(headerValuesMap.get("headerMessage"))));
+            facesContext.addMessage(null, new FacesMessage("Message from HeaderValuesMap: " + Arrays.toString(headerValuesMap.get("User-Agent"))));
 
             facesContext.addMessage(null, new FacesMessage("Resource handler JSF_SCRIPT_LIBRARY_NAME constant: " + resourceHandler.JSF_SCRIPT_LIBRARY_NAME));
 

--- a/dev/io.openliberty.org.testcontainers/cache/projects
+++ b/dev/io.openliberty.org.testcontainers/cache/projects
@@ -121,6 +121,7 @@ com.ibm.ws.jpa.tests.spec20_jpa_3.1_fat
 com.ibm.ws.jpa.tests.spec20_jpa_3.2_fat
 com.ibm.ws.jsf.2.2_fat
 com.ibm.ws.jsf.2.3_fat
+com.ibm.ws.jsfContainer_fat_2.3
 com.ibm.ws.logstash.collector_fat
 com.ibm.ws.microprofile.health.2.0_fat
 com.ibm.ws.microprofile.reactive.messaging_fat


### PR DESCRIPTION
fixes  #24558

The following FAT tests were failing in com.ibm.ws.jsfContainer_fat_2.3:
- testPushWebSocket_EE10_FEATURES - JSF23WebSocketTests
- testOpenAndCloseWebsocket_EE10_FEATURES - JSF23WebSocketTests
- testInjectableELImplicitObjects_EE10_FEATURES - JSF23CDIGeneralTests
- testELResolutionImplicitObjects_EE10_FEATURES - JSF23CDIGeneralTests
- testFacesConverterBeanInjection_EE10_FEATURES - JSF23CDIGeneralTests
- testFacesValidatorBeanInjection_EE10_FEATURES - JSF23CDIGeneraltests
- testFacesBehaviorBeanInjection_EE10_FEATURES - JSF23CDIGeneralTests

These tests were failing because of the upgrade to MyFaces 4.0, HTMLUnit stopped working for some of these tests. Selenium was used to fix these tests and the remaining tests that were still passing with HTMLUnit were left unchanged.

**Important Note**: The tests were originally checking between being >=EE9, but this was changed to >=EE10 because EE9 was causing an internal server error. @volosied reviewed the error with me and can share more insight as to why it is important to revisit.

#build

