### PR TITLE
Use MP Fault Tolerance 4.1-RC1 API

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2972,6 +2972,11 @@
       <version>4.0.2</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+      <artifactId>microprofile-fault-tolerance-api</artifactId>
+      <version>4.1-RC1</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.microprofile.graphql</groupId>
       <artifactId>microprofile-graphql-api</artifactId>
       <version>1.0.2</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -590,6 +590,7 @@ org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.0.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:3.0
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:4.0.2
+org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:4.1-RC1
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.2
 org.eclipse.microprofile.graphql:microprofile-graphql-api:2.0
 org.eclipse.microprofile.health:microprofile-health-api:1.0

--- a/dev/io.openliberty.org.eclipse.microprofile/faulttolerance.4.1.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/faulttolerance.4.1.bnd
@@ -19,9 +19,9 @@ Export-Package: \
   org.eclipse.microprofile.faulttolerance.exceptions;version=1.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api;4.0.2;EXACT}
+  @${repo;org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api;4.1.0.RC1;EXACT}
 
 -maven-dependencies: \
-   dep1;groupId=org.eclipse.microprofile.fault-tolerance;artifactId=microprofile-fault-tolerance-api;version=4.0.2;scope=runtime
+   dep1;groupId=org.eclipse.microprofile.fault-tolerance;artifactId=microprofile-fault-tolerance-api;version=4.1-RC1;scope=runtime
 
 WS-TraceGroup: FAULTTOLERANCE


### PR DESCRIPTION
Doesn't actually have any changes since 4.0, but we should use the correct version anyway.
