### PR TITLE
JAX-WS: Refactor service-ref logging webservices-bnd tests

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/WsBndServiceRefOverrideTest_Lite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/WsBndServiceRefOverrideTest_Lite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.BufferedReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
@@ -165,23 +164,6 @@ public class WsBndServiceRefOverrideTest_Lite {
         server.waitForStringInLog("CWWKZ0001I.*wsBndServiceRefOverride");
         String result = getServletResponse(getServletAddr());
         assertTrue("WSDL Location Override is not working, and the result is not expected: " + result, "Hello".equals(result));
-    }
-
-    @Test
-    public void testOverrideLogginInOutInterceptorPropertyCXFFeature() throws Exception {
-        TestUtils.publishFileToServer(server,
-                                      "WsBndServiceRefOverrideTest", "ibm-ws-bnd_testLoggingInOutInterceptorProp.xml",
-                                      "dropins/wsBndServiceRefOverride.war/WEB-INF/", "ibm-ws-bnd.xml");
-        String wsdlAddr = getDefaultEndpointAddr() + "?wsdl";
-        TestUtils.replaceServerFileString(server, "dropins/wsBndServiceRefOverride.war/WEB-INF/ibm-ws-bnd.xml", "#WSDL_LOCATION#", wsdlAddr);
-        server.startServer();
-        server.waitForStringInLog("CWWKZ0001I.*wsBndServiceRefOverride");
-        getServletResponse(getServletAddr());
-        List<String> dumpInMessages = server.findStringsInLogs("REQ_OUT");
-        List<String> dumpOutMessages = server.findStringsInLogs("RESP_IN");
-        assertTrue("Can't find inBoundMessage, the return inboundmessage is: " + dumpInMessages.toString(), !dumpInMessages.isEmpty());
-        assertTrue("Can't find outBoundMessage, the return outboundmessage is: " + dumpOutMessages.toString(), !dumpOutMessages.isEmpty());
-
     }
 
     protected String getServletResponse(String servletUrl) throws Exception {

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/WsBndServiceRefOverrideTest/ibm-ws-bnd_testLoggingInOutInterceptorProp.xml
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/publish/files/WsBndServiceRefOverrideTest/ibm-ws-bnd_testLoggingInOutInterceptorProp.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<webservices-bnd xmlns="http://websphere.ibm.com/xml/ns/javaee" 
-					  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-					  xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ws-bnd_1_0.xsd" version="1.0">
-  <service-ref name="service/SimpleEchoService" wsdl-location="#WSDL_LOCATION#">
-  <properties enableLoggingInOutInterceptor="true"/>
-    <port name="SimpleEchoPort" namespace="http://server.overriddenuri.test.ws.ibm.com/" />
-  </service-ref>
-</webservices-bnd>

--- a/dev/io.openliberty.jaxws.config_fat/.classpath
+++ b/dev/io.openliberty.jaxws.config_fat/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/simpleTestService/src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.jaxws.config_fat/.project
+++ b/dev/io.openliberty.jaxws.config_fat/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.jaxws.config_fat</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.jaxws.config_fat/bnd.bnd
+++ b/dev/io.openliberty.jaxws.config_fat/bnd.bnd
@@ -1,0 +1,44 @@
+#*******************************************************************************
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+          
+bVersion=1.0
+
+src: \
+	fat/src,\
+	test-applications/simpleTestService/src
+	
+fat.project: true
+
+# These features get added programmatically
+tested.features: \
+  jaxws-2.2,\
+  jaxws-2.3, \
+  jaxb-2.3, \
+  jsp-2.2, \
+  jsp-2.3, \
+  pages-3.0, \
+  servlet-5.0, \
+  xmlBinding-3.0, \
+  xmlWS-3.0, \
+  expressionlanguage-5.0, \
+  xmlws-4.0, \
+  xmlbinding-4.0, \
+  pages-3.1, \
+  servlet-6.0
+
+-buildpath: \
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
+	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
+	com.sun.xml.messaging.saaj:saaj-impl;version=1.4.0,\
+	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
+	com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
+	com.ibm.websphere.javaee.servlet.3.1;version=latest

--- a/dev/io.openliberty.jaxws.config_fat/build.gradle
+++ b/dev/io.openliberty.jaxws.config_fat/build.gradle
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+configurations {
+  junitdependencies
+}
+
+dependencies {
+  junitdependencies 'com.sun.xml.messaging.saaj:saaj-impl:1.4.0',
+  		'com.sun.xml.ws:policy:2.4',
+  		'com.sun.xml.stream.buffer:streambuffer:1.5.3',
+  		'com.sun.org.apache.xml.internal:resolver:20050927',
+  		'org.jvnet.staxex:stax-ex:1.7.7',
+  		'org.glassfish.gmbal:gmbal-api-only:4.0.3',
+  		'com.sun.xml.ws:jaxws-rt:2.3.6',
+  		'com.sun.xml.ws:jaxws-tools:2.3.6',
+  		'com.sun.xml.ws:policy:2.4',
+  		'com.sun.org.apache.xml.internal:resolver:20050927',
+  		'org.jvnet.staxex:stax-ex:1.7.7',
+  		'com.sun.xml.stream.buffer:streambuffer:1.5.3'
+}
+
+task addJunitdependencies(type: Copy) {
+  from configurations.junitdependencies
+  into "${buildDir}/autoFVT/lib/"
+}
+
+addRequiredLibraries {
+  dependsOn addJunitdependencies
+}
+
+addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/io.openliberty.jaxws.config_fat/fat/src/io/openliberty/jaxws/config/fat/FATSuite.java
+++ b/dev/io.openliberty.jaxws.config_fat/fat/src/io/openliberty/jaxws/config/fat/FATSuite.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jaxws.config.fat;
+
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+	WebServiceBndServiceRefPropertiesConfigTest.class,
+})
+public class FATSuite {
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11)).andWith(FeatureReplacementAction.EE10_FEATURES());
+
+}

