### PR TITLE
Repeat jsfContainer_fat_2.3 against MyFaces 4.1.0-RC2

### DIFF
--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/bnd.bnd
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/bnd.bnd
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -25,18 +22,24 @@ tested.features: \
   enterprisebeanslite-5.0, \
   facesContainer-3.0, \
   facesContainer-4.0, \
+  facesContainer-4.1, \
   cdi-3.0, \
   cdi-4.0, \
+  cdi-4.1, \
   xmlBinding-3.0, \
   xmlBinding-4.0, \
   concurrent-2.0, \
   concurrent-3.0, \
+  concurrent-3.1, \
   persistenceContainer-3.0, \
   persistenceContainer-3.1, \
+  persistenceContainer-3.2, \
   beanvalidation-3.0, \
+  beanvalidation-3.1, \
   beanvalidation-4.0, \
   faces-3.0, \
-  faces-4.0
+  faces-4.0, \
+  faces-4.1
 
 src: \
     fat/src,\

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/build.gradle
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/build.gradle
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 configurations {
@@ -19,6 +16,8 @@ configurations {
     myfaces30
     mojarra40
     myfaces40
+    mojarra41
+    myfaces41
 }
 
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
@@ -106,7 +105,11 @@ dependencies {
     // Do not update since newer JS (in MyFaces 4.0.0-RC5+) is not supported 
     myfaces40 'org.apache.myfaces.core:myfaces-api:4.0.1',
       'org.apache.myfaces.core:myfaces-impl:4.0.1'
+    mojarra41 'org.glassfish:jakarta.faces:4.1.0'
+    myfaces41 'org.apache.myfaces.core:myfaces-api:4.1.0-RC2',
+      'org.apache.myfaces.core:myfaces-impl:4.1.0-RC2'
     }
+    
 
 task addMojarra(type: Copy) {
     from configurations.mojarra
@@ -121,6 +124,11 @@ task addMojarra30(type: Copy) {
 task addMojarra40(type: Copy) {
     from configurations.mojarra40
     into "${buildDir}/autoFVT/publish/files/mojarra40/"
+}
+
+task addMojarra41(type: Copy) {
+    from configurations.mojarra41
+    into "${buildDir}/autoFVT/publish/files/mojarra41/"
 }
 
 task addMyFaces(type: Copy) {
@@ -138,6 +146,11 @@ task addMyFaces40(type: Copy) {
     into "${buildDir}/autoFVT/publish/files/myfaces40"
 }
 
+task addMyFaces41(type: Copy) {
+    from configurations.myfaces41
+    into "${buildDir}/autoFVT/publish/files/myfaces41"
+}
+
 task addMyFacesLibs(type: Copy) {
     from configurations.myfacesLibs
     into "${buildDir}/autoFVT/publish/files/myfaces-libs"
@@ -152,9 +165,11 @@ addRequiredLibraries {
     dependsOn addMojarra
     dependsOn addMojarra30
     dependsOn addMojarra40
+    dependsOn addMojarra41
     dependsOn addMyFaces
     dependsOn addMyFaces30
     dependsOn addMyFaces40
+    dependsOn addMyFaces41
     dependsOn addMyFacesLibs
     dependsOn copyPermissionFile
     dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
@@ -67,9 +67,14 @@ public class FATSuite extends TestContainerSuite {
                 repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
                                 .andWith(FeatureReplacementAction.EE10_FEATURES());
             } else {
+                // EE10 requires Java 11.
+                // EE11 requires Java 17
+                // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
+                // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
                 repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                                .andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly())
-                                .andWith(FeatureReplacementAction.EE10_FEATURES());
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
+                    .andWith(FeatureReplacementAction.EE11_FEATURES());
             }
 
         } else {
@@ -80,12 +85,16 @@ public class FATSuite extends TestContainerSuite {
 
     public static final String MOJARRA_API_IMP = "publish/files/mojarra/javax.faces-2.3.9.jar";
     public static final String MOJARRA_API_IMP_40 = "publish/files/mojarra40/jakarta.faces-4.0.0.jar";
-    public static final String MYFACES_API = "publish/files/myfaces/myfaces-api-2.3.10.jar";
+    public static final String MOJARRA_API_IMP_41 = "publish/files/mojarra41/jakarta.faces-4.1.0.jar";
     public static final String MYFACES_IMP = "publish/files/myfaces/myfaces-impl-2.3.10.jar";
-    public static final String MYFACES_IMP_40 = "publish/files/myfaces40//myfaces-impl-4.0.1.jar";
+    public static final String MYFACES_IMP_30 = "publish/files/myfaces30/myfaces-impl-3.0.2.jar";
+    public static final String MYFACES_IMP_40 = "publish/files/myfaces40/myfaces-impl-4.0.1.jar";
+    public static final String MYFACES_IMP_41 = "publish/files/myfaces41/myfaces-impl-4.1.0-RC2.jar";
     // For ErrorPathsTest#testBadImplVersion_MyFaces Test (apps need the correct api since the tests checks for a bad implementation)
+    public static final String MYFACES_API = "publish/files/myfaces/myfaces-api-2.3.10.jar";
     public static final String MYFACES_API_30 = "publish/files/myfaces30/myfaces-api-3.0.2.jar";
     public static final String MYFACES_API_40 = "publish/files/myfaces40/myfaces-api-4.0.1.jar";
+    public static final String MYFACES_API_41 = "publish/files/myfaces41/myfaces-api-4.1.0-RC2.jar";
 
     public static DockerImageName getChromeImage() {
         if (FATRunner.ARM_ARCHITECTURE) {
@@ -96,7 +105,9 @@ public class FATSuite extends TestContainerSuite {
     }
 
     public static WebArchive addMojarra(WebArchive app) throws Exception {
-        if (JakartaEEAction.isEE10OrLaterActive()) {
+        if (JakartaEEAction.isEE11Active()){
+            return app.addAsLibraries(new File("publish/files/mojarra41/").listFiles());
+        } else if (JakartaEEAction.isEE10Active()) {
             return app.addAsLibraries(new File("publish/files/mojarra40/").listFiles());
         } else if (JakartaEEAction.isEE9Active()) {
             return app.addAsLibraries(new File("publish/files/mojarra30/").listFiles());
@@ -105,7 +116,9 @@ public class FATSuite extends TestContainerSuite {
     }
 
     public static WebArchive addMyFaces(WebArchive app) throws Exception {
-        if (JakartaEEAction.isEE10OrLaterActive()) {
+        if (JakartaEEAction.isEE11Active()) {
+            return app.addAsLibraries(new File("publish/files/myfaces41/").listFiles());
+        } else if (JakartaEEAction.isEE10Active()) {
             return app.addAsLibraries(new File("publish/files/myfaces40/").listFiles());
         } else if (JakartaEEAction.isEE9Active()) {
             return app.addAsLibraries(new File("publish/files/myfaces30/").listFiles()).addAsLibraries(new File("publish/files/myfaces-libs/").listFiles());

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF22StatelessViewTests.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF22StatelessViewTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -265,14 +265,14 @@ public class JSF22StatelessViewTests extends FATServletClient {
      * Since the view here is stateless, the ViewScoped bean should be re-initialized on every submit.
      */
     // Faces 4.0 doesn't support ManagedBeans and there is already a CDI test.
-    @SkipForRepeat(SkipForRepeat.EE10_FEATURES)
+    @SkipForRepeat(SkipForRepeat.EE10_OR_LATER_FEATURES)
     @Test
     public void JSF22StatelessView_TestViewScopeManagedBeanTransient_Mojarra() throws Exception {
         testViewScopeManagedBeanTransient(MOJARRA_APP, "/JSF22StatelessView_ViewScope_Transient.xhtml");
     }
 
     // Faces 4.0 doesn't support ManagedBeans and there is already a CDI test.
-    @SkipForRepeat(SkipForRepeat.EE10_FEATURES)
+    @SkipForRepeat(SkipForRepeat.EE10_OR_LATER_FEATURES)
     @Test
     public void JSF22StatelessView_TestViewScopeManagedBeanTransient_MyFaces() throws Exception {
         testViewScopeManagedBeanTransient(MYFACES_APP, "/JSF22StatelessView_ViewScope_Transient.xhtml");
@@ -296,7 +296,7 @@ public class JSF22StatelessViewTests extends FATServletClient {
      * Checks the behavior of a ViewScoped CDI bean, when embedded in a stateless view.
      * Since the view here is stateless, the ViewScoped bean should be re-initialized on every submit.
      */
-    @SkipForRepeat(SkipForRepeat.EE10_FEATURES) // Bug in Mojarra?
+    @SkipForRepeat(SkipForRepeat.EE10_OR_LATER_FEATURES) // Bug in Mojarra?
     @Test
     public void JSF22StatelessView_TestViewScopeCDIBeanTransient_Mojarra() throws Exception {
         testViewScopeManagedBeanTransient(MOJARRA_APP, "/JSF22StatelessView_ViewScope_CDI_Transient.xhtml");

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSFContainerTest.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSFContainerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -78,7 +78,7 @@ public class JSFContainerTest extends FATServletClient {
     }
 
     // ManagedBeans are no longer supported in Faces 4.0.
-    @SkipForRepeat(SkipForRepeat.EE10_FEATURES)
+    @SkipForRepeat(SkipForRepeat.EE10_OR_LATER_FEATURES)
     @Test
     public void testJSFBean_Mojarra() throws Exception {
         // Note that Mojarra does not support injecting @EJB into a JSF @ManagedBean
@@ -95,7 +95,7 @@ public class JSFContainerTest extends FATServletClient {
     }
 
     // ManagedBeans are no longer supported in Faces 4.0.
-    @SkipForRepeat(SkipForRepeat.EE10_FEATURES)
+    @SkipForRepeat(SkipForRepeat.EE10_OR_LATER_FEATURES)
     @Test
     public void testJSFBean_MyFaces() throws Exception {
         HttpUtils.findStringInReadyUrl(server, '/' + MYFACES_APP + "/TestBean.jsf",

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/utils/JSFUtils.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/utils/JSFUtils.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf.container.fat.utils;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/files/beans.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/files/beans.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
  <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/files/permissions/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/files/permissions/META-INF/permissions.xml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 
 <permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.beanval/bootstrap.properties
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.beanval/bootstrap.properties
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf.*=all:com.ibm.ws.jsf.container=all
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.cdi/bootstrap.properties
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.cdi/bootstrap.properties
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf.*=all:com.ibm.ws.jsf.container=all

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.config/bootstrap.properties
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.config/bootstrap.properties
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf.*=all:com.ibm.ws.jsf.container=all:\

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.errorpaths/bootstrap.properties
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.errorpaths/bootstrap.properties
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf.*=all:com.ibm.ws.jsf.container=all

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.ws/bootstrap.properties
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.ws/bootstrap.properties
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf.*=all:com.ibm.ws.jsf.container=all

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat/bootstrap.properties
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf.*=all:com.ibm.ws.jsf.container=all:com.ibm.ws.app.manager=all

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/BeanValidationTests/resources/BeanValidation.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/BeanValidationTests/resources/BeanValidation.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/BeanValidationTests/resources/WEB-INF/faces-config.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/BeanValidationTests/resources/WEB-INF/faces-config.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <faces-config xmlns="http://xmlns.jcp.org/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/BeanValidationTests/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/BeanValidationTests/resources/WEB-INF/web.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 
 <web-app id="WebApp_ID" version="3.1" 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/BeanValidationTests/resources/success.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/BeanValidationTests/resources/success.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/BeanValidationTests/src/jsf/beanval/BeanValTestServlet.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/BeanValidationTests/src/jsf/beanval/BeanValTestServlet.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.beanval;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/CDIManagedProperty/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/CDIManagedProperty/resources/WEB-INF/web.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <web-app id="WebApp_ID" version="4.0"
     xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/CDIManagedProperty/src/com/ibm/ws/jsf23/fat/cdi/managedproperty/ManagedPropertyBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/CDIManagedProperty/src/com/ibm/ws/jsf23/fat/cdi/managedproperty/ManagedPropertyBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat.cdi.managedproperty;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/CDIManagedProperty/src/com/ibm/ws/jsf23/fat/cdi/managedproperty/TestBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/CDIManagedProperty/src/com/ibm/ws/jsf23/fat/cdi/managedproperty/TestBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat.cdi.managedproperty;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/WEB-INF/faces-config.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/WEB-INF/faces-config.xml
@@ -7,8 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <faces-config
     xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/WEB-INF/web.xml
@@ -7,8 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <web-app id="WebApp_ID" version="4.0"
     xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/index.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/index.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/page2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/page2.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/src/com/ibm/ws/jsf/conversationscoped/bean/ConversationScopedBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/src/com/ibm/ws/jsf/conversationscoped/bean/ConversationScopedBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf.conversationscoped.bean;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/resources/JSFArtifactsInjection.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/resources/JSFArtifactsInjection.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/resources/WEB-INF/beans.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/resources/WEB-INF/beans.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/resources/WEB-INF/taglib.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/resources/WEB-INF/taglib.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <facelet-taglib version="2.2"
                 xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/resources/WEB-INF/web.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <web-app id="WebApp_ID" version="4.0"
     xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/resources/index.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/resources/index.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/src/com/ibm/ws/jsf23/fat/converter_validator/beans/JSFArtifactsInjectionBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/src/com/ibm/ws/jsf23/fat/converter_validator/beans/JSFArtifactsInjectionBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat.converter_validator.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/src/com/ibm/ws/jsf23/fat/converter_validator/beans/TestBehavior.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/src/com/ibm/ws/jsf23/fat/converter_validator/beans/TestBehavior.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat.converter_validator.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/src/com/ibm/ws/jsf23/fat/converter_validator/beans/TestCDIBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/src/com/ibm/ws/jsf23/fat/converter_validator/beans/TestCDIBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat.converter_validator.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/src/com/ibm/ws/jsf23/fat/converter_validator/beans/TestConverter.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/src/com/ibm/ws/jsf23/fat/converter_validator/beans/TestConverter.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat.converter_validator.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/src/com/ibm/ws/jsf23/fat/converter_validator/beans/TestValidator.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConverterValidatorBehaviorInjectionTarget/src/com/ibm/ws/jsf23/fat/converter_validator/beans/TestValidator.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat.converter_validator.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resources/WEB-INF/resources/test/compositeTest.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resources/WEB-INF/resources/test/compositeTest.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:composite="http://xmlns.jcp.org/jsf/composite">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resources/WEB-INF/web.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <web-app id="WebApp_ID" version="4.0"
     xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resources/flow_index.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resources/flow_index.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resources/index.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resources/index.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resources/simpleBean/simpleBean-flow.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resources/simpleBean/simpleBean-flow.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <faces-config version="2.3" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resources/simpleBean/simpleBean.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resources/simpleBean/simpleBean.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resourcesFaces40/implicit_objects.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resourcesFaces40/implicit_objects.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resourcesJSF23/implicit_objects.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/resourcesJSF23/implicit_objects.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/src/com/ibm/ws/jsf23/fat/elcdi/beans/ELImplicitObjectBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/src/com/ibm/ws/jsf23/fat/elcdi/beans/ELImplicitObjectBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat.elcdi.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/src/com/ibm/ws/jsf23/fat/elcdi/beans/TestBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ELImplicitObjectsViaCDI/src/com/ibm/ws/jsf23/fat/elcdi/beans/TestBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat.elcdi.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/JSF22Flows_index.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/JSF22Flows_index.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/JSF22Flows_noAccess.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/JSF22Flows_noAccess.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/JSF22Flows_return.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/JSF22Flows_return.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/WEB-INF/beans.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/WEB-INF/beans.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/WEB-INF/faces-config.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/WEB-INF/faces-config.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 
 <faces-config version="2.2"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/WEB-INF/web.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 
 <web-app id="WebApp_ID" version="3.1"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/initializeFinalize/initializeFinalize-2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/initializeFinalize/initializeFinalize-2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/initializeFinalize/initializeFinalize-flow.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/initializeFinalize/initializeFinalize-flow.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/initializeFinalize/initializeFinalize.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/initializeFinalize/initializeFinalize.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/mixedNested1/mixedNested1-2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/mixedNested1/mixedNested1-2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/mixedNested1/mixedNested1.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/mixedNested1/mixedNested1.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/mixedNested2/mixedNested2-flow.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/mixedNested2/mixedNested2-flow.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/mixedNested2/mixedNested2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/mixedNested2/mixedNested2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/programmaticSwitch/programmaticSwitch-2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/programmaticSwitch/programmaticSwitch-2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/programmaticSwitch/programmaticSwitch.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/programmaticSwitch/programmaticSwitch.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/simpleBean/simpleBean-2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/simpleBean/simpleBean-2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/simpleBean/simpleBean-flow.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/simpleBean/simpleBean-flow.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/simpleBean/simpleBean.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/simpleBean/simpleBean.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/simpleFlowBuilder/simpleFlowBuilder-2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/simpleFlowBuilder/simpleFlowBuilder-2.xhtml
@@ -8,9 +8,6 @@
    http://www.eclipse.org/legal/epl-2.0/
    
    SPDX-License-Identifier: EPL-2.0
-
-   Contributors:
-       IBM Corporation - initial API and implementation
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/simpleFlowBuilder/simpleFlowBuilder.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/resources/simpleFlowBuilder/simpleFlowBuilder.xhtml
@@ -8,9 +8,6 @@
    http://www.eclipse.org/legal/epl-2.0/
    
    SPDX-License-Identifier: EPL-2.0
-
-   Contributors:
-       IBM Corporation - initial API and implementation
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/src/jsf/cdi/flow/beans/CountBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/src/jsf/cdi/flow/beans/CountBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.cdi.flow.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/src/jsf/cdi/flow/beans/MixedNested1.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/src/jsf/cdi/flow/beans/MixedNested1.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.cdi.flow.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/src/jsf/cdi/flow/beans/ProgrammaticSwitch.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/src/jsf/cdi/flow/beans/ProgrammaticSwitch.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.cdi.flow.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/src/jsf/cdi/flow/beans/SimpleFlowBuilder.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/src/jsf/cdi/flow/beans/SimpleFlowBuilder.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.cdi.flow.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/src/jsf/cdi/flow/beans/TestBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/src/jsf/cdi/flow/beans/TestBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.cdi.flow.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/src/jsf/cdi/flow/beans/TestBeanInitFinalize.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22CDIFacesFlows/src/jsf/cdi/flow/beans/TestBeanInitFinalize.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.cdi.flow.beans;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/jar/META-INF/faces-config.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/jar/META-INF/faces-config.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 
 <faces-config version="2.2"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/jar/META-INF/flows/simple-jar/simple-jar-2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/jar/META-INF/flows/simple-jar/simple-jar-2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/jar/META-INF/flows/simple-jar/simple-jar.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/jar/META-INF/flows/simple-jar/simple-jar.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/JSF22Flows_index.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/JSF22Flows_index.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/JSF22Flows_noAccess.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/JSF22Flows_noAccess.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/JSF22Flows_return.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/JSF22Flows_return.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/WEB-INF/faces-config.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/WEB-INF/faces-config.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 
 <faces-config version="2.2"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/WEB-INF/web.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 
 <web-app id="WebApp_ID" version="3.1"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeNested1/declarativeNested1-2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeNested1/declarativeNested1-2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeNested1/declarativeNested1-flow.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeNested1/declarativeNested1-flow.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeNested1/declarativeNested1.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeNested1/declarativeNested1.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeNested2/declarativeNested2-2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeNested2/declarativeNested2-2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeNested2/declarativeNested2-flow.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeNested2/declarativeNested2-flow.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeNested2/declarativeNested2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeNested2/declarativeNested2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeSwitch/declarativeSwitch-2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeSwitch/declarativeSwitch-2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeSwitch/declarativeSwitch-flow.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeSwitch/declarativeSwitch-flow.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeSwitch/declarativeSwitch.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/declarativeSwitch/declarativeSwitch.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simple/simple-2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simple/simple-2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simple/simple-flow.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simple/simple-flow.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simple/simple.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simple/simple.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simpleFacesConfig/simpleFacesConfig-2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simpleFacesConfig/simpleFacesConfig-2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simpleFacesConfig/simpleFacesConfig.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simpleFacesConfig/simpleFacesConfig.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simpleNavigationDeclarative/simpleNavigationDeclarative-flow.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simpleNavigationDeclarative/simpleNavigationDeclarative-flow.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simpleNavigationDeclarative/simpleNavigationDeclarative.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simpleNavigationDeclarative/simpleNavigationDeclarative.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simpleNavigationDeclarative/simpleNavigationDeclarative2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/resources/war/simpleNavigationDeclarative/simpleNavigationDeclarative2.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/src/jsf/flow/beans/faces40/InitializerBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/src/jsf/flow/beans/faces40/InitializerBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.flow.beans.faces40;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/src/jsf/flow/beans/jsf22/InitializerBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22FacesFlows/src/jsf/flow/beans/jsf22/InitializerBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.flow.beans.jsf22;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_Simple.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_Simple.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_ViewScope_CDI_NotTransient.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_ViewScope_CDI_NotTransient.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_ViewScope_CDI_Transient.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_ViewScope_CDI_Transient.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_ViewScope_NotTransient.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_ViewScope_NotTransient.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_ViewScope_Transient.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_ViewScope_Transient.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_isTransient_default.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_isTransient_default.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_isTransient_false.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_isTransient_false.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_isTransient_true.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/resources/JSF22StatelessView_isTransient_true.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/src/jsf/view/beans/faces40/StatelessViewBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/src/jsf/view/beans/faces40/StatelessViewBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.view.beans.faces40;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/src/jsf/view/beans/jsf22/StatelessViewBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/src/jsf/view/beans/jsf22/StatelessViewBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.view.beans.jsf22;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/src/jsf/view/beans/jsf22/ViewScopedManagedBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/JSF22StatelessView/src/jsf/view/beans/jsf22/ViewScopedManagedBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.view.beans.jsf22;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/PostRenderViewEvent/resources/WEB-INF/faces-config.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/PostRenderViewEvent/resources/WEB-INF/faces-config.xml
@@ -6,9 +6,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <faces-config xmlns="http://xmlns.jcp.org/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/PostRenderViewEvent/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/PostRenderViewEvent/resources/WEB-INF/web.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <web-app id="WebApp_ID" version="4.0"
     xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/PostRenderViewEvent/resources/index.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/PostRenderViewEvent/resources/index.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/PostRenderViewEvent/src/com/ibm/ws/jsf23/fat/prve/events/RenderResponsePhaseListener.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/PostRenderViewEvent/src/com/ibm/ws/jsf23/fat/prve/events/RenderResponsePhaseListener.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat.prve.events;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/PostRenderViewEvent/src/com/ibm/ws/jsf23/fat/prve/events/RenderViewEventsBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/PostRenderViewEvent/src/com/ibm/ws/jsf23/fat/prve/events/RenderViewEventsBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat.prve.events;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/resources/META-INF/permissions.xml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
 -->
 
 <permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/resources/WEB-INF/faces-config.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/resources/WEB-INF/faces-config.xml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
 -->
 
 <faces-config version="2.0" xmlns="http://java.sun.com/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/resources/WEB-INF/web.xml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
 -->
 
 <web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/resources/index.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/resources/index.xhtml
@@ -8,9 +8,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/src/jsf/container/viewhandlertest/CustomApplication.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/src/jsf/container/viewhandlertest/CustomApplication.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.container.viewhandlertest;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/src/jsf/container/viewhandlertest/CustomApplicationFactory.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/src/jsf/container/viewhandlertest/CustomApplicationFactory.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.container.viewhandlertest;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/src/jsf/container/viewhandlertest/CustomViewHandler.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/src/jsf/container/viewhandlertest/CustomViewHandler.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.container.viewhandlertest;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/src/jsf/container/viewhandlertest/TestBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ViewHandlerTest/src/jsf/container/viewhandlertest/TestBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.container.viewhandlertest;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/WEB-INF/web.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <web-app id="WebApp_ID" version="4.0"
     xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/faces40/OpenCloseWebSocketTest.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/faces40/OpenCloseWebSocketTest.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/faces40/PushWebSocketTest.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/faces40/PushWebSocketTest.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/faces40/websocketListeners.js
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/faces40/websocketListeners.js
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 function websocketMessageListener(message, channel, event) {
    	document.getElementById("messageId").innerHTML += message + "<br/>";

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/jsf23/OpenCloseWebSocketTest.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/jsf23/OpenCloseWebSocketTest.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/jsf23/PushWebSocketTest.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/jsf23/PushWebSocketTest.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/jsf23/websocketListeners.js
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/resources/jsf23/websocketListeners.js
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 function websocketMessageListener(message, channel, event) {
    	document.getElementById("messageId").innerHTML += message + "<br/>";

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/src/com/ibm/ws/jsf23/fat/websocket/WebsocketPushBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/WebSocket/src/com/ibm/ws/jsf23/fat/websocket/WebsocketPushBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat.websocket;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/jsfApp/resources-myfaces/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/jsfApp/resources-myfaces/WEB-INF/web.xml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <web-app id="WebApp_ID" version="4.0"
     xmlns="http://xmlns.jcp.org/xml/ns/javaee"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/jsfApp/resources/TestBean.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/jsfApp/resources/TestBean.xhtml
@@ -7,9 +7,6 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <html xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:f="http://xmlns.jcp.org/jsf/core"

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/jsfApp/src/jsf/container/bean/CDIBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/jsfApp/src/jsf/container/bean/CDIBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.container.bean;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/jsfApp/src/jsf/container/bean/TestEJB.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/jsfApp/src/jsf/container/bean/TestEJB.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.container.bean;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/jsfApp/src/jsf/container/bean/jsf23/JSFBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/jsfApp/src/jsf/container/bean/jsf23/JSFBean.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.container.bean.jsf23;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/noJsfApp/src/jsf/container/nojsf/web/TestServlet.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/noJsfApp/src/jsf/container/nojsf/web/TestServlet.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.container.nojsf.web;
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/noJsfApp/src/jsf/container/somelib/SomeLibClass.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/noJsfApp/src/jsf/container/somelib/SomeLibClass.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jsf.container.somelib;
 


### PR DESCRIPTION
for #27415

Adds MyFaces 4.1 & EE11 testing support for jsfContainer_fat_2.3 bucket.

**Note:** Mojarra does not currently have a release of 4.1 so Mojarra tests have been skipped on the EE11 repeat. Once a release does come these skips should be removed.