### PR TITLE
Added a wait for FFDC to be produced so that it doesn't leak into another test

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPJava17Test.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPJava17Test.java
@@ -198,10 +198,10 @@ public class JSPJava17Test {
         assertTrue("The response did not contain: success", response.getText().contains("success-text-block"));
         assertTrue("The response did not contain: success", response.getText().contains("success-pattern-matching"));
 
-        //Wait for FFDC to be produced so that it doesn't leak into another test when Jakarta EE 11 and Later is not active
+        //Wait for FFDC to be produced when Java 2 Security is enabled so that it doesn't leak into another test when Jakarta EE 11 and later is not active
         //Java2 Security is not enabled for Jakarta EE11 and above
 
-        if (!JakartaEEAction.isEE11OrLaterActive()){
+        if (!JakartaEEAction.isEE11OrLaterActive() && server.isJava2SecurityEnabled()){
             assertTrue("The expected FFDC was not produced!",server.waitForStringInLogUsingMark("FFDC1015I")!=null);
         }
     }

--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPJava17Test.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPJava17Test.java
@@ -33,6 +33,7 @@ import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
+import componenttest.rules.repeater.JakartaEEAction;
 
 /**
  * JSP 2.3 tests which use Java 17 specific features.
@@ -196,6 +197,13 @@ public class JSPJava17Test {
                      200, response.getResponseCode());
         assertTrue("The response did not contain: success", response.getText().contains("success-text-block"));
         assertTrue("The response did not contain: success", response.getText().contains("success-pattern-matching"));
+
+        //Wait for FFDC to be produced so that it doesn't leak into another test when Jakarta EE 11 and Later is not active
+        //Java2 Security is not enabled for Jakarta EE11 and above
+
+        if (!JakartaEEAction.isEE11OrLaterActive()){
+            assertTrue("The expected FFDC was not produced!",server.waitForStringInLogUsingMark("FFDC1015I")!=null);
+        }
     }
 
     /**


### PR DESCRIPTION
When running the com.ibm.ws.jsp23.fat.tests FAT bucket locally, the Java17Test class throws a java.security.PrevilegedActionException. To stop this, a wait for the FFDC was introduced in the test so that it doesn't leak into the next test