--- a/dev/io.openliberty.jaxws.config_fat/fat/src/io/openliberty/jaxws/config/fat/WebServiceBndServiceRefPropertiesConfigTest.java
+++ b/dev/io.openliberty.jaxws.config_fat/fat/src/io/openliberty/jaxws/config/fat/WebServiceBndServiceRefPropertiesConfigTest.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jaxws.config.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPBody;
+import javax.xml.soap.SOAPConstants;
+import javax.xml.soap.SOAPElement;
+import javax.xml.soap.SOAPHeader;
+import javax.xml.soap.SOAPMessage;
+import javax.xml.ws.Dispatch;
+import javax.xml.ws.Service;
+import javax.xml.ws.soap.SOAPBinding;
+import javax.xml.ws.soap.SOAPFaultException;
+
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+/** 
+ * 
+ * This test class tests the <service-ref> configuration with the <webservices-bnd> binding configuration. 
+ * This configuration can be set in both the ibm-ws-bnd.xml and server.xml, so tests should cover both uses cases. 
+ * 
+ * Example of this configuration looks like this: 
+ * 
+ * <webservices-bnd >
+ *       <service-ref name="service/SimpleEchoService">
+ *             <properties enableLoggingInOutInterceptor="true" />
+ *       </service-ref>
+ * </webservices-bnd>
+ * 
+ * The service-ref name attribute must match the @WebServiceRef(name="sevice/SimpleEchoService") or the value in the <service-ref> DD for injection/JDNI look ups. 
+ * 
+ * These tests use a "serviceRef" request parameter to tell the test servlet which instance of the @WebServiceRef client to use, as each client is mapped
+ * to a specific configuration in either the ibm-ws-bnd.xml or server.xml files. Using multiple client instances prevents us from having to reload the server/application by changing
+ * config for the same client instance. 
+ * 
+ * We use the the @see com.ibm.ws.test.stubclient packages from the com.ibm.ws.jaxws.2.2.webcontainer_fat project for this test, with the modifications to 
+ * the @see com.ibm.ws.test.stubclient.client.SimpleStubClientServlet change to use cdi injected @WebServiceRef client, which this configuration requires. 
+ * 
+ * The test uses the @see com.ibm.ws.test.stubclient.SimpleEcho as the Web Service, which simply returns whatever string it was passed in the request back to the client
+ */
+@RunWith(FATRunner.class)
+public class WebServiceBndServiceRefPropertiesConfigTest {
+    @Server("WebServiceRefBndConfigTestServer")
+    public static LibertyServer server;
+
+    private static final String APP_NAME = "simpleTestService";
+
+    private static final String SERVLET_PATH = "/" + APP_NAME + "/SimpleStubClientServlet";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        ShrinkHelper.defaultApp(server, APP_NAME, "io.openliberty.jaxws.fat.stubclient",
+                                      "io.openliberty.jaxws.fat.stubclient.client");
+        server.startServer();
+        
+
+        assertNotNull("Application hello does not appear to have started.", server.waitForStringInLog("CWWKZ0001I:.*" + APP_NAME));
+    }
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+    
+    /**
+     * This tests configuring the enableLoggingInOutInterceptor=true in the server.xml file. This tests invokes the test servlet, which uses a @WebServiceRef service client
+     * to send a simple soap request to the SimpleEcho Web Service. 
+     * 
+     * If the configuration is properly applied, the inbound/outbound SOAP Request/Responses will show up in the logs with 
+     * the "REQ_OUT" "RESP_IN". The test verifies expected messages exist in the logs. 
+     * 
+     * 
+     * The test passes serviceRef="server" to tell the SimpleStubClientServlet to use the @WebServiceRef client that's bound to the <service-ref> in the server.xml file
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testEnableLoggingInOutInterceptorServer() throws Exception {
+
+
+    	   String serviceRef = "server";
+            String response = invokeService(serviceRef); // Call the SimpleStubClientServlet invoke the SimpleService Web Service
+            assertTrue("Expected response to contain Pass but contained: " + response, response.contains("Pass"));
+            
+            // Verify message.log contains the SOAP Message logging
+            List<String> dumpInMessages = server.findStringsInLogs("REQ_OUT");
+            List<String> dumpOutMessages = server.findStringsInLogs("RESP_IN");
+            assertTrue("Can't find inBoundMessage, the return inboundmessage is: " + dumpInMessages.toString(), !dumpInMessages.isEmpty());
+            assertTrue("Can't find outBoundMessage, the return outboundmessage is: " + dumpOutMessages.toString(), !dumpOutMessages.isEmpty());
+    }
+    
+    /**
+     * This tests configuring the enableLoggingInOutInterceptor=true in the ibm-ws-bnd.xml file. This tests invokes the test servlet, which uses a @WebServiceRef service client
+     * to send a simple soap request to the SimpleEcho Web Service. 
+     * 
+     * If the configuration is properly applied, the inbound/outbound SOAP Request/Responses will show up in the logs with 
+     * the "REQ_OUT" "RESP_IN". The test verifies expected messages exist in the logs. 
+     * 
+     * The test passes serviceRef="bnd" to tell the SimpleStubClientServlet to use the @WebServiceRef client that's bound to the <service-ref> in the ibm-ws-bnd.xml file
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testEnableLoggingInOutInterceptorIbmWsBnd() throws Exception {
+
+        	String serviceRef = "bnd";
+            String response = invokeService(serviceRef); // Call the SimpleStubClientServlet invoke the SimpleService Web Service
+            assertTrue("Expected response to contain Pass but contained: " + response, response.contains("Pass"));
+            
+
+            // Verify message.log contains the SOAP Message logging
+            List<String> dumpInMessages = server.findStringsInLogs("REQ_OUT");
+            List<String> dumpOutMessages = server.findStringsInLogs("RESP_IN");
+            assertTrue("Can't find inBoundMessage, the return inboundmessage is: " + dumpInMessages.toString(), !dumpInMessages.isEmpty());
+            assertTrue("Can't find outBoundMessage, the return outboundmessage is: " + dumpOutMessages.toString(), !dumpOutMessages.isEmpty());
+    }
+
+
+    /**
+     * util method to make HTTPUrlConnection to the test servlet
+     * @param serviceRef 
+     * 
+     * @returns: the response from the test servlet - SimpleStubClientServlet
+     */
+    private String invokeService(String serviceRef) throws Exception {
+        StringBuilder sBuilder = new StringBuilder("http://").append(server.getHostname()).append(":").append(server.getHttpDefaultPort()).append(SERVLET_PATH).append("?").append("serviceRef=").append(serviceRef);
+        String urlStr = sBuilder.toString();
+
+        HttpURLConnection con = HttpUtils.getHttpConnection(new URL(urlStr), HttpURLConnection.HTTP_OK, 5);
+        BufferedReader br = HttpUtils.getConnectionStream(con);
+        String line = br.readLine();
+        return line;
+
+    }
+
+
+}

