### PR TITLE
Updated Validation 3.1 APIs to released version

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1554,7 +1554,7 @@
     <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>
-      <version>3.1.0-M2</version>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>jakarta.websocket</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -306,7 +306,7 @@ jakarta.servlet:jakarta.servlet-api:6.1.0
 jakarta.transaction:jakarta.transaction-api:1.3.3
 jakarta.transaction:jakarta.transaction-api:2.0.1
 jakarta.validation:jakarta.validation-api:3.0.2
-jakarta.validation:jakarta.validation-api:3.1.0-M2
+jakarta.validation:jakarta.validation-api:3.1.0
 jakarta.websocket:jakarta.websocket-api:2.0.0
 jakarta.websocket:jakarta.websocket-api:2.1.1
 jakarta.websocket:jakarta.websocket-api:2.2.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.validation-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.validation-3.1.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.jakarta.validation-3.1
 visibility=private
 singleton=true
 -features=com.ibm.websphere.appserver.eeCompatible-11.0
--bundles=io.openliberty.jakarta.validation.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.validation:jakarta.validation-api:3.1.0-M2"
+-bundles=io.openliberty.jakarta.validation.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.validation:jakarta.validation-api:3.1.0"
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.jakarta/validation.3.1.bnd
+++ b/dev/io.openliberty.jakarta/validation.3.1.bnd
@@ -20,7 +20,7 @@ Bundle-SymbolicName: io.openliberty.jakarta.validation.3.1; singleton:=true
 Export-Package: jakarta.validation.*;version="3.1.0"
 
 -includeresource: \
-  @${repo;jakarta.validation:jakarta.validation-api;3.1.0.M2;EXACT}!/!(META-INF/maven/*|module-info.class)
+  @${repo;jakarta.validation:jakarta.validation-api;3.1.0;EXACT}!/!(META-INF/maven/*|module-info.class)
 
 -maven-dependencies: \
-   dep1;groupId=jakarta.validation;artifactId=jakarta.validation-api;version=3.1.0-M2;scope=runtime
+   dep1;groupId=jakarta.validation;artifactId=jakarta.validation-api;version=3.1.0;scope=runtime


### PR DESCRIPTION
The final version of Jakarta Validation 3.1 is released, so all of the places referencing the M2 version is updated.
Everything referencing 3.1.0-M2 or 3.1.0.M2 is changed to 3.1.0
fixes #28764