### PR TITLE
Update to move data-1.0 feature to core edition

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VersionlessTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VersionlessTest.java
@@ -295,9 +295,6 @@ public class VersionlessTest {
                     //each feature dependency of the platform
                     Set<FeatureInfo> publicDepFeatures = getAllPublicDependentFeatures(featureInfo);
                     for (FeatureInfo depInfo : publicDepFeatures) {
-                        if (depInfo.getKind().equals("noship")){
-                            continue;
-                        }
                         System.out.println("        [ " + depInfo.getBaseName() + " - " + depInfo.getVersion() + " ]");
 
                         if (depInfo.isAlsoKnownAsSet()) {
@@ -321,8 +318,8 @@ public class VersionlessTest {
                                                     new VersionlessFeatureDefinition(featureTitle, featureTitle,
                                                                                      new String[] { depInfo.getShortName(),
                                                                                                     baseName.replace("javaee", "jakartaee") + "-" + version,
-                                                                                                    depInfo.getName()},
-                                                                                                    depInfo.getEdition()));
+                                                                                                    depInfo.getName() },
+                                                                                     depInfo.getEdition()));
                         }
 
                         //Keep track of features with updated names via the alsoknownas metadata

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
@@ -413,18 +413,6 @@ public class VisibilityTest {
                         break;
                     }
                 }
-            } else if (baseFeatureName.equals("com.ibm.websphere.appserver.org.eclipse.persistence-")) {
-                // The 2.6 and 2.7 versions are used by the jpa-2.6 and 2.7 features, but in 3.0 and later features it is not used by the persistence features.
-                // As such, the 2.6 and 2.7 features are in core and the 3.0 and later versions are in base because they are only used by base features.
-                // If future versions end up being needed by core features, this test will fail and need to be updated.
-                for (Iterator<FeatureInfo> it = featureInfos.iterator(); it.hasNext();) {
-                    FeatureInfo featureInfo = it.next();
-                    if ((featureInfo.getName().equals("com.ibm.websphere.appserver.org.eclipse.persistence-2.6") ||
-                         featureInfo.getName().equals("com.ibm.websphere.appserver.org.eclipse.persistence-2.7"))
-                        && featureInfo.getEdition().equals("core")) {
-                        it.remove();
-                    }
-                }
             } else if (baseFeatureName.equals("com.ibm.websphere.appserver.passwordUtilities-")) {
                 // The 1.0 feature depended on a jca / connectors feature which is in base.
                 // When 1.1 was created, the dependency on jca / connectors was removed to allow it to move to core.

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.data1.0-jdbc.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.data1.0-jdbc.feature
@@ -13,4 +13,4 @@ IBM-Provision-Capability: \
   io.openliberty.data.internal.persistence
 IBM-Install-Policy: when-satisfied
 kind=beta
-edition=base
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.persistence-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.persistence-3.0.feature
@@ -7,5 +7,5 @@ IBM-Process-Types: server, \
   com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=io.openliberty.persistence.3.0.thirdparty; apiJar=false; location:=dev/api/third-party/; mavenCoordinates="org.eclipse.persistence:eclipselink:3.0.0"
 kind=ga
-edition=base
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.persistence-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.persistence-3.1.feature
@@ -7,5 +7,5 @@ IBM-Process-Types: server, \
   com.ibm.websphere.appserver.eeCompatible-10.0
 -bundles=io.openliberty.persistence.3.1.thirdparty; apiJar=false; location:=dev/api/third-party/; mavenCoordinates="org.eclipse.persistence:eclipselink:4.0.0"
 kind=ga
-edition=base
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.persistence-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.persistence-3.2.feature
@@ -7,5 +7,5 @@ IBM-Process-Types: server, \
   com.ibm.websphere.appserver.eeCompatible-11.0
 -bundles=io.openliberty.persistence.3.2.thirdparty; apiJar=false; location:=dev/api/third-party/; mavenCoordinates="org.eclipse.persistence:eclipselink:4.0.0"
 kind=beta
-edition=base
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.data-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.data-1.0.feature
@@ -5,4 +5,4 @@ singleton=true
 -features= \
     io.openliberty.data-1.0
 kind=beta
-edition=base
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.data-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.data-1.0.feature
@@ -9,5 +9,5 @@ singleton=true
 -bundles=\
   io.openliberty.jakarta.data.1.0; location:="dev/api/spec/,lib/"
 kind=beta
-edition=base
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.persistenceService-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.persistenceService-2.0.feature
@@ -17,5 +17,5 @@ IBM-API-Package: com.ibm.websphere.persistence.mbean; type="ibm-api"
  bin/ddlGen.bat, \
  bin/ddlGen; ibm.file.encoding:=ebcdic
 kind=ga
-edition=base
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/io.openliberty.data-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/io.openliberty.data-1.0.feature
@@ -23,7 +23,7 @@ Subsystem-Name: Jakarta Data 1.0
   io.openliberty.data.internal.beandef,\
   io.openliberty.data.1.0.internal
 kind=beta
-edition=base
+edition=core
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
 WLP-Platform: jakartaee-11.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data/io.openliberty.versionless.data.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data/io.openliberty.versionless.data.feature
@@ -5,4 +5,4 @@ IBM-ShortName: data
 Subsystem-Name: data
 -features=io.openliberty.internal.versionless.data-1.0
 kind=beta
-edition=base
+edition=core


### PR DESCRIPTION
- Because of data-1.0's dependency on persistenceService-2.0 it had been put into the base edition instead of the core edition.  This will be a problem for when webProfile-11.0 is moved to beta since that feature is in the core edition.
- As part of this change the persistenceService-2.0 and org.eclipse.persistence 3.x features are moved back to core as well.
- Also the VersionlessTest is updated to no longer skip noship features. This is a follow on change now that all noship features from jakartaee 11 are now referenced by the versionless features.
