### PR TITLE
Fix Subject.getSubject changes for Java 23

### DIFF
--- a/dev/com.ibm.ws.componenttest/src/componenttest/app/FATUtilities.java
+++ b/dev/com.ibm.ws.componenttest/src/componenttest/app/FATUtilities.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package componenttest.app;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.security.AccessController;
+
+import javax.security.auth.Subject;
+
+/**
+ * A class for testing related utilities
+ */
+public class FATUtilities {
+
+    /**
+     * In Java 23, the Subject.getSubject(...) method always throws an UnsupportedOperationException
+     * So for versions before Java 23, we can still use Subject.getSubject(), but for Java 23 and beyond,
+     * we need to switch to using Subject.current(), which was introduced in Java 18.
+     *
+     * So for Java 22 and earlier, this returns Subject.getSubject(...)
+     * For Java 23 and later, this method returns Subject.current()
+     *
+     * @return
+     */
+    public static Subject getCurrentSubject() {
+        if (JavaInfo.JAVA_VERSION <= 22) {
+            // return Subject.getSubject(...)
+            return Subject.getSubject(AccessController.getContext());
+        } else {
+            // return Subject.current()
+            try {
+                final MethodType subjectMethodType = MethodType.methodType(Subject.class);
+                MethodHandle getCurrentMethodHandle = MethodHandles.lookup().findStatic(Subject.class, "current", subjectMethodType);
+                return (Subject) getCurrentMethodHandle.invoke();
+            } catch (Throwable e) {
+                return null;
+            }
+        }
+    }
+}