--- a/dev/io.openliberty.jaxws.config_fat/publish/servers/WebServiceRefBndConfigTestServer/bootstrap.properties
+++ b/dev/io.openliberty.jaxws.config_fat/publish/servers/WebServiceRefBndConfigTestServer/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+# Uncomment for bnd proccessing trace
+#com.ibm.ws.logging.trace.specification=*=info=enabled:com.ibm.ws.jaxws.*=all=enabled:com.ibm.ws.javaee.ddmodel.wsbnd.*=all=enabled

--- a/dev/io.openliberty.jaxws.config_fat/publish/servers/WebServiceRefBndConfigTestServer/server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/servers/WebServiceRefBndConfigTestServer/server.xml
@@ -1,0 +1,20 @@
+<server>
+    <featureManager>
+        <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <webApplication name="simpleTestService" location="simpleTestService.war" context-root="simpleTestService">
+		<webservices-bnd>
+			<service-ref name="service/SimpleEchoServiceServer">
+				<properties enableLoggingInOutInterceptor="true" />
+			</service-ref>
+		</webservices-bnd>
+	</webApplication>
+    
+    <applicationManager autoExpand="true" />
+    
+    <javaPermission className="java.security.AllPermission" name="*" actions="*"/>
+</server>

--- a/dev/io.openliberty.jaxws.config_fat/test-applications/simpleTestService/resources/WEB-INF/ibm-ws-bnd.xml
+++ b/dev/io.openliberty.jaxws.config_fat/test-applications/simpleTestService/resources/WEB-INF/ibm-ws-bnd.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<webservices-bnd xmlns="http://websphere.ibm.com/xml/ns/javaee" 
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                      xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ws-bnd_1_0.xsd" version="1.0">
+                      
+            <service-ref name="service/SimpleEchoServiceBnd">
+				<properties enableLoggingInOutInterceptor="true"/>
+			</service-ref>
+</webservices-bnd>

