### PR TITLE
Adding platforms to ESA

### DIFF
--- a/dev/com.ibm.ws.repository.parsers/src/com/ibm/ws/repository/parsers/EsaParser.java
+++ b/dev/com.ibm.ws.repository.parsers/src/com/ibm/ws/repository/parsers/EsaParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 IBM Corporation and others.
+ * Copyright (c) 2015, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -251,6 +251,21 @@ public class EsaParser extends ParserBase implements Parser<EsaResourceWritable>
                     resource.addRequireFix(fix);
                 }
             }
+        }
+
+        // handle platforms
+        String platformsValue = feature.getHeader("WLP-Platform");
+        if (platformsValue != null && !platformsValue.isEmpty()) {
+            ArrayList newPlatformsList = new ArrayList();
+            String[] myPlatforms = platformsValue.split(",");
+            for (String platform : myPlatforms) {
+                platform = platform.trim();
+                if (!platform.isEmpty()) {
+                    newPlatformsList.add(platform);
+                }
+            }
+            if (!newPlatformsList.isEmpty())
+                resource.setPlatforms(newPlatformsList);
         }
 
         resource.setShortName(shortName);

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/EsaResource.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/EsaResource.java
@@ -132,4 +132,11 @@ public interface EsaResource extends RepositoryResource, ApplicableToProduct {
      * @return The AppliesToFilter header property
      */
     public Collection<AppliesToFilterInfo> getAppliesToFilterInfo();
+
+    /**
+     * Returns a collection of platform Strings this feature "belongs" in
+     *
+     * @return a collection of platform Strings this feature "belongs" in, WLP-Platforms header property
+     */
+    public Collection<String> getPlatforms();
 }

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
@@ -419,6 +419,7 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
         setShortName(esaRes.getShortName());
         setVanityURL(esaRes.getVanityURL());
         setSingleton(esaRes.getSingleton());
+        setPlatforms(esaRes.getPlatforms());
         setIBMInstallTo(esaRes.getIBMInstallTo());
     }
 
@@ -824,6 +825,18 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
     @Override
     public void setIBMInstallTo(String ibmInstallTo) {
         _asset.getWlpInformation().setIbmInstallTo(ibmInstallTo);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Collection<String> getPlatforms() {
+        return _asset.getWlpInformation().getPlatforms();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setPlatforms(Collection<String> platforms) {
+        _asset.getWlpInformation().setPlatforms(platforms);
     }
 
 }

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/writeable/EsaResourceWritable.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/writeable/EsaResourceWritable.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -68,6 +68,13 @@ public interface EsaResourceWritable extends WebDisplayable, ApplicableToProduct
     public void addRequireFeatureWithTolerates(String feature, Collection<String> tolerates);
 
     /**
+     * Sets the collection of platforms for this feature
+     *
+     * @param platforms The collection of platforms for this feature
+     */
+    public void setPlatforms(Collection<String> platforms);
+
+    /**
      * Add the supplied fix to the list of required fixes
      *
      * @param fix The ID of the fix to add
@@ -126,7 +133,7 @@ public interface EsaResourceWritable extends WebDisplayable, ApplicableToProduct
      * Sets the ibmProvisionCapability field.
      *
      * @param ibmProvisionCapability
-     *            The new ibmProvisionCapability to be used
+     *                                   The new ibmProvisionCapability to be used
      */
     public void setProvisionCapability(String provisionCapability);
 
@@ -144,10 +151,10 @@ public interface EsaResourceWritable extends WebDisplayable, ApplicableToProduct
      * Specify the minimum/maximum Java version needed by this ESA, and the Require-Capability headers from each contained bundle which have led to the requirement. All fields are
      * allowed to be null.
      *
-     * @param minimum an OSGI version string representing the minimum Java version required.
-     * @param maximum an OSGI version string representing the minimum Java version required.
-     * @param displayMinimum An alternative representation of the minimum version for display purposes
-     * @param displayMaximum An alternative representation of the maximum version for display purposes
+     * @param minimum               an OSGI version string representing the minimum Java version required.
+     * @param maximum               an OSGI version string representing the minimum Java version required.
+     * @param displayMinimum        An alternative representation of the minimum version for display purposes
+     * @param displayMaximum        An alternative representation of the maximum version for display purposes
      * @param rawBundleRequirements The Require-Capability headers from all the bundles contained in this ESA
      */
     public void setJavaSEVersionRequirements(String minimum, String maximum, Collection<String> rawBundleRequirements);

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/model/WlpInformation.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/model/WlpInformation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 IBM Corporation and others.
+ * Copyright (c) 2015, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -66,6 +66,7 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
     private String vanityRelativeURL;
     private String featuredWeight;
     private Collection<String> supersededBy;
+    private Collection<String> platforms;
     private Collection<String> supersededByOptional;
     private JavaSEVersionRequirements javaSEVersionRequirements;
     private String mainAttachmentSHA256;
@@ -107,6 +108,7 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
         vanityRelativeURL = other.vanityRelativeURL;
         featuredWeight = other.featuredWeight;
         supersededBy = copyCollection(other.supersededBy);
+        platforms = copyCollection(other.platforms);
         supersededByOptional = copyCollection(other.supersededByOptional);
         javaSEVersionRequirements = copyObject(other.javaSEVersionRequirements, JavaSEVersionRequirements::new);
         mainAttachmentSHA256 = other.mainAttachmentSHA256;
@@ -425,6 +427,14 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
 
     public void setSupersededBy(Collection<String> supersededBy) {
         this.supersededBy = supersededBy;
+    }
+
+    public Collection<String> getPlatforms() {
+        return this.platforms;
+    }
+
+    public void setPlatforms(Collection<String> myPlatforms) {
+        this.platforms = myPlatforms;
     }
 
     public Collection<String> getSupersededByOptional() {
@@ -798,6 +808,14 @@ public class WlpInformation extends AbstractJSON implements VersionableContent, 
                 return false;
         } else if (!ibmInstallTo.equals(other.ibmInstallTo))
             return false;
+
+        if (platforms == null) {
+            if (other.platforms != null) {
+                return false;
+            }
+        } else if (!platforms.equals(other.platforms)) {
+            return false;
+        }
 
         return true;
     }


### PR DESCRIPTION
Part of the overall ["Versionless" Epic](https://github.com/OpenLiberty/open-liberty/issues/25704) - feature platforms are now tracked for public features that are "part of" a programming model "platform", and these designate platform versions for each singleton feature version they belong in.

These changes now track this metadata in ESA's / json, allowing the feature API's to access the when determining resolution of required features needed.