### PR TITLE
add javaee6 to wlp platform for some feature files

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
@@ -25,4 +25,4 @@ edition=core
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
 
-WLP-Platform: javaee-7.0,javaee-8.0
+WLP-Platform: javaee-6.0,javaee-7.0,javaee-8.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jacc-1.5/com.ibm.websphere.appserver.jacc-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jacc-1.5/com.ibm.websphere.appserver.jacc-1.5.feature
@@ -18,4 +18,4 @@ kind=ga
 edition=core
 -jars=com.ibm.websphere.appserver.api.jacc; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jacc_1.0-javadoc.zip
-WLP-Platform: javaee-7.0,javaee-8.0
+WLP-Platform: javaee-6.0,javaee-7.0,javaee-8.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaspic-1.1/com.ibm.websphere.appserver.jaspic-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaspic-1.1/com.ibm.websphere.appserver.jaspic-1.1.feature
@@ -24,4 +24,4 @@ edition=core
 -jars=com.ibm.websphere.appserver.spi.jaspic; location:=dev/spi/ibm/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jaspic_1.1-javadoc.zip
 WLP-InstantOn-Enabled: true
-WLP-Platform: javaee-7.0,javaee-8.0
+WLP-Platform: javaee-6.0,javaee-7.0,javaee-8.0


### PR DESCRIPTION
Add javaee6.0 to the WLP-Platform element for the following feature files:

- com.ibm.websphere.appserver.concurrent-1.0
- com.ibm.websphere.appserver.jacc-1.5
- com.ibm.websphere.appserver.jaspic-1.1
