### PR TITLE
Update to not include fattest.simplicity.jar in autoFVT.zip files

### DIFF
--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -4,27 +4,32 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <project name="standard.launch.tasks">
 
+	<target name="initBootstrapProperties">
+		<property name="bootstrapping.properties" value="${dir.component.root}/bootstrapping.properties" />
+		<property file="${bootstrapping.properties}" />
+	</target>
+
 	<!-- This is needed for Moonstone autowas to work -->
-	<target name="init-test-tasks-autowas" unless="inited-test-tasks">
+	<target name="init-test-tasks-autowas" unless="inited-test-tasks" depends="initBootstrapProperties">
 		<property name="inited-test-tasks" value="true" />
+		<condition property="local.java.dir" value="lib" else="build/libs/lib">
+			<available file="${local.java}/lib"/>
+		</condition>
 		<path id="test-buildtasks-autowas">
-			<fileset dir="./build/lib/" includes="infra.buildtasks*.jar" />
-			<fileset dir="./build/lib/" includes="jsch*.jar" />
+			<fileset dir="${local.java}/${local.java.dir}/" includes="infra.buildtasks*.jar" />
+			<fileset dir="${local.java}/${local.java.dir}/" includes="asm*.jar" />
+			<fileset dir="${local.java}/${local.java.dir}/" includes="jsch*.jar" />
 		</path>
 		<taskdef resource="com/ibm/aries/componenttest/buildtasks/buildtasks.properties" classpathref="test-buildtasks-autowas" loaderref="test-buildtasks-autowas_ldr" />
 		<taskdef resource="com/ibm/aries/buildtasks/buildtasks.properties" classpathref="test-buildtasks-autowas" loaderref="test-buildtasks-autowas_ldr" />
 	</target>
 
-	<target name="initProperties" depends="init-test-tasks-autowas">
-		<property name="bootstrapping.properties" value="${dir.component.root}/bootstrapping.properties" />
+	<target name="initProperties" depends="initBootstrapProperties,init-test-tasks-autowas">
 		<property name="configuration.properties" value="${dir.component.root}/configuration.properties" />
 		<property name="logging.properties" value="${dir.component.root}/logging.properties" />
 		<property name="gen.logging.properties" value="${dir.log}/logging.properties" />
@@ -85,7 +90,7 @@
 		<condition property="is.zos.platform" else="false">
 			<os family="z/os" />
 		</condition>
-		
+
 		<condition property="is.windows.platform" else="false">
 			<os family="windows" />
 		</condition>
@@ -109,7 +114,6 @@
 			<istrue value="${is.java15.orHigher}"/>
 		</condition>
 		<property name="illegal.access.permit.fat" value=""/>
-		
 		
 		<!-- Java 17 began the security manager's deprecation process (https://openjdk.java.net/jeps/411).
 			     In Java 18, the `java.security.manager` system property's default changed from `allow` to `disallow`, which causes our build process to fail.  
@@ -188,19 +192,37 @@
 			</fileset>
 
 			<!-- We want our doctored simplicity high on the classpath -->
-			<fileset dir="${basedir}/lib/">
+			<fileset dir="${basedir}/lib/" erroronmissingdir="false">
 				<include name="*.jar" />
 				<exclude name="${bnd.transform.jar.to.exclude}" />
 			</fileset>
 
+			<!-- fattest.simplicity -->
+			<fileset dir="${local.java}/lib/" erroronmissingdir="false">
+				<include name="fattest.simplicity.jar" />
+				<include name="com.ibm.ws.componenttest.jar" />
+			</fileset>
+
+			<fileset dir="${local.java}/build/libs/lib/" erroronmissingdir="false">
+				<include name="fattest.simplicity.jar" />
+				<include name="com.ibm.ws.componenttest.jar" />
+			</fileset>
+
 			<!-- shared libraries from bootstrapping.properties -->
-			<fileset dir="${local.sharedLib}">
+			<fileset dir="${local.sharedLib}" erroronmissingdir="false">
 				<include name="**/*.jar" />
 			</fileset>
 
 			<!-- java libraries for secure SSH authentication -->
