### PR TITLE
InstallRepoVersionless

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
@@ -57,6 +57,7 @@ public class FeatureUtility {
     private final Boolean noCache;
     private final Boolean licenseAccepted;
     private final List<String> featuresToInstall;
+    private final Collection<String> platforms;
     private final List<String> additionalJsons;
     private String openLibertyVersion;
     private String openLibertyEdition;
@@ -78,7 +79,7 @@ public class FeatureUtility {
      * Constructor for unit testing only.
      */
     protected FeatureUtility(InstallKernelMap map, File fromDir, List<File> esaFiles, Boolean noCache,
-	    Boolean licenseAccepted, List<String> featuresToInstall, List<String> additionalJsons,
+	    Boolean licenseAccepted, List<String> featuresToInstall, List<String> platforms, List<String> additionalJsons,
 	    String openLibertyVersion, String openLibertyEdition, Logger logger, ProgressBar progressBar,
 	    Map<String, String> featureToExt, boolean isInstallServerFeature, VerifyOption verifyOption) {
 	super();
@@ -88,6 +89,7 @@ public class FeatureUtility {
 	this.noCache = noCache;
 	this.licenseAccepted = licenseAccepted;
 	this.featuresToInstall = featuresToInstall;
+	this.platforms = platforms;
 	this.additionalJsons = additionalJsons;
 	this.openLibertyVersion = openLibertyVersion;
 	this.openLibertyEdition = openLibertyEdition;
@@ -99,7 +101,8 @@ public class FeatureUtility {
     }
 
     private FeatureUtility(FeatureUtilityBuilder builder) throws IOException, InstallException {
-        this.logger = InstallLogUtils.getInstallLogger();
+        
+		this.logger = InstallLogUtils.getInstallLogger();
         this.progressBar = ProgressBar.getInstance();
 
         this.openLibertyVersion = getLibertyVersion();
@@ -109,6 +112,7 @@ public class FeatureUtility {
                             Messages.INSTALL_KERNEL_MESSAGES.getMessage("ERROR_BETA_EDITION_NOT_SUPPORTED"));
         }
 	this.additionalJsons = builder.additionalJsons;
+	this.platforms = builder.platforms;
         this.to = builder.to;
 	this.fromDir = builder.fromDir; // this can be overwritten by the env prop
 
@@ -249,9 +253,11 @@ public class FeatureUtility {
 	    map.put(InstallConstants.RUNTIME_INSTALL_DIR, Utils.getInstallDir());
 	    map.put(InstallConstants.INSTALL_LOCAL_ESA, true);
 	    map.put(InstallConstants.SINGLE_JSON_FILE, jsonPaths);
-        if (featuresToInstall != null) {
-	    map.put(InstallConstants.FEATURES_TO_RESOLVE, featuresToInstall);
-
+	    if (featuresToInstall != null) {
+		    map.put(InstallConstants.FEATURES_TO_RESOLVE, featuresToInstall);
+	    }
+        if (platforms != null) {
+        	map.put(InstallConstants.PLATFORMS, platforms);
         }
         if (esaFiles != null && !esaFiles.isEmpty()) {
 	    map.put(InstallConstants.INDIVIDUAL_ESAS, esaFiles);
@@ -831,6 +837,7 @@ public class FeatureUtility {
     public static class FeatureUtilityBuilder {
         File fromDir;
         Collection<String> featuresToInstall;
+        Collection<String> platforms;
         List<String> additionalJsons;
         List<File> esaFiles;
         boolean noCache;
@@ -873,14 +880,19 @@ public class FeatureUtility {
             return this;
         } 
 
-	public FeatureUtilityBuilder setVerify(String verifyOption) {
-	    this.verifyOption = verifyOption;
-	    return this;
-	}
+		public FeatureUtilityBuilder setVerify(String verifyOption) {
+		    this.verifyOption = verifyOption;
+		    return this;
+		}
 
         public FeatureUtility build() throws IOException, InstallException {
             return new FeatureUtility(this);
         }
+
+		public FeatureUtilityBuilder setPlatforms(List<String> platformNames) {
+			this.platforms = platformNames;
+		    return this;
+		}
 
     }
 

--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/cli/InstallServerAction.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/cli/InstallServerAction.java
@@ -35,6 +35,7 @@ import com.ibm.ws.install.featureUtility.FeatureUtility;
 import com.ibm.ws.install.featureUtility.FeatureUtilityExecutor;
 import com.ibm.ws.install.internal.InstallLogUtils;
 import com.ibm.ws.install.internal.InstallUtils;
+import com.ibm.ws.install.internal.InstallUtils.FeaturesPlatforms;
 import com.ibm.ws.install.internal.ProgressBar;
 import com.ibm.ws.install.internal.InstallLogUtils.Messages;
 import com.ibm.ws.install.internal.asset.ServerAsset;
@@ -59,6 +60,7 @@ public class InstallServerAction implements ActionHandler {
         private Logger logger;
         private List<String> argList;
         private List<String> featureNames;
+        private List<String> platformNames;
         private String fromDir;
         private String toDir;
         private String featuresBom;
@@ -92,6 +94,7 @@ public class InstallServerAction implements ActionHandler {
                 this.logger = InstallLogUtils.getInstallLogger();
                 this.installKernel = InstallKernelFactory.getInteractiveInstance();
                 this.featureNames = new ArrayList<String>();
+                this.platformNames = new ArrayList<String>();
                 this.servers = new HashSet<>();
 
                 this.argList = args.getPositionalArguments();
@@ -218,7 +221,9 @@ public class InstallServerAction implements ActionHandler {
 
                 try {
 					// get original server features now
-					featuresToInstall.addAll(installKernel.getServerFeaturesToInstall(servers, false));
+                    			FeaturesPlatforms fp = installKernel.getServerFeaturesToInstall(servers, false);
+					featuresToInstall.addAll(fp.getFeatures());
+					platformNames.addAll(fp.getPlatforms());
                         logger.fine("all server features: " + featuresToInstall);
                 } catch (InstallException ie) {
                         logger.log(Level.SEVERE, ie.getMessage(), ie);
@@ -259,7 +264,7 @@ public class InstallServerAction implements ActionHandler {
         private ExitCode install() {
                 try {
                         featureUtility = new FeatureUtility.FeatureUtilityBuilder().setFromDir(fromDir)
-				.setFeaturesToInstall(featureNames).setNoCache(noCache)
+				.setFeaturesToInstall(featureNames).setNoCache(noCache).setPlatforms(platformNames)
 				.setlicenseAccepted(acceptLicense).setAdditionalJsons(additionalJsons).setVerify(verify)
 				.build();
                         featureUtility.setFeatureToExt(featureToExt);

--- a/dev/com.ibm.ws.install.featureUtility/test/com/ibm/ws/install/featureUtility/FeatureUtilityTest.java
+++ b/dev/com.ibm.ws.install.featureUtility/test/com/ibm/ws/install/featureUtility/FeatureUtilityTest.java
@@ -14,7 +14,7 @@ import com.ibm.ws.install.InstallException;
 
 public class FeatureUtilityTest {
 
-    FeatureUtility featureUtility = new FeatureUtility(null, null, null, null, null, null, null, null, null, null, null,
+    FeatureUtility featureUtility = new FeatureUtility(null, null, null, null, null, null, null, null, null, null, null, null,
 	    null, false, null);
 
     @Before

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
@@ -155,6 +155,27 @@ public class InstallServerTest extends FeatureUtilityToolTest {
 	checkCommandOutput(po, 21, "CWWKF1405E", null);
 	Log.exiting(c, METHOD_NAME);
     }
+    
+    /**
+     * Test the install of versionless servlet from maven central. Multi-version is not
+     * supported with installServerFeature as it cannot be installed to same
+     * resource.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testVersionlessWithPlatformFeatures() throws Exception {
+	final String METHOD_NAME = "testInvalidMultiVersionFeatures";
+	Log.entering(c, METHOD_NAME);
+
+	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/versionlessWPlatform/server.xml");
+
+	String[] param1s = { "installServerFeatures", "serverX", "--verbose" };
+	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
+
+	checkCommandOutput(po, 21, "CWWKF1405E", null);
+	Log.exiting(c, METHOD_NAME);
+    }
 
     /**
      * Install an user feature with the "--featuresBom" parameters

--- a/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessWPlatform/server.xml
+++ b/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessWPlatform/server.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <!-- Enable features -->
+    <featureManager>
+	   <platform>jakartaee-10.0</platform>
+	   <feature>servlet</feature>
+    </featureManager>
+</server>
+

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallConstants.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallConstants.java
@@ -75,6 +75,7 @@ public class InstallConstants {
     public static final String INSTALL_LOCAL_ESA = "install.local.esa";
     public static final String SINGLE_JSON_FILE = "single.json.file";
     public static final String FEATURES_TO_RESOLVE = "features.to.resolve";
+    public static final String PLATFORMS = "platforms";
     public static final String INDIVIDUAL_ESAS = "individual.esas";
     public static final String INSTALL_INDIVIDUAL_ESAS = "install.individual.esas";
     public static final String LICENSE_ACCEPT = "license.accept";

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallKernelInteractive.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallKernelInteractive.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import com.ibm.ws.install.internal.InstallUtils.FeaturesPlatforms;
 import com.ibm.ws.install.internal.asset.ServerAsset;
 import com.ibm.ws.install.internal.asset.ServerPackageAsset;
 import com.ibm.ws.repository.connections.RepositoryConnectionList;
@@ -190,11 +191,11 @@ public interface InstallKernelInteractive {
      *
      * @param servers     set of ServerAssets
      * @param offlineOnly if features should only be acquired offline
-     * @return Collection of server features as Strings
+     * @return FeaturesPlatforms Collections of server features and platforms as Strings
      * @throws InstallException
      * @throws IOException
      */
-    public Collection<String> getServerFeaturesToInstall(Set<ServerAsset> servers, boolean offlineOnly) throws InstallException, IOException;
+    public FeaturesPlatforms getServerFeaturesToInstall(Set<ServerAsset> servers, boolean offlineOnly) throws InstallException, IOException;
 
     /**
      * Deploys the server package given by an archive file

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelImpl.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelImpl.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -38,6 +38,7 @@ import com.ibm.ws.install.InstalledFeatureCollection;
 import com.ibm.ws.install.ReapplyFixException;
 import com.ibm.ws.install.RepositoryConfigUtils;
 import com.ibm.ws.install.internal.InstallLogUtils.Messages;
+import com.ibm.ws.install.internal.InstallUtils.FeaturesPlatforms;
 import com.ibm.ws.install.internal.asset.ServerAsset;
 import com.ibm.ws.install.internal.asset.ServerPackageAsset;
 import com.ibm.ws.repository.common.enums.ResourceType;
@@ -262,7 +263,7 @@ public class InstallKernelImpl implements InstallKernel, InstallKernelInteractiv
     }
 
     @Override
-    public Collection<String> getServerFeaturesToInstall(Set<ServerAsset> servers, boolean offlineOnly) throws InstallException, IOException {
+    public FeaturesPlatforms getServerFeaturesToInstall(Set<ServerAsset> servers, boolean offlineOnly) throws InstallException, IOException {
         this.director.fireProgressEvent(InstallProgressEvent.RESOLVE, 0,
                                         Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("STATE_CHECKING_MISSING_SERVER_FEATURES"));
         return this.director.getServerFeaturesToInstall(servers, offlineOnly);

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -510,6 +510,12 @@ public class InstallKernelMap implements Map {
             } else {
                 throw new IllegalArgumentException();
             }
+        } else if (InstallConstants.PLATFORMS.equals(key)) {
+            if (value instanceof Collection) {
+                data.put(InstallConstants.PLATFORMS, value);
+            } else {
+                throw new IllegalArgumentException();
+            }
         } else if (InstallConstants.VERIFY_OPTION.equals(key)) {
             if (value instanceof VerifyOption) {
                 data.put(InstallConstants.VERIFY_OPTION, value);
@@ -956,7 +962,8 @@ public class InstallKernelMap implements Map {
             if (!isInstallServerFeature) {
                 resolveResult = resolver.resolve((Collection<String>) data.get(InstallConstants.FEATURES_TO_RESOLVE));
             } else {
-                resolveResult = resolver.resolveAsSet((Collection<String>) data.get(InstallConstants.FEATURES_TO_RESOLVE));
+                resolveResult = resolver.resolveAsSet((Collection<String>) data.get(InstallConstants.FEATURES_TO_RESOLVE),
+                                                      (Collection<String>) data.get(InstallConstants.PLATFORMS));
             }
 
             if (!resolveResult.isEmpty()) {

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/FeatureTreeWalker.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/FeatureTreeWalker.java
@@ -205,7 +205,6 @@ public class FeatureTreeWalker {
         if (tolerates != null) {
             for (String toleratedVersion : tolerates) {
                 String featureName = baseName + toleratedVersion;
-
                 feature = getFeatureByNameFunction.apply(featureName);
                 if (feature != null) {
                     result.add(feature);

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -45,9 +45,9 @@ public class RepositoryResolutionException extends RepositoryException {
      * @param cause
      * @param topLevelFeaturesNotResolved
      * @param allRequirementsNotFound
-     * @param missingProductInformation all the product information requirements that could not be found. Can be empty but must not be <code>null</code>
+     * @param missingProductInformation        all the product information requirements that could not be found. Can be empty but must not be <code>null</code>
      * @param allRequirementsResourcesNotFound The {@link MissingRequirement} objects that were not found. Must not be <code>null</code>.
-     * @param featureConflicts the details of any feature conflicts which occurred during feature resolution, as returned from {@link Result#getConflicts()}
+     * @param featureConflicts                 the details of any feature conflicts which occurred during feature resolution, as returned from {@link Result#getConflicts()}
      */
     public RepositoryResolutionException(ResolutionException cause, Collection<String> topLevelFeaturesNotResolved, Collection<String> allRequirementsNotFound,
                                          Collection<ProductRequirementInformation> missingProductInformation, Collection<MissingRequirement> allRequirementsResourcesNotFound,
@@ -106,9 +106,9 @@ public class RepositoryResolutionException extends RepositoryException {
      * on a {@link ProductRequirementInformation} is not in the form digit.digit.digit.digit then it will be ignored.
      *
      * @param productId The product ID to find the minimum missing version for or <code>null</code> to match to all products
-     * @param version The version to find the minimum missing version for by matching the first three parts so if you supply "9.0.0.0" and this item applies to version "8.5.5.3"
-     *            and "9.0.0.1" then "9.0.0.1" will be returned. Supply <code>null</code> to match all versions
-     * @param edition The edition to find the minimum missing version for or <code>null</code> to match to all products
+     * @param version   The version to find the minimum missing version for by matching the first three parts so if you supply "9.0.0.0" and this item applies to version "8.5.5.3"
+     *                      and "9.0.0.1" then "9.0.0.1" will be returned. Supply <code>null</code> to match all versions
+     * @param edition   The edition to find the minimum missing version for or <code>null</code> to match to all products
      * @return The minimum missing version or <code>null</code> if there were no relevant matches
      */
     public String getMinimumVersionForMissingProduct(String productId, String version, String edition) {
@@ -152,7 +152,7 @@ public class RepositoryResolutionException extends RepositoryException {
      * This method will iterate through the missingProductInformation and returned a filtered collection of all the {@link ProductRequirementInformation#versionRange}s.
      *
      * @param productId The product ID to find the version for or <code>null</code> to match to all products
-     * @param edition The edition to find the version for or <code>null</code> to match to all editions
+     * @param edition   The edition to find the version for or <code>null</code> to match to all editions
      *
      * @return the version ranges which apply to the given product ID and edition
      */
@@ -185,9 +185,9 @@ public class RepositoryResolutionException extends RepositoryException {
      * indicate a fairly odd repository setup.</p>
      *
      * @param productId The product ID to find the maximum missing version for or <code>null</code> to match to all products
-     * @param version The version to find the maximum missing version for by matching the first three parts so if you supply "8.5.5.2" and this item applies to version "8.5.5.3"
-     *            and "9.0.0.1" then "8.5.5.3" will be returned. Supply <code>null</code> to match all versions
-     * @param edition The edition to find the maximum missing version for or <code>null</code> to match to all products
+     * @param version   The version to find the maximum missing version for by matching the first three parts so if you supply "8.5.5.2" and this item applies to version "8.5.5.3"
+     *                      and "9.0.0.1" then "8.5.5.3" will be returned. Supply <code>null</code> to match all versions
+     * @param edition   The edition to find the maximum missing version for or <code>null</code> to match to all products
      * @return The maximum missing version or <code>null</code> if there were no relevant matches or the maximum version is unbounded
      */
     public String getMaximumVersionForMissingProduct(String productId, String version, String edition) {

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -83,6 +83,11 @@ public class RepositoryResolver {
     Set<String> requestedFeatureNames;
 
     /**
+     * The platforms passed to {@link #resolve(Collection)} which will help resolve versionless features
+     */
+    Collection<String> requestedPlatformNames;
+
+    /**
      * The list of samples the user has requested to install
      */
     List<SampleResource> samplesToInstall;
@@ -240,6 +245,7 @@ public class RepositoryResolver {
         resolverRepository = new KernelResolverRepository(installDefintion, repoConnections);
         resolverRepository.addInstalledFeatures(installedFeatures);
         resolverRepository.addFeatures(repoFeatures);
+
     }
 
     Collection<ProvisioningFeatureDefinition> getKernelFeatures(Collection<ProvisioningFeatureDefinition> installedFeatures) {
@@ -308,7 +314,7 @@ public class RepositoryResolver {
      * @throws RepositoryResolutionException If the resource cannot be resolved
      */
     public Collection<List<RepositoryResource>> resolve(Collection<String> toResolve) throws RepositoryResolutionException {
-        return resolve(toResolve, ResolutionMode.IGNORE_CONFLICTS);
+        return resolve(toResolve, null, ResolutionMode.IGNORE_CONFLICTS);
     }
 
     /**
@@ -370,14 +376,63 @@ public class RepositoryResolver {
      * @throws RepositoryResolutionException If the resource cannot be resolved
      */
     public Collection<List<RepositoryResource>> resolveAsSet(Collection<String> toResolve) throws RepositoryResolutionException {
-        return resolve(toResolve, ResolutionMode.DETECT_CONFLICTS);
+        return resolve(toResolve, null, ResolutionMode.DETECT_CONFLICTS);
     }
 
-    Collection<List<RepositoryResource>> resolve(Collection<String> toResolve, ResolutionMode resolutionMode) throws RepositoryResolutionException {
+    /**
+     * Takes a list of feature names that the user wants to install and returns a minimal set of the {@link RepositoryResource}s that should be installed to allow those features to
+     * start together in one server.
+     * <p>
+     * This method uses the same resolution logic that is used by the kernel at server startup to decide which features to start. Therefore calling this method with a list of
+     * feature names and installing the resources returned will guarantee that a server which has the same list of feature names in its server.xml will start.
+     * <p>
+     * The caller must provide the full set of features from the server.xml, including those that are already installed, so that tolerated dependencies and auto-features can be
+     * resolved correctly.
+     * <p>
+     * This method will fail if there's no valid set of dependencies for the required features that doesn't include conflicting versions of singleton features.
+     * <p>
+     * For example, {@code resolve(Arrays.asList("javaee-7.0", "javaee-8.0"))} would work but {@code resolveAsSet(Arrays.asList("javaee-7.0", "javaee-8.0"))} would fail because
+     * javaee-7.0 and javaee-8.0 contain features which conflict with each other (and other versions are not tolerated).
+     * <p>
+     * This method guarantees that it will return all the features required to start the requested features but will not ensure that the requested features will work with features
+     * which were already installed but were not requested in the call to this method.
+     * <p>
+     * For example, if {@code ejbLite-3.2} is already installed and {@code resolve(Arrays.asList("cdi-2.0"))} is called, it will not return the autofeature which would be required
+     * for {@code cdi-2.0} and {@code ejbLite-3.2} to work together.
+     *
+     * @param toResolve A collection of the identifiers of the resources to resolve. It should be in the form:</br>
+     *                      <code>{name}/{version}</code></br>
+     *                      <p>Where the <code>{name}</code> can be either the symbolic name, short name or lower case short name of the resource and <code>/{version}</code> is
+     *                      optional. The collection may contain a mixture of symbolic names and short names. Must not be <code>null</code> or empty.</p>
+     * @param platforms A collection of the identifiers of the platforms used for resolving versionless features
+     *
+     * @return <p>A collection of ordered lists of {@link RepositoryResource}s to install. Each list represents a collection of resources that must be installed together or not
+     *         at all. They should be installed in the iteration order of the list(s). Note that if a resource is required by multiple different resources then it will appear in
+     *         multiple lists. For instance if you have requested to install A and B and A requires N which requires M and O whereas B requires Z that requires O then the returned
+     *         collection will be (represented in JSON):</p>
+     *         <code>
+     *         [[M, O, N, A],[O, Z, B]]
+     *         </code>
+     *         <p>This will not return <code>null</code> although it may return an empty collection if there isn't anything to install (i.e. it resolves to resources that are
+     *         already installed)</p>
+     *         <p>Every auto-feature will have it's own list in the collection, this is to stop the failure to install either an auto feature or one of it's dependencies from
+     *         stopping everything from installing. Therefore if you have features A and B that are required to provision auto feature C and you ask to resolve A and B then this
+     *         method will return:</p>
+     *         <code>
+     *         [[A],[B],[A,B,C]]
+     *         </code>
+     *
+     * @throws RepositoryResolutionException If the resource cannot be resolved
+     */
+    public Collection<List<RepositoryResource>> resolveAsSet(Collection<String> toResolve, Collection<String> platforms) throws RepositoryResolutionException {
+        return resolve(toResolve, platforms, ResolutionMode.DETECT_CONFLICTS);
+    }
+
+    Collection<List<RepositoryResource>> resolve(Collection<String> toResolve, Collection<String> platforms, ResolutionMode resolutionMode) throws RepositoryResolutionException {
         initResolve();
         initializeResolverRepository(installDefinition);
 
-        processNames(toResolve);
+        processNames(toResolve, platforms);
 
         if (resolutionMode == ResolutionMode.DETECT_CONFLICTS) {
             // Call the kernel resolver to determine the features needed
@@ -409,6 +464,7 @@ public class RepositoryResolver {
         samplesToInstall = new ArrayList<>();
         resolvedFeatures = new HashMap<>();
         requestedFeatureNames = new HashSet<>();
+        requestedPlatformNames = new HashSet<>();
         featuresMissing = new ArrayList<>();
         resourcesWrongProduct = new ArrayList<>();
         requirementsFoundForOtherProducts = new HashSet<>();
@@ -422,8 +478,21 @@ public class RepositoryResolver {
      * Populates {@link #samplesToInstall} and {@link #featureNamesToResolve} by processing the list of names to resolve and identifying which are samples.
      *
      * @param namesToResolve the list of names to resolve
+     *
      */
     void processNames(Collection<String> namesToResolve) {
+        processNames(namesToResolve, null);
+    }
+
+    /**
+     * Populates {@link #samplesToInstall} and {@link #featureNamesToResolve} by processing the list of names to resolve and identifying which are samples.
+     *
+     * @param namesToResolve the list of names to resolve
+     * @param platforms
+     */
+    void processNames(Collection<String> namesToResolve, Collection<String> platforms) {
+        if (platforms != null)
+            requestedPlatformNames = platforms;
         for (String name : namesToResolve) {
             SampleResource sample = sampleIndex.get(name.toLowerCase());
             if (sample != null) {
@@ -477,8 +546,7 @@ public class RepositoryResolver {
      */
     void resolveFeaturesAsSet() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        Result result = resolver.resolve(resolverRepository, kernelFeatures, featureNamesToResolve, Collections.<String> emptySet(), false, Collections.<String> emptySet());
-
+        Result result = resolver.resolve(resolverRepository, kernelFeatures, featureNamesToResolve, Collections.<String> emptySet(), false, requestedPlatformNames);
         featureConflicts.putAll(result.getConflicts());
 
         for (String name : result.getResolvedFeatures()) {
@@ -802,6 +870,7 @@ public class RepositoryResolver {
      * @return the install list
      */
     private List<RepositoryResource> createInstallList(Collection<ProvisioningFeatureDefinition> featureRoots, SampleResource sampleRoot) {
+
         Map<ProvisioningFeatureDefinition, List<ProvisioningFeatureDefinition>> reverseDependencyMap = new HashMap<>();
         List<ProvisioningFeatureDefinition> dependentFeatures = new ArrayList<>();
 
@@ -838,7 +907,6 @@ public class RepositoryResolver {
         if (sampleRoot != null) {
             installList.add(sampleRoot);
         }
-
         return installList;
     }
 
@@ -930,7 +998,6 @@ public class RepositoryResolver {
         for (MissingRequirement req : missingRequirements) {
             missingRequirementNames.add(req.getRequirementName());
         }
-
         throw new RepositoryResolutionException(null, missingTopLevelRequirements, missingRequirementNames, missingProductInformation, missingRequirements, featureConflicts);
     }
 

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import org.osgi.framework.Version;
 
@@ -98,7 +97,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
      *
      * If the feature is an auto-feature, add it to the collection of
      * auto-features.
-     * 
+     *
      * Clear the preferred features collection. It must be recomputed.
      *
      * @param feature The feature which is to be added.
@@ -106,9 +105,8 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
     public void addFeature(ProvisioningFeatureDefinition feature) {
         String symbolicName = feature.getSymbolicName();
 
-        List<ProvisioningFeatureDefinition> features =
-            symbolicNameToFeature.computeIfAbsent(symbolicName,
-                                                  (String useName) -> new ArrayList<>());
+        List<ProvisioningFeatureDefinition> features = symbolicNameToFeature.computeIfAbsent(symbolicName,
+                                                                                             (String useName) -> new ArrayList<>());
 
         // Don't add the feature if an installed feature is already present
         // with the symbolic name.
@@ -403,11 +401,10 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
      * @return The preferred versions of all features in the repository.
      */
     public Collection<ProvisioningFeatureDefinition> getAllFeatures() {
-        if ( allFeatureCache == null ) {
+        if (allFeatureCache == null) {
             List<ProvisioningFeatureDefinition> preferred = new ArrayList<>();
             symbolicNameToFeature.forEach(
-                (String symbolicName, List<ProvisioningFeatureDefinition> features) ->
-                    preferred.add(getPreferredVersion(symbolicName, features)));
+                                          (String symbolicName, List<ProvisioningFeatureDefinition> features) -> preferred.add(getPreferredVersion(symbolicName, features)));
             allFeatureCache = preferred;
         }
         return allFeatureCache;


### PR DESCRIPTION
This PR has changes required to both the install and repo components for supporting versionless features and "platforms" 
1) Changes to InstallUtils that reads the server.xml for a list of features, now returns both features and platforms lists
2) FeatureUtility propogates these values for the "InstallServerAction"
3) Most of these changes I tried to follow the patterns used, buy please let me know if it looks wrong...
4) I added a test, but maybe should be commented out - will only work with Beta flag on...
5) The platforms are now also added to the RepositoryResolver "resolveAsSet" method, and created the old signature that passes a null for platforms...   
