### PR TITLE
Test - select database rotation buckets based on feature declaration

### DIFF
--- a/dev/build.example.testcontainers_fat/bnd.bnd
+++ b/dev/build.example.testcontainers_fat/bnd.bnd
@@ -39,7 +39,7 @@ fat.project: true
 # The databaseRotation feature is required to tell the SOE build system that this FAT suite
 # should be run in the databaseRotation build.
 tested.features: \
-    databaseRotation,servlet-5.0
+    databaseRotation, servlet-5.0
 	
 fat.test.container.images: kyleaure/postgres-test-table:3.0
 

--- a/dev/build.example.testcontainers_fat/bnd.bnd
+++ b/dev/build.example.testcontainers_fat/bnd.bnd
@@ -24,10 +24,6 @@ fat.project: true
 # External contributors will need to have docker installed on their local machine.
 #fat.test.use.remote.docker: true
 
-# This property is used to tell the SOE build system that this FAT suite
-# should be run in the database rotation build.
-fat.test.databases: true
-
 # Uncomment to test against alternative databases
 # This allows you to locally tell gradle what database you want to test against.
 # This is the same way the database rotation build sets the database. 
@@ -40,8 +36,10 @@ fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-5.0 is added programmatically at runtime by the RepeatTests rule.
+# The databaseRotation feature is required to tell the SOE build system that this FAT suite
+# should be run in the databaseRotation build.
 tested.features: \
-	servlet-5.0
+    databaseRotation,servlet-5.0
 	
 fat.test.container.images: kyleaure/postgres-test-table:3.0
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/bnd.bnd
@@ -20,9 +20,8 @@ src: \
 	test-bundles/timerInterfacesTestFeature/src
 
 fat.project: true
-fat.test.databases: true
 
-tested.features: servlet-5.0,concurrent-2.0,jdbc-4.2,connectors-2.0
+tested.features: databaseRotation,servlet-5.0,concurrent-2.0,jdbc-4.2,connectors-2.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 	test-application/demotimers/src
 
 fat.project: true
-fat.test.databases: true
+tested.features: databaseRotation
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgre, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 	test-applications/failoverTimersApp/src
 
 fat.project: true
-fat.test.databases: true
+tested.features: databaseRotation
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 	test-applications/pxlocktest/src
 
 fat.project: true
-fat.test.databases: true
+tested.features: databaseRotation
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiple/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiple/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 	test-applications/persistmultitest/src
 
 fat.project: true
-fat.test.databases: true
+tested.features: databaseRotation
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 	test-applications/timersapp/src
 
 fat.project: true
-fat.test.databases: true
+tested.features: databaseRotation
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jdbc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat/bnd.bnd
@@ -23,7 +23,7 @@ src: \
 	test-applications/dsdfat_global_lib/src
 
 fat.project: true
-fat.test.databases: true
+tested.features: databaseRotation
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 # fat.test.use.remote.docker: true

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, beanValidation-1.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation,jpa-2.0, beanValidation-1.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.0_fat/bnd.bnd
@@ -17,7 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-tested.features: databaseRotation,jpa-2.0, beanValidation-1.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, beanValidation-1.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, beanValidation-1.1, ejbLite-3.2, servlet-3.1, el-3.0, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, beanValidation-1.1, ejbLite-3.2, servlet-3.1, el-3.0, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, beanValidation-2.0, ejbLite-3.2, servlet-4.0, el-3.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, beanValidation-2.0, ejbLite-3.2, servlet-4.0, el-3.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, beanValidation-3.0, enterpriseBeansLite-4.0, servlet-5.0, expressionLanguage-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, beanValidation-3.0, enterpriseBeansLite-4.0, servlet-5.0, expressionLanguage-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, beanValidation-3.0, enterpriseBeansLite-4.0, servlet-6.0, expressionLanguage-4.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0, expressionlanguage-5.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, beanValidation-3.0, enterpriseBeansLite-4.0, servlet-6.0, expressionLanguage-4.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0, expressionlanguage-5.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, validation-3.1, enterpriseBeansLite-4.0, servlet-6.1, expressionLanguage-4.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0, expressionlanguage-5.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, validation-3.1, enterpriseBeansLite-4.0, servlet-6.1, expressionLanguage-4.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0, expressionlanguage-5.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, servlet-3.1, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, servlet-3.1, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.eclipselink_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, el-3.0, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, el-3.0, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.eclipselink_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.eclipselink_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.eclipselink_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistencecontainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.1, persistencecontainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.eclipselink_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistencecontainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.2, persistencecontainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.jpa_31_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.jpa_31_fat/bnd.bnd
@@ -22,8 +22,7 @@ src: \
     test-applications/eclAsmService/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: el-3.0, persistence-3.0, servlet-5.0, cdi-3.0, beanValidation-3.0, enterprisebeanslite-4.0, persistence-3.1, persistencecontainer-3.1, xmlbinding-4.0, servlet-6.0, persistence-3.2, servlet-6.1
