### PR TITLE
remove some workarounds to allow Jakarta Persistence 3.2 JPQL to be used in some cases

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -726,6 +726,36 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Repository delete method with query language (JPQL) that contains
+     * an entity identifier variable.
+     */
+    @Test
+    public void testDeleteQueryWithEntityIdentifierVariable() {
+        products.purge("TestDeleteQueryWithEntityIdentifierVariable-Product-%");
+
+        Product prod1 = new Product();
+        prod1.pk = UUID.nameUUIDFromBytes("TestDeleteQueryWithEntityIdentifierVariable-1".getBytes());
+        prod1.name = "TestDeleteQueryWithEntityIdentifierVariable-Product-1";
+        prod1.price = 1.99f;
+
+        Product prod2 = new Product();
+        prod2.pk = UUID.nameUUIDFromBytes("TestDeleteQueryWithEntityIdentifierVariable-2".getBytes());
+        prod2.name = "TestDeleteQueryWithEntityIdentifierVariable-Product-2";
+        prod2.price = 2.39f;
+
+        Product prod3 = new Product();
+        prod3.pk = UUID.nameUUIDFromBytes("TestDeleteQueryWithEntityIdentifierVariable-3".getBytes());
+        prod3.name = "TestDeleteQueryWithEntityIdentifierVariable-Product-3";
+        prod3.price = 3.89f;
+
+        products.saveMultiple(prod1, prod2, prod3);
+
+        assertEquals(3, products.purge("TestDeleteQueryWithEntityIdentifierVariable-Product-%"));
+
+        assertEquals(0, products.purge("TestDeleteQueryWithEntityIdentifierVariable-Product-%"));
+    }
+
+    /**
      * Unannotated entity with an attribute that is an embeddable type.
      */
     @SkipIfSysProp(DB_Postgres) //Failing on Postgres due to eclipselink issue.  https://github.com/OpenLiberty/open-liberty/issues/28380

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
@@ -48,6 +48,9 @@ public interface Products {
 
     Optional<Product> findByPK(UUID id);
 
+    @Query("DELETE FROM Product p WHERE p.name LIKE ?1")
+    int purge(String namePattern);
+
     @Query("UPDATE Product SET price = price - (?2 * price) WHERE name LIKE CONCAT('%', ?1, '%')")
     long putOnSale(String nameContains, float discount);
 


### PR DESCRIPTION
Attempt to remove some workarounds that convert JDQL/JPQL back to 3.1 form.
Unfortunately, there are still a lot of EclipseLink bugs in JPQL for v3.2 around syntax that is compatible with JDQL, so most queries still require workarounds.  This PR aims to at least remove some workarounds where possible while we wait for bug fixes for the others.
Also, this adds a test case for JPQL DELETE in `@Query` which was missing.