### PR TITLE
Add more complete platform validation test to VersionlessTest

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VersionlessTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VersionlessTest.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.junit.Assert;
@@ -29,6 +30,8 @@ import com.ibm.ws.feature.utils.FeatureInfo;
 import com.ibm.ws.feature.utils.FeatureMapFactory;
 import com.ibm.ws.feature.utils.VersionlessFeatureCreator;
 import com.ibm.ws.feature.utils.VersionlessFeatureDefinition;
+
+import aQute.bnd.header.Attrs;
 
 //Generating reports on EE and MP features as well as creating versionless features
 public class VersionlessTest {
@@ -90,11 +93,13 @@ public class VersionlessTest {
         if (!processedDepFeatures.add(featureInfo.getName())) {
             return;
         }
-        featureInfo.forEachSortedDepName((String depName) -> {
+        featureInfo.getDependentFeatures().forEach((String depName, Attrs attr) -> {
             FeatureInfo depInfo = getFeature(depName);
             if (depInfo == null) {
                 System.out.println("        [ " + depName + " ** NOT FOUND ** ]");
-            } else {
+                // Only include dependent features that do not have tolerates.  If a feature depends on particular version it will have been
+                // included in the convenience feature due to how tolerates works to not be transitive.
+            } else if (!attr.containsKey("ibm.tolerates:") || depName.startsWith("com.ibm.websphere.appserver.jdbc-")) {
                 if (depInfo.isPublic()) {
                     publicDepFeatures.add(depInfo);
                 }
@@ -262,6 +267,135 @@ public class VersionlessTest {
         }
     }
 
+    @Test
+    public void validatePlatformSettings() {
+        StringBuilder errorMessage = new StringBuilder();
+        Map<String, Set<String>> featureToPlatformMapping = new HashMap<>();
+        Set<String> platformFeatureBaseNames = new HashSet<>();
+        getSelectorCohorts().forEach((String baseName, List<String> featureBaseNames) -> {
+
+            for (String featureBaseName : featureBaseNames) {
+                List<String> cohort = cohorts.get(featureBaseName);
+                //loops through each version of a platform
+                for (String version : cohort) {
+                    // We are only doing javaee-8.0 platform and not doing jakartaee-8.0 platform
+                    // If that changes this condition should be removed.
+                    if (baseName.equals("jakartaee") && version.equals("8.0")) {
+                        continue;
+                    }
+
+                    boolean isMP = baseName.equals("microProfile");
+                    String featureName = featureBaseName + "-" + version;
+                    String featureShortName = baseName + "-" + version;
+                    FeatureInfo featureInfo = getFeature(featureName);
+                    if (featureInfo != null) {
+                        //each feature dependency of the platform
+                        Set<FeatureInfo> publicDepFeatures = getAllPublicDependentFeatures(featureInfo);
+                        for (FeatureInfo depInfo : publicDepFeatures) {
+                            String featureTitle = depInfo.getShortName().split("-")[0]; //Just the name not the version
+
+                            if (skipFeatures.contains(featureTitle)) {
+                                continue;
+                            }
+
+                            // Only MicroProfile features (short names that start with "mp") include the microProfile platforms.
+                            if (isMP && !depInfo.getShortName().startsWith("mp")) {
+                                continue;
+                            }
+
+                            platformFeatureBaseNames.add(depInfo.getBaseName());
+
+                            Set<String> platforms = featureToPlatformMapping.get(depInfo.getName());
+                            if (platforms == null) {
+                                platforms = new HashSet<>();
+                                featureToPlatformMapping.put(depInfo.getName(), platforms);
+                            }
+                            platforms.add(featureShortName);
+                        }
+                    }
+                }
+            }
+        });
+
+        // Special cases of features that were removed from the platform and from the convenience feature, but are still compatible with later MP / Jakarta
+        // versions
+        featureToPlatformMapping.get("io.openliberty.enterpriseBeans-4.0").add("jakartaee-11.0");
+        featureToPlatformMapping.get("io.openliberty.enterpriseBeansHome-4.0").add("jakartaee-11.0");
+        featureToPlatformMapping.get("io.openliberty.xmlBinding-4.0").add("jakartaee-11.0");
+        featureToPlatformMapping.get("io.openliberty.xmlWS-4.0").add("jakartaee-11.0");
+        featureToPlatformMapping.get("io.openliberty.mpMetrics-5.1").add("microProfile-7.0");
+
+        // jdbc is special
+        featureToPlatformMapping.get("com.ibm.websphere.appserver.jdbc-4.1").remove("javaee-8.0");
+        featureToPlatformMapping.get("com.ibm.websphere.appserver.jdbc-4.2").add("javaee-8.0");
+        featureToPlatformMapping.get("com.ibm.websphere.appserver.jdbc-4.2").remove("jakartaee-11.0");
+        Set<String> jdbc43Platform = new HashSet<>();
+        jdbc43Platform.add("jakartaee-11.0");
+        featureToPlatformMapping.put("com.ibm.websphere.appserver.jdbc-4.3", jdbc43Platform);
+
+        // Now that we have a mapping of features to the platform features that they belong to validates that the platform settings in the features
+        // include all of the convenience features that enable those features.
+
+        for (Entry<String, Set<String>> entry : featureToPlatformMapping.entrySet()) {
+            String featureName = entry.getKey();
+            Set<String> platforms = entry.getValue();
+            FeatureInfo feature = getFeature(featureName);
+            Set<String> featurePlatforms = feature.getPlatforms();
+
+            int matches = 0;
+            for (String featurePlatform : featurePlatforms) {
+                // Skip javaee-6.0 since javaee 6 convenience feature isn't in Open Liberty
+                if (featurePlatform.equals("javaee-6.0")) {
+                    continue;
+                }
+                if (platforms.contains(featurePlatform)) {
+                    matches++;
+                } else {
+                    errorMessage.append(featureName).append(" contains a platform ").append(featurePlatform)
+                                .append(" even though it isn't enabled by that platform convenience feature\n");
+                }
+            }
+            if (matches != platforms.size()) {
+                for (String platform : platforms) {
+                    if (!featurePlatforms.contains(platform)) {
+                        errorMessage.append(featureName).append(" is missing platform ").append(platform).append("\n");
+                    }
+                }
+            }
+        }
+
+        // Special private features that also should have platforms listed in them
+        platformFeatureBaseNames.add("io.openliberty.internal.mpVersion");
+        platformFeatureBaseNames.add("com.ibm.websphere.appserver.eeCompatible");
+
+        // Special versions of features that are not part of a convenience feature even though
+        // they share the base feature name as feature we expect to have platforms listed
+        Set<String> exceptionCases = new HashSet<>();
+        exceptionCases.add("com.ibm.websphere.appserver.appSecurity-1.0"); // We use appSecurity-2.0 for EE 6 and EE 7
+        exceptionCases.add("com.ibm.websphere.appserver.websocket-1.0"); // We use websocket-1.1 for EE 7 instead of 1.0
+        exceptionCases.add("com.ibm.websphere.appserver.eeCompatible-0.0"); // Special 0.0 version that purposely doesn't have platforms listed
+        exceptionCases.add("com.ibm.websphere.appserver.servlet-servletSpi1.0"); // Private feature that has a public feature base name
+
+        for (FeatureInfo featureInfo : featureRepo.values()) {
+            String featureName = featureInfo.getName();
+            boolean expectsPlatforms = platformFeatureBaseNames.contains(featureInfo.getBaseName());
+
+            // If it is a feature that we expect to have platforms listed in it and we haven't already reported it and it isn't a special
+            // feature that we don't expect a Platform to be associated with it.
+            if (!featureInfo.isAutoFeature() && expectsPlatforms && featureInfo.getPlatforms().isEmpty() && !featureToPlatformMapping.containsKey(featureName)
+                && !exceptionCases.contains(featureName)) {
+                errorMessage.append(featureName).append(" is a feature that expects Platforms to be listed\n");
+            }
+
+            if (!expectsPlatforms && !featureInfo.getPlatforms().isEmpty()) {
+                errorMessage.append(featureName).append(" is not part of a versionless feature so it shouldn't have any Platforms listed\n");
+            }
+        }
+        if (errorMessage.length() != 0) {
+            Assert.fail("Found features that have incorrect WLP-Platform settings:\n" + errorMessage.toString());
+        }
+    }
+
     /**
      * Generate versionless features
      * 1. Create a map of each feature (ex. servlet) and data on each of its versions
@@ -270,7 +404,6 @@ public class VersionlessTest {
      */
     @Test
     public void listSelectorDetails() {
-        StringBuilder errorMessage = new StringBuilder();
         Map<String, VersionlessFeatureDefinition> versionlessFeatures = new HashMap<String, VersionlessFeatureDefinition>();
 
         System.out.println("Selectors:");
@@ -303,10 +436,6 @@ public class VersionlessTest {
 
                         //
                         String featureTitle = depInfo.getShortName().split("-")[0]; //Just the name not the version
-
-                        if (!skipFeatures.contains(featureTitle) && depInfo.getPlatforms().isEmpty()) {
-                            errorMessage.append(depInfo.getName()).append('\n');
-                        }
 
                         //add features to our map and add data on its platform-version link
                         if (versionlessFeatures.containsKey(featureTitle)) {
@@ -378,10 +507,6 @@ public class VersionlessTest {
                              "Verify the data inside the feature files are correct, then copy the features from 'build/versionless' into 'visibility'.\n" + createdFeatures;
 
         Assert.assertEquals(errorOutput, "", createdFeatures);
-
-        if (errorMessage.length() != 0) {
-            Assert.fail("Found features that are missing WLP-Platform settings:\n" + errorMessage.toString());
-        }
     }
 
     private static final Map<String, List<String>> selectorCohorts;

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
@@ -340,7 +340,7 @@ public class FeatureInfo {
             String platformString = builder.getProperty("WLP-Platform");
 
             if (platformString != null) {
-                String[] platformArray = platformString.split(",'");
+                String[] platformArray = platformString.split(",");
                 for (String platform : platformArray) {
                     platforms.add(platform);
                 }

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.1/io.openliberty.data-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.1/io.openliberty.data-1.1.feature
@@ -34,3 +34,4 @@ kind=noship
 edition=full
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
+WLP-Platform: jakartaee-12.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/dataContainer-1.0/io.openliberty.dataContainer-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/dataContainer-1.0/io.openliberty.dataContainer-1.0.feature
@@ -23,4 +23,3 @@ kind=beta
 edition=core
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
-WLP-Platform: jakartaee-11.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-2.1/com.ibm.websphere.appserver.jpaContainer-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-2.1/com.ibm.websphere.appserver.jpaContainer-2.1.feature
@@ -30,4 +30,3 @@ IBM-App-ForceRestart: uninstall, \
 -bundles=com.ibm.ws.jpa.container.v21, \
  com.ibm.ws.jpa.container, \
  com.ibm.ws.jpa.container.thirdparty
-WLP-Platform: javaee-7.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-2.2/com.ibm.websphere.appserver.jpaContainer-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-2.2/com.ibm.websphere.appserver.jpaContainer-2.2.feature
@@ -32,4 +32,3 @@ IBM-App-ForceRestart: uninstall, \
  com.ibm.ws.jpa.container.thirdparty
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
-WLP-Platform: javaee-8.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-5.1/io.openliberty.mpMetrics-5.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-5.1/io.openliberty.mpMetrics-5.1.feature
@@ -50,4 +50,4 @@ Subsystem-Name: MicroProfile Metrics 5.1
 kind=ga
 edition=core
 WLP-InstantOn-Enabled: true
-WLP-Platform: microProfile-6.1
+WLP-Platform: microProfile-6.1,microProfile-7.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.0/io.openliberty.persistenceContainer-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.0/io.openliberty.persistenceContainer-3.0.feature
@@ -25,4 +25,3 @@ IBM-App-ForceRestart: uninstall, \
  com.ibm.ws.jpa.container.thirdparty.jakarta
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
-WLP-Platform: jakartaee-9.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.1/io.openliberty.persistenceContainer-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.1/io.openliberty.persistenceContainer-3.1.feature
@@ -25,4 +25,3 @@ IBM-App-ForceRestart: uninstall, \
  com.ibm.ws.jpa.container.thirdparty.jakarta
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
-WLP-Platform: jakartaee-10.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.2/io.openliberty.persistenceContainer-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.2/io.openliberty.persistenceContainer-3.2.feature
@@ -25,4 +25,3 @@ IBM-App-ForceRestart: uninstall, \
  com.ibm.ws.jpa.container.thirdparty.jakarta
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
-WLP-Platform: jakartaee-11.0


### PR DESCRIPTION
- Add Platform test to make sure that the values in WLP-Platform match what is expected from looking at the convenience features
- Add microProfile-7.0 to mpMetrics-5.1 as discussed at the externals review to match what we have done with enterpriseBeans, enterpriseBeansHome, xmlBinding and xmlWS
- Remove WLP-Platform setting from the jpa/persistenceContainer dataContainer-.10 features until we decide to make those versionless features
- Update data-1.1 to have a platform listed of jakartaee-12.0
