### PR TITLE
Issue #24949: Richer APIs for user information

### DIFF
--- a/dev/com.ibm.websphere.security/src/com/ibm/websphere/security/AttributeReader.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/websphere/security/AttributeReader.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.security;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Defines read-only API contract for UserRegistry implementations.
+ * Methods must not have side-effects which alter contents of the UserRegistry.
+ * UserRegistry implementations must support dynamic configuration updates.
+ */
+public interface AttributeReader {
+
+    /**
+     * Returns the attributes for <i>userSecurityName</i>.
+     *
+     * @param userSecurityName the name of the user.
+     * @param attributeNames
+     * @return a Map of attributes for the user.
+     *         <code>null</code> is not returned.
+     * @exception EntryNotFoundException  if userSecurityName does not exist.
+     * @exception CustomRegistryException if there is any registry specific problem
+     **/
+    Map<String, Object> getAttributesForUser(String userSecurityName, List<String> attributeNames) throws EntryNotFoundException, CustomRegistryException;
+
+    /**
+     * Gets a list of users that match an <i>attributeName</i> with specified
+     * <i>value</i> in the UserRegistry.
+     * The maximum number of users returned is defined by the <i>limit</i>
+     * argument. This is very useful in situations where there are thousands of
+     * users in the UserRegistry and getting all of them at once is not
+     * practical.
+     *
+     * @param attributeName the attributeName to match.
+     * @param value         the value of the attributeName to match.
+     * @param limit         the maximum number of users that should be returned.
+     *                          A value of 0 implies get all the users.
+     *                          Specifying a negative value returns an empty Result.
+     * @return a <i>Result</i> object that contains the list of users
+     *         requested and a flag to indicate if more users exist.
+     *         <code>null</code> is not returned.
+     * @exception CustomRegistryException if there is any UserRegistry specific problem
+     **/
+    Result findUsersByAttribute(String attributeName, String value, int limit) throws CustomRegistryException;
+
+}

--- a/dev/com.ibm.ws.security.registry/src/com/ibm/ws/security/registry/AttributeReader.java
+++ b/dev/com.ibm.ws.security.registry/src/com/ibm/ws/security/registry/AttributeReader.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.registry;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Defines read-only API contract for UserRegistry implementations.
+ * Methods must not have side-effects which alter contents of the UserRegistry.
+ * UserRegistry implementations must support dynamic configuration updates.
+ */
+public interface AttributeReader {
+
+    /**
+     * Returns the attributes for <i>userSecurityName</i>.
+     *
+     * @param userSecurityName the name of the user.
+     * @param attributeNames
+     * @return a Map of attributes for the user.
+     *         <code>null</code> is not returned.
+     * @exception EntryNotFoundException   if uniqueUserId does not exist.
+     * @exception RegistryException        if there is any UserRegistry specific problem
+     * @exception IllegalArgumentException if userSecurityName is <code>null</code> or empty
+     **/
+    Map<String, Object> getAttributesForUser(String userSecurityName, List<String> attributeNames) throws EntryNotFoundException, RegistryException;
+
+    /**
+     * Gets a list of users that match an <i>attributeName</i> with specified
+     * <i>value</i> in the UserRegistry.
+     * The maximum number of users returned is defined by the <i>limit</i>
+     * argument. This is very useful in situations where there are thousands of
+     * users in the UserRegistry and getting all of them at once is not
+     * practical.
+     *
+     * @param attributeName the attributeName to match.
+     * @param value         the value of the attributeName to match.
+     * @param limit         the maximum number of users that should be returned.
+     *                          A value of 0 implies get all the users.
+     *                          Specifying a negative value returns an empty SearchResult.
+     * @return a <i>SearchResult</i> object that contains the list of users
+     *         requested and a flag to indicate if more users exist.
+     *         <code>null</code> is not returned.
+     * @exception RegistryException        if there is any UserRegistry specific problem
+     * @exception IllegalArgumentException if attributeName is <code>null</code> or empty
+     * @exception IllegalArgumentException if value is <code>null</code> or empty
+     **/
+    SearchResult findUsersByAttribute(String attributeName, String value, int limit) throws RegistryException;
+
+}

