### PR TITLE
Add MicroProfile 7.0 repeats to FaultTolerance buckets

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
@@ -26,6 +26,7 @@ tested.features: mpFaultTolerance-1.0,\
                  mpFaultTolerance-2.1,\
                  mpFaultTolerance-3.0,\
                  mpFaultTolerance-4.0,\
+                 mpFaultTolerance-4.1,\
                  mpConfig-1.1,\
                  mpConfig-1.2,\
                  mpConfig-1.3,\
@@ -35,23 +36,30 @@ tested.features: mpFaultTolerance-1.0,\
                  cdi-2.0,\
                  cdi-3.0,\
                  cdi-4.0,\
+                 cdi-4.1,\
                  servlet-3.1,\
                  servlet-5.0,\
                  servlet-6.0,\
+                 servlet-6.1,\
                  appsecurity-3.0,\
                  appsecurity-4.0,\
                  appsecurity-5.0,\
+                 appsecurity-6.0,\
                  expressionlanguage-4.0,\
                  expressionlanguage-5.0,\
+                 expressionlanguage-6.0,\
                  enterprisebeanslite-4.0,\
                  enterprisebeanslite-5.0,\
                  el-3.0,\
                  restfulwsclient-3.0,\
                  restfulwsclient-3.1,\
+                 restfulwsclient-4.0,\
                  concurrent-2.0,\
                  concurrent-3.0,\
+                 concurrent-3.1,\
                  restfulws-3.0,\
                  restfulws-3.1,\
+                 restfulws-4.0,\
                  jsonp-2.0,\
                  jsonp-2.1
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleClassLoading.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleClassLoading.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.websphere.microprofile.faulttolerance_fat.multimodule.tests;
 
