### PR TITLE
Change the audit-2.0 feature from beta to GA

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.audit2.0.restHandler.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.audit2.0.restHandler.feature
@@ -10,5 +10,5 @@ IBM-Install-Policy: when-satisfied
 
 -bundles=io.openliberty.request.probe.audit.rest
 WLP-Activation-Type: parallel
-kind=beta
+kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/audit-2.0/com.ibm.websphere.appserver.audit-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/audit-2.0/com.ibm.websphere.appserver.audit-2.0.feature
@@ -10,6 +10,6 @@ Subsystem-Name: Audit 2.0
   io.openliberty.auditCollector1.0.internal.ee-6.0; ibm.tolerates:="9.0"
 -bundles=com.ibm.ws.security.audit.utils, \
   com.ibm.ws.security.audit.file
-kind=beta
+kind=ga
 edition=core
 WLP-InstantOn-Enabled: true


### PR DESCRIPTION
We want to deliver `audit-2.0` so we are changing the feature from beta to ga.