### PR TITLE
JAX-WS: Beta webServices server.xml configuration

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
@@ -80,7 +80,8 @@ DynamicImport-Package: com.sun.xml.bind.v2, \
   com.ibm.ws.jaxws.threading.LibertyThreadPoolAdapter,\
   com.ibm.ws.jaxws.client.injection.ServiceRefObjectFactory,\
   com.ibm.ws.jaxws.JaxwsConduitConfigActivator, \
-  com.ibm.ws.jaxws.client.WebServiceClientConfigImpl
+  com.ibm.ws.jaxws.client.WebServiceClientConfigImpl, \
+  com.ibm.ws.jaxws.endpoint.WebServiceConfigImpl
   
 # include the service providers and metatype
 Include-Resource: \

--- a/dev/com.ibm.ws.jaxws.2.3.common/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jaxws.2.3.common/resources/OSGI-INF/l10n/metatype.properties
@@ -13,6 +13,12 @@
 #NLS_ENCODING=UNICODE
 #NLS_MESSAGEFORMAT_NONE
 
+webservice=JAX-WS web service configuration
+webservice.desc=Configuration for JAX-WS web services.
+
+portName=JAX-WS web service port name
+portName.desc=The name of the port to configure. This value is set in the port element in the WSDL definition or in the @WebService annotation.
+
 webserviceClient=JAX-WS web service client configuration
 webserviceClient.desc=Configuration for JAX-WS clients.
 
@@ -23,4 +29,4 @@ ignoreUnexpectedElements=Ignore unexpected elements
 ignoreUnexpectedElements.desc=Ignore unexpected elements in the SOAPMessage object. The default value for ignoring unexpected elements is false for the webServiceClient configuration element and true for the webService configuration element.
 
 enableSchemaValidation=Enable schema validation
-enableSchemaValidation.desc=Enable schema validation in the SOAPMessage object. The default value for enabling schema validation is true for the webServiceClient configuration element and false for the webService configuration element.
+enableSchemaValidation.desc=Enable schema validation in the SOAPMessage object. The default value is false for the webService configuration element.

--- a/dev/com.ibm.ws.jaxws.2.3.common/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jaxws.2.3.common/resources/OSGI-INF/metatype/metatype.xml
@@ -22,4 +22,14 @@
         <Object ocdref="com.ibm.ws.jaxws.clientConfig.metatype" />
     </Designate>
    
+    <OCD id="com.ibm.ws.jaxws.config.metatype" description="%webservice.desc" name="%webservice" ibm:alias="webService" ibm:beta="true" >
+         <AD id="portName" name="%portName" description="%portName.desc" required="false" type="String" />
+         <AD id="ignoreUnexpectedElements" name="%ignoreUnexpectedElements" description="%ignoreUnexpectedElements.desc" required="false" type="Boolean" default="false" />
+         <AD id="enableSchemaValidation" name="%enableSchemaValidation" description="%enableSchemaValidation.desc" required="false" type="Boolean"/>
+    </OCD>
+    
+    <Designate factoryPid="com.ibm.ws.jaxws.config">
+        <Object ocdref="com.ibm.ws.jaxws.config.metatype" />
+    </Designate>
+   
 </metatype:MetaData>

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/AbstractJaxWsWebEndpoint.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/AbstractJaxWsWebEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2022 IBM Corporation and others.
+ * Copyright (c) 2019,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -258,7 +258,7 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
             } else {
                 // Running beta exception, issue message if we haven't already issued one for this class
                 if (!issuedBetaMessage) {
-                    Tr.info(tc, "BETA: A webServiceClient configuration beta method has been invoked for the class " + this.getClass().getName() + " for the first time.");
+                    Tr.debug(tc, "BETA: A webService configuration beta method has been invoked for the class " + this.getClass().getName() + " for the first time.");
                     issuedBetaMessage = !issuedBetaMessage;
                 }
                 
@@ -297,7 +297,7 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
         org.apache.cxf.service.model.EndpointInfo cxfEndpointInfo = destination.getEndpointInfo();
         
         if (debug) {
-            Tr.info(tc, portName + " will be used to find webService Configuration");
+            Tr.debug(tc, portName + " will be used to find webService Configuration");
         }
         
         Object enableSchemaValidation = null;
@@ -318,7 +318,7 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
             }
             
 
