### PR TITLE
Reduce FFDC during shutdown

### DIFF
--- a/dev/com.ibm.rls.jdbc/src/com/ibm/ws/recoverylog/custom/jdbc/impl/SQLMultiScopeRecoveryLog.java
+++ b/dev/com.ibm.rls.jdbc/src/com/ibm/ws/recoverylog/custom/jdbc/impl/SQLMultiScopeRecoveryLog.java
@@ -1990,7 +1990,7 @@ public class SQLMultiScopeRecoveryLog implements LogCursorCallback, MultiScopeLo
 
     public void forceSections(boolean throttle) throws InternalLogException {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "forceSections", new java.lang.Object[] { this });
+            Tr.entry(tc, "forceSections", this, throttle);
 
         // PH22988 introduces "throttle" code to improve concurrent access to the cache of inserts, updates and removes at runtime.
         // _throttleWaiters counts the number of threads attempting to forceSections(). If that number passes a threshold, then throttling is enabled.
@@ -2021,6 +2021,9 @@ public class SQLMultiScopeRecoveryLog implements LogCursorCallback, MultiScopeLo
         } else {
             internalForceSections();
         }
+
+        if (tc.isEntryEnabled())
+            Tr.exit(tc, "forceSections");
     }
 
     // Must NOT be called when holding intrinsic lock unless already holding _DBAccessIntentLock

--- a/dev/com.ibm.tx.jta/src/com/ibm/tx/jta/impl/TxRecoveryAgentImpl.java
+++ b/dev/com.ibm.tx.jta/src/com/ibm/tx/jta/impl/TxRecoveryAgentImpl.java
@@ -256,7 +256,7 @@ public class TxRecoveryAgentImpl implements RecoveryAgent {
                     try {
                         fsc = createFailureScopeController(fs);
                     } catch (Exception exc) {
-                        FFDCFilter.processException(exc, "com.ibm.ws.runtime.component.TxServiceImpl.initiateRecovery", "1177", this);
+                        FFDCFilter.processException(exc, "com.ibm.tx.jta.impl.TxRecoveryAgentImpl.initiateRecovery", "259", this);
                         if (tc.isDebugEnabled())
                             Tr.debug(tc, "Exception caught whist creating FailureScopeController", exc);
                         throw new RecoveryFailedException(exc);
@@ -580,34 +580,14 @@ public class TxRecoveryAgentImpl implements RecoveryAgent {
                     }
                 }
             }
-
-        } catch (
-
-        InvalidFailureScopeException e) {
-            FFDCFilter.processException(e, "com.ibm.ws.runtime.component.TxServiceImpl.initiateRecovery", "1599", this);
+        } catch (InvalidFailureScopeException | InvalidLogPropertiesException | URISyntaxException | PrivilegedActionException e) {
+            if (!_serverStopping)
+                FFDCFilter.processException(e, "com.ibm.tx.jta.impl.TxRecoveryAgentImpl.initiateRecovery", "586", this);
             Tr.error(tc, "WTRN0016_EXC_DURING_RECOVERY", e);
 
             if (tc.isEntryEnabled())
                 Tr.exit(tc, "initiateRecovery", e);
-            throw new RecoveryFailedException(e); // 171598
-        } catch (InvalidLogPropertiesException e) {
-            FFDCFilter.processException(e, "com.ibm.ws.runtime.component.TxServiceImpl.initiateRecovery", "1599", this);
-            Tr.error(tc, "WTRN0016_EXC_DURING_RECOVERY", e);
-            if (tc.isEntryEnabled())
-                Tr.exit(tc, "initiateRecovery", e);
-            throw new RecoveryFailedException(e); // 171598
-        } catch (URISyntaxException e) {
-            FFDCFilter.processException(e, "com.ibm.ws.runtime.component.TxServiceImpl.initiateRecovery", "1599", this);
-            Tr.error(tc, "WTRN0016_EXC_DURING_RECOVERY", e);
-            if (tc.isEntryEnabled())
-                Tr.exit(tc, "initiateRecovery", e);
-            throw new RecoveryFailedException(e); // 171598
-        } catch (PrivilegedActionException e) {
-            FFDCFilter.processException(e, "com.ibm.ws.runtime.component.TxServiceImpl.initiateRecovery", "463", this);
-            Tr.error(tc, "WTRN0016_EXC_DURING_RECOVERY", e);
-            if (tc.isEntryEnabled())
-                Tr.exit(tc, "initiateRecovery", e);
-            throw new RecoveryFailedException(e); // 171598
+            throw new RecoveryFailedException(e);
         }
 
         if (tc.isEntryEnabled())
