### PR TITLE
Ensure fattest.simplicity is available to FAT suites after jar

### DIFF
--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -90,6 +90,18 @@ task assembleBinaryDependencies() {
     }
 }
 
+// Ensure development changes to fattest.simplicity are copied to the lib directory
+// for use by FAT suites without having to assemble everytime.
+task assembleSimplicity() {
+  File buildDirLib = new File(buildDir, 'lib')
+  doLast {
+    copy {
+        from new File(buildDir, 'fattest.simplicity.jar')
+        into buildDirLib
+    }
+  }
+}
+
 configurations {
     arquillianFeature
     arquillianJakartaFeature21
@@ -133,6 +145,7 @@ jar {
     dependsOn assembleBootstrap
     dependsOn extractArquillianSupportFeature
     dependsOn extractArquillianSupportJakartaFeature21
+    finalizedBy assembleSimplicity
 }
 
 task publishArquillianSupportFeature(type:Copy) {

--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -21,7 +21,6 @@ task assembleBootstrap(type: Copy) {
 }
 
 task assembleBinaryDependencies() {
-    dependsOn jar
     dependsOn ':com.ibm.websphere.javaee.jaxb.2.2:jar'
     dependsOn ':com.ibm.websphere.javaee.jsonp.1.0:jar'
     dependsOn ':com.ibm.ws.common.encoder:jar'
@@ -90,18 +89,6 @@ task assembleBinaryDependencies() {
     }
 }
 
-// Ensure development changes to fattest.simplicity are copied to the lib directory
-// for use by FAT suites without having to assemble everytime.
-task assembleSimplicity() {
-  File buildDirLib = new File(buildDir, 'lib')
-  doLast {
-    copy {
-        from new File(buildDir, 'fattest.simplicity.jar')
-        into buildDirLib
-    }
-  }
-}
-
 configurations {
     arquillianFeature
     arquillianJakartaFeature21
@@ -145,7 +132,7 @@ jar {
     dependsOn assembleBootstrap
     dependsOn extractArquillianSupportFeature
     dependsOn extractArquillianSupportJakartaFeature21
-    finalizedBy assembleSimplicity
+    finalizedBy assembleBinaryDependencies
 }
 
 task publishArquillianSupportFeature(type:Copy) {
@@ -158,6 +145,5 @@ task publishArquillianSupportFeature(type:Copy) {
 }
 
 assemble {
-    dependsOn assembleBinaryDependencies
     dependsOn publishArquillianSupportFeature
 }

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -152,7 +152,7 @@ task autoFVT {
   dependsOn ':cnf:copyMavenLibs'
   dependsOn addRequiredLibraries
   dependsOn copyFeatureBundles
-  dependsOn ':fattest.simplicity:assembleBinaryDependencies'
+  
   enabled project.file('fat').exists()
 
   ext.getFeature = { line ->


### PR DESCRIPTION
Currently, FAT suites point to `fattest.simplicity/build/libs/lib/` to get fattest.simplicy and it's dependencies at test runtime.

If I make a change to fattest.simplicity I'd expect that fattest.simplicity will be built and used by my FAT Suite locally.
Right now that does not happen because fattest.simplicity is only copied to the aforementioned lib directory during the `assemble` task. So any intermediary builds of fattest.simplicity will never be picked up and used by FAT Suites.

Possible solutions:
1. developers have to run `./gradlew fattest.simplicity:assemble` after every change.
2. finalize the `jar` task with a task that updates the version of fattest.simplicity in the `fattest.simplicity/build/libs/lib/` which is the goal of this PR. 
