### PR TITLE
Ensure filter annotations on test servlets are honored

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -147,6 +147,11 @@
       <version>3.3.4</version>
     </dependency>
     <dependency>
+      <groupId>com.github.mwiede</groupId>
+      <artifactId>jsch</artifactId>
+      <version>0.2.18</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
       <version>2.4.0</version>
@@ -230,11 +235,6 @@
       <groupId>com.icegreen</groupId>
       <artifactId>greenmail</artifactId>
       <version>1.5.10</version>
-    </dependency>
-    <dependency>
-      <groupId>com.github.mwiede</groupId>
-      <artifactId>jsch</artifactId>
-      <version>0.2.18</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/SyntheticServletTest.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/SyntheticServletTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,8 +12,11 @@
  *******************************************************************************/
 package componenttest.custom.junit.runner;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.stream.Stream;
 
 import org.junit.runners.model.FrameworkMethod;
 
@@ -24,6 +27,7 @@ import componenttest.topology.utils.FATServletClient;
 
 public class SyntheticServletTest extends FrameworkMethod {
 
+    private final Class<?> servletClass;
     private final Field server;
     private final String queryPath;
     private final String testName;
@@ -31,6 +35,7 @@ public class SyntheticServletTest extends FrameworkMethod {
 
     public SyntheticServletTest(Class<?> servletClass, Field server, String queryPath, Method method) {
         super(method);
+        this.servletClass = servletClass;
         this.server = server;
         this.queryPath = queryPath;
         this.testName = method.getName();
@@ -48,5 +53,38 @@ public class SyntheticServletTest extends FrameworkMethod {
     @Override
     public String getName() {
         return this.syntheticName;
+    }
+
+    @Override
+    public Annotation[] getAnnotations() {
+        final HashMap<Class<? extends Annotation>, Annotation> collection = new HashMap<>();
+
+        Stream<Annotation> methodAnnos = Stream.of(super.getAnnotations());
+        Stream<Annotation> servletAnnos = Stream.of(servletClass.getAnnotations())
+                        .filter(anno -> anno.annotationType().getCanonicalName().startsWith("componenttest."));
+
+        Stream.concat(servletAnnos, methodAnnos)
+                        .forEachOrdered(anno -> {
+                            Annotation overwritten = collection.put(anno.annotationType(), anno);
+                            if (overwritten != null)
+                                Log.warning(SyntheticServletTest.class, "The test method " + testName + " was annotated with " + anno +
+                                                                        " and the test servlet " + servletClass.getSimpleName() + " was annotated with " + overwritten +
+                                                                        " the servlet annotation will be ignored.");
+                        });
+
+        return collection.values().toArray(new Annotation[collection.size()]); //TODO use .toArray(Annotation[]::new); in java 11
+    }
+
+    @Override
+    public <T extends Annotation> T getAnnotation(Class<T> annotationType) {
+        T anno = null;
+
+        anno = super.getAnnotation(annotationType);
+        if (anno != null) {
+            return anno;
+        }
+
+        anno = servletClass.getAnnotation(annotationType);
+        return anno; //Null or annotation from servlet class
     }
 }

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/SystemPropertyFilter.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/SystemPropertyFilter.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,21 +22,14 @@ import componenttest.annotation.SkipIfSysProp;
 
 public class SystemPropertyFilter extends Filter {
 
+    private static Class<?> getMyClass() {
+        return SystemPropertyFilter.class;
+    }
+
     /** {@inheritDoc} */
     @Override
     public String describe() {
         return null;
-    }
-
-    /**
-     * Like {@link Description#getTestClass}, but without initializing the class.
-     */
-    private Class<?> getTestClass(Description desc) {
-        try {
-            return Class.forName(desc.getClassName(), false, getClass().getClassLoader());
-        } catch (ClassNotFoundException e) {
-            return null;
-        }
     }
 
     /** {@inheritDoc} */
@@ -48,8 +41,8 @@ public class SystemPropertyFilter extends Filter {
     /**
      * Decide if we should skip this test based on the SkipIfSysProp annotation
      *
-     * @param desc
-     * @return true (we must skip), false (we should run unless something else prevents us)
+     * @param  desc
+     * @return      true (we must skip), false (we should run unless something else prevents us)
      */
     private boolean shouldSkipViaSysProp(Description desc) {
         SkipIfSysProp anno = desc.getAnnotation(SkipIfSysProp.class);
@@ -57,7 +50,7 @@ public class SystemPropertyFilter extends Filter {
         if (anno == null) {
             //there was no method level annotation
             //check for a test class level annotation
-            anno = getTestClass(desc).getAnnotation(SkipIfSysProp.class);
+            anno = FilterUtils.getTestClass(desc, getMyClass()).getAnnotation(SkipIfSysProp.class);
         }
 
         return shouldSkipViaSysProp(anno, desc.getDisplayName());
@@ -96,8 +89,8 @@ public class SystemPropertyFilter extends Filter {
     /**
      * Decide if we should run this test based on the OnlyIfSysProp annotation
      *
-     * @param desc
-     * @return true (we should run unless something else prevents us), false (we must skip)
+     * @param  desc
+     * @return      true (we should run unless something else prevents us), false (we must skip)
      */
     private boolean shouldRunViaSysProp(Description desc) {
         OnlyIfSysProp anno = desc.getAnnotation(OnlyIfSysProp.class);
@@ -105,7 +98,7 @@ public class SystemPropertyFilter extends Filter {
         if (anno == null) {
             //there was no method level annotation
             //check for a test class level annotation
-            anno = getTestClass(desc).getAnnotation(OnlyIfSysProp.class);
+            anno = FilterUtils.getTestClass(desc, getMyClass()).getAnnotation(OnlyIfSysProp.class);
         }
 
         return shouldRunViaSysProp(anno, desc.getDisplayName());

--- a/dev/fattest.simplicity/test/componenttest/annotation/processor/TestServletProcessorTests.java
+++ b/dev/fattest.simplicity/test/componenttest/annotation/processor/TestServletProcessorTests.java
@@ -6,13 +6,11 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package componenttest.annotation.processor;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
@@ -42,8 +40,7 @@ public class TestServletProcessorTests {
             TestServletProcessor.getServletTests(new TestClass(NonStaticServletTestClass.class));
             fail("Annotated field must be static");
         } catch (RuntimeException e) {
-            //pass
-            System.out.println("Caught: " + e.toString());
+            assertTrue(e.getMessage().endsWith("' must be static."));
         }
     }
 
@@ -58,8 +55,7 @@ public class TestServletProcessorTests {
             TestServletProcessor.getServletTests(new TestClass(PrivateServletTestClass.class));
             fail("Annotated field must be public");
         } catch (RuntimeException e) {
-            //pass
-            System.out.println("Caught: " + e.toString());
+            assertTrue(e.getMessage().endsWith("' must be public."));
         }
     }
 
@@ -74,8 +70,7 @@ public class TestServletProcessorTests {
             TestServletProcessor.getServletTests(new TestClass(NonServerServletTestClass.class));
             fail("Annotated field must be LibertyServer");
         } catch (RuntimeException e) {
-            //pass
-            System.out.println("Caught: " + e.toString());
+            assertTrue(e.getMessage().contains("' must be of type or subtype of "));
         }
     }
 

--- a/dev/fattest.simplicity/test/componenttest/annotation/processor/TestServletProcessorTests.java
+++ b/dev/fattest.simplicity/test/componenttest/annotation/processor/TestServletProcessorTests.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.annotation.processor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.TestClass;
+
+import componenttest.annotation.TestServlet;
+import componenttest.app.FATServlet;
+import componenttest.topology.impl.LibertyServer;
+import jakarta.servlet.annotation.WebServlet;
+
+public class TestServletProcessorTests {
+    public static class NOOPTestServlet extends FATServlet {}
+
+    public static class NonStaticServletTestClass {
+        @TestServlet(servlet = NOOPTestServlet.class)
+        public LibertyServer NOOP;
+    }
+
+    @Test
+    public void testNotStaticServer() {
+        try {
+            TestServletProcessor.getServletTests(new TestClass(NonStaticServletTestClass.class));
+            fail("Annotated field must be static");
+        } catch (RuntimeException e) {
+            //pass
+            System.out.println("Caught: " + e.toString());
+        }
+    }
+
+    public static class PrivateServletTestClass {
+        @TestServlet(servlet = NOOPTestServlet.class)
+        private static LibertyServer NOOP;
+    }
+
+    @Test
+    public void testPrivateServer() {
+        try {
+            TestServletProcessor.getServletTests(new TestClass(PrivateServletTestClass.class));
+            fail("Annotated field must be public");
+        } catch (RuntimeException e) {
+            //pass
+            System.out.println("Caught: " + e.toString());
+        }
+    }
+
+    public static class NonServerServletTestClass {
+        @TestServlet(servlet = NOOPTestServlet.class)
+        public static String NOOP;
+    }
+
+    @Test
+    public void testNonServer() {
+        try {
+            TestServletProcessor.getServletTests(new TestClass(NonServerServletTestClass.class));
+            fail("Annotated field must be LibertyServer");
+        } catch (RuntimeException e) {
+            //pass
+            System.out.println("Caught: " + e.toString());
+        }
+    }
+
+    public static class InvalidServletTestClass {
+        @TestServlet(servlet = InvalidTestServlet.class)
+        public static LibertyServer NOOP;
+
+        public static class InvalidTestServlet {}
+    }
+
+    @Test
+    public void testHttpServletCheck() {
+        try {
+            TestServletProcessor.getServletTests(new TestClass(InvalidServletTestClass.class));
+            fail("Non-servlet class should not be valid for @TestServlet servlet field");
+        } catch (IllegalArgumentException e) {
+            //pass
+            System.out.println("Caught: " + e.toString());
+        }
+    }
+
+    public static class ServletTestClass {
+        @TestServlet(servlet = ValidTestServlet.class)
+        public static LibertyServer NOOP;
+
+        @WebServlet("/*")
+        public static class ValidTestServlet extends FATServlet {
+            @Before
+            public void setup() {}
+
+            @Test
+            public void test1() {}
+
+            @Test
+            public void test2() {}
+
+            public void nonTest() {}
+
+            @After
+            public void teardown() {}
+        }
+    }
+
+    @Test
+    public void testProcessorCount() {
+        List<FrameworkMethod> methods = TestServletProcessor.getServletTests(new TestClass(ServletTestClass.class));
+        assertEquals(6, methods.size());
+        assertEquals("setup", methods.get(0).getMethod().getName());
+        assertEquals("test1", methods.get(1).getMethod().getName());
+        assertEquals("teardown", methods.get(2).getMethod().getName());
+        assertEquals("setup", methods.get(3).getMethod().getName());
+        assertEquals("test2", methods.get(4).getMethod().getName());
+        assertEquals("teardown", methods.get(5).getMethod().getName());
+    }
+}

--- a/dev/fattest.simplicity/test/componenttest/custom/junit/runner/CompoundFilterTests.java
+++ b/dev/fattest.simplicity/test/componenttest/custom/junit/runner/CompoundFilterTests.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package componenttest.custom.junit.runner;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runner.manipulation.Filter;
+
+import componenttest.app.FATServlet;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import jakarta.servlet.annotation.WebServlet;
+
+/**
+ *
+ */
+public class CompoundFilterTests {
+    private static final Filter[] testFiltersToApply = new Filter[] {
+                                                                      new TestModeFilter(),
+                                                                      new TestNameFilter(),
+                                                                      new FeatureFilter(),
+                                                                      new SystemPropertyFilter(),
+                                                                      new JavaLevelFilter(),
+                                                                      new CheckpointSupportFilter()
+    };
+
+    @Mode(TestMode.FULL) //Should be superseeded by servlet or method annotation
+    @RunWith(FATRunner.class)
+    public static class TestClassFull {
+        public static LibertyServer NOOP;
+
+        @Test
+        public void dummyTestForRunner() {}
+    }
+
+    @WebServlet("*/")
+    public static class TestServletLiteMethod extends FATServlet {
+
+        @Mode(TestMode.LITE)
+        public void testMethod() {}
+    }
+
+    @Test
+    public void testMethodFilterSuperseedsTestClassFilter() throws Exception {
+        SyntheticServletTest testMethod = new SyntheticServletTest(TestServletLiteMethod.class, //
+                        TestClassFull.class.getField("NOOP"), //
+                        "FAKE/QUERY", //
+                        TestServletLiteMethod.class.getMethod("testMethod"));
+
+        //Replicate FATRunner.describeChild()
+        Description testDescription = Description.createTestDescription(TestClassFull.class, testMethod.getName(), testMethod.getAnnotations());
+
+        CompoundFilter filter = new CompoundFilter(testFiltersToApply);
+
+        assertTrue(filter.shouldRun(testDescription));
+    }
+
+    @Mode(TestMode.LITE)
+    @WebServlet("*/")
+    public static class TestServletLite extends FATServlet {
+
+        public void testMethod() {}
+    }
+
+    @Test
+    public void testServletFilterSuperseedsTestClassFilter() throws Exception {
+        SyntheticServletTest testMethod = new SyntheticServletTest(TestServletLite.class, //
+                        TestClassFull.class.getField("NOOP"), //
+                        "FAKE/QUERY", //
+                        TestServletLite.class.getMethod("testMethod"));
+
+        //Replicate FATRunner.describeChild()
+        Description testDescription = Description.createTestDescription(TestClassFull.class, testMethod.getName(), testMethod.getAnnotations());
+
+        CompoundFilter filter = new CompoundFilter(testFiltersToApply);
+
+        assertTrue(filter.shouldRun(testDescription));
+    }
+
+    @RunWith(FATRunner.class)
+    public static class TestClass {
+        public static LibertyServer NOOP;
+
+        @Test
+        public void dummyTestForRunner() {}
+    }
+
+    @Mode(TestMode.FULL) //Should be superseeded by method annotation
+    @WebServlet("*/")
+    public static class TestServletFullWithLiteMethod extends FATServlet {
+
+        @Mode(TestMode.LITE)
+        public void testMethod() {}
+    }
+
+    @Test
+    public void testServletMethodFilterSuperseedsTestServletFilter() throws Exception {
+        SyntheticServletTest testMethod = new SyntheticServletTest(TestServletFullWithLiteMethod.class, //
+                        TestClass.class.getField("NOOP"), //
+                        "FAKE/QUERY", //
+                        TestServletFullWithLiteMethod.class.getMethod("testMethod"));
+
+        //Replicate FATRunner.describeChild()
+        Description testDescription = Description.createTestDescription(TestClass.class, testMethod.getName(), testMethod.getAnnotations());
+
+        CompoundFilter filter = new CompoundFilter(testFiltersToApply);
+
+        assertTrue(filter.shouldRun(testDescription));
+    }
+
+}

--- a/dev/fattest.simplicity/test/componenttest/custom/junit/runner/SyntheticServletTests.java
+++ b/dev/fattest.simplicity/test/componenttest/custom/junit/runner/SyntheticServletTests.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package componenttest.custom.junit.runner;
 

--- a/dev/fattest.simplicity/test/componenttest/custom/junit/runner/SyntheticServletTests.java
+++ b/dev/fattest.simplicity/test/componenttest/custom/junit/runner/SyntheticServletTests.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.custom.junit.runner;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import jakarta.servlet.annotation.WebServlet;
+
+public class SyntheticServletTests {
+
+    public static class TestClass {
+        public static LibertyServer NOOP;
+    }
+
+    @WebServlet("*/")
+    public static class TestFilterByMethodServlet extends FATServlet {
+
+        @Mode(TestMode.FULL)
+        public void fullTest() {}
+
+        @Mode(TestMode.LITE)
+        public void liteTest() {}
+
+        public void defaultTest() {}
+    }
+
+    @Test
+    public void testSyntheticTestHonorsMethodAnnotations() throws Exception {
+        SyntheticServletTest fullTest = new SyntheticServletTest(TestFilterByMethodServlet.class, //
+                        TestClass.class.getField("NOOP"), //
+                        "FAKE/QUERY", //
+                        TestFilterByMethodServlet.class.getMethod("fullTest"));
+
+        assertEquals(1, fullTest.getAnnotations().length);
+        assertEquals(TestMode.FULL, fullTest.getAnnotation(Mode.class).value());
+
+        SyntheticServletTest liteTest = new SyntheticServletTest(TestFilterByMethodServlet.class, //
+                        TestClass.class.getField("NOOP"), //
+                        "FAKE/QUERY", //
+                        TestFilterByMethodServlet.class.getMethod("liteTest"));
+
+        assertEquals(1, liteTest.getAnnotations().length);
+        assertEquals(TestMode.LITE, liteTest.getAnnotation(Mode.class).value());
+
+        SyntheticServletTest defaultTest = new SyntheticServletTest(TestFilterByMethodServlet.class, //
+                        TestClass.class.getField("NOOP"), //
+                        "FAKE/QUERY", //
+                        TestFilterByMethodServlet.class.getMethod("defaultTest"));
+
+        assertEquals(0, defaultTest.getAnnotations().length);
+    }
+
+    @Mode(TestMode.FULL)
+    @WebServlet("*/")
+    public static class TestFilterByClassAndMethodServlet extends FATServlet {
+
+        @Mode(TestMode.FULL)
+        public void fullTest() {}
+
+        @Mode(TestMode.LITE)
+        public void liteTest() {}
+
+        public void defaultTest() {}
+    }
+
+    @Test
+    public void testSyntheticTestHonorsServletAnnotations() throws Exception {
+        SyntheticServletTest fullTest = new SyntheticServletTest(TestFilterByClassAndMethodServlet.class, //
+                        TestClass.class.getField("NOOP"), //
+                        "FAKE/QUERY", //
+                        TestFilterByClassAndMethodServlet.class.getMethod("fullTest"));
+
+        assertEquals(1, fullTest.getAnnotations().length);
+        assertEquals(TestMode.FULL, fullTest.getAnnotation(Mode.class).value());
+
+        SyntheticServletTest liteTest = new SyntheticServletTest(TestFilterByClassAndMethodServlet.class, //
+                        TestClass.class.getField("NOOP"), //
+                        "FAKE/QUERY", //
+                        TestFilterByClassAndMethodServlet.class.getMethod("liteTest"));
+
+        assertEquals(1, liteTest.getAnnotations().length);
+        assertEquals(TestMode.LITE, liteTest.getAnnotation(Mode.class).value());
+
+        SyntheticServletTest defaultTest = new SyntheticServletTest(TestFilterByClassAndMethodServlet.class, //
+                        TestClass.class.getField("NOOP"), //
+                        "FAKE/QUERY", //
+                        TestFilterByClassAndMethodServlet.class.getMethod("defaultTest"));
+
+        assertEquals(1, defaultTest.getAnnotations().length);
+        assertEquals(TestMode.FULL, defaultTest.getAnnotation(Mode.class).value());
+    }
+}


### PR DESCRIPTION
When tests from a FATServlet class are added to the FATRunner they are necessarily associated with the test class that contains the `@TestServlet` field.  Therefore, filter type annotations on the FATServlet class itself are never honored.

Fix that, and make sure we do honor those annotations.
Also add unit tests.