### PR TITLE
Fix oracle kerberos testing on Java 23

### DIFF
--- a/dev/build.example.testcontainers_fat/build.gradle
+++ b/dev/build.example.testcontainers_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,9 +15,22 @@
  // This bundle is required both at compiletime and runtime.
  addRequiredLibraries.dependsOn copyTestContainers
  
+ //TODO temporary while we switch from ojdbc8_g to ojdbc8
+ task copyJdbcDriversOracleRename(type: Copy) {
+  mustRunAfter jar
+  from configurations.jdbcDrivers
+  into new File(autoFvtDir, 'publish/shared/resources/jdbc')
+  rename 'jcc.*.jar', 'jcc.jar'
+  rename 'derby-.*.jar', 'derby.jar'
+  rename 'derbyclient-.*.jar', 'derbyclient.jar'
+  rename 'ojdbc8_g.*.jar', 'ojdbc8.jar'
+  rename 'postgresql.*.jar', 'postgresql.jar'
+  rename 'mssql-jdbc.*.jar', 'mssql-jdbc.jar'
+}
+ 
  // If you are preforming database testing use the copyJdbcDrivers
  // task to copy the common JDBC drivers into the
  // publish/shared/resources/jdbc directory 
- addRequiredLibraries.dependsOn copyJdbcDrivers
+ addRequiredLibraries.dependsOn copyJdbcDriversOracleRename
 
  addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -258,6 +258,16 @@
     </dependency>
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc11</artifactId>
+      <version>23.4.0.24.05</version>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc8</artifactId>
+      <version>23.4.0.24.05</version>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ucp</artifactId>
       <version>21.8.0.0</version>
     </dependency>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -47,6 +47,8 @@ com.microsoft.sqlserver:mssql-jdbc:9.2.1.jre8
 com.nimbusds:nimbus-jose-jwt:4.23
 com.oracle.database.jdbc.debug:ojdbc11_g:21.8.0.0
 com.oracle.database.jdbc.debug:ojdbc8_g:21.8.0.0
+com.oracle.database.jdbc:ojdbc11:23.4.0.24.05
+com.oracle.database.jdbc:ojdbc8:23.4.0.24.05
 com.oracle.database.jdbc:ucp:21.8.0.0
 com.oracle.database.security:oraclepki:21.8.0.0
 com.oracle.database.security:osdt_cert:21.8.0.0

--- a/dev/com.ibm.ws.jdbc_fat_krb5/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,23 +12,33 @@
  *******************************************************************************/
 
 configurations {
-	oracle11 { transitive = false; }
+    oracle8  { transitive = false; }
+    oracle11 { transitive = false; }
 }
 
 dependencies {
-	oracle11 'com.oracle.database.jdbc.debug:ojdbc11_g:21.8.0.0'
+    oracle8 'com.oracle.database.jdbc:ojdbc8:23.4.0.24.05'
+    oracle11 'com.oracle.database.jdbc:ojdbc11:23.4.0.24.05'
+}
+
+task addOracle8(type: Copy) {
+  mustRunAfter jar
+  from configurations.oracle8
+  into new File(autoFvtDir, 'publish/shared/resources/jdbc')
+  rename 'ojdbc8.*.jar', 'ojdbc8.jar'
 }
 
 task addOracle11(type: Copy) {
   mustRunAfter jar
   from configurations.oracle11
   into new File(autoFvtDir, 'publish/shared/resources/jdbc')
-  rename 'ojdbc11_g.*.jar', 'ojdbc11_g.jar'
+  rename 'ojdbc11.*.jar', 'ojdbc11.jar'
 }
 
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
+  dependsOn addOracle8
   dependsOn addOracle11
   dependsOn addJakartaTransformer
   dependsOn copyTestContainers

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import com.ibm.ws.jdbc.fat.krb5.containers.KerberosPlatformRule;
 import com.ibm.ws.jdbc.fat.krb5.containers.OracleKerberosContainer;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -47,6 +48,9 @@ import jdbc.krb5.oracle.web.OracleKerberosTestServlet;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
