### PR TITLE
Fix JPA FAT project dependency

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_32_fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_32_fat.common/bnd.bnd
@@ -35,6 +35,10 @@ javac.target: 17
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true
 
+# Included projects must be built first
+-dependson: \
+    com.ibm.ws.jpa.tests.eclipselink.query_31_fat.common
+
 -includeresource: \
     @${repo;com.ibm.ws.jpa.tests.eclipselink.query_31_fat.common}, \
     ${bin}


### PR DESCRIPTION
com.ibm.ws.jpa.tests.eclipselink.query_32_fat.common may fail to build when parallel builds enabled
- Added a dependson for required jpa 31 project to ensure it completes building first