+tested.features: databaseRotation, el-3.0, persistence-3.0, servlet-5.0, cdi-3.0, beanValidation-3.0, enterprisebeanslite-4.0, persistence-3.1, persistencecontainer-3.1, xmlbinding-4.0, servlet-6.0, persistence-3.2, servlet-6.1
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/bnd.bnd
@@ -19,8 +19,7 @@ src: \
     test-applications/jpabootstrap/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistencecontainer-3.2, servlet-6.1
+tested.features: databaseRotation, persistence-3.2, persistencecontainer-3.2, servlet-6.1
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/com.ibm.ws.jpa.tests.jpa_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.jpa_fat/bnd.bnd
@@ -24,7 +24,7 @@ src: \
     test-applications/helpers/DatabaseManagement/src
 
 fat.project: true
-#fat.test.databases: true
+# databaseRotation
 tested.features: el-3.0, persistence-3.0, servlet-5.0, cdi-3.0, beanValidation-3.0, enterpriseBeansLite-4.0, jdbc-4.0, beanvalidation-1.1, jpa-2.0, concurrent-2.0, persistence-3.1, persistencecontainer-3.1, xmlbinding-4.0, servlet-6.0, concurrent-3.0, persistence-3.2, concurrent-3.1, servlet-6.1
 
 #-sub: *.bnd

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.jpaconfig_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: enterpriseBeansLite-4.0, jdbc-4.2, jndi-1.0, persistence-3.1, persistencecontainer-3.1, xmlbinding-4.0, servlet-6.0
+tested.features: databaseRotation, enterpriseBeansLite-4.0, jdbc-4.2, jndi-1.0, persistence-3.1, persistencecontainer-3.1, xmlbinding-4.0, servlet-6.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: enterpriseBeansLite-4.0, jdbc-4.2, jndi-1.0, persistence-3.2, persistencecontainer-3.2, xmlbinding-4.0, servlet-6.1
+tested.features: databaseRotation, enterpriseBeansLite-4.0, jdbc-4.2, jndi-1.0, persistence-3.2, persistencecontainer-3.2, xmlbinding-4.0, servlet-6.1
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, beanValidation-3.0, enterpriseBeansLite-4.0, servlet-6.0, expressionLanguage-4.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0, expressionlanguage-5.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, beanValidation-3.0, enterpriseBeansLite-4.0, servlet-6.0, expressionLanguage-4.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0, expressionlanguage-5.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, beanValidation-3.0, enterpriseBeansLite-4.0, servlet-6.1, expressionLanguage-4.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0, expressionlanguage-5.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, beanValidation-3.0, enterpriseBeansLite-4.0, servlet-6.1, expressionLanguage-4.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0, expressionlanguage-5.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: enterpriseBeansLite-4.0, jdbc-4.2, jndi-1.0, persistence-3.1, persistencecontainer-3.1, xmlbinding-4.0, servlet-6.0
+tested.features: databaseRotation, enterpriseBeansLite-4.0, jdbc-4.2, jndi-1.0, persistence-3.1, persistencecontainer-3.1, xmlbinding-4.0, servlet-6.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entity_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: enterpriseBeansLite-4.0, jdbc-4.2, jndi-1.0, persistence-3.2, persistencecontainer-3.2, xmlbinding-4.0, servlet-6.1
+tested.features: databaseRotation, enterpriseBeansLite-4.0, jdbc-4.2, jndi-1.0, persistence-3.2, persistencecontainer-3.2, xmlbinding-4.0, servlet-6.1
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat/bnd.bnd
@@ -19,8 +19,7 @@ src: \
     test-applications/injection_dpu/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0
+tested.features: databaseRotation, jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.dfi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.dfi_fat/bnd.bnd
@@ -19,8 +19,7 @@ src: \
     test-applications/helpers/DatabaseManagement/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0
