### PR TITLE
Server is already non-secured, use normal HTTP call (io.openliberty.http.monitor.fat)

### DIFF
--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
@@ -149,7 +149,7 @@ public abstract class BaseTestClass {
     }
 
     protected String getVendorMetrics(LibertyServer server) throws Exception {
-        String vendorMetricsOutput = requestHttpSecureServlet("/metrics?scope=vendor", server, HttpMethod.GET);
+        String vendorMetricsOutput = requestHttpServlet("/metrics?scope=vendor", server, HttpMethod.GET);
         Log.info(c, "getVendorMetrics", vendorMetricsOutput);
         return vendorMetricsOutput;
     }


### PR DESCRIPTION
Fixes #28651
#build

Some issue encountered when trying to make a HTTPS connection with the current way.
To fix the problem for now, will use a unsecured (http) connection stead.
*The servers already have authentication = false set.

Issue created to address methodology of making requests: https://github.com/OpenLiberty/open-liberty/issues/28704