--- a/dev/io.openliberty.jaxws.config_fat/test-applications/simpleTestService/src/io/openliberty/jaxws/fat/stubclient/SimpleEcho.java
+++ b/dev/io.openliberty.jaxws.config_fat/test-applications/simpleTestService/src/io/openliberty/jaxws/fat/stubclient/SimpleEcho.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jaxws.fat.stubclient;
+
+import javax.jws.WebService;
+
+@WebService
+public class SimpleEcho {
+
+    public String echo(String value) {
+        return value;
+    }
+}

--- a/dev/io.openliberty.jaxws.config_fat/test-applications/simpleTestService/src/io/openliberty/jaxws/fat/stubclient/client/SimpleEcho.java
+++ b/dev/io.openliberty.jaxws.config_fat/test-applications/simpleTestService/src/io/openliberty/jaxws/fat/stubclient/client/SimpleEcho.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jaxws.fat.stubclient.client;
+
+import javax.jws.WebMethod;
+import javax.jws.WebParam;
+import javax.jws.WebResult;
+import javax.jws.WebService;
+import javax.xml.ws.RequestWrapper;
+import javax.xml.ws.ResponseWrapper;
+
+@WebService(name = "SimpleEcho", targetNamespace = "http://stubclient.fat.jaxws.openliberty.io/")
+public interface SimpleEcho {
+
+    /**
+     *
+     * @param arg0
+     * @return
+     *         returns java.lang.String
+     */
+    @WebMethod
+    @WebResult(targetNamespace = "")
+    @RequestWrapper(localName = "echo", targetNamespace = "http://stubclient.fat.jaxws.openliberty.io/", className = "com.ibm.ws.test.stubclient.client.Echo")
+    @ResponseWrapper(localName = "echoResponse", targetNamespace = "http://stubclient.fat.jaxws.openliberty.io/", className = "com.ibm.ws.test.stubclient.client.EchoResponse")
+    public String echo(
+                       @WebParam(name = "arg0", targetNamespace = "") String arg0);
+
+}

