### PR TITLE
JAXB 2.2: Remove RI from TCCL

### DIFF
--- a/dev/com.ibm.ws.jaxb.tools/bnd.bnd
+++ b/dev/com.ibm.ws.jaxb.tools/bnd.bnd
@@ -52,7 +52,7 @@ DynamicImport-Package: \
   javax.activation
 
 Export-Package: \
-  com.sun.xml.bind.*;version="2.3.9";thread-context=true
+  com.sun.xml.bind.*;version="2.3.9"
 
 Include-Resource: \
   @${repo;com.sun.xml.bind:jaxb-impl;2.3.9;EXACT}!/!(META-INF/maven/*|module-info.class), \

--- a/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxb_fat.no-jaxb-feature/server.xml
+++ b/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxb_fat.no-jaxb-feature/server.xml
@@ -7,7 +7,6 @@
         <!-- Various features get added dynamically during the test -->
     </featureManager>
     <webApplication name="thirdPartyJaxbApp" location="thirdPartyJaxbApp.war" context-root="thirdPartyJaxbApp">
-    	<classLoader delegation="parentLast" />
     </webApplication>
     
     <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/thirdPartyJaxbApp/src/jaxb/thirdparty/web/ThirdPartyJAXBFromAppTestServlet.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/thirdPartyJaxbApp/src/jaxb/thirdparty/web/ThirdPartyJAXBFromAppTestServlet.java
@@ -74,7 +74,7 @@ public class ThirdPartyJAXBFromAppTestServlet extends FATServlet {
      */
     @Test
     @SkipForRepeat({ SkipForRepeat.EE9_FEATURES })
-    public void testJaxbAPILoadedFromAppEE10() throws Exception {
+    public void testJaxbAPILoadedFromAppEE8AndEE10() throws Exception {
         // Verify JAX-B API came from the application dependencies
         ClassLoader apiLoader = JAXBContext.class.getClassLoader();
         CodeSource apiSrc = JAXBContext.class.getProtectionDomain().getCodeSource();

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/thirdPartyJaxbApp/src/jaxb/thirdparty/web/ThirdPartyJAXBFromAppTestServlet.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/thirdPartyJaxbApp/src/jaxb/thirdparty/web/ThirdPartyJAXBFromAppTestServlet.java
@@ -10,7 +10,6 @@
 package jaxb.thirdparty.web;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.StringWriter;
@@ -49,13 +48,13 @@ public class ThirdPartyJAXBFromAppTestServlet extends FATServlet {
     private static String IMPL_LOCATION = "WEB-INF/lib";
 
     /**
-     * This test verifies that a app packaged JAXB 2.2 or XML Binding 3.0 is loaded from the ParentLastClassLoader classloader and WEB-INF/lib directory of the
+     * This test verifies that a app packaged XML Binding 3.0 is loaded from the ParentLastClassLoader classloader and WEB-INF/lib directory of the
      * application rather from our internal classloader, and bundle location.
      */
     @Test
-    @SkipForRepeat({ SkipForRepeat.EE10_FEATURES })
+    @SkipForRepeat({ SkipForRepeat.NO_MODIFICATION, SkipForRepeat.EE10_FEATURES })
     public void testJaxbAPILoadedFromApp() throws Exception {
-		
+
         // Verify JAX-B API came from the application dependencies
         ClassLoader apiLoader = JAXBContext.class.getClassLoader();
         CodeSource apiSrc = JAXBContext.class.getProtectionDomain().getCodeSource();
@@ -70,14 +69,11 @@ public class ThirdPartyJAXBFromAppTestServlet extends FATServlet {
     }
 
     /**
-     * This test verifies that an app packaged XML Binding 4.0 is loaded from the AppClassLoader classloader and WEB-INF/lib directory of the
+     * This test verifies that an app packaged JAXB 2.2 or XML Binding 4.0 is loaded from the AppClassLoader classloader and WEB-INF/lib directory of the
      * application rather from our internal classloader, and bundle location.
-     *
-     * Since EE10 is the only platform that doesn't require classloading delegation to be parent last
-     * we need to assert to make sure it came from the app classloader
      */
     @Test
-    @SkipForRepeat({ SkipForRepeat.NO_MODIFICATION, SkipForRepeat.EE9_FEATURES })
+    @SkipForRepeat({ SkipForRepeat.EE9_FEATURES })
     public void testJaxbAPILoadedFromAppEE10() throws Exception {
         // Verify JAX-B API came from the application dependencies
         ClassLoader apiLoader = JAXBContext.class.getClassLoader();


### PR DESCRIPTION
This PR does the following:

    Removes the `com.sun.xml.bind.*` packages from the TCCL as the current JAXB spec will always use the TCCL in its first attempt to load the implementation.
    Adds repeats for the `com.ibm.ws.jaxb_fat` bucket's ThirdPartyJAXBFromAppTest to verify a third-party impl of JAXB can be used without conflicting with the internal feature.
