### PR TITLE
resource accessor methods without authDataRef

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -542,8 +542,9 @@ public class DBStoreEMBuilder extends EntityManagerBuilder {
                 if (dbStoreRefs.isEmpty())
                     throw new IllegalStateException("The " + dbStoreFilter + " resource that is used by the repository is not available."); // TODO NLS
 
-                String authDataFilter = (String) dbStoreRefs.iterator().next().getProperty("AuthData.target");
-                if (authDataFilter != null) {
+                ServiceReference<DatabaseStore> ref = dbStoreRefs.iterator().next();
+                if (ref.getProperty("authDataRef") != null) {
+                    String authDataFilter = (String) ref.getProperty("AuthData.target");
                     ServiceReference<?>[] authDataRefs = bc.getServiceReferences("com.ibm.websphere.security.auth.data.AuthData",
                                                                                  authDataFilter);
                     if (authDataRefs == null)

--- a/dev/io.openliberty.data.internal_fat_datastore/publish/servers/io.openliberty.data.internal.fat.datastore/server.xml
+++ b/dev/io.openliberty.data.internal_fat_datastore/publish/servers/io.openliberty.data.internal.fat.datastore/server.xml
@@ -30,6 +30,8 @@
     <file name="${shared.resource.dir}/derby/derby.jar"/>
   </library>
 
+  <authData id="ResRefAuth1" user="resrefuser1" password="resrefpwd1"/>
+
   <dataSource id="DefaultDataSource">
     <jdbcDriver libraryRef="DerbyLib"/>
     <properties.derby.embedded createDatabase="create" databaseName="memory:defaultdb" user="defaultuser1" password="defaultpwd1"/>

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/resources/WEB-INF/ibm-web-bnd.xml
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/resources/WEB-INF/ibm-web-bnd.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://websphere.ibm.com/xml/ns/javaee"
+         xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd"
+         version="1.0">
+    
+  	<resource-ref name="java:app/env/jdbc/ServerDataSourceRef">
+		<authentication-alias name="ResRefAuth1"/>
+	</resource-ref>
+
+</web-bnd>

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/DefaultDSEntity.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/DefaultDSEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,8 +14,10 @@ package test.jakarta.data.datastore.web;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "DefDSEntity")
 public class DefaultDSEntity {
 
     @Id

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/DefaultDSRepo.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/DefaultDSRepo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,12 +12,16 @@
  *******************************************************************************/
 package test.jakarta.data.datastore.web;
 
+import java.sql.Connection;
+
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Repository;
 
 @Repository(dataStore = "java:comp/DefaultDataSource")
 public interface DefaultDSRepo extends DataRepository<DefaultDSEntity, Long> {
+
+    Connection connect();
 
     @Insert
     void insert(DefaultDSEntity e);

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/PersistenceUnitRepo.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/PersistenceUnitRepo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,10 +12,14 @@
  *******************************************************************************/
 package test.jakarta.data.datastore.web;
 
+import java.sql.Connection;
 import java.util.List;
 
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
+import jakarta.persistence.EntityManager;
+
+import javax.sql.DataSource;
 
 /**
  * This repository has its dataStore set to a PersistenceUnit reference from DataStoreTestServlet
@@ -23,6 +27,12 @@ import jakarta.data.repository.Save;
  */
 @Repository(dataStore = "persistence/MyPersistenceUnitRef") // java:comp/env/ is implied
 public interface PersistenceUnitRepo {
+
+    Connection connection();
+
+    DataSource dataSource();
+
+    EntityManager entityManager();
 
     // Entity type is inferred from the Insert annotation.
     // Do not add other methods or inheritance to this class.

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/ServerDSIdRepo.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/ServerDSIdRepo.java
@@ -15,8 +15,12 @@ package test.jakarta.data.datastore.web;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Repository;
 
+import javax.sql.DataSource;
+
 @Repository(dataStore = "ServerDataSource") // id of dataSource in server.xml
 public interface ServerDSIdRepo {
+
+    DataSource findById();
 
     boolean existsById(String id);
 

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/ServerDSJNDIRepo.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/ServerDSJNDIRepo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,11 +12,15 @@
  *******************************************************************************/
 package test.jakarta.data.datastore.web;
 
+import java.sql.Connection;
+
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Repository;
 
 @Repository(dataStore = "jdbc/ServerDataSource") // jndiName of dataSource in server.xml
 public interface ServerDSJNDIRepo {
+
+    Connection createConnection();
 
     @Insert
     Void insert(ServerDSEntity e);

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/ServerDSResRefRepo.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestWeb/src/test/jakarta/data/datastore/web/ServerDSResRefRepo.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.datastore.web;
+
+import java.util.Optional;
+
+import jakarta.data.repository.By;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
+
+import javax.sql.DataSource;
+
+/**
+ * A repository that uses a resource reference to a dataSource in server.xml.
+ * The resource reference has container managed authentication with
+ * auth data where the user name is resrefuser1.
+ */
+@Repository(dataStore = "java:app/env/jdbc/ServerDataSourceRef")
+public interface ServerDSResRefRepo {
+
+    DataSource getDataStore();
+
+    @Find
+    Optional<ServerDSEntity> read(@By("id") String id);
+
+    @Save
+    ServerDSEntity write(ServerDSEntity e);
+}


### PR DESCRIPTION
Implementation to handle DataSource/Connection resource accessor methods when lacking a databaseStore authDataRef, using an id or jndiName of a data source as the repository dataStore.  Also, add a test for persistence unit reference for a EntityManager resource accessor method.