### PR TITLE
JAX-WS: Add config for matching binding files in fat tests

### DIFF
--- a/dev/io.openliberty.jaxws.security_fat.1/publish/files/JaxWsTransportSecurityServer/serverConfigs/basicAuthWithSSL.xml
+++ b/dev/io.openliberty.jaxws.security_fat.1/publish/files/JaxWsTransportSecurityServer/serverConfigs/basicAuthWithSSL.xml
@@ -9,6 +9,7 @@
     <include location="../fatTestPorts.xml"/>
     
     <!-- use the default SSL configuration -->
+    <ssl id="defaultSSLConfig" verifyHostname="false" />
     <keyStore id="defaultKeyStore" password="passw0rd" />
     
     <application id="TransportSecurityClient" name="TransportSecurityClient" location="TransportSecurityClient.war"

--- a/dev/io.openliberty.jaxws.security_fat.1/publish/files/JaxWsTransportSecurityServer/serverConfigs/clientCertFailOverToBasicAuthConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.1/publish/files/JaxWsTransportSecurityServer/serverConfigs/clientCertFailOverToBasicAuthConfiguration.xml
@@ -7,17 +7,17 @@
      </featureManager>
 
      <include location="../fatTestPorts.xml" />
-
      <!-- Server SSL configuration -->
      <ssl id="defaultSSLConfig" keyStoreRef="serverKeyStore" trustStoreRef="serverTrustStore" 
-        clientAuthenticationSupported="true"/>
+        clientAuthenticationSupported="true">
+     </ssl>
      <keyStore id="serverKeyStore" location="serverKey.jks" type="JKS" password="passw0rd" /> 
      <keyStore id="serverTrustStore" location="trust.jks" type="JKS" password="passw0rd" /> 
 
      <!-- Allow fail over to basic-auth -->
      <webAppSecurity allowFailOverToBasicAuth="true" /> 
      <!-- customize SSL configuration -->
-     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" /> 
+     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" verifyHostname="false"/> 
      <keyStore id="clientKeyStore" location="clientKey.jks" type="JKS" password="passw0rd" /> 
      <keyStore id="clientTrustStore" location="clientTrust.jks" type="JKS" password="passw0rd" /> 
      

--- a/dev/io.openliberty.jaxws.security_fat.1/publish/files/JaxWsTransportSecurityServer/serverConfigs/customizeSSLConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.1/publish/files/JaxWsTransportSecurityServer/serverConfigs/customizeSSLConfiguration.xml
@@ -13,7 +13,7 @@
           password="passw0rd" />
 
      <!-- customize SSL configuration -->
-     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" /> 
+     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore"  verifyHostname="false"/> 
      <keyStore id="clientKeyStore" location="clientKey.jks" type="JKS" password="passw0rd" /> 
      <keyStore id="clientTrustStore" location="clientTrust.jks" type="JKS" password="passw0rd" /> 
      

--- a/dev/io.openliberty.jaxws.security_fat.1/publish/files/JaxWsTransportSecurityServer/serverConfigs/defaultClientCertConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.1/publish/files/JaxWsTransportSecurityServer/serverConfigs/defaultClientCertConfiguration.xml
@@ -15,7 +15,7 @@
      <keyStore id="serverTrustStore" location="trust.jks" type="JKS" password="passw0rd" /> 
 
      <!-- customize SSL configuration -->
-     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" /> 
+     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" verifyHostname="false"/> 
      <keyStore id="clientKeyStore" location="clientKey.jks" type="JKS" password="passw0rd" /> 
      <keyStore id="clientTrustStore" location="clientTrust.jks" type="JKS" password="passw0rd" /> 
      

--- a/dev/io.openliberty.jaxws.security_fat.1/publish/files/JaxWsTransportSecurityServer/serverConfigs/patchyServerTrustStoreConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.1/publish/files/JaxWsTransportSecurityServer/serverConfigs/patchyServerTrustStoreConfiguration.xml
@@ -17,7 +17,7 @@
      <webAppSecurity allowFailOverToBasicAuth="true" /> 
      
      <!-- customize SSL configuration -->