+//TODO The current Oracle JDBC driver (ojdbc8.jar v23.4.0.24.05) only supports Java 11-21
+//modify/remove this line once it or another driver release supports 23+
+@MaximumJavaLevel(javaLevel = 21)
 public class OracleKerberosTest extends FATServletClient {
 
     private static final Class<?> c = OracleKerberosTest.class;
@@ -75,16 +79,17 @@ public class OracleKerberosTest extends FATServletClient {
         ShrinkHelper.defaultDropinApp(server, APP_NAME, "jdbc.krb5.oracle.web");
 
         if (JavaInfo.JAVA_VERSION >= 1.8 && JavaInfo.JAVA_VERSION < 11) {
-            server.addEnvVar("ORACLE_DRIVER", "ojdbc8_g.jar");
+            server.addEnvVar("ORACLE_DRIVER", "ojdbc8.jar");
         }
 
         if (JavaInfo.JAVA_VERSION >= 11 && JavaInfo.JAVA_VERSION < 21) {
-            server.addEnvVar("ORACLE_DRIVER", "ojdbc11_g.jar");
+            server.addEnvVar("ORACLE_DRIVER", "ojdbc11.jar");
         }
 
-        // Precaution in case there are breaking changes to the driver in Java 21
+        // TODO update to next ojdbc version that supports Java 23
+        // for now use ojdbc11.jar as a place holder for local testing.
         if (JavaInfo.JAVA_VERSION >= 21) {
-            server.addEnvVar("ORACLE_DRIVER", "ojdbc11_g.jar");
+            server.addEnvVar("ORACLE_DRIVER", "ojdbc11.jar");
         }
 
         server.addEnvVar("ORACLE_DBNAME", oracle.getDatabaseName());

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerType.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerType.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package componenttest.topology.database.container;
 
+import java.io.File;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,25 +38,27 @@ import com.ibm.websphere.simplicity.log.Log;
  */
 @SuppressWarnings("rawtypes")
 public enum DatabaseContainerType {
-    DB2("jcc.jar", Db2Container.class.getCanonicalName(), Properties_db2_jcc.class, //
+    DB2("jcc.jar", "", Db2Container.class.getCanonicalName(), Properties_db2_jcc.class, //
         DockerImageName.parse("kyleaure/db2:1.0").asCompatibleSubstituteFor("ibmcom/db2")),
-    Derby("derby.jar", DerbyNoopContainer.class.getCanonicalName(), Properties_derby_embedded.class, DockerImageName.parse("")),
-    DerbyClient("derbyclient.jar", DerbyClientContainer.class.getCanonicalName(), Properties_derby_client.class, DockerImageName.parse("")),
-    Oracle("ojdbc8_g.jar", OracleContainer.class.getCanonicalName(), Properties_oracle.class, //
+    Derby("derby.jar", "", DerbyNoopContainer.class.getCanonicalName(), Properties_derby_embedded.class, DockerImageName.parse("")),
+    DerbyClient("derbyclient.jar", "", DerbyClientContainer.class.getCanonicalName(), Properties_derby_client.class, DockerImageName.parse("")),
+    Oracle("ojdbc8_g.jar", "ojdbc8.jar", OracleContainer.class.getCanonicalName(), Properties_oracle.class, //
            DockerImageName.parse("gvenzl/oracle-free:23.3-full-faststart")),
-    Postgres("postgresql.jar", PostgreSQLContainer.class.getCanonicalName(), Properties_postgresql.class, //
+    Postgres("postgresql.jar", "", PostgreSQLContainer.class.getCanonicalName(), Properties_postgresql.class, //
              DockerImageName.parse("postgres:14.1-alpine")),
-    SQLServer("mssql-jdbc.jar", MSSQLServerContainer.class.getCanonicalName(), Properties_microsoft_sqlserver.class, //
+    SQLServer("mssql-jdbc.jar", "", MSSQLServerContainer.class.getCanonicalName(), Properties_microsoft_sqlserver.class, //
               DockerImageName.parse("mcr.microsoft.com/mssql/server:2019-CU18-ubuntu-20.04"));
 
     private final String driverName;
+    private final String altDriverName; //TODO temporary while we switch from ojdbc8_g to ojdbc8
     private final Class<DataSourceProperties> dsPropsClass;
     private final Class<? extends JdbcDatabaseContainer> containerClass;
     private final DockerImageName imageName;
 
     @SuppressWarnings("unchecked")
-    DatabaseContainerType(final String driverName, final String containerClassName, final Class dsPropsClass, final DockerImageName imageName) {
+    DatabaseContainerType(final String driverName, final String altDriverName, final String containerClassName, final Class dsPropsClass, final DockerImageName imageName) {
         this.driverName = driverName;
+        this.altDriverName = altDriverName;
 
         //Use reflection to get classes at runtime.
         Class containerClass = null;
@@ -77,7 +80,21 @@ public enum DatabaseContainerType {
      * @return String - JDBC Driver Name
      */
     public String getDriverName() {
-        return driverName;
+        //TODO temporary while we switch from ojdbc8_g to ojdbc8
+        // return this.driverName;
+        File primary = new File("publish/shared/resources/jdbc/" + this.driverName);
+        File secondary = new File("publish/shared/resources/jdbc/" + (this.altDriverName == "" ? "null" : this.altDriverName));
+
+        if (primary.exists()) {
+            Log.info(this.containerClass, "getDriverName", "FOUND: " + this + " JDBC driver in location: " + primary.getAbsolutePath());
+            return this.driverName;
+        } else if (secondary.exists()) {
+            Log.info(this.containerClass, "getDriverName", "FOUND: " + this + " JDBC driver in location: " + secondary.getAbsolutePath());
+            return this.altDriverName;
+        } else {
+            Log.warning(this.containerClass, "MISSING: " + this + " JDBC driver not in location: " + primary.getAbsolutePath());
+            return this.driverName;
+        }
     }
 
     /**

--- a/dev/io.openliberty.org.testcontainers/cache/projects
+++ b/dev/io.openliberty.org.testcontainers/cache/projects
@@ -172,6 +172,7 @@ com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes
 com.ibm.ws.wsat.migration_fat.6
 com.ibm.ws.wsat.recovery_fat.multi.6
 fattest.simplicity
+io.openliberty.checkpoint_fat_jcache_hazelcast
 io.openliberty.checkpoint_fat_persistence
 io.openliberty.checkpoint_fat_session_cache_infinispan_container
 io.openliberty.checkpoint_fat_springboot_data


### PR DESCRIPTION
Prepare to update all tests to use Oracle JDBC 23 driver (not to be confused with Java 23 JDK)

