### PR TITLE
Update package names to match their directory name

### DIFF
--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/selenium_util/CustomDriver.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/selenium_util/CustomDriver.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
  */
-package com.ibm.ws.jsf23.fat.selenium_util;
+package com.ibm.ws.jsf.container.fat.selenium_util;
 
 import java.net.URI;
 import java.net.URLDecoder;

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/selenium_util/ExtendedWebDriver.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/selenium_util/ExtendedWebDriver.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
  */
-package com.ibm.ws.jsf23.fat.selenium_util;
+package com.ibm.ws.jsf.container.fat.selenium_util;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/selenium_util/WebPage.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/selenium_util/WebPage.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
  */
-package com.ibm.ws.jsf23.fat.selenium_util;
+package com.ibm.ws.jsf.container.fat.selenium_util;
 
 import org.openqa.selenium.*;
 import org.openqa.selenium.By;

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF23CDIGeneralTests.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF23CDIGeneralTests.java
@@ -46,9 +46,9 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.jsf.container.fat.FATSuite;
 import com.ibm.ws.jsf.container.fat.utils.JSFUtils;
-import com.ibm.ws.jsf23.fat.selenium_util.CustomDriver;
-import com.ibm.ws.jsf23.fat.selenium_util.ExtendedWebDriver;
-import com.ibm.ws.jsf23.fat.selenium_util.WebPage;
+import com.ibm.ws.jsf.container.fat.selenium_util.CustomDriver;
+import com.ibm.ws.jsf.container.fat.selenium_util.ExtendedWebDriver;
+import com.ibm.ws.jsf.container.fat.selenium_util.WebPage;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF23WebSocketTests.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF23WebSocketTests.java
@@ -35,9 +35,9 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.jsf.container.fat.FATSuite;
 import com.ibm.ws.jsf.container.fat.utils.JSFUtils;
-import com.ibm.ws.jsf23.fat.selenium_util.CustomDriver;
-import com.ibm.ws.jsf23.fat.selenium_util.ExtendedWebDriver;
-import com.ibm.ws.jsf23.fat.selenium_util.WebPage;
+import com.ibm.ws.jsf.container.fat.selenium_util.CustomDriver;
+import com.ibm.ws.jsf.container.fat.selenium_util.ExtendedWebDriver;
+import com.ibm.ws.jsf.container.fat.selenium_util.WebPage;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;


### PR DESCRIPTION
- Classes were copied over from another project, but their package names were not updated to the package they were put into in the new project.  When this happens, gradle builds clean, but things do not build cleanly in eclipse.
