### PR TITLE
add bouncy castle jars directly to prevent jar signature problem

### DIFF
--- a/dev/com.ibm.ws.security.spnego.fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.spnego.fat.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2023 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,11 @@ src: \
 
 test.project: true
 
+# Using the actual bouncycastle libraries instead of io.openliberty.org.bouncycastle ones because sshd has issues.
 -buildpath: \
+    org.bouncycastle:bcpg-jdk18on;version=1.78.1,\
+    org.bouncycastle:bcpkix-jdk18on;version=1.78.1,\
+    org.bouncycastle:bcprov-jdk18on;version=1.78.1,\
     fattest.simplicity;version=latest,\
     io.openliberty.org.apache.commons.codec;version=latest,\
     io.openliberty.org.apache.commons.logging;version=latest,\


### PR DESCRIPTION
Fixes RTC Defect 300701

Using the `io.openliberty.org.bouncycastle.bcprov-jdk18on.jar` wrapper project for the BC jars was causing an issue for the apache.sshd lib when running on certain JDK levels
```
com.ibm.ws.security.spnego.fat.FATSuite:org.apache.sshd.common.SshException: DefaultAuthFuture[ssh-connection]: Failed (NoSuchProviderException) to execute: JCE cannot authenticate the provider BC
    at org.apache.sshd.common.future.AbstractSshFuture.lambda$verifyResult$1(AbstractSshFuture.java:132)
    ...
Caused by: java.util.jar.JarException: file: .../dev/autoFVT/fattest.simplicity/lib/io.openliberty.org.bouncycastle.bcprov-jdk18on.jar has unsigned entries - org/bouncycastle/LICENSE.class
```