### PR TITLE
Revert mail-api 2.1 update from PR #27761

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1434,7 +1434,7 @@
     <dependency>
       <groupId>jakarta.mail</groupId>
       <artifactId>jakarta.mail-api</artifactId>
-      <version>2.1.3</version>
+      <version>2.1.1</version>
     </dependency>
     <dependency>
       <groupId>jakarta.nosql</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -282,7 +282,7 @@ jakarta.json:jakarta.json-api:2.0.2
 jakarta.json:jakarta.json-api:2.1.3
 jakarta.jws:jakarta.jws-api:3.0.0
 jakarta.mail:jakarta.mail-api:2.0.1
-jakarta.mail:jakarta.mail-api:2.1.3
+jakarta.mail:jakarta.mail-api:2.1.1
 jakarta.nosql:nosql-column:1.0.0-b6
 jakarta.nosql:nosql-core:1.0.0-b6
 jakarta.nosql:nosql-document:1.0.0-b6

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.mail-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.mail-2.1.feature
@@ -8,7 +8,7 @@ IBM-Process-Types: client, \
 -features=com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="11.0", \
   io.openliberty.jakarta.activation-2.1
 -bundles=\
-  io.openliberty.jakarta.mail.2.1;location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.mail:jakarta.mail-api:2.1.3"
+  io.openliberty.jakarta.mail.2.1;location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.mail:jakarta.mail-api:2.1.1"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.jakarta/mail.2.1.bnd
+++ b/dev/io.openliberty.jakarta/mail.2.1.bnd
@@ -31,8 +31,8 @@ Import-Package: jakarta.activation;version="[2.1,3)", \
   *
 
 -includeresource: \
-  @${repo;jakarta.mail:jakarta.mail-api;2.1.3;EXACT}!/!(META-INF/maven/*|module-info.class)
+  @${repo;jakarta.mail:jakarta.mail-api;2.1.1;EXACT}!/!(META-INF/maven/*|module-info.class)
 
 -maven-dependencies: \
-   dep1;groupId=jakarta.mail;artifactId=jakarta.mail-api;version=2.1.3;scope=runtime
+   dep1;groupId=jakarta.mail;artifactId=jakarta.mail-api;version=2.1.1;scope=runtime
 


### PR DESCRIPTION
- mail-api 2.1 changes in #27761 caused test failures.  Undo just those changes in this PR.
- io.openliberty.mail.2.0.internal_fat were the tests that broke.