### PR TITLE
Remove internal package exposed as API in Telemetry-2.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-2.0/io.openliberty.mpTelemetry-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpTelemetry-2.0/io.openliberty.mpTelemetry-2.0.feature
@@ -17,7 +17,6 @@ IBM-API-Package: \
   io.opentelemetry.context;type="third-party",\
   io.opentelemetry.context.propagation;type="third-party",\
   io.opentelemetry.extension.incubator.metrics;type="third-party",\
-  io.opentelemetry.internal.shaded.jctools.queues;type="third-party",\
   io.opentelemetry.sdk.trace;type="third-party",\
   io.opentelemetry.sdk.trace.export;type="third-party",\
   io.opentelemetry.sdk.trace.data;type="third-party",\


### PR DESCRIPTION
`io.opentelemetry.internal.shaded.jctools.queues` is not a required package for the MpTelemetry-2.0 APIs 