@@ -667,7 +647,7 @@ public class TxRecoveryAgentImpl implements RecoveryAgent {
         try {
             recoveryDirector = RecoveryDirectorFactory.recoveryDirector();
         } catch (InternalLogException exc) {
-            FFDCFilter.processException(exc, "com.ibm.ws.runtime.component.TxServiceImpl.terminateRecovery", "1274", this);
+            FFDCFilter.processException(exc, "com.ibm.tx.jta.impl.TxRecoveryAgentImpl.terminateRecovery", "650", this);
             if (tc.isEntryEnabled())
                 Tr.exit(tc, "terminateRecovery");
             throw new TerminationFailedException(exc);
@@ -700,7 +680,7 @@ public class TxRecoveryAgentImpl implements RecoveryAgent {
             // and if this occurs then this indicates that there is a defect in the code. This exception is
             // raised by the RLS in the event that ot does not recognize this failure scope and recovery agent
             // conbindation.
-            FFDCFilter.processException(exc, "com.ibm.ws.runtime.component.TxServiceImpl.terminateRecovery", "1308", this);
+            FFDCFilter.processException(exc, "com.ibm.tx.jta.impl.TxRecoveryAgentImpl.terminateRecovery", "683", this);
             if (tc.isDebugEnabled())
                 Tr.debug(tc, "Unable to indicate termination completion to recovery director: " + exc);
             if (tc.isEntryEnabled())

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.longleasecompete/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.longleasecompete/bootstrap.properties
@@ -1,5 +1,4 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=Transaction=all:WAS.j2c=all:RRA=all:WAS.database=all:ClassLoadingService=all:SharedLibrary=all
-ds.loglevel=DEBUG
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true
 osgi.console=5471

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.longleaselogfail/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.longleaselogfail/bootstrap.properties
@@ -1,5 +1,4 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=Transaction=all:WAS.j2c=all:RRA=all:WAS.database=all
-ds.loglevel=DEBUG
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true
 osgi.console=5471

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.noShutdown/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.noShutdown/bootstrap.properties
@@ -1,5 +1,4 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=Transaction=all:WAS.j2c=all:RRA=all:WAS.database=all:ClassLoadingService=all:SharedLibrary=all
-ds.loglevel=DEBUG
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true
 osgi.console=5471

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.norecoverygroup/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.norecoverygroup/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,5 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:Transaction=all
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.peerServerPrecedence/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.peerServerPrecedence/bootstrap.properties
@@ -1,5 +1,4 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=Transaction=all:WAS.j2c=all:RRA=all:WAS.database=all:ClassLoadingService=all:SharedLibrary=all
-ds.loglevel=DEBUG
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true
 osgi.console=5471

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.shortlease/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.shortlease/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,5 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:Transaction=all
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,5 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:Transaction=all
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD002.nopeerlocking/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD002.nopeerlocking/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2023 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,5 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:Transaction=all:WAS.j2c=all:RRA=all:WAS.database=all:ClassLoadingService=all:SharedLibrary=all
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD002.shortlease/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD002.shortlease/bootstrap.properties
@@ -11,6 +11,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:Transaction=all:WAS.j2c=all:RRA=all:WAS.database=all:ClassLoadingService=all:SharedLibrary=all
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true
 com.ibm.tx.scupperRecovery=true

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD002/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD002/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,5 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:Transaction=all:WAS.j2c=all:RRA=all:WAS.database=all:ClassLoadingService=all:SharedLibrary=all
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_CLOUD002/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_CLOUD002/bootstrap.properties
@@ -1,5 +1,4 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=com.ibm.tx.jta.util.TxTMHelper=all=enabled
-ds.loglevel=DEBUG
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true
 osgi.console=5471

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_CLOUD002/server.xml
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_CLOUD002/server.xml
@@ -59,7 +59,4 @@
     <javaPermission className="java.lang.RuntimePermission" name="*" actions="*"/>
     <javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read,write,delete"/>
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
-        
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:com.ibm.wsspi.kernel.service.*=all:*=info=enabled"/>
-     
 </server>

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_FSCLOUD001/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_FSCLOUD001/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 com.ibm.tx.auditRecovery=true
-com.ibm.ws.logging.trace.specification=com.ibm.tx.jta.util.TxTMHelper=all=enabled
+com.ibm.ws.logging.trace.specification=Transaction=all

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_FSCLOUD001/server.xml
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_FSCLOUD001/server.xml
@@ -38,6 +38,4 @@
     <javaPermission codebase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
     <javaPermission className="java.lang.RuntimePermission" name="*" actions="*"/>
     <javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read,write,delete"/>
-
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:*=info=enabled"/>
 </server>

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_FSCLOUD002/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_FSCLOUD002/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 com.ibm.tx.auditRecovery=true
-com.ibm.ws.logging.trace.specification=com.ibm.tx.jta.util.TxTMHelper=all=enabled
+com.ibm.ws.logging.trace.specification=Transaction=all

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_FSCLOUD002/server.xml
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_FSCLOUD002/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017,2021 IBM Corporation and others.
+    Copyright (c) 2017, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -46,5 +46,4 @@
     <javaPermission className="java.lang.RuntimePermission" name="*" actions="*"/>
     <javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read,write,delete"/>
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:*=info=enabled"/>
 </server>

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_longtran/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_longtran/bootstrap.properties
@@ -1,5 +1,4 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=com.ibm.tx.jta.util.TxTMHelper=all=enabled
-ds.loglevel=DEBUG
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true
 osgi.console=5471

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_longtran/server.xml
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/com.ibm.ws.transaction_longtran/server.xml
@@ -54,7 +54,4 @@
     <javaPermission codebase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
     <javaPermission className="java.lang.RuntimePermission" name="*" actions="*"/>
     <javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read,write,delete"/>
-        
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:com.ibm.wsspi.kernel.service.*=all:*=info=enabled"/>
-     
 </server>

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/longLeaseLengthFSServer1/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/longLeaseLengthFSServer1/bootstrap.properties
@@ -1,5 +1,4 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=com.ibm.tx.jta.util.TxTMHelper=all=enabled
-ds.loglevel=DEBUG
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true
 osgi.console=5471

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/longLeaseLengthFSServer1/server.xml
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/longLeaseLengthFSServer1/server.xml
@@ -26,6 +26,4 @@
     <javaPermission codebase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
     <javaPermission className="java.lang.RuntimePermission" name="*" actions="*"/>
     <javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read,write,delete"/>
-
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:*=info=enabled"/>
 </server>

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/longLeaseLengthServer1/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/longLeaseLengthServer1/bootstrap.properties
@@ -1,5 +1,4 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=com.ibm.tx.jta.util.TxTMHelper=all=enabled
-ds.loglevel=DEBUG
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true
 osgi.console=5471

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/longLeaseLengthServer1/server.xml
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/longLeaseLengthServer1/server.xml
@@ -50,7 +50,4 @@
     <javaPermission codebase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
     <javaPermission className="java.lang.RuntimePermission" name="*" actions="*"/>
     <javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read,write,delete"/>
-
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:com.ibm.wsspi.kernel.service.*=all:*=info=enabled"/>
-     
 </server>

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/peerPrecedenceServer1/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/peerPrecedenceServer1/bootstrap.properties
@@ -1,5 +1,4 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=com.ibm.tx.jta.util.TxTMHelper=all=enabled
-ds.loglevel=DEBUG
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true
 osgi.console=5471

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/peerPrecedenceServer1/server.xml
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/publish/servers/peerPrecedenceServer1/server.xml
@@ -52,7 +52,4 @@
     <javaPermission codebase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
     <javaPermission className="java.lang.RuntimePermission" name="*" actions="*"/>
     <javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read,write,delete"/>
-        
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:com.ibm.wsspi.kernel.service.*=all:*=info=enabled"/>
-     
 </server>

--- a/dev/com.ibm.ws.transaction/bnd.bnd
+++ b/dev/com.ibm.ws.transaction/bnd.bnd
@@ -102,7 +102,8 @@ Export-Package: \
  com.ibm.ws.transaction.services.RemoteTransactionControllerService,\
  com.ibm.ws.transaction.services.TransactionSynchronizationRegistryService
 
-instrument.classesExcludes: com/ibm/ws/transaction/services/TransactionMessages*.class
+instrument.classesExcludes: com/ibm/ws/transaction/services/TransactionMessages*.class,\
+ com.ibm.ws.transaction.services.JTM*.class
 
 -buildpath: \
   com.ibm.tx.jta;version=latest,\


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.jta_fat,com.ibm.ws.transaction.cloud_fat.base,com.ibm.ws.transaction.cloud_fat.db2.0,com.ibm.ws.transaction.cloud_fat.db2.1,com.ibm.ws.transaction.cloud_fat.db2.2,com.ibm.ws.transaction.cloud_fat.derby.0,com.ibm.ws.transaction.cloud_fat.derby.1,com.ibm.ws.transaction.cloud_fat.derby.2,com.ibm.ws.transaction.cloud_fat.dualFS,com.ibm.ws.transaction.cloud_fat.oracle.0,com.ibm.ws.transaction.cloud_fat.oracle.1,com.ibm.ws.transaction.cloud_fat.oracle.2,com.ibm.ws.transaction.cloud_fat.peerlocking.1,com.ibm.ws.transaction.cloud_fat.peerlocking.2,com.ibm.ws.transaction.cloud_fat.postgresql.0,com.ibm.ws.transaction.cloud_fat.postgresql.1,com.ibm.ws.transaction.cloud_fat.postgresql.2,com.ibm.ws.transaction.cloud_fat.simpleFS,com.ibm.ws.transaction.cloud_fat.sqlserver.0,com.ibm.ws.transaction.cloud_fat.sqlserver.1,com.ibm.ws.transaction.cloud_fat.sqlserver.2,com.ibm.ws.transaction.core_fat.base,com.ibm.ws.transaction.core_fat.baseDB,com.ibm.ws.transaction.core_fat.cdi,com.ibm.ws.transaction.core_fat.commitPriority,com.ibm.ws.transaction.core_fat.heuristics,com.ibm.ws.transaction.core_fat.heuristicsDB,com.ibm.ws.transaction.core_fat.misc,com.ibm.ws.transaction.core_fat.startMultiEJB,com.ibm.ws.transaction.core_fat.startup,com.ibm.ws.transaction.core_fat.xa,com.ibm.ws.transaction.core_fat.xaDB,com.ibm.ws.transaction.db_fat,com.ibm.ws.transaction.hadb_fat.db2.1,com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.db2.retriablecodes,com.ibm.ws.transaction.hadb_fat.derby.1,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.derby.retriablecodes,com.ibm.ws.transaction.hadb_fat.oracle.1,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.oracle.retriablecodes,com.ibm.ws.transaction.hadb_fat.postgresql.1,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.postgresql.retriablecodes,com.ibm.ws.transaction.hadb_fat.sqlserver.1,com.ibm.ws.transaction.hadb_fat.sqlserver.2,com.ibm.ws.transaction.hadb_fat.sqlserver.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes,com.ibm.ws.transaction.recovery_fat.1,com.ibm.ws.transaction.recovery_fat.2,com.ibm.ws.transaction.recovery_fat.3,com.ibm.ws.tx.jta_fat,com.ibm.ws.tx.jta_fat_hibernate,com.ibm.ws.wsat.common_fat,com.ibm.ws.wsat.concurrent_fat,com.ibm.ws.wsat.migration_fat.1,com.ibm.ws.wsat.migration_fat.2,com.ibm.ws.wsat.migration_fat.3,com.ibm.ws.wsat.migration_fat.4,com.ibm.ws.wsat.migration_fat.5,com.ibm.ws.wsat.migration_fat.6,com.ibm.ws.wsat.migration_fat.7,com.ibm.ws.wsat.recovery_fat.lps,com.ibm.ws.wsat.recovery_fat.multi.1,com.ibm.ws.wsat.recovery_fat.multi.2,com.ibm.ws.wsat.recovery_fat.multi.3,com.ibm.ws.wsat.recovery_fat.multi.4,com.ibm.ws.wsat.recovery_fat.multi.5,com.ibm.ws.wsat.recovery_fat.multi.6,com.ibm.ws.wsat.recovery_fat.multi.7,com.ibm.ws.wsat.recovery_fat.single.1,com.ibm.ws.wsat.recovery_fat.single.2,com.ibm.ws.wsat_fat.assertion,com.ibm.ws.wsat_fat.db,com.ibm.ws.wsat_fat.db_optional,com.ibm.ws.wsat_fat.dbs,com.ibm.ws.wsat_fat.dbs_optional,com.ibm.ws.wsat_fat.multi,com.ibm.ws.wsat_fat.multi.misroute,com.ibm.ws.wsat_fat.ssl.misroute,com.ibm.ws.wsat_fat.ssl,io.openliberty.checkpoint_fat_transaction