### PR TITLE
Test checkpoint variable substitution for JDBC DS on restore

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleCheckpointTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleCheckpointTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jdbc.fat.oracle;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.testcontainers.oracle.OracleContainer;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.CheckpointTest;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+import web.OracleTestServlet;
+
+@CheckpointTest
+@RunWith(FATRunner.class)
+public class OracleCheckpointTest {
+    public static final String JEE_APP = "oraclejdbcfat";
+    public static final String SERVLET_NAME = "OracleTestServlet";
+
+    @Server("com.ibm.ws.jdbc.fat.oracle")
+    @TestServlet(servlet = OracleTestServlet.class, path = JEE_APP + "/" + SERVLET_NAME)
+    public static LibertyServer server;
+
+    public static final OracleContainer oracle = FATSuite.createOracleContainer();
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // Set server environment variables
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put("ORACLE_URL", oracle.getJdbcUrl());
+        envVars.put("ORACLE_USER", oracle.getUsername());
+        envVars.put("ORACLE_PASSWORD", oracle.getPassword());
+        envVars.put("ORACLE_DBNAME", oracle.getSid());
+        envVars.put("ORACLE_PORT", Integer.toString(oracle.getFirstMappedPort()));
+        envVars.put("ORACLE_HOST", oracle.getHost());
+
+        // Create a normal Java EE application and export to server
+        ShrinkHelper.defaultApp(server, JEE_APP, "web");
+
+        server.setCheckpoint(CheckpointPhase.AFTER_APP_START, false, null);
+
+        // Start Server
+        server.startServer();
+
+        server.addEnvVarsForCheckpoint(envVars);
+
+        server.checkpointRestore();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server.isStarted()) {
+            server.stopServer();
+        }
+        if (oracle.isRunning()) {
+            oracle.stop();
+        }
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
@@ -12,7 +12,7 @@
  -->
 <server>
     <featureManager>
-      <feature>servlet-3.1</feature>
+      <feature>servlet-4.0</feature>
       <feature>jdbc-4.2</feature>
       <feature>jndi-1.0</feature>
       <feature>componenttest-1.0</feature>
@@ -34,29 +34,30 @@
     
     <dataSource id="DefaultDataSource">
     	<jdbcDriver libraryRef="DBLib"/>
-    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
+    	<properties.oracle URL="${ORACLE_URL}" user="${ORACLE_USER}" password="${ORACLE_PASSWORD}"/>
     </dataSource>
 
     <dataSource id="casting-ds" jndiName="jdbc/casting-ds" enableConnectionCasting="true">
     	<jdbcDriver libraryRef="DBLib"/>
-    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" roleName="TestRole"/>
+    	<properties.oracle URL="${ORACLE_URL}" user="${ORACLE_USER}" password="${ORACLE_PASSWORD}" roleName="TestRole"/>
     	<onConnect>UPDATE CONCOUNT SET NUMCONNECTIONS = NUMCONNECTIONS + 1</onConnect>
     	<onConnect>CREATE GLOBAL TEMPORARY TABLE ${TEMP_TABLE_NAME}(CURTIME NVARCHAR2(100)) ON COMMIT PRESERVE ROWS</onConnect>
     	<onConnect>INSERT INTO ${TEMP_TABLE_NAME} VALUES (CURRENT_TIMESTAMP)</onConnect>
     </dataSource>
     
     <dataSource id="driver-ds" jndiName="jdbc/driver-ds" type="java.sql.Driver">
-    	<properties.oracle URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
+    	<properties.oracle URL="${ORACLE_URL}" user="${ORACLE_USER}" password="${ORACLE_PASSWORD}"/>
     	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
     <dataSource id="generic-driver-ds" jndiName="jdbc/generic-driver-ds">
-    	<properties URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"/>
+    	<properties URL="${ORACLE_URL}" user="${ORACLE_USER}" password="${ORACLE_PASSWORD}"/>
     	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
+    <variable name="ORACLE_PORT" defaultValue="9999" />
     <dataSource id="inferred-ds" jndiName="jdbc/inferred-ds">
-    	<properties databaseName="${env.ORACLE_DBNAME}" portNumber="${env.ORACLE_PORT}" serverName="${env.ORACLE_HOST}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" driverType="thin"/>
+    	<properties databaseName="${ORACLE_DBNAME}" portNumber="${ORACLE_PORT}" serverName="${ORACLE_HOST}" user="${ORACLE_USER}" password="${ORACLE_PASSWORD}" driverType="thin"/>
     	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
@@ -66,7 +67,7 @@
     <dataSource id="driver-url-preferred" jndiName="jdbc/driver-url-preferred" type="java.sql.Driver">
       <jdbcDriver libraryRef="DBLib"/>
       <containerAuthData user="${ORACLE_USER}" password="${ORACLE_PASSWORD}"/>
-      <properties.oracle url="jdbc:oracle:thin:@${env.ORACLE_HOST}:${env.ORACLE_PORT}:${env.ORACLE_DBNAME}"
+      <properties.oracle url="jdbc:oracle:thin:@${ORACLE_HOST}:${ORACLE_PORT}:${ORACLE_DBNAME}"
       serverName="$INVALID" portNumber="000" serviceName="$INVALID"/> <!-- Should be ignored -->
     </dataSource>
     