--- a/dev/io.openliberty.jaxws.config_fat/test-applications/simpleTestService/src/io/openliberty/jaxws/fat/stubclient/client/SimpleEchoService.java
+++ b/dev/io.openliberty.jaxws.config_fat/test-applications/simpleTestService/src/io/openliberty/jaxws/fat/stubclient/client/SimpleEchoService.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jaxws.fat.stubclient.client;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Logger;
+
+import javax.xml.namespace.QName;
+import javax.xml.ws.Service;
+import javax.xml.ws.WebEndpoint;
+import javax.xml.ws.WebServiceClient;
+import javax.xml.ws.WebServiceFeature;
+
+@WebServiceClient(name = "SimpleEchoService", targetNamespace = "http://stubclient.fat.jaxws.openliberty.io/", wsdlLocation = "http://localhost:8010/simpleTestService/SimpleEchoService?wsdl")
+public class SimpleEchoService extends Service {
+
+    private final static URL SIMPLEECHOSERVICE_WSDL_LOCATION;
+    private final static Logger logger = Logger.getLogger(io.openliberty.jaxws.fat.stubclient.client.SimpleEchoService.class.getName());
+
+    static {
+        URL url = null;
+        try {
+            URL baseUrl;
+            baseUrl = io.openliberty.jaxws.fat.stubclient.client.SimpleEchoService.class.getResource(".");
+            url = new URL(baseUrl, new StringBuilder().append("http://localhost:").append(Integer.getInteger("bvt.prop.HTTP_default")).append("/simpleTestService/SimpleEchoService?wsdl").toString());
+            } catch (MalformedURLException e) {
+            logger.warning("Failed to create URL for the wsdl Location: " + new StringBuilder().append("http://localhost:").append(Integer.getInteger("bvt.prop.HTTP_default")).append("/simpleService/SimpleEchoService?wsdl").toString()+ ", retrying as a local file");
+            logger.warning(e.getMessage());
+        }
+        SIMPLEECHOSERVICE_WSDL_LOCATION = url;
+    }
+
+    public SimpleEchoService(URL wsdlLocation, QName serviceName) {
+        super(wsdlLocation, serviceName);
+    }
+
+    public SimpleEchoService() {
+        super(SIMPLEECHOSERVICE_WSDL_LOCATION, new QName("http://stubclient.fat.jaxws.openliberty.io/", "SimpleEchoService"));
+    }
+
+    /**
+     *
+     * @return
+     *         returns SimpleEcho
+     */
+    @WebEndpoint(name = "SimpleEchoPort")
+    public SimpleEcho getSimpleEchoPort() {
+        return super.getPort(new QName("http://stubclient.fat.jaxws.openliberty.io/", "SimpleEchoPort"), SimpleEcho.class);
+    }
+
+    /**
+     *
+     * @param features
+     *                     A list of {@link javax.xml.ws.WebServiceFeature} to configure on the proxy. Supported features not in the <code>features</code> parameter will have their
+     *                     default
+     *                     values.
+     * @return
+     *         returns SimpleEcho
+     */
+    @WebEndpoint(name = "SimpleEchoPort")
+    public SimpleEcho getSimpleEchoPort(WebServiceFeature... features) {
+        return super.getPort(new QName("http://stubclient.fat.jaxws.openliberty.io/", "SimpleEchoPort"), SimpleEcho.class, features);
+    }
+
+}

