### PR TITLE
Do not pool connections before checkpoint restore

### DIFF
--- a/dev/com.ibm.ws.jca.cm/bnd.bnd
+++ b/dev/com.ibm.ws.jca.cm/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2022 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -78,6 +78,7 @@ instrument.disabled: true
 	com.ibm.websphere.javaee.connector.1.6;version=latest,\
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.ws.javaee.dd.common;version=latest,\
+	com.ibm.ws.kernel.boot.common;version=latest,\
 	com.ibm.ws.kernel.service,\
 	com.ibm.ws.classloading;version=latest,\
 	com.ibm.ws.container.service;version=latest,\

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
@@ -335,10 +335,10 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
 
                 boolean beforeCheckpoint = !CheckpointPhase.getPhase().restored();
                 if (beforeCheckpoint) {
-                    mcWrapper.markStale();
                     if (isTraceOn && tc.isDebugEnabled()) {
-                        Tr.debug(this, tc, "Marked the mcWrapper stale " + mcWrapper + " Do not pool any connection before checkpoint restore");
+                        Tr.debug(this, tc, "Marking the mcWrapper as not poolable before checkpoint restore " + mcWrapper);
                     }
+                    mcWrapper.markNotPoolable();
                 }
             } catch (ResourceException e) {
                 mcWrapper.setPoolState(poolState);

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2021 IBM Corporation and others.
+ * Copyright (c) 1997, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,6 +65,8 @@ import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
 import com.ibm.ws.tx.rrs.RRSXAResourceFactory;
 import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 import com.ibm.wsspi.resource.ResourceFactory;
+
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 
 /**
  * An instance of the ConnectionManager class is created by the
@@ -329,6 +331,14 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
                                                                 "this failure may have been logged during the connection error event " +
                                                                 "logging.");
                     throw e;
+                }
+
+                boolean beforeCheckpoint = !CheckpointPhase.getPhase().restored();
+                if (beforeCheckpoint) {
+                    mcWrapper.markStale();
+                    if (isTraceOn && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "Marked the mcWrapper stale " + mcWrapper + " Do not pool any connection before checkpoint restore");
+                    }
                 }
             } catch (ResourceException e) {
                 mcWrapper.setPoolState(poolState);

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
@@ -248,9 +248,8 @@ public final class FreePool implements JCAPMIHelper {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.entry(this, tc, "returnToFreePool", gConfigProps.cfName);
         }
-        if (mcWrapper.shouldBeDestroyed() || mcWrapper.hasFatalErrorNotificationOccurred(fatalErrorNotificationTime)
-            || ((pm.agedTimeout != -1)
-                && (mcWrapper.hasAgedTimedOut(pm.agedTimeoutMillis)))) {
+        if (mcWrapper.shouldBeDestroyed() || mcWrapper.hasFatalErrorNotificationOccurred(fatalErrorNotificationTime) || !mcWrapper.isPoolable()
+            || ((pm.agedTimeout != -1) && (mcWrapper.hasAgedTimedOut(pm.agedTimeoutMillis)))) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 if (mcWrapper.shouldBeDestroyed()) {
                     Tr.debug(this, tc, "Connection destroy flag is set, removing connection " + mcWrapper);
@@ -264,6 +263,9 @@ public final class FreePool implements JCAPMIHelper {
                 if (mcWrapper.isDestroyState()) {
                     Tr.debug(this, tc, "Mbean method purgePoolContents with option immediate was used." +
                                        "  Connection cleanup and destroy is being processed.");
+                }
+                if (!mcWrapper.isPoolable()) {
+                    Tr.debug(this, tc, "Connection was flagged as not poolable and will not be returned to the free pool.");
                 }
             }
             if (mcWrapper.isDestroyState()) {

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
@@ -364,6 +364,15 @@ public final class MCWrapper implements com.ibm.ws.j2c.MCWrapper, JCAPMIHelper {
     private boolean inSharedPool = false;
 
     /**
+     * During specific server states (such as during instantOn checkpoint) we may not
+     * want to allow connections to pool and disregard user configuration.
+     * This is another property like stale and do_not_reuse_mcw that will prevent pooling.
+     * However, this property is not related to an error state and is expected to allow
+     * valid connections to be discarded after use.
+     */
+    private boolean poolable = true;
+
+    /**
      * There is one recoveryToken needed per ManagedConnectionFactory and thus one per PoolManager.
      * The <code>PoolManager</code> will get the token from the transaction service in it's constructor
      * and pass it into the MCWrapperPool. The MCWrapper pool will in turn set it into all the MCWrapper
@@ -3191,5 +3200,15 @@ public final class MCWrapper implements com.ibm.ws.j2c.MCWrapper, JCAPMIHelper {
     @Override
     public int getMaximumConnectionValue() {
         return this.pm.maxConnections;
+    }
+
+    @Override
+    public void markNotPoolable() {
+        this.poolable = false;
+    }
+
+    @Override
+    public boolean isPoolable() {
+        return this.poolable;
     }
 }

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/j2c/MCWrapper.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/j2c/MCWrapper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2013 IBM Corporation and others.
+ * Copyright (c) 1997, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -106,6 +106,12 @@ public interface MCWrapper {
      */
     void markStale();
 
+    /**
+     * Marks this connection for destruction.
+     * Used during specific server states where valid connections should not be pooled.
+     */
+    void markNotPoolable();
+
     boolean hasFatalErrorNotificationOccurred(int fatalErrorNotificationTime);
 
     boolean hasAgedTimedOut(long timeoutValue);
@@ -113,6 +119,14 @@ public interface MCWrapper {
     boolean hasIdleTimedOut(long timeoutValue);
 
     void markInUse();
+
+    /**
+     * Returns true if the connection is poolable as determined by the MCWrapper property poolable.
+     * Does not check any other state such as agedTimeout, idleTimeout, or stale.
+     *
+     * @return
+     */
+    boolean isPoolable();
 
     boolean isStale();
 

--- a/dev/io.openliberty.checkpoint_fat_persistence/fat/src/io/openliberty/checkpoint/fat/JakartaDataTest.java
+++ b/dev/io.openliberty.checkpoint_fat_persistence/fat/src/io/openliberty/checkpoint/fat/JakartaDataTest.java
@@ -20,6 +20,7 @@ import java.sql.PreparedStatement;
 import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -87,6 +88,9 @@ public class JakartaDataTest extends FATServletClient {
         envVars.put("DB_HOST", postgre.getHost());
 
         ShrinkHelper.defaultApp(server, DATA_APP, "io.openliberty.checkpoint.data.app", "io.openliberty.checkpoint.data.entity", "io.openliberty.checkpoint.data.repo");
+
+        for (Entry<String, String> e : envVars.entrySet())
+            server.addEnvVar(e.getKey(), e.getValue());
 
         server.setCheckpoint(CheckpointPhase.AFTER_APP_START, false, null);
         server.startServer();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
@@ -210,11 +210,21 @@ public class DataProvider implements //
     public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {
         Collection<FutureEMBuilder> futures = futureEMBuilders.remove(appInfo.getName());
         if (futures != null) {
+            boolean beforeCheckpoint = !CheckpointPhase.getPhase().restored();
             for (FutureEMBuilder futureEMBuilder : futures) {
-                // This delays createEMBuilder until restore.
-                // While this works by avoiding all connections to the data source, it does make restore much slower.
-                // TODO figure out how to do more work on restore without having to make a connection to the data source
-                CheckpointPhase.onRestore(() -> futureEMBuilder.completeAsync(futureEMBuilder::createEMBuilder, executor));
+                if (beforeCheckpoint)
+                    try {
+                        // Run the task in the foreground if before a checkpoint.
+                        // This is necessary to ensure this task completes before the checkpoint.
+                        // Application startup performance is not as important before checkpoint
+                        // and this ensures we don't do this work on restore side which will make
+                        // restore faster.
+                        futureEMBuilder.complete(futureEMBuilder.createEMBuilder());
+                    } catch (Throwable x) {
+                        futureEMBuilder.completeExceptionally(x);
+                    }
+                else
+                    futureEMBuilder.completeAsync(futureEMBuilder::createEMBuilder, executor);
             }
         }
     }


### PR DESCRIPTION
- Reintroduce instant-on for entity manager for Jakarta data (removed #28569)
- Do not pool connections before checkpoint restore