### PR TITLE
Add MP7 repeats for Metrics

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWS3.1-mpMetrics-monitor1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWS3.1-mpMetrics-monitor1.0.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.restfulWS3.1-mpMetrics-monitor1.0
 Manifest-Version: 1.0
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.mpMetrics-5.0)(osgi.identity=io.openliberty.mpMetrics-5.1)))", \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.restfulWS-3.1))"
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.restfulWS-3.1)(osgi.identity=io.openliberty.restfulWS-4.0)))"
 IBM-Install-Policy: when-satisfied
 -bundles=io.openliberty.restfulWS.mpMetrics.filter
 kind=ga

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/MPMetricsElement.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/MPMetricsElement.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.websphere.simplicity.config;
 
@@ -20,9 +17,14 @@ import javax.xml.bind.annotation.XmlAttribute;
 public class MPMetricsElement {
 
     private Boolean authentication;
+    private String libraryRef;
 
     public Boolean getAuthentication() {
         return authentication;
+    }
+
+    public String getLibraryRef() {
+        return libraryRef;
     }
 
     @XmlAttribute(name = "authentication")
@@ -30,10 +32,17 @@ public class MPMetricsElement {
         this.authentication = authentication;
     }
 
+    @XmlAttribute(name = "libraryRef")
+    public void setLibraryRef(String libraryRef) {
+        this.libraryRef = libraryRef;
+    }
+
     @Override
     public String toString() {
         StringBuffer sb = new StringBuffer("mpMetricsElement [");
         sb.append("authentication=").append(authentication);
+        sb.append(",");
+        sb.append("libraryRef=").append(libraryRef);
         sb.append("]");
         return sb.toString();
     }

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/bnd.bnd
@@ -1,14 +1,11 @@
 #*******************************************************************************
-# Copyright (c) 2023 IBM Corporation and others.
+# Copyright (c) 2023, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -19,6 +16,8 @@ src: \
 	test-applications/testDefaultBucketsApp/src
 
 fat.project: true
+
+tested.features: restfulwsclient-4.0, restfulws-4.0, cdi-4.1
 
 javac.source: 11
 javac.target: 11

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/build.gradle
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/build.gradle
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 	
 configurations {
@@ -86,7 +83,7 @@ task copySimpleClient(type: Copy) {
   into new File(autoFvtDir, 'publish/shared/resources/prometheuslib/')
 }
 
- addRequiredLibraries {
+addRequiredLibraries {
   dependsOn copyMicrometerCore
   dependsOn copyPrometheus
   dependsOn copyHdrHistogramPrometheus
@@ -96,4 +93,5 @@ task copySimpleClient(type: Copy) {
   dependsOn copySimpleClientTracerOtelAgent
   dependsOn copySimpleClientTracerOtel
   dependsOn copySimpleClient
+  dependsOn addJakartaTransformer
 }

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/fat/src/io/openliberty/microprofile/metrics/internal/fat/DefaultHistogramBucketsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/fat/src/io/openliberty/microprofile/metrics/internal/fat/DefaultHistogramBucketsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -42,6 +42,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -51,6 +52,8 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -61,8 +64,14 @@ public class DefaultHistogramBucketsTest {
 
 	private static Class<?> c = DefaultHistogramBucketsTest.class;
 
-	@Server("DefaultBucketServer")
+	public static final String SERVER_NAME = "DefaultBucketServer";
+
+	@Server(SERVER_NAME)
 	public static LibertyServer server;
+
+	@ClassRule
+	public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME,
+			MicroProfileActions.MP61, MicroProfileActions.MP70_EE11);
 
 	@BeforeClass
 	public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/fat/src/io/openliberty/microprofile/metrics/internal/fat/LibraryRefTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/fat/src/io/openliberty/microprofile/metrics/internal/fat/LibraryRefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -42,278 +43,329 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
 public class LibraryRefTest {
 
-    private static Class<?> c = LibraryRefTest.class;
+	private static Class<?> c = LibraryRefTest.class;
 
-    @Server("MicrometerPrometheus")
-    public static LibertyServer serverMicrometerPrometheus;
+	@Server("MicrometerPrometheus")
+	public static LibertyServer serverMicrometerPrometheus;
 
-    @Server("MicrometerUseless")
-    public static LibertyServer serverMicrometerUseless;
+	@Server("MicrometerUseless")
+	public static LibertyServer serverMicrometerUseless;
 
-    @Server("NonExistentLibrary")
-    public static LibertyServer serverNonExistentLibrary;
+	@Server("NonExistentLibrary")
+	public static LibertyServer serverNonExistentLibrary;
 
-    @Server("NoMicrometerCore")
-    public static LibertyServer serverNoMicrometerCore;
+	@Server("NoMicrometerCore")
+	public static LibertyServer serverNoMicrometerCore;
 
-    public static LibertyServer server;
+	public static LibertyServer server;
 
-    public static boolean isJava11014 = false;
+	public static boolean isJava11014 = false;
 
-    @BeforeClass
-    public static void setUp() throws Exception {
-        trustAll();
-        //Check what JVM the server is running on the (remote) machine
-        server = serverMicrometerPrometheus;
-        isJava11014();
-    }
+	@ClassRule
+	public static RepeatTests r = MicroProfileActions.repeat(
+			FeatureReplacementAction.ALL_SERVERS, MicroProfileActions.MP61,
+			MicroProfileActions.MP70_EE11);
 
-    @Before
-    /*
-     * Check that Java is not 11.0.14; known to cause javacores
-     * Skip if it is the case.
-     */
-    public void checkJava() {
-        if (isJava11014) {
-            Log.info(c, "checkJava", "Detected Java to be 11.0.14. SKIPPING");
-        }
+	@BeforeClass
+	public static void setUp() throws Exception {
+		trustAll();
+		// Check what JVM the server is running on the (remote) machine
+		server = serverMicrometerPrometheus;
+		isJava11014();
+	}
 
-        assumeTrue(!isJava11014);
-    }
+	@Before
+	/*
+	 * Check that Java is not 11.0.14; known to cause javacores Skip if it is
+	 * the case.
+	 */
+	public void checkJava() {
+		if (isJava11014) {
+			Log.info(c, "checkJava", "Detected Java to be 11.0.14. SKIPPING");
+		}
 
-    @After
-    public void after() throws Exception {
-        //catch if a server is still running.
-        if (server != null && server.isStarted()) {
-            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWPMI2006W", "CWMMC0013E", "CWWKG0033W");
-        }
-    }
+		assumeTrue(!isJava11014);
+	}
 
-    /*
-     * Java 11.0.14 known to cause issues.
-     */
-    private static void isJava11014() throws IOException {
-        JavaInfo javaInfo = JavaInfo.forServer(server);
+	@After
+	public void after() throws Exception {
+		// catch if a server is still running.
+		if (server != null && server.isStarted()) {
+			server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E",
+					"CWMCG5003E", "CWPMI2006W", "CWMMC0013E", "CWWKG0033W");
+		}
+	}
 
-        Log.info(c, "isJava11014",
-                 "Major.minor.micro : [" + JavaInfo.forServer(server).majorVersion()
-                                   + "."
-                                   + JavaInfo.forServer(server).minorVersion()
-                                   + "." + JavaInfo.forServer(server).microVersion()
-                                   + "]");
-        if (javaInfo.majorVersion() == 11 && javaInfo.microVersion() == 14)
-            isJava11014 = true;
-    }
+	/*
+	 * Java 11.0.14 known to cause issues.
+	 */
+	private static void isJava11014() throws IOException {
+		JavaInfo javaInfo = JavaInfo.forServer(server);
 
-    /*
-     * Not actually a test regarding metrics and libraryRef attribute.
-     * This is emitted by the Config component when it can't find a matching library reference.
-     * Might as well test it anyways.
-     */
-    @Test
-    public void nonExistentLibrary() throws Exception {
-        server = serverNonExistentLibrary;
-        server.startServer();
+		Log.info(c, "isJava11014",
+				"Major.minor.micro : ["
+						+ JavaInfo.forServer(server).majorVersion() + "."
+						+ JavaInfo.forServer(server).minorVersion() + "."
+						+ JavaInfo.forServer(server).microVersion() + "]");
+		if (javaInfo.majorVersion() == 11 && javaInfo.microVersion() == 14)
+			isJava11014 = true;
+	}
 
-        //CWWKG0033W The value [<value>] specified for the reference attribute [libraryRef] was not found in the configuration.
-        Assert.assertNotNull("CWWKG0033W Not found", server.waitForStringInLogUsingMark("CWWKG0033W"));
+	/*
+	 * Not actually a test regarding metrics and libraryRef attribute. This is
+	 * emitted by the Config component when it can't find a matching library
+	 * reference. Might as well test it anyways.
+	 */
+	@Test
+	public void nonExistentLibrary() throws Exception {
+		server = serverNonExistentLibrary;
+		server.startServer();
 
-    }
+		// CWWKG0033W The value [<value>] specified for the reference attribute
+		// [libraryRef] was not found in the configuration.
+		Assert.assertNotNull("CWWKG0033W Not found",
+				server.waitForStringInLogUsingMark("CWWKG0033W"));
 
-    /*
-     * Provided a libray that is missing the micrometer core jar.
-     * This emits a CWMMC0013E
-     * Also an FFDC is created which tells us what is missing.
-     */
-    @Test
-    @AllowedFFDC
-    public void noMicrometerCore() throws Exception {
-        server = serverNoMicrometerCore;
-        server.startServer();
+	}
 
-        //CWMMC0014I emits that metrics is using libraryRef
-        Assert.assertNotNull("CWMMC0014I Not found", server.waitForStringInLogUsingMark("CWMMC0014I"));
+	/*
+	 * Provided a libray that is missing the micrometer core jar. This emits a
+	 * CWMMC0013E Also an FFDC is created which tells us what is missing.
+	 */
+	@Test
+	@AllowedFFDC
+	public void noMicrometerCore() throws Exception {
+		server = serverNoMicrometerCore;
+		server.startServer();
 
-        //Realize that we don't have the classes necessary (i.e. micrometer core)
+		// CWMMC0014I emits that metrics is using libraryRef
+		Assert.assertNotNull("CWMMC0014I Not found",
+				server.waitForStringInLogUsingMark("CWMMC0014I"));
 
-        //CWMMC0013E The MicroProfile Metrics feature was unable to initialize. A class that is required for a user-provided Micrometer Library is missing.
-        Assert.assertNotNull("CWMMC0013E Not found", server.waitForStringInLogUsingMark("CWMMC0013E"));
+		// Realize that we don't have the classes necessary (i.e. micrometer
+		// core)
 
-    }
+		// CWMMC0013E The MicroProfile Metrics feature was unable to initialize.
+		// A class that is required for a user-provided Micrometer Library is
+		// missing.
+		Assert.assertNotNull("CWMMC0013E Not found",
+				server.waitForStringInLogUsingMark("CWMMC0013E"));
 
-    /*
-     * This MicrometerPrometheus is configured to use external Micrometer Libraries.
-     * Configured via the libraryRef attribute of mpMetrics
-     * The <library> referenced contains Micrometer Core, Prometheus registry, and its dependencies
-     *
-     * Note: see build.gradle
-     */
-    @Test
-    public void externalPrometheusMicrometer() throws Exception {
+	}
 
-        server = serverMicrometerPrometheus;
+	/*
+	 * This MicrometerPrometheus is configured to use external Micrometer
+	 * Libraries. Configured via the libraryRef attribute of mpMetrics The
+	 * <library> referenced contains Micrometer Core, Prometheus registry, and
+	 * its dependencies
+	 *
+	 * Note: see build.gradle
+	 */
+	@Test
+	public void externalPrometheusMicrometer() throws Exception {
 
-        String installRoot = server.getInstallRoot();
-        String prometheusLibPath = installRoot + "/usr/shared/resources/prometheusLib";
-        String micrometerPath = installRoot + "/usr/shared/resources/micrometercore";
+		server = serverMicrometerPrometheus;
 
-        Log.info(c, "externalPrometheusMicrometer", "Prom library directory: " + prometheusLibPath);
-        Log.info(c, "externalPrometheusMicrometer", "Micrometer library directory: " + micrometerPath);
-        try {
-            File f = new File(prometheusLibPath);
+		String installRoot = server.getInstallRoot();
+		String prometheusLibPath = installRoot
+				+ "/usr/shared/resources/prometheusLib";
+		String micrometerPath = installRoot
+				+ "/usr/shared/resources/micrometercore";
 
-            if (f.isDirectory()) {
-                for (File ff : f.listFiles()) {
-                    Log.info(c, "externalPrometheusMicrometer", "Prom lib files found: " + ff.getName());
-                }
-            } else {
-                Log.info(c, "externalPrometheusMicrometer", "Not a directory: " + prometheusLibPath);
-            }
+		Log.info(c, "externalPrometheusMicrometer",
+				"Prom library directory: " + prometheusLibPath);
+		Log.info(c, "externalPrometheusMicrometer",
+				"Micrometer library directory: " + micrometerPath);
+		try {
+			File f = new File(prometheusLibPath);
 
-            File f2 = new File(micrometerPath);
-            if (f.isDirectory()) {
-                for (File ff : f2.listFiles()) {
-                    Log.info(c, "externalPrometheusMicrometer", "Micrometer lib files found: " + ff.getName());
-                }
-            } else {
-                Log.info(c, "externalPrometheusMicrometer", "Not a directory: " + micrometerPath);
-            }
+			if (f.isDirectory()) {
+				for (File ff : f.listFiles()) {
+					Log.info(c, "externalPrometheusMicrometer",
+							"Prom lib files found: " + ff.getName());
+				}
+			} else {
+				Log.info(c, "externalPrometheusMicrometer",
+						"Not a directory: " + prometheusLibPath);
+			}
 
-        } catch (Exception e) {
-            Log.info(c, "externalPrometheusMicrometer", "Encountered exception while trying to list files of shared library " + e);
-        }
+			File f2 = new File(micrometerPath);
+			if (f.isDirectory()) {
+				for (File ff : f2.listFiles()) {
+					Log.info(c, "externalPrometheusMicrometer",
+							"Micrometer lib files found: " + ff.getName());
+				}
+			} else {
+				Log.info(c, "externalPrometheusMicrometer",
+						"Not a directory: " + micrometerPath);
+			}
 
-        server.startServer();
+		} catch (Exception e) {
+			Log.info(c, "externalPrometheusMicrometer",
+					"Encountered exception while trying to list files of shared library "
+							+ e);
+		}
 
-        //CWMMC0014I emits that metrics is using libraryRef
-        Assert.assertNotNull("CWMMC0014I Not found", server.waitForStringInLogUsingMark("CWMMC0014I"));
+		server.startServer();
 
-        //CWWKF0011I server ready
-        Assert.assertNotNull("CWWKF0011I Not found", server.waitForStringInLogUsingMark("CWWKF0011I"));
+		// CWMMC0014I emits that metrics is using libraryRef
+		Assert.assertNotNull("CWMMC0014I Not found",
+				server.waitForStringInLogUsingMark("CWMMC0014I"));
 
-        server.resetLogMarks();
+		// CWWKF0011I server ready
+		Assert.assertNotNull("CWWKF0011I Not found",
+				server.waitForStringInLogUsingMark("CWWKF0011I"));
 
-        Assert.assertNotNull("CWWKO0219I Not found", server.waitForStringInLogUsingMark("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl"));
+		server.resetLogMarks();
 
-        //Check SR implementation log that Promethues Registry created
-        //Note that SR makes THIS explicit log for Prometheus, other meter registries are logged differently following a template
-        String line = server.waitForStringInTrace("Prometheus MeterRegistry created");
-        Assert.assertNotNull("Expected \"Prometheus MeterRegistry created\"", line);
+		Assert.assertNotNull("CWWKO0219I Not found",
+				server.waitForStringInLogUsingMark(
+						"CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl"));
 
-        String exceptionString = null;
-        try {
-            String output = getHttpsServlet("/metrics");
-            Log.info(c, "externalPrometheusMicrometer", output);
-            Assert.assertNotNull("Results of /metrics output should not have been null", output);
+		// Check SR implementation log that Promethues Registry created
+		// Note that SR makes THIS explicit log for Prometheus, other meter
+		// registries are logged differently following a template
+		String line = server
+				.waitForStringInTrace("Prometheus MeterRegistry created");
+		Assert.assertNotNull("Expected \"Prometheus MeterRegistry created\"",
+				line);
 
-            //just do simple check for jvm.uptime metric
-            boolean containsMetrics = output.contains("jvm_uptime_seconds{mp_scope=\"base\",");
-            Assert.assertTrue("Expected to see the always present base metric jvm.uptime from /metriccs output", containsMetrics);
+		String exceptionString = null;
+		try {
+			String output = getHttpsServlet("/metrics");
+			Log.info(c, "externalPrometheusMicrometer", output);
+			Assert.assertNotNull(
+					"Results of /metrics output should not have been null",
+					output);
 
-        } catch (ConnectException exception) {
-            exceptionString = exception.toString();
-            Log.error(c, "externalPrometheusMicrometer", exception);
-        }
-        Assert.assertNull("Was not expecting ConnectException", exceptionString);
-    }
+			// just do simple check for jvm.uptime metric
+			boolean containsMetrics = output
+					.contains("jvm_uptime_seconds{mp_scope=\"base\",");
+			Assert.assertTrue(
+					"Expected to see the always present base metric jvm.uptime from /metriccs output",
+					containsMetrics);
 
-    /*
-     * This MicrometerPrometheus is configured to use no external Micrometer Libraries.
-     * Albeit the libraryRef is configured and does point to a micrometer core.
-     * The Micrometer Core is so that SR can actually initialize so that we can
-     * check that SmallRye does not emit the message indicating a registry is registered to global
-     * registry: "created and registered to the Micrometer global registry" which originates from the
-     * SharedMetricRegistires.java class
-     *
-     */
-    @Test
-    public void externalMicrometerUselessJar() throws Exception {
-        server = serverMicrometerUseless;
-        server.startServer();
+		} catch (ConnectException exception) {
+			exceptionString = exception.toString();
+			Log.error(c, "externalPrometheusMicrometer", exception);
+		}
+		Assert.assertNull("Was not expecting ConnectException",
+				exceptionString);
+	}
 
-        //CWMMC0014I emits that metrics is using libraryRef
-        Assert.assertNotNull("CWMMC0014I Not found", server.waitForStringInLogUsingMark("CWMMC0014I"));
+	/*
+	 * This MicrometerPrometheus is configured to use no external Micrometer
+	 * Libraries. Albeit the libraryRef is configured and does point to a
+	 * micrometer core. The Micrometer Core is so that SR can actually
+	 * initialize so that we can check that SmallRye does not emit the message
+	 * indicating a registry is registered to global registry:
+	 * "created and registered to the Micrometer global registry" which
+	 * originates from the SharedMetricRegistires.java class
+	 *
+	 */
+	@Test
+	public void externalMicrometerUselessJar() throws Exception {
+		server = serverMicrometerUseless;
+		server.startServer();
 
-        //CWWKF0011I server ready
-        Assert.assertNotNull("CWWKF0011I Not found", server.waitForStringInLogUsingMark("CWWKF0011I"));
+		// CWMMC0014I emits that metrics is using libraryRef
+		Assert.assertNotNull("CWMMC0014I Not found",
+				server.waitForStringInLogUsingMark("CWMMC0014I"));
 
-        /*
-         * Check that this SR log is not emmitted.
-         * This is emitted for every Meter Registry detected.
-         * Since we aren't using any real registries, we don't expect this.
-         */
-        String line = server.waitForStringInTrace("created and registered to the Micrometer global registry", 10000);
-        Assert.assertNull("Expected not to see \"created and registered to the Micrometer global registry\" in trace.", line);
-    }
+		// CWWKF0011I server ready
+		Assert.assertNotNull("CWWKF0011I Not found",
+				server.waitForStringInLogUsingMark("CWWKF0011I"));
 
-    private static void trustAll() throws Exception {
-        try {
-            SSLContext sslContext = SSLContext.getInstance("SSL");
-            sslContext.init(null, new TrustManager[] { new X509TrustManager() {
-                @Override
-                public void checkClientTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
-                }
+		/*
+		 * Check that this SR log is not emmitted. This is emitted for every
+		 * Meter Registry detected. Since we aren't using any real registries,
+		 * we don't expect this.
+		 */
+		String line = server.waitForStringInTrace(
+				"created and registered to the Micrometer global registry",
+				10000);
+		Assert.assertNull(
+				"Expected not to see \"created and registered to the Micrometer global registry\" in trace.",
+				line);
+	}
 
-                @Override
-                public void checkServerTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
-                }
+	private static void trustAll() throws Exception {
+		try {
+			SSLContext sslContext = SSLContext.getInstance("SSL");
+			sslContext.init(null, new TrustManager[]{new X509TrustManager() {
+				@Override
+				public void checkClientTrusted(X509Certificate[] arg0,
+						String arg1) throws CertificateException {
+				}
 
-                @Override
-                public X509Certificate[] getAcceptedIssuers() {
-                    return null;
-                }
-            } }, new SecureRandom());
-            SSLContext.setDefault(sslContext);
-            HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
-        } catch (Exception e) {
-            Log.error(c, "trustAll", e);
-        }
-    }
+				@Override
+				public void checkServerTrusted(X509Certificate[] arg0,
+						String arg1) throws CertificateException {
+				}
 
-    private String getHttpsServlet(String servletPath) throws Exception {
-        HttpsURLConnection con = null;
-        try {
-            String sURL = "https://" + server.getHostname() + ":" + server.getHttpDefaultSecurePort() + servletPath;
-            Log.info(c, "getHttpsServlet", sURL);
-            URL checkerServletURL = new URL(sURL);
-            con = (HttpsURLConnection) checkerServletURL.openConnection();
-            con.setDoInput(true);
-            con.setDoOutput(true);
-            con.setUseCaches(false);
-            con.setHostnameVerifier(new HostnameVerifier() {
-                @Override
-                public boolean verify(String arg0, SSLSession arg1) {
-                    return true;
-                }
-            });
-            String authorization = "Basic "
-                                   + Base64.getEncoder().encodeToString(("theUser:thePassword").getBytes(StandardCharsets.UTF_8)); // Java
-                                                                                                                                                                   // 8
-            con.setRequestProperty("Authorization", authorization);
-            con.setRequestProperty("Accept", "text/plain");
-            con.setRequestMethod("GET");
+				@Override
+				public X509Certificate[] getAcceptedIssuers() {
+					return null;
+				}
+			}}, new SecureRandom());
+			SSLContext.setDefault(sslContext);
+			HttpsURLConnection
+					.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
+		} catch (Exception e) {
+			Log.error(c, "trustAll", e);
+		}
+	}
 
-            String sep = System.getProperty("line.separator");
-            String line = null;
-            StringBuilder lines = new StringBuilder();
-            BufferedReader br = new BufferedReader(new InputStreamReader(con.getInputStream()));
+	private String getHttpsServlet(String servletPath) throws Exception {
+		HttpsURLConnection con = null;
+		try {
+			String sURL = "https://" + server.getHostname() + ":"
+					+ server.getHttpDefaultSecurePort() + servletPath;
+			Log.info(c, "getHttpsServlet", sURL);
+			URL checkerServletURL = new URL(sURL);
+			con = (HttpsURLConnection) checkerServletURL.openConnection();
+			con.setDoInput(true);
+			con.setDoOutput(true);
+			con.setUseCaches(false);
+			con.setHostnameVerifier(new HostnameVerifier() {
+				@Override
+				public boolean verify(String arg0, SSLSession arg1) {
+					return true;
+				}
+			});
+			String authorization = "Basic "
+					+ Base64.getEncoder().encodeToString(("theUser:thePassword")
+							.getBytes(StandardCharsets.UTF_8)); // Java
+																// 8
+			con.setRequestProperty("Authorization", authorization);
+			con.setRequestProperty("Accept", "text/plain");
+			con.setRequestMethod("GET");
 
-            while ((line = br.readLine()) != null && line.length() > 0) {
-                if (!line.startsWith("#"))
-                    lines.append(line).append(sep);
-            }
-            Log.info(c, "getHttpsServlet", sURL);
-            return lines.toString();
-        } finally {
-            if (con != null)
-                con.disconnect();
-        }
-    }
+			String sep = System.getProperty("line.separator");
+			String line = null;
+			StringBuilder lines = new StringBuilder();
+			BufferedReader br = new BufferedReader(
+					new InputStreamReader(con.getInputStream()));
+
+			while ((line = br.readLine()) != null && line.length() > 0) {
+				if (!line.startsWith("#"))
+					lines.append(line).append(sep);
+			}
+			Log.info(c, "getHttpsServlet", sURL);
+			return lines.toString();
+		} finally {
+			if (con != null)
+				con.disconnect();
+		}
+	}
 
 }

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/bnd.bnd
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -18,6 +15,8 @@ src: \
 	fat/src
 
 fat.project: true
+
+tested.features: restfulwsclient-4.0, restfulws-4.0, cdi-4.1
 
 javac.source: 11
 javac.target: 11

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/build.gradle
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/build.gradle
@@ -1,17 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 	
 dependencies {
   requiredLibs 'org.hamcrest:hamcrest-all:1.3'
+}
+
+addRequiredLibraries {
+  dependsOn addJakartaTransformer
 }
 

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/fat/src/io/openliberty/microprofile/metrics51/internal/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/fat/src/io/openliberty/microprofile/metrics51/internal/tck/launcher/MetricsTCKLauncher.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.microprofile.metrics51.internal.tck.launcher;
 
@@ -20,6 +17,7 @@ import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -28,6 +26,8 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
@@ -40,8 +40,16 @@ import componenttest.topology.utils.tck.TCKRunner;
 @RunWith(FATRunner.class)
 public class MetricsTCKLauncher {
 
-    @Server("MetricsTCKServer")
+    private static final String SERVER_NAME = "MetricsTCKServer";
+
+    @Server(SERVER_NAME)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME,
+                                                             MicroProfileActions.MP61,
+                                                             MicroProfileActions.MP70_EE10,
+                                                             MicroProfileActions.MP70_EE11);
 
     /*
      * Java 11.0.14 known to cause issues.

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/bnd.bnd
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -29,7 +26,11 @@ tested.features:\
 	mpMetrics-5.0,\
 	cdi-4.0,\
 	mpMetrics-5.1,\
-	mpConfig-3.1
+	mpConfig-3.1,\
+	restfulwsclient-4.0,\
+	restfulws-4.0,\
+	cdi-4.1,\
+	servlet-6.1
 	
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/build.gradle
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/build.gradle
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 	
 dependencies {
@@ -89,4 +86,5 @@ addRequiredLibraries {
   dependsOn addDerbyToServerDir7
   dependsOn addDerbyToServerDir8
   dependsOn addDerbyToServerDir9
+  dependsOn addJakartaTransformer
 }

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.microprofile.metrics.internal.monitor_fat;
 
@@ -33,6 +30,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -44,6 +42,8 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
@@ -66,9 +66,17 @@ public class ComputedMetricsTest {
     
     private static boolean initialServerStart = true;
 
-    @Server("ComputedMetricsServer")
+    private static final String SERVER_NAME = "ComputedMetricsServer";
+    
+    @Server(SERVER_NAME)
     public static LibertyServer computedMetricsServer;
 
+    @ClassRule
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME,
+                                                             MicroProfileActions.MP70_EE10, //MP61 is the same features here
+                                                             MicroProfileActions.MP70_EE11,
+                                                             MicroProfileActions.MP60);
+    
     @BeforeClass
     public static void setUp() throws Exception {
         trustAll();

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
@@ -42,6 +42,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -72,7 +73,7 @@ public class ComputedMetricsTest {
     public static LibertyServer computedMetricsServer;
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME,
+    public static RepeatTests r = MicroProfileActions.repeat(FeatureReplacementAction.ALL_SERVERS,
                                                              MicroProfileActions.MP70_EE10, //MP61 is the same features here
                                                              MicroProfileActions.MP70_EE11,
                                                              MicroProfileActions.MP60);

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/FATSuite.java
@@ -1,40 +1,21 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.microprofile.metrics.internal.monitor_fat;
 
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({ComputedMetricsTest.class, MetricsMonitorTest.class,
         TestEnableDisableFeaturesTest.class})
 public class FATSuite {
-
-    /*
-     * The below commented ClassRule is used to administer the execution of this FAT for
-     * multiple version of mpMetrics-5.x.
-     * 
-     * It is left here, commented out, for later use when subsequent version of
-     * mpMetrics-5.x are available (i.e when 5.1 is released)
-     */
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new FeatureReplacementAction("mpMetrics-5.0", "mpMetrics-5.1").withID("MPM51").forceAddFeatures(false));
-
 
 }

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.microprofile.metrics.internal.monitor_fat;
 