+tested.features: databaseRotation, jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.dmi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.dmi_fat/bnd.bnd
@@ -19,8 +19,7 @@ src: \
     test-applications/helpers/DatabaseManagement/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0
+tested.features: databaseRotation, jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat/bnd.bnd
@@ -20,8 +20,7 @@ src: \
     test-applications/injection_ejbinwar_javacomp/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0, persistence-3.1, xmlbinding-4.0, servlet-6.0
+tested.features: databaseRotation, jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0, persistence-3.1, xmlbinding-4.0, servlet-6.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.jndi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.jndi_fat/bnd.bnd
@@ -19,8 +19,7 @@ src: \
     test-applications/helpers/DatabaseManagement/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0, xmlbinding-4.0, persistence-3.1, servlet-6.0
+tested.features: databaseRotation, jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0, xmlbinding-4.0, persistence-3.1, servlet-6.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.mdb_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.mdb_fat/bnd.bnd
@@ -20,8 +20,7 @@ src: \
     test-applications/helpers/DatabaseManagement/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0, xmlbinding-4.0, persistence-3.1, servlet-6.0, persistence-3.2, servlet-6.1, connectors-2.1
+tested.features: databaseRotation, jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0, xmlbinding-4.0, persistence-3.1, servlet-6.0, persistence-3.2, servlet-6.1, connectors-2.1
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.issues_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.issues_fat/bnd.bnd
@@ -19,8 +19,7 @@ src: \
     test-applications/helpers/DatabaseManagement/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0, servlet-5.0, cdi-3.0, beanValidation-3.0, enterpriseBeansLite-4.0, xmlbinding-4.0, persistence-3.1, servlet-6.0, persistence-3.2,  servlet-6.1
+tested.features: databaseRotation, jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0, servlet-5.0, cdi-3.0, beanValidation-3.0, enterpriseBeansLite-4.0, xmlbinding-4.0, persistence-3.1, servlet-6.0, persistence-3.2,  servlet-6.1
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.packaging_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.packaging_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.packaging_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.packaging_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.packaging_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.packaging_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.packaging_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.packaging_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.packaging_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.packaging_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.spec10.packaging_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.packaging_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, jdbc-4.2, jndi-1.0, xmlbinding-4.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.jpa.tests.spec20_jpa_2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec20_jpa_2.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
+tested.features: databaseRotation, jpa-2.0, ejbLite-3.1, servlet-3.0, jdbc-4.0, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec20_jpa_2.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec20_jpa_2.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, el-3.0, jdbc-4.1, jndi-1.0
+tested.features: databaseRotation, jpa-2.1, jpaContainer-2.1, ejbLite-3.2, servlet-3.1, el-3.0, jdbc-4.1, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec20_jpa_2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec20_jpa_2.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, el-3.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, jpa-2.2, jpaContainer-2.2, ejbLite-3.2, servlet-4.0, el-3.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec20_jpa_3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec20_jpa_3.0_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, expressionLanguage-4.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.0, persistenceContainer-3.0, enterpriseBeansLite-4.0, servlet-5.0, expressionLanguage-4.0, jdbc-4.2, jndi-1.0
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer

--- a/dev/com.ibm.ws.jpa.tests.spec20_jpa_3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec20_jpa_3.1_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, expressionLanguage-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.1, persistenceContainer-3.1, enterpriseBeansLite-4.0, servlet-6.0, expressionLanguage-5.0, jdbc-4.2, jndi-1.0
 
 javac.source: 11
 javac.target: 11

--- a/dev/com.ibm.ws.jpa.tests.spec20_jpa_3.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec20_jpa_3.2_fat/bnd.bnd
@@ -17,8 +17,7 @@ src: \
     fat/src
 
 fat.project: true
-fat.test.databases: true
-tested.features: persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, expressionLanguage-5.0, jdbc-4.2, jndi-1.0
+tested.features: databaseRotation, persistence-3.2, persistenceContainer-3.2, enterpriseBeansLite-4.0, servlet-6.1, expressionLanguage-5.0, jdbc-4.2, jndi-1.0
 
 javac.source: 17
 javac.target: 17

