### PR TITLE
Run SSLBasic21Test before Basic21Test

### DIFF
--- a/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/FATSuite.java
+++ b/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/FATSuite.java
@@ -32,8 +32,8 @@ import io.openliberty.wsoc.tests.SSLBasic21Test;
  * below should represent all of the test cases for this FAT.
  */
 @SuiteClasses({
-                Basic21Test.class,
-                SSLBasic21Test.class
+                SSLBasic21Test.class, // run this first to avoid jetty timeouts in Basic21Test
+                Basic21Test.class
 })
 public class FATSuite {
 

--- a/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/tests/Basic21Test.java
+++ b/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/tests/Basic21Test.java
@@ -96,10 +96,6 @@ public class Basic21Test {
         wt_secure = new WsocTest(LS, true);
         ssl = new SSLTest(wt_secure);
         bwst.setUp();
-
-        // Allow Jetty to finish starting up - https://github.com/OpenLiberty/open-liberty/issues/23172
-        // Updated to 5100 - Jan 2nd 2024
-        Thread.sleep(5100);
     }
 
     @AfterClass


### PR DESCRIPTION
For Defect 292475.

Jetty websocket timeouts for some odd reason -- only if it runs first. My hope is to switch the test class order will avoid this timeout problem. 

If this doesn't work, I will need to update the jetty libraries.

- [x] Considered risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes)
- [x] Resolved Issues: Fixes #FILLMEIN... (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions)
- [x] Resolved external Known Issues (including APARS): Fixes #FILLMEIN...
