### PR TITLE
FeatureUtility enable no proxy

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -313,6 +313,11 @@ public class FeatureUtility {
 
 		}
 
+		// override no_proxy settings
+		if (System.getProperty("featureUtility.beta").equals("true") && FeatureUtilityProperties.getNoProxySetting() != null) {
+		    overrideMap.put("http.nonProxyHosts", FeatureUtilityProperties.getNoProxySetting());
+		}
+
         // override the local feature repo
         if(FeatureUtilityProperties.getFeatureLocalRepo() != null){
             overrideMap.put("FEATURE_LOCAL_REPO", FeatureUtilityProperties.getFeatureLocalRepo());
@@ -347,6 +352,13 @@ public class FeatureUtility {
         }
 
 	map.put(InstallConstants.OVERRIDE_ENVIRONMENT_VARIABLES, overrideMap);
+
+	if (map.get(InstallConstants.ACTION_ERROR_MESSAGE) != null) {
+	    // error with installation
+	    fine("action.exception.stacktrace: " + map.get(InstallConstants.ACTION_EXCEPTION_STACKTRACE));
+	    String exceptionMessage = (String) map.get(InstallConstants.ACTION_ERROR_MESSAGE);
+	    throw new InstallException(exceptionMessage);
+	}
     }
 
     /**

--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/props/FeatureUtilityProperties.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/props/FeatureUtilityProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -39,7 +39,7 @@ public class FeatureUtilityProperties {
     private final static String FILEPATH_EXT = "/etc/featureUtility.properties";
     private final static String FeatureVerifyQualifier = "feature.verify";
     private final static Set<String> DEFINED_OPTIONS = new HashSet<>(Arrays.asList("proxyHost", "proxyPort",
-	    "proxyUser", "proxyPassword", "featureLocalRepo", FeatureVerifyQualifier));
+	    "proxyUser", "proxyPassword", "http.nonProxyHosts", "featureLocalRepo", FeatureVerifyQualifier));
     private static Map<String, String> definedVariables = new HashMap<>();
     private static List<MavenRepository> repositoryList = new ArrayList<>();
     private static List<String> bomIdList = new ArrayList<>();
@@ -97,6 +97,10 @@ public class FeatureUtilityProperties {
 
     public static String getProxyPassword(){
         return definedVariables.get("proxyPassword"); // char array instead?
+    }
+
+    public static String getNoProxySetting() {
+	return definedVariables.get("http.nonProxyHosts");
     }
 
     public static String getFeatureLocalRepo(){

--- a/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.install.featureUtility_fat/bnd.bnd
@@ -1,5 +1,5 @@
-#*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+a#*******************************************************************************
+# Copyright (c) 2019, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
@@ -372,13 +372,13 @@ public abstract class FeatureUtilityToolTest {
 
     protected ProgramOutput runFeatureUtility(String testcase, String[] params, boolean debug) throws Exception {
         Properties envProps = new Properties();
-	// add beta property here
-	// envProps.put("JVM_ARGS", "-Dbeta.property=true");
         return runFeatureUtility(testcase, params, envProps);
     }
 
     protected ProgramOutput runFeatureUtility(String testcase, String[] params, Properties envProps) throws Exception {
-	// always run feature utility with minified root
+    		// add beta property here
+	    envProps.put("JVM_ARGS", "-DfeatureUtility.beta=true");    
+    		// always run feature utility with minified root
         return runCommand(minifiedRoot, testcase, "featureUtility", params, envProps);
     }
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -45,6 +45,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	private static String userFeatureSigPath = "/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa.asc";
 	static Network network = Network.newNetwork();
 	
+	
 //	@ClassRule
 	/*
 	 * Increased startup timeout because nexus container might take more than 60
@@ -723,8 +724,6 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	public void testVerifyhttpKeyServer() throws Exception {
 	    final String METHOD_NAME = "testVerifyhttpKeyServer";
 	    Log.entering(c, METHOD_NAME);
-	    Properties envProps = new Properties();
-	    envProps.put("FEATURE_VERIFY", "all");
 
 	    String containerUrl = "http://" + container.getHost() + ":" + container.getMappedPort(8080)
 		    + "/validKey.asc";
@@ -984,7 +983,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	  
 	    try {
 		checkCommandOutput(po, 0, null, filesList);
-	    } catch(Exception e) {
+	    } catch (AssertionError e) {
 		checkProxyLog(METHOD_NAME, proxyContainer);
 		  throw e;
 	    }
@@ -1016,13 +1015,13 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "mavenCentralMirror.user", "admin");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "mavenCentralMirror.password", "golf");
 	    
-	    String[] param1s = { "installFeature", "json-1.0", "--verbose" };
+	    String[] param1s = { "installFeature", "json-1.0", "--verbose", "--noCache" };
 	    String[] filesList = { "/lib/features/com.ibm.websphere.appserver.json-1.0.mf" };
 	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
 
 	    try {
 		checkCommandOutput(po, 0, null, filesList);
-	    } catch (Exception e) {
+	    } catch (AssertionError e) {
 		checkProxyLog(METHOD_NAME, proxyContainer);
 		  throw e;
 	    }
@@ -1056,13 +1055,13 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "mavenCentralMirror.password",
 		    "{xor}ODAzOQ==");
 
-	    String[] param1s = { "installFeature", "json-1.0", "--verbose" };
+	    String[] param1s = { "installFeature", "json-1.0", "--verbose", "--noCache" };
 	    String[] filesList = { "/lib/features/com.ibm.websphere.appserver.json-1.0.mf" };
 	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
 
 	    try {
 		checkCommandOutput(po, 0, null, filesList);
-	    } catch (Exception e) {
+	    } catch (AssertionError e) {
 		checkProxyLog(METHOD_NAME, proxyContainer);
 		throw e;
 	    }
@@ -1070,5 +1069,86 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    Log.exiting(c, METHOD_NAME);
 	    
 	}
+
+	/*
+	 * Test no proxy using environment variable Try downloading public key from
+	 * external key server. It should fail because keyserver can only be connected
+	 * through proxy. (testcontainer network)
+	 */
+	@Test
+	public void testnoProxyEnv() throws Exception {
+	    final String METHOD_NAME = "testnoProxyEnv";
+	    Log.entering(c, METHOD_NAME);
+
+	    String proxyHost = "http://" + proxyContainer.getHost();
+	    String proxyPort = proxyContainer.getMappedPort(3128).toString();
+	    String containerUrl = "http://keyserver:8080/validKey.asc";
+
+	    Properties envProps = new Properties();
+	    envProps.put("no_proxy", "keyserver");
+
+
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "proxyHost", proxyHost);
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "proxyPort", proxyPort);
+	    
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "feature.verify", "all");
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyid", "0x71f8e6239b6834aa");
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl", containerUrl);
+
+	    String[] filesList = { "usr/extension/lib/features/testesa1.mf", "usr/extension/bin/testesa1.bat" };
+
+	    String[] param1s = { "installFeature", "testesa1",
+		    "--featuresBOM=com.ibm.ws.userFeature:features-bom:19.0.0.8", "--verbose" };
+
+	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s, envProps);
+
+	    try {
+		checkCommandOutput(po, InstallException.SIGNATURE_VERIFICATION_FAILED, "CWWKF1506E", null);
+	    } catch (AssertionError e) {
+		checkProxyLog(METHOD_NAME, proxyContainer);
+		throw e;
+	    }
+
+	    Log.exiting(c, METHOD_NAME);
+
+	}
+
+	/*
+	 * Test no proxy using properties
+	 */
+	@Test
+	public void testnoProxyProps() throws Exception {
+	    final String METHOD_NAME = "testnoProxyProps";
+	    Log.entering(c, METHOD_NAME);
+
+	    String proxyHost = "http://" + proxyContainer.getHost();
+	    String proxyPort = proxyContainer.getMappedPort(3128).toString();
+	    String containerUrl = "http://keyserver:8080/validKey.asc";
+
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "proxyHost", proxyHost);
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "proxyPort", proxyPort);
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "http.nonProxyHosts", "keyserver");
+
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "feature.verify", "all");
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyid", "0x71f8e6239b6834aa");
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl", containerUrl);
+
+	    String[] filesList = { "usr/extension/lib/features/testesa1.mf", "usr/extension/bin/testesa1.bat" };
+
+	    String[] param1s = { "installFeature", "testesa1",
+		    "--featuresBOM=com.ibm.ws.userFeature:features-bom:19.0.0.8", "--verbose" };
+	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
+
+	    try {
+		checkCommandOutput(po, InstallException.SIGNATURE_VERIFICATION_FAILED, "CWWKF1506E", null);
+	    } catch (AssertionError e) {
+		checkProxyLog(METHOD_NAME, proxyContainer);
+		throw e;
+	    }
+
+	    Log.exiting(c, METHOD_NAME);
+
+	}
+
 
 }

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,9 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Authenticator;
-import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
-import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -311,7 +309,6 @@ public class ArtifactDownloader implements AutoCloseable {
      */
     protected boolean testConnection(MavenRepository repository) {
         try {
-            ArtifactDownloaderUtils.checkValidProxy(envMap);
             ArtifactDownloaderUtils.verifyPassword(repository.getPassword());
             int responseCode = ArtifactDownloaderUtils.exists(repository.getRepositoryUrl(), envMap, repository);
             logger.fine("Response code - " + repository.getRepositoryUrl() + ":" + responseCode);
@@ -324,19 +321,19 @@ public class ArtifactDownloader implements AutoCloseable {
     }
 
     private void downloadInternal(URI address, File destination, MavenRepository repository) throws IOException, InstallException {
-        Proxy proxy;
+        URL url = address.toURL();
+        if (System.getProperty("featureUtility.beta").equals("true")) {
+            logger.fine("non Proxy Hosts: " + System.getProperty("http.nonProxyHosts"));
+        }
+        logger.fine("downloadInternal url host: " + url.getHost());
         String proxyEncodedAuth = "";
-        if (envMap.get("https.proxyHost") != null) {
-            proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress((String) envMap.get("https.proxyHost"), Integer.parseInt((String) envMap.get("https.proxyPort"))));
+        if (url.getProtocol().equals("https") && envMap.get("https.proxyHost") != null) {
             proxyEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication((String) envMap.get("https.proxyUser"), (String) envMap.get("https.proxyPassword"));
         } else if (envMap.get("http.proxyHost") != null) {
-            proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress((String) envMap.get("http.proxyHost"), Integer.parseInt((String) envMap.get("http.proxyPort"))));
             proxyEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication((String) envMap.get("http.proxyUser"), (String) envMap.get("http.proxyPassword"));
-        } else {
-            proxy = Proxy.NO_PROXY;
         }
-        URL url = address.toURL();
-        URLConnection conn = url.openConnection(proxy);
+
+        URLConnection conn = url.openConnection();
 
         final String userAgentValue = calculateUserAgent();
         String repoEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication(repository.getUserId(), repository.getPassword());

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -545,6 +545,8 @@ public class InstallKernelMap implements Map {
         } else if (InstallConstants.OVERRIDE_ENVIRONMENT_VARIABLES.equals(key)) {
             if (value instanceof Map<?, ?>) {
                 overrideEnvMap((Map<String, Object>) value);
+                //set proxy system properties
+                setProxy();
             } else {
                 throw new IllegalArgumentException();
             }
@@ -1109,6 +1111,59 @@ public class InstallKernelMap implements Map {
         envMap.putAll(overrideMap);
         logger.fine("printing envmap after");
         logger.fine(envMap.toString());
+
+    }
+
+    /**
+     * set proxy jvm system properties
+     * http.nonProxyHosts:a list of hosts that should be reached directly, bypassing the proxy. This is a list of patterns separated by '|'. The patterns may start or end with a
+     * '*' for wildcards. Any host matching one of these patterns will be reached through a direct connection instead of through a proxy.
+     */
+    protected void setProxy() {
+        //set up basic auth HTTP tunnel
+        System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
+
+        try {
+            if (envMap.get("https.proxyHost") != null) {
+                checkValidProxy("https");
+                System.setProperty("https.proxyHost", (String) envMap.get("https.proxyHost"));
+                System.setProperty("https.proxyPort", (String) envMap.get("https.proxyPort"));
+            }
+            if (envMap.get("http.proxyHost") != null) {
+                checkValidProxy("http");
+                System.setProperty("http.proxyHost", (String) envMap.get("http.proxyHost"));
+                System.setProperty("http.proxyPort", (String) envMap.get("http.proxyPort"));
+                if (envMap.get("https.proxyHost") == null) {
+                    System.setProperty("https.proxyHost", (String) envMap.get("http.proxyHost"));
+                    System.setProperty("https.proxyPort", (String) envMap.get("http.proxyPort"));
+                }
+            }
+            if (System.getProperty("featureUtility.beta").equals("true") && envMap.get("http.nonProxyHosts") != null) {
+                String noProxyHosts = (String) envMap.get("http.nonProxyHosts");
+                //if users provide list of hosts using ",", replace to "|"
+                noProxyHosts = noProxyHosts.replace(",", "|");
+                System.setProperty("http.nonProxyHosts", noProxyHosts);
+            }
+        } catch (InstallException e) {
+            data.put(InstallConstants.ACTION_ERROR_MESSAGE, e.getMessage());
+            data.put(InstallConstants.ACTION_EXCEPTION_STACKTRACE, ExceptionUtils.stacktraceToString(e));
+        }
+
+    }
+
+    protected void checkValidProxy(String protocol) throws InstallException {
+        String proxyPort = (String) envMap.get(protocol + ".proxyPort");
+        if (protocol != null) {
+            int proxyPortnum = Integer.parseInt(proxyPort);
+            if (((String) envMap.get(protocol + ".proxyHost")).isEmpty()) {
+                throw ExceptionUtils.createByKey("ERROR_TOOL_PROXY_HOST_MISSING");
+            } else if (proxyPortnum < 0 || proxyPortnum > 65535) {
+                throw ExceptionUtils.createByKey("ERROR_TOOL_INVALID_PROXY_PORT", proxyPort);
+            } else if (envMap.get(protocol + "proxyUser") != null && (envMap.get(protocol + ".proxyPassword") == null
+                                                                      || ((String) envMap.get(protocol + ".proxyPassword")).isEmpty())) {
+                throw ExceptionUtils.createByKey("ERROR_TOOL_PROXY_PWD_MISSING");
+            }
+        }
     }
 
     private static Collection<String> keepFirstInstance(Collection<String> dupStrCollection) {
@@ -1903,6 +1958,9 @@ public class InstallKernelMap implements Map {
                 envMapRet.put(key, httpsProxyVariables.get(key));
             }
         }
+        if (System.getProperty("featureUtility.beta").equals("true")) {
+            envMapRet.put("http.nonProxyHosts", System.getenv("no_proxy"));
+        }
 
         envMapRet.put("FEATURE_REPO_URL", System.getenv("FEATURE_REPO_URL"));
         envMapRet.put("FEATURE_REPO_USER", System.getenv("FEATURE_REPO_USER"));
@@ -1917,7 +1975,8 @@ public class InstallKernelMap implements Map {
 
         envMapRet.put("FEATURE_VERIFY", System.getenv("FEATURE_VERIFY"));
 
-        //search through the properties file to look for overrides if they exist TODO
+        //search through the properties file to look for overrides if they exist
+        //TODO remove? - Do we use featureUtility.env ?
         Map<String, String> propsFileMap = getFeatureUtilEnvProps();
         if (!propsFileMap.isEmpty()) {
             fine("The properties found in featureUtility.env will override latent environment variables of the same name");

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/VerifySignatureUtility.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/VerifySignatureUtility.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,9 +19,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
-import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
 import java.time.Instant;
@@ -146,20 +144,15 @@ public class VerifySignatureUtility {
             URLConnection conn;
             try {
                 logger.fine("Downloading key... " + key.getValue());
-                ArtifactDownloaderUtils.checkValidProxy(envMap);
                 URL keyUrl = new URL(key.getValue());
-                Proxy proxy;
                 String proxyEncodedAuth = "";
-                if (envMap.get("https.proxyHost") != null) {
-                    proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress((String) envMap.get("https.proxyHost"), Integer.parseInt((String) envMap.get("https.proxyPort"))));
+                if (keyUrl.getProtocol().equals("https") && envMap.get("https.proxyHost") != null) {
                     proxyEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication((String) envMap.get("https.proxyUser"), (String) envMap.get("https.proxyPassword"));
                 } else if (envMap.get("http.proxyHost") != null) {
-                    proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress((String) envMap.get("http.proxyHost"), Integer.parseInt((String) envMap.get("http.proxyPort"))));
                     proxyEncodedAuth = ArtifactDownloaderUtils.getBasicAuthentication((String) envMap.get("http.proxyUser"), (String) envMap.get("http.proxyPassword"));
-                } else {
-                    proxy = Proxy.NO_PROXY;
                 }
-                conn = keyUrl.openConnection(proxy);
+
+                conn = keyUrl.openConnection();
                 conn.setConnectTimeout(10000);
 
                 if (!proxyEncodedAuth.isEmpty()) {


### PR DESCRIPTION
To set no_proxy using the environment variable, use no_proxy.
To set it using featureUtility.properties, use http.nonProxyHosts (name used by jvm system properties)
In beta.