-			<fileset dir="${local.java}/lib/">
+			<fileset dir="${local.java}/lib/" erroronmissingdir="false">
 				<include name="*.jar" />
+				<exclude name="${bnd.transform.jar.to.exclude}" />
+			</fileset>
+
+			<!-- The maven dependencies of fattest.simplicity -->
+			<fileset dir="${local.java}/build/libs/lib" erroronmissingdir="false">
+				<include name="*.jar" />
+				<exclude name="${bnd.transform.jar.to.exclude}" />
 			</fileset>
 
 			<fileset dir="${ant.home}/lib/" includes="ant-junit*.jar, ant.jar" />

--- a/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.jmx_fat/override/autoFVT/src/ant/launch.xml
@@ -293,9 +293,20 @@
 			</fileset>
 
 			<!-- We want our doctored simplicity high on the classpath -->
-			<fileset dir="${basedir}/lib/">
+			<fileset dir="${basedir}/lib/" erroronmissingdir="false">
 				<include name="*.jar" />
 				<exclude name="${bnd.transform.jar.to.exclude}" />
+			</fileset>
+
+			<!-- fattest.simplicity -->
+			<fileset dir="${local.java}/lib/" erroronmissingdir="false">
+				<include name="fattest.simplicity.jar" />
+				<include name="com.ibm.ws.componenttest.jar" />
+			</fileset>
+
+			<fileset dir="${local.java}/build/libs/lib/" erroronmissingdir="false">
+				<include name="fattest.simplicity.jar" />
+				<include name="com.ibm.ws.componenttest.jar" />
 			</fileset>
 
 			<!-- shared libraries from bootstrapping.properties -->

--- a/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
+++ b/dev/com.ibm.ws.kernel.boot_fat/override/autoFVT/src/ant/launch.xml
@@ -293,9 +293,20 @@
 			</fileset>
 
 			<!-- We want our doctored simplicity high on the classpath -->
-			<fileset dir="${basedir}/lib/">
+			<fileset dir="${basedir}/lib/" erroronmissingdir="false">
 				<include name="*.jar" />
 				<exclude name="${bnd.transform.jar.to.exclude}" />
