### PR TITLE
Update fattest.simplicity to generate replacement

### DIFF
--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -64,6 +64,7 @@ Include-Resource: \
     init-sqlserver.sql=resources/init-sqlserver.sql
 
 test.project: true
+generate.replacement: true
 
 # These are the images used by the org.testcontainers and componenttest.topology.database.container packages
 fat.test.container.images: testcontainers/ryuk:0.6.0, testcontainers/sshd:1.1.0, testcontainers/vnc-recorder:1.3.0, kyleaure/db2:1.0, gvenzl/oracle-free:23.3-full-faststart, postgres:14.1-alpine, mcr.microsoft.com/mssql/server:2019-CU18-ubuntu-20.04


### PR DESCRIPTION
- Export fattest.simplicity project to be used by repos that depend on OL.  Namely this is the websphere liberty repo.
