### PR TITLE
resolver result holds versionless and platform errors

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -1486,9 +1486,20 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
             }
 
             @Override
-            public Set<String> getUnresolvedVersionless() {
+            public Map<String, String> getVersionlessFeatures(){
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public Set<String> getResolvedPlatforms(){
                 return Collections.emptySet();
             }
+
+            @Override
+            public Set<String> getMissingPlatforms(){
+                return Collections.emptySet();
+            }
+
         };
     }
 
@@ -1982,9 +1993,11 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
         }
 
         if(isBeta){
-            for(String versionlessFeature : result.getUnresolvedVersionless()){
-                reportedErrors = true;
-                Tr.error(tc, "UNRESOLVED_VERSIONLESS_FEATURE", getFeatureName(versionlessFeature));
+            for (Map.Entry<String, String> versionlessResolved : result.getVersionlessFeatures().entrySet()) {
+                if(versionlessResolved.getValue() == null){
+                    reportedErrors = true;
+                    Tr.error(tc, "UNRESOLVED_VERSIONLESS_FEATURE", versionlessResolved.getKey());
+                }
             }
         }
 

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverResultImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverResultImpl.java
@@ -44,7 +44,11 @@ public class FeatureResolverResultImpl implements Result {
 
         this._conflicts = new HashMap<>(0);
 
-        this._unresolvedVersionless = new HashSet<>();
+        this._missingPlatforms = new HashSet<String>(0);
+
+        this._versionlessFeatures = new HashMap<>(0);
+
+        this._resolvedPlatforms = new HashSet<>(0);
 
         this._resolved = new LinkedHashSet<>();
     }
@@ -56,7 +60,9 @@ public class FeatureResolverResultImpl implements Result {
         return !(_missing.isEmpty() &&
                  _nonPublicRoots.isEmpty() &&
                  _wrongProcessTypes.isEmpty() &&
-                 _conflicts.isEmpty());
+                 _conflicts.isEmpty() && 
+                 !_versionlessFeatures.values().contains(null) &&
+                 _missingPlatforms.isEmpty());
     }
 
     //
@@ -316,16 +322,37 @@ public class FeatureResolverResultImpl implements Result {
 
     //
 
-    protected final Set<String> _unresolvedVersionless;
+    protected final HashMap<String, String> _versionlessFeatures;
 
     @Override
-    public Set<String> getUnresolvedVersionless(){
-        return _unresolvedVersionless;
+    public HashMap<String, String> getVersionlessFeatures(){
+        return _versionlessFeatures;
     }
 
-    protected void addUnresolvedVersionless(String versionlessFeature){
-        trace("Unresolvable versionless feature  [ " + versionlessFeature + "]");
-        _unresolvedVersionless.add(versionlessFeature);
+    protected void addVersionlessFeature(String versionlessFeature, String versionedFeature){
+        _versionlessFeatures.put(versionlessFeature, versionedFeature);
+    }
+
+    protected final HashSet<String> _resolvedPlatforms;
+
+    @Override
+    public HashSet<String> getResolvedPlatforms(){
+        return _resolvedPlatforms;
+    }
+
+    protected void addResolvedPlatform(String platform){
+        _resolvedPlatforms.add(platform);
+    }
+
+    protected final HashSet<String> _missingPlatforms;
+
+    @Override
+    public HashSet<String> getMissingPlatforms(){
+        return _missingPlatforms;
+    }
+
+    protected void addMissingPlatform(String platform){
+        _missingPlatforms.add(platform);
     }
 
     // Remember the resolved in resolution order.

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/resolver/FeatureResolver.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/resolver/FeatureResolver.java
@@ -113,7 +113,11 @@ public interface FeatureResolver {
 
         Map<String, Collection<Chain>> getConflicts();
 
-        Set<String> getUnresolvedVersionless();
+        Map<String, String> getVersionlessFeatures();
+
+        Set<String> getResolvedPlatforms();
+
+        Set<String> getMissingPlatforms();
     }
 
     public static final List<String> EMPTY_STRINGS = Collections.emptyList();


### PR DESCRIPTION
Feature Resolver result will now keep track of some versionless-specific information and errors such as missing platforms, resolved platforms, and what versionless features resolve to.