+			</fileset>
+
+			<!-- fattest.simplicity -->
+			<fileset dir="${local.java}/lib/" erroronmissingdir="false">
+				<include name="fattest.simplicity.jar" />
+				<include name="com.ibm.ws.componenttest.jar" />
+			</fileset>
+
+			<fileset dir="${local.java}/build/libs/lib/" erroronmissingdir="false">
+				<include name="fattest.simplicity.jar" />
+				<include name="com.ibm.ws.componenttest.jar" />
 			</fileset>
 
 			<!-- shared libraries from bootstrapping.properties -->

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/build.gradle
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/build.gradle
@@ -1,16 +1,22 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 addRequiredLibraries.dependsOn addJakartaTransformer
+
+configurations {
+  requiredLibs {
+    transitive = false
+  }
+}
 
 dependencies {
   requiredLibs project(':io.openliberty.org.apache.commons.logging'), project(':io.openliberty.org.apache.commons.codec')

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -273,9 +273,20 @@
 			</fileset>
 
 			<!-- We want our doctored simplicity high on the classpath -->
-			<fileset dir="${basedir}/lib/">
+			<fileset dir="${basedir}/lib/" erroronmissingdir="false">
 				<include name="*.jar" />
 				<exclude name="${bnd.transform.jar.to.exclude}" />
+			</fileset>
+
+			<!-- fattest.simplicity -->
+			<fileset dir="${local.java}/lib/" erroronmissingdir="false">
+				<include name="fattest.simplicity.jar" />
+				<include name="com.ibm.ws.componenttest.jar" />
+			</fileset>
+
+			<fileset dir="${local.java}/build/libs/lib/" erroronmissingdir="false">
+				<include name="fattest.simplicity.jar" />
+				<include name="com.ibm.ws.componenttest.jar" />
 			</fileset>
 
 			<!-- shared libraries from bootstrapping.properties -->

--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -21,6 +21,7 @@ task assembleBootstrap(type: Copy) {
 }
 
 task assembleBinaryDependencies() {
+    dependsOn jar
     dependsOn ':com.ibm.websphere.javaee.jaxb.2.2:jar'
     dependsOn ':com.ibm.websphere.javaee.jsonp.1.0:jar'
     dependsOn ':com.ibm.ws.common.encoder:jar'
@@ -54,6 +55,7 @@ task assembleBinaryDependencies() {
         copy {
             from new File(project(':com.ibm.websphere.javaee.jaxb.2.2').buildDir, 'com.ibm.websphere.javaee.jaxb.2.2.jar')
             from new File(project(':com.ibm.websphere.javaee.jsonp.1.0').buildDir, 'com.ibm.websphere.javaee.jsonp.1.0.jar')
+            from new File(project(':com.ibm.ws.componenttest').buildDir, 'com.ibm.ws.componenttest.jar')
             from new File(project(':com.ibm.ws.jaxb.tools').buildDir, 'com.ibm.ws.jaxb.tools.jar')
             from new File(project(':com.ibm.ws.junit.extensions').buildDir, 'com.ibm.ws.junit.extensions.jar')
             from new File(project(':com.ibm.ws.logging.core').buildDir, 'com.ibm.ws.logging.core.jar')
@@ -66,6 +68,7 @@ task assembleBinaryDependencies() {
             from new File(project(':io.openliberty.org.bouncycastle.bcprov-jdk18on').buildDir, 'io.openliberty.org.bouncycastle.bcprov-jdk18on.jar')
             from new File(project(':io.openliberty.org.bouncycastle.bcutil-jdk18on').buildDir, 'io.openliberty.org.bouncycastle.bcutil-jdk18on.jar')
             from new File(project(':io.openliberty.org.testcontainers').buildDir, 'io.openliberty.org.testcontainers.jar')
+            from new File(buildDir, 'fattest.simplicity.jar')
             into buildDirLib
         }
         copy {
@@ -127,7 +130,6 @@ task extractArquillianSupportJakartaFeature21(type:Sync) {
 
 jar {
     dependsOn assembleBootstrap
-    dependsOn assembleBinaryDependencies
     dependsOn extractArquillianSupportFeature
     dependsOn extractArquillianSupportJakartaFeature21
 }
@@ -141,4 +143,7 @@ task publishArquillianSupportFeature(type:Copy) {
     into(buildImage.file('wlp'))
 }
 
-assemble.dependsOn publishArquillianSupportFeature
+assemble {
+    dependsOn assembleBinaryDependencies
+    dependsOn publishArquillianSupportFeature
+}

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -289,18 +289,21 @@ task autoFVT {
 
     // Copy the component test libs
     // TODO: It looks like the componenttest.app.jar got combined into something else, so this is now way more source in the jar than was there before. This might need changing then.
-    copy {
+    /*copy {
       from project(':com.ibm.ws.componenttest').buildDir
       include 'com.ibm.ws.componenttest.jar'
       rename 'com.ibm.ws.componenttest.jar', 'componenttest.app.jar'
       into new File(autoFvtDir, 'lib')
-    }
+    }*/
 
     // Copy the fattest libs
-    copy {
-      from project(':fattest.simplicity').buildDir
-      include 'fattest*.*'
-      into new File(autoFvtDir, 'lib')
+    // TCK project's depend on the fattest.simplicity.jar being in the autoFVT/lib directory for their pom.xml files
+    if (project.name.contains('tck')) {
+      copy {
+        from project(':fattest.simplicity').buildDir
+        include 'fattest.simplicity.jar'
+        into new File(autoFvtDir, 'lib')
+      }
     }
 
     // TODO: This is to compensate for the fact that the ant build of fattest.simplicity produced this jar but the gradle build doesn't


### PR DESCRIPTION
- Update to have fattest.simplicity.jar and com.ibm.ws.componenttest.jar in fattest.simplicity/build/libs/lib and not in the autoFVT.zip files.
