### PR TITLE
Update FAT building to depend on fattest.simplicity assemble task

### DIFF
--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -152,6 +152,7 @@ task autoFVT {
   dependsOn ':cnf:copyMavenLibs'
   dependsOn addRequiredLibraries
   dependsOn copyFeatureBundles
+  dependsOn ':fattest.simplicity:assemble'
   enabled project.file('fat').exists()
 
   ext.getFeature = { line ->


### PR DESCRIPTION
- Before building a FAT would run fattest.simplicity jar task implicitly due to the dependency on fattest.simplicity.jar file.  Now that operations are done in assemble instead of jar, the buildfat task needs to depend on fattest.simplicity assemble task instead.
