### PR TITLE
jvm metrics followup

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/isolation/InMemoryMetricReader.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/isolation/InMemoryMetricReader.java
@@ -69,7 +69,7 @@ public class InMemoryMetricReader implements MetricReader {
         return collectionRegistration.collectAllMetrics().stream()
                         .filter(
                                 metric -> !metric.getName().equals("queueSize")) //Filter out a metric that's always present
-                        .filter(metric -> !metric.getName().startsWith("jvm")) //We are testing ft metrics, ignore JVM metrics
+                        .filter(metric -> metric.getName().startsWith("ft")) //We are testing ft metrics, ignore JVM, HTTP, etc metrics
                         .count() == 0;
     }
 }


### PR DESCRIPTION
part of #https://github.com/OpenLiberty/open-liberty/issues/27711

Now https://github.com/OpenLiberty/open-liberty/pull/28732 has been delivered this does some follow ups that were not worth delaying the big PR for.

- It moves the registration of hooks for JVM metrics to only the server scoped oTel instance and limits them to just hotspot and j9
- Now we've got more metrics on the way like http the test for ft metric has a more agressive filter for alien metrics.