@@ -51,6 +48,8 @@ public class TestMultiModuleClassLoading extends FATServletClient {
     //run against EE10, EE9, EE8 and EE7 features
     @ClassRule
     public static RepeatTests r = RepeatFaultTolerance.repeat(SERVER_NAME, TestMode.FULL,
+                                                              MicroProfileActions.MP70_EE10,
+                                                              MicroProfileActions.MP70_EE11,
                                                               MicroProfileActions.MP61,
                                                               MicroProfileActions.MP13,
                                                               RepeatFaultTolerance.MP21_METRICS20,

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleConfigLoad.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleConfigLoad.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.websphere.microprofile.faulttolerance_fat.multimodule.tests;
 
@@ -62,6 +59,8 @@ public class TestMultiModuleConfigLoad extends FATServletClient {
     //run against EE10, EE9, EE8 and EE7 features
     @ClassRule
     public static RepeatTests r = RepeatFaultTolerance.repeat(SERVER_NAME, TestMode.FULL,
+                                                              MicroProfileActions.MP70_EE10,
+                                                              MicroProfileActions.MP70_EE11,
                                                               MicroProfileActions.MP61,
                                                               MicroProfileActions.MP13,
                                                               RepeatFaultTolerance.MP21_METRICS20,

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/FaultToleranceMainTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/FaultToleranceMainTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.websphere.microprofile.faulttolerance_fat.tests;
 
@@ -92,7 +89,7 @@ public class FaultToleranceMainTest extends FATServletClient {
     @Rule
     public AnnotationFilter filter = AnnotationFilter
                     .requireAnnotations(BasicTest.class)
-                    .forAllRepeatsExcept(MicroProfileActions.MP61_ID)
+                    .forAllRepeatsExcept(MicroProfileActions.MP70_EE10_ID)
                     .inModes(TestMode.LITE);
 
     @BeforeClass
@@ -214,7 +211,9 @@ public class FaultToleranceMainTest extends FATServletClient {
                      MicroProfileActions.MP41_ID,
                      MicroProfileActions.MP50_ID,
                      MicroProfileActions.MP60_ID,
-                     MicroProfileActions.MP61_ID }) // FT 3.0+ does not close executors until the application shuts down
+                     MicroProfileActions.MP61_ID,// FT 3.0+ does not close executors until the application shuts down
+                     MicroProfileActions.MP70_EE10_ID,
+                     MicroProfileActions.MP70_EE11_ID}) 
     @Test
     public void testExecutorsClose() throws Exception {
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/ejb/AsyncEJBTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/ejb/AsyncEJBTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
@@ -33,6 +33,7 @@ tested.features: mpfaulttolerance-1.0,\
                  cdi-2.0,\
                  cdi-3.0,\
                  cdi-4.0,\
+                 cdi-4.1,\
                  appsecurity-3.0,\
                  el-3.0,\
                  mpmetrics-1.0,\
@@ -45,7 +46,10 @@ tested.features: mpfaulttolerance-1.0,\
                  mpMetrics-5.1,\
                  servlet-5.0,\
                  servlet-6.0,\
+                 servlet-6.1,\
                  mpTelemetry-2.0,\
+                 restfulwsclient-4.0,\
+                 restfulws-4.0
 
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/TelemetryMetricCombinationTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/TelemetryMetricCombinationTest.java
@@ -53,7 +53,7 @@ public class TelemetryMetricCombinationTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE10);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/TelemetryMetricIsolationTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/TelemetryMetricIsolationTest.java
@@ -48,7 +48,7 @@ public class TelemetryMetricIsolationTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE10);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/publish/servers/CDIFaultToleranceMetricsAndTelemetry/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/publish/servers/CDIFaultToleranceMetricsAndTelemetry/server.xml
@@ -6,21 +6,18 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
 
 	<include location="../fatTestPorts.xml" />
 
 	<featureManager>
-		<feature>componenttest-1.0</feature>
+		<feature>componenttest-2.0</feature>
 		<feature>osgiconsole-1.0</feature>
 		<feature>localConnector-1.0</feature>
 		<feature>cdi-4.0</feature>
 		<feature>servlet-6.0</feature>
-		<feature>mpFaultTolerance-4.0</feature>
+		<feature>mpFaultTolerance-4.1</feature>
 		<feature>mpTelemetry-2.0</feature>
 		<feature>mpMetrics-5.1</feature>
 	</featureManager>

--- a/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
@@ -55,10 +55,10 @@ public class RepeatFaultTolerance {
     }
 
     /**
-     * @param server The server to repeat on
+     * @param server                   The server to repeat on
      * @param otherFeatureSetsTestMode The test mode to run the otherFeatureSets
-     * @param firstFeatureSet The first FeatureSet to repeat with. This is run in LITE mode.
-     * @param otherFeatureSets The other FeatureSets to repeat with. These are in the mode specified by otherFeatureSetsTestMode
+     * @param firstFeatureSet          The first FeatureSet to repeat with. This is run in LITE mode.
+     * @param otherFeatureSets         The other FeatureSets to repeat with. These are in the mode specified by otherFeatureSetsTestMode
      * @return A RepeatTests instance
      */
     public static RepeatTests repeat(String serverName, TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {
@@ -76,11 +76,12 @@ public class RepeatFaultTolerance {
     }
 
     /**
-     * Return a rule to repeat tests for MicroProfile 6.0, 4.0 and 2.0.
-     * This translates to FT 4.0, 3.0 and 1.1 respectively.
+     * Return a rule to repeat tests for MicroProfile 7.0, 4.0 and 2.0.
+     * This translates to FT 4.1, 3.0 and 1.1 respectively.
      * <p>
      * FT 1.x has a mostly separate implementation from 2.x and higher.
      * FT 4.0 is a transformed version of 3.0, which works on EE9.
+     * FT 4.1 is the same as 4.0 but with Telemetry integration added and support for EE10 and EE11.
      *
      * This is the default set of repeats for most FT tests. It provides good coverage of most code paths.
      *
@@ -88,7 +89,10 @@ public class RepeatFaultTolerance {
      * @return the RepeatTests rule
      */
     public static RepeatTests repeatDefault(String server) {
-        return repeat(server, TestMode.FULL, MicroProfileActions.MP61, MicroProfileActions.MP40, MicroProfileActions.MP20);
+        return repeat(server, TestMode.FULL,
+                      MicroProfileActions.MP70_EE10, //FT 4.1
+                      MicroProfileActions.MP40, //FT 3.0
+                      MicroProfileActions.MP20); //FT 1.1
     }
 
     /**
@@ -102,6 +106,8 @@ public class RepeatFaultTolerance {
      */
     public static RepeatTests repeatAll(String server) {
         return repeat(server, TestMode.LITE,
+                      MicroProfileActions.MP70_EE10,
+                      MicroProfileActions.MP70_EE11,
                       MicroProfileActions.MP61,
                       MicroProfileActions.MP60,
                       MicroProfileActions.MP13,
@@ -122,6 +128,8 @@ public class RepeatFaultTolerance {
      */
     public static RepeatTests repeat20AndAbove(String server) {
         return repeat(server, TestMode.FULL,
+                      MicroProfileActions.MP70_EE10,
+                      MicroProfileActions.MP70_EE11,
                       MicroProfileActions.MP61,
                       MicroProfileActions.MP60,
                       MicroProfileActions.MP22,

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
@@ -54,19 +54,19 @@ public class FATSuite {
                                              .andWith(new FeatureReplacementAction("mpConfig-1.4", "mpConfig-2.0")
                                                       .addFeature("mpMetrics-3.0").removeFeature("mpMetrics-2.3")
                                                       .addFeature("mpRestClient-2.0").removeFeature("mpRestClient-1.4")
-                                                      .withID("mp4.0").fullFATOnly())
+                                                      .withID(MicroProfileActions.MP40_ID+"_mpGraphQL10").fullFATOnly())
                                              .andWith(new JakartaEE9Action()
                                                       .removeFeatures(setOf("mpConfig-1.4", "mpConfig-2.0")).addFeature("mpConfig-3.0")
                                                       .removeFeatures(setOf("mpMetrics-3.0", "mpMetrics-2.3")).addFeature("mpMetrics-4.0")
                                                       .removeFeatures(setOf("mpRestClient-2.0", "mpRestClient-1.4")).addFeature("mpRestClient-3.0")
                                                       .removeFeature("mpGraphQL-1.0").addFeature("mpGraphQL-2.0")
-                                                      .withID(MicroProfileActions.STANDALONE9_ID).conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                                                      .withID(JakartaEE9Action.ID+"_mpGraphQL20").conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
                                              .andWith(new JakartaEE10Action()
                                                       .removeFeatures(setOf("mpConfig-1.4", "mpConfig-2.0")).addFeature("mpConfig-3.0")
                                                       .removeFeatures(setOf("mpMetrics-3.0", "mpMetrics-2.3", "mpMetrics-4.0")).addFeature("mpMetrics-5.0")
                                                       .removeFeatures(setOf("mpRestClient-2.0", "mpRestClient-1.4")).addFeature("mpRestClient-3.0")
                                                       .removeFeature("mpGraphQL-1.0").addFeature("mpGraphQL-2.0").alwaysAddFeature("servlet-6.0")
-                                                      .withID(MicroProfileActions.STANDALONE10_ID));
+                                                      .withID(JakartaEE10Action.ID+"_mpGraphQL20"));
 
     private static Set<String> setOf(String... strings) {
         // basically does what Java 11's Set.of(...) does

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureUtilities.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureUtilities.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package componenttest.rules.repeater;
 
@@ -18,7 +15,6 @@ import java.util.HashSet;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.ibm.websphere.simplicity.OperatingSystem;
 import com.ibm.websphere.simplicity.log.Log;
@@ -113,8 +109,7 @@ public class FeatureUtilities {
      * @return the set of short names
      */
     public static Set<String> allMpFeatures() {
-        return Stream.concat(MicroProfileActions.ALL.stream(),
-                             MicroProfileActions.STANDALONE_ALL.stream())
+        return MicroProfileActions.ALL.stream()
                         .flatMap(s -> s.getFeatures().stream())
                         .collect(Collectors.toSet());
     }
@@ -130,8 +125,7 @@ public class FeatureUtilities {
      * @return           the set of compatible MP feature short names
      */
     public static Set<String> compatibleMpFeatures(EEVersion eeVersion) {
-        return Stream.concat(MicroProfileActions.ALL.stream(),
-                             MicroProfileActions.STANDALONE_ALL.stream())
+        return MicroProfileActions.ALL.stream()
                         .filter(s -> s.getEEVersion() == eeVersion)
                         .flatMap(s -> s.getFeatures().stream())
                         .collect(Collectors.toSet());
@@ -160,7 +154,7 @@ public class FeatureUtilities {
      * Tell if a feature a public, non-test feature.
      *
      * @param  featureFile A feature file.
-     * @return                    the list of public short names
+     * @return             the list of public short names
      */
     public static boolean isPublicFeature(File featureFile) {
         String name = featureFile.getName();

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package componenttest.rules.repeater;
 
@@ -70,12 +67,12 @@ public class MicroProfileActions {
                                                           "mpRestClient-1.1" };
 
     private static final String[] MP20_FEATURES_ARRAY = { "microProfile-2.0",
-                                                          "servlet-4.0",
-                                                          "cdi-2.0",
-                                                          "jaxrs-2.1",
-                                                          "jaxrsClient-2.1",
-                                                          "jsonb-1.0",
-                                                          "jsonp-1.1",
+                                                          "servlet-4.0", //ee8
+                                                          "cdi-2.0", //ee8
+                                                          "jaxrs-2.1", //ee8
+                                                          "jaxrsClient-2.1", //ee8
+                                                          "jsonb-1.0", //ee8
+                                                          "jsonp-1.1", //ee8
                                                           "mpConfig-1.3",
                                                           "mpFaultTolerance-1.1",
                                                           "mpHealth-1.0",
@@ -83,15 +80,21 @@ public class MicroProfileActions {
                                                           "mpMetrics-1.1",
                                                           "mpOpenAPI-1.0",
                                                           "mpOpenTracing-1.1",
-                                                          "mpRestClient-1.1" };
+                                                          "mpRestClient-1.1",
+                                                          "mpContextPropagation-1.0", //standalone
+                                                          "mpGraphQL-1.0", //standalone
+                                                          "mpLRA-1.0", //standalone
+                                                          "mpLRACoordinator-1.0", //standalone
+                                                          "mpReactiveMessaging-1.0", //standalone
+                                                          "mpReactiveStreams-1.0" }; //standalone
 
     private static final String[] MP21_FEATURES_ARRAY = { "microProfile-2.1",
-                                                          "servlet-4.0",
-                                                          "cdi-2.0",
-                                                          "jaxrs-2.1",
-                                                          "jaxrsClient-2.1",
-                                                          "jsonb-1.0",
-                                                          "jsonp-1.1",
+                                                          "servlet-4.0", //ee8
+                                                          "cdi-2.0", //ee8
+                                                          "jaxrs-2.1", //ee8
+                                                          "jaxrsClient-2.1", //ee8
+                                                          "jsonb-1.0", //ee8
+                                                          "jsonp-1.1", //ee8
                                                           "mpConfig-1.3",
                                                           "mpFaultTolerance-1.1",
                                                           "mpHealth-1.0",
@@ -99,15 +102,21 @@ public class MicroProfileActions {
                                                           "mpMetrics-1.1",
                                                           "mpOpenAPI-1.0",
                                                           "mpOpenTracing-1.2",
-                                                          "mpRestClient-1.1" };
+                                                          "mpRestClient-1.1",
+                                                          "mpContextPropagation-1.0", //standalone
+                                                          "mpGraphQL-1.0", //standalone
+                                                          "mpLRA-1.0", //standalone
+                                                          "mpLRACoordinator-1.0", //standalone
+                                                          "mpReactiveMessaging-1.0", //standalone
+                                                          "mpReactiveStreams-1.0" }; //standalone
 
     private static final String[] MP22_FEATURES_ARRAY = { "microProfile-2.2",
-                                                          "servlet-4.0",
-                                                          "cdi-2.0",
-                                                          "jaxrs-2.1",
-                                                          "jaxrsClient-2.1",
-                                                          "jsonb-1.0",
-                                                          "jsonp-1.1",
+                                                          "servlet-4.0", //ee8
+                                                          "cdi-2.0", //ee8
+                                                          "jaxrs-2.1", //ee8
+                                                          "jaxrsClient-2.1", //ee8
+                                                          "jsonb-1.0", //ee8
+                                                          "jsonp-1.1", //ee8
                                                           "mpConfig-1.3",
                                                           "mpFaultTolerance-2.0",
                                                           "mpHealth-1.0",
@@ -115,15 +124,21 @@ public class MicroProfileActions {
                                                           "mpMetrics-1.1",
                                                           "mpOpenAPI-1.0",
                                                           "mpOpenTracing-1.3",
-                                                          "mpRestClient-1.2" };
+                                                          "mpRestClient-1.2",
+                                                          "mpContextPropagation-1.0", //standalone
+                                                          "mpGraphQL-1.0", //standalone
+                                                          "mpLRA-1.0", //standalone
+                                                          "mpLRACoordinator-1.0", //standalone
+                                                          "mpReactiveMessaging-1.0", //standalone
+                                                          "mpReactiveStreams-1.0" }; //standalone
 
     private static final String[] MP30_FEATURES_ARRAY = { "microProfile-3.0",
-                                                          "servlet-4.0",
-                                                          "cdi-2.0",
-                                                          "jaxrs-2.1",
-                                                          "jaxrsClient-2.1",
-                                                          "jsonb-1.0",
-                                                          "jsonp-1.1",
+                                                          "servlet-4.0", //ee8
+                                                          "cdi-2.0", //ee8
+                                                          "jaxrs-2.1", //ee8
+                                                          "jaxrsClient-2.1", //ee8
+                                                          "jsonb-1.0", //ee8
+                                                          "jsonp-1.1", //ee8
                                                           "mpConfig-1.3",
                                                           "mpFaultTolerance-2.0",
                                                           "mpHealth-2.0",
@@ -131,15 +146,21 @@ public class MicroProfileActions {
                                                           "mpMetrics-2.0",
                                                           "mpOpenAPI-1.1",
                                                           "mpOpenTracing-1.3",
-                                                          "mpRestClient-1.3" };
+                                                          "mpRestClient-1.3",
+                                                          "mpContextPropagation-1.0", //standalone
+                                                          "mpGraphQL-1.0", //standalone
+                                                          "mpLRA-1.0", //standalone
+                                                          "mpLRACoordinator-1.0", //standalone
+                                                          "mpReactiveMessaging-1.0", //standalone
+                                                          "mpReactiveStreams-1.0" }; //standalone
 
     private static final String[] MP32_FEATURES_ARRAY = { "microProfile-3.2",
-                                                          "servlet-4.0",
-                                                          "cdi-2.0",
-                                                          "jaxrs-2.1",
-                                                          "jaxrsClient-2.1",
-                                                          "jsonb-1.0",
-                                                          "jsonp-1.1",
+                                                          "servlet-4.0", //ee8
+                                                          "cdi-2.0", //ee8
+                                                          "jaxrs-2.1", //ee8
+                                                          "jaxrsClient-2.1", //ee8
+                                                          "jsonb-1.0", //ee8
+                                                          "jsonp-1.1", //ee8
                                                           "mpConfig-1.3",
                                                           "mpFaultTolerance-2.0",
                                                           "mpHealth-2.1",
@@ -147,15 +168,21 @@ public class MicroProfileActions {
                                                           "mpMetrics-2.2",
                                                           "mpOpenAPI-1.1",
                                                           "mpOpenTracing-1.3",
-                                                          "mpRestClient-1.3" };
+                                                          "mpRestClient-1.3",
+                                                          "mpContextPropagation-1.0", //standalone
+                                                          "mpGraphQL-1.0", //standalone
+                                                          "mpLRA-1.0", //standalone
+                                                          "mpLRACoordinator-1.0", //standalone
+                                                          "mpReactiveMessaging-1.0", //standalone
+                                                          "mpReactiveStreams-1.0" }; //standalone
 
     private static final String[] MP33_FEATURES_ARRAY = { "microProfile-3.3",
-                                                          "servlet-4.0",
-                                                          "cdi-2.0",
-                                                          "jaxrs-2.1",
-                                                          "jaxrsClient-2.1",
-                                                          "jsonb-1.0",
-                                                          "jsonp-1.1",
+                                                          "servlet-4.0", //ee8
+                                                          "cdi-2.0", //ee8
+                                                          "jaxrs-2.1", //ee8
+                                                          "jaxrsClient-2.1", //ee8
+                                                          "jsonb-1.0", //ee8
+                                                          "jsonp-1.1", //ee8
                                                           "mpConfig-1.4",
                                                           "mpFaultTolerance-2.1",
                                                           "mpHealth-2.2",
@@ -163,15 +190,21 @@ public class MicroProfileActions {
                                                           "mpMetrics-2.3",
                                                           "mpOpenAPI-1.1",
                                                           "mpOpenTracing-1.3",
-                                                          "mpRestClient-1.4" };
+                                                          "mpRestClient-1.4",
+                                                          "mpContextPropagation-1.0", //standalone
+                                                          "mpGraphQL-1.0", //standalone
+                                                          "mpLRA-1.0", //standalone
+                                                          "mpLRACoordinator-1.0", //standalone
+                                                          "mpReactiveMessaging-1.0", //standalone
+                                                          "mpReactiveStreams-1.0" }; //standalone
 
     private static final String[] MP40_FEATURES_ARRAY = { "microProfile-4.0",
-                                                          "servlet-4.0",
-                                                          "cdi-2.0",
-                                                          "jaxrs-2.1",
-                                                          "jaxrsClient-2.1",
-                                                          "jsonb-1.0",
-                                                          "jsonp-1.1",
+                                                          "servlet-4.0", //ee8
+                                                          "cdi-2.0", //ee8
+                                                          "jaxrs-2.1", //ee8
+                                                          "jaxrsClient-2.1", //ee8
+                                                          "jsonb-1.0", //ee8
+                                                          "jsonp-1.1", //ee8
                                                           "mpConfig-2.0",
                                                           "mpFaultTolerance-3.0",
                                                           "mpHealth-3.0",
@@ -179,15 +212,21 @@ public class MicroProfileActions {
                                                           "mpMetrics-3.0",
                                                           "mpOpenAPI-2.0",
                                                           "mpOpenTracing-2.0",
-                                                          "mpRestClient-2.0" };
+                                                          "mpRestClient-2.0",
+                                                          "mpContextPropagation-1.2", //standalone
+                                                          "mpGraphQL-1.0", //standalone
+                                                          "mpLRA-1.0", //standalone
+                                                          "mpLRACoordinator-1.0", //standalone
+                                                          "mpReactiveMessaging-1.0", //standalone
+                                                          "mpReactiveStreams-1.0" }; //standalone
 
     private static final String[] MP41_FEATURES_ARRAY = { "microProfile-4.1",
-                                                          "servlet-4.0",
-                                                          "cdi-2.0",
-                                                          "jaxrs-2.1",
-                                                          "jaxrsClient-2.1",
-                                                          "jsonb-1.0",
-                                                          "jsonp-1.1",
+                                                          "servlet-4.0", //ee8
+                                                          "cdi-2.0", //ee8
+                                                          "jaxrs-2.1", //ee8
+                                                          "jaxrsClient-2.1", //ee8
+                                                          "jsonb-1.0", //ee8
+                                                          "jsonp-1.1", //ee8
                                                           "mpConfig-2.0",
                                                           "mpFaultTolerance-3.0",
                                                           "mpHealth-3.1",
@@ -195,15 +234,21 @@ public class MicroProfileActions {
                                                           "mpMetrics-3.0",
                                                           "mpOpenAPI-2.0",
                                                           "mpOpenTracing-2.0",
-                                                          "mpRestClient-2.0" };
+                                                          "mpRestClient-2.0",
+                                                          "mpContextPropagation-1.2", //standalone
+                                                          "mpGraphQL-1.0", //standalone
+                                                          "mpLRA-1.0", //standalone
+                                                          "mpLRACoordinator-1.0", //standalone
+                                                          "mpReactiveMessaging-1.0", //standalone
+                                                          "mpReactiveStreams-1.0" }; //standalone
 
     private static final String[] MP50_FEATURES_ARRAY = { "microProfile-5.0",
-                                                          "servlet-5.0",
-                                                          "cdi-3.0",
-                                                          "restfulWS-3.0",
-                                                          "restfulWSClient-3.0",
-                                                          "jsonb-2.0",
-                                                          "jsonp-2.0",
+                                                          "servlet-5.0", //ee9
+                                                          "cdi-3.0", //ee9
+                                                          "restfulWS-3.0", //ee9
+                                                          "restfulWSClient-3.0", //ee9
+                                                          "jsonb-2.0", //ee9
+                                                          "jsonp-2.0", //ee9
                                                           "mpConfig-3.0",
                                                           "mpFaultTolerance-4.0",
                                                           "mpHealth-4.0",
@@ -211,14 +256,18 @@ public class MicroProfileActions {
                                                           "mpOpenAPI-3.0",
                                                           "mpMetrics-4.0",
                                                           "mpOpenTracing-3.0",
-                                                          "mpRestClient-3.0" };
+                                                          "mpRestClient-3.0",
+                                                          "mpContextPropagation-1.3", //standalone
+                                                          "mpGraphQL-2.0", //standalone
+                                                          "mpReactiveMessaging-3.0", //standalone
+                                                          "mpReactiveStreams-3.0" }; //standalone
 
     private static final String[] MP60_FEATURES_ARRAY = { "microProfile-6.0",
-                                                          "cdi-4.0",
-                                                          "restfulWS-3.1",
-                                                          "restfulWSClient-3.1",
-                                                          "jsonb-3.0",
-                                                          "jsonp-2.1",
+                                                          "cdi-4.0", //ee10
+                                                          "restfulWS-3.1", //ee10
+                                                          "restfulWSClient-3.1", //ee10
+                                                          "jsonb-3.0", //ee10
+                                                          "jsonp-2.1", //ee10
                                                           "mpConfig-3.0",
                                                           "mpFaultTolerance-4.0",
                                                           "mpHealth-4.0",
@@ -226,14 +275,18 @@ public class MicroProfileActions {
                                                           "mpOpenAPI-3.1",
                                                           "mpMetrics-5.0",
                                                           "mpTelemetry-1.0",
-                                                          "mpRestClient-3.0" };
+                                                          "mpRestClient-3.0",
+                                                          "mpContextPropagation-1.3", //standalone
+                                                          "mpGraphQL-2.0", //standalone
+                                                          "mpReactiveMessaging-3.0", //standalone
+                                                          "mpReactiveStreams-3.0" };//standalone
 
     private static final String[] MP61_FEATURES_ARRAY = { "microProfile-6.1",
-                                                          "cdi-4.0",
-                                                          "restfulWS-3.1",
-                                                          "restfulWSClient-3.1",
-                                                          "jsonb-3.0",
-                                                          "jsonp-2.1",
+                                                          "cdi-4.0", //ee10
+                                                          "restfulWS-3.1", //ee10
+                                                          "restfulWSClient-3.1", //ee10
+                                                          "jsonb-3.0", //ee10
+                                                          "jsonp-2.1", //ee10
                                                           "mpConfig-3.1",
                                                           "mpFaultTolerance-4.0",
                                                           "mpHealth-4.0",
@@ -241,37 +294,49 @@ public class MicroProfileActions {
                                                           "mpOpenAPI-3.1",
                                                           "mpMetrics-5.1",
                                                           "mpTelemetry-1.1",
-                                                          "mpRestClient-3.0" };
+                                                          "mpRestClient-3.0",
+                                                          "mpContextPropagation-1.3", //standalone
+                                                          "mpGraphQL-2.0", //standalone
+                                                          "mpReactiveMessaging-3.0", //standalone
+                                                          "mpReactiveStreams-3.0" };//standalone
 
     private static final String[] MP70_EE10_FEATURES_ARRAY = { "microProfile-7.0",
-                                                               "cdi-4.0",
-                                                               "restfulWS-3.1",
-                                                               "restfulWSClient-3.1",
-                                                               "jsonb-3.0",
-                                                               "jsonp-2.1",
+                                                               "cdi-4.0", //ee10
+                                                               "restfulWS-3.1", //ee10
+                                                               "restfulWSClient-3.1", //ee10
+                                                               "jsonb-3.0", //ee10
+                                                               "jsonp-2.1", //ee10
                                                                "mpConfig-3.1",
                                                                "mpFaultTolerance-4.1",
                                                                "mpHealth-4.0",
                                                                "mpJwt-2.1",
                                                                "mpOpenAPI-4.0",
-                                                               "mpMetrics-5.1",
                                                                "mpTelemetry-2.0",
-                                                               "mpRestClient-4.0" };
+                                                               "mpRestClient-4.0",
+                                                               "mpMetrics-5.1", //standalone
+                                                               "mpContextPropagation-1.3", //standalone
+                                                               "mpGraphQL-2.0", //standalone
+                                                               "mpReactiveMessaging-3.0", //standalone
+                                                               "mpReactiveStreams-3.0" };//standalone
 
     private static final String[] MP70_EE11_FEATURES_ARRAY = { "microProfile-7.0",
-                                                               "cdi-4.1",
-                                                               "restfulWS-4.0",
-                                                               "restfulWSClient-4.0",
-                                                               "jsonb-3.0",
-                                                               "jsonp-2.1",
+                                                               "cdi-4.1", //ee11
+                                                               "restfulWS-4.0", //ee11
+                                                               "restfulWSClient-4.0", //ee11
+                                                               "jsonb-3.0", //ee11
+                                                               "jsonp-2.1", //ee11
                                                                "mpConfig-3.1",
                                                                "mpFaultTolerance-4.1",
                                                                "mpHealth-4.0",
                                                                "mpJwt-2.1",
                                                                "mpOpenAPI-4.0",
-                                                               "mpMetrics-5.1",
                                                                "mpTelemetry-2.0",
-                                                               "mpRestClient-4.0" };
+                                                               "mpRestClient-4.0",
+                                                               "mpMetrics-5.1", //standalone
+                                                               "mpContextPropagation-1.3", //standalone
+                                                               "mpGraphQL-2.0", //standalone
+                                                               "mpReactiveMessaging-3.0", //standalone
+                                                               "mpReactiveStreams-3.0" };//standalone
 
     private static final Set<String> MP10_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MP10_FEATURES_ARRAY)));
     private static final Set<String> MP12_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MP12_FEATURES_ARRAY)));
@@ -332,50 +397,6 @@ public class MicroProfileActions {
     //All MicroProfile FeatureSets - must be descending order
     private static final FeatureSet[] ALL_SETS_ARRAY = { MP70_EE11, MP70_EE10, MP61, MP60, MP50, MP41, MP40, MP33, MP32, MP30, MP22, MP21, MP20, MP14, MP13, MP12, MP10 };
     public static final List<FeatureSet> ALL = Collections.unmodifiableList(Arrays.asList(ALL_SETS_ARRAY));
-
-    //TODO: These feature sets are only used by the EE Compatibility Tests and don't make sense in other contexts. We should move them to those tests.
-
-    private static final String[] STANDALONE8_FEATURES_ARRAY = { "mpContextPropagation-1.0",
-                                                                 "mpContextPropagation-1.2",
-                                                                 "mpGraphQL-1.0",
-                                                                 "mpLRA-1.0",
-                                                                 "mpLRACoordinator-1.0",
-                                                                 "mpReactiveMessaging-1.0",
-                                                                 "mpReactiveStreams-1.0" };
-
-    private static final String[] STANDALONE9_FEATURES_ARRAY = { "mpContextPropagation-1.3",
-                                                                 "mpGraphQL-2.0",
-                                                                 "mpReactiveMessaging-3.0",
-                                                                 "mpReactiveStreams-3.0" };
-
-    private static final String[] STANDALONE10_FEATURES_ARRAY = { "mpContextPropagation-1.3",
-                                                                  "mpGraphQL-2.0",
-                                                                  "mpReactiveMessaging-3.0",
-                                                                  "mpReactiveStreams-3.0" };
-
-    private static final String[] STANDALONE11_FEATURES_ARRAY = { "mpContextPropagation-1.3",
-                                                                  "mpGraphQL-2.0",
-                                                                  "mpReactiveMessaging-3.0",
-                                                                  "mpReactiveStreams-3.0" };
-
-    private static final Set<String> STANDALONE8_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(STANDALONE8_FEATURES_ARRAY)));
-    private static final Set<String> STANDALONE9_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(STANDALONE9_FEATURES_ARRAY)));
-    private static final Set<String> STANDALONE10_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(STANDALONE10_FEATURES_ARRAY)));
-    private static final Set<String> STANDALONE11_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(STANDALONE11_FEATURES_ARRAY)));
-
-    public static final String STANDALONE8_ID = EE8FeatureReplacementAction.ID + "_STANDALONE";
-    public static final String STANDALONE9_ID = JakartaEE9Action.ID + "_STANDALONE";
-    public static final String STANDALONE10_ID = JakartaEE10Action.ID + "_STANDALONE";
-    public static final String STANDALONE11_ID = JakartaEE11Action.ID + "_STANDALONE";
-
-    public static final FeatureSet MP_STANDALONE8 = new FeatureSet(STANDALONE8_ID, STANDALONE8_FEATURE_SET, EEVersion.EE8);
-    public static final FeatureSet MP_STANDALONE9 = new FeatureSet(STANDALONE9_ID, STANDALONE9_FEATURE_SET, EEVersion.EE9);
-    public static final FeatureSet MP_STANDALONE10 = new FeatureSet(STANDALONE10_ID, STANDALONE10_FEATURE_SET, EEVersion.EE10);
-    public static final FeatureSet MP_STANDALONE11 = new FeatureSet(STANDALONE11_ID, STANDALONE11_FEATURE_SET, EEVersion.EE11);
-
-    //All MicroProfile Standalone FeatureSets
-    private static final FeatureSet[] ALL_STANDALONE_SETS_ARRAY = { MP_STANDALONE11, MP_STANDALONE10, MP_STANDALONE9, MP_STANDALONE8 };
-    public static final List<FeatureSet> STANDALONE_ALL = Collections.unmodifiableList(Arrays.asList(ALL_STANDALONE_SETS_ARRAY));
 
     /**
      * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in FULL.

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/MicroProfileActions.java
@@ -82,7 +82,6 @@ public class MicroProfileActions {
                                                           "mpOpenTracing-1.1",
                                                           "mpRestClient-1.1",
                                                           "mpContextPropagation-1.0", //standalone
-                                                          "mpGraphQL-1.0", //standalone
                                                           "mpLRA-1.0", //standalone
                                                           "mpLRACoordinator-1.0", //standalone
                                                           "mpReactiveMessaging-1.0", //standalone
@@ -104,7 +103,6 @@ public class MicroProfileActions {
                                                           "mpOpenTracing-1.2",
                                                           "mpRestClient-1.1",
                                                           "mpContextPropagation-1.0", //standalone
-                                                          "mpGraphQL-1.0", //standalone
                                                           "mpLRA-1.0", //standalone
                                                           "mpLRACoordinator-1.0", //standalone
                                                           "mpReactiveMessaging-1.0", //standalone
@@ -126,7 +124,6 @@ public class MicroProfileActions {
                                                           "mpOpenTracing-1.3",
                                                           "mpRestClient-1.2",
                                                           "mpContextPropagation-1.0", //standalone
-                                                          "mpGraphQL-1.0", //standalone
                                                           "mpLRA-1.0", //standalone
                                                           "mpLRACoordinator-1.0", //standalone
                                                           "mpReactiveMessaging-1.0", //standalone
@@ -148,7 +145,6 @@ public class MicroProfileActions {
                                                           "mpOpenTracing-1.3",
                                                           "mpRestClient-1.3",
                                                           "mpContextPropagation-1.0", //standalone
-                                                          "mpGraphQL-1.0", //standalone
                                                           "mpLRA-1.0", //standalone
                                                           "mpLRACoordinator-1.0", //standalone
                                                           "mpReactiveMessaging-1.0", //standalone
@@ -170,7 +166,6 @@ public class MicroProfileActions {
                                                           "mpOpenTracing-1.3",
                                                           "mpRestClient-1.3",
                                                           "mpContextPropagation-1.0", //standalone
-                                                          "mpGraphQL-1.0", //standalone
                                                           "mpLRA-1.0", //standalone
                                                           "mpLRACoordinator-1.0", //standalone
                                                           "mpReactiveMessaging-1.0", //standalone
@@ -216,9 +211,7 @@ public class MicroProfileActions {
                                                           "mpContextPropagation-1.2", //standalone
                                                           "mpGraphQL-1.0", //standalone
                                                           "mpLRA-1.0", //standalone
-                                                          "mpLRACoordinator-1.0", //standalone
-                                                          "mpReactiveMessaging-1.0", //standalone
-                                                          "mpReactiveStreams-1.0" }; //standalone
+                                                          "mpLRACoordinator-1.0" }; //standalone
 
     private static final String[] MP41_FEATURES_ARRAY = { "microProfile-4.1",
                                                           "servlet-4.0", //ee8
@@ -238,9 +231,7 @@ public class MicroProfileActions {
                                                           "mpContextPropagation-1.2", //standalone
                                                           "mpGraphQL-1.0", //standalone
                                                           "mpLRA-1.0", //standalone
-                                                          "mpLRACoordinator-1.0", //standalone
-                                                          "mpReactiveMessaging-1.0", //standalone
-                                                          "mpReactiveStreams-1.0" }; //standalone
+                                                          "mpLRACoordinator-1.0" }; //standalone
 
     private static final String[] MP50_FEATURES_ARRAY = { "microProfile-5.0",
                                                           "servlet-5.0", //ee9

--- a/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/bnd.bnd
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -21,7 +18,10 @@ fat.project: true
 
 tested.features:\
   mpTelemetry-2.0,\
-  mpFaultTolerance-4.1
+  mpFaultTolerance-4.1,\
+  restfulwsclient-4.0,\
+  restfulws-4.0,\
+  cdi-4.1
 
 fat.minimum.java.level: 11
 

--- a/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance41/tck/FaultToleranceTck41Launcher.java
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance41/tck/FaultToleranceTck41Launcher.java
@@ -51,7 +51,7 @@ public class FaultToleranceTck41Launcher {
     private static final boolean FAT_TEST_LOCALRUN = Boolean.getBoolean("fat.test.localrun");
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE10);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11);
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/publish/servers/FaultTolerance41TCKServer/server.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/publish/servers/FaultTolerance41TCKServer/server.xml
@@ -6,18 +6,15 @@
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
    <featureManager>
         <feature>mpFaultTolerance-4.1</feature>
-        <feature>restfulWS-3.0</feature>
+        <feature>restfulWS-3.1</feature>
         <feature>localConnector-1.0</feature>
         <feature>arquillian-support-jakarta-2.1</feature>
         <feature>mpTelemetry-2.0</feature>
-        <feature>mpMetrics-4.0</feature>
+        <feature>mpMetrics-5.1</feature>
    </featureManager>
 
    <include location="../fatTestPorts.xml"/>


### PR DESCRIPTION
This PR replaces https://github.com/OpenLiberty/open-liberty/pull/28746

Update MP Fault Tolerance buckets to repeat against MP 7.0 with both EE10 and EE11

Also, instead of listing standalone features separately from the main MP features, they are instead included in the main MP repeat actions. This avoids the need to add further custom repeats and makes the EE compatibility tests a little simpler.