### PR TITLE
Versionless prep for install

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/FeatureUtility.java
@@ -57,6 +57,7 @@ public class FeatureUtility {
     private final Boolean noCache;
     private final Boolean licenseAccepted;
     private final List<String> featuresToInstall;
+    private final Collection<String> platforms;
     private final List<String> additionalJsons;
     private String openLibertyVersion;
     private String openLibertyEdition;
@@ -78,7 +79,7 @@ public class FeatureUtility {
      * Constructor for unit testing only.
      */
     protected FeatureUtility(InstallKernelMap map, File fromDir, List<File> esaFiles, Boolean noCache,
-	    Boolean licenseAccepted, List<String> featuresToInstall, List<String> additionalJsons,
+	    Boolean licenseAccepted, List<String> featuresToInstall, List<String> platforms, List<String> additionalJsons,
 	    String openLibertyVersion, String openLibertyEdition, Logger logger, ProgressBar progressBar,
 	    Map<String, String> featureToExt, boolean isInstallServerFeature, VerifyOption verifyOption) {
 	super();
@@ -88,6 +89,7 @@ public class FeatureUtility {
 	this.noCache = noCache;
 	this.licenseAccepted = licenseAccepted;
 	this.featuresToInstall = featuresToInstall;
+	this.platforms = platforms;
 	this.additionalJsons = additionalJsons;
 	this.openLibertyVersion = openLibertyVersion;
 	this.openLibertyEdition = openLibertyEdition;
@@ -99,7 +101,8 @@ public class FeatureUtility {
     }
 
     private FeatureUtility(FeatureUtilityBuilder builder) throws IOException, InstallException {
-        this.logger = InstallLogUtils.getInstallLogger();
+        
+		this.logger = InstallLogUtils.getInstallLogger();
         this.progressBar = ProgressBar.getInstance();
 
         this.openLibertyVersion = getLibertyVersion();
@@ -109,6 +112,7 @@ public class FeatureUtility {
                             Messages.INSTALL_KERNEL_MESSAGES.getMessage("ERROR_BETA_EDITION_NOT_SUPPORTED"));
         }
 	this.additionalJsons = builder.additionalJsons;
+	this.platforms = builder.platforms;
         this.to = builder.to;
 	this.fromDir = builder.fromDir; // this can be overwritten by the env prop
 
@@ -249,9 +253,11 @@ public class FeatureUtility {
 	    map.put(InstallConstants.RUNTIME_INSTALL_DIR, Utils.getInstallDir());
 	    map.put(InstallConstants.INSTALL_LOCAL_ESA, true);
 	    map.put(InstallConstants.SINGLE_JSON_FILE, jsonPaths);
-        if (featuresToInstall != null) {
-	    map.put(InstallConstants.FEATURES_TO_RESOLVE, featuresToInstall);
-
+	    if (featuresToInstall != null) {
+		    map.put(InstallConstants.FEATURES_TO_RESOLVE, featuresToInstall);
+	    }
+        if (platforms != null) {
+        	map.put(InstallConstants.PLATFORMS, platforms);
         }
         if (esaFiles != null && !esaFiles.isEmpty()) {
 	    map.put(InstallConstants.INDIVIDUAL_ESAS, esaFiles);
@@ -831,6 +837,7 @@ public class FeatureUtility {
     public static class FeatureUtilityBuilder {
         File fromDir;
         Collection<String> featuresToInstall;
+        Collection<String> platforms;
         List<String> additionalJsons;
         List<File> esaFiles;
         boolean noCache;
@@ -873,14 +880,19 @@ public class FeatureUtility {
             return this;
         } 
 
-	public FeatureUtilityBuilder setVerify(String verifyOption) {
-	    this.verifyOption = verifyOption;
-	    return this;
-	}
+		public FeatureUtilityBuilder setVerify(String verifyOption) {
+		    this.verifyOption = verifyOption;
+		    return this;
+		}
 
         public FeatureUtility build() throws IOException, InstallException {
             return new FeatureUtility(this);
         }
+
+		public FeatureUtilityBuilder setPlatforms(List<String> platformNames) {
+			this.platforms = platformNames;
+		    return this;
+		}
 
     }
 

--- a/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/cli/InstallServerAction.java
+++ b/dev/com.ibm.ws.install.featureUtility/src/com/ibm/ws/install/featureUtility/cli/InstallServerAction.java
@@ -35,6 +35,7 @@ import com.ibm.ws.install.featureUtility.FeatureUtility;
 import com.ibm.ws.install.featureUtility.FeatureUtilityExecutor;
 import com.ibm.ws.install.internal.InstallLogUtils;
 import com.ibm.ws.install.internal.InstallUtils;
+import com.ibm.ws.install.internal.InstallUtils.FeaturesPlatforms;
 import com.ibm.ws.install.internal.ProgressBar;
 import com.ibm.ws.install.internal.InstallLogUtils.Messages;
 import com.ibm.ws.install.internal.asset.ServerAsset;
@@ -59,6 +60,7 @@ public class InstallServerAction implements ActionHandler {
         private Logger logger;
         private List<String> argList;
         private List<String> featureNames;
+        private List<String> platformNames;
         private String fromDir;
         private String toDir;
         private String featuresBom;
@@ -92,6 +94,7 @@ public class InstallServerAction implements ActionHandler {
                 this.logger = InstallLogUtils.getInstallLogger();
                 this.installKernel = InstallKernelFactory.getInteractiveInstance();
                 this.featureNames = new ArrayList<String>();
+                this.platformNames = new ArrayList<String>();
                 this.servers = new HashSet<>();
 
                 this.argList = args.getPositionalArguments();
@@ -218,7 +221,9 @@ public class InstallServerAction implements ActionHandler {
 
                 try {
 					// get original server features now
-					featuresToInstall.addAll(installKernel.getServerFeaturesToInstall(servers, false));
+                    FeaturesPlatforms fp = installKernel.getServerFeaturesAndPlatformsToInstall(servers, false);
+					featuresToInstall.addAll(fp.getFeatures());
+					platformNames.addAll(fp.getPlatforms());
                         logger.fine("all server features: " + featuresToInstall);
                 } catch (InstallException ie) {
                         logger.log(Level.SEVERE, ie.getMessage(), ie);
@@ -259,7 +264,7 @@ public class InstallServerAction implements ActionHandler {
         private ExitCode install() {
                 try {
                         featureUtility = new FeatureUtility.FeatureUtilityBuilder().setFromDir(fromDir)
-				.setFeaturesToInstall(featureNames).setNoCache(noCache)
+				.setFeaturesToInstall(featureNames).setNoCache(noCache).setPlatforms(platformNames)
 				.setlicenseAccepted(acceptLicense).setAdditionalJsons(additionalJsons).setVerify(verify)
 				.build();
                         featureUtility.setFeatureToExt(featureToExt);

--- a/dev/com.ibm.ws.install.featureUtility/test/com/ibm/ws/install/featureUtility/FeatureUtilityTest.java
+++ b/dev/com.ibm.ws.install.featureUtility/test/com/ibm/ws/install/featureUtility/FeatureUtilityTest.java
@@ -14,7 +14,7 @@ import com.ibm.ws.install.InstallException;
 
 public class FeatureUtilityTest {
 
-    FeatureUtility featureUtility = new FeatureUtility(null, null, null, null, null, null, null, null, null, null, null,
+    FeatureUtility featureUtility = new FeatureUtility(null, null, null, null, null, null, null, null, null, null, null, null,
 	    null, false, null);
 
     @Before

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
@@ -21,6 +21,7 @@ import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.ibm.websphere.simplicity.ProgramOutput;
@@ -148,6 +149,28 @@ public class InstallServerTest extends FeatureUtilityToolTest {
 	Log.entering(c, METHOD_NAME);
 
 	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/multiVersionServerXml/server.xml");
+
+	String[] param1s = { "installServerFeatures", "serverX", "--verbose" };
+	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
+
+	checkCommandOutput(po, 21, "CWWKF1405E", null);
+	Log.exiting(c, METHOD_NAME);
+    }
+    
+    /**
+     * Test the install of versionless servlet from maven central. Multi-version is not
+     * supported with installServerFeature as it cannot be installed to same
+     * resource.
+     *
+     * @throws Exception
+     */
+    @Ignore
+    @Test
+    public void testVersionlessWithPlatformFeatures() throws Exception {
+	final String METHOD_NAME = "testInvalidMultiVersionFeatures";
+	Log.entering(c, METHOD_NAME);
+
+	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/versionlessWPlatform/server.xml");
 
 	String[] param1s = { "installServerFeatures", "serverX", "--verbose" };
 	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);

--- a/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessWPlatform/server.xml
+++ b/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessWPlatform/server.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <!-- Enable features -->
+    <featureManager>
+	   <platform>jakartaee-10.0</platform>
+	   <feature>servlet</feature>
+    </featureManager>
+</server>
+

--- a/dev/com.ibm.ws.install/publish/servers/serverA/server.xml
+++ b/dev/com.ibm.ws.install/publish/servers/serverA/server.xml
@@ -3,6 +3,7 @@
 
     <!-- Enable features -->
     <featureManager>
+		<platform>jakartaee-10.0</platform>
         <feature>genericCoreFeature</feature>
 		<feature>featureA-1.0</feature>
 		<feature>featureB-1.0</feature>

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallConstants.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallConstants.java
@@ -75,6 +75,7 @@ public class InstallConstants {
     public static final String INSTALL_LOCAL_ESA = "install.local.esa";
     public static final String SINGLE_JSON_FILE = "single.json.file";
     public static final String FEATURES_TO_RESOLVE = "features.to.resolve";
+    public static final String PLATFORMS = "platforms";
     public static final String INDIVIDUAL_ESAS = "individual.esas";
     public static final String INSTALL_INDIVIDUAL_ESAS = "install.individual.esas";
     public static final String LICENSE_ACCEPT = "license.accept";

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallKernelInteractive.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallKernelInteractive.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import com.ibm.ws.install.internal.InstallUtils.FeaturesPlatforms;
 import com.ibm.ws.install.internal.asset.ServerAsset;
 import com.ibm.ws.install.internal.asset.ServerPackageAsset;
 import com.ibm.ws.repository.connections.RepositoryConnectionList;
@@ -195,6 +196,16 @@ public interface InstallKernelInteractive {
      * @throws IOException
      */
     public Collection<String> getServerFeaturesToInstall(Set<ServerAsset> servers, boolean offlineOnly) throws InstallException, IOException;
+
+    /**
+     *
+     * @param servers     set of ServerAssets
+     * @param offlineOnly if features should only be acquired offline
+     * @return FeaturesPlatforms Collections of server features and platforms as Strings
+     * @throws InstallException
+     * @throws IOException
+     */
+    public FeaturesPlatforms getServerFeaturesAndPlatformsToInstall(Set<ServerAsset> servers, boolean offlineOnly) throws InstallException, IOException;
 
     /**
      * Deploys the server package given by an archive file

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/Director.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/Director.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -47,6 +47,7 @@ import com.ibm.ws.install.InstalledFeature;
 import com.ibm.ws.install.InstalledFeatureCollection;
 import com.ibm.ws.install.ReapplyFixException;
 import com.ibm.ws.install.internal.InstallLogUtils.Messages;
+import com.ibm.ws.install.internal.InstallUtils.FeaturesPlatforms;
 import com.ibm.ws.install.internal.asset.ESAAsset;
 import com.ibm.ws.install.internal.asset.FixAsset;
 import com.ibm.ws.install.internal.asset.InstallAsset;
@@ -467,13 +468,16 @@ public class Director extends AbstractDirector {
      * @throws InstallException
      * @throws IOException
      */
-    public Collection<String> getServerFeaturesToInstall(Set<ServerAsset> servers, boolean offlineOnly) throws InstallException, IOException {
+    public FeaturesPlatforms getServerFeaturesAndPlatformsToInstall(Set<ServerAsset> servers, boolean offlineOnly) throws InstallException, IOException {
         Set<String> features = new TreeSet<String>();
         Set<String> serverNames = new HashSet<String>(servers.size());
+        Set<String> platforms = new TreeSet<String>();
 
         for (ServerAsset sa : servers) {
             File serverXmlFile = sa.getServerXmlFile();
-            Collection<String> requiredFeatures = InstallUtils.getFeatures(serverXmlFile.getAbsolutePath(), serverXmlFile.getName(), new HashSet<String>());
+            FeaturesPlatforms fp = InstallUtils.getFeatures(serverXmlFile.getAbsolutePath(), serverXmlFile.getName(), new HashSet<String>());
+            Set<String> requiredFeatures = fp.getFeatures();
+            Set<String> requiredPlatforms = fp.getPlatforms();
 
             // process the configDropins folders (Defaults and overrides)
             File serverDirectory = sa.getServerDirectory();
@@ -486,8 +490,11 @@ public class Director extends AbstractDirector {
                     logger.fine("Processing " + folder);
                     Files.newDirectoryStream(Paths.get(folder.toURI()),
                                              path -> path.toString().endsWith(".xml")).forEach(path -> {
+                                                 FeaturesPlatforms fep;
                                                  try {
-                                                     requiredFeatures.addAll(InstallUtils.getFeatures(path.toString(), path.getFileName().toString(), new HashSet<String>()));
+                                                     fep = InstallUtils.getFeatures(path.toString(), path.getFileName().toString(), new HashSet<String>());
+                                                     requiredFeatures.addAll(fep.getFeatures());
+                                                     requiredPlatforms.addAll(fep.getPlatforms());
                                                  } catch (IOException e) {
                                                      logger.fine("Could not process " + path);
                                                  }
@@ -502,6 +509,7 @@ public class Director extends AbstractDirector {
                                                                                         sa.getServerName(),
                                                                                         InstallUtils.getFeatureListOutput(requiredFeatures)));
                 features.addAll(requiredFeatures);
+                platforms.addAll(requiredPlatforms);
                 serverNames.add(sa.getServerName());
 
             }
@@ -509,7 +517,7 @@ public class Director extends AbstractDirector {
 
         InstallUtils.setServerXmlInstallTrue();
 
-        return features;
+        return new FeaturesPlatforms(features, platforms);
     }
 
     /**

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelImpl.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelImpl.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -38,6 +38,7 @@ import com.ibm.ws.install.InstalledFeatureCollection;
 import com.ibm.ws.install.ReapplyFixException;
 import com.ibm.ws.install.RepositoryConfigUtils;
 import com.ibm.ws.install.internal.InstallLogUtils.Messages;
+import com.ibm.ws.install.internal.InstallUtils.FeaturesPlatforms;
 import com.ibm.ws.install.internal.asset.ServerAsset;
 import com.ibm.ws.install.internal.asset.ServerPackageAsset;
 import com.ibm.ws.repository.common.enums.ResourceType;
@@ -265,7 +266,15 @@ public class InstallKernelImpl implements InstallKernel, InstallKernelInteractiv
     public Collection<String> getServerFeaturesToInstall(Set<ServerAsset> servers, boolean offlineOnly) throws InstallException, IOException {
         this.director.fireProgressEvent(InstallProgressEvent.RESOLVE, 0,
                                         Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("STATE_CHECKING_MISSING_SERVER_FEATURES"));
-        return this.director.getServerFeaturesToInstall(servers, offlineOnly);
+        FeaturesPlatforms fep;
+        fep = this.director.getServerFeaturesAndPlatformsToInstall(servers, offlineOnly);
+        return fep.getFeatures();
+    }
+
+    public FeaturesPlatforms getServerFeaturesAndPlatformsToInstall(Set<ServerAsset> servers, boolean offlineOnly) throws InstallException, IOException {
+        this.director.fireProgressEvent(InstallProgressEvent.RESOLVE, 0,
+                                        Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("STATE_CHECKING_MISSING_SERVER_FEATURES"));
+        return this.director.getServerFeaturesAndPlatformsToInstall(servers, offlineOnly);
     }
 
     @Override

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -510,6 +510,12 @@ public class InstallKernelMap implements Map {
             } else {
                 throw new IllegalArgumentException();
             }
+        } else if (InstallConstants.PLATFORMS.equals(key)) {
+            if (value instanceof Collection) {
+                data.put(InstallConstants.PLATFORMS, value);
+            } else {
+                throw new IllegalArgumentException();
+            }
         } else if (InstallConstants.VERIFY_OPTION.equals(key)) {
             if (value instanceof VerifyOption) {
                 data.put(InstallConstants.VERIFY_OPTION, value);
@@ -958,6 +964,8 @@ public class InstallKernelMap implements Map {
                 resolveResult = resolver.resolve((Collection<String>) data.get(InstallConstants.FEATURES_TO_RESOLVE));
             } else {
                 resolveResult = resolver.resolveAsSet((Collection<String>) data.get(InstallConstants.FEATURES_TO_RESOLVE));
+                // TODO - After Resolver changes, also start passing platforms
+                //         (Collection<String>) data.get(InstallConstants.PLATFORMS));
             }
 
             if (!resolveResult.isEmpty()) {

--- a/dev/com.ibm.ws.install/test/com/ibm/ws/install/ServerAssetTest.java
+++ b/dev/com.ibm.ws.install/test/com/ibm/ws/install/ServerAssetTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,12 +19,16 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.util.Arrays;
+import java.util.HashSet;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
+import com.ibm.ws.install.internal.InstallUtils;
+import com.ibm.ws.install.internal.InstallUtils.FeaturesPlatforms;
 import com.ibm.ws.install.internal.asset.ServerAsset;
 import com.ibm.ws.kernel.boot.cmdline.Utils;
 
@@ -94,6 +98,29 @@ public class ServerAssetTest {
             if (dServerXML.exists())
                 dServerXML.delete();
         }
+    }
+
+    @Test
+    public void testGetServerFeaturesAndPlatforms() throws Exception {
+        initializeTestCase("testGetServerFeaturesAndPlatforms");
+
+        File sServerXML = new File("publish/servers/serverA/server.xml");
+        File dServerXML = new File(testDir, "server.xml");
+
+        try {
+            copyFile(sServerXML, dServerXML);
+            assertTrue("Cannot find server.xml file: " + dServerXML.getCanonicalPath(), dServerXML.isFile());
+
+            ServerAsset sa = new ServerAsset(dServerXML);
+            File serverXmlFile = sa.getServerXmlFile();
+            FeaturesPlatforms fp = InstallUtils.getFeatures(serverXmlFile.getAbsolutePath(), serverXmlFile.getName(), new HashSet<String>());
+            assertTrue(fp.getFeatures().containsAll(Arrays.asList("genericCoreFeature", "featureA-1.0", "featureB-1.0", "featureC-1.0")));
+            assertTrue(fp.getPlatforms().containsAll(Arrays.asList("jakartaee-10.0")));
+        } finally {
+            if (dServerXML.exists())
+                dServerXML.delete();
+        }
+
     }
 
     private static void copyFile(File sourceFile, File destFile) throws IOException {


### PR DESCRIPTION
Initial code changes preparing for passing "platforms" from server.xml in install scenarios

- Changes to InstallUtils that reads the server.xml for a list of features, now returns both features and platforms lists

- FeatureUtility propagates these values for the "InstallServerAction"

- Added tests for passing platforms and versionless features (Although disabled until all code is in place)

- Added unit test for Server Asses reading features and platforms

Previous question around also passing EnvVar values...  this is not needed, as the Kernel resolver does all of this work, and only needs the new "platforms" list to help determine what feature set to install.

Repository changes are also coming, and we'll need to change the TODO in the InstalMap class to also pass platform list.

For now this will put the parsing, and tests in place...