### PR TITLE
Skip testDeleteQueryWithEntityIdentifierVariable on PostgreSQL

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -729,6 +729,7 @@ public class DataTestServlet extends FATServlet {
      * Repository delete method with query language (JPQL) that contains
      * an entity identifier variable.
      */
+    @SkipIfSysProp(DB_Postgres) //TODO Failing on Postgres due to eclipselink issue.  https://github.com/OpenLiberty/open-liberty/issues/28368
     @Test
     public void testDeleteQueryWithEntityIdentifierVariable() {
         products.purge("TestDeleteQueryWithEntityIdentifierVariable-Product-%");


### PR DESCRIPTION
Eclipselink + PostgreSQL does not support UUID