### PR TITLE
Add no_proxy for FeatureUtility 

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
@@ -314,7 +314,7 @@ public class FeatureUtility {
 		}
 
 		// override no_proxy settings
-		if (FeatureUtilityProperties.getNoProxySetting() != null) {
+		if (System.getProperty("featureUtility.beta").equals("true") && FeatureUtilityProperties.getNoProxySetting() != null) {
 		    overrideMap.put("http.nonProxyHosts", FeatureUtilityProperties.getNoProxySetting());
 		}
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
@@ -373,13 +373,13 @@ public abstract class FeatureUtilityToolTest {
 
     protected ProgramOutput runFeatureUtility(String testcase, String[] params, boolean debug) throws Exception {
         Properties envProps = new Properties();
-	// add beta property here
-	// envProps.put("JVM_ARGS", "-Dbeta.property=true");
         return runFeatureUtility(testcase, params, envProps);
     }
 
     protected ProgramOutput runFeatureUtility(String testcase, String[] params, Properties envProps) throws Exception {
-	// always run feature utility with minified root
+    		// add beta property here
+	    envProps.put("JVM_ARGS", "-DfeatureUtility.beta=true");    
+    		// always run feature utility with minified root
         return runCommand(minifiedRoot, testcase, "featureUtility", params, envProps);
     }
 

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
@@ -322,8 +322,10 @@ public class ArtifactDownloader implements AutoCloseable {
 
     private void downloadInternal(URI address, File destination, MavenRepository repository) throws IOException, InstallException {
         URL url = address.toURL();
-        logger.fine("non Proxy Hosts: " + System.getProperty("http.nonProxyHosts"));
-        logger.fine("url: " + url.getHost());
+        if (System.getProperty("featureUtility.beta") != null && System.getProperty("featureUtility.beta").equals("true")) {
+            logger.fine("non Proxy Hosts: " + System.getProperty("http.nonProxyHosts"));
+        }
+        logger.fine("downloadInternal url host: " + url.getHost());
         String proxyEncodedAuth = "";
         if (url.getProtocol().equals("https") && envMap.get("https.proxyHost") != null) {
             proxyEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication((String) envMap.get("https.proxyUser"), (String) envMap.get("https.proxyPassword"));

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -1138,7 +1138,7 @@ public class InstallKernelMap implements Map {
                     System.setProperty("https.proxyPort", (String) envMap.get("http.proxyPort"));
                 }
             }
-            if (envMap.get("http.nonProxyHosts") != null) {
+            if (System.getProperty("featureUtility.beta") != null && System.getProperty("featureUtility.beta").equals("true") && envMap.get("http.nonProxyHosts") != null) {
                 String noProxyHosts = (String) envMap.get("http.nonProxyHosts");
                 //if users provide list of hosts using ",", replace to "|"
                 noProxyHosts = noProxyHosts.replace(",", "|");
@@ -1958,7 +1958,9 @@ public class InstallKernelMap implements Map {
                 envMapRet.put(key, httpsProxyVariables.get(key));
             }
         }
-        envMapRet.put("http.nonProxyHosts", System.getenv("no_proxy"));
+        if (System.getProperty("featureUtility.beta") != null && System.getProperty("featureUtility.beta").equals("true")) {
+            envMapRet.put("http.nonProxyHosts", System.getenv("no_proxy"));
+        }
 
         envMapRet.put("FEATURE_REPO_URL", System.getenv("FEATURE_REPO_URL"));
         envMapRet.put("FEATURE_REPO_USER", System.getenv("FEATURE_REPO_USER"));
@@ -1974,7 +1976,7 @@ public class InstallKernelMap implements Map {
         envMapRet.put("FEATURE_VERIFY", System.getenv("FEATURE_VERIFY"));
 
         //search through the properties file to look for overrides if they exist
-        //TODO remove?
+        //TODO remove? - Do we use featureUtility.env ?
         Map<String, String> propsFileMap = getFeatureUtilEnvProps();
         if (!propsFileMap.isEmpty()) {
             fine("The properties found in featureUtility.env will override latent environment variables of the same name");


### PR DESCRIPTION
To set no_proxy using the environment variable, use no_proxy.
To set it using featureUtility.properties, use http.nonProxyHosts (name used by jvm system properties)
In beta. 