### PR TITLE
Add missing tolerates for EE 11 features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appAuthorization/io.openliberty.versionless.appAuthorization.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appAuthorization/io.openliberty.versionless.appAuthorization.feature
@@ -3,6 +3,6 @@ symbolicName=io.openliberty.versionless.appAuthorization
 visibility=public
 IBM-ShortName: appAuthorization
 Subsystem-Name: appAuthorization
--features=io.openliberty.internal.versionless.jacc-1.5; ibm.tolerates:="2.0,2.1"
+-features=io.openliberty.internal.versionless.jacc-1.5; ibm.tolerates:="2.0,2.1,3.0"
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jacc/io.openliberty.versionless.jacc.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jacc/io.openliberty.versionless.jacc.feature
@@ -3,6 +3,6 @@ symbolicName=io.openliberty.versionless.jacc
 visibility=public
 IBM-ShortName: jacc
 Subsystem-Name: jacc
--features=io.openliberty.internal.versionless.jacc-1.5; ibm.tolerates:="2.0,2.1"
+-features=io.openliberty.internal.versionless.jacc-1.5; ibm.tolerates:="2.0,2.1,3.0"
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/websocket/io.openliberty.versionless.websocket.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/websocket/io.openliberty.versionless.websocket.feature
@@ -3,6 +3,6 @@ symbolicName=io.openliberty.versionless.websocket
 visibility=public
 IBM-ShortName: websocket
 Subsystem-Name: websocket
--features=io.openliberty.internal.versionless.websocket-1.1; ibm.tolerates:="2.0,2.1"
+-features=io.openliberty.internal.versionless.websocket-1.1; ibm.tolerates:="2.0,2.1,2.2"
 kind=beta
 edition=core


### PR DESCRIPTION
- Adds tolerates for jacc / appAuthorization and websocket for the EE 11 versionless private feature.  The private features already existed. Only the tolerates was missing.
- Persistence is still not right, but is being done in the persistence 3.2 beta PR.
