### PR TITLE
Remove packageServerConflict for MP7

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -643,7 +643,6 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&microProfile7Features
-        packageServerConflict = "io.openliberty.microProfile,io.openliberty.mpConfig,io.openliberty.mpTelemetry,io.openliberty.org.eclipse.microprofile.config,io.openliberty.mpCompatible,io.openliberty.internal.mpVersion"
         outputTo new File(packageDir, "microProfile7")
         doLast {
             copy {


### PR DESCRIPTION
At this point in time, the MP7 zip should not contain multiple versions of any features and so should not have any allowed conflicts.