--- a/dev/com.ibm.ws.security.registry/src/com/ibm/ws/security/registry/internal/UserRegistryOpenWrapper.java
+++ b/dev/com.ibm.ws.security.registry/src/com/ibm/ws/security/registry/internal/UserRegistryOpenWrapper.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.registry.internal;
+
+import java.util.List;
+import java.util.Map;
+
+import com.ibm.websphere.security.CustomRegistryException;
+import com.ibm.websphere.security.EntryNotFoundException;
+import com.ibm.websphere.security.Result;
+import com.ibm.ws.security.registry.AttributeReader;
+import com.ibm.ws.security.registry.RegistryException;
+import com.ibm.ws.security.registry.SearchResult;
+import com.ibm.ws.security.registry.UserRegistry;
+
+public class UserRegistryOpenWrapper extends UserRegistryWrapper implements com.ibm.websphere.security.AttributeReader {
+    private final AttributeReader wrappedUrAttr;
+
+    public UserRegistryOpenWrapper(UserRegistry wrappedUr) {
+        super(wrappedUr);
+        if (wrappedUr instanceof AttributeReader) {
+            wrappedUrAttr = (AttributeReader) wrappedUr;
+        } else {
+            throw new IllegalArgumentException();
+
+        }
+    }
+
+    @Override
+    public Map<String, Object> getAttributesForUser(String userSecurityName, List<String> attributeNames) throws EntryNotFoundException, CustomRegistryException {
+        try {
+            return wrappedUrAttr.getAttributesForUser(userSecurityName, attributeNames);
+        } catch (RegistryException e) {
+            throw new CustomRegistryException(e.getMessage(), e);
+        } catch (com.ibm.ws.security.registry.EntryNotFoundException e) {
+            throw new EntryNotFoundException(e.getMessage(), e);
+        }
+
+    }
+
+    @Override
+    public Result findUsersByAttribute(String attributeName, String value, int limit) throws CustomRegistryException {
+        try {
+            SearchResult ret = wrappedUrAttr.findUsersByAttribute(attributeName, value, limit);
+            Result result = new Result();
+            result.setList(ret.getList());
+            if (ret.hasMore()) {
+                result.setHasMore();
+            }
+            return result;
+
+        } catch (RegistryException e) {
+            throw new CustomRegistryException(e.getMessage(), e);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.registry/src/com/ibm/ws/security/registry/internal/UserRegistryServiceImpl.java
+++ b/dev/com.ibm.ws.security.registry/src/com/ibm/ws/security/registry/internal/UserRegistryServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ import com.ibm.ws.bnd.metatype.annotation.Ext;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.service.util.ServiceRegistrationModifier;
 import com.ibm.ws.kernel.service.util.ServiceRegistrationModifier.ServicePropertySupplier;
+import com.ibm.ws.security.registry.AttributeReader;
 import com.ibm.ws.security.registry.ExternalUserRegistryWrapper;
 import com.ibm.ws.security.registry.FederationRegistry;
 import com.ibm.ws.security.registry.RegistryException;
@@ -602,6 +603,8 @@ public class UserRegistryServiceImpl implements UserRegistryService, ServiceProp
     public com.ibm.websphere.security.UserRegistry getExternalUserRegistry(UserRegistry userRegistry) {
         if (userRegistry instanceof ExternalUserRegistryWrapper) {
             return ((ExternalUserRegistryWrapper) userRegistry).getExternalUserRegistry();
+        } else if (userRegistry instanceof AttributeReader) {
+            return new UserRegistryOpenWrapper(userRegistry);
         }
         return new UserRegistryWrapper(userRegistry);
     }

--- a/dev/com.ibm.ws.security.wim.registry/src/com/ibm/ws/security/wim/registry/WIMUserRegistry.java
+++ b/dev/com.ibm.ws.security.wim.registry/src/com/ibm/ws/security/wim/registry/WIMUserRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,6 +32,7 @@ import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.bnd.metatype.annotation.Ext;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.registry.AttributeReader;
 import com.ibm.ws.security.registry.CertificateMapFailedException;
 import com.ibm.ws.security.registry.CertificateMapNotSupportedException;
 import com.ibm.ws.security.registry.CustomRegistryException;
@@ -65,7 +66,7 @@ interface WIMUserRegistryConfig {
  */
 //TODO policy REQUIRE when we count this....
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true, property = { "service.vendor=IBM", "com.ibm.ws.security.registry.type=WIM" })
-public class WIMUserRegistry implements FederationRegistry, UserRegistry {
+public class WIMUserRegistry implements FederationRegistry, UserRegistry, AttributeReader {
 
     private static final TraceComponent tc = Tr.register(WIMUserRegistry.class);
 
@@ -549,5 +550,35 @@ public class WIMUserRegistry implements FederationRegistry, UserRegistry {
     @Override
     public void removeAllFederatedRegistries() {
         mappingUtils.removeAllFederatedRegistries();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Map<String, Object> getAttributesForUser(final String userSecurityName, List<String> attributeNames) throws EntryNotFoundException, RegistryException {
+        Map<String, Object> returnValue = null;
+        try {
+            returnValue = searchBridge.getAttributesForUser(userSecurityName, attributeNames);
+        } catch (Exception excp) {
+            if (excp instanceof RegistryException)
+                throw (RegistryException) excp;
+            else
+                throw new RegistryException(excp.getMessage(), excp);
+        }
+
+        return returnValue;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SearchResult findUsersByAttribute(String attributeName, String value, int limit) throws RegistryException {
+        try {
+            SearchResult returnValue = searchBridge.findUsersByAttribute(attributeName, value, limit);
+            return returnValue;
+        } catch (Exception excp) {
+            if (excp instanceof RegistryException)
+                throw (RegistryException) excp;
+            else
+                throw new RegistryException(excp.getMessage(), excp);
+        }
     }
 }

--- a/dev/com.ibm.ws.security.wim.registry/test/com/ibm/ws/security/wim/registry/WIMUserRegistryTest.java
+++ b/dev/com.ibm.ws.security.wim.registry/test/com/ibm/ws/security/wim/registry/WIMUserRegistryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -736,5 +737,142 @@ public class WIMUserRegistryTest {
             String errorMessage = e.getMessage();
             assertEquals("Call completed successfully", true, false + " with " + errorMessage);
         }
+    }
+
+    @Test
+    public void testFindUsersByAttribute() throws Exception {
+        Map<String, Object> urProps = new HashMap<String, Object>();
+        UR = newWIMUR(urProps);
+        WIMUserRegistry WIMUR = (WIMUserRegistry) UR;
+
+        SearchResult result = WIMUR.findUsersByAttribute("uid", "user1", 10);
+        List<String> resultList = result.getList();
+
+        int i = resultList.size();
+
+        assertEquals("Number of members mismatched", 1, i);
+        assertEquals("CN Mismatched", "uid=user1,o=defaultWIMFileBasedRealm", resultList.get(0));
+    }
+
+    @Test
+    public void testFindUsersByAttributeNameNull() {
+        try {
+            Map<String, Object> urProps = new HashMap<String, Object>();
+            UR = newWIMUR(urProps);
+            WIMUserRegistry WIMUR = (WIMUserRegistry) UR;
+
+            WIMUR.findUsersByAttribute(null, "test", 10);
+            fail("expected fail");
+        } catch (Exception e) {
+            String errorMessage = e.getMessage();
+            assertEquals("Incorrect exception thrown", RegistryException.class, e.getClass());
+            assertEquals("The error code for RegistryException", null, errorMessage);
+        }
+    }
+
+    @Test
+    public void testFindUsersByAttributeValueNull() {
+        try {
+            Map<String, Object> urProps = new HashMap<String, Object>();
+            UR = newWIMUR(urProps);
+            WIMUserRegistry WIMUR = (WIMUserRegistry) UR;
+
+            WIMUR.findUsersByAttribute("uid", null, 10);
+            fail("expected fail");
+        } catch (Exception e) {
+            String errorMessage = e.getMessage();
+            assertEquals("Incorrect exception thrown", RegistryException.class, e.getClass());
+            assertEquals("The error code for RegistryException", null, errorMessage);
+        }
+    }
+
+    @Test
+    public void testGetAllAttributesForUser() throws Exception {
+        Map<String, Object> urProps = new HashMap<String, Object>();
+        UR = newWIMUR(urProps);
+        WIMUserRegistry WIMUR = (WIMUserRegistry) UR;
+
+        List<String> attrList = new ArrayList();
+        attrList.add("*");
+        Map<String, Object> result = WIMUR.getAttributesForUser("user1", attrList);
+
+        int i = result.size();
+
+        assertEquals("Number of attributes mismatched", 5, i);
+        assertEquals("SN Mismatched", "user1", result.get("sn"));
+        assertEquals("CN Mismatched", "user1", result.get("cn"));
+    }
+
+    @Test
+    public void testGetAttributesForUser() throws Exception {
+        Map<String, Object> urProps = new HashMap<String, Object>();
+        UR = newWIMUR(urProps);
+        WIMUserRegistry WIMUR = (WIMUserRegistry) UR;
+
+        List<String> attrList = new ArrayList();
+        attrList.add("sn");
+        attrList.add("cn");
+        attrList.add("");
+        Map<String, Object> result = WIMUR.getAttributesForUser("user1", attrList);
+
+        int i = result.size();
+
+        assertEquals("Number of attributes mismatched", 2, i);
+        assertEquals("SN Mismatched", "user1", result.get("sn"));
+        assertEquals("CN Mismatched", "user1", result.get("cn"));
+    }
+
+    @Test
+    public void testNotSetAttributeForUser() throws Exception {
+        Map<String, Object> urProps = new HashMap<String, Object>();
+        UR = newWIMUR(urProps);
+        WIMUserRegistry WIMUR = (WIMUserRegistry) UR;
+
+        List<String> attrList = new ArrayList();
+        attrList.add("title");
+        attrList.add("mail");
+        Map<String, Object> result = WIMUR.getAttributesForUser("user1", attrList);
+
+        int i = result.size();
+
+        assertEquals("Number of attributes mismatched", 0, i);
+    }
+
+    @Test
+    public void testGetAttributesForUserNull() throws Exception {
+        try {
+	        Map<String, Object> urProps = new HashMap<String, Object>();
+	        UR = newWIMUR(urProps);
+	        WIMUserRegistry WIMUR = (WIMUserRegistry) UR;
+	
+	        List<String> attrList = new ArrayList();
+	        attrList.add("sn");
+	        attrList.add("cn");
+	        WIMUR.getAttributesForUser(null, attrList);
+	        fail("expected fail");
+        } catch (Exception e) {
+	        String errorMessage = e.getMessage();
+	        assertEquals("Incorrect exception thrown", RegistryException.class, e.getClass());
+	        assertEquals("The error code for RegistryException", null, errorMessage);
+	    }
+    }
+
+    @Test
+    public void testGetAttributesForUserListNull() throws Exception {
+        try {
+	        Map<String, Object> urProps = new HashMap<String, Object>();
+	        UR = newWIMUR(urProps);
+	        WIMUserRegistry WIMUR = (WIMUserRegistry) UR;
+	
+	        List<String> attrList = new ArrayList();
+	        attrList.add("sn");
+	        attrList.add("cn");
+	        WIMUR.getAttributesForUser("user1", null);
+	        fail("expected fail");
+        } catch (Exception e) {
+	        String errorMessage = e.getMessage();
+	        assertEquals("Incorrect exception thrown", RegistryException.class, e.getClass());
+	        assertEquals("The error code for RegistryException", null, errorMessage);
+	    }
     }
 }


### PR DESCRIPTION
Introduce New User Attribute Interface

- Use a new interface to prevent breaking any custom registry classes that other Open Liberty users may have created (if reviewers think this is too conservative of an approach, we could change the UserRegistry interface with default method implementations that throw unsupported exceptions instead)

- Define a new AttributeReader interface to provide minimum required API methods to start off (with more to come later)

- Code that calls RegistryHelper will use instanceof check for new interface


