### PR TITLE
helpful message for disallowed java:comp lookup from EJB module

### DIFF
--- a/dev/io.openliberty.data.internal.ejb/src/io/openliberty/data/internal/ejb/EJBModuleTracker.java
+++ b/dev/io.openliberty.data.internal.ejb/src/io/openliberty/data/internal/ejb/EJBModuleTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -175,7 +175,8 @@ public class DataExtension implements Extension {
             // This needs to be done with the correct metadata on the thread,
             // but that might not be available yet.
 
-            FutureEMBuilder futureEMBuilder = new FutureEMBuilder(provider, loader, dataStore, moduleName);
+            FutureEMBuilder futureEMBuilder = new FutureEMBuilder( //
+                            provider, repositoryInterface, loader, dataStore, moduleName);
 
             Class<?>[] primaryEntityClassReturnValue = new Class<?>[1];
             Map<Class<?>, List<QueryInfo>> queriesPerEntityClass = new HashMap<>();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/Namespace.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/Namespace.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.data.internal.persistence.cdi;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * Namespace prefix of a Repository dataStore value.
+ */
+@Trivial
+enum Namespace {
+    GLOBAL, // java:global
+    APP, // java:app
+    MODULE, // java:module
+    COMP; // java:comp
+
+    /**
+     * Returns true if the granularity of this namespace exceeds
+     * that of the specified namespace.
+     *
+     * @param ns namespace to compare with. Null is compared as java:global.
+     * @return true if more granular. Otherwise false.
+     */
+    final boolean isMoreGranularThan(Namespace ns) {
+        return ordinal() > (ns == null ? GLOBAL : ns).ordinal();
+    }
+
+    /**
+     * Returns the Namespace enumeration constant given the prefix of the JNDI name.
+     *
+     * @param jndiName JNDI name.
+     * @return enumeration value, of if non-matching then NULL.
+     */
+    static Namespace of(String jndiName) {
+        if (jndiName.startsWith("java:"))
+            if (jndiName.regionMatches(5, "app/", 0, 4))
+                return APP;
+            else if (jndiName.regionMatches(5, "module/", 0, 7))
+                return MODULE;
+            else if (jndiName.regionMatches(5, "comp/", 0, 5))
+                return COMP;
+            else if (jndiName.regionMatches(5, "global/", 0, 7))
+                return GLOBAL;
+
+        return null;
+    }
+
+    /**
+     * Returns a textual representation of the namespace prefix.
+     *
+     * @return a textual representation of the namespace prefix.
+     */
+    @Override
+    public String toString() {
+        switch (this) {
+            case GLOBAL:
+                return "java:global";
+            case APP:
+                return "java:app";
+            case MODULE:
+                return "java:module";
+            case COMP:
+                return "java:comp";
+            default:
+                throw new IllegalStateException(); // unreachable
+        }
+    }
+}

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
@@ -12,14 +12,11 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence.provider;
 
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 
 import javax.sql.DataSource;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
@@ -34,13 +31,6 @@ import jakarta.persistence.PersistenceException;
  * This builder is used when a persistence unit reference JNDI name is configured as the repository dataStore.
  */
 public class PUnitEMBuilder extends EntityManagerBuilder {
-    private static final TraceComponent tc = Tr.register(PUnitEMBuilder.class);
-
-    /**
-     * These are present only if needed to disambiguate a persistence unit reference JNDI name
-     * that is in java:app, java:module, or java:comp
-     */
-    private final String application, module;
 
     private final EntityManagerFactory emf;
 
@@ -55,9 +45,6 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
         super(provider, repositoryClassLoader);
         this.emf = emf;
         this.persistenceUnitRef = emf.toString();
-
-        this.application = null;
-        this.module = null;
 
         try {
             collectEntityInfo(entityTypes);
@@ -85,9 +72,6 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
      * @param emf                   entity manager factory.
      * @param pesistenceUnitRef     persistence unit reference.
      * @param metaDataIdentifier    metadata identifier for the class loader of the repository interface.
-     * @param application           application in which the repository interface is defined.
-     * @param module                module in which the repository interface is defined. Null if not in a module.
-     * @param component             component in which the repository interface is defined. Null if not in a component or in web module.
      * @param entityTypes           entity classes as known by the user, not generated.
      */
     public PUnitEMBuilder(DataExtensionProvider provider,
@@ -95,14 +79,10 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
                           EntityManagerFactory emf,
                           String persistenceUnitRef,
                           String metadataIdentifier,
-                          String application,
-                          String module,
                           Set<Class<?>> entityTypes) {
         super(provider, repositoryClassLoader);
         this.emf = emf;
         this.persistenceUnitRef = persistenceUnitRef;
-        this.application = application;
-        this.module = module;
 
         try {
             collectEntityInfo(entityTypes);
@@ -126,17 +106,6 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
         return emf.createEntityManager();
     }
 
-    @Override
-    @Trivial
-    public boolean equals(Object o) {
-        PUnitEMBuilder b;
-        return this == o || o instanceof PUnitEMBuilder
-                            && persistenceUnitRef.equals((b = (PUnitEMBuilder) o).persistenceUnitRef)
-                            && Objects.equals(application, b.application)
-                            && Objects.equals(module, b.module)
-                            && Objects.equals(getRepositoryClassLoader(), b.getRepositoryClassLoader());
-    }
-
     @FFDCIgnore(PersistenceException.class)
     @Override
     public DataSource getDataSource() {
@@ -156,24 +125,11 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
 
     @Override
     @Trivial
-    public int hashCode() {
-        return persistenceUnitRef.hashCode() +
-               (application == null ? 0 : application.hashCode()) +
-               (module == null ? 0 : module.hashCode());
-
-    }
-
-    @Override
-    @Trivial
     public String toString() {
-        return new StringBuilder(27 + persistenceUnitRef.length() +
-                                 (application == null ? 4 : application.length()) +
-                                 (module == null ? 4 : module.length())) //
-                                                 .append("PUnitEMBuilder@") //
-                                                 .append(Integer.toHexString(hashCode())) //
-                                                 .append(":").append(persistenceUnitRef) //
-                                                 .append(' ').append(application) //
-                                                 .append('#').append(module) //
-                                                 .toString();
+        return new StringBuilder(27 + persistenceUnitRef.length()) //
+                        .append("PUnitEMBuilder@") //
+                        .append(Integer.toHexString(hashCode())) //
+                        .append(":").append(persistenceUnitRef) //
+                        .toString();
     }
 }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -67,6 +67,7 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.Configuration;
 
+import com.ibm.websphere.csi.J2EEName;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
@@ -130,13 +131,13 @@ public class DBStoreEMBuilder extends EntityManagerBuilder {
      *                                  if obtained from CDI then the config.displayId of a dataSource.
      * @param isJNDIName            indicates if the dataStore name is a JNDI name (begins with java: or is inferred to be java:comp/env/...)
      * @param metaDataIdentifier    metadata identifier for the class loader of the repository interface.
-     * @param appModComp            application/module/component in which the repository interface is defined.
+     * @param jeeName               application/module/component in which the repository interface is defined.
      *                                  Module and component might be null or absent.
      * @param entityTypes           entity classes as known by the user, not generated.
      */
     public DBStoreEMBuilder(DataExtensionProvider provider, ClassLoader repositoryClassLoader,
                             String dataStore, boolean isJNDIName,
-                            String metadataIdentifier, String[] appModComp,
+                            String metadataIdentifier, J2EEName jeeName,
                             Set<Class<?>> entityTypes) {
         super(provider, repositoryClassLoader);
         final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -144,24 +145,19 @@ public class DBStoreEMBuilder extends EntityManagerBuilder {
         try {
             String qualifiedName = null;
             boolean javaApp = false, javaModule = false, javaComp = false;
-            String application = appModComp.length < 1 ? null : appModComp[0];
-            String module = appModComp.length < 2 ? null : appModComp[1];
-            String component = appModComp.length < 3 ? null : appModComp[2];
+            String application = jeeName == null ? null : jeeName.getApplication();
+            String module = jeeName == null ? null : jeeName.getModule();
 
             // Qualify resource reference and DataSourceDefinition JNDI names with the application/module/component name to make them unique
             if (isJNDIName) {
                 javaApp = dataStore.regionMatches(5, "app", 0, 3);
                 javaModule = !javaApp && dataStore.regionMatches(5, "module", 0, 6);
-                // TODO detect web module metadata to avoid including component
                 javaComp = !javaApp && !javaModule && dataStore.regionMatches(5, "comp", 0, 4);
                 StringBuilder s = new StringBuilder(dataStore.length() + 80);
                 if (application != null && (javaApp || javaModule || javaComp)) {
                     s.append("application[").append(application).append(']').append('/');
-                    if (module != null && (javaModule || javaComp)) {
+                    if (module != null && (javaModule || javaComp))
                         s.append("module[").append(module).append(']').append('/');
-                        if (component != null && javaComp)
-                            s.append("component[").append(component).append(']').append('/');
-                    }
                 }
                 qualifiedName = s.append("databaseStore[").append(dataStore).append(']').toString();
 
@@ -178,15 +174,13 @@ public class DBStoreEMBuilder extends EntityManagerBuilder {
                 BundleContext bc = FrameworkUtil.getBundle(DatabaseStore.class).getBundleContext();
                 ServiceReference<ResourceFactory> dsRef = null;
                 if (isJNDIName) {
-                    // Look for DataSourceDefinition with jndiName and application/module/component matching
+                    // Look for DataSourceDefinition with jndiName and application/module matching
                     StringBuilder filter = new StringBuilder(200) //
                                     .append("(&(service.factoryPid=com.ibm.ws.jdbc.dataSource)");
                     if (application != null && (javaApp || javaModule || javaComp))
                         filter.append(FilterUtils.createPropertyFilter("application", application));
                     if (module != null && javaModule || javaComp)
                         filter.append(FilterUtils.createPropertyFilter("module", module));
-                    if (component != null && javaComp)
-                        filter.append(FilterUtils.createPropertyFilter("jndiName", dataStore));
                     filter.append(FilterUtils.createPropertyFilter("jndiName", dataStore)) //
                                     .append(')');
 
@@ -512,15 +506,6 @@ public class DBStoreEMBuilder extends EntityManagerBuilder {
         return persistenceServiceUnit.createEntityManager();
     }
 
-    @Override
-    @Trivial
-    public boolean equals(Object o) {
-        DBStoreEMBuilder b;
-        return this == o || o instanceof DBStoreEMBuilder
-                            && databaseStoreId.equals((b = (DBStoreEMBuilder) o).databaseStoreId)
-                            && getRepositoryClassLoader().equals(b.getRepositoryClassLoader());
-    }
-
     /**
      * Initially copied from @nmittles pull #25248
      *
@@ -726,13 +711,6 @@ public class DBStoreEMBuilder extends EntityManagerBuilder {
     @Trivial
     protected Class<?> getRecordClass(Class<?> generatedEntityClass) {
         return generatedToRecordClass.get(generatedEntityClass);
-    }
-
-    @Override
-    @Trivial
-    public int hashCode() {
-        return databaseStoreId.hashCode();
-
     }
 
     @Override


### PR DESCRIPTION
Jakarta Data repositories that are defined in EJB modules cannot look up java:comp names because they aren't accessible to the module.
Jakarta Data repositories that are defined outside of a module cannot use java:module (or java:comp) names because they aren't accessible outside of a module.
Also, clean up some code in this area.