### PR TITLE
Update to depend on assembleBinaryDependencies instead of assemble

### DIFF
--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -152,7 +152,7 @@ task autoFVT {
   dependsOn ':cnf:copyMavenLibs'
   dependsOn addRequiredLibraries
   dependsOn copyFeatureBundles
-  dependsOn ':fattest.simplicity:assemble'
+  dependsOn ':fattest.simplicity:assembleBinaryDependencies'
   enabled project.file('fat').exists()
 
   ext.getFeature = { line ->


### PR DESCRIPTION
- Change the autoFVT task to depend on assembleBinaryDependencies instead of assemble.  In some environments depending on assemble caused weird gradle errors and we only need to depend on assembleBinaryDependencies in reality.

This PR is modifying what was done in PR #28678.