-            // if messageServiceName != null, try to get ignoreUnexpectedElements value from configuration, if it's == null try to get the default configuration value
+            // if portName != null, try to get ignoreUnexpectedElements value from configuration, if it's == null try to get the default configuration value
             if(WebServicesConfigHolder.getIgnoreUnexpectedElements(portName) != null) {
                 
                 ignoreUnexpectedElements = WebServicesConfigHolder.getIgnoreUnexpectedElements(portName);
@@ -331,7 +331,7 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
 
             
         } else {
-            // if messageSevice == null then try to get the global configuration values, if its not set keep values null
+            // if portName == null then try to get the global configuration values, if its not set keep values null
             enableSchemaValidation = (WebServicesConfigHolder.getEnableSchemaValidation(WebServiceConfigConstants.DEFAULT_PROP) != null) ? WebServicesConfigHolder.getEnableSchemaValidation(WebServiceConfigConstants.DEFAULT_PROP) : null;
 
             ignoreUnexpectedElements = (WebServicesConfigHolder.getIgnoreUnexpectedElements(WebServiceConfigConstants.DEFAULT_PROP) != null) ? WebServicesConfigHolder.getIgnoreUnexpectedElements(WebServiceConfigConstants.DEFAULT_PROP) : null;            
@@ -341,7 +341,7 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
         
         if ((enableSchemaValidation == null && ignoreUnexpectedElements == null)) {
             if (debug) {
-                Tr.info(tc, "No webServiceClient configuration found. returning.");
+                Tr.debug(tc, "No webService configuration found. returning.");
             }
             return;
         }
@@ -353,31 +353,21 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
             cxfEndpointInfo.setProperty("schema-validation-enabled",  enableSchemaValidation);
 
             if (debug) {
-                Tr.info(tc, "Set schema-validation-enabled to " + enableSchemaValidation);
+                Tr.debug(tc, "Set schema-validation-enabled to " + enableSchemaValidation);
 
             }
         } else {
 
             if (debug) {
-                Tr.info(tc, "enableSchemaValdiation was null, not configuring schema-validation-enabled on client the client");
+                Tr.debug(tc, "enableSchemaValdiation was null, not configuring schema-validation-enabled on the Web Service Endpoint");
 
             }
         }
-        
-//        if(JavaInfo.majorVersion() != 8 && JavaInfo.vendor().equals("ibm")) {
-//
-//            if (debug) {
-//                Tr.info(tc, "XLXP does not support Validation Event Handlers, no ignoreUnexpecteeElements configuration will be applied");
-//
-//            }
-//            
-//            return;
-//        
-//        }
        
 
         // Set ignoreUnexpectedElements if true
         if (ignoreUnexpectedElements != null && (boolean) ignoreUnexpectedElements == true) {
+           
             cxfEndpointInfo.setProperty(JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER, ignoreUnexpectedElements);
             
             // Set our custom validation event handler
@@ -385,12 +375,12 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
             cxfEndpointInfo.setProperty(JAXBDataBinding.READER_VALIDATION_EVENT_HANDLER, unexpectedElementValidationEventHandler); 
 
             if (debug) {
-                Tr.info(tc, "Set JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER to  " + ignoreUnexpectedElements);
+                Tr.debug(tc, "Set JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER to  " + ignoreUnexpectedElements);
             }
 
         } else {
             if (debug) {
-                Tr.info(tc, "ignoreUnexpectedElements was " + ignoreUnexpectedElements + " not configuring ignoreUnexpectedElements on the client");
+                Tr.debug(tc, "ignoreUnexpectedElements was " + ignoreUnexpectedElements + " not configuring ignoreUnexpectedElements on the Web Service Endpoint");
 
             }
         }

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/WebServiceConfigImpl.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/WebServiceConfigImpl.java
@@ -30,7 +30,7 @@ import com.ibm.ws.kernel.productinfo.ProductInfo;
  * The declarative service responsible for processing a given <webService> element in the server.xml
  * Adapted from com.ibm.ws.jaxrs20.clientconfig.JAXRSClientConfig
  */
