### PR TITLE
add minimum java level to tests

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessJavaEEToMicroProfileTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessJavaEEToMicroProfileTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.annotation.MinimumJavaLevel;
 
 @RunWith(FATRunner.class)
 public class VersionlessJavaEEToMicroProfileTest extends VersionlessTestBase {
@@ -25,6 +26,7 @@ public class VersionlessJavaEEToMicroProfileTest extends VersionlessTestBase {
     public static final String[] ALLOWED_ERRORS = { "CWWKF0001E", "CWWKF0048E" };
 
     @Test
+    @MinimumJavaLevel(javaLevel = 11)
     public void ee10toHealthAndMetricsMaxTest() throws Exception {
         String preferredVersions = PlatformConstants.MICROPROFILE_DESCENDING;
 
@@ -34,6 +36,7 @@ public class VersionlessJavaEEToMicroProfileTest extends VersionlessTestBase {
     }
 
     @Test
+    @MinimumJavaLevel(javaLevel = 11)
     public void ee10toHealthAndMetricsMinTest() throws Exception {
         String preferredVersions = PlatformConstants.MICROPROFILE_ASCENDING;
 

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessServletToMicroProfileTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessServletToMicroProfileTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.annotation.MinimumJavaLevel;
 
 @RunWith(FATRunner.class)
 public class VersionlessServletToMicroProfileTest extends VersionlessTestBase {
@@ -153,6 +154,7 @@ public class VersionlessServletToMicroProfileTest extends VersionlessTestBase {
     public static final String SERVER_NAME_SERVLET6_METRICS = "Servlet6toMetrics";
 
     @Test
+    @MinimumJavaLevel(javaLevel = 11)
     public void servlet6MetricsMaxTest() throws Exception {
         String preferredVersions = PlatformConstants.MICROPROFILE_DESCENDING;
         String expectedResolved[] = { "mpMetrics-5.1" };
@@ -161,6 +163,7 @@ public class VersionlessServletToMicroProfileTest extends VersionlessTestBase {
     }
 
     @Test
+    @MinimumJavaLevel(javaLevel = 11)
     public void servlet6MetricsMinTest() throws Exception {
         String preferredVersions = PlatformConstants.MICROPROFILE_ASCENDING;
         String expectedResolved[] = { "mpMetrics-5.0" };


### PR DESCRIPTION
mpMetrics-5.0 and 5.1 must be with java 11 or higher