### PR TITLE
Enable Open Telemetry 2.0 TCK; DRAFT

### DIFF
--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/LibertyOpenTelemetryTCKExecutor.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/LibertyOpenTelemetryTCKExecutor.java
@@ -1,0 +1,29 @@
+package com.ibm.ws.fat.util.tck;
+
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+//Use jakarta because this code goes in applications and will not be transformed.
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+public class LibertyOpenTelemetryTCKExecutor implements Executor {
+
+    private static final Logger LOG = Logger.getLogger(LibertyOpenTelemetryTCKExecutor.class.getName());
+
+    @Override
+    public void execute(Runnable command) {
+        try {
+            ManagedExecutorService mes = (ManagedExecutorService) InitialContext.doLookup("java:comp/DefaultManagedExecutorService");
+            mes.execute(command);
+        } catch (NamingException e) {
+            Log.error(LibertyOpenTelemetryTCKExecutor.class, "execute", e);
+            throw new RuntimeException(e);
+        }
+
+    }
+
+}

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/TCKArchiveModifications.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/TCKArchiveModifications.java
@@ -68,6 +68,13 @@ public enum TCKArchiveModifications implements ArchiveModification {
             LOG.log(Level.INFO, "WLP: Adding Extension com.ibm.ws.fat.util.tck.WiremockArchiveProcessor");
             extensionBuilder.service(ApplicationArchiveProcessor.class, WiremockArchiveProcessor.class);
         }
+    },
+    TELEMETRY_PORTING {
+        @Override
+        public void applyModification(ExtensionBuilder extensionBuilder) {
+            LOG.log(Level.INFO, "WLP: Adding Extension com.ibm.ws.fat.util.tck.TelemetryPortingArchiveProcessor");
+            extensionBuilder.service(ApplicationArchiveProcessor.class, TelemetryPortingArchiveProcessor.class);
+        }
     };
 
     private static final Logger LOG = Logger.getLogger(TCKArchiveModifications.class.getName());

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/TelemetryPortingArchiveProcessor.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/tck/TelemetryPortingArchiveProcessor.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.fat.util.tck;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+
+/**
+ * Open Telemetry requires implementors of the TCK to provide a porting jar
+ */
+public class TelemetryPortingArchiveProcessor extends AbstractArchiveWeaver {
+
+    private static final String EXECUTOR_PROPERTY_NAME = "telemetry.tck.executor";
+    private static final String PATH = "META-INF/microprofile-telemetry-tck.properties";
+
+    @Override
+    protected Set<Class<?>> getClassesToWeave() {
+        Set<Class<?>> classes = new HashSet<Class<?>>();
+        classes.add(LibertyOpenTelemetryTCKExecutor.class);
+        return classes;
+    }
+
+    @Override
+    protected Map<String, StringAsset> getStringFilesToWeave() {
+        HashMap<String, StringAsset> map = new HashMap<String, StringAsset>();
+        StringAsset Stringasset = new StringAsset(EXECUTOR_PROPERTY_NAME + "=" + LibertyOpenTelemetryTCKExecutor.class.getName());
+        map.put(PATH, Stringasset);
+        return map;
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
 		<slf4j.version>2.0.6</slf4j.version>
 
         <opentelemetry.version>1.35.0</opentelemetry.version>
-        <mptelemetry.version>1.1</mptelemetry.version>
+        <mptelemetry.version>2.0-SNAPSHOT</mptelemetry.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>
@@ -62,8 +62,20 @@
         </dependency>
         
         <dependency>
-            <groupId>org.eclipse.microprofile.telemetry.tracing</groupId>
+            <groupId>org.eclipse.microprofile.telemetry</groupId>
             <artifactId>microprofile-telemetry-tracing-tck</artifactId>
+            <version>${mptelemetry.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.telemetry</groupId>
+            <artifactId>microprofile-telemetry-metrics-tck</artifactId>
+            <version>${mptelemetry.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.telemetry</groupId>
+            <artifactId>microprofile-telemetry-logs-tck</artifactId>
             <version>${mptelemetry.version}</version>
         </dependency>
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/tckRunner/tck/src/test/java/io/openliberty/microprofile/telemetry/test/ArquillianLoadableExtension.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/tckRunner/tck/src/test/java/io/openliberty/microprofile/telemetry/test/ArquillianLoadableExtension.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.test;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import com.ibm.ws.fat.util.tck.AbstractArquillianLoadableExtension;
+import com.ibm.ws.fat.util.tck.TCKArchiveModifications;
+
+public class ArquillianLoadableExtension extends AbstractArquillianLoadableExtension {
+    @Override
+    public Set<TCKArchiveModifications> getModifications() {
+        return EnumSet.of(TCKArchiveModifications.TEST_LOGGER, 
+                          TCKArchiveModifications.TELEMETRY_PORTING);
+    }
+}
+

--- a/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/tckRunner/tck/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/tckRunner/tck/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,1 +1,1 @@
-com.ibm.ws.fat.util.tck.BasicArquillianLoadableExtension
+io.openliberty.microprofile.telemetry.test.ArquillianLoadableExtension


### PR DESCRIPTION
This PR contains new needed to get the OpenTelemetry 2.0 TCK working in our FAT system.

It is not yet ready, for one thing there isn't even an upstream release of the TCK. But for now please include this in your local workspace when running snapshots of the OpenTelemetry 2.0 TCK