-@Component(configurationPid = "com.ibm.ws.jaxws.clientConfig",
+@Component(configurationPid = "com.ibm.ws.jaxws.config",
            configurationPolicy = ConfigurationPolicy.REQUIRE, // Must be ConfigurationPolicy.REQUIRE to prevent the DS being activated without the configuration present. 
            service = { WebServiceConfig.class },
            immediate = true,
@@ -53,7 +53,7 @@ public class WebServiceConfigImpl extends WebServiceConfig {
         } else {
         // Running beta exception, issue message if we haven't already issued one for this class
             if (!issuedBetaMessage) {
-                Tr.info(tc, "BETA: A webService configuration beta method has been invoked for the class " + this.getClass().getName() + " for the first time.");
+                Tr.debug(tc, "BETA: A webService configuration beta method has been invoked for the class " + this.getClass().getName() + " for the first time.");
                 issuedBetaMessage = !issuedBetaMessage;
            }
         }
@@ -79,9 +79,9 @@ public class WebServiceConfigImpl extends WebServiceConfig {
             return;
         }
         
-        String portName = getPortName(properties); // find serviceName
+        String portName = getPortName(properties); // find portName
         
-        // Add config for serviceName
+        // Add config for portName
         WebServicesConfigHolder.addConfig(this.toString(), portName,
                                                 filterProps(properties));
     }

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/WebServiceConfigImpl.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/WebServiceConfigImpl.java
@@ -1,0 +1,184 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.endpoint;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.jaxws.internal.ConfigValidation;
+import com.ibm.ws.jaxws.internal.WebServiceConfig;
+import com.ibm.ws.jaxws.internal.WebServiceConfigConstants;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
+
+/**
+ * The declarative service responsible for processing a given <webService> element in the server.xml
+ * Adapted from com.ibm.ws.jaxrs20.clientconfig.JAXRSClientConfig
+ */
+@Component(configurationPid = "com.ibm.ws.jaxws.clientConfig",
+           configurationPolicy = ConfigurationPolicy.REQUIRE, // Must be ConfigurationPolicy.REQUIRE to prevent the DS being activated without the configuration present. 
+           service = { WebServiceConfig.class },
+           immediate = true,
+           property = { "service.vendor=IBM" })
+public class WebServiceConfigImpl extends WebServiceConfig {
+    private static final TraceComponent tc = Tr.register(WebServiceConfigImpl.class);
+
+    static {
+        // remove the serviceName from the properties to be checked, since we use the serviceName as a key
+        propertiesToRemove.add(WebServiceConfigConstants.PORT_NAME_PROP);
+    }
+    
+    // Flag tells us if the message for a call to a beta method has been issued
+    private static boolean issuedBetaMessage = false;
+    
+    private void betaFenceCheck() throws UnsupportedOperationException {
+        // Not running beta edition, throw exception
+        if (!ProductInfo.getBetaEdition()) { 
+            throw new UnsupportedOperationException("The webService configuration is in beta and is not available.");
+        } else {
+        // Running beta exception, issue message if we haven't already issued one for this class
+            if (!issuedBetaMessage) {
+                Tr.info(tc, "BETA: A webService configuration beta method has been invoked for the class " + this.getClass().getName() + " for the first time.");
+                issuedBetaMessage = !issuedBetaMessage;
+           }
+        }
+    }
+
+    
+    
+    @Deprecated
+    @Activate
+    public WebServiceConfigImpl(Map<String, Object> properties) {
+        betaFenceCheck();
+        
+        if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
+            Tr.debug(tc, "ConfigImpl activate - " + properties);
+        }
+        
+        if (properties == null) {
+            
+            if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
+                Tr.debug(tc, "properites are null returning");
+            }
+            
+            return;
+        }
+        
+        String portName = getPortName(properties); // find serviceName
+        
+        // Add config for serviceName
+        WebServicesConfigHolder.addConfig(this.toString(), portName,
+                                                filterProps(properties));
+    }
+    
+    @Deprecated
+    @Modified
+    protected void modified(Map<String, Object> properties) {        
+
+        betaFenceCheck();
+        
+        if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
+            Tr.debug(tc, "entering modified - " + properties);
+        }
+        
+        if (properties == null) {
+            
+            if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
+                Tr.debug(tc, "properites are null returning");
+            }
+            
+            return;
+        }
+        
+        // Clear existing config
+        WebServicesConfigHolder.removeConfig(this.toString());
+        
+        // Re-add modfied config
+        String portName = getPortName(properties);
+        WebServicesConfigHolder.addConfig(this.toString(), portName,
+                                                filterProps(properties));
+    }
+
+    @Deprecated
+    @Deactivate
+    protected void deactivate() {
+        
+
+        betaFenceCheck();
+        
+        if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
+            Tr.debug(tc, "entering deactivate");
+        }
+        WebServicesConfigHolder.removeConfig(this.toString());
+    }
+
+    /**
+     * given the map of properties, remove ones we don't care about, and translate
+     * some others. If it's not one we're familiar with, transfer it unaltered
+     *
+     * @param props - input list of properties
+     * @return - a new Map of the filtered properties.
+     */
+    protected Map<String, Object> filterProps(Map<String, Object> props) {
+        HashMap<String, Object> filteredProps = new HashMap<>();
+        Iterator<String> it = props.keySet().iterator();
+
+        while (it.hasNext()) {
+            String key = it.next();
+            
+            if(key == null) {
+                continue;
+            }
+
+            if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
+                Tr.debug(tc, "key: " + key + " value: " + props.get(key) + " of type " + props.get(key).getClass());
+            }
+            // skip stuff we don't care about
+            if (propertiesToRemove.contains(key)) {
+                continue;
+            }
+            if (key.compareTo(WebServiceConfigConstants.ENABLE_SCHEMA_VALIDATION_PROP) == 0) {
+                if (!ConfigValidation.validateEnableSchemaValidation((boolean) props.get(key)))
+                    continue;
+            }
+            if (key.compareTo(WebServiceConfigConstants.IGNORE_UNEXPECTED_ELEMENTS_PROP) == 0) {
+                if (!ConfigValidation.validateIgnoreUnexpectedElements((boolean) props.get(key)))
+                    continue;
+            }
+            filteredProps.put(key, props.get(key));
+
+        }
+        return filteredProps;
+    }
+
+    /**
+     * find the portName parameter which we will key off of
+     *
+     * @param props
+     * @return value of portName param within props, or null if no portName param
+     */
+    private String getPortName(Map<String, Object> props) {
+        if (props == null)
+            return null;
+        if (props.keySet().contains(WebServiceConfigConstants.PORT_NAME_PROP)) {
+            return (props.get(WebServiceConfigConstants.PORT_NAME_PROP).toString());
+        } else {
+            return WebServiceConfigConstants.DEFAULT_PROP;
+        }
+    }
+}

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/WebServicesConfigHolder.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/WebServicesConfigHolder.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.jaxws.endpoint;
+
+import com.ibm.ws.jaxws.internal.ConfigHolder;
+
+/**
+ * The webServiceClient configuration holder, currently since 
+ * configuration is identical with webService this just extends the
+ * ConfigHolder class. Any client unqiue configuration to be held should be 
+ * added here.
+ */
+public class WebServicesConfigHolder extends ConfigHolder {
+
+}

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/WebServicesConfigHolder.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/WebServicesConfigHolder.java
@@ -12,9 +12,9 @@ package com.ibm.ws.jaxws.endpoint;
 import com.ibm.ws.jaxws.internal.ConfigHolder;
 
 /**
- * The webServiceClient configuration holder, currently since 
+ * The webService configuration holder, currently since 
  * configuration is identical with webService this just extends the
- * ConfigHolder class. Any client unqiue configuration to be held should be 
+ * ConfigHolder class. Any client unique configuration to be held should be 
  * added here.
  */
 public class WebServicesConfigHolder extends ConfigHolder {


### PR DESCRIPTION
This PR does the following:

1. Adds the `webService` beta configuration with child elements `ignoreUnknownElements` and `enableSchemaValidation` 
2. Updates messages related to metatype
3. Adds the configuration's declarative service, `WebServiceConfigImpl`, and related implementation classes. 
4. Updates the `AbstractJaxWsEndpoint` class to dynamically apply  any beta `webService` configuration to the Web Service endpoint at the time it is invoked. 
