### PR TITLE
JAX-WS: enableSchemaValidation client side beta config and test

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/.classpath
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/.classpath
@@ -21,6 +21,7 @@
 	<classpathentry kind="src" path="test-applications/POJOServiceSecurity/src"/>
 	<classpathentry kind="src" path="test-applications/POJOServiceSecurityClient/src"/>
 	<classpathentry kind="src" path="test-applications/policyAttachmentsClient1/src"/>
+	<classpathentry kind="src" path="test-applications/enableSchemaValidation/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/bnd.bnd
@@ -19,6 +19,7 @@ src: \
   test-applications/addNumbersClient/src,\
   test-applications/ejbServiceRefBndAppCodes/src,\
   test-applications/encodingTest/src,\
+  test-applications/enableSchemaValidation/src,\
   test-applications/helloClient/src,\
   test-applications/helloClientDDMerge/src,\
   test-applications/helloClientServiceResource/src,\

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/EnableSchemaValidationTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/EnableSchemaValidationTest.java
@@ -41,11 +41,11 @@ import componenttest.topology.utils.HttpUtils;
  * 2.) enableschemaValiation="false" - "global" setting
  * 3.) enableSchemValidation="true" serviceName="SayHelloServiceWithHandler" - targeted client setting
  * 4.) enableSchemValidation="false" serviceName="SayHelloServiceWithHandler" - targeted client setting
- * 4.) Combination of 1 and 4
- * 5.) Combination of 2 and 3
- * 4.) enableSchemValidation="false" serviceName="IncorrectServiceName" - targeted client setting with the wrong serviceName
+ * 5.) Combination of 1 and 4
+ * 6.) Combination of 2 and 3
+ * 7.) enableSchemValidation="false" serviceName="IncorrectServiceName" - targeted client setting with the wrong serviceName
  *
- * This Test uses a Mock endpoint to create "bad" responses that the client will fail to unmarshall unless enableSchemaValodation=false
+ * This Test uses a Mock endpoint to create "bad" responses that the client will fail to unmarshall unless enableSchemaValidation=false
  *
  * @see com.ibm.ws.jaxws.fat.mock.endpoint.MockJaxwsEndpointServlet
  *