@@ -76,7 +77,7 @@
     <dataSource id="ds-url-preferred" jndiName="jdbc/ds-url-preferred" type="javax.sql.DataSource">
       <jdbcDriver libraryRef="DBLib"/>
       <containerAuthData user="${ORACLE_USER}" password="${ORACLE_PASSWORD}"/>
-      <properties.oracle URL="jdbc:oracle:thin:@${env.ORACLE_HOST}:${env.ORACLE_PORT}:${env.ORACLE_DBNAME}"
+      <properties.oracle URL="jdbc:oracle:thin:@${ORACLE_HOST}:${ORACLE_PORT}:${ORACLE_DBNAME}"
       serverName="$INVALID" portNumber="000" serviceName="$INVALID"/> <!-- Should be ignored -->
     </dataSource>
     

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -61,6 +61,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Scanner;
 import java.util.Set;
@@ -541,6 +542,27 @@ public class LibertyServer implements LogMonitorClient {
             checkpointInfo.checkpointRegexIgnoreMessages.add(regEx);
         }
         return this;
+    }
+
+    public void addEnvVarsForCheckpoint(Map<String, String> props) throws Exception {
+        File serverEnvFile;
+        if (fileExistsInLibertyServerRoot("server.env")) {
+            serverEnvFile = new File(getFileFromLibertyServerRoot("server.env").getAbsolutePath());
+        } else {
+            serverEnvFile = new File(getServerRoot() + "/" + "server.env");
+            serverEnvFile.createNewFile();
+        }
+        Properties mergeProps = new Properties();
+        try (InputStream in = new FileInputStream(serverEnvFile)) {
+            mergeProps.load(in);
+        }
+        mergeProps.putAll(props);
+        try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(serverEnvFile), "8859_1"))) {
+            for (Entry<Object, Object> entry : mergeProps.entrySet()) {
+                bw.write(entry.getKey() + "=" + entry.getValue());
+                bw.newLine();
+            }
+        }
     }
 
     public static class CheckpointInfo {

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
@@ -12,12 +12,8 @@
  *******************************************************************************/
 package test.jakarta.data;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.OutputStream;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import jakarta.enterprise.inject.spi.Extension;
@@ -79,12 +75,15 @@ public class DataTestCheckpoint extends FATServletClient {
                         .addAsLibrary(providerJar);
         ShrinkHelper.exportAppToServer(server, providerWar);
 
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
+
         server.setCheckpoint(CheckpointPhase.AFTER_APP_START, false, null);
         server.startServer();
 
         //Server started, application started, checkpoint taken, server is now stopped.
         //Configure environment variable used by servlet
-        configureEnvVariable(server, Collections.singletonMap("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName()));
+        server.addEnvVarsForCheckpoint(envVars);
 
         server.checkpointRestore();
     }
@@ -92,14 +91,5 @@ public class DataTestCheckpoint extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer();
-    }
-
-    static void configureEnvVariable(LibertyServer server, Map<String, String> newEnv) throws Exception {
-        Properties serverEnvProperties = new Properties();
-        serverEnvProperties.putAll(newEnv);
-        File serverEnvFile = new File(server.getFileFromLibertyServerRoot("server.env").getAbsolutePath());
-        try (OutputStream out = new FileOutputStream(serverEnvFile)) {
-            serverEnvProperties.store(out, "");
-        }
     }
 }

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.checkpoint.fat/server.env
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.checkpoint.fat/server.env
@@ -1,1 +1,0 @@
-# Placeholder for server environment variables after checkpoint

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATestCheckpoint.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATestCheckpoint.java
@@ -12,12 +12,8 @@
  *******************************************************************************/
 package test.jakarta.data.jpa;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.OutputStream;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -61,14 +57,15 @@ public class DataJPATestCheckpoint extends FATServletClient {
         WebArchive war = ShrinkHelper.buildDefaultApp("DataJPATestApp", "test.jakarta.data.jpa.web");
         ShrinkHelper.exportAppToServer(server, war);
 
-        configureEnvVariable(server, Collections.singletonMap("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName()));
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
 
         server.setCheckpoint(CheckpointPhase.AFTER_APP_START, false, null);
         server.startServer();
 
         //Server started, application started, checkpoint taken, server is now stopped.
         //Configure environment variable used by servlet
-        configureEnvVariable(server, Collections.singletonMap("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName()));
+        server.addEnvVarsForCheckpoint(envVars);
 
         server.checkpointRestore();
     }
@@ -76,14 +73,5 @@ public class DataJPATestCheckpoint extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer();
-    }
-
-    static void configureEnvVariable(LibertyServer server, Map<String, String> newEnv) throws Exception {
-        Properties serverEnvProperties = new Properties();
-        serverEnvProperties.putAll(newEnv);
-        File serverEnvFile = new File(server.getFileFromLibertyServerRoot("server.env").getAbsolutePath());
-        try (OutputStream out = new FileOutputStream(serverEnvFile)) {
-            serverEnvProperties.store(out, "");
-        }
     }
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.checkpoint.fat.jpa/server.env
+++ b/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.checkpoint.fat.jpa/server.env
@@ -1,1 +1,0 @@
-# Placeholder for server environment variables after checkpoint


### PR DESCRIPTION
With a parameterized server.xml only set the environment values after checkpoint.  On restore varify the DS is updated properly.