### PR TITLE
Write TCK adoc files to extras directory.

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -15,6 +15,7 @@ package componenttest.topology.utils.tck;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -127,10 +128,20 @@ public class TCKResultsWriter {
                 }
             }
             output.write("----");
-
         } catch (IOException e) {
             throw new RuntimeException(e);
         } catch (SAXException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Files written to the extras directory are copied to the build directory on LibFS (by default, the location is configurable on the pipeline).
+        // This copying only occurs in CI Orchestrator environments as the code wrapping FAT execution is responsible for performing the upload to LibFS.
+        // Here, the use case is to make .adoc files available in the build directory without having to extract them from the FAT output zip every time.
+        try {
+            Path extrasPath = Paths.get("extras", filename);
+            Files.createDirectories(extrasPath.getParent());
+            Files.copy(outputPath, extrasPath);
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -135,9 +135,10 @@ public class TCKResultsWriter {
             throw new RuntimeException(e);
         }
 
-        // Files written to the extras directory are copied to the build directory on LibFS (by default, the location is configurable on the pipeline).
-        // This copying only occurs in CI Orchestrator environments as the code wrapping FAT execution is responsible for performing the upload to LibFS.
-        // Here, the use case is to make .adoc files available in the build directory without having to extract them from the FAT output zip every time.
+        // Files written to the extras directory are included in the FAT output zip, but can also be uploaded to an additional location by setting the
+        // 'extraFatOutputPath' property to a path on LibFS (e.g. /liberty/dev/Xo/release/BUILD_LABEL) to retain them beyond the life cycle of FAT output.
+        // Note that this copying *only* occurs in CI Orchestrator environments as the code wrapping FAT execution is responsible for performing the upload to LibFS.
+        // The use case here is to make .adoc files available in the build directory without having to extract them from the FAT output zip every time.
         try {
             Path extrasPath = Paths.get("extras", filename);
             Files.createDirectories(extrasPath.getParent());

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
@@ -140,7 +141,7 @@ public class TCKResultsWriter {
         try {
             Path extrasPath = Paths.get("extras", filename);
             Files.createDirectories(extrasPath.getParent());
-            Files.copy(outputPath, extrasPath);
+            Files.copy(outputPath, extrasPath, StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Copy the .adoc files to an "extras" directory parallel to the "results" directory when writing them. This then allows the CI Orchestrator to copy and retain these in a more convenient and accessible location. 