### PR TITLE
update saml request cookie management

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/SPInitiated/BasicSolicitedSPInitiatedTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/SPInitiated/BasicSolicitedSPInitiatedTests.java
@@ -199,6 +199,95 @@ public class BasicSolicitedSPInitiatedTests extends BasicSAMLTests {
         sessionAffinityTest(HttpMethod.GET);
 
     }
+    
+    /**
+    *
+    * initial request cookie expiration is set to 3 seconds (using the authnRequestTime attribute in the configuration)
+    * test waits for 5 seconds
+    * server is re-started in the middle of the testing, so runtime will need initial request cookie to access information regarding relay state and initial request
+    * since the cookie expires in the middle of the run, runtime throws relay state not recognized error
+    *
+    * @throws Exception
+    */
+   @Mode(TestMode.LITE)
+   @Test
+   @ExpectedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException" })
+   public void basicSolicitedSPInitiatedTest_setInitialRequestCookieAge_3_seconds() throws Exception {
+
+       //authnRequestTime = 3s
+       testSAMLServer.reconfigServer("server_1_setAuthnRequestTime.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+       initialRequestCookieExpirationTest(5);
+   }
+   
+   /**
+   *
+   * wassamlreq_ cookie expiration is set to 5 seconds (using the authnRequestTime attribute in the configuration. disableInitialRequestCookie is set to true for this test)
+   * test waits for 2 seconds
+   * wassamlreq_ cookie is not expired, and runtime should be able to get the initial request information from local cache entry 
+   *
+   * @throws Exception
+   */
+  @Mode(TestMode.LITE)
+  @Test
+  public void basicSolicitedSPInitiatedTest_setWASSamlReq_CookieAge_5_seconds() throws Exception {
+
+      //authnRequestTime = 5 seconds
+      testSAMLServer.reconfigServer("server_1_setAuthnRequestTime.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
+      WASSamlReqCookieExpirationTest(2);
+  }
+   
+   /**
+    *
+    *
+    * @throws Exception
+    */
+   protected void initialRequestCookieExpirationTest(int expiration_time) throws Exception {
+
+       WebClient webClient = getAndSaveWebClient();
+       SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
+       updatedTestSettings.updatePartnerInSettings("sp1", true);
+       // we want to pass some parms on the first request (without having to duplicate code)
+       // dummy up values to pass on initial request - they won't really be used for anything
+       updatedTestSettings.setRSSettings(SAMLConstants.SAML_DEFAULT_AUTHORIZATION_HEADER_NAME, "DummyHeaderFormat", "DummyTokenFormat");
+
+       List<validationData> expectations = msgUtils.addForbiddenExpectation(SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE_KEEPING_COOKIES, null);
+       expectations = helpers.addMessageExpectation(testSAMLServer, expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE_KEEPING_COOKIES, SAMLConstants.SAML_MESSAGES_LOG, SAMLConstants.STRING_CONTAINS, "Did not receive an error message indicating that the SAML request took too long.", SAMLMessageConstants.CWWKS5029E_RELAY_STATE_NOT_RECOGNIZED);
+       helpers.setSimpleServletExpectations(expectations, testSettings);
+
+       Object somePage = helpers.buildSolicitedSPInitiatedRequest(_testName, webClient, updatedTestSettings, expectations, HttpMethod.POST);   
+       updatedTestSettings.setSleepBeforeTokenUse(expiration_time);
+       
+       logTestCaseInServerSideLog("MID-Test server Stop", testSAMLServer);
+       testSAMLServer.restartServer("server_1_setAuthnRequestTime.xml", _testName, extraApps, extraMsgs, true);
+       logTestCaseInServerSideLog("MID-Test server Start", testSAMLServer);
+
+       somePage = helpers.performIDPLogin(_testName, webClient, (HtmlPage) somePage, updatedTestSettings, expectations);
+
+       helpers.invokeACSWithSAMLResponse(_testName, webClient, somePage, updatedTestSettings, expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE_KEEPING_COOKIES, true);
+
+   }
+   
+   /**
+   *
+   *
+   * @throws Exception
+   */
+  protected void WASSamlReqCookieExpirationTest(int expiration_time) throws Exception {
+
+      WebClient webClient = getAndSaveWebClient();
+      SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
+      updatedTestSettings.updatePartnerInSettings("sp2", true);
+
+      List<validationData> expectations = helpers.setDefaultGoodSAMLExpectationsThroughACSOnly(SAMLConstants.BUILD_POST_SP_INITIATED_REQUEST, testSettings, null);
+      expectations = vData.addExpectation(expectations, SAMLConstants.INVOKE_DEFAULT_APP, SAMLConstants.RESPONSE_TITLE, SAMLConstants.STRING_CONTAINS, "Did not land on default app", null, SAMLConstants.APP1_TITLE);
+      helpers.setSimpleServletExpectations(expectations, testSettings);
+      
+      Object somePage = helpers.buildSolicitedSPInitiatedRequest(_testName, webClient, updatedTestSettings, expectations, HttpMethod.POST);
+      updatedTestSettings.setSleepBeforeTokenUse(expiration_time);
+      somePage = helpers.performIDPLogin(_testName, webClient, (HtmlPage) somePage, updatedTestSettings, expectations);
+      helpers.invokeACSWithSAMLResponse(_testName, webClient, somePage, updatedTestSettings, expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE_KEEPING_COOKIES, true);
+
+  }
 
     /**
      * This test attempts to mimic a cluster situation where we show that session affinity does not come into play in the

--- a/dev/com.ibm.ws.security.saml.sso_fat/publish/files/serversettings/samlProvider1AuthnRequestTime.xml
+++ b/dev/com.ibm.ws.security.saml.sso_fat/publish/files/serversettings/samlProvider1AuthnRequestTime.xml
@@ -1,0 +1,79 @@
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<server>
+
+	<samlWebSso20
+		id="sp1"
+		authFilterRef="myAuthFilter1"
+		wantAssertionsSigned="true"
+		signatureMethodAlgorithm="SHA256"
+		authnRequestsSigned="true"
+        authnRequestTime="3s"
+		forceAuthn="false"
+		isPassive="false"
+ 		idpMetadata="${server.config.dir}/imports/${tfimIdpServer}/Fed1MetaData.xml"
+		keyStoreRef="samlKeyStore"
+		keyAlias="sslspservercert"
+		trustStoreRef="serverStore"
+		clockSkew="300s"
+		tokenReplayTimeout="30m"
+		includeTokenInSubject="true"
+		mapToUserRegistry="No"
+		nameIDFormat="unspecified" 
+	>
+	</samlWebSso20>
+	
+		<samlWebSso20
+		id="sp2"
+		authFilterRef="myAuthFilter2"
+		wantAssertionsSigned="true"
+		signatureMethodAlgorithm="SHA256"
+		authnRequestsSigned="true"
+        authnRequestTime="5s"
+        disableInitialRequestCookie="true"
+		forceAuthn="false"
+		isPassive="false"
+ 		idpMetadata="${server.config.dir}/imports/${tfimIdpServer}/Fed1MetaData.xml"
+		keyStoreRef="samlKeyStore"
+		keyAlias="sslspservercert"
+		trustStoreRef="serverStore"
+		clockSkew="300s"
+		tokenReplayTimeout="30m"
+		includeTokenInSubject="true"
+		mapToUserRegistry="No"
+		nameIDFormat="unspecified" 
+	>
+	</samlWebSso20>
+<!--		
+		nameIDFormat="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+-->
+	<!-- userIdentifier="" groupIdentifier="" userUniqueIdentifier="subjectUniqueId" 
+		realmIdentifier="" -->
+
+	<authFilter id="myAuthFilter1">
+		<requestUrl
+			id="myRequestUrl"
+			urlPattern="/samlclient/fat/sp1/"
+			matchType="contains" />
+	</authFilter>
+	
+		<authFilter id="myAuthFilter2">
+		<requestUrl
+			id="myRequestUrl2"
+			urlPattern="/samlclient/fat/sp2/"
+			matchType="contains" />
+	</authFilter>
+
+</server>    

--- a/dev/com.ibm.ws.security.saml.sso_fat/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat/configs/server_1_setAuthnRequestTime.xml
+++ b/dev/com.ibm.ws.security.saml.sso_fat/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat/configs/server_1_setAuthnRequestTime.xml
@@ -1,0 +1,22 @@
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<server>
+	<include location="${server.config.dir}/imports/saml_only_features.xml" />
+	<include location="${server.config.dir}/imports/BasicRegistry_withoutIDPUsers.xml" />
+	<include location="${server.config.dir}/imports/misc.xml" />
+	<include location="${server.config.dir}/imports/samlProvider1AuthnRequestTime.xml" />
+	<include location="${server.config.dir}/imports/samlTestApplication.xml" />
+	<include location="${server.config.dir}/imports/goodSSLSettings.xml" />
+</server>

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/ForwardRequestInfo.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/ForwardRequestInfo.java
@@ -46,7 +46,7 @@ public class ForwardRequestInfo extends HttpRequestInfo implements Serializable 
 
     boolean bNeedFragment = true;
 
-    private long fragmentCookieMaxAge = 10;
+    private long fragmentCookieMaxAge = 10*60*1000; //10 minutes
 
     /**
      *
@@ -239,7 +239,7 @@ public class ForwardRequestInfo extends HttpRequestInfo implements Serializable 
         StringBuffer sb = new StringBuffer();
         sb.append("\n<SCRIPT type=\"TEXT/JAVASCRIPT\" language=\"JavaScript\">\n");
         sb.append("document.cookie = '");
-        sb.append(cookieName + "=' + encodeURIComponent(window.location.href) + '; Path=/;"); // session cookie
+        sb.append(cookieName + "=' + encodeURIComponent(window.location.href) + ';" + cookieMaxAge + "Path=/;"); // session cookie
         JavaScriptUtils jsUtils = new JavaScriptUtils();
         String cookieProps = jsUtils.createHtmlCookiePropertiesString(jsUtils.getWebAppSecurityConfigCookieProperties());
         sb.append(cookieProps);
@@ -251,7 +251,7 @@ public class ForwardRequestInfo extends HttpRequestInfo implements Serializable 
 
     public String getSamlRequestCookieTimeoutString() {
 
-        long samlLoginRequestTimeoutMillis = this.fragmentCookieMaxAge * 60 * 1000; // default - 10 minutes
+        long samlLoginRequestTimeoutMillis = this.fragmentCookieMaxAge; // default - 10 minutes
         Date timeout = new Date(System.currentTimeMillis() + samlLoginRequestTimeoutMillis);
 
         SimpleDateFormat utc_sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/InitialRequestUtil.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/InitialRequestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -265,7 +265,8 @@ public class InitialRequestUtil {
             String initialrequest_cookie_name = updateInitialRequestCookieNameWithRelayState(relayState);
             String initialrequest_cookie_value = digestInitialRequestCookieValue(irBytesStr, ssoService);
             if (initialrequest_cookie_name != null && initialrequest_cookie_value != null) {
-                RequestUtil.createCookie(req, resp, initialrequest_cookie_name, initialrequest_cookie_value);
+                int cookieMaxAge = ((int)ssoService.getConfig().getAuthnRequestTime())*60; //seconds
+                RequestUtil.createCookie(req, resp, initialrequest_cookie_name, initialrequest_cookie_value, cookieMaxAge);
             }        
         }
         return irBytesStr;

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/InitialRequestUtil.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/InitialRequestUtil.java
@@ -265,7 +265,7 @@ public class InitialRequestUtil {
             String initialrequest_cookie_name = updateInitialRequestCookieNameWithRelayState(relayState);
             String initialrequest_cookie_value = digestInitialRequestCookieValue(irBytesStr, ssoService);
             if (initialrequest_cookie_name != null && initialrequest_cookie_value != null) {
-                int cookieMaxAge = ((int)ssoService.getConfig().getAuthnRequestTime())*60; //seconds
+                int cookieMaxAge = (int)ssoService.getConfig().getAuthnRequestTime()/1000; //seconds
                 RequestUtil.createCookie(req, resp, initialrequest_cookie_name, initialrequest_cookie_value, cookieMaxAge);
             }        
         }

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/RequestUtil.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/RequestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -158,6 +158,23 @@ public class RequestUtil extends KnownSamlUrl {
         Cookie c = referrerURLCookieHandler.createCookie(cookieName,
                                                          cookieValue,
                                                          req);
+        response.addCookie(c);
+    }
+    
+    public static void createCookie(HttpServletRequest req,
+                                    HttpServletResponse response,
+                                    String cookieName,
+                                    String cookieValue, int maxAge) {
+        // cookieName and cookieValue has been verified as non-null
+        WebAppSecurityConfig webAppSecurityConfig = WebAppSecurityCollaboratorImpl.getGlobalWebAppSecurityConfig();
+        ReferrerURLCookieHandler referrerURLCookieHandler = webAppSecurityConfig.createReferrerURLCookieHandler();
+        Cookie c = referrerURLCookieHandler.createCookie(cookieName,
+                                                         cookieValue,
+                                                         req);
+        c.setMaxAge(maxAge); // seconds
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "cookie " + cookieName + ", expires in " + c.getMaxAge() + " seconds");
+        }
         response.addCookie(c);
     }
 

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/sp/Solicited.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/sp/Solicited.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2021,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -404,6 +404,7 @@ public class Solicited {
             requestInfo.setFragmentCookieId(cachingRequestInfo.getFragmentCookieId());
             requestInfo.setParameter("RelayState", new String[] { relayState });
             requestInfo.setParameter("SAMLRequest", new String[] { samlRequest });
+            requestInfo.setFragmentCookieMaxAge(ssoService.getConfig().getAuthnRequestTime());
             requestInfo.redirectPostRequest(req,
                                             resp,
                                             null, // In SP_INIT, we do not depend on cookie to store sp_init id

--- a/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/utils/ForwardRequestInfoTest.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/utils/ForwardRequestInfoTest.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.saml.sso20.internal.utils;
+
+import static org.junit.Assert.assertTrue;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class ForwardRequestInfoTest {
+
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.saml.sso20.*=all");
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    public final Mockery mockery = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+
+    @Rule
+    public final TestName testName = new TestName();
+    private ForwardRequestInfo forwardRequest = null;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.resetStreams();
+        outputMgr.restoreStreams();
+        outputMgr.trace("*=all=disabled");
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        System.out.println("Entering test: " + testName.getMethodName());
+        forwardRequest = new ForwardRequestInfo("http://idp/login");
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @After
+    public void tearDown() throws Exception {
+        mockery.assertIsSatisfied();
+        System.out.println("Exiting test: " + testName.getMethodName());
+    }
+
+    @Test
+    public void testGetSamlRequestCookieTimeoutCurrentPlusFiveMinutes() {
+        String methodName = "testGetSamlRequestCookieTimeoutCurrentPlusFiveMinutes";
+        Date current = new Date(System.currentTimeMillis());
+        forwardRequest.setFragmentCookieMaxAge(5*60*1000); //5 minutes
+        try {
+            SimpleDateFormat utc_sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+            utc_sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date currentplusfivemins = current;
+
+            currentplusfivemins = utc_sdf.parse(forwardRequest.getSamlRequestCookieTimeoutString());
+
+            assertTrue("Did not find expected cookie age!", currentplusfivemins.after(current));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(methodName, t);
+        }
+    }
+
+}


### PR DESCRIPTION
- use authnRequestTime value to set the exp on the initial request cookies
- we already expire the saml authn request if we don't get IdP response within the interval set by the authnRequestTime 
- this new update will allow the cookies to be expired as well (if we don't get the response from IdP for any reason)
- address #28658 
