### PR TITLE
Add mpCompatible dependencies back in

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.faulttolerance-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.faulttolerance-4.0.feature
@@ -1,8 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.org.eclipse.microprofile.faulttolerance-4.0
 singleton=true
-# io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0,6.1" comes from io.openliberty.microprofile.cdi.api features
--features=io.openliberty.microprofile.cdi.api-3.0; ibm.tolerates:="4.0"
+-features=\
+ io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0,6.1",\
+ io.openliberty.microprofile.cdi.api-3.0; ibm.tolerates:="4.0"
 -bundles=io.openliberty.org.eclipse.microprofile.faulttolerance.4.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:4.0.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.faulttolerance-4.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.faulttolerance-4.1.feature
@@ -1,8 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.org.eclipse.microprofile.faulttolerance-4.1
 singleton=true
-# io.openliberty.mpCompatible-x.x comes from io.openliberty.microprofile.cdi.api features
--features=io.openliberty.microprofile.cdi.api-4.0; ibm.tolerates:="4.1"
+-features=\
+ io.openliberty.mpCompatible-7.0,\
+ io.openliberty.microprofile.cdi.api-4.0; ibm.tolerates:="4.1"
 # TODO before GA, check maven coordinates 
 -bundles=io.openliberty.org.eclipse.microprofile.faulttolerance.4.1; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:4.1.0"
 kind=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.rest.client-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.rest.client-3.0.feature
@@ -1,8 +1,8 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.org.eclipse.microprofile.rest.client-3.0
 singleton=true
-# io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0,6.1" comes from io.openliberty.microprofile.cdi.api features
 -features=\
+  io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0,6.1",\
   io.openliberty.jakarta.annotation-2.0; ibm.tolerates:="2.1", \
   io.openliberty.microprofile.cdi.api-3.0; ibm.tolerates:="4.0", \
   io.openliberty.jakarta.restfulWS-3.0; ibm.tolerates:="3.1", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.rest.client-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.rest.client-4.0.feature
@@ -1,8 +1,8 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.org.eclipse.microprofile.rest.client-4.0
 singleton=true
-# io.openliberty.mpCompatible-x.x comes from io.openliberty.microprofile.cdi.api features
 -features=\
+  io.openliberty.mpCompatible-7.0, \
   io.openliberty.jakarta.annotation-2.1; ibm.tolerates:="3.0", \
   io.openliberty.microprofile.cdi.api-4.0; ibm.tolerates:="4.1", \
   io.openliberty.jakarta.restfulWS-3.1; ibm.tolerates:="4.0", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpFaultTolerance-4.0/io.openliberty.mpFaultTolerance-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpFaultTolerance-4.0/io.openliberty.mpFaultTolerance-4.0.feature
@@ -8,8 +8,9 @@ IBM-API-Package: org.eclipse.microprofile.faulttolerance.exceptions;  type="stab
                  org.eclipse.microprofile.faulttolerance;  type="stable"
 IBM-ShortName: mpFaultTolerance-4.0
 Subsystem-Name: MicroProfile Fault Tolerance 4.0
-# io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0,6.1" comes from io.openliberty.mpConfig features
--features=io.openliberty.mpConfig-3.0; ibm.tolerates:="3.1", \
+-features=\
+  io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0,6.1", \
+  io.openliberty.mpConfig-3.0; ibm.tolerates:="3.1", \
   io.openliberty.org.eclipse.microprofile.faulttolerance-4.0, \
   io.openliberty.cdi-3.0; ibm.tolerates:="4.0"
 -bundles=com.ibm.ws.microprofile.faulttolerance; apiJar=false; location:="lib/", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpRestClient-3.0/io.openliberty.mpRestClient-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpRestClient-3.0/io.openliberty.mpRestClient-3.0.feature
@@ -17,8 +17,8 @@ IBM-API-Package: \
 IBM-ShortName: mpRestClient-3.0
 Subsystem-Name: MicroProfile Rest Client 3.0
 
-# io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0,6.1" comes from io.openliberty.mpConfig features
 -features=\
+  io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0,6.1", \
   io.openliberty.jsonp-2.0; ibm.tolerates:="2.1", \
   io.openliberty.restfulWSClient-3.0; ibm.tolerates:="3.1", \
   io.openliberty.mpConfig-3.0; ibm.tolerates:="3.1", \


### PR DESCRIPTION
Until recently it was OK to rely on other features such as MP Config to infer the mpCompatible dependency. That is no longer true since the latest version of mpConfig (3.1) now has compatibility with MP 7 on both EE10 and EE11. This is not appropriate for features that have been updated in MP 7 such as FaultTolerance and RestClient.

