### PR TITLE
Provide MPTel Porting Package

### DIFF
--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -115,4 +115,6 @@ fat.test.container.images: testcontainers/ryuk:0.6.0, testcontainers/sshd:1.1.0,
     org.seleniumhq.selenium:selenium-support;version=4.8.3,\
     io.openliberty.org.bouncycastle.bcpkix-jdk18on;version=latest,\
     io.openliberty.org.bouncycastle.bcprov-jdk18on;version=latest,\
-    io.openliberty.org.bouncycastle.bcutil-jdk18on;version=latest
+    io.openliberty.org.bouncycastle.bcutil-jdk18on;version=latest,\
+    io.openliberty.jakarta.concurrency.3.1;version=latest,\
+    io.openliberty.jakarta.annotation.3.0;version=latest

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/AbstractArchiveWeaver.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/AbstractArchiveWeaver.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,8 @@
 package com.ibm.ws.fat.util.tck;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -20,6 +22,7 @@ import java.util.logging.Logger;
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 /**
@@ -36,16 +39,41 @@ public abstract class AbstractArchiveWeaver implements ApplicationArchiveProcess
      */
     @Override
     public void process(Archive<?> applicationArchive, TestClass testClass) {
+
+        if (getJarsToWeave().isEmpty() && getClassesToWeave().isEmpty() && getStringFilesToWeave().isEmpty()) {
+            throw new IllegalStateException("Trying to weave into " + applicationArchive + " but had nothing to add");
+        }
+
         if (applicationArchive instanceof WebArchive) {
-            for (File file : getFilesToWeave()) {
+            for (File file : getJarsToWeave()) {
                 //File file = new File(WLP_DIR, "/usr/servers/FATServer/" + fileName);
                 LOG.log(Level.INFO, "WLP: Adding Jar: {0} to {1}", new String[] { file.getAbsolutePath(), applicationArchive.getName() });
                 ((WebArchive) applicationArchive).addAsLibraries(file);
+            }
+
+            for (Class clazz : getClassesToWeave()) {
+                LOG.log(Level.INFO, "WLP: Adding Class: {0} to {1}", new String[] { clazz.getName(), applicationArchive.getName() });
+                ((WebArchive) applicationArchive).addClass(clazz);
+            }
+
+            for (String path : getStringFilesToWeave().keySet()) {
+                LOG.log(Level.INFO, "WLP: Adding asset: {0} to {1}", new String[] { path, applicationArchive.getName() });
+                ((WebArchive) applicationArchive).addAsResource(getStringFilesToWeave().get(path), path);
             }
         } else {
             LOG.log(Level.INFO, "Attempted to add org.json jar(s) but {0} was not a WebArchive", applicationArchive);
         }
     }
 
-    protected abstract Set<File> getFilesToWeave();
+    protected Set<File> getJarsToWeave() {
+        return Collections.emptySet();
+    }
+
+    protected Map<String, StringAsset> getStringFilesToWeave() {
+        return Collections.emptyMap();
+    }
+
+    protected Set<Class<?>> getClassesToWeave() {
+        return Collections.emptySet();
+    }
 }

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/AbstractArchiveWeaver.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/AbstractArchiveWeaver.java
@@ -41,27 +41,27 @@ public abstract class AbstractArchiveWeaver implements ApplicationArchiveProcess
     public void process(Archive<?> applicationArchive, TestClass testClass) {
 
         if (getJarsToWeave().isEmpty() && getClassesToWeave().isEmpty() && getStringFilesToWeave().isEmpty()) {
-            throw new IllegalStateException("Trying to weave into " + applicationArchive + " but had nothing to add");
+            LOG.log(Level.INFO, getWeaverName() + ", Trying to weave into " + applicationArchive + " but had nothing to add");
         }
 
         if (applicationArchive instanceof WebArchive) {
             for (File file : getJarsToWeave()) {
                 //File file = new File(WLP_DIR, "/usr/servers/FATServer/" + fileName);
-                LOG.log(Level.INFO, "WLP: Adding Jar: {0} to {1}", new String[] { file.getAbsolutePath(), applicationArchive.getName() });
+                LOG.log(Level.INFO, getWeaverName() + ", WLP: Adding Jar: {0} to {1}", new String[] { file.getAbsolutePath(), applicationArchive.getName() });
                 ((WebArchive) applicationArchive).addAsLibraries(file);
             }
 
             for (Class clazz : getClassesToWeave()) {
-                LOG.log(Level.INFO, "WLP: Adding Class: {0} to {1}", new String[] { clazz.getName(), applicationArchive.getName() });
+                LOG.log(Level.INFO, getWeaverName() + ", WLP: Adding Class: {0} to {1}", new String[] { clazz.getName(), applicationArchive.getName() });
                 ((WebArchive) applicationArchive).addClass(clazz);
             }
 
             for (String path : getStringFilesToWeave().keySet()) {
-                LOG.log(Level.INFO, "WLP: Adding asset: {0} to {1}", new String[] { path, applicationArchive.getName() });
+                LOG.log(Level.INFO, getWeaverName() + ", WLP: Adding asset: {0} to {1}", new String[] { path, applicationArchive.getName() });
                 ((WebArchive) applicationArchive).addAsResource(getStringFilesToWeave().get(path), path);
             }
         } else {
-            LOG.log(Level.INFO, "Attempted to add org.json jar(s) but {0} was not a WebArchive", applicationArchive);
+            LOG.log(Level.INFO, getWeaverName() + ", Attempted to add org.json jar(s) but {0} was not a WebArchive", applicationArchive);
         }
     }
 