--- a/dev/io.openliberty.jaxws.config_fat/test-applications/simpleTestService/src/io/openliberty/jaxws/fat/stubclient/client/SimpleStubClientServlet.java
+++ b/dev/io.openliberty.jaxws.config_fat/test-applications/simpleTestService/src/io/openliberty/jaxws/fat/stubclient/client/SimpleStubClientServlet.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jaxws.fat.stubclient.client;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.ws.WebServiceRef;
+
+/*
+ * SimpleStubClientServlet is the endpoint that invokes the Web Service by
+ * using a "serviceRef" http request parameter passed by the test method.
+ * The servlet checks the value and uses it to determine which instance of the
+ * @WebServiceRef annotated service to use.
+ */
+@WebServlet("/SimpleStubClientServlet")
+public class SimpleStubClientServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 4838332634689830661L;
+
+    @WebServiceRef(name = "service/SimpleEchoServiceServer")
+    SimpleEchoService simpleEchoServiceServer;
+    
+
+    @WebServiceRef(name = "service/SimpleEchoServiceBnd")
+    SimpleEchoService simpleEchoServiceBnd;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        doPost(req, resp);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    	// name of the client to use for this test
+        String serviceRef = req.getParameter("serviceRef");
+        System.out.println("serviceRef = " + serviceRef);
+        SimpleEcho simpleEcho;
+        if(serviceRef.contains("bnd")) {
+        	
+            simpleEcho = simpleEchoServiceBnd.getSimpleEchoPort();
+            
+        } else {
+        
+        	simpleEcho = simpleEchoServiceServer.getSimpleEchoPort();
+        	System.out.println("Using SimpleEchoServiceServer");
+        }
+         
+        String response = simpleEcho.echo("echo");
+        if (response != null && response.equals("echo")) {
+            resp.getWriter().write("Pass");
+        } else {
+            resp.getWriter().write("Fail");
+        }
+    }
+}

--- a/dev/io.openliberty.jaxws.config_fat/test-applications/simpleTestService/src/io/openliberty/jaxws/fat/stubclient/client/package-info.java
+++ b/dev/io.openliberty.jaxws.config_fat/test-applications/simpleTestService/src/io/openliberty/jaxws/fat/stubclient/client/package-info.java
@@ -1,0 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://stubclient.fat.jaxws.openliberty.io/")
+package io.openliberty.jaxws.fat.stubclient.client;


### PR DESCRIPTION
This PR does the following:

1. Creates a new JAX-WS fat bucket for liberty specific configuration `io.openliberty.jaxws.config_fat`
2. Migrates the tests for the following configuration from the `WsBndServiceRefOverrideTest_Lite` to the new `WebServiceBndServiceRefPropertiesConfigTest`: 
```
		<webservices-bnd>
			<service-ref name="service/SimpleEchoServiceServer">
				<properties enableLoggingInOutInterceptor="true" />
			</service-ref>
		</webservices-bnd>
```
3. Refactors these tests to prevent the tests depending on reconfiguration of the application/server
4. Adds an additional tests for the configuration in the server.xml