--- a/dev/com.ibm.ws.componenttest/src/componenttest/app/JavaInfo.java
+++ b/dev/com.ibm.ws.componenttest/src/componenttest/app/JavaInfo.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package componenttest.app;
+
+/**
+ * A class used for identifying properties of a JDK
+ */
+public class JavaInfo {
+    private static JavaInfo instance;
+
+    public static int JAVA_VERSION = majorVersion();
+
+    private final String JAVA_HOME;
+    private final int MAJOR;
+    private final int MINOR;
+    private final int MICRO;
+    private final int SERVICE_RELEASE;
+    private final int FIXPACK;
+
+    private JavaInfo() {
+        JAVA_HOME = System.getProperty("java.home");
+
+        String version = System.getProperty("java.version");
+        String[] versionElements = version.split("\\D"); // split on non-digits
+
+        // Pre-JDK 9 the java.version is 1.MAJOR.MINOR
+        // Post-JDK 9 the java.version is MAJOR.MINOR
+        int i = Integer.parseInt(versionElements[0]) == 1 ? 1 : 0;
+        MAJOR = Integer.parseInt(versionElements[i++]);
+
+        if (i < versionElements.length)
+            MINOR = Integer.parseInt(versionElements[i++]);
+        else
+            MINOR = 0;
+
+        if (i < versionElements.length)
+            MICRO = Integer.parseInt(versionElements[i]);
+        else
+            MICRO = 0;
+
+        // Parse service release
+        String buildInfo = System.getProperty("java.runtime.version");
+        int sr = 0;
+        int srloc = buildInfo.toLowerCase().indexOf("sr");
+        if (srloc > (-1)) {
+            srloc += 2;
+            if (srloc < buildInfo.length()) {
+                int len = 0;
+                while ((srloc + len < buildInfo.length()) && Character.isDigit(buildInfo.charAt(srloc + len))) {
+                    len++;
+                }
+                sr = Integer.parseInt(buildInfo.substring(srloc, srloc + len));
+            }
+        }
+        SERVICE_RELEASE = sr;
+
+        // Parse fixpack
+        int fp = 0;
+        int fploc = buildInfo.toLowerCase().indexOf("fp");
+        if (fploc > (-1)) {
+            fploc += 2;
+            if (fploc < buildInfo.length()) {
+                int len = 0;
+                while ((fploc + len < buildInfo.length()) && Character.isDigit(buildInfo.charAt(fploc + len))) {
+                    len++;
+                }
+                fp = Integer.parseInt(buildInfo.substring(fploc, fploc + len));
+            }
+        }
+        FIXPACK = fp;
+    }
+
+    private static JavaInfo instance() {
+        if (instance == null)
+            instance = new JavaInfo();
+        return instance;
+    }
+
+    public static int majorVersion() {
+        return instance().MAJOR;
+    }
+
+    public static int minorVersion() {
+        return instance().MINOR;
+    }
+
+    public static int microVersion() {
+        return instance().MICRO;
+    }
+
+    public static String javaHome() {
+        return instance().JAVA_HOME;
+    }
+
+    public static int serviceRelease() {
+        return instance().SERVICE_RELEASE;
+    }
+
+    public static int fixpack() {
+        return instance().FIXPACK;
+    }
+
+    @Override
+    public String toString() {
+        return "major=" + MAJOR + ", minor=" + MINOR + ", micro=" + MICRO + ", service release=" + SERVICE_RELEASE
+               + ", fixpack=" + FIXPACK + ", javaHome=" + JAVA_HOME;
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/MPConcurrentConfigTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/MPConcurrentConfigTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2021 IBM Corporation and others.
+ * Copyright (c) 2019,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.security.AccessController;
 import java.security.Principal;
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
@@ -52,8 +51,8 @@ import org.test.context.location.TestContextTypes;
 import com.ibm.websphere.security.WSSecurityException;
 import com.ibm.websphere.security.auth.WSSubject;
 
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.app.FATServlet;
+import componenttest.app.FATUtilities;
 
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/MPConcurrentConfigTestServlet")
@@ -397,19 +396,18 @@ public class MPConcurrentConfigTestServlet extends FATServlet {
     /**
      * Security context propagation should include subjects that are created by the application.
      */
-    @MaximumJavaLevel(javaLevel = 22) //Subject.doAs fails in Java 23, Subject.runAs for replacement is only in Java 18+: https://bugs.openjdk.org/browse/JDK-8327134
     @Test
     public void testSecurityContextPropagatesSubjectCreatedByApp() throws Exception {
         Subject subject = new Subject();
         subject.setReadOnly();
         CompletableFuture<Subject> cf = Subject.doAs(subject, (PrivilegedExceptionAction<CompletableFuture<Subject>>) () -> {
             // verify that it works before we try propagating it
-            Subject s = Subject.getSubject(AccessController.getContext());
+            Subject s = FATUtilities.getCurrentSubject();
             assertTrue(s.isReadOnly());
             assertSame(subject, s);
 
             return securityContextExecutor.supplyAsync(() -> {
-                Subject sub = Subject.getSubject(AccessController.getContext());
+                Subject sub = FATUtilities.getCurrentSubject();
                 // assertTrue(sub.isReadOnly()); // TODO fails - Subject from AccessControlContext is null
                 return sub;
             });
@@ -435,7 +433,7 @@ public class MPConcurrentConfigTestServlet extends FATServlet {
              // verify that it works before we try propagating it
              assertSame(subject, WSSubject.getRunAsSubject());
              assertSame(subject, WSSubject.getCallerSubject());
-             Subject s = Subject.getSubject(AccessController.getContext());
+             Subject s = FATUtilities.getCurrentSubject();
              assertTrue(s.isReadOnly());
              assertSame(subject, s);
 
@@ -447,7 +445,7 @@ public class MPConcurrentConfigTestServlet extends FATServlet {
                      throw new CompletionException(x);
                  }
 
-                 Subject sub = Subject.getSubject(AccessController.getContext());
+                 Subject sub = FATUtilities.getCurrentSubject();
                  // assertTrue(sub.isReadOnly()); // TODO fails - Subject from AccessControlContext is null
                  return sub;
              });

--- a/dev/com.ibm.ws.jca_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat/bnd.bnd
@@ -42,7 +42,7 @@ tested.features:\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.ws.logging;version=latest,\
 	com.ibm.ws.security.jaas.common;version=latest,\
-        io.openliberty.jakarta.messaging.3.0;version=latest,\
+	io.openliberty.jakarta.messaging.3.0;version=latest,\
 	com.ibm.websphere.javaee.jaspic.1.1;version=latest,\
 	com.ibm.ws.jdbc;version=latest,\
 	com.ibm.websphere.javaee.validation.1.1;version=latest,\


### PR DESCRIPTION
Starting in Java 23, the `Subject.getSubject()` method always throws an `UnsupportedOperationException`.  So calls to `Subject.getSubject()` need to be changed to `Subject.current()` if in Java 23+.