### PR TITLE
Add MP7 repeats to MP FaultTolerance FATs

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
@@ -26,6 +26,7 @@ tested.features: mpFaultTolerance-1.0,\
                  mpFaultTolerance-2.1,\
                  mpFaultTolerance-3.0,\
                  mpFaultTolerance-4.0,\
+                 mpFaultTolerance-4.1,\
                  mpConfig-1.1,\
                  mpConfig-1.2,\
                  mpConfig-1.3,\
@@ -35,9 +36,11 @@ tested.features: mpFaultTolerance-1.0,\
                  cdi-2.0,\
                  cdi-3.0,\
                  cdi-4.0,\
+                 cdi-4.1,\
                  servlet-3.1,\
                  servlet-5.0,\
                  servlet-6.0,\
+                 servlet-6.1,\
                  appsecurity-3.0,\
                  appsecurity-4.0,\
                  appsecurity-5.0,\

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
@@ -1,14 +1,11 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2021 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -53,6 +50,7 @@ tested.features: mpFaultTolerance-1.0,\
                  restfulwsclient-3.1,\
                  concurrent-2.0,\
                  concurrent-3.0,\
+                 concurrent-3.1,\
                  restfulws-3.0,\
                  restfulws-3.1,\
                  jsonp-2.0,\

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleClassLoading.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleClassLoading.java
@@ -51,6 +51,8 @@ public class TestMultiModuleClassLoading extends FATServletClient {
     //run against EE10, EE9, EE8 and EE7 features
     @ClassRule
     public static RepeatTests r = RepeatFaultTolerance.repeat(SERVER_NAME, TestMode.FULL,
+                                                              RepeatFaultTolerance.MP70_EE10_METRICS51,
+                                                              RepeatFaultTolerance.MP70_EE11_METRICS51,
                                                               MicroProfileActions.MP61,
                                                               MicroProfileActions.MP13,
                                                               RepeatFaultTolerance.MP21_METRICS20,

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleConfigLoad.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleConfigLoad.java
@@ -62,6 +62,8 @@ public class TestMultiModuleConfigLoad extends FATServletClient {
     //run against EE10, EE9, EE8 and EE7 features
     @ClassRule
     public static RepeatTests r = RepeatFaultTolerance.repeat(SERVER_NAME, TestMode.FULL,
+                                                              RepeatFaultTolerance.MP70_EE10_METRICS51,
+                                                              RepeatFaultTolerance.MP70_EE11_METRICS51,
                                                               MicroProfileActions.MP61,
                                                               MicroProfileActions.MP13,
                                                               RepeatFaultTolerance.MP21_METRICS20,

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/FaultToleranceMainTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/FaultToleranceMainTest.java
@@ -92,7 +92,7 @@ public class FaultToleranceMainTest extends FATServletClient {
     @Rule
     public AnnotationFilter filter = AnnotationFilter
                     .requireAnnotations(BasicTest.class)
-                    .forAllRepeatsExcept(MicroProfileActions.MP61_ID)
+                    .forAllRepeatsExcept(RepeatFaultTolerance.MP70_EE10_METRICS51_ID)
                     .inModes(TestMode.LITE);
 
     @BeforeClass
@@ -214,7 +214,9 @@ public class FaultToleranceMainTest extends FATServletClient {
                      MicroProfileActions.MP41_ID,
                      MicroProfileActions.MP50_ID,
                      MicroProfileActions.MP60_ID,
-                     MicroProfileActions.MP61_ID }) // FT 3.0+ does not close executors until the application shuts down
+                     MicroProfileActions.MP61_ID,
+                     RepeatFaultTolerance.MP70_EE10_METRICS51_ID,
+                     RepeatFaultTolerance.MP70_EE11_METRICS51_ID }) // FT 3.0+ does not close executors until the application shuts down
     @Test
     public void testExecutorsClose() throws Exception {
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
@@ -33,6 +33,7 @@ tested.features: mpfaulttolerance-1.0,\
                  cdi-2.0,\
                  cdi-3.0,\
                  cdi-4.0,\
+                 cdi-4.1,\
                  appsecurity-3.0,\
                  el-3.0,\
                  mpmetrics-1.0,\
@@ -45,7 +46,10 @@ tested.features: mpfaulttolerance-1.0,\
                  mpMetrics-5.1,\
                  servlet-5.0,\
                  servlet-6.0,\
+                 servlet-6.1,\
                  mpTelemetry-2.0,\
+                 restfulwsclient-4.0,\
+                 restfulws-4.0
 
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/TelemetryMetricCombinationTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/TelemetryMetricCombinationTest.java
@@ -32,10 +32,10 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.isolation.IsolationServlet;
 import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.isolation.PullExporterAutoConfigurationCustomizerProvider;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.faulttolerance.fat.repeat.RepeatFaultTolerance;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
@@ -53,7 +53,7 @@ public class TelemetryMetricCombinationTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE10);
+    public static RepeatTests r = RepeatFaultTolerance.repeat(SERVER_NAME, RepeatFaultTolerance.MP70_EE10_METRICS51, RepeatFaultTolerance.MP70_EE11_METRICS51);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/TelemetryMetricIsolationTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/TelemetryMetricIsolationTest.java
@@ -48,7 +48,7 @@ public class TelemetryMetricIsolationTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE10);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/CircuitBreakerMetricTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/CircuitBreakerMetricTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/publish/servers/CDIFaultToleranceMetricsAndTelemetry/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/publish/servers/CDIFaultToleranceMetricsAndTelemetry/server.xml
@@ -6,16 +6,13 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
 
 	<include location="../fatTestPorts.xml" />
 
 	<featureManager>
-		<feature>componenttest-1.0</feature>
+		<feature>componenttest-2.0</feature>
 		<feature>osgiconsole-1.0</feature>
 		<feature>localConnector-1.0</feature>
 		<feature>cdi-4.0</feature>

--- a/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance.fat.repeat;
 
@@ -38,12 +35,17 @@ import componenttest.rules.repeater.RepeatTests;
  * MicroProfile 4.1 = Fault Tolerance 3.0
  * MicroProfile 5.0 = Fault Tolerance 4.0 (Transformed Impl for EE9)
  * MicroProfile 6.0 = Fault Tolerance 4.0
+ * MicroProfile 6.1 = Fault Tolerance 4.1 (both EE10 and EE11)
  */
 public class RepeatFaultTolerance {
 
-    public static final String MP21_METRICS20_ID = "MP21_METRICS20";
+    public static final String MP21_METRICS20_ID = MicroProfileActions.MP21_ID + "_METRICS20";
+    public static final String MP70_EE10_METRICS51_ID = MicroProfileActions.MP70_EE10_ID + "_METRICS51";
+    public static final String MP70_EE11_METRICS51_ID = MicroProfileActions.MP70_EE11_ID + "_METRICS51";
 
     public static final FeatureSet MP21_METRICS20 = MicroProfileActions.MP21.removeFeature("mpMetrics-1.1").addFeature("mpMetrics-2.0").build(MP21_METRICS20_ID);
+    public static final FeatureSet MP70_EE10_METRICS51 = MicroProfileActions.MP70_EE10.addFeature("mpMetrics-5.1").build(MP70_EE10_METRICS51_ID);
+    public static final FeatureSet MP70_EE11_METRICS51 = MicroProfileActions.MP70_EE11.addFeature("mpMetrics-5.1").build(MP70_EE11_METRICS51_ID);
 
     //All MicroProfile ReactiveMessaging FeatureSets - must be descending order
     private static final List<FeatureSet> ALL;
@@ -52,13 +54,38 @@ public class RepeatFaultTolerance {
         ALL = new ArrayList<>(MicroProfileActions.ALL);
         //put the updated FeatureSet in just before MP21
         ALL.add(ALL.indexOf(MicroProfileActions.MP21), MP21_METRICS20);
+        //put the updated FeatureSet in just before MP70_EE10
+        ALL.add(ALL.indexOf(MicroProfileActions.MP70_EE10), MP70_EE10_METRICS51);
+        //put the updated FeatureSet in just before MP70_EE10
+        ALL.add(ALL.indexOf(MicroProfileActions.MP70_EE11), MP70_EE11_METRICS51);
     }
 
     /**
-     * @param server The server to repeat on
+     * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in FULL.
+     * Usage: The following example will repeat the tests using MicroProfile versions 1.2, 1.3, 1.4, 3.3 and 4.0 (1.2 in LITE mode, the others in FULL).
+     *
+     * <pre>
+     * <code>
+     * &#64;ClassRule
+     * public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP12, MicroProfileActions.MP13,
+     *                                    MicroProfileActions.MP14, MicroProfileActions.MP33, MicroProfileActions.MP40);
+     * </code>
+     * </pre>
+     *
+     * @param server           The server to repeat on
+     * @param firstFeatureSet  The first FeatureSet
+     * @param otherFeatureSets The other FeatureSets
+     * @return a RepeatTests instance
+     */
+    public static RepeatTests repeat(String server, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
+        return repeat(server, TestMode.FULL, firstFeatureSet, otherFeatureSets);
+    }
+
+    /**
+     * @param server                   The server to repeat on
      * @param otherFeatureSetsTestMode The test mode to run the otherFeatureSets
-     * @param firstFeatureSet The first FeatureSet to repeat with. This is run in LITE mode.
-     * @param otherFeatureSets The other FeatureSets to repeat with. These are in the mode specified by otherFeatureSetsTestMode
+     * @param firstFeatureSet          The first FeatureSet to repeat with. This is run in LITE mode.
+     * @param otherFeatureSets         The other FeatureSets to repeat with. These are in the mode specified by otherFeatureSetsTestMode
      * @return A RepeatTests instance
      */
     public static RepeatTests repeat(String serverName, TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
@@ -88,11 +115,12 @@ public class RepeatFaultTolerance {
      * @return the RepeatTests rule
      */
     public static RepeatTests repeatDefault(String server) {
-        return repeat(server, TestMode.FULL, MicroProfileActions.MP61, MicroProfileActions.MP40, MicroProfileActions.MP20);
+        return repeat(server, TestMode.FULL, MP70_EE10_METRICS51, MP70_EE11_METRICS51, MicroProfileActions.MP61, MicroProfileActions.MP40,
+                      MicroProfileActions.MP20);
     }
 
     /**
-     * Return a rule to repeat tests for FT 1.0, 1.1, 2.0, 2.1, 3.0 and 4.0.
+     * Return a rule to repeat tests for FT 1.0, 1.1, 2.0, 2.1, 3.0, 4.0 and 4.1.
      * All will be run in LITE mode
      * <p>
      * We run a few tests using this rule so that we have some coverage of all implementations
@@ -102,6 +130,8 @@ public class RepeatFaultTolerance {
      */
     public static RepeatTests repeatAll(String server) {
         return repeat(server, TestMode.LITE,
+                      MP70_EE10_METRICS51,
+                      MP70_EE11_METRICS51,
                       MicroProfileActions.MP61,
                       MicroProfileActions.MP60,
                       MicroProfileActions.MP13,
@@ -115,13 +145,15 @@ public class RepeatFaultTolerance {
     }
 
     /**
-     * Repeat on FaultTolerance 2.0 and above (MP22 and above). MP60 (FT 4.0) will be in LITE mode, the others in FULL mode.
+     * Repeat on FaultTolerance 2.0 and above (MP22 and above). MP70 (FT 4.1) will be in LITE mode, the others in FULL mode.
      *
      * @param server the server name
      * @return the RepeatTests rule
      */
     public static RepeatTests repeat20AndAbove(String server) {
         return repeat(server, TestMode.FULL,
+                      MicroProfileActions.MP70_EE10,
+                      MicroProfileActions.MP70_EE11,
                       MicroProfileActions.MP61,
                       MicroProfileActions.MP60,
                       MicroProfileActions.MP22,

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
@@ -254,7 +254,6 @@ public class MicroProfileActions {
                                                                "mpHealth-4.0",
                                                                "mpJwt-2.1",
                                                                "mpOpenAPI-4.0",
-                                                               "mpMetrics-5.1",
                                                                "mpTelemetry-2.0",
                                                                "mpRestClient-4.0" };
 
@@ -269,7 +268,6 @@ public class MicroProfileActions {
                                                                "mpHealth-4.0",
                                                                "mpJwt-2.1",
                                                                "mpOpenAPI-4.0",
-                                                               "mpMetrics-5.1",
                                                                "mpTelemetry-2.0",
                                                                "mpRestClient-4.0" };
 
@@ -350,11 +348,13 @@ public class MicroProfileActions {
 
     private static final String[] STANDALONE10_FEATURES_ARRAY = { "mpContextPropagation-1.3",
                                                                   "mpGraphQL-2.0",
+                                                                  "mpMetrics-5.1",
                                                                   "mpReactiveMessaging-3.0",
                                                                   "mpReactiveStreams-3.0" };
 
     private static final String[] STANDALONE11_FEATURES_ARRAY = { "mpContextPropagation-1.3",
                                                                   "mpGraphQL-2.0",
+                                                                  "mpMetrics-5.1",
                                                                   "mpReactiveMessaging-3.0",
                                                                   "mpReactiveStreams-3.0" };
 


### PR DESCRIPTION
Update MP Fault Tolerance buckets to repeat against MP 7.0 with both EE10 and EE11