@@ -287,11 +287,11 @@ public class EnableSchemaValidationTest {
     // serviceName True Tests
 
     /**
-     * Test the global setting of enableSchemaValidation=true in server.xml, with an additional element <arg0> following the <response> element
+     * Test the targeted setting of enableSchemaValidation=true in server.xml, with an additional element <arg0> following the <response> element
      * which will cause s No child element is expected at this point exception with the default schema validation enabled.
      *
      * Server config - servicename-true-server.xml
-     * Expected response - Unmarshalling Error: cvc-complex-type.2.4.a
+     * Expected response - Unmarshalling Error: No child element is expected at this point.
      *
      * @throws Exception
      */
@@ -305,12 +305,12 @@ public class EnableSchemaValidationTest {
         LOG.info("testAddedElementServiceNameSchemaValidationTrue - Response = " + response);
 
         assertNull("Expected null response from server, but was" + response, response);
-        assertNotNull("Expected Unmarshalling Error: unexpected element exception is not thrown",
+        assertNotNull("Expected Unmarshalling Error: No child element is expected at this point.",
                       server.waitForStringInLog("No child element is expected at this point."));
     }
 
     /**
-     * Test the global setting of enableSchemaValidation=true in server.xml, with the wrong element name where <response> element is expected
+     * Test the targeted setting of enableSchemaValidation=true in server.xml, with the wrong element name where <response> element is expected
      * which will cause an cvc-complex-type.2.4.a exception with the default schema validation enabled.
      *
      * Server config - servicename-true-server.xml
@@ -328,12 +328,12 @@ public class EnableSchemaValidationTest {
         LOG.info("testWrongElementNameServiceNameSchemaValidationTrue - Response = " + response);
 
         assertNull("Expected null response from server, but was" + response, response);
-        assertNotNull("Expected Unmarshalling Error: cvc-complex-type.2.4.a  in server logs",
+        assertNotNull("Expected Unmarshalling Error: cvc-complex-type.2.4.a not found in server logs",
                       server.waitForStringInLog("cvc-complex-type.2.4.a"));
     }
 
     /**
-     * Test the global setting of enableSchemaValidation=true in server.xml, with the wrong namespace in the <response> element
+     * Test the targeted setting of enableSchemaValidation=true in server.xml, with the wrong namespace in the <response> element
      * which will cause an cvc-complex-type.2.4.a exception with the default schema validation enabled.
      *
      * Server config - servicename-true-server.xml
@@ -351,12 +351,12 @@ public class EnableSchemaValidationTest {
         LOG.info("testWrongNamespaceServiceNameSchemaValidationTrue - Response = " + response);
 
         assertNull("Expected null response from server, but was" + response, response);
-        assertNotNull("Expected Unmarshalling Error: cvc-complex-type.2.4.a  in server logs",
+        assertNotNull("Expected Unmarshalling Error: cvc-complex-type.2.4.a not found in server logs",
                       server.waitForStringInLog("cvc-complex-type.2.4.a"));
     }
 
     /**
-     * Test the global setting of enableSchemaValidation=true in server.xml, with the wrong content in the <response> element
+     * Test the targeted setting of enableSchemaValidation=true in server.xml, with the wrong content in the <response> element
      * The response will contain an addtional child element <WrongElementContent> which will cause an Unexected Element exception
      * with the default schema validation enabled.
      *
@@ -375,14 +375,14 @@ public class EnableSchemaValidationTest {
         LOG.info("testWrongElementContentServiceNameSchemaValidationTrue - Response = " + response);
 
         assertNull("Expected null response from server, but was" + response, response);
-        assertNotNull("Expected Unmarshalling Error: Expected elements are (none) in server logs",
+        assertNotNull("Expected Unmarshalling Error: WrongelementContent is not found in server logs",
                       server.waitForStringInLog("local:\"WrongElementContent\""));
     }
 
     // serviceName FALSE TESTS
 
     /**
-     * Test the global setting of enableSchemaValidation=false in server.xml, with an additional element <arg0> following the <response> element
+     * Test the targeted setting of enableSchemaValidation=false in server.xml, with an additional element <arg0> following the <response> element
      * which is ignored when schema validation is disabled.
      *
      * Server config - servicename-false-server.xml
@@ -404,7 +404,7 @@ public class EnableSchemaValidationTest {
     }
 
     /**
-     * Test the global setting of enableSchemaValidation=false in server.xml, with the wrong element name where <response> element is expected
+     * Test the targeted setting of enableSchemaValidation=false in server.xml, with the wrong element name where <response> element is expected
      * which with schema valdation disabled will just be ignored and the response will be null when unmarshalled
      *
      * Server config - servicename-false-server.xml
@@ -426,7 +426,7 @@ public class EnableSchemaValidationTest {
     }
 
     /**
-     * Test the global setting of enableSchemaValidation=false in server.xml, with the wrong namespace set on <response> element
+     * Test the targeted setting of enableSchemaValidation=false in server.xml, with the wrong namespace set on <response> element
      * which with schema valdation disabled will just be ignored and the response will be null when unmarshalled
      *
      * Server config - servicename-false-server.xml
@@ -448,7 +448,7 @@ public class EnableSchemaValidationTest {
     }
 
     /**
-     * Test the global setting of enableSchemaValidation=false in server.xml, with wrong child elements of the <response> element
+     * Test the targeted setting of enableSchemaValidation=false in server.xml, with wrong child elements of the <response> element
      * which with schema valdation disabled will just be ignored and the response will be empty since response no longer contains a valid value.
      *
      * Server config - servicename-false-server.xml
@@ -473,7 +473,7 @@ public class EnableSchemaValidationTest {
 
     /**
      * Test the serviceName takes precedent over the global setting of enableSchemaValidation=true in server.xml, with an additional element <arg0> following the <response> element
-     * which will cause s No child element is expected at this point exception with the default schema validation enabled.
+     * which will causes No child element is expected at this point exception with the default schema validation enabled.
      *
      * Server config - servicename-true-global-false-server.xml
      * Expected response - Unmarshalling Error: cvc-complex-type.2.4.a
@@ -490,12 +490,13 @@ public class EnableSchemaValidationTest {
         LOG.info("testAddedElementServiceNameTrueGlobalSchemaValidationFalse - Response = " + response);
 
         assertNull("Expected null response from server, but was" + response, response);
-        assertNotNull("Expected Unmarshalling Error: unexpected element exception is not thrown",
+        assertNotNull("Expected Unmarshalling Error: No child element is expected at this point exception is not thrown",
                       server.waitForStringInLog("No child element is expected at this point."));
     }
 
     /**
-     * Test the global setting of enableSchemaValidation=false in server.xml, with an additional element <arg0> following the <response> element
+     * Test the serviceName takes precedent over the global setting of enableSchemaValidation=false in server.xml, with an additional element <arg0> following the <response>
+     * element
      * which is ignored when schema validation is disabled.
      *
      * Server config - servicename-false-global-truee-server.xml
@@ -523,7 +524,7 @@ public class EnableSchemaValidationTest {
      * will cause s No child element is expected at this point exception with the default schema validation enabled.
      *
      * Server config - incorrect-servicename-server.xml
-     * Expected response - Unmarshalling Error: cvc-complex-type.2.4.a
+     * Expected response - SAXParseException.*unexpected element
      *
      * @throws Exception
      */
@@ -538,7 +539,7 @@ public class EnableSchemaValidationTest {
 
         assertNull("Expected null response from server, but was" + response, response);
         assertNotNull("Expected Unmarshalling Error: unexpected element exception is not thrown",
-                      server.waitForStringInLog("unexpected element"));
+                      server.waitForStringInLog("SAXParseException.*unexpected element"));
     }
 
     private String runTest(LibertyServer server, String pathAndParams) throws ProtocolException, IOException {

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/EnableSchemaValidationTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/EnableSchemaValidationTest.java
@@ -1,0 +1,553 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.fat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.util.logging.Logger;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+/**
+ * This test suite tests the following variations of the <webServiceClient enableSchemaValidation="true/false" /> server.xml configuration:
+ *
+ * 1.) enableSchemValidation="true" - "global" setting
+ * 2.) enableschemaValiation="false" - "global" setting
+ * 3.) enableSchemValidation="true" serviceName="SayHelloServiceWithHandler" - targeted client setting
+ * 4.) enableSchemValidation="false" serviceName="SayHelloServiceWithHandler" - targeted client setting
+ * 4.) Combination of 1 and 4
+ * 5.) Combination of 2 and 3
+ * 4.) enableSchemValidation="false" serviceName="IncorrectServiceName" - targeted client setting with the wrong serviceName
+ *
+ * This Test uses a Mock endpoint to create "bad" responses that the client will fail to unmarshall unless enableSchemaValodation=false
+ *
+ * @see com.ibm.ws.jaxws.fat.mock.endpoint.MockJaxwsEndpointServlet
+ *
+ *      Each test uses a specific server.xml configuration that's reconfigured at test start. It calls the @see IgnoreUnexpectedElementTestServiceServlet servlet
+ *      along with a HTTP request parameter. That parameter is added to the SOAP Request, and when the mock JAX-WS endpoint receives the request, it checks for the string
+ *      and correlates it to the "bad" response the endpoint then returns. After the client recieves the inbound response, the test checks the response from the
+ *      IgnoreUnexpectedElementTestServiceServlet servlet
+ *      for the specified response or exception in the server logs.
+ *
+ *      TODO: Test Dispatch clients
+ */
+@RunWith(FATRunner.class)
+public class EnableSchemaValidationTest {
+
+    Logger LOG = Logger.getLogger("EnableSchemaValidationTest.class");
+
+    private final static int REQUEST_TIMEOUT = 10;
+
+    @Server("EnableSchemaValidationTestServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        ShrinkHelper.defaultApp(server, "enableSchemaValidation", "com.ibm.ws.jaxws.fat.mock.endpoint");
+
+        ShrinkHelper.defaultDropinApp(server, "testHandlerClient", "com.ibm.samples.jaxws.client",
+                                      "com.ibm.samples.jaxws.client.handler",
+                                      "com.ibm.samples.jaxws.client.servlet");
+
+        server.startServer("HandlerChainClientAddedElement.log");
+
+        assertNotNull("Application hello does not appear to have started.", server.waitForStringInLog("CWWKZ0001I:.*" + "testHandlerClient"));
+    }
+
+    /**
+     * Have to reconfig to the initial server.xml after each test, since each configuration
+     * might be repeated across multiple tests
+     *
+     * @throws Exception
+     */
+    @After
+    public void reconfigOnAfter() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/server.xml", "CWWKG0017I");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    // Global True Tests
+
+    /**
+     * Test the global setting of enableSchemaValidation=true in server.xml, with an additional element <arg0> following the <response> element
+     * which will cause s No child element is expected at this point exception with the default schema validation enabled.
+     *
+     * Server config - global-true-server.xml
+     * Expected response - Unmarshalling Error: cvc-complex-type.2.4.a
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAddedElementGlobalSchemaValidationTrue() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/global-true-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=AddedElement");
+        // Log response to output.txt
+        LOG.info("testAddedElementGlobalSchemaValidationTrue - Response = " + response);
+
+        assertNull("Expected null response from server, but was" + response, response);
+        assertNotNull("Expected Unmarshalling Error: unexpected element exception is not thrown",
+                      server.waitForStringInLog("No child element is expected at this point."));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=true in server.xml, with the wrong element name where <response> element is expected
+     * which will cause an cvc-complex-type.2.4.a exception with the default schema validation enabled.
+     *
+     * Server config - global-true-server.xml
+     * Expected response - Unmarshalling Error: cvc-complex-type.2.4.a
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWrongElementNameGlobalSchemaValidationTrue() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/global-true-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=WrongElementName");
+        // Log response to output.txt
+        LOG.info("testWrongElementNameGlobalSchemaValidationTrue - Response = " + response);
+
+        assertNull("Expected null response from server, but was" + response, response);
+        assertNotNull("Expected Unmarshalling Error: cvc-complex-type.2.4.a  in server logs",
+                      server.waitForStringInLog("cvc-complex-type.2.4.a"));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=true in server.xml, with the wrong namespace in the <response> element
+     * which will cause an cvc-complex-type.2.4.a exception with the default schema validation enabled.
+     *
+     * Server config - global-true-server.xml
+     * Expected response - Unmarshalling Error: cvc-complex-type.2.4.a
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWrongNamespaceGlobalSchemaValidationTrue() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/global-true-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=WrongNamespace");
+        // Log response to output.txt
+        LOG.info("testWrongNamespaceGlobalSchemaValidationTrue - Response = " + response);
+
+        assertNull("Expected null response from server, but was" + response, response);
+        assertNotNull("Expected Unmarshalling Error: cvc-complex-type.2.4.a  in server logs",
+                      server.waitForStringInLog("cvc-complex-type.2.4.a"));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=true in server.xml, with the wrong content in the <response> element
+     * The response will contain an addtional child element <WrongElementContent> which will cause an Unexected Element exception
+     * with the default schema validation enabled.
+     *
+     * Server config - global-true-server.xml
+     * Expected response - Unmarshalling Error: unexpected element
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWrongElementContentGlobalSchemaValidationTrue() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/global-true-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=WrongElementContent");
+        // Log response to output.txt
+        LOG.info("testWrongElementContentGlobalSchemaValidationTrue - Response = " + response);
+
+        assertNull("Expected null response from server, but was" + response, response);
+        assertNotNull("Expected Unmarshalling Error: Expected elements are (none) in server logs",
+                      server.waitForStringInLog("local:\"WrongElementContent\""));
+    }
+
+    // GLOBAL FALSE TESTS
+
+    /**
+     * Test the global setting of enableSchemaValidation=false in server.xml, with an additional element <arg0> following the <response> element
+     * which is ignored when schema validation is disabled.
+     *
+     * Server config - global-false-server.xml
+     * Expected response - Hello, AddedElement
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAddedElementGlobalSchemaValidationFalse() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/global-false-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=AddedElement");
+        // Log response to output.txt
+        LOG.info("testAddedElementGlobalSchemaValidationFalse - Response = " + response);
+
+        assertTrue("Expected successful response, but response was " + response,
+                   response.contains("Hello, AddedElement"));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=false in server.xml, with the wrong element name where <response> element is expected
+     * which with schema valdation disabled will just be ignored and the response will be null when unmarshalled
+     *
+     * Server config - global-false-server.xml
+     * Expected response - null
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWrongElementNameGlobalSchemaValidationFalse() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/global-false-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=WrongElementName");
+        // Log response to output.txt
+        LOG.info("testWrongElementNameGlobalSchemaValidationFalse - Response = " + response);
+
+        assertTrue("Expected successful response, but response was " + response,
+                   response.contains("null"));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=false in server.xml, with the wrong namespace set on <response> element
+     * which with schema valdation disabled will just be ignored and the response will be null when unmarshalled
+     *
+     * Server config - global-false-server.xml
+     * Expected response - null
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWrongNamespaceGlobalSchemaValidationFalse() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/global-false-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=WrongNamespace");
+        // Log response to output.txt
+        LOG.info("testWrongNamespaceGlobalSchemaValidationFalse - Response = " + response);
+
+        assertTrue("Expected successful response, but response was " + response,
+                   response.contains("null"));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=false in server.xml, with wrong child elements of the <response> element
+     * which with schema valdation disabled will just be ignored and the response will be empty since response no longer contains a valid value.
+     *
+     * Server config - global-false-server.xml
+     * Expected response - null
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWrongElementContentGlobalSchemaValidationFalse() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/global-false-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=WrongElementContent");
+        // Log response to output.txt
+        LOG.info("testWrongElementContentGlobalSchemaValidationFalse - Response = " + response);
+
+        assertTrue("Expected successful response, but response was " + response,
+                   response.contains(": "));
+    }
+
+    // serviceName True Tests
+
+    /**
+     * Test the global setting of enableSchemaValidation=true in server.xml, with an additional element <arg0> following the <response> element
+     * which will cause s No child element is expected at this point exception with the default schema validation enabled.
+     *
+     * Server config - servicename-true-server.xml
+     * Expected response - Unmarshalling Error: cvc-complex-type.2.4.a
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAddedElementServiceNameSchemaValidationTrue() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/servicename-true-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=AddedElement");
+        // Log response to output.txt
+        LOG.info("testAddedElementServiceNameSchemaValidationTrue - Response = " + response);
+
+        assertNull("Expected null response from server, but was" + response, response);
+        assertNotNull("Expected Unmarshalling Error: unexpected element exception is not thrown",
+                      server.waitForStringInLog("No child element is expected at this point."));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=true in server.xml, with the wrong element name where <response> element is expected
+     * which will cause an cvc-complex-type.2.4.a exception with the default schema validation enabled.
+     *
+     * Server config - servicename-true-server.xml
+     * Expected response - Unmarshalling Error: cvc-complex-type.2.4.a
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWrongElementNameServiceNameSchemaValidationTrue() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/servicename-true-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=WrongElementName");
+        // Log response to output.txt
+        LOG.info("testWrongElementNameServiceNameSchemaValidationTrue - Response = " + response);
+
+        assertNull("Expected null response from server, but was" + response, response);
+        assertNotNull("Expected Unmarshalling Error: cvc-complex-type.2.4.a  in server logs",
+                      server.waitForStringInLog("cvc-complex-type.2.4.a"));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=true in server.xml, with the wrong namespace in the <response> element
+     * which will cause an cvc-complex-type.2.4.a exception with the default schema validation enabled.
+     *
+     * Server config - servicename-true-server.xml
+     * Expected response - Unmarshalling Error: cvc-complex-type.2.4.a
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWrongNamespaceServiceNameSchemaValidationTrue() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/servicename-true-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=WrongNamespace");
+        // Log response to output.txt
+        LOG.info("testWrongNamespaceServiceNameSchemaValidationTrue - Response = " + response);
+
+        assertNull("Expected null response from server, but was" + response, response);
+        assertNotNull("Expected Unmarshalling Error: cvc-complex-type.2.4.a  in server logs",
+                      server.waitForStringInLog("cvc-complex-type.2.4.a"));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=true in server.xml, with the wrong content in the <response> element
+     * The response will contain an addtional child element <WrongElementContent> which will cause an Unexected Element exception
+     * with the default schema validation enabled.
+     *
+     * Server config - servicename-true-server.xml
+     * Expected response - Unmarshalling Error: unexpected element
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWrongElementContentServiceNameSchemaValidationTrue() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/servicename-true-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=WrongElementContent");
+        // Log response to output.txt
+        LOG.info("testWrongElementContentServiceNameSchemaValidationTrue - Response = " + response);
+
+        assertNull("Expected null response from server, but was" + response, response);
+        assertNotNull("Expected Unmarshalling Error: Expected elements are (none) in server logs",
+                      server.waitForStringInLog("local:\"WrongElementContent\""));
+    }
+
+    // serviceName FALSE TESTS
+
+    /**
+     * Test the global setting of enableSchemaValidation=false in server.xml, with an additional element <arg0> following the <response> element
+     * which is ignored when schema validation is disabled.
+     *
+     * Server config - servicename-false-server.xml
+     * Expected response - Hello, AddedElement
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAddedElementServiceNameSchemaValidationFalse() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/servicename-false-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=AddedElement");
+        // Log response to output.txt
+        LOG.info("testAddedElementServiceNameSchemaValidationFalse - Response = " + response);
+
+        assertTrue("Expected successful response, but response was " + response,
+                   response.contains("Hello, AddedElement"));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=false in server.xml, with the wrong element name where <response> element is expected
+     * which with schema valdation disabled will just be ignored and the response will be null when unmarshalled
+     *
+     * Server config - servicename-false-server.xml
+     * Expected response - null
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWrongElementNameServiceNameSchemaValidationFalse() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/servicename-false-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=WrongElementName");
+        // Log response to output.txt
+        LOG.info("testWrongElementNameServiceNameSchemaValidationFalse - Response = " + response);
+
+        assertTrue("Expected successful response, but response was " + response,
+                   response.contains("null"));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=false in server.xml, with the wrong namespace set on <response> element
+     * which with schema valdation disabled will just be ignored and the response will be null when unmarshalled
+     *
+     * Server config - servicename-false-server.xml
+     * Expected response - null
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWrongNamespaceServiceNameSchemaValidationFalse() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/servicename-false-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=WrongNamespace");
+        // Log response to output.txt
+        LOG.info("testWrongNamespaceServiceNameSchemaValidationFalse - Response = " + response);
+
+        assertTrue("Expected successful response, but response was " + response,
+                   response.contains("null"));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=false in server.xml, with wrong child elements of the <response> element
+     * which with schema valdation disabled will just be ignored and the response will be empty since response no longer contains a valid value.
+     *
+     * Server config - servicename-false-server.xml
+     * Expected response - null
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWrongElementContentServiceNameSchemaValidationFalse() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/servicename-false-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=WrongElementContent");
+        // Log response to output.txt
+        LOG.info("testWrongElementContentServiceNameSchemaValidationFalse - Response = " + response);
+
+        assertTrue("Expected successful response, but response was " + response,
+                   response.contains(": "));
+    }
+
+    // serviceName and Global Tests
+
+    /**
+     * Test the serviceName takes precedent over the global setting of enableSchemaValidation=true in server.xml, with an additional element <arg0> following the <response> element
+     * which will cause s No child element is expected at this point exception with the default schema validation enabled.
+     *
+     * Server config - servicename-true-global-false-server.xml
+     * Expected response - Unmarshalling Error: cvc-complex-type.2.4.a
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAddedElementServiceNameTrueGlobalSchemaValidationFalse() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/servicename-true-global-false-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=AddedElement");
+        // Log response to output.txt
+        LOG.info("testAddedElementServiceNameTrueGlobalSchemaValidationFalse - Response = " + response);
+
+        assertNull("Expected null response from server, but was" + response, response);
+        assertNotNull("Expected Unmarshalling Error: unexpected element exception is not thrown",
+                      server.waitForStringInLog("No child element is expected at this point."));
+    }
+
+    /**
+     * Test the global setting of enableSchemaValidation=false in server.xml, with an additional element <arg0> following the <response> element
+     * which is ignored when schema validation is disabled.
+     *
+     * Server config - servicename-false-global-truee-server.xml
+     * Expected response - Hello, AddedElement
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAddedElementServiceNameFalseGlobalSchemaValidationTrue() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/servicename-false-global-true-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=AddedElement");
+        // Log response to output.txt
+        LOG.info("testAddedElementServiceNameFalseGlobalSchemaValidationTrue - Response = " + response);
+
+        assertTrue("Expected successful response, but response was " + response,
+                   response.contains("Hello, AddedElement"));
+    }
+
+    // incorrect serviceName tests
+
+    /**
+     * Test the when the incorrect serviceName is given with enableSchemaValidation is set to true server.xml, with an additional element <arg0> following the <response> element
+     * will cause s No child element is expected at this point exception with the default schema validation enabled.
+     *
+     * Server config - incorrect-servicename-server.xml
+     * Expected response - Unmarshalling Error: cvc-complex-type.2.4.a
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAddedElementIncorrectServiceNameSchemaValidatinFalse() throws Exception {
+        server.reconfigureServer("EnableSchemaValidationTestServer/incorrect-servicename-server.xml", "CWWKG0017I");
+
+        // Visit the URL:  http://hostName:hostPort/testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=user
+        String response = runTest(server, "testHandlerClient/IgnoreUnexpectedElementTestServiceServlet?target=AddedElement");
+        // Log response to output.txt
+        LOG.info("testAddedElementIncorrectServiceNameSchemaValidatinFalse - Response = " + response);
+
+        assertNull("Expected null response from server, but was" + response, response);
+        assertNotNull("Expected Unmarshalling Error: unexpected element exception is not thrown",
+                      server.waitForStringInLog("unexpected element"));
+    }
+
+    private String runTest(LibertyServer server, String pathAndParams) throws ProtocolException, IOException {
+        URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + pathAndParams);
+        Log.info(this.getClass(), "assertResponseNotNull", "Calling Application with URL=" + url.toString());
+
+        HttpURLConnection con = HttpUtils.getHttpConnection(url, HttpURLConnection.HTTP_OK, REQUEST_TIMEOUT);
+        BufferedReader br = HttpUtils.getConnectionStream(con);
+        String line = br.readLine();
+        return line;
+    }
+}

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/FATSuite.java
@@ -26,6 +26,7 @@ import componenttest.rules.repeater.RepeatTests;
 @SuiteClasses({
                 ColocatedDynamicPolicyAttachmentsTest.class,
                 EJBServiceRefBndTest.class,
+                EnableSchemaValidationTest.class,
                 EncodingTest.class,
                 HandlerChainTest.class,
                 HandlerChainWithWebServiceClientTest.class,

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/global-false-server.xml
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/global-false-server.xml
@@ -1,0 +1,15 @@
+<server>
+    <featureManager>
+        <feature>jsp-2.2</feature>
+        <feature>jaxws-2.2</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+    
+    <webServiceClient enableSchemaValidation="false" />
+    
+    <webApplication name="enableSchemaValidation" location="enableSchemaValidation.war" context-root="testHandlerProvider" />	
+    
+    <javaPermission className="java.security.AllPermission" name="*" actions="*"/>
+    
+</server>

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/global-true-server.xml
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/global-true-server.xml
@@ -1,0 +1,15 @@
+<server>
+    <featureManager>
+        <feature>jsp-2.2</feature>
+        <feature>jaxws-2.2</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+    
+    <webApplication name="enableSchemaValidation" location="enableSchemaValidation.war" context-root="testHandlerProvider" />
+    
+    <webServiceClient enableSchemaValidation="true" />
+    
+    <javaPermission className="java.security.AllPermission" name="*" actions="*"/>
+    
+</server>

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/incorrect-servicename-server.xml
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/incorrect-servicename-server.xml
@@ -1,0 +1,15 @@
+<server>
+    <featureManager>
+        <feature>jsp-2.2</feature>
+        <feature>jaxws-2.2</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <webApplication name="enableSchemaValidation" location="enableSchemaValidation.war" context-root="testHandlerProvider" />
+    
+    <webServiceClient serviceName="IncorrectServiceName"  enableSchemaValidation="false" />
+    
+    <javaPermission className="java.security.AllPermission" name="*" actions="*"/>
+    
+</server>

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/server.xml
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/server.xml
@@ -1,0 +1,13 @@
+<server>
+    <featureManager>
+        <feature>jsp-2.2</feature>
+        <feature>jaxws-2.2</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+    
+    <webApplication name="enableSchemaValidation" location="enableSchemaValidation.war" context-root="testHandlerProvider" />
+    
+    <javaPermission className="java.security.AllPermission" name="*" actions="*"/>
+    
+</server>

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/servicename-false-global-true-server.xml
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/servicename-false-global-true-server.xml
@@ -1,0 +1,19 @@
+<server>
+    <featureManager>
+        <feature>jsp-2.2</feature>
+        <feature>jaxws-2.2</feature>
+    </featureManager>
+    
+   
+
+    <include location="../fatTestPorts.xml"/>
+    
+    <webApplication name="enableSchemaValidation" location="enableSchemaValidation.war" context-root="testHandlerProvider" />
+    
+    <webServiceClient serviceName="SayHelloServiceWithHandler"  enableSchemaValidation="false" />
+    
+    <webServiceClient enableSchemaValidation="true" />
+    
+    <javaPermission className="java.security.AllPermission" name="*" actions="*"/>
+    
+</server>

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/servicename-false-server.xml
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/servicename-false-server.xml
@@ -1,0 +1,17 @@
+<server>
+    <featureManager>
+        <feature>jsp-2.2</feature>
+        <feature>jaxws-2.2</feature>
+    </featureManager>
+    
+   
+
+    <include location="../fatTestPorts.xml"/>
+    
+    <webApplication name="enableSchemaValidation" location="enableSchemaValidation.war" context-root="testHandlerProvider" />
+    
+    <webServiceClient serviceName="SayHelloServiceWithHandler"  enableSchemaValidation="false" />
+    
+    <javaPermission className="java.security.AllPermission" name="*" actions="*"/>
+    
+</server>

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/servicename-true-global-false-server.xml
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/servicename-true-global-false-server.xml
@@ -1,0 +1,19 @@
+<server>
+    <featureManager>
+        <feature>jsp-2.2</feature>
+        <feature>jaxws-2.2</feature>
+    </featureManager>
+    
+   
+
+    <include location="../fatTestPorts.xml"/>
+    
+    <webApplication name="enableSchemaValidation" location="enableSchemaValidation.war" context-root="testHandlerProvider" />
+    
+    <webServiceClient serviceName="SayHelloServiceWithHandler"  enableSchemaValidation="true" />
+    
+    <webServiceClient enableSchemaValidation="false" />
+    
+    <javaPermission className="java.security.AllPermission" name="*" actions="*"/>
+    
+</server>

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/servicename-true-server.xml
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/EnableSchemaValidationTestServer/servicename-true-server.xml
@@ -1,0 +1,16 @@
+<server>
+    <featureManager>
+        <feature>jsp-2.2</feature>
+        <feature>jaxws-2.2</feature>
+    </featureManager>
+    
+   
+
+    <include location="../fatTestPorts.xml"/>
+    <webApplication name="enableSchemaValidation" location="enableSchemaValidation.war" context-root="testHandlerProvider" />
+    
+    <webServiceClient serviceName="SayHelloServiceWithHandler"  enableSchemaValidation="true" />
+    
+    <javaPermission className="java.security.AllPermission" name="*" actions="*"/>
+    
+</server>

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/servers/EnableSchemaValidationTestServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/servers/EnableSchemaValidationTestServer/bootstrap.properties
@@ -1,0 +1,1 @@
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/servers/EnableSchemaValidationTestServer/jvm.options
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/servers/EnableSchemaValidationTestServer/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/servers/EnableSchemaValidationTestServer/server.xml
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/servers/EnableSchemaValidationTestServer/server.xml
@@ -1,0 +1,13 @@
+<server>
+    <featureManager>
+        <feature>jsp-2.2</feature>
+        <feature>jaxws-2.2</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+    
+    <webApplication name="enableSchemaValidation" location="enableSchemaValidation.war" context-root="testHandlerProvider" />
+    
+    <javaPermission className="java.security.AllPermission" name="*" actions="*"/>
+    
+</server>

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/test-applications/enableSchemaValidation/src/com/ibm/ws/jaxws/fat/mock/endpoint/MockJaxwsEndpointServlet.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/test-applications/enableSchemaValidation/src/com/ibm/ws/jaxws/fat/mock/endpoint/MockJaxwsEndpointServlet.java
@@ -52,16 +52,16 @@ public class MockJaxwsEndpointServlet extends HttpServlet {
 
         LOG.info("Received request: " + requestPayload);
 
-        // Now that we've got the request, we can the value of the "name" parameter sent by the client
+        // Now that we've got the request, we can check the value of the "name" parameter sent by the client
         // This will allow us to know which test we are running, and which response to send back to the client.
-        if (requestPayload.contains("AddedElement")) {
 
-            response.setStatus(200);
-            response.setContentType("text/xml");
-            response.setHeader("Address", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
-            response.setHeader("ServiceName", "SayHelloService");
-            response.setHeader("PortName", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
-            PrintWriter writer = response.getWriter();
+        response.setStatus(200);
+        response.setContentType("text/xml");
+        response.setHeader("Address", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
+        response.setHeader("ServiceName", "SayHelloService");
+        response.setHeader("PortName", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
+        PrintWriter writer = response.getWriter();
+        if (requestPayload.contains("AddedElement")) {
             writer.append("<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
                           + "  <soap:Body>\n"
                           + "    <ns2:sayHelloResponse xmlns:ns2=\"http://jaxws.samples.ibm.com.handler/\">\n"
@@ -71,13 +71,6 @@ public class MockJaxwsEndpointServlet extends HttpServlet {
                           + "  </soap:Body>\n"
                           + "</soap:Envelope>");
         } else if (requestPayload.contains("WrongElementName")) {
-
-            response.setStatus(200);
-            response.setContentType("text/xml");
-            response.setHeader("Address", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
-            response.setHeader("ServiceName", "SayHelloService");
-            response.setHeader("PortName", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
-            PrintWriter writer = response.getWriter();
             writer.append("<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
                           + "  <soap:Body>\n"
                           + "    <ns2:sayHelloResponse xmlns:ns2=\"http://jaxws.samples.ibm.com.handler/\">\n"
@@ -87,13 +80,6 @@ public class MockJaxwsEndpointServlet extends HttpServlet {
                           + "</soap:Envelope>");
 
         } else if (requestPayload.contains("WrongNamespace")) {
-
-            response.setStatus(200);
-            response.setContentType("text/xml");
-            response.setHeader("Address", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
-            response.setHeader("ServiceName", "SayHelloService");
-            response.setHeader("PortName", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
-            PrintWriter writer = response.getWriter();
             writer.append("<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
                           + "  <soap:Body>\n"
                           + "    <ns2:sayHelloResponse xmlns:ns2=\"http://jaxws.samples.ibm.com.handler/\">\n" // change namespace to wrong.namespacee
@@ -103,13 +89,6 @@ public class MockJaxwsEndpointServlet extends HttpServlet {
                           + "</soap:Envelope>");
 
         } else if (requestPayload.contains("WrongElementContent")) {
-
-            response.setStatus(200);
-            response.setContentType("text/xml");
-            response.setHeader("Address", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
-            response.setHeader("ServiceName", "SayHelloService");
-            response.setHeader("PortName", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
-            PrintWriter writer = response.getWriter();
             writer.append("<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
                           + "  <soap:Body>\n"
                           + "    <ns2:sayHelloResponse xmlns:ns2=\"http://jaxws.samples.ibm.com.handler/\">\n"

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/test-applications/enableSchemaValidation/src/com/ibm/ws/jaxws/fat/mock/endpoint/MockJaxwsEndpointServlet.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/test-applications/enableSchemaValidation/src/com/ibm/ws/jaxws/fat/mock/endpoint/MockJaxwsEndpointServlet.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.fat.mock.endpoint;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.logging.Logger;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * This servlet acts as a Mock JAX-WS Endpoint that returns a "malformed" response that will cause the JAXB Unmarshaller on the
+ * client side to fail when processed.
+ *
+ * We take the inbound request, convert it to a string, and check for the "name" element, which will tell us which test is being invoked,
+ * based on that we will send a specific response, designed to cause a JAXB Unmarshaller failure.
+ *
+ * We set the publish servlet at http://127.0.0.1:8010/testHandlerProvider/SayHelloServiceWithHandler which
+ * allows the JAX-WS client in IgnoreUnexpectedElementTestServiceClient invoke this "Web Service".
+ *
+ * When enableSchemaValidation=false, these malformed responses may or may not still cause additional failures since the default schema validation will be disabled
+ * but the JAX-WS runtime still might not be able to process the message
+ */
+//Publishing the Servlet to the endpoint of a pre-existing Web Serbvice so we can use the client without modification
+@WebServlet("/SayHelloServiceWithHandler")
+public class MockJaxwsEndpointServlet extends HttpServlet {
+
+    Logger LOG = Logger.getLogger("MockJaxwsEndpointServlet.class");
+
+    /**
+     * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        // Convert inbound request payload to a string
+        BufferedReader requestBufferedReader = request.getReader();
+        String requestPayload = new String();
+        for (String payLoadLine; (payLoadLine = requestBufferedReader.readLine()) != null; requestPayload += payLoadLine);
+
+        LOG.info("Received request: " + requestPayload);
+
+        // Now that we've got the request, we can the value of the "name" parameter sent by the client
+        // This will allow us to know which test we are running, and which response to send back to the client.
+        if (requestPayload.contains("AddedElement")) {
+
+            response.setStatus(200);
+            response.setContentType("text/xml");
+            response.setHeader("Address", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
+            response.setHeader("ServiceName", "SayHelloService");
+            response.setHeader("PortName", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
+            PrintWriter writer = response.getWriter();
+            writer.append("<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                          + "  <soap:Body>\n"
+                          + "    <ns2:sayHelloResponse xmlns:ns2=\"http://jaxws.samples.ibm.com.handler/\">\n"
+                          + "      <return>Hello, AddedElement</return>\n"
+                          + "      <arg0>Hello again, AddedElement</arg0>\n" // Additional element in the response
+                          + "    </ns2:sayHelloResponse>\n"
+                          + "  </soap:Body>\n"
+                          + "</soap:Envelope>");
+        } else if (requestPayload.contains("WrongElementName")) {
+
+            response.setStatus(200);
+            response.setContentType("text/xml");
+            response.setHeader("Address", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
+            response.setHeader("ServiceName", "SayHelloService");
+            response.setHeader("PortName", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
+            PrintWriter writer = response.getWriter();
+            writer.append("<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                          + "  <soap:Body>\n"
+                          + "    <ns2:sayHelloResponse xmlns:ns2=\"http://jaxws.samples.ibm.com.handler/\">\n"
+                          + "      <wrongElement>Hello, WrongElementName</wrongElement>\n" // change return to wrongElement
+                          + "    </ns2:sayHelloResponse>\n"
+                          + "  </soap:Body>\n"
+                          + "</soap:Envelope>");
+
+        } else if (requestPayload.contains("WrongNamespace")) {
+
+            response.setStatus(200);
+            response.setContentType("text/xml");
+            response.setHeader("Address", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
+            response.setHeader("ServiceName", "SayHelloService");
+            response.setHeader("PortName", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
+            PrintWriter writer = response.getWriter();
+            writer.append("<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                          + "  <soap:Body>\n"
+                          + "    <ns2:sayHelloResponse xmlns:ns2=\"http://jaxws.samples.ibm.com.handler/\">\n" // change namespace to wrong.namespacee
+                          + "      <ns2:return xmlns:ns2=\"http://wrong.namespace/\">Hello, WrongElementNamespace</ns2:return>\n"
+                          + "    </ns2:sayHelloResponse>\n"
+                          + "  </soap:Body>\n"
+                          + "</soap:Envelope>");
+
+        } else if (requestPayload.contains("WrongElementContent")) {
+
+            response.setStatus(200);
+            response.setContentType("text/xml");
+            response.setHeader("Address", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
+            response.setHeader("ServiceName", "SayHelloService");
+            response.setHeader("PortName", "http://127.0.0.1:8010/testHandlerProvider/SayHelloService");
+            PrintWriter writer = response.getWriter();
+            writer.append("<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                          + "  <soap:Body>\n"
+                          + "    <ns2:sayHelloResponse xmlns:ns2=\"http://jaxws.samples.ibm.com.handler/\">\n"
+                          + "      <return>"
+                          + "           <WrongElementContent>Hello again, AddedElement</WrongElementContent>\n" // Additional child elements of return
+                          + "      </return>\n"
+                          + "    </ns2:sayHelloResponse>\n"
+                          + "  </soap:Body>\n"
+                          + "</soap:Envelope>");
+        }
+
+    }
+}

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
@@ -105,13 +105,22 @@ public class LibertyWebServiceClientInInterceptor extends AbstractPhaseIntercept
         }
         
 
-        // Enable or disable schema validation as long as property is non-null
+        // As long as property is non-null:
+        // Enable enhanced schema validation if true, or disable it along with default validation if false 
         if ( enableSchemaValidation != null) {
-            message.put("schema-validation-enabled", (boolean) enableSchemaValidation);
+            if ((boolean) enableSchemaValidation == true) {
+                // enable Schema Validation 
+                message.put("schema-validation-enabled", (boolean) enableSchemaValidation);
+                
+                if (debug) {
+                    Tr.debug(tc, "Set schema-validation-enabled to " + (boolean) enableSchemaValidation);
 
-            if (debug) {
-                Tr.debug(tc, "Set schema-validation-enabled to " + (boolean) enableSchemaValidation);
-
+                }
+            } else if ((boolean) enableSchemaValidation == false) {
+                // Make sure schema validation is disabled
+                message.put("schema-validation-enabled", false);
+                // Disable the default vaildation as well
+                message.put(JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER, false);
             }
         } else {
 

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
@@ -110,10 +110,10 @@ public class LibertyWebServiceClientInInterceptor extends AbstractPhaseIntercept
         if ( enableSchemaValidation != null) {
             if ((boolean) enableSchemaValidation == true) {
                 // enable Schema Validation 
-                message.put("schema-validation-enabled", (boolean) enableSchemaValidation);
+                message.put("schema-validation-enabled", true);
                 
                 if (debug) {
-                    Tr.debug(tc, "Set schema-validation-enabled to " + (boolean) enableSchemaValidation);
+                    Tr.debug(tc, "Set schema-validation-enabled to " + true);
 
                 }
             } else if ((boolean) enableSchemaValidation == false) {
@@ -121,6 +121,13 @@ public class LibertyWebServiceClientInInterceptor extends AbstractPhaseIntercept
                 message.put("schema-validation-enabled", false);
                 // Disable the default vaildation as well
                 message.put(JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER, false);
+                
+
+                
+                if (debug) {
+                    Tr.debug(tc, "Set schema-validation-enabled to " + false + " and " + JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER + " to " + false);
+
+                }
             }
         } else {
 

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/ConfigHolder.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/ConfigHolder.java
@@ -111,7 +111,7 @@ public class ConfigHolder {
         } else {
             
             if(getDebugEnabled()) {
-                Tr.debug(tc, "getIgnoreUnexpectedElements is returning null because no properties exist for name - " + name);
+                Tr.debug(tc, "getEnableSchemaValidation is returning null because no properties exist for name - " + name);
             }
             return null; // No properties exist so return null
             
@@ -244,7 +244,7 @@ public class ConfigHolder {
                 return null; // We found neither properties for the serviceName/portName or any default properties
             }
             if (debug) {
-                Tr.debug(tc, "getNameProps final result for nameame: " + name + " values: " + mergedProps);
+                Tr.debug(tc, "getNameProps final result for name: " + name + " values: " + mergedProps);
             }
 
             return mergedProps;


### PR DESCRIPTION
This PR does the following: 

1. Adds the `EnableSchemaValidationTest` to the `com.ibm.ws.jaxws.2.2.webcontainer_fat_extended` fat bucket. This tests the `<webServiceClient enableSchemaValidation="true/false" />` beta server.xml configuration.
2. Corrects the behavior of the `enableSchemaValidation` to properly disable CXF's default validation.