@@ -75,5 +75,9 @@ public abstract class AbstractArchiveWeaver implements ApplicationArchiveProcess
 
     protected Set<Class<?>> getClassesToWeave() {
         return Collections.emptySet();
+    }
+
+    protected String getWeaverName() {
+        return getClass().getName();
     }
 }

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/Hamcrest21ArchiveProcessor.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/Hamcrest21ArchiveProcessor.java
@@ -24,7 +24,7 @@ public class Hamcrest21ArchiveProcessor extends AbstractArchiveWeaver {
     private final Set<File> files = Collections.singleton(new File("../../../lib/hamcrest-2.1.jar"));
 
     @Override
-    protected Set<File> getFilesToWeave() {
+    protected Set<File> getJarsToWeave() {
         return files;
     }
 }

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/HamcrestArchiveProcessor.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/HamcrestArchiveProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 IBM Corporation and others.
+ * Copyright (c) 2018-2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,7 @@ public class HamcrestArchiveProcessor extends AbstractArchiveWeaver {
     private final Set<File> files = Collections.singleton(new File("../../../lib/hamcrest-all-1.3.jar"));
 
     @Override
-    protected Set<File> getFilesToWeave() {
+    protected Set<File> getJarsToWeave() {
         return files;
     }
 }

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/JettyArchivesProcessor.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/JettyArchivesProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 IBM Corporation and others.
+ * Copyright (c) 2018-2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ import java.util.Set;
 public class JettyArchivesProcessor extends AbstractArchiveWeaver {
 
     @Override
-    protected Set<File> getFilesToWeave() {
+    protected Set<File> getJarsToWeave() {
         File[] jettyFiles = new File(System.getProperty("wlp"), "/usr/servers/FATServer").listFiles((dir, name) -> name.startsWith("jetty-"));
         return new HashSet<>(Arrays.asList(jettyFiles));
     }

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/LibertyOpenTelemetryTCKExecutor.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/LibertyOpenTelemetryTCKExecutor.java
@@ -1,0 +1,29 @@
+package com.ibm.ws.fat.util.tck;
+
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+//Use jakarta because this code goes in applications and will not be transformed.
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+public class LibertyOpenTelemetryTCKExecutor implements Executor {
+
+    private static final Logger LOG = Logger.getLogger(LibertyOpenTelemetryTCKExecutor.class.getName());
+
+    @Override
+    public void execute(Runnable command) {
+        try {
+            ManagedExecutorService mes = (ManagedExecutorService) InitialContext.doLookup("java:comp/DefaultManagedExecutorService");
+            mes.execute(command);
+        } catch (NamingException e) {
+            Log.error(LibertyOpenTelemetryTCKExecutor.class, "execute", e);
+            throw new RuntimeException(e);
+        }
+
+    }
+
+}

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/OrgJsonArchiveProcessor.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/OrgJsonArchiveProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ public class OrgJsonArchiveProcessor extends AbstractArchiveWeaver {
                                                                    "/usr/servers/FATServer/json-20190722.jar"));
 
     @Override
-    protected Set<File> getFilesToWeave() {
+    protected Set<File> getJarsToWeave() {
         return files;
     }
 }

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/TCKArchiveModifications.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/TCKArchiveModifications.java
@@ -68,6 +68,13 @@ public enum TCKArchiveModifications implements ArchiveModification {
             LOG.log(Level.INFO, "WLP: Adding Extension com.ibm.ws.fat.util.tck.WiremockArchiveProcessor");
             extensionBuilder.service(ApplicationArchiveProcessor.class, WiremockArchiveProcessor.class);
         }
+    },
+    TELEMETRY_PORTING {
+        @Override
+        public void applyModification(ExtensionBuilder extensionBuilder) {
+            LOG.log(Level.INFO, "WLP: Adding Extension com.ibm.ws.fat.util.tck.TelemetryPortingArchiveProcessor");
+            extensionBuilder.service(ApplicationArchiveProcessor.class, TelemetryPortingArchiveProcessor.class);
+        }
     };
 
     private static final Logger LOG = Logger.getLogger(TCKArchiveModifications.class.getName());

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/TelemetryPortingArchiveProcessor.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/TelemetryPortingArchiveProcessor.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.fat.util.tck;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+
+/**
+ * Open Telemetry requires implementors of the TCK to provide a porting jar
+ */
+public class TelemetryPortingArchiveProcessor extends AbstractArchiveWeaver {
+
+    private static final String EXECUTOR_PROPERTY_NAME = "telemetry.tck.executor";
+    private static final String PATH = "META-INF/microprofile-telemetry-tck.properties";
+
+    @Override
+    protected Set<Class<?>> getClassesToWeave() {
+        Set<Class<?>> classes = new HashSet<Class<?>>();
+        classes.add(LibertyOpenTelemetryTCKExecutor.class);
+        return classes;
+    }
+
+    @Override
+    protected Map<String, StringAsset> getStringFilesToWeave() {
+        HashMap<String, StringAsset> map = new HashMap<String, StringAsset>();
+        StringAsset Stringasset = new StringAsset(EXECUTOR_PROPERTY_NAME + "=" + LibertyOpenTelemetryTCKExecutor.class.getName());
+        map.put(PATH, Stringasset);
+        return map;
+    }
+
+}

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/WiremockArchiveProcessor.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/WiremockArchiveProcessor.java
@@ -23,7 +23,7 @@ import java.util.Set;
 public class WiremockArchiveProcessor extends AbstractArchiveWeaver {
 
     @Override
-    protected Set<File> getFilesToWeave() {
+    protected Set<File> getJarsToWeave() {
         File[] wiremockFiles = new File(System.getProperty("wlp"), "/usr/servers/FATServer").listFiles((dir, name) -> name.startsWith("wiremock-standalone-"));
         return new HashSet<>(Arrays.asList(wiremockFiles));
     }


### PR DESCRIPTION
fixes #28902

This PR:

- Modifies the fattest.simplicty code for weaving into the TCK test apps so it can add jars, classes, or string files. Previously it could only do string files. 
- Uses the new feature to add a class and a string file to the Telemetry TCKs, this lets the tck use our ManagedExecutorService.
- Updates the pom.xml to for the telemetry TCK to include the stuff I needed to run the tests.