### PR TITLE
Accommodate `302` response for `jsp_defaultHTML()` 

### DIFF
--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/JSPApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/JSPApplicationTest.java
@@ -114,7 +114,14 @@ public class JSPApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
 
-        assertTrue(validatePrometheusHTTPMetric(getVendorMetrics(server), expectedRoute, responseStatus, requestMethod));
+        /*
+         * If 200 isn't present. The server may have redirected the request to the default page
+         * and issued a 302.
+         */
+        if (!validatePrometheusHTTPMetric(getVendorMetrics(server), expectedRoute, responseStatus, requestMethod)) {
+            responseStatus = "302";
+            assertTrue(validatePrometheusHTTPMetric(getVendorMetrics(server), expectedRoute, responseStatus, requestMethod));
+        }
 
         route = CONTEXT_ROOT + "/Testhtml.html";
         expectedRoute = CONTEXT_ROOT + "/\\*";


### PR DESCRIPTION
#build

Follow up fix to #28629
There are two asserts in this the `jsp_defaultHTML()` test.
The first [first PR](https://github.com/OpenLiberty/open-liberty/pull/28630) the second assert, this PR fixes the first assert.