### PR TITLE
JAX-RS: add jaxb bundle to feature jars for wadl2java

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
@@ -28,7 +28,8 @@ IBM-SPI-Package: com.ibm.wsspi.webservices.handler
   com.ibm.ws.jaxrs.2.0.common, \
   com.ibm.ws.jaxrs.2.x.config, \
   com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3
--jars=com.ibm.ws.jaxrs.2.0.tools
+-jars=com.ibm.ws.jaxrs.2.0.tools, \
+  io.openliberty.jaxrs.2.0.wadl2java.jaxb.runtime
 -files=\
   bin/jaxrs/wadl2java, \
   bin/jaxrs/wadl2java.bat, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
@@ -25,8 +25,9 @@ IBM-App-ForceRestart: uninstall, \
   com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2, \
   com.ibm.ws.org.apache.cxf.cxf.rt.rs.service.description.3.2, \
   com.ibm.ws.org.apache.cxf.cxf.rt.rs.sse.3.2
--jars=com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2, \
-  com.ibm.ws.org.apache.cxf.cxf.tools.wadlto.jaxrs.3.2, \
+-jars=\
+  io.openliberty.jaxrs.2.0.wadl2java.jaxb.runtime, \
+  com.ibm.ws.jaxrs.2.0.common, \
   com.ibm.ws.jaxrs.2.0.tools
 -files=\
   bin/jaxrs/wadl2java, \

--- a/dev/com.ibm.ws.jaxrs.2.0.tools/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.tools/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2023 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxrs.2.0.tools/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.tools/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2024 IBM Corporation and others.
+# Copyright (c) 2017, 2023 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/WADLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/WADLTest.java
@@ -97,6 +97,9 @@ public class WADLTest {
         RemoteFile wadl2javaBat = server.getFileFromLibertyInstallRoot(wadl2javaBatPath);
         String wadl2javaArgs = new StringBuilder().append("-d ").append(WADL2JAVASrcDir.getAbsolutePath()).append(" -p ").append(TEST_PACKAGE).append(" ").append(TEST_WADL_LOCATION).toString();
 
+
+        Log.info(WADLTest.class, "calling wadl2jjava with these args", wadl2javaArgs);
+
         assertTrue("The file bin/jaxrs/wadl2java does not exist.", wadl2java.exists());
         assertTrue("The file bin/jaxrs/wadl2java.bat does not exist.", wadl2javaBat.exists());
 


### PR DESCRIPTION
This PR fixes the following issues in wadl2java:

- The `jaxrs-2.1` feature no longer needs the `jaxrs-2.0` feature to be installed for `wadl2java` to work. 
- The `wadl2java` no longer throws `Caused by: java.lang.ClassNotFoundException: com.sun.tools.internal.xjc.api.XJC` 

Addresses #28615