### PR TITLE
Change exception package replacement logic when processing FFDCs

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
@@ -684,22 +684,22 @@ public class FATRunner extends BlockJUnit4ClassRunner {
                 String[] exceptionClasses = ffdc.value();
                 if (RepeatTestFilter.isAnyRepeatActionActive()) {
                     RepeatTestAction repeatTestAction = RepeatTestFilter.getMostRecentRepeatAction();
-                    if (repeatTestAction instanceof JakartaEEAction && !((JakartaEEAction) repeatTestAction).isSkipTransformation()) {
-                        String[] jakarta9ReplacementExceptionClasses = new String[exceptionClasses.length];
-                        System.arraycopy(exceptionClasses, 0, jakarta9ReplacementExceptionClasses, 0, exceptionClasses.length);
-                        int index = 0;
-                        for (String exceptionClass : exceptionClasses) {
-                            if (ee9Helper == null) {
-                                ee9Helper = new EE9PackageReplacementHelper();
-                            }
-                            jakarta9ReplacementExceptionClasses[index++] = ee9Helper.replacePackages(exceptionClass);
-                        }
-                        exceptionClasses = jakarta9ReplacementExceptionClasses;
-                    }
+                    boolean doExceptionPackageReplacement = repeatTestAction instanceof JakartaEEAction && !((JakartaEEAction) repeatTestAction).isSkipTransformation();
                     for (String repeatAction : ffdc.repeatAction()) {
-                        if (repeatAction.equals(ExpectedFFDC.ALL_REPEAT_ACTIONS) || RepeatTestFilter.isRepeatActionActive(repeatAction)) {
+                        boolean isAllRepeatActions = repeatAction.equals(ExpectedFFDC.ALL_REPEAT_ACTIONS);
+                        boolean isSpecificRepeatAction = !isAllRepeatActions && RepeatTestFilter.isRepeatActionActive(repeatAction);
+                        if (isAllRepeatActions || isSpecificRepeatAction) {
                             for (String exceptionClass : exceptionClasses) {
-                                annotationListPerClass.add(exceptionClass);
+                                // If package replacement is disabled, or the ExpectedFFDC is for a specific repeat action, there is no need
+                                // to do the package replacement processing.
+                                if (!doExceptionPackageReplacement || isSpecificRepeatAction) {
+                                    annotationListPerClass.add(exceptionClass);
+                                } else {
+                                    if (ee9Helper == null) {
+                                        ee9Helper = new EE9PackageReplacementHelper();
+                                    }
+                                    annotationListPerClass.add(ee9Helper.replacePackages(exceptionClass));
+                                }
                             }
                         }
                     }
@@ -739,22 +739,22 @@ public class FATRunner extends BlockJUnit4ClassRunner {
                 String[] exceptionClasses = ffdc.value();
                 if (RepeatTestFilter.isAnyRepeatActionActive()) {
                     RepeatTestAction repeatTestAction = RepeatTestFilter.getMostRecentRepeatAction();
-                    if (repeatTestAction instanceof JakartaEEAction && !((JakartaEEAction) repeatTestAction).isSkipTransformation()) {
-                        String[] jakarta9ReplacementExceptionClasses = new String[exceptionClasses.length];
-                        System.arraycopy(exceptionClasses, 0, jakarta9ReplacementExceptionClasses, 0, exceptionClasses.length);
-                        int index = 0;
-                        for (String exceptionClass : exceptionClasses) {
-                            if (ee9Helper == null) {
-                                ee9Helper = new EE9PackageReplacementHelper();
-                            }
-                            jakarta9ReplacementExceptionClasses[index++] = ee9Helper.replacePackages(exceptionClass);
-                        }
-                        exceptionClasses = jakarta9ReplacementExceptionClasses;
-                    }
+                    boolean doExceptionPackageReplacement = repeatTestAction instanceof JakartaEEAction && !((JakartaEEAction) repeatTestAction).isSkipTransformation();
                     for (String repeatAction : ffdc.repeatAction()) {
-                        if (repeatAction.equals(AllowedFFDC.ALL_REPEAT_ACTIONS) || RepeatTestFilter.isRepeatActionActive(repeatAction)) {
+                        boolean isAllRepeatActions = repeatAction.equals(AllowedFFDC.ALL_REPEAT_ACTIONS);
+                        boolean isSpecificRepeatAction = !isAllRepeatActions && RepeatTestFilter.isRepeatActionActive(repeatAction);
+                        if (isAllRepeatActions || isSpecificRepeatAction) {
                             for (String exceptionClass : exceptionClasses) {
-                                annotationListPerClass.add(exceptionClass);
+                                // If package replacement is disabled, or the exception class is the default of all ffdc, or the AllowedFFDC is for
+                                // a specific repeat action, there is no need to do the package replacement processing.
+                                if (!doExceptionPackageReplacement || AllowedFFDC.ALL_FFDC.equals(exceptionClass) || isSpecificRepeatAction) {
+                                    annotationListPerClass.add(exceptionClass);
+                                } else {
+                                    if (ee9Helper == null) {
+                                        ee9Helper = new EE9PackageReplacementHelper();
+                                    }
+                                    annotationListPerClass.add(ee9Helper.replacePackages(exceptionClass));
+                                }
                             }
                         }
                     }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEEAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEEAction.java
@@ -374,9 +374,10 @@ public abstract class JakartaEEAction extends FeatureReplacementAction {
             classLoadError = e;
         }
         if (classLoadError != null || !new File(TRANSFORMER_RULES_ROOT).exists()) {
-            String mesg = "Unable to find the transformer rules OR failed to load the org.eclipse.transformer.cli.JakartaTransformerCLI class. \n" +
-                          "Did you include 'addRequiredLibraries.dependsOn addJakartaTransformer' in the FAT's build.gradle file?\n" +
-                          "If applications are already Jakarta-based, update to call setSkipTransformation(true) on your JakartaEEAction repeat action(s).";
+            String mesg = "Unable to find the transformer rules for doing package replacement for ExpectedFFDC and AllowedFFDC annotations.\n" +
+                          "IF applications are already Jakarta-based, update to call setSkipTransformation(true) on your JakartaEEAction repeat action(s)\n" +
+                          "or update MicroProfileActions or EERepeatActions repeat method call to pass true to a repeat method with a skipTransformation argument.\n" +
+                          "OTHERWISE, did you include 'addRequiredLibraries.dependsOn addJakartaTransformer' in the FAT's build.gradle file?";
             Log.error(c, m, classLoadError, mesg);
             throw new RuntimeException(mesg, classLoadError);
         }

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/build.gradle
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/build.gradle
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -44,5 +44,3 @@ addRequiredLibraries {
   dependsOn addWiremockAndJetty
   dependsOn addHttpcore
 }
-
-addRequiredLibraries.dependsOn addJakartaTransformer


### PR DESCRIPTION
- Add in error message so do not get a NullPointerException when addJakartaTransformer is not added to the FAT build.gradle file.
- If AllowFFDC is called allowing all FFDCs do not try to do package replacement on that so that addJakartaTransformer is not required.  This is a common scenario for TCK FATs that do repeats.
- Add additional details to the application transformation path for MicroProfileActions and EERepeatActions scenarios.
- Update a TCK fat to not depend on addJakartaTransformer to show this is working