--- a/dev/com.ibm.ws.transaction.cloud_fat.db2.0/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.db2.0/bnd.bnd
@@ -17,11 +17,11 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.db2.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.db2.1/bnd.bnd
@@ -17,11 +17,11 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.db2.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.db2.2/bnd.bnd
@@ -17,11 +17,11 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.derby.0/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.derby.0/bnd.bnd
@@ -17,11 +17,11 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.derby.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.derby.1/bnd.bnd
@@ -17,11 +17,11 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.derby.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.derby.2/bnd.bnd
@@ -17,11 +17,11 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.oracle.0/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.oracle.0/bnd.bnd
@@ -17,16 +17,16 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
-	cdi-2.0, cdi-3.0, cdi-4.0,\
+  databaseRotation,\
+  cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
-	jdbc-4.2,\
+  jdbc-4.2,\
   jsp-2.3,\
-	servlet-3.1, servlet-4.0, servlet-5.0, servlet-6.0
+  servlet-3.1, servlet-4.0, servlet-5.0, servlet-6.0
 
 -buildpath: \
 	com.ibm.tx.jta;version=latest,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.oracle.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.oracle.1/bnd.bnd
@@ -17,16 +17,16 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
-	cdi-2.0, cdi-3.0, cdi-4.0,\
+  databaseRotation,\
+  cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
-	jdbc-4.2,\
+  jdbc-4.2,\
   jsp-2.3,\
-	servlet-3.1, servlet-4.0, servlet-5.0, servlet-6.0
+  servlet-3.1, servlet-4.0, servlet-5.0, servlet-6.0
 
 -buildpath: \
 	com.ibm.tx.jta;version=latest,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.oracle.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.oracle.2/bnd.bnd
@@ -17,11 +17,11 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.postgresql.0/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.postgresql.0/bnd.bnd
@@ -17,13 +17,13 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 fat.test.container.images: jonhawkes/postgresql-ssl:1.0
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.postgresql.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.postgresql.1/bnd.bnd
@@ -17,13 +17,13 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 fat.test.container.images: jonhawkes/postgresql-ssl:1.0
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.postgresql.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.postgresql.2/bnd.bnd
@@ -17,13 +17,13 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 fat.test.container.images: jonhawkes/postgresql-ssl:1.0
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.0/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.0/bnd.bnd
@@ -17,11 +17,11 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.1/bnd.bnd
@@ -17,11 +17,11 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.2/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.2/bnd.bnd
@@ -17,11 +17,11 @@ src: \
 	fat/src
 
 fat.project: true
-fat.test.databases: true
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\
+  databaseRotation,\
   cdi-2.0, cdi-3.0, cdi-4.0,\
   el-3.0,\
   jdbc-4.2,\

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -100,7 +100,7 @@
 		<!-- Work out the actual entry point based on the current java level and database properties -->
 		<echo message="Checking min java level for project based on bootstrapping.properties file..." />
 
-		<!-- Get fat.test.databases and fat.minimum.java.level properties-->
+		<!-- Get fat.minimum.java.level properties-->
 		<property file="${basedir}/fat.bnd.properties" />
 		<property file="${basedir}/fat.sys.properties" />
 		
@@ -126,39 +126,6 @@
 		<echo message="fat.minimum.java.level=${fat.minimum.java.level}" />
 		<echo message="java.specification.version=${java.specification.version}" />
 		<echo message="micro.version=${micro.version}" />
-
-		<!-- Enforce fat.test.databases.only rule.  If bucket is not enlisted in database rotation skip it -->
-		<condition property="skip.no.db.tests" value="true">
-			<and>
-				<istrue value="${fat.test.databases.only}" />
-				<not>
-					<isTrue value="${fat.test.databases}" />
-				</not>
-			</and>
-		</condition>
-
-		<!-- Determine if we are going to skip testing or not -->
-		<!-- Bypass the tests by invoking the always passes test instead of real FAT tests -->
-		<iff>
-			<or>
-				<istrue value="${skip.no.db.tests}" />
-				<istrue value="${skip.java.level}" />
-			</or>
-			<then>
-				<var name="test.bucket.class" unset="true" />
-				<var name="test.bucket.name" unset="true" />
-				<property name="test.bucket.class" value="componenttest.custom.junit.runner.AlwaysPassesTest" />
-				<property name="test.bucket.name" value="${test.bucket.class}" />
-
-				<echo message="FAT bucket WILL NOT run tests, due to the following properties:" />
-				<echo message="     Only run database rotation buckets:  ${fat.test.databases.only}" />
-				<echo message="     This bucket uses database rotation:  ${fat.test.databases}" />
-				<echo message="     This bucket uses java level:         ${fat.minimum.java.level}" />
-			</then>
-			<else>
-				<property name="test.bucket.class" value="${entry.point}" />
-			</else>
-		</iff>
 
 		<!-- What will our entry point be? -->
 		<echo message="FAT entry point will be: ${test.bucket.class}" />

