### PR TITLE
JAX-WS: Refactor configuration fats for clearer repeat rules

### DIFF
--- a/dev/io.openliberty.jaxws.config_fat/bnd.bnd
+++ b/dev/io.openliberty.jaxws.config_fat/bnd.bnd
@@ -26,6 +26,7 @@ tested.features: \
   jsp-2.2, \
   jsp-2.3, \
   pages-3.0, \
+  servlet-4.0, \
   servlet-5.0, \
   xmlBinding-3.0, \
   xmlWS-3.0, \

--- a/dev/io.openliberty.jaxws.config_fat/fat/src/io/openliberty/jaxws/config/fat/FATSuite.java
+++ b/dev/io.openliberty.jaxws.config_fat/fat/src/io/openliberty/jaxws/config/fat/FATSuite.java
@@ -26,6 +26,8 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11)).andWith(FeatureReplacementAction.EE10_FEATURES());
-
+    public static RepeatTests r = RepeatTests.with(new EmptyAction())
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17));
 }


### PR DESCRIPTION
This PR refactors `io.openliberty.jaxws.config_fat` to add additional fat repeats for EE 8. 