-     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" /> 
+     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" verifyHostname="false"/> 
      <keyStore id="clientKeyStore" location="clientKey.jks" type="JKS" password="passw0rd" /> 
      <keyStore id="clientTrustStore" location="clientTrust.jks" type="JKS" password="passw0rd" /> 
      

--- a/dev/io.openliberty.jaxws.security_fat.1/publish/files/JaxWsTransportSecurityServer/serverConfigs/withAliasClientCertConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.1/publish/files/JaxWsTransportSecurityServer/serverConfigs/withAliasClientCertConfiguration.xml
@@ -16,7 +16,7 @@
 
      <!-- customize SSL configuration -->
      <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" 
-        clientKeyAlias="admin0"/>
+        clientKeyAlias="admin0" verifyHostname="false"/>
      <keyStore id="clientKeyStore" location="clientKey.jks" type="JKS" password="passw0rd" /> 
      <keyStore id="clientTrustStore" location="clientTrust.jks" type="JKS" password="passw0rd" /> 
      

--- a/dev/io.openliberty.jaxws.security_fat.ssl/fat/src/com/ibm/ws/jaxws/security/fat/AbstractJaxWsTransportSecurityBaseTest.java
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/fat/src/com/ibm/ws/jaxws/security/fat/AbstractJaxWsTransportSecurityBaseTest.java
@@ -288,7 +288,7 @@ abstract public class AbstractJaxWsTransportSecurityBaseTest {
 
         if (null != expectedServerInfos) {
             for (String info : expectedServerInfos) {
-                assertNotNull("The expected output in server log is " + info, server.waitForStringInLog(info));
+                assertNotNull("The expected output in server log is " + info, server.waitForStringInLog(info, WAIT_TIME_OUT));
             }
         }
     }

