### PR TITLE
wait for application-defined DataSources to become available

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -30,6 +30,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
 
@@ -54,6 +55,8 @@ import jakarta.persistence.metamodel.Type;
  * or from a PersistenceServiceUnit of a databaseStore.
  */
 public abstract class EntityManagerBuilder {
+    public static final long MAX_WAIT_FOR_RESOURCE_NS = TimeUnit.SECONDS.toNanos(60);
+
     private static final TraceComponent tc = Tr.register(EntityManagerBuilder.class);
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtensionProvider.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtensionProvider.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 
@@ -205,6 +206,8 @@ public class DataExtensionProvider implements //
                         // and this ensures we don't do this work on restore side which will make
                         // restore faster.
                         futureEMBuilder.complete(futureEMBuilder.createEMBuilder());
+                    } catch (CompletionException x) {
+                        futureEMBuilder.completeExceptionally(x.getCause());
                     } catch (Throwable x) {
                         futureEMBuilder.completeExceptionally(x);
                     }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -95,7 +95,6 @@ import jakarta.persistence.Table;
  */
 public class DBStoreEMBuilder extends EntityManagerBuilder {
     static final String EOLN = String.format("%n");
-    private static final long MAX_WAIT_FOR_SERVICE_NS = TimeUnit.SECONDS.toNanos(60);
     private static final TraceComponent tc = Tr.register(DBStoreEMBuilder.class);
 
     private final ClassDefiner classDefiner = new ClassDefiner();
@@ -302,13 +301,13 @@ public class DBStoreEMBuilder extends EntityManagerBuilder {
                 Collection<ServiceReference<DatabaseStore>> refs = bc.getServiceReferences(DatabaseStore.class,
                                                                                            FilterUtils.createPropertyFilter("id", databaseStoreId));
                 if (refs.isEmpty()) {
-                    if (System.nanoTime() - start < MAX_WAIT_FOR_SERVICE_NS) {
+                    if (System.nanoTime() - start < MAX_WAIT_FOR_RESOURCE_NS) {
                         if (trace && tc.isDebugEnabled())
                             Tr.debug(this, tc, "Wait " + poll_ms + " ms for service reference to become available...");
                         TimeUnit.MILLISECONDS.sleep(poll_ms);
                     } else {
                         throw new IllegalStateException("The " + databaseStoreId + " service component did not become available within " +
-                                                        TimeUnit.NANOSECONDS.toSeconds(MAX_WAIT_FOR_SERVICE_NS) + " seconds.");
+                                                        TimeUnit.NANOSECONDS.toSeconds(MAX_WAIT_FOR_RESOURCE_NS) + " seconds."); // TODO NLS
                     }
                 } else {
                     ref = refs.iterator().next();


### PR DESCRIPTION
This workaround temporarily fixes #28845 

A side effect is causing a delay if a dataStore JNDI name is incorrect and never becomes available. It is also a more general problem that should be more fully solved elsewhere.