--- a/dev/fattest.simplicity/src/componenttest/topology/database/DatabaseTester.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/DatabaseTester.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -175,32 +175,32 @@ public class DatabaseTester {
     /**
      * Options for database environment set up and tear down.
      *
-     * @param args Set of strings<ul>
-     *            <li>[0] bootstrapping file name
-     *            <li>[1] option
-     *            <br><b>create</b> - create the database and/or user IDs.
-     *            <br>&nbsp;&nbsp;&nbsp;The database or user IDs are NOT created if database.dropandcreate=false
-     *            and the names are provided.
-     *            <br>
-     *            <br><b>drop</b> - drop the database or user IDs.
-     *            <br>&nbsp;&nbsp;&nbsp;The database or user IDs are NOT dropped if database.keepdatabase was added to the
-     *            bootstrapping.properties file during the create option. It is then the tester's responsibility
-     *            to drop the database or user IDs when they are no longer needed.
-     *            <br>
-     *            <br><b>runDDL</b> - execute all DDL files in the ddl directory for the database type
-     *            <br>
-     *            <br><b>startDerbyNet</b> - start Derby Network Server
-     *            <br>
-     *            <br><b>stopDerbyNet</b> - stop Derby Network Server
-     *            <li>[2] test bucket path name
-     *            <li>[3] (optional) database properties/jars directory (i.e. /path/to/prereq.dbtest/lib/DB2 ).
-     *            Omit this parameter to reuse the database information that is stored in bootstrapping.properties
-     *            after a test has previously invoked the create operation.
-     *            <li>[4] (optional) The path to the JDBC driver jar to use. If this argument is null,<br>
-     *            then the database jar will be used from the location specified in arg [3]. Note that if
-     *            the bootstrapping.properties file already has a liberty.db_jars property set, that value
-     *            will always be used and not overridden by arg[3] or arg[4].
-     *            </ul>
+     * @param  args      Set of strings<ul>
+     *                       <li>[0] bootstrapping file name
+     *                       <li>[1] option
+     *                       <br><b>create</b> - create the database and/or user IDs.
+     *                       <br>&nbsp;&nbsp;&nbsp;The database or user IDs are NOT created if database.dropandcreate=false
+     *                       and the names are provided.
+     *                       <br>
+     *                       <br><b>drop</b> - drop the database or user IDs.
+     *                       <br>&nbsp;&nbsp;&nbsp;The database or user IDs are NOT dropped if database.keepdatabase was added to the
+     *                       bootstrapping.properties file during the create option. It is then the tester's responsibility
+     *                       to drop the database or user IDs when they are no longer needed.
+     *                       <br>
+     *                       <br><b>runDDL</b> - execute all DDL files in the ddl directory for the database type
+     *                       <br>
+     *                       <br><b>startDerbyNet</b> - start Derby Network Server
+     *                       <br>
+     *                       <br><b>stopDerbyNet</b> - stop Derby Network Server
+     *                       <li>[2] test bucket path name
+     *                       <li>[3] (optional) database properties/jars directory (i.e. /path/to/prereq.dbtest/lib/DB2 ).
+     *                       Omit this parameter to reuse the database information that is stored in bootstrapping.properties
+     *                       after a test has previously invoked the create operation.
+     *                       <li>[4] (optional) The path to the JDBC driver jar to use. If this argument is null,<br>
+     *                       then the database jar will be used from the location specified in arg [3]. Note that if
+     *                       the bootstrapping.properties file already has a liberty.db_jars property set, that value
+     *                       will always be used and not overridden by arg[3] or arg[4].
+     *                       </ul>
      *
      * @throws Exception see exception for details
      */
@@ -317,13 +317,6 @@ public class DatabaseTester {
     }
 
     private static void blowUpUnlessDerby(String msg) throws Exception {
-        // To run with a different DB, fat.test.databases=true must be set
-        String fat_test_databases = System.getProperty("fat.test.databases");
-        if (!"true".equals(fat_test_databases)) {
-            Log.info(c, "blowUpUnlessDerby", msg + " This is OK because we are running with Derby.");
-            return;
-        }
-
         String fat_bucket_db_type = System.getProperty("fat.bucket.db.type", "Derby");
         if ("Derby".equals(fat_bucket_db_type)) {
             Log.info(c, "blowUpUnlessDerby", msg + " This is OK because we are running with Derby.");

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
@@ -95,8 +95,9 @@ public class DatabaseContainerFactory {
         Log.info(c, "create", "System property: fat.bucket.db.type is " + dbProperty);
 
         if (!validateDatabaseRotationFeature) {
-            throw new IllegalArgumentException("To use a generic database, the FAT must be opted into database rotation by setting 'testedFeatures: " //
-                                               + databaseRotationTestFeature + "' in the FAT project's bnd.bnd file");
+            // TODO throw this exception once WL is updated
+//            throw new IllegalArgumentException("To use a generic database, the FAT must be opted into database rotation by setting 'testedFeatures: " //
+//                                               + databaseRotationTestFeature + "' in the FAT project's bnd.bnd file");
         }
 
         DatabaseContainerType type = null;

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
@@ -35,7 +35,7 @@ import componenttest.custom.junit.runner.FATRunner;
  *
  * The {fat.bucket.db.type} property is set to different databases
  * by our test infrastructure when a fat-suite is enlisted in
- * database rotation by setting the property {fat.test.databases} to true.</br>
+ * database rotation by setting 'databaseRotation' on the tested.features property in bnd.bnd.</br>
  *
  * <br> Container Information: <br>
  * Derby: Uses a derby no-op test container <br>
@@ -50,7 +50,8 @@ import componenttest.custom.junit.runner.FATRunner;
 public class DatabaseContainerFactory {
     private static final Class<DatabaseContainerFactory> c = DatabaseContainerFactory.class;
 
-    private static final String databaseRotationTestFeature = "databaseRotation";
+    // Features in fat-metadata.json are transformed to lowercase by default
+    private static final String databaseRotationTestFeature = "databaserotation";
 
     /**
      * Used for <b>database rotation testing</b>.
@@ -64,7 +65,7 @@ public class DatabaseContainerFactory {
      *
      * @return                          JdbcDatabaseContainer - The test container.
      *
-     * @throws IllegalArgumentException - if database rotation {fat.test.databases} is not set or is false,
+     * @throws IllegalArgumentException - if databaseRotation is not set on tested.features,
      *                                      or database type {fat.bucket.db.type} is unsupported.
      */
     public static JdbcDatabaseContainer<?> create() throws IllegalArgumentException {

--- a/dev/io.openliberty.data.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat/bnd.bnd
@@ -23,10 +23,8 @@ javac.target: 17
 
 fat.minimum.java.level: 17
 fat.project: true
-fat.test.databases: true
 
-tested.features: \
-  checkpoint
+tested.features: databaseRotation, checkpoint
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true

--- a/dev/io.openliberty.data.internal_fat_jpa/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat_jpa/bnd.bnd
@@ -22,10 +22,8 @@ javac.target: 17
 
 fat.minimum.java.level: 17
 fat.project: true
-fat.test.databases: true
 
-tested.features: \
-  checkpoint
+tested.features: databaseRotation, checkpoint
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true

--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/bnd.bnd
@@ -22,9 +22,8 @@ javac.target: 17
 
 fat.minimum.java.level: 17
 fat.project: true
-fat.test.databases: true
 
-tested.features: cdi-4.1
+tested.features: databaseRotation, cdi-4.1
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/bnd.bnd
@@ -28,10 +28,6 @@ fat.project: true
 # External contributors will need to have docker installed on their local machine.
 #fat.test.use.remote.docker: true
 
-# This property is used to tell the SOE build system that this FAT suite
-# should be run in the database rotation build.
-fat.test.databases: true
-
 # Uncomment to test against alternative databases
 # This allows you to locally tell gradle what database you want to test against.
 # This is the same way the database rotation build sets the database. 
@@ -40,8 +36,7 @@ fat.test.databases: true
 
 fat.test.container.images: mongo:6.0.6
 
-tested.features:\
-	data-1.0
+tested.features: databaseRotation, data-1.0
 
 -buildpath: \
 	io.openliberty.org.testcontainers;version=latest


### PR DESCRIPTION
- Removes fattest.simplicity ant logic that skips tests when fat.test.database.only is configured
- Ensures buckets that use databaseRotation configure `tested.features: databaseRotation` in bnd.bnd
- `fat.test.databases: true` -> `tested.features: databaseRotation`