--- a/dev/io.openliberty.jaxws.security_fat.ssl/fat/src/com/ibm/ws/jaxws/security/fat/SSLConfigurationTest.java
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/fat/src/com/ibm/ws/jaxws/security/fat/SSLConfigurationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -86,7 +86,7 @@ public class SSLConfigurationTest extends AbstractJaxWsTransportSecuritySSLTest 
     @Mode(componenttest.custom.junit.runner.Mode.TestMode.FULL)
     @Test
     public void testDefaultSSLConfig() throws Exception {
-        prepareForTest("serverConfigs/" + DEFAULT_SSL_SERVER_CONFIG, "basicAuthWithSSL_provider_web.xml", null);
+        prepareForTest("serverConfigs/" + DEFAULT_SSL_SERVER_CONFIG, "basicAuthWithSSL_provider_web.xml", "bindings/defaultSSLConfig.xml");
 
         List<RequestParams> params = new ArrayList<>(Arrays.asList(
                                                                    new RequestParams("employee", "pojo", SCHEMA, SECURE_PORT, "/unauthorized/employPojoService", "Hello, employee from SayHelloPojoService"),
@@ -101,7 +101,7 @@ public class SSLConfigurationTest extends AbstractJaxWsTransportSecuritySSLTest 
     @Mode(componenttest.custom.junit.runner.Mode.TestMode.FULL)
     @Test
     public void testNoSSLConfig() throws Exception {
-        prepareForTest("serverConfigs/" + NO_SSL_CONFIG, "basicAuthWithSSL_provider_web.xml", null);
+        prepareForTest("serverConfigs/" + NO_SSL_CONFIG, "basicAuthWithSSL_provider_web.xml", "bindings/defaultSSLConfig.xml");
 
         List<RequestParams> params = new ArrayList<>(Arrays.asList(
                                                                    new RequestParams("employee", "pojo", SCHEMA, SECURE_PORT, "/unauthorized/employPojoService", noSSLResps),
@@ -126,7 +126,7 @@ public class SSLConfigurationTest extends AbstractJaxWsTransportSecuritySSLTest 
     @Mode(componenttest.custom.junit.runner.Mode.TestMode.FULL)
     public void testNoTrustStoreInDefaultSSLConfig() throws Exception {
         prepareForTest("serverConfigs/" + DEFAULT_SSL_WITHOUT_TRUST_STORE_SERVER_CONFIG,
-                       "basicAuthWithSSL_provider_web.xml", null);
+                       "basicAuthWithSSL_provider_web.xml", "bindings/defaultSSLConfig.xml");
 
         List<RequestParams> params = new ArrayList<>(Arrays.asList(
                                                                    new RequestParams("employee", "pojo", SCHEMA, SECURE_PORT, "/unauthorized/employPojoService", "Hello, employee from SayHelloPojoService"),

--- a/dev/io.openliberty.jaxws.security_fat.ssl/fat/src/com/ibm/ws/jaxws/security/fat/SSLConfigurationUnmanagedTest.java
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/fat/src/com/ibm/ws/jaxws/security/fat/SSLConfigurationUnmanagedTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -87,7 +87,7 @@ public class SSLConfigurationUnmanagedTest extends AbstractJaxWsTransportSecurit
     // 1 Default SSL configuration
     @Test
     public void testUnmanagedDefaultSSLConfig() throws Exception {
-        prepareForTest("serverConfigs/" + DEFAULT_SSL_SERVER_CONFIG, "basicAuthWithSSL_provider_web.xml", null);
+        prepareForTest("serverConfigs/" + DEFAULT_SSL_SERVER_CONFIG, "basicAuthWithSSL_provider_web.xml", "bindings/defaultSSLConfig.xml");
 
         List<RequestParams> params = new ArrayList<>(Arrays.asList(
                                                                    new RequestParams("employee", "pojo", SCHEMA, SECURE_PORT, "/unauthorized/employPojoService", "Hello, employee from SayHelloPojoService"),
@@ -102,7 +102,7 @@ public class SSLConfigurationUnmanagedTest extends AbstractJaxWsTransportSecurit
     // 2 SSLRef in DefaultSSL configuration
     @Test
     public void testSSLRefInDefaultSSLConfig() throws Exception {
-        prepareForTest("serverConfigs/" + SSLREF_IN_SSL_DEFAULT_CONFIG, "basicAuthWithSSL_provider_web.xml", null);
+        prepareForTest("serverConfigs/" + SSLREF_IN_SSL_DEFAULT_CONFIG, "basicAuthWithSSL_provider_web.xml", "bindings/defaultSSLConfig.xml");
 
         List<RequestParams> params = new ArrayList<>(Arrays.asList(
                                                                    new RequestParams("employee", "pojo", SCHEMA, SECURE_PORT, "/unauthorized/employPojoService", "Hello, employee from SayHelloPojoService"),

--- a/dev/io.openliberty.jaxws.security_fat.ssl/fat/src/com/ibm/ws/jaxws/security/fat/SSLRefConfigurationTest.java
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/fat/src/com/ibm/ws/jaxws/security/fat/SSLRefConfigurationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -73,7 +73,7 @@ public class SSLRefConfigurationTest extends AbstractJaxWsTransportSecuritySSLTe
 
     @Test
     public void testSSLRefInDefaultSSLConfig() throws Exception {
-        prepareForTest("serverConfigs/" + SSLREF_IN_SSL_DEFAULT_CONFIG, "basicAuthWithSSL_provider_web.xml", null);
+        prepareForTest("serverConfigs/" + SSLREF_IN_SSL_DEFAULT_CONFIG, "basicAuthWithSSL_provider_web.xml", "bindings/sslRefSSLConfig.xml");
 
         List<RequestParams> params = new ArrayList<>(Arrays.asList(new RequestParams("employee", "pojo", SCHEMA, SECURE_PORT, "/unauthorized/employPojoService", "Hello, employee from SayHelloPojoService"),
                                                                    new RequestParams("employee", "stateless", SCHEMA, SECURE_PORT, "/unauthorized/employStatelessService", "From other bean: Hello, employee from SayHelloStatelessService"),
@@ -85,7 +85,7 @@ public class SSLRefConfigurationTest extends AbstractJaxWsTransportSecuritySSLTe
     @Test
     public void testSSLRefInOutboundDefaultSSLConfig() throws Exception {
         prepareForTest("serverConfigs/" + SSLREF_IN_SSL_OUTBOUND_DEFAULT_CONFIG, "basicAuthWithSSL_provider_web.xml",
-                       null);
+                       "bindings/sslRefSSLConfig.xml");
 
         List<RequestParams> params = new ArrayList<>(Arrays.asList(new RequestParams("employee", "pojo", SCHEMA, SECURE_PORT, "/unauthorized/employPojoService", "Hello, employee from SayHelloPojoService"),
                                                                    new RequestParams("employee", "stateless", SCHEMA, SECURE_PORT, "/unauthorized/employStatelessService", "From other bean: Hello, employee from SayHelloStatelessService"),
@@ -97,7 +97,7 @@ public class SSLRefConfigurationTest extends AbstractJaxWsTransportSecuritySSLTe
     @Test
     public void testSSLRefInOutboundFilterSSLConfig() throws Exception {
         prepareForTest("serverConfigs/" + SSLREF_IN_SSL_OUTBOUND_FILTER_CONFIG, "basicAuthWithSSL_provider_web.xml",
-                       null);
+                       "bindings/sslRefSSLConfig.xml");
 
         List<RequestParams> params = new ArrayList<>(Arrays.asList(new RequestParams("employee", "pojo", SCHEMA, SECURE_PORT, "/unauthorized/employPojoService", "Hello, employee from SayHelloPojoService"),
                                                                    new RequestParams("employee", "stateless", SCHEMA, SECURE_PORT, "/unauthorized/employStatelessService", "From other bean: Hello, employee from SayHelloStatelessService"),

--- a/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/bindings/defaultSSLConfig.xml
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/bindings/defaultSSLConfig.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<webservices-bnd id="idvalue0" version="1.0" xmlns="http://websphere.ibm.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ws-bnd_1_0.xsd">
+  <!-- POJO service reference binding-->
+  <service-ref name="service/SayHelloPojoService">
+    <port name="SayHelloPojoPort" 
+       namespace="http://ibm.com/ws/jaxws/transport/security/"
+       ssl-ref="defaultSSLConfig"
+     />
+     <properties http.conduit.tlsClientParameters.disableCNCheck="true" />
+  </service-ref>
+  <!-- Stateless service reference binding-->
+  <service-ref name="service/SayHelloStatelessService">
+    <port name="SayHelloStatelessPort" 
+       namespace="http://ibm.com/ws/jaxws/transport/security/"
+       ssl-ref="defaultSSLConfig"
+     />
+     <properties http.conduit.tlsClientParameters.disableCNCheck="true" />
+  </service-ref>
+  <!-- Singleton service reference binding-->
+  <service-ref name="service/SayHelloSingletonService">
+    <port name="SayHelloSingletonPort" 
+       namespace="http://ibm.com/ws/jaxws/transport/security/"
+       ssl-ref="defaultSSLConfig"
+     />
+     <properties http.conduit.tlsClientParameters.disableCNCheck="true" />
+  </service-ref>
+</webservices-bnd>

--- a/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/bindings/sslRefSSLConfig.xml
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/bindings/sslRefSSLConfig.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<webservices-bnd id="idvalue0" version="1.0" xmlns="http://websphere.ibm.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ws-bnd_1_0.xsd">
+  <!-- POJO service reference binding-->
+  <service-ref name="service/SayHelloPojoService">
+    <port name="SayHelloPojoPort" 
+       namespace="http://ibm.com/ws/jaxws/transport/security/"
+       ssl-ref="myDefaultServerSSLSettings"
+     />
+     <properties http.conduit.tlsClientParameters.disableCNCheck="true" />
+  </service-ref>
+  <!-- Stateless service reference binding-->
+  <service-ref name="service/SayHelloStatelessService">
+    <port name="SayHelloStatelessPort" 
+       namespace="http://ibm.com/ws/jaxws/transport/security/"
+       ssl-ref="myDefaultServerSSLSettings"
+     />
+     <properties http.conduit.tlsClientParameters.disableCNCheck="true" />
+  </service-ref>
+  <!-- Singleton service reference binding-->
+  <service-ref name="service/SayHelloSingletonService">
+    <port name="SayHelloSingletonPort" 
+       namespace="http://ibm.com/ws/jaxws/transport/security/"
+       ssl-ref="myDefaultServerSSLSettings"
+     />
+     <properties http.conduit.tlsClientParameters.disableCNCheck="true" />
+  </service-ref>
+</webservices-bnd>

--- a/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/basicAuthWithSSL.xml
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/basicAuthWithSSL.xml
@@ -9,6 +9,7 @@
     <include location="../fatTestPorts.xml"/>
     
     <!-- use the default SSL configuration -->
+    <ssl id="defaultSSLConfig" verifyHostname="false" />
     <keyStore id="defaultKeyStore" password="passw0rd" />
     
     <application id="TransportSecurityClient" name="TransportSecurityClient" location="TransportSecurityClient.war"

--- a/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/customizeSSLConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/customizeSSLConfiguration.xml
@@ -11,9 +11,10 @@
      <!-- Server SSL configuration -->
      <keyStore id="defaultKeyStore" location="serverKey.jks"
           password="passw0rd" />
+     <ssl id="defaultSSLConfig" verifyHostname="false" />
 
      <!-- customize SSL configuration -->
-     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" /> 
+     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" verifyHostname="false"/> 
      <keyStore id="clientKeyStore" location="clientKey.jks" type="JKS" password="passw0rd" /> 
      <keyStore id="clientTrustStore" location="clientTrust.jks" type="JKS" password="passw0rd" /> 
      

--- a/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/defaultSSLConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/defaultSSLConfiguration.xml
@@ -9,7 +9,7 @@
     <include location="../fatTestPorts.xml"/>
     
     <!-- default SSL Configuration -->
-    <ssl id="defaultSSLConfig" keyStoreRef="serverKeyStore" trustStoreRef="serverTrustStore" />
+    <ssl id="defaultSSLConfig" keyStoreRef="serverKeyStore" trustStoreRef="serverTrustStore" verifyHostname="false"/>
     <keyStore id="serverKeyStore" location="key.jks" type="JKS" password="passw0rd" />
     <keyStore id="serverTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
     

--- a/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/noTrustStoreInCustomizeSSLConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/noTrustStoreInCustomizeSSLConfiguration.xml
@@ -11,9 +11,10 @@
      <!-- Server SSL configuration -->
      <keyStore id="defaultKeyStore" location="serverKey.jks"
           password="passw0rd" />
+     <ssl id="defaultSSLConfig" verifyHostname="false" />
 
      <!-- customize SSL configuration -->
-     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" /> 
+     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" verifyHostname="false" /> 
      <keyStore id="clientKeyStore" location="clientKey.jks" type="JKS" password="passw0rd" /> 
      
      <application id="TransportSecurityClient" name="TransportSecurityClient"

--- a/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/noTrustStoreInDefaultSSLConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/noTrustStoreInDefaultSSLConfiguration.xml
@@ -7,9 +7,9 @@
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>
-    
     <!-- no trustStore in default SSL Configuration -->
     <keyStore id="defaultKeyStore" password="passw0rd" /> 
+     <ssl id="defaultSSLConfig" verifyHostname="false" />
     
     <application id="TransportSecurityClient" name="TransportSecurityClient" location="TransportSecurityClient.war"
         context="TransportSecurityClient" type="war" />

--- a/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/noValidTrustCertInCustomizeSSLConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/noValidTrustCertInCustomizeSSLConfiguration.xml
@@ -11,9 +11,11 @@
      <!-- Server SSL configuration -->
      <keyStore id="defaultKeyStore" location="serverKey.jks"
           password="passw0rd" />
+          
+     <ssl id="defaultSSLConfig" verifyHostname="false" />
 
      <!-- customize SSL configuration -->
-     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" /> 
+     <ssl id="customizeSSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" verifyHostname="false"/> 
      <keyStore id="clientKeyStore" location="clientKey.jks" type="JKS" password="passw0rd" /> 
      <keyStore id="clientTrustStore" location="clientInvalidTrust.jks" type="JKS" password="passw0rd" /> 
      

--- a/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/sslRefInSSLDefaultConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/sslRefInSSLDefaultConfiguration.xml
@@ -10,7 +10,7 @@
     
     <!-- default SSL Configuration -->
     <sslDefault sslRef="myDefaultServerSSLSettings" />
-    <ssl id="myDefaultServerSSLSettings" keyStoreRef="serverKeyStore" trustStoreRef="serverTrustStore" />
+    <ssl id="myDefaultServerSSLSettings" keyStoreRef="serverKeyStore" trustStoreRef="serverTrustStore" verifyHostname="false"/>
     <keyStore id="serverKeyStore" location="key.jks" type="JKS" password="passw0rd" />
     <keyStore id="serverTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
     

--- a/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/sslRefInSSLOutboundDefaultConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/sslRefInSSLOutboundDefaultConfiguration.xml
@@ -11,11 +11,11 @@
     
     <!-- outbound default SSL Configuration -->
     <sslDefault outboundSSLRef="myDefaultServerSSLSettings" />
-    <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" />
+    <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" verifyHostname="false"/>
     <keyStore id="defaultKeyStore" location="defaultKey.jks" type="JKS" password="passw0rd" />
     <keyStore id="defaultTrustStore" location="defaultTrust.jks" type="JKS" password="passw0rd" />
 
-    <ssl id="myDefaultServerSSLSettings" keyStoreRef="serverKeyStore" trustStoreRef="serverTrustStore" />
+    <ssl id="myDefaultServerSSLSettings" keyStoreRef="serverKeyStore" trustStoreRef="serverTrustStore" verifyHostname="false"/>
     <keyStore id="serverKeyStore" location="key.jks" type="JKS" password="passw0rd" />
     <keyStore id="serverTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
     

--- a/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/sslRefInSSLOutboundFilterConfiguration.xml
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/publish/files/JaxWsTransportSecurityServer/serverConfigs/sslRefInSSLOutboundFilterConfiguration.xml
@@ -9,11 +9,11 @@
 
     <include location="../fatTestPorts.xml"/>
     
-    <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" />
+    <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" verifyHostname="false"/>
     <keyStore id="defaultKeyStore" location="defaultKey.jks" type="JKS" password="passw0rd" />
     <keyStore id="defaultTrustStore" location="defaultTrust.jks" type="JKS" password="passw0rd" />
 
-    <ssl id="myDefaultServerSSLSettings" keyStoreRef="serverKeyStore" trustStoreRef="serverTrustStore" >
+    <ssl id="myDefaultServerSSLSettings" keyStoreRef="serverKeyStore" trustStoreRef="serverTrustStore" verifyHostname="false">
      	<outboundConnection host="localhost" port="${bvt.prop.HTTP_default.secure}" />
      	<outboundConnection host="127.0.0.1" port="${bvt.prop.HTTP_default.secure}" />
     </ssl>

--- a/dev/io.openliberty.jaxws.security_fat.ssl/test-applications/TransportSecurityClient/src/com/ibm/ws/jaxws/transport/client/security/servlet/TestUnmanagedJaxWsTransportSecurityServlet.java
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/test-applications/TransportSecurityClient/src/com/ibm/ws/jaxws/transport/client/security/servlet/TestUnmanagedJaxWsTransportSecurityServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -108,6 +108,9 @@ public class TestUnmanagedJaxWsTransportSecurityServlet extends HttpServlet {
         String urlPath = sBuilder.toString();
         System.out.println(clazz.getSimpleName() + ": The request web service url is: " + urlPath);
         provider.getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, urlPath);
+
+        // add disableCNCheck to match the value being set in ibm-ws-bnd.xml config for the unmanaged clients.
+        provider.getRequestContext().put("http.conduit.tlsClientParameters.disableCNCheck", "true");
 
         return client;
     }


### PR DESCRIPTION
This PR adds default config to match the binding configuration settings in the related JAX-WS fat buckets.