### PR TITLE
resource accessor methods for datasource and connection

### DIFF
--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
@@ -717,7 +717,7 @@ public class DatabaseStoreImpl implements DatabaseStore {
      */
     protected String createOrm(String schemaName,
                                String tablePrefix,
-                               Set<String> tableNames, // entries correspond to entityClassNames
+                               LinkedHashSet<String> tableNames, // entries correspond to entityClassNames
                                String[] entityClassNames,
                                String[] entityClassEntries) {
         StringBuilder builder = new StringBuilder();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -71,7 +71,7 @@ public abstract class EntityManagerBuilder implements Runnable {
     /**
      * OSGi service component that provides the CDI extension for Data.
      */
-    final DataExtensionProvider provider;
+    public final DataExtensionProvider provider;
 
     /**
      * The class loader for repository classes.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -31,6 +31,8 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.sql.DataSource;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
@@ -101,6 +103,14 @@ public abstract class EntityManagerBuilder implements Runnable {
      * @return a new EntityManager instance.
      */
     public abstract EntityManager createEntityManager();
+
+    /**
+     * Obtains the DataSource that is used by the EntityManager.
+     *
+     * @return the DataSource that is used by the EntityManager.
+     * @throws UnsupportedOperationException if the DataSource cannot be obtained from the EntityManager.
+     */
+    public abstract DataSource getDataSource();
 
     /**
      * Returns the record class that corresponds to the specified generated entity class.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtensionProvider.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtensionProvider.java
@@ -46,6 +46,7 @@ import com.ibm.ws.container.service.metadata.MetaDataException;
 import com.ibm.ws.container.service.metadata.ModuleMetaDataListener;
 import com.ibm.ws.runtime.metadata.ApplicationMetaData;
 import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
+import com.ibm.wsspi.resource.ResourceConfigFactory;
 import com.ibm.wsspi.resource.ResourceFactory;
 
 import io.openliberty.cdi.spi.CDIExtensionMetadata;
@@ -90,6 +91,8 @@ public class DataExtensionProvider implements CDIExtensionMetadata, CDIExtension
 
     @Reference
     public LocalTransactionCurrent localTranCurrent;
+
+    public @Reference ResourceConfigFactory resourceConfigFactory;
 
     @Reference
     public EmbeddableWebSphereTransactionManager tranMgr;

--- a/dev/io.openliberty.data.internal_fat_config/publish/servers/io.openliberty.data.internal.fat.config/server.xml
+++ b/dev/io.openliberty.data.internal_fat_config/publish/servers/io.openliberty.data.internal.fat.config/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023 IBM Corporation and others.
+    Copyright (c) 2023.2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@
 
   <authData id="auth1" user="dbuser1" password="dbpwd1"/>
 
-  <databaseStore id="defaultDatabaseStore" authDataRef="auth1" createDatabase="true" dropDatabase="false"/>
+  <databaseStore id="defaultDatabaseStore" authDataRef="auth1" createTables="true" dropTables="false" tablePrefix="TEST"/>
 
   <dataSource id="DefaultDataSource">
     <jdbcDriver libraryRef="DerbyLib"/>

--- a/dev/io.openliberty.data.internal_fat_config/test-applications/DataConfigTestApp/src/test/jakarta/data/config/web/DataConfigTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_config/test-applications/DataConfigTestApp/src/test/jakarta/data/config/web/DataConfigTestServlet.java
@@ -17,6 +17,9 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.SQLSyntaxErrorException;
 
@@ -151,4 +154,28 @@ public class DataConfigTestServlet extends FATServlet {
         }
     }
 
+    /**
+     * Verifies that the databaseStore tablePrefix is included in the table name when configured.
+     */
+    @Test
+    public void testTablePrefix(HttpServletRequest request, PrintWriter response) throws SQLException {
+        employees.save(new Employee(444555, "Thomas", "testTablePrefix", 40));
+        students.save(new Student(4567, "Teresa", "testTablePrefix", 20));
+
+        try (Connection con = employees.getDataSource().getConnection()) {
+            assertEquals("dbuser1", con.getMetaData().getUserName().toLowerCase());
+
+            ResultSet result = con.createStatement().executeQuery("SELECT firstName FROM TESTemp WHERE employeeId = 444555");
+            assertEquals(true, result.next());
+            assertEquals("Thomas", result.getString(1));
+        }
+
+        try (Connection con = students.getConnection()) {
+            assertEquals("dbuser1", con.getMetaData().getUserName().toLowerCase());
+
+            ResultSet result = con.createStatement().executeQuery("SELECT firstName FROM TESTStudent WHERE studentId = 4567");
+            assertEquals(true, result.next());
+            assertEquals("Teresa", result.getString(1));
+        }
+    }
 }

--- a/dev/io.openliberty.data.internal_fat_config/test-applications/DataConfigTestApp/src/test/jakarta/data/config/web/Employee.java
+++ b/dev/io.openliberty.data.internal_fat_config/test-applications/DataConfigTestApp/src/test/jakarta/data/config/web/Employee.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,11 +14,13 @@ package test.jakarta.data.config.web;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  *
  */
 @Entity
+@Table(name = "emp")
 public class Employee extends Person {
 
     @Id

--- a/dev/io.openliberty.data.internal_fat_config/test-applications/DataConfigTestApp/src/test/jakarta/data/config/web/Employees.java
+++ b/dev/io.openliberty.data.internal_fat_config/test-applications/DataConfigTestApp/src/test/jakarta/data/config/web/Employees.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,9 +15,12 @@ package test.jakarta.data.config.web;
 import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Repository;
 
+import javax.sql.DataSource;
+
 /**
  *
  */
 @Repository
 public interface Employees extends BasicRepository<Employee, Integer> {
+    DataSource getDataSource();
 }

--- a/dev/io.openliberty.data.internal_fat_config/test-applications/DataConfigTestApp/src/test/jakarta/data/config/web/Students.java
+++ b/dev/io.openliberty.data.internal_fat_config/test-applications/DataConfigTestApp/src/test/jakarta/data/config/web/Students.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package test.jakarta.data.config.web;
 
+import java.sql.Connection;
+
 import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Repository;
 
@@ -20,4 +22,5 @@ import jakarta.data.repository.Repository;
  */
 @Repository
 public interface Students extends BasicRepository<Student, Integer> {
+    Connection getConnection();
 }


### PR DESCRIPTION
Add resource accessor method support for DataSource and Connection. Also, work around an error in persistence service computing table names, and default the table prefix to empty because users won't expect a prefix to be added to their entities.