### PR TITLE
Issue #29031: Add permissions in JPA FAT

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_fat.common/fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -25,9 +25,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/fat/src/com/ibm/ws/jpa/tests/container/checkpoint/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.container.checkpoint_fat.common/fat/src/com/ibm/ws/jpa/tests/container/checkpoint/tests/AbstractFATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,9 +18,20 @@ import com.ibm.ws.testtooling.jpaprovider.JPAPersistenceProvider;
 import componenttest.containers.TestContainerSuite;
 
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     public static String repeatPhase = "";
 

--- a/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/fat/src/com/ibm/ws/jpaContainer/fat/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.container_modifyconfig_fat/fat/src/com/ibm/ws/jpaContainer/fat/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,9 +22,20 @@ import componenttest.containers.TestContainerSuite;
 import componenttest.topology.database.container.DatabaseContainerFactory;
 
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/fat/src/com/ibm/ws/jpa/tests/eclipselink/query/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/fat/src/com/ibm/ws/jpa/tests/eclipselink/query/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -25,9 +25,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.eclipselink_fat.common/fat/src/com/ibm/ws/jpa/tests/eclipselink/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink_fat.common/fat/src/com/ibm/ws/jpa/tests/eclipselink/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,9 +22,20 @@ import componenttest.containers.TestContainerSuite;
 import componenttest.topology.database.container.DatabaseContainerFactory;
 
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.javasupport_fat/fat/src/io/openliberty/jpa/test/javasupport/AbstractTestJavaSourceLevel.java
+++ b/dev/com.ibm.ws.jpa.tests.javasupport_fat/fat/src/io/openliberty/jpa/test/javasupport/AbstractTestJavaSourceLevel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,9 +34,20 @@ import componenttest.topology.utils.PrivHelper;
  *
  */
 public class AbstractTestJavaSourceLevel {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     public final static int MIN_JAVA_LEVEL = 7;
     public final static int MAX_JAVA_LEVEL = 21; // Update this when supporting a new level of JDK

--- a/dev/com.ibm.ws.jpa.tests.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPADefaultDataSourceTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPADefaultDataSourceTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -38,9 +38,20 @@ import componenttest.topology.utils.PrivHelper;
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class JPADefaultDataSourceTest {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @Server("JPADefaultDataSourceServer_JTANJTA")
     public static LibertyServer server_JTA_NJTA;

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/fat/src/com/ibm/ws/jpa/tests/jpaconfig/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_fat.common/fat/src/com/ibm/ws/jpa/tests/jpaconfig/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -25,9 +25,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/callback/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/callback/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,9 +23,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat.common/fat/src/com/ibm/ws/jpa/tests/embeddable/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat.common/fat/src/com/ibm/ws/jpa/tests/embeddable/tests/AbstractFATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,9 +22,20 @@ import componenttest.containers.TestContainerSuite;
 import componenttest.topology.database.container.DatabaseContainerFactory;
 
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entity/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entity/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -25,9 +25,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entitymanager/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/entitymanager/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,9 +23,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/inheritance/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/inheritance/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,9 +23,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/dpu/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/dpu/FATSuite.java
@@ -30,9 +30,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.dfi_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/dfi/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.dfi_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/dfi/FATSuite.java
@@ -38,9 +38,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.dmi_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/dmi/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.dmi_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/dmi/FATSuite.java
@@ -38,9 +38,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/ejb_in_war/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/ejb_in_war/FATSuite.java
@@ -33,9 +33,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.jarfile_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.jarfile_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
@@ -36,9 +36,21 @@ import componenttest.rules.repeater.RepeatTests;
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
+
     @ClassRule
     public static RepeatTests r = RepeatTests
                     .with(new RepeatWithJPA21())

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.jndi_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/jndi/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.jndi_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/jndi/FATSuite.java
@@ -38,9 +38,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.mdb_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/mdb/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.mdb_fat/fat/src/com/ibm/ws/jpa/tests/spec10/injection/mdb/FATSuite.java
@@ -38,9 +38,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.issues_fat/fat/src/com/ibm/ws/jpa/spec10/olgh/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.issues_fat/fat/src/com/ibm/ws/jpa/spec10/olgh/FATSuite.java
@@ -31,9 +31,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.packaging_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/packaging/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.packaging_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/packaging/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,9 +23,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/query/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -25,9 +25,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,9 +23,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,9 +23,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,9 +23,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_fat.common/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,9 +23,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/com.ibm.ws.jpa.tests.spec20_fat.common/fat/src/com/ibm/ws/jpa/tests/spec20/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec20_fat.common/fat/src/com/ibm/ws/jpa/tests/spec20/tests/AbstractFATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -25,9 +25,20 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
  *
  */
 public class AbstractFATSuite extends TestContainerSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+    public final static String[] JAXB_PERMS = { "// Required by JAXB",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+                                                "",
+                                                "// Required by jrt:/openjceplus for local runs with Java Semeru",
+                                                "permission java.io.FilePermission \"${java.home}${/}-\", \"read\";",
+                                                "permission java.lang.RuntimePermission \"loadLibrary.*\";",
+                                                "permission java.util.PropertyPermission \"java.home\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"java.security.auth.debug\", \"read\";",
+                                                "permission java.util.PropertyPermission \"jgskit.library.path\", \"read\";",
+                                                "permission java.util.PropertyPermission \"ock.library.path\", \"read\";",
+                                                "permission java.security.SecurityPermission \"putProviderProperty.OpenJCEPlus\";" };
 
     @ClassRule
     public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();


### PR DESCRIPTION
Update many of the JPA FAT projects to add permissions to avoid Java 2 security warnings when running the FAT locally on Windows with IBM Java Semeru 17.


- [x] Considered risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes)
- [x] Resolved Issues: Fixes #29031
