### PR TITLE
JAX-WS: Runtime permissions are added to tests

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/files/serversettings/java2Permissions.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/publish/files/serversettings/java2Permissions.xml
@@ -25,6 +25,7 @@
         <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.com.sun.xml.internal.messaging.saaj.soap.name"/>
         <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.com.sun.xml.internal.messaging.saaj.soap.impl"/>
         <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.com.sun.org.apache.xerces.internal.dom"/>
+        <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.sun.misc"/>
         <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
         <javaPermission className="java.net.NetPermission" name="setDefaultAuthenticator"/>
         <javaPermission className="java.util.PropertyPermission" name="javax.xml.soap.MessageFactory" actions="read"/>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/publish/files/serversettings/java2Permissions.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/publish/files/serversettings/java2Permissions.xml
@@ -25,6 +25,7 @@
         <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.com.sun.xml.internal.messaging.saaj.soap.name"/> 
         <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.com.sun.xml.internal.messaging.saaj.soap.impl"/>
         <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.com.sun.org.apache.xerces.internal.dom"/>
+        <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.sun.misc"/>
         <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
         <javaPermission className="java.util.PropertyPermission" name="javax.xml.soap.MessageFactory" actions="read"/>
         <javaPermission className="java.util.PropertyPermission" name="java.home" actions="read"/>


### PR DESCRIPTION
Added permission `java.security.AccessControlException: Access denied ("java.lang.RuntimePermission" "accessClassInPackage.sun.misc")` on Java 17 Semeru on SUSE OS. Same issue happened on 2 different FAT buckets. 