### PR TITLE
Fix the source view save in Server Config

### DIFF
--- a/dev/com.ibm.ws.ui.tool.serverConfig/resources/WEB-CONTENT/js/components/editor.js
+++ b/dev/com.ibm.ws.ui.tool.serverConfig/resources/WEB-CONTENT/js/components/editor.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * Copyright (c) 2015, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui.tool.serverConfig/resources/WEB-CONTENT/js/components/editor.js
+++ b/dev/com.ibm.ws.ui.tool.serverConfig/resources/WEB-CONTENT/js/components/editor.js
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -240,9 +240,9 @@
 
         // Obtain content to save
         var contentToSave = null;
-        if($("#editorDesignView").is(":visible")) {
+        if(!$("#editorDesignView").hasClass("hidden")) {
             contentToSave = serializeConfigurationFile();
-        } else if($("#editorSourceView").is(":visible")) {
+        } else if(!$("#editorSourceView").hasClass("hidden")) {
             contentToSave = source.orionEditor.editor.getText();
         }
         // if bidi, make sure there aren't control characters


### PR DESCRIPTION
This PR fixes the Server Config source view save function which checks to see what tab is currently visible. The `.is(":visible")` was not an accurate way to telling if the tab was visible because the Bootstrap class used to hide the tab was still visible but just off of the viewport. This is changed to check for the `hidden` class for when it is actually hidden.

Fixes https://github.com/OpenLiberty/open-liberty/issues/28716