@@ -33,6 +30,7 @@ import javax.net.ssl.X509TrustManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,6 +39,8 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
@@ -49,9 +49,17 @@ public class MetricsMonitorTest {
 
     private static Class<?> c = MetricsMonitorTest.class;
 
-    @Server("MetricsMonitorServer")
+    private static final String SERVER_NAME = "MetricsMonitorServer";
+    
+    @Server(SERVER_NAME)
     public static LibertyServer server;
 
+    @ClassRule
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME,
+                                                             MicroProfileActions.MP70_EE10, //MP61 is the same features here
+                                                             MicroProfileActions.MP70_EE11,
+                                                             MicroProfileActions.MP60);
+    
     @BeforeClass
     public static void setUp() throws Exception {
         trustAll();

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.microprofile.metrics.internal.monitor_fat;
 
@@ -33,6 +30,7 @@ import javax.net.ssl.X509TrustManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -43,6 +41,9 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
@@ -80,6 +81,17 @@ public class TestEnableDisableFeaturesTest {
 
     private static LibertyServer currentServ;
 
+    private static final String SERVER_NAME = "MetricsMonitorServer";
+    
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = MicroProfileActions.repeat(FeatureReplacementAction.ALL_SERVERS,
+                                                             MicroProfileActions.MP70_EE10, //MP61 is the same features here
+                                                             MicroProfileActions.MP70_EE11,
+                                                             MicroProfileActions.MP60);
+    
     private static boolean serverEDF6FirstUse = true;
 
     @BeforeClass

--- a/dev/io.openliberty.restfulWS.mpMetrics.filter/bnd.bnd
+++ b/dev/io.openliberty.restfulWS.mpMetrics.filter/bnd.bnd
@@ -31,9 +31,10 @@ src: src
 WS-TraceGroup: JAXRS
 
 Import-Package: \
-    com.ibm.websphere.servlet.container, \
-    jakarta.servlet; version="[6.0,7)", \
-    org.eclipse.microprofile.metrics;version="[5.0,6)",\
+	com.ibm.websphere.servlet.container, \
+	jakarta.servlet; version="[6.0,7)", \
+	jakarta.ws.rs.container; version="[3.0.0,5.0.0)", \
+	org.eclipse.microprofile.metrics;version="[5.0,6)",\
 	org.eclipse.microprofile.metrics.*;version="[5.0,6)",\
 	io.openliberty.microprofile.metrics50,\
 	io.openliberty.microprofile.metrics.internal.monitor,\


### PR DESCRIPTION
Add MP7 repeats to mpMetrics-5.1 FAT buckets. This currently translates to MP61, MP70_EE10 and MP70_EE11 ... although in most cases, the set of features for MP61 and MP70_EE